### PR TITLE
GraphConnector testing expanded

### DIFF
--- a/src/internal/connector/graph_connector_test.go
+++ b/src/internal/connector/graph_connector_test.go
@@ -55,8 +55,8 @@ func TestDisconnectedGraphSuite(t *testing.T) {
 }
 
 func (suite *GraphConnectorIntegrationSuite) TestGraphConnector_setTenantUsers() {
-	result := suite.connector.setTenantUsers()
-	assert.Nil(suite.T(), result)
+	err := suite.connector.setTenantUsers()
+	assert.NoError(suite.T(), err)
 	suite.Greater(len(suite.connector.Users), 0)
 }
 


### PR DESCRIPTION
Branch adds the following:
setTenantUsers covered and switched the test account for an account with
less corner cases.