### PR TITLE
Wire up RestorePoints to backup list

### DIFF
--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -1,7 +1,10 @@
 package backup
 
 import (
+	"os"
+
 	"github.com/pkg/errors"
+	"github.com/segmentio/cli"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -103,7 +106,7 @@ var exchangeListCmd = &cobra.Command{
 func listExchangeCmd(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 
-	_, acct, err := config.GetStorageAndAccount(true, nil)
+	s, acct, err := config.GetStorageAndAccount(true, nil)
 	if err != nil {
 		return err
 	}
@@ -117,7 +120,25 @@ func listExchangeCmd(cmd *cobra.Command, args []string) error {
 		"Called - "+cmd.CommandPath(),
 		"tenantID", m365.TenantID)
 
-	// todo (keepers issue #251): e2e hookup
+	r, err := repository.Connect(ctx, acct, s)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to connect to the %s repository", s.Provider)
+	}
+	defer utils.CloseRepo(ctx, r)
 
+	rps, err := r.RestorePoints(ctx)
+	if err != nil {
+		return errors.Wrap(err, "Failed to list restorepoints in the repository")
+	}
+
+	// TODO: Can be used to print in alternative forms (e.g. json)
+	p, err := cli.Format("text", os.Stdout)
+	if err != nil {
+		return err
+	}
+	defer p.Flush()
+	for _, rp := range rps {
+		p.Print(*rp)
+	}
 	return nil
 }

--- a/src/go.mod
+++ b/src/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/microsoftgraph/msgraph-sdk-go v0.28.0
 	github.com/microsoftgraph/msgraph-sdk-go-core v0.26.1
 	github.com/pkg/errors v0.9.1
+	github.com/segmentio/cli v0.5.0
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.12.0

--- a/src/go.sum
+++ b/src/go.sum
@@ -319,6 +319,8 @@ github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBO
 github.com/rs/xid v1.4.0 h1:qd7wPTDkN6KQx2VmMBLrpHkiyQwgFXRnkOLacUiaSNY=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/segmentio/cli v0.5.0 h1:AssNAdZV728i8u6LWfq9pqoeQGxiyXmTt0jrCfnjcx0=
+github.com/segmentio/cli v0.5.0/go.mod h1:rktB/5TnLUnEBYdRG+jlAii0bkHWpnrb+jpXiFkoPxs=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alcionai/corso/internal/kopia"
 	"github.com/alcionai/corso/internal/operations"
 	"github.com/alcionai/corso/pkg/account"
+	"github.com/alcionai/corso/pkg/restorepoint"
 	"github.com/alcionai/corso/pkg/selectors"
 	"github.com/alcionai/corso/pkg/storage"
 )
@@ -145,4 +146,22 @@ func (r Repository) NewRestore(ctx context.Context, restorePointID string, targe
 		r.Account,
 		restorePointID,
 		targets)
+}
+
+// RestorePoints lists restorepoints in a respository
+func (r Repository) RestorePoints(ctx context.Context) ([]*restorepoint.RestorePoint, error) {
+	bms, err := r.modelStore.GetIDsForType(ctx, kopia.RestorePointModel, nil)
+	if err != nil {
+		return nil, err
+	}
+	rps := make([]*restorepoint.RestorePoint, 0, len(bms))
+	for _, bm := range bms {
+		rp := restorepoint.RestorePoint{}
+		err := r.modelStore.GetWithModelStoreID(ctx, kopia.RestorePointModel, bm.ModelStoreID, &rp)
+		if err != nil {
+			return nil, err
+		}
+		rps = append(rps, &rp)
+	}
+	return rps, nil
 }


### PR DESCRIPTION
Currently displays the restorepoints in tablular form. We can add `json` output in a follow-up using the segment-cli library.

Closes #269 