### PR TITLE
Add 'repo' cli command set

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -5,6 +5,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
+	"github.com/alcionai/corso/cli/repo"
 )
 
 // The root-level command.
@@ -34,6 +36,9 @@ func handleCorsoCmd(cmd *cobra.Command, args []string) {
 // Handle builds and executes the cli processor.
 func Handle() {
 	corsoCmd.Flags().BoolP("version", "v", version, "current version info")
+
+	repo.AddCommands(corsoCmd)
+
 	if err := corsoCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/src/cli/repo/repo.go
+++ b/src/cli/repo/repo.go
@@ -1,0 +1,60 @@
+package repo
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// AddCommands attaches all `corso repo * *` commands to the parent.
+func AddCommands(parent *cobra.Command) {
+	parent.AddCommand(repoCmd)
+	repoCmd.AddCommand(initCmd)
+	repoCmd.AddCommand(connectCmd)
+}
+
+// The repo category of commands.
+// `corso repo [<subcommand>] [<flag>...]`
+var repoCmd = &cobra.Command{
+	Use:   "repo",
+	Short: "Manage your repositories.",
+	Long:  `Initialize, configure, and connect to your account backup repositories.`,
+	Run:   handleRepoCmd,
+	Args:  cobra.NoArgs,
+}
+
+// Handler for flat calls to `corso repo`.
+// Produces the same output as `corso repo --help`.
+func handleRepoCmd(cmd *cobra.Command, args []string) {
+	cmd.Help()
+}
+
+// The repo init subcommand.
+// `corso repo init <repository> [<flag>...]`
+var initCommand = "init"
+var initCmd = &cobra.Command{
+	Use:   initCommand,
+	Short: "Initialize a repository.",
+	Long:  `Create a new repository to store your backups.`,
+	Run:   handleInitCmd,
+	Args:  cobra.NoArgs,
+}
+
+// Handler for calls to `corso repo init`.
+func handleInitCmd(cmd *cobra.Command, args []string) {
+	cmd.Help()
+}
+
+// The repo connect subcommand.
+// `corso repo connect <repository> [<flag>...]`
+var connectCommand = "connect"
+var connectCmd = &cobra.Command{
+	Use:   connectCommand,
+	Short: "Connect to a repository.",
+	Long:  `Connect to an existing repository.`,
+	Run:   handleInitCmd,
+	Args:  cobra.NoArgs,
+}
+
+// Handler for calls to `corso repo connect`.
+func handleConnectCmd(cmd *cobra.Command, args []string) {
+	cmd.Help()
+}


### PR DESCRIPTION
Adds the 'repo' command and its primary subcommands to the
Corso cli command list.