### PR TITLE
Struct with information about completed uploads

### DIFF
--- a/src/internal/kopia/kopia.go
+++ b/src/internal/kopia/kopia.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/snapshot"
 	"github.com/pkg/errors"
 
 	"github.com/alcionai/corso/pkg/storage"
@@ -18,6 +19,26 @@ var (
 	errInit    = errors.New("initializing repo")
 	errConnect = errors.New("connecting repo")
 )
+
+type BackupStats struct {
+	TotalFileCount      int
+	TotalDirectoryCount int
+	IgnoredErrorCount   int
+	ErrorCount          int
+	Incomplete          bool
+	IncompleteReason    string
+}
+
+func manifestToStats(man *snapshot.Manifest) BackupStats {
+	return BackupStats{
+		TotalFileCount:      int(man.Stats.TotalFileCount),
+		TotalDirectoryCount: int(man.Stats.TotalDirectoryCount),
+		IgnoredErrorCount:   int(man.Stats.IgnoredErrorCount),
+		ErrorCount:          int(man.Stats.ErrorCount),
+		Incomplete:          man.IncompleteReason == "",
+		IncompleteReason:    man.IncompleteReason,
+	}
+}
 
 type KopiaWrapper struct {
 	storage storage.Storage


### PR DESCRIPTION
POD struct that holds some simple information about a kopia upload. Not
wrapping or returning a handle to a kopia struct to keep upper layers of
corso clear of type dependencies. Struct will help with tests as it can
be returned from public functions in the KopiaWrapper package allowing
more black-box testing. Especially useful since we don't yet have a
restore flow, which means we can't test data == restore(backup(data)).

This assumes we are alright with simple tests that just check the number
of files uploaded by kopia (this is what kopia's uploader tests do). More
detailed tests that actually check the snapshot for specific files would
not require this struct.

More information on the underlying `snapshot.Manifest` [here](https://pkg.go.dev/github.com/kopia/kopia@v0.10.7/snapshot#Manifest) and
[here](https://pkg.go.dev/github.com/kopia/kopia@v0.10.7/snapshot#Stats)