### PR TITLE
Issue #118: GraphData Import added

### DIFF
--- a/src/internal/connector/dataTransport/exchangeData.go
+++ b/src/internal/connector/dataTransport/exchangeData.go
@@ -1,15 +1,20 @@
 package dataTransport
 
+import (
+	"bytes"
+	"io"
+)
+
 type ExchangeData struct {
-	// Provides file data to kopia.
-	uuid string
-	Data []byte
+	GraphData
+	uuid    string
+	message []byte
 }
 
 func NewExchangeData(name string) ExchangeData {
 	exchange := ExchangeData{
-		uuid: name,
-		Data: make([]byte, 0),
+		uuid:    name,
+		message: make([]byte, 0),
 	}
 	return exchange
 }
@@ -22,12 +27,20 @@ func NewExchangeDataFilled(name string, bytes []byte) ExchangeData {
 		bArray = make([]byte, 0)
 	}
 	exchange := ExchangeData{
-		uuid: name,
-		Data: bArray,
+		uuid:    name,
+		message: bArray,
 	}
 	return exchange
 }
 
 func (exchange *ExchangeData) UUID() string {
 	return exchange.uuid
+}
+
+func (exchange *ExchangeData) ToReader() *io.Reader {
+	return exchange
+}
+
+func (exchange *ExchangeData) Read(bytes []byte) (int, error) {
+	return 0, nil
 }

--- a/src/internal/connector/dataTransport/graphData.go
+++ b/src/internal/connector/dataTransport/graphData.go
@@ -1,8 +1,11 @@
 package dataTransport
 
+import "io"
+
 // GraphData is an interface that encapsulates serialized data
 // from the M365 to the BackupWriter
 type GraphData interface {
 	//Provides file name for BackupWriter
 	UUID() string
+	ToReader() *io.Reader
 }


### PR DESCRIPTION
The main portion of this interface is its ability to provide a UUID. It
may not be a great idea to have a call inside to get a new reader.
Will await draft review.