### PR TITLE
add readme to corso/src (#101)

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,20 @@
+# SRC Directory
+
+## /pkg
+API and Components which are exposed for external usage.
+
+* /pkg/repository  
+Control layer for coordinating connections and communication with storage provider repositories.
+
+* /pkg/storage  
+Manages compilation and validation of repository configuration and consts.  Both those that are specific to storage providers, and those that are provider-agnostic.
+
+-----
+
+## /cli
+Command Line Interface controller.  Utilizes /pkg/repository as an exernal dependency.
+
+-----
+
+## /internal
+Packages which are only intended for use within Corso.


### PR DESCRIPTION
Additional documentation to help guide new developers through the
repository layout and design decisions backing that layout.