### PR TITLE
Implement ToReader for ExchangeData

### DIFF
--- a/src/internal/connector/exchange_data_collection.go
+++ b/src/internal/connector/exchange_data_collection.go
@@ -1,6 +1,9 @@
 package connector
 
-import "io"
+import (
+	"bytes"
+	"io"
+)
 
 // A DataCollection represents a collection of data of the
 // same type (e.g. mail)
@@ -13,7 +16,8 @@ type DataCollection interface {
 // DataStream represents a single item within a DataCollection
 // that can be consumed as a stream (it embeds io.Reader)
 type DataStream interface {
-	io.Reader
+	// Returns an io.Reader for the DataStream
+	ToReader() io.Reader
 	// Provides a unique identifier for this data
 	UUID() string
 }
@@ -72,7 +76,6 @@ func (ed *ExchangeData) UUID() string {
 	return ed.id
 }
 
-func (ed *ExchangeData) Read(bytes []byte) (int, error) {
-	// TODO: Copy ed.message into []bytes. Will need to take care of partial reads
-	return 0, nil
+func (ed *ExchangeData) ToReader() io.Reader {
+	return bytes.NewReader(ed.message)
 }

--- a/src/internal/connector/exchange_data_collection_test.go
+++ b/src/internal/connector/exchange_data_collection_test.go
@@ -1,0 +1,27 @@
+package connector
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type ExchangeDataCollectionSuite struct {
+	suite.Suite
+}
+
+func TestExchangeDataCollectionSuite(t *testing.T) {
+	suite.Run(t, new(ExchangeDataCollectionSuite))
+}
+
+func (suite *ExchangeDataCollectionSuite) TestExchangeDataReader() {
+	m := []byte("test message")
+	ed := &ExchangeData{message: m}
+
+	// Read the message using the `ExchangeData` reader and validate it matches what we set
+	buf := &bytes.Buffer{}
+	buf.ReadFrom(ed.ToReader())
+	assert.Equal(suite.T(), buf.Bytes(), m)
+}


### PR DESCRIPTION
Add `ToReader` to return the `io.Reader` instead of embedding `io.Reader`.
This allows us to leverage `bytes.NewReader` instead of implementing our own.
