### PR TITLE
add operation results structs

### DIFF
--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -23,15 +23,15 @@ type BackupOperation struct {
 
 // BackupResults aggregate the details of the result of the operation.
 type BackupResults struct {
-	operationSummary
-	operationMetrics
+	summary
+	metrics
 	// todo: RestorePoint RestorePoint
 }
 
 // NewBackupOperation constructs and validates a backup operation.
 func NewBackupOperation(
 	ctx context.Context,
-	opts OperationOpts,
+	opts Options,
 	kw *kopia.KopiaWrapper,
 	acct account.Account,
 	targets []string,

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -43,20 +43,20 @@ func (suite *BackupOpIntegrationSuite) TestNewBackupOperation() {
 
 	table := []struct {
 		name     string
-		opts     operations.OperationOpts
+		opts     operations.Options
 		kw       *kopia.KopiaWrapper
 		acct     account.Account
 		targets  []string
 		errCheck assert.ErrorAssertionFunc
 	}{
-		{"good", operations.OperationOpts{}, kw, acct, nil, assert.NoError},
-		{"missing kopia", operations.OperationOpts{}, nil, acct, nil, assert.Error},
+		{"good", operations.Options{}, kw, acct, nil, assert.NoError},
+		{"missing kopia", operations.Options{}, nil, acct, nil, assert.Error},
 	}
 	for _, test := range table {
 		suite.T().Run(test.name, func(t *testing.T) {
 			_, err := operations.NewBackupOperation(
 				context.Background(),
-				operations.OperationOpts{},
+				operations.Options{},
 				test.kw,
 				test.acct,
 				nil)

--- a/src/internal/operations/operation.go
+++ b/src/internal/operations/operation.go
@@ -27,22 +27,22 @@ const (
 // Specific processes (eg: backups, restores, etc) are expected to wrap operation
 // with process specific details.
 type operation struct {
-	ID        uuid.UUID     `json:"id"`        // system generated identifier
-	CreatedAt time.Time     `json:"createdAt"` // datetime of the operation's creation
-	Options   OperationOpts `json:"options"`
-	Status    opStatus      `json:"status"`
+	ID        uuid.UUID `json:"id"`        // system generated identifier
+	CreatedAt time.Time `json:"createdAt"` // datetime of the operation's creation
+	Options   Options   `json:"options"`
+	Status    opStatus  `json:"status"`
 
 	kopia *kopia.KopiaWrapper
 }
 
-// OperationOpts configure some parameters of the operation
-type OperationOpts struct {
+// Options configure some parameters of the operation
+type Options struct {
 	// todo: collision handling
 	// todo: fast fail vs best attempt
 }
 
 func newOperation(
-	opts OperationOpts,
+	opts Options,
 	kw *kopia.KopiaWrapper,
 ) operation {
 	return operation{
@@ -67,15 +67,15 @@ func (op operation) validate() error {
 
 // Summary tracks the total files touched and errors produced
 // during an operation.
-type operationSummary struct {
-	ItemsRead    int              `json:"itemsRead"`
-	ItemsWritten int              `json:"itemsWritten"`
-	ReadErrors   multierror.Error `json:"readErrors"`
-	WriteErrors  multierror.Error `json:"writeErrors"`
+type summary struct {
+	ItemsRead    int              `json:"itemsRead,omitempty"`
+	ItemsWritten int              `json:"itemsWritten,omitempty"`
+	ReadErrors   multierror.Error `json:"readErrors,omitempty"`
+	WriteErrors  multierror.Error `json:"writeErrors,omitempty"`
 }
 
 // Metrics tracks performance details such as timing, throughput, etc.
-type operationMetrics struct {
+type metrics struct {
 	StartedAt   time.Time `json:"startedAt"`
 	CompletedAt time.Time `json:"completedAt"`
 }

--- a/src/internal/operations/operation_test.go
+++ b/src/internal/operations/operation_test.go
@@ -19,7 +19,7 @@ func TestOperationSuite(t *testing.T) {
 
 func (suite *OperationSuite) TestNewOperation() {
 	t := suite.T()
-	op := newOperation(OperationOpts{}, nil)
+	op := newOperation(Options{}, nil)
 	assert.NotNil(t, op.ID)
 }
 
@@ -35,7 +35,7 @@ func (suite *OperationSuite) TestOperation_Validate() {
 	}
 	for _, test := range table {
 		suite.T().Run(test.name, func(t *testing.T) {
-			op := newOperation(OperationOpts{}, test.kw)
+			op := newOperation(Options{}, test.kw)
 			test.errCheck(t, op.validate())
 		})
 	}

--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -24,14 +24,14 @@ type RestoreOperation struct {
 
 // RestoreResults aggregate the details of the results of the operation.
 type RestoreResults struct {
-	operationSummary
-	operationMetrics
+	summary
+	metrics
 }
 
 // NewRestoreOperation constructs and validates a restore operation.
 func NewRestoreOperation(
 	ctx context.Context,
-	opts OperationOpts,
+	opts Options,
 	kw *kopia.KopiaWrapper,
 	acct account.Account,
 	restorePointID string,

--- a/src/internal/operations/restore_test.go
+++ b/src/internal/operations/restore_test.go
@@ -37,20 +37,20 @@ func (suite *RestoreOpIntegrationSuite) TestNewRestoreOperation() {
 
 	table := []struct {
 		name     string
-		opts     operations.OperationOpts
+		opts     operations.Options
 		kw       *kopia.KopiaWrapper
 		acct     account.Account
 		targets  []string
 		errCheck assert.ErrorAssertionFunc
 	}{
-		{"good", operations.OperationOpts{}, kw, acct, nil, assert.NoError},
-		{"missing kopia", operations.OperationOpts{}, nil, acct, nil, assert.Error},
+		{"good", operations.Options{}, kw, acct, nil, assert.NoError},
+		{"missing kopia", operations.Options{}, nil, acct, nil, assert.Error},
 	}
 	for _, test := range table {
 		suite.T().Run(test.name, func(t *testing.T) {
 			_, err := operations.NewRestoreOperation(
 				context.Background(),
-				operations.OperationOpts{},
+				operations.Options{},
 				test.kw,
 				test.acct,
 				"restore-point-id",

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -94,7 +94,7 @@ func (r *Repository) Close(ctx context.Context) error {
 func (r Repository) NewBackup(ctx context.Context, targets []string) (operations.BackupOperation, error) {
 	return operations.NewBackupOperation(
 		ctx,
-		operations.OperationOpts{},
+		operations.Options{},
 		r.dataLayer,
 		r.Account,
 		targets)
@@ -104,7 +104,7 @@ func (r Repository) NewBackup(ctx context.Context, targets []string) (operations
 func (r Repository) NewRestore(ctx context.Context, restorePointID string, targets []string) (operations.RestoreOperation, error) {
 	return operations.NewRestoreOperation(
 		ctx,
-		operations.OperationOpts{},
+		operations.Options{},
 		r.dataLayer,
 		r.Account,
 		restorePointID,


### PR DESCRIPTION
Operations, both backup and restore, need to hold the
results of their operation, and be able to marshal the struct
to json for output.