### PR TITLE
add restore, backup result persistence skeleton

### DIFF
--- a/src/internal/operations/operation.go
+++ b/src/internal/operations/operation.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	multierror "github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 
 	"github.com/alcionai/corso/internal/kopia"
@@ -68,10 +67,10 @@ func (op operation) validate() error {
 // Summary tracks the total files touched and errors produced
 // during an operation.
 type summary struct {
-	ItemsRead    int              `json:"itemsRead,omitempty"`
-	ItemsWritten int              `json:"itemsWritten,omitempty"`
-	ReadErrors   multierror.Error `json:"readErrors,omitempty"`
-	WriteErrors  multierror.Error `json:"writeErrors,omitempty"`
+	ItemsRead    int   `json:"itemsRead,omitempty"`
+	ItemsWritten int   `json:"itemsWritten,omitempty"`
+	ReadErrors   error `json:"readErrors,omitempty"`
+	WriteErrors  error `json:"writeErrors,omitempty"`
 }
 
 // Metrics tracks performance details such as timing, throughput, etc.

--- a/src/internal/operations/restore_test.go
+++ b/src/internal/operations/restore_test.go
@@ -1,18 +1,65 @@
-package operations_test
+package operations
 
 import (
 	"context"
 	"testing"
+	"time"
 
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/internal/connector"
 	"github.com/alcionai/corso/internal/kopia"
-	"github.com/alcionai/corso/internal/operations"
 	ctesting "github.com/alcionai/corso/internal/testing"
 	"github.com/alcionai/corso/pkg/account"
 )
+
+// ---------------------------------------------------------------------------
+// unit
+// ---------------------------------------------------------------------------
+
+type RestoreOpSuite struct {
+	suite.Suite
+}
+
+func TestRestoreOpSuite(t *testing.T) {
+	suite.Run(t, new(RestoreOpSuite))
+}
+
+// TODO: after modelStore integration is added, mock the store and/or
+// move this to an integration test.
+func (suite *RestoreOpSuite) TestRestoreOperation_PersistResults() {
+	t := suite.T()
+	ctx := context.Background()
+
+	var (
+		kw        = &kopia.KopiaWrapper{}
+		acct      = account.Account{}
+		now       = time.Now()
+		cs        = []connector.DataCollection{&connector.ExchangeDataCollection{}}
+		readErrs  = multierror.Append(nil, assert.AnError)
+		writeErrs = assert.AnError
+	)
+
+	op, err := NewRestoreOperation(ctx, Options{}, kw, acct, "foo", nil)
+	require.NoError(t, err)
+
+	op.persistResults(now, cs, readErrs, writeErrs)
+
+	assert.Equal(t, op.Status, Failed)
+	assert.Equal(t, op.Results.ItemsRead, len(cs))
+	assert.Equal(t, op.Results.ReadErrors, readErrs)
+	assert.Equal(t, op.Results.ItemsWritten, -1)
+	assert.Equal(t, op.Results.WriteErrors, writeErrs)
+	assert.Equal(t, op.Results.StartedAt, now)
+	assert.Less(t, now, op.Results.CompletedAt)
+}
+
+// ---------------------------------------------------------------------------
+// integration
+// ---------------------------------------------------------------------------
 
 type RestoreOpIntegrationSuite struct {
 	suite.Suite
@@ -37,20 +84,20 @@ func (suite *RestoreOpIntegrationSuite) TestNewRestoreOperation() {
 
 	table := []struct {
 		name     string
-		opts     operations.Options
+		opts     Options
 		kw       *kopia.KopiaWrapper
 		acct     account.Account
 		targets  []string
 		errCheck assert.ErrorAssertionFunc
 	}{
-		{"good", operations.Options{}, kw, acct, nil, assert.NoError},
-		{"missing kopia", operations.Options{}, nil, acct, nil, assert.Error},
+		{"good", Options{}, kw, acct, nil, assert.NoError},
+		{"missing kopia", Options{}, nil, acct, nil, assert.Error},
 	}
 	for _, test := range table {
 		suite.T().Run(test.name, func(t *testing.T) {
-			_, err := operations.NewRestoreOperation(
+			_, err := NewRestoreOperation(
 				context.Background(),
-				operations.Options{},
+				Options{},
 				test.kw,
 				test.acct,
 				"restore-point-id",


### PR DESCRIPTION
e2e wiring of persistence is not yet complete.
Will need modelstore integration, and additional
information about file and error counts from kw and gc.