### PR TITLE
Fix AWS access key override logic

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/kopia/kopia v0.10.7
 	github.com/microsoft/kiota-authentication-azure-go v0.3.0
+	github.com/microsoft/kiota-serialization-json-go v0.5.1
 	github.com/microsoftgraph/msgraph-sdk-go v0.25.0
 	github.com/microsoftgraph/msgraph-sdk-go-core v0.26.0
 	github.com/pkg/errors v0.9.1
@@ -51,7 +52,6 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/microsoft/kiota-abstractions-go v0.8.0 // indirect
 	github.com/microsoft/kiota-http-go v0.5.0 // indirect
-	github.com/microsoft/kiota-serialization-json-go v0.5.1 // indirect
 	github.com/microsoft/kiota-serialization-text-go v0.4.0 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/minio/minio-go/v7 v7.0.27 // indirect

--- a/src/pkg/credentials/aws.go
+++ b/src/pkg/credentials/aws.go
@@ -21,7 +21,7 @@ type AWS struct {
 // GetAWS is a helper for aggregating aws secrets and credentials.
 func GetAWS(override map[string]string) AWS {
 	accessKey := os.Getenv(AWSAccessKeyID)
-	if ovr, ok := override[AWSAccessKeyID]; ok {
+	if ovr, ok := override[AWSAccessKeyID]; ok && ovr != "" {
 		accessKey = ovr
 	}
 	secretKey := os.Getenv(AWSSecretAccessKey)


### PR DESCRIPTION
The override logic doesn't account for the default value of the `--access-key` flag which is `""`.

In a follow-up, I believe we should just remove this flag for now since there isn't a use case to
specify *just* the access key via a flag.

Also minor fix in `go.mod` to add a direct import.