### PR TITLE
hook up restore cli to repository restore runner

### DIFF
--- a/src/cli/restore/exchange.go
+++ b/src/cli/restore/exchange.go
@@ -78,7 +78,14 @@ func createExchangeCmd(cmd *cobra.Command, args []string) error {
 	}
 	defer utils.CloseRepo(cmd.Context(), r)
 
-	// todo (keepers): actually restore things
+	ro, err := r.NewRestore(cmd.Context(), []string{user, folder, mail})
+	if err != nil {
+		return errors.Wrap(err, "Failed to initialize Exchange restore")
+	}
+
+	if _, err := ro.Run(cmd.Context()); err != nil {
+		return errors.Wrap(err, "Failed to run Exchange restore")
+	}
 
 	fmt.Printf("Restored Exchange in %s for user %s.\n", s.Provider, user)
 	return nil

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -111,3 +111,18 @@ func (r Repository) NewBackup(ctx context.Context, targets []string) (operations
 		creds,
 		targets)
 }
+
+// NewRestore generates a restoreOperation runner.
+func (r Repository) NewRestore(ctx context.Context, targets []string) (operations.RestoreOperation, error) {
+	creds := credentials.M365{
+		ClientID:     r.Account.ClientID,
+		ClientSecret: r.Account.ClientSecret,
+		TenantID:     r.Account.TenantID,
+	}
+	return operations.NewRestoreOperation(
+		ctx,
+		operations.OperationOpts{},
+		r.dataLayer,
+		creds,
+		targets)
+}


### PR DESCRIPTION
Introduces a NewRestore method to the Repository struct.
cli/restore/exchange now generates a restoreOperation
and kicks off a Run() when `corso restore exchange` is called.
The restore operation still only accepts the placeholder
Target string slice.