### PR TITLE
Add remainder of BackupCollections code

### DIFF
--- a/src/internal/kopia/kopia_test.go
+++ b/src/internal/kopia/kopia_test.go
@@ -149,12 +149,10 @@ func (suite *KopiaUnitSuite) TestBuildDirectoryTree_NoAncestorDirs() {
 func (suite *KopiaUnitSuite) TestBuildDirectoryTree_Fails() {
 	table := []struct {
 		name   string
-		err    error
 		layout []connector.DataCollection
 	}{
 		{
 			"MultipleRoots",
-			errDirRoots,
 			// Directory structure would look like:
 			// - user1
 			//   - emails
@@ -175,7 +173,6 @@ func (suite *KopiaUnitSuite) TestBuildDirectoryTree_Fails() {
 		},
 		{
 			"NoCollectionPath",
-			errStreamID,
 			[]connector.DataCollection{
 				mockconnector.NewMockExchangeDataCollection(
 					nil,
@@ -185,7 +182,6 @@ func (suite *KopiaUnitSuite) TestBuildDirectoryTree_Fails() {
 		},
 		{
 			"MixedDirectory",
-			errMixedDir,
 			// Directory structure would look like (but should return error):
 			// - a-tenant
 			//   - user1
@@ -210,7 +206,7 @@ func (suite *KopiaUnitSuite) TestBuildDirectoryTree_Fails() {
 
 		suite.T().Run(test.name, func(t *testing.T) {
 			_, err := inflateDirTree(ctx, test.layout)
-			assert.ErrorIs(t, err, test.err)
+			assert.Error(t, err)
 		})
 	}
 }


### PR DESCRIPTION
Takes a slice of `DataStream`s and translates them into a directory hierarchy that kopia understands

Can chunk into separate functions (with the last one pulling in the tests too) if that makes people more comfortable

~Pending merge and rebase on some PR with mocks~

closes #45 