### PR TITLE
Allow multiple items in DataCollection from kopia

### DIFF
--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -329,10 +329,12 @@ func (w Wrapper) restoreSingleItem(
 	pathWithRoot := []string{rootDir.Name()}
 	pathWithRoot = append(pathWithRoot, itemPath[:len(itemPath)-1]...)
 
-	return &singleItemCollection{
-		stream: kopiaDataStream{
-			uuid:   itemPath[len(itemPath)-1],
-			reader: r,
+	return &kopiaDataCollection{
+		streams: []connector.DataStream{
+			&kopiaDataStream{
+				uuid:   f.Name(),
+				reader: r,
+			},
 		},
 		path: pathWithRoot,
 	}, nil

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -302,11 +302,13 @@ func (suite *KopiaSimpleRepoIntegrationSuite) SetupTest() {
 	suite.w = &Wrapper{c}
 
 	collections := []connector.DataCollection{
-		&singleItemCollection{
+		&kopiaDataCollection{
 			path: testPath,
-			stream: &kopiaDataStream{
-				uuid:   testFileUUID,
-				reader: io.NopCloser(bytes.NewReader(testFileData)),
+			streams: []connector.DataStream{
+				&kopiaDataStream{
+					uuid:   testFileUUID,
+					reader: io.NopCloser(bytes.NewReader(testFileData)),
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Use a slice to back the data instead of adding directly to the channel
for two reasons (this may change in the future though):
  * kopia loads all data about a directory at the same time
  * consumers of the DataCollection may not pull items from the channel
    at a fast rate, which could block adding to the channel. This could
    lead to delays in discovering other directories to traverse in
    multi-threaded scenarios

prep for #188 