### PR TITLE
add RestoreOperation

### DIFF
--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -1,0 +1,58 @@
+package operations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/alcionai/corso/internal/kopia"
+	"github.com/alcionai/corso/pkg/credentials"
+)
+
+// RestoreOperation wraps an operation with restore-specific props.
+type RestoreOperation struct {
+	operation
+	Version string
+
+	creds credentials.M365
+
+	Targets []string // something for targets/filter/source/app&users/etc
+}
+
+// NewRestoreOperation constructs and validates a restore operation.
+func NewRestoreOperation(
+	ctx context.Context,
+	opts OperationOpts,
+	kw *kopia.KopiaWrapper,
+	creds credentials.M365,
+	targets []string,
+) (RestoreOperation, error) {
+	op := RestoreOperation{
+		operation: newOperation(opts, kw),
+		Version:   "v0",
+		creds:     creds,
+		Targets:   targets,
+	}
+	if err := op.validate(); err != nil {
+		return RestoreOperation{}, err
+	}
+
+	return op, nil
+}
+
+func (op RestoreOperation) validate() error {
+	if err := op.creds.Validate(); err != nil {
+		return errors.Wrap(err, "invalid credentials")
+	}
+	return op.operation.validate()
+}
+
+// Run begins a synchronous restore operation.
+// todo (keepers): return stats block in first param.
+func (op *RestoreOperation) Run(ctx context.Context) (any, error) {
+
+	// todo: hook up with KW and GC restore operations.
+
+	op.Status = Successful
+	return nil, nil
+}

--- a/src/internal/operations/restore_test.go
+++ b/src/internal/operations/restore_test.go
@@ -1,0 +1,63 @@
+package operations_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/internal/kopia"
+	"github.com/alcionai/corso/internal/operations"
+	ctesting "github.com/alcionai/corso/internal/testing"
+	"github.com/alcionai/corso/pkg/credentials"
+)
+
+type RestoreOpIntegrationSuite struct {
+	suite.Suite
+}
+
+func TestRestoreOpIntegrationSuite(t *testing.T) {
+	if err := ctesting.RunOnAny(ctesting.CorsoCITests); err != nil {
+		t.Skip(err)
+	}
+	suite.Run(t, new(RestoreOpIntegrationSuite))
+}
+
+func (suite *RestoreOpIntegrationSuite) SetupSuite() {
+	_, err := ctesting.GetRequiredEnvVars(
+		credentials.TenantID,
+		credentials.ClientID,
+		credentials.ClientSecret,
+	)
+	require.NoError(suite.T(), err)
+}
+
+func (suite *RestoreOpIntegrationSuite) TestNewRestoreOperation() {
+	kw := &kopia.KopiaWrapper{}
+	creds := credentials.GetM365()
+	table := []struct {
+		name     string
+		opts     operations.OperationOpts
+		kw       *kopia.KopiaWrapper
+		creds    credentials.M365
+		targets  []string
+		errCheck assert.ErrorAssertionFunc
+	}{
+		{"good", operations.OperationOpts{}, kw, creds, nil, assert.NoError},
+		{"missing kopia", operations.OperationOpts{}, nil, creds, nil, assert.Error},
+		{"invalid creds", operations.OperationOpts{}, kw, credentials.M365{}, nil, assert.Error},
+	}
+	for _, test := range table {
+		suite.T().Run(test.name, func(t *testing.T) {
+			_, err := operations.NewRestoreOperation(
+				context.Background(),
+				operations.OperationOpts{},
+				test.kw,
+				test.creds,
+				nil)
+			test.errCheck(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Adds the RestoreOperation to the /internal/operations pkg.
restoreOp.Run() is a no-op at this time since data layer
packages are not prepared to hook up e2e.