### PR TITLE
Use MockExchangeData in kopia backup tests

### DIFF
--- a/src/internal/connector/mockconnector/mock_data_collection.go
+++ b/src/internal/connector/mockconnector/mock_data_collection.go
@@ -54,14 +54,14 @@ func (medc *MockExchangeDataCollection) Items() <-chan connector.DataStream {
 
 // ExchangeData represents a single item retrieved from exchange
 type MockExchangeData struct {
-	id     string
-	reader io.ReadCloser
+	ID     string
+	Reader io.ReadCloser
 }
 
 func (med *MockExchangeData) UUID() string {
-	return med.id
+	return med.ID
 }
 
 func (med *MockExchangeData) ToReader() io.ReadCloser {
-	return med.reader
+	return med.Reader
 }

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -304,9 +304,9 @@ func (suite *KopiaSimpleRepoIntegrationSuite) SetupTest() {
 		&kopiaDataCollection{
 			path: testPath,
 			streams: []connector.DataStream{
-				&kopiaDataStream{
-					uuid:   testFileUUID,
-					reader: io.NopCloser(bytes.NewReader(testFileData)),
+				&mockconnector.MockExchangeData{
+					ID:     testFileUUID,
+					Reader: io.NopCloser(bytes.NewReader(testFileData)),
 				},
 			},
 		},
@@ -314,10 +314,10 @@ func (suite *KopiaSimpleRepoIntegrationSuite) SetupTest() {
 
 	stats, err := suite.w.BackupCollections(suite.ctx, collections)
 	require.NoError(t, err)
+	require.Equal(t, stats.ErrorCount, 0)
 	require.Equal(t, stats.TotalFileCount, 1)
 	require.Equal(t, stats.TotalDirectoryCount, 3)
 	require.Equal(t, stats.IgnoredErrorCount, 0)
-	require.Equal(t, stats.ErrorCount, 0)
 	require.False(t, stats.Incomplete)
 
 	suite.snapshotID = manifest.ID(stats.SnapshotID)


### PR DESCRIPTION
This implements the `DataStreamInfo` interface needed by `BackupCollections`