### PR TITLE
add cron action to purge s3 test bucket weekly

### DIFF
--- a/.github/workflows/weekly_cleanup.yml
+++ b/.github/workflows/weekly_cleanup.yml
@@ -1,4 +1,4 @@
-name: First Cron Job
+name: Weekly S3 Test Bucket Cleanup
 on:
   schedule:
     # every saturday at 23:59 (11:59pm)


### PR DESCRIPTION
Removes all objects in the `test-corso-repo-init` s3 bucket
on a weekly basis (Saturdays at 23:59 UTC).  This bucket
stores all data generated by corso integration tests.