### PR TITLE
swap logger to zerolog for comparison

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -69,8 +69,7 @@ func Handle() {
 	repo.AddCommands(corsoCmd)
 	backup.AddCommands(corsoCmd)
 
-	ctx, log := logger.Seed(context.Background())
-	defer log.Sync() // flush all logs in the buffer
+	ctx := logger.Seed(context.Background())
 
 	if err := corsoCmd.ExecuteContext(ctx); err != nil {
 		fmt.Println(err)

--- a/src/cli/repo/s3.go
+++ b/src/cli/repo/s3.go
@@ -59,13 +59,13 @@ func initS3Cmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	log.Debugw(
-		"Called - "+cmd.CommandPath(),
-		"bucket", s3Cfg.Bucket,
-		"clientID", m365.ClientID,
-		"hasClientSecret", len(m365.ClientSecret) > 0,
-		"accessKey", s3Cfg.AccessKey,
-		"hasSecretKey", len(s3Cfg.SecretKey) > 0)
+	log.Debug().
+		Str("bucket", s3Cfg.Bucket).
+		Str("clientID", m365.ClientID).
+		Bool("hasClientSecret", len(m365.ClientSecret) > 0).
+		Str("accessKey", s3Cfg.AccessKey).
+		Bool("hasSecretKey", len(s3Cfg.SecretKey) > 0).
+		Msg("Called - " + cmd.CommandPath())
 
 	a := repository.Account{
 		TenantID:     m365.TenantID,
@@ -106,13 +106,13 @@ func connectS3Cmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	log.Debugw(
-		"Called - "+cmd.CommandPath(),
-		"bucket", s3Cfg.Bucket,
-		"clientID", m365.ClientID,
-		"hasClientSecret", len(m365.ClientSecret) > 0,
-		"accessKey", s3Cfg.AccessKey,
-		"hasSecretKey", len(s3Cfg.SecretKey) > 0)
+	log.Debug().
+		Str("bucket", s3Cfg.Bucket).
+		Str("clientID", m365.ClientID).
+		Bool("hasClientSecret", len(m365.ClientSecret) > 0).
+		Str("accessKey", s3Cfg.AccessKey).
+		Bool("hasSecretKey", len(s3Cfg.SecretKey) > 0).
+		Msg("Called - " + cmd.CommandPath())
 
 	a := repository.Account{
 		TenantID:     m365.TenantID,

--- a/src/go.mod
+++ b/src/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/microsoftgraph/msgraph-sdk-go v0.25.0
 	github.com/microsoftgraph/msgraph-sdk-go-core v0.26.0
 	github.com/pkg/errors v0.9.1
+	github.com/rs/zerolog v1.27.0
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.7.1
@@ -48,6 +49,8 @@ require (
 	github.com/klauspost/cpuid/v2 v2.0.12 // indirect
 	github.com/klauspost/pgzip v1.2.5 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/microsoft/kiota-abstractions-go v0.8.0 // indirect
 	github.com/microsoft/kiota-http-go v0.5.0 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -78,6 +78,7 @@ github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XP
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -108,6 +109,7 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=
 github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
@@ -222,6 +224,10 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/magiconair/properties v1.8.6 h1:5ibWZ6iY0NctNGWo87LalDlEZ6R41TqbbDamhfG/Qzo=
 github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
+github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
+github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
+github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
+github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/microsoft/kiota-abstractions-go v0.8.0 h1:mtilyDlfM9EUe4blByCmQh/iO7S0176zHd+oxr7rh20=
@@ -302,8 +308,11 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
+github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/xid v1.4.0 h1:qd7wPTDkN6KQx2VmMBLrpHkiyQwgFXRnkOLacUiaSNY=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
+github.com/rs/zerolog v1.27.0 h1:1T7qCieN22GVc8S4Q2yuexzBb1EqjbgjSH9RohbMjKs=
+github.com/rs/zerolog v1.27.0/go.mod h1:7frBqO0oezxmnO7GF86FY++uy8I0Tk/If5ni1G9Qc0U=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -518,6 +527,8 @@ golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/src/pkg/logger/logger.go
+++ b/src/pkg/logger/logger.go
@@ -4,34 +4,12 @@ import (
 	"context"
 	"os"
 
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
-var logCore *zapcore.Core
-
-func coreSingleton() *zapcore.Core {
-	if logCore == nil {
-		// level handling
-		highPriority := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
-			return lvl >= zapcore.ErrorLevel
-		})
-		lowPriority := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
-			return lvl < zapcore.ErrorLevel
-		})
-		// level-based output
-		consoleDebugging := zapcore.Lock(os.Stdout)
-		consoleErrors := zapcore.Lock(os.Stderr)
-		// encoder type
-		consoleEncoder := zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig())
-		// combine into a logger core
-		core := zapcore.NewTee(
-			zapcore.NewCore(consoleEncoder, consoleErrors, highPriority),
-			zapcore.NewCore(consoleEncoder, consoleDebugging, lowPriority),
-		)
-		logCore = &core
-	}
-	return logCore
+func subLogger() zerolog.Logger {
+	return log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 }
 
 type loggingKey string
@@ -39,17 +17,11 @@ type loggingKey string
 const ctxKey loggingKey = "corsoLogger"
 
 // Seed embeds a logger into the context for later retrieval.
-func Seed(ctx context.Context) (context.Context, *zap.SugaredLogger) {
-	l := zap.New(*coreSingleton())
-	s := l.Sugar()
-	return context.WithValue(ctx, ctxKey, s), s
+func Seed(ctx context.Context) context.Context {
+	return subLogger().WithContext(ctx)
 }
 
 // Ctx retrieves the logger embedded in the context.
-func Ctx(ctx context.Context) *zap.SugaredLogger {
-	l := ctx.Value(ctxKey)
-	if l == nil {
-		return zap.New(*coreSingleton()).Sugar()
-	}
-	return l.(*zap.SugaredLogger)
+func Ctx(ctx context.Context) *zerolog.Logger {
+	return log.Ctx(ctx)
 }


### PR DESCRIPTION
As a proof-of-concept comparison, replaces the zap
logger for the zerolog version.

Poc/skeleton implementation only to prove out the design/lib.

Competes for succession with https://github.com/alcionai/corso/pull/155