### PR TITLE
Adds s3 repo commands

### DIFF
--- a/src/cli/repo/repo.go
+++ b/src/cli/repo/repo.go
@@ -9,13 +9,45 @@ func AddCommands(parent *cobra.Command) {
 	parent.AddCommand(repoCmd)
 	repoCmd.AddCommand(initCmd)
 	repoCmd.AddCommand(connectCmd)
+
+	for _, addF := range repoProviders {
+		addPerProviderCommands(initCmd, addF)
+		addPerProviderCommands(connectCmd, addF)
+	}
+}
+
+// All of the supported repository providers.
+var repoProviders = []func(*cobra.Command) *cobra.Command{
+	addS3Commands,
+}
+
+// m365 account info from flags
+var (
+	m365Tenant       string
+	m365ClientID     string
+	m365ClientSecret string
+)
+
+// initialze the per-provider commands for each
+func addPerProviderCommands(parent *cobra.Command, addCommands func(*cobra.Command) *cobra.Command) {
+	c := addCommands(parent)
+
+	// m365 flags are available independent of the provider
+	fs := c.Flags()
+	fs.StringVar(&m365Tenant, "tenant", "", "Your m365 account ID.")
+	fs.StringVar(&m365ClientID, "client-id", "", "Your m365 application client ID.")
+
+	if parent.Use == initUse {
+		c.MarkFlagRequired("m365-tenant")
+		c.MarkFlagRequired("m365-client-id")
+	}
 }
 
 // The repo category of commands.
 // `corso repo [<subcommand>] [<flag>...]`
 var repoCmd = &cobra.Command{
 	Use:   "repo",
-	Short: "Manage your repositories.",
+	Short: "Manage your repositories",
 	Long:  `Initialize, configure, and connect to your account backup repositories.`,
 	Run:   handleRepoCmd,
 	Args:  cobra.NoArgs,
@@ -29,10 +61,10 @@ func handleRepoCmd(cmd *cobra.Command, args []string) {
 
 // The repo init subcommand.
 // `corso repo init <repository> [<flag>...]`
-var initCommand = "init"
+var initUse = "init"
 var initCmd = &cobra.Command{
-	Use:   initCommand,
-	Short: "Initialize a repository.",
+	Use:   initUse,
+	Short: "Initialize a repository",
 	Long:  `Create a new repository to store your backups.`,
 	Run:   handleInitCmd,
 	Args:  cobra.NoArgs,
@@ -45,10 +77,10 @@ func handleInitCmd(cmd *cobra.Command, args []string) {
 
 // The repo connect subcommand.
 // `corso repo connect <repository> [<flag>...]`
-var connectCommand = "connect"
+var connectUse = "connect"
 var connectCmd = &cobra.Command{
-	Use:   connectCommand,
-	Short: "Connect to a repository.",
+	Use:   connectUse,
+	Short: "Connect to a repository",
 	Long:  `Connect to an existing repository.`,
 	Run:   handleInitCmd,
 	Args:  cobra.NoArgs,

--- a/src/cli/repo/s3.go
+++ b/src/cli/repo/s3.go
@@ -1,0 +1,79 @@
+package repo
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// s3 bucket info from flags
+var (
+	bucket    string
+	accessKey string
+)
+
+// called by repo.go to map parent subcommands to provider-specific handling.
+func addS3Commands(parent *cobra.Command) *cobra.Command {
+	var c *cobra.Command
+	switch parent.Use {
+	case initUse:
+		c = s3InitCmd
+	case connectUse:
+		c = s3ConnectCmd
+	}
+
+	parent.AddCommand(c)
+
+	fs := c.Flags()
+	fs.StringVar(&bucket, "bucket", "", "Name of the S3 bucket (required).")
+	fs.StringVar(&accessKey, "access-key", "", "Access key ID (replaces the AWS_ACCESS_KEY_ID env variable).")
+
+	return c
+}
+
+// `corso repo init s3 [<flag>...]`
+var s3InitCmd = &cobra.Command{
+	Use:   "s3",
+	Short: "Initialize a S3 repository",
+	Long:  `Bootstraps a new S3 repository and connects it to your m356 account.`,
+	Run:   initS3Cmd,
+	Args:  cobra.NoArgs,
+}
+
+// initializes a s3 repo.
+func initS3Cmd(cmd *cobra.Command, args []string) {
+	oci := os.Getenv("O365_CLIENT_ID")
+	ocs := os.Getenv("O356_SECRET")
+	asak := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	fmt.Printf(
+		"Called -\n`corso repo init s3`\nbucket:\t%s\nkey:\t%s\n356Client:\t%s\nfound 356Secret:\t%v\nfound awsSecret:\t%v\n",
+		bucket,
+		accessKey,
+		oci,
+		len(ocs) > 0,
+		len(asak) > 0)
+}
+
+// `corso repo connect s3 [<flag>...]`
+var s3ConnectCmd = &cobra.Command{
+	Use:   "s3",
+	Short: "Connect to a S3 repository",
+	Long:  `Ensures a connection to an existing S3 repository.`,
+	Run:   connectS3Cmd,
+	Args:  cobra.NoArgs,
+}
+
+// connects to an existing s3 repo.
+func connectS3Cmd(cmd *cobra.Command, args []string) {
+	oci := os.Getenv("O365_CLIENT_ID")
+	ocs := os.Getenv("O356_SECRET")
+	asak := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	fmt.Printf(
+		"Called -\n`corso repo connect s3`\nbucket:\t%s\nkey:\t%s\n356Client:\t%s\nfound 356Secret:\t%v\nfound awsSecret:\t%v\n",
+		bucket,
+		accessKey,
+		oci,
+		len(ocs) > 0,
+		len(asak) > 0)
+}


### PR DESCRIPTION
Extends the repo command package with S3 provider
commands.  Also packs in a handful of new flags such as
m365 account details, and some lookups for env-based secrets.