### PR TITLE
Only run CI once for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: ['**']
+    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
Currently CI is triggered twice when a PR is updated (the second run being triggered by the branch push).
This removes that trigger.