### PR TITLE
Replace fmt prints with the logger

### DIFF
--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alcionai/corso/cli/config"
 	"github.com/alcionai/corso/cli/utils"
 	"github.com/alcionai/corso/pkg/credentials"
+	"github.com/alcionai/corso/pkg/logger"
 	"github.com/alcionai/corso/pkg/repository"
 )
 
@@ -40,6 +41,12 @@ var exchangeCreateCmd = &cobra.Command{
 
 // initializes a s3 repo.
 func createExchangeCmd(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	if utils.HasNoFlagsAndShownHelp(cmd) {
+		return nil
+	}
+
 	s, cfgTenantID, err := config.MakeS3Config(true, nil)
 	if err != nil {
 		return err
@@ -55,25 +62,24 @@ func createExchangeCmd(cmd *cobra.Command, args []string) error {
 		a.TenantID = cfgTenantID
 	}
 
-	fmt.Printf(
-		"Called - %s\n\t365TenantID:\t%s\n\t356Client:\t%s\n\tfound 356Secret:\t%v\n",
-		cmd.CommandPath(),
-		m365.TenantID,
-		m365.ClientID,
-		len(m365.ClientSecret) > 0)
+	logger.Ctx(ctx).Debugw(
+		"Called - "+cmd.CommandPath(),
+		"tenantID", m365.TenantID,
+		"clientID", m365.ClientID,
+		"hasClientSecret", len(m365.ClientSecret) > 0)
 
-	r, err := repository.Connect(cmd.Context(), a, s)
+	r, err := repository.Connect(ctx, a, s)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to connect to the %s repository", s.Provider)
 	}
-	defer utils.CloseRepo(cmd.Context(), r)
+	defer utils.CloseRepo(ctx, r)
 
-	bo, err := r.NewBackup(cmd.Context(), []string{user})
+	bo, err := r.NewBackup(ctx, []string{user})
 	if err != nil {
 		return errors.Wrap(err, "Failed to initialize Exchange backup")
 	}
 
-	if _, err := bo.Run(cmd.Context()); err != nil {
+	if _, err := bo.Run(ctx); err != nil {
 		return errors.Wrap(err, "Failed to run Exchange backup")
 	}
 

--- a/src/cli/repo/s3.go
+++ b/src/cli/repo/s3.go
@@ -52,7 +52,12 @@ var s3InitCmd = &cobra.Command{
 
 // initializes a s3 repo.
 func initS3Cmd(cmd *cobra.Command, args []string) error {
-	log := logger.Ctx(cmd.Context())
+	ctx := cmd.Context()
+	log := logger.Ctx(ctx)
+
+	if utils.HasNoFlagsAndShownHelp(cmd) {
+		return nil
+	}
 
 	overrides := map[string]string{
 		credentials.AWSAccessKeyID: accessKey,
@@ -87,11 +92,11 @@ func initS3Cmd(cmd *cobra.Command, args []string) error {
 		"accessKey", s3Cfg.AccessKey,
 		"hasSecretKey", len(s3Cfg.SecretKey) > 0)
 
-	r, err := repository.Initialize(cmd.Context(), a, s)
+	r, err := repository.Initialize(ctx, a, s)
 	if err != nil {
 		return errors.Wrap(err, "Failed to initialize a new S3 repository")
 	}
-	defer utils.CloseRepo(cmd.Context(), r)
+	defer utils.CloseRepo(ctx, r)
 
 	fmt.Printf("Initialized a S3 repository within bucket %s.\n", s3Cfg.Bucket)
 
@@ -112,7 +117,12 @@ var s3ConnectCmd = &cobra.Command{
 
 // connects to an existing s3 repo.
 func connectS3Cmd(cmd *cobra.Command, args []string) error {
-	log := logger.Ctx(cmd.Context())
+	ctx := cmd.Context()
+	log := logger.Ctx(ctx)
+
+	if utils.HasNoFlagsAndShownHelp(cmd) {
+		return nil
+	}
 
 	overrides := map[string]string{
 		credentials.AWSAccessKeyID: accessKey,
@@ -147,11 +157,11 @@ func connectS3Cmd(cmd *cobra.Command, args []string) error {
 		"accessKey", s3Cfg.AccessKey,
 		"hasSecretKey", len(s3Cfg.SecretKey) > 0)
 
-	r, err := repository.Connect(cmd.Context(), a, s)
+	r, err := repository.Connect(ctx, a, s)
 	if err != nil {
 		return errors.Wrap(err, "Failed to connect to the S3 repository")
 	}
-	defer utils.CloseRepo(cmd.Context(), r)
+	defer utils.CloseRepo(ctx, r)
 
 	fmt.Printf("Connected to S3 bucket %s.\n", s3Cfg.Bucket)
 

--- a/src/cli/utils/utils.go
+++ b/src/cli/utils/utils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/alcionai/corso/pkg/repository"
+	"github.com/spf13/cobra"
 )
 
 // RequireProps validates the existence of the properties
@@ -24,4 +25,17 @@ func CloseRepo(ctx context.Context, r *repository.Repository) {
 	if err := r.Close(ctx); err != nil {
 		fmt.Print("Error closing repository:", err)
 	}
+}
+
+// HasNoFlagsAndShownHelp shows the Help output if no flags
+// were provided to the command.  Returns true if the help
+// was shown.
+// Use for when the non-flagged usage of a command
+// (ex: corso backup restore exchange) is expected to no-op.
+func HasNoFlagsAndShownHelp(cmd *cobra.Command) bool {
+	if cmd.Flags().NFlag() == 0 {
+		cmd.Help()
+		return true
+	}
+	return false
 }

--- a/src/internal/connector/errors_test.go
+++ b/src/internal/connector/errors_test.go
@@ -1,6 +1,7 @@
 package connector
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -26,8 +27,8 @@ func (suite *GraphConnectorErrorSuite) TestWrapAndAppend() {
 	suite.True(strings.Contains(returnErr.Error(), "arc376"))
 	suite.Error(returnErr)
 	multi := &multierror.Error{Errors: []error{err1, err2}}
-	suite.True(strings.Contains(ListErrors(*multi), "two")) // Does not contain the wrapped information
-	suite.T().Log(ListErrors(*multi))
+	suite.True(strings.Contains(ListErrors(context.Background(), *multi), "two")) // Does not contain the wrapped information
+	suite.T().Log(ListErrors(context.Background(), *multi))
 }
 
 func (suite *GraphConnectorErrorSuite) TestWrapAndAppend_OnVar() {

--- a/src/internal/connector/graph_connector_test.go
+++ b/src/internal/connector/graph_connector_test.go
@@ -1,6 +1,7 @@
 package connector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -63,7 +64,7 @@ func (suite *GraphConnectorIntegrationSuite) TestGraphConnector_ExchangeDataColl
 	if err := ctesting.RunOnAny(ctesting.CorsoCITests); err != nil {
 		suite.T().Skip(err)
 	}
-	collectionList, err := suite.connector.ExchangeDataCollection("lidiah@8qzvrj.onmicrosoft.com")
+	collectionList, err := suite.connector.ExchangeDataCollection(context.Background(), "lidiah@8qzvrj.onmicrosoft.com")
 	assert.NotNil(suite.T(), collectionList)
 	assert.Error(suite.T(), err) // TODO Remove after https://github.com/alcionai/corso/issues/140
 	if err != nil {
@@ -89,7 +90,7 @@ func (suite *GraphConnectorIntegrationSuite) TestGraphConnector_restoreMessages(
 	edc := NewExchangeDataCollection("tenant", []string{"tenantId", evs[user], mailCategory, "Inbox"})
 	edc.PopulateCollection(ds)
 	edc.FinishPopulation()
-	err = suite.connector.restoreMessages(&edc)
+	err = suite.connector.restoreMessages(context.Background(), &edc)
 	assert.NoError(suite.T(), err)
 }
 

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -55,7 +55,7 @@ func (op *BackupOperation) Run(ctx context.Context) (*kopia.BackupStats, error) 
 		return nil, errors.Wrap(err, "connecting to graph api")
 	}
 
-	cs, err := gc.ExchangeDataCollection(op.Targets[0])
+	cs, err := gc.ExchangeDataCollection(ctx, op.Targets[0])
 	if err != nil {
 		return nil, errors.Wrap(err, "retrieving application data")
 	}


### PR DESCRIPTION
Now that we have the logger in place, we should use it
in place of fmt.Print calls for development and debugging output.

Any remaining fmt.Print calls are not dev/debugging focuesed,
but are intended to be output to the CLI user.  Those will get
handled by a different output writer in the future.