### PR TITLE
Use testify for repository tests

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -7,12 +7,14 @@ require (
 	github.com/kopia/kopia v0.10.7
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.4.0
+	github.com/stretchr/testify v1.7.1
 )
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/chmduquesne/rollinghash v4.0.0+incompatible // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
@@ -30,6 +32,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/natefinch/atomic v1.0.1 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
@@ -51,4 +54,5 @@ require (
 	google.golang.org/grpc v1.45.0 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/src/go.sum
+++ b/src/go.sum
@@ -254,6 +254,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -558,6 +559,7 @@ google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.66.2 h1:XfR1dOYubytKy4Shzc2LHrrGhU0lDCfDGG1yLPmpgsI=

--- a/src/pkg/repository/repository_test.go
+++ b/src/pkg/repository/repository_test.go
@@ -2,55 +2,65 @@ package repository_test
 
 import (
 	"context"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/pkg/repository"
 	"github.com/alcionai/corso/pkg/storage"
 )
 
-func TestInitialize(t *testing.T) {
+type RepositorySuite struct {
+	suite.Suite
+}
+
+func TestRepositorySuite(t *testing.T) {
+	suite.Run(t, new(RepositorySuite))
+}
+
+func (suite *RepositorySuite) TestInitialize() {
 	table := []struct {
-		storage     storage.Storage
-		account     repository.Account
-		expectedErr string
+		name     string
+		storage  storage.Storage
+		account  repository.Account
+		errCheck assert.ErrorAssertionFunc
 	}{
 		{
+			storage.ProviderUnknown.String(),
 			storage.NewStorage(storage.ProviderUnknown),
 			repository.Account{},
-			"provider details are required",
+			assert.Error,
 		},
 	}
 	for _, test := range table {
-		t.Run(test.expectedErr, func(t *testing.T) {
+		suite.T().Run(test.name, func(t *testing.T) {
 			_, err := repository.Initialize(context.Background(), test.account, test.storage)
-			if err == nil || !strings.Contains(err.Error(), test.expectedErr) {
-				t.Fatalf("expected error with [%s], got [%v]", test.expectedErr, err)
-			}
+			test.errCheck(suite.T(), err, "")
 		})
 	}
 }
 
 // repository.Connect involves end-to-end communication with kopia, therefore this only
 // tests expected error cases from
-func TestConnect(t *testing.T) {
+func (suite *RepositorySuite) TestConnect() {
 	table := []struct {
-		storage     storage.Storage
-		account     repository.Account
-		expectedErr string
+		name     string
+		storage  storage.Storage
+		account  repository.Account
+		errCheck assert.ErrorAssertionFunc
 	}{
 		{
+			storage.ProviderUnknown.String(),
 			storage.NewStorage(storage.ProviderUnknown),
 			repository.Account{},
-			"provider details are required",
+			assert.Error,
 		},
 	}
 	for _, test := range table {
-		t.Run(test.expectedErr, func(t *testing.T) {
+		suite.T().Run(test.name, func(t *testing.T) {
 			_, err := repository.Connect(context.Background(), test.account, test.storage)
-			if err == nil || !strings.Contains(err.Error(), test.expectedErr) {
-				t.Fatalf("expected error with [%s], got [%v]", test.expectedErr, err)
-			}
+			test.errCheck(suite.T(), err)
 		})
 	}
 }


### PR DESCRIPTION
Also moved away from error string comparison which "pseudo exports" internal package details.

