### PR TITLE
break gc iterator cb to own func, fix err scope

### DIFF
--- a/src/internal/connector/graph_connector_test.go
+++ b/src/internal/connector/graph_connector_test.go
@@ -65,9 +65,9 @@ func (suite *GraphConnectorIntegrationSuite) TestGraphConnector_ExchangeDataColl
 		suite.T().Skip(err)
 	}
 	collectionList, err := suite.connector.ExchangeDataCollection(context.Background(), "lidiah@8qzvrj.onmicrosoft.com")
-	assert.NotNil(suite.T(), collectionList)
+	assert.NotNil(suite.T(), collectionList, "collection list")
 	assert.Error(suite.T(), err) // TODO Remove after https://github.com/alcionai/corso/issues/140
-	assert.NotNil(suite.T(), suite.connector.status)
+	assert.NotNil(suite.T(), suite.connector.status, "connector status")
 	suite.NotContains(err.Error(), "attachment failed") // TODO Create Retry Exceeded Error
 	exchangeData := collectionList[0]
 	suite.Greater(len(exchangeData.FullPath()), 2)

--- a/src/internal/connector/support/errors.go
+++ b/src/internal/connector/support/errors.go
@@ -39,12 +39,12 @@ func SetNonRecoverableError(e error) error {
 
 // WrapErrorAndAppend helper function used to attach identifying information to an error
 // and return it as a mulitierror
-func WrapAndAppend(identifier string, e error, previous error) error {
+func WrapAndAppend(identifier string, e, previous error) error {
 	return multierror.Append(previous, errors.Wrap(e, identifier))
 }
 
 // WrapErrorAndAppendf format version of WrapErrorAndAppend
-func WrapAndAppendf(identifier interface{}, e error, previous error) error {
+func WrapAndAppendf(identifier interface{}, e, previous error) error {
 	return multierror.Append(previous, errors.Wrapf(e, "%v", identifier))
 }
 


### PR DESCRIPTION
A misuse of variable declaration that overlapped with
var shadowing on 'err' was causing the attachment retry
error to get lost, meaning failures to retrieve attachments
are occurring silently.