### PR TITLE
Fix building base image on Mac.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ ARG gid=1000
 # with the same UID and GID as the current user so that the mounted directory
 # doesn't end up with files with strange permissions.
 
-RUN groupadd -g "${gid}" build && \
+RUN if [ ! $(getent group ${gid}) ]; then groupadd -g "${gid}" build; fi && \
     useradd -m -u "${uid}" -g "${gid}" build
 
-USER build:build
+USER build:${gid}


### PR DESCRIPTION
Open to discussion on how to handle this. At this point though, I think the
options are probably do nothing about user/group IDs in the container (and
then all files created in the mounted volumes will have owner/group of root
on the host system) or run as a "service" group when using Mac (see
below).

Mac uses low group IDs, which would cause groupadd
to fail as the group already existed. Only make a new group if it
doesn't already exist.

This does raise other questions though as now we are technically having
the container run with a "services" group.