### PR TITLE
Allow getting data from kopia for a directory subtree

### DIFF
--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -358,7 +358,7 @@ func (w Wrapper) collectItems(
 		return nil, errors.New("requested object is not a file")
 	}
 
-	c, err := w.restoreSingleItem(ctx, f, itemPath[:len(itemPath)-1])
+	c, err := restoreSingleItem(ctx, f, itemPath[:len(itemPath)-1])
 	if err != nil {
 		return nil, err
 	}
@@ -393,7 +393,7 @@ func (w Wrapper) RestoreSingleItem(
 // does not exist in kopia or is not a file an error is returned. The UUID of
 // the returned DataStreams will be the name of the kopia file the data is
 // sourced from.
-func (w Wrapper) restoreSingleItem(
+func restoreSingleItem(
 	ctx context.Context,
 	f fs.File,
 	itemPath []string,

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -270,6 +270,21 @@ func (suite *KopiaUnitSuite) TestBuildDirectoryTree_Fails() {
 	}
 }
 
+func (suite *KopiaUnitSuite) TestRestoreItem() {
+	ctx := context.Background()
+
+	file := &mockkopia.MockFile{
+		Entry: &mockkopia.MockEntry{
+			EntryName: testFileName2,
+			EntryMode: mockkopia.DefaultPermissions,
+		},
+		OpenErr: assert.AnError,
+	}
+
+	_, err := restoreSingleItem(ctx, file, nil)
+	assert.Error(suite.T(), err)
+}
+
 func (suite *KopiaUnitSuite) TestRestoreDirectory_FailGettingReader() {
 	ctx := context.Background()
 	t := suite.T()


### PR DESCRIPTION
Current implementation is naive. It uses a single goroutine and returns all DataCollections at the end. If an error occurs, it returns immediately

closes #188 