### PR TITLE
Add cobra and cli to corso

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// The root-level command.
+// `corso <command> [<subcommand>] [<service>] [<flag>...]`
+var corsoCmd = &cobra.Command{
+	Use:   "corso",
+	Short: "Protect your Microsoft 365 data.",
+	Long:  `Reliable, secure, and efficient data protection for Microsoft 365.`,
+	Run:   handleCorsoCmd,
+}
+
+// the root-level flags
+var (
+	version bool
+)
+
+// Handler for flat calls to `corso`.
+// Produces the same output as `corso --help`.
+func handleCorsoCmd(cmd *cobra.Command, args []string) {
+	if version {
+		fmt.Printf("Corso\nversion:\tpre-alpha\n")
+	} else {
+		cmd.Help()
+	}
+}
+
+// Handle builds and executes the cli processor.
+func Handle() {
+	corsoCmd.Flags().BoolP("version", "v", version, "current version info")
+	if err := corsoCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/src/corso.go
+++ b/src/corso.go
@@ -1,7 +1,9 @@
 package main
 
-import "fmt"
+import (
+	"github.com/alcionai/corso/cli"
+)
 
 func main() {
-	fmt.Println("Hello, Corso")
+	cli.Handle()
 }

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,3 +1,10 @@
 module github.com/alcionai/corso
 
 go 1.18
+
+require github.com/spf13/cobra v1.4.0
+
+require (
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/src/go.sum
+++ b/src/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
+github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
+github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
Adds the spf13/cobra cli handling package.  Main() now
processes cli commands defined by the /cli package.