### PR TITLE
reduce restore point details to matching refs

### DIFF
--- a/src/pkg/selectors/exchange.go
+++ b/src/pkg/selectors/exchange.go
@@ -3,7 +3,7 @@ package selectors
 import (
 	"strings"
 
-	"github.com/alcionai/corso/pkg/restorepoint"
+	"github.com/alcionai/corso/pkg/backup"
 )
 
 // ---------------------------------------------------------------------------
@@ -404,9 +404,9 @@ func idPath(cat exchangeCategory, path []string) map[exchangeCategory]string {
 	return m
 }
 
-// FilterDetails reduces the entries in a restorePointDetails struct to only
+// FilterDetails reduces the entries in a backupDetails struct to only
 // those that match the inclusions and exclusions in the selector.
-func (s *ExchangeRestore) FilterDetails(deets *restorepoint.Details) []string {
+func (s *ExchangeRestore) FilterDetails(deets *backup.Details) []string {
 	if deets == nil {
 		return []string{}
 	}

--- a/src/pkg/selectors/exchange_test.go
+++ b/src/pkg/selectors/exchange_test.go
@@ -3,7 +3,7 @@ package selectors
 import (
 	"testing"
 
-	"github.com/alcionai/corso/pkg/restorepoint"
+	"github.com/alcionai/corso/pkg/backup"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -604,12 +604,12 @@ func (suite *ExchangeSourceSuite) TestIdPath() {
 }
 
 func (suite *ExchangeSourceSuite) TestExchangeRestore_FilterDetails() {
-	makeDeets := func(refs ...string) *restorepoint.Details {
-		deets := &restorepoint.Details{
-			Entries: []restorepoint.DetailsEntry{},
+	makeDeets := func(refs ...string) *backup.Details {
+		deets := &backup.Details{
+			Entries: []backup.DetailsEntry{},
 		}
 		for _, r := range refs {
-			deets.Entries = append(deets.Entries, restorepoint.DetailsEntry{
+			deets.Entries = append(deets.Entries, backup.DetailsEntry{
 				RepoRef: r,
 			})
 		}
@@ -622,7 +622,7 @@ func (suite *ExchangeSourceSuite) TestExchangeRestore_FilterDetails() {
 	)
 	table := []struct {
 		name         string
-		deets        *restorepoint.Details
+		deets        *backup.Details
 		makeSelector func() *ExchangeRestore
 		expect       []string
 	}{


### PR DESCRIPTION
A selector should be able to reduce a set of restore point
details to only those that pass its inclusion and
exclusion rules.

Note that the diff is currently pointing at Vaibhav's `rp_backup_details` branch.  Once that is merged in, this will get pointed to main instead.  Only then will it get merged.