### PR TITLE
add --all and --data to backup create

### DIFF
--- a/src/cli/backup/backup.go
+++ b/src/cli/backup/backup.go
@@ -4,13 +4,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// service-agnostic flags
-// associated flag delcaration may occur in individual service handlers.
-var (
-	all  bool
-	data []string
-)
-
 var backupCommands = []func(parent *cobra.Command) *cobra.Command{
 	addExchangeCommands,
 }

--- a/src/cli/backup/exchange_test.go
+++ b/src/cli/backup/exchange_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/cli/utils"
 	ctesting "github.com/alcionai/corso/internal/testing"
 )
 
@@ -111,7 +112,7 @@ func (suite *ExchangeSuite) TestExchangeBackupCreateSelectors() {
 		},
 		{
 			name:             "all users, no data",
-			user:             []string{"*"},
+			user:             []string{utils.Wildcard},
 			expectIncludeLen: 3,
 		},
 		{
@@ -121,7 +122,7 @@ func (suite *ExchangeSuite) TestExchangeBackupCreateSelectors() {
 		},
 		{
 			name:             "all users, contacts",
-			user:             []string{"*"},
+			user:             []string{utils.Wildcard},
 			data:             []string{dataContacts},
 			expectIncludeLen: 1,
 		},
@@ -133,7 +134,7 @@ func (suite *ExchangeSuite) TestExchangeBackupCreateSelectors() {
 		},
 		{
 			name:             "all users, email",
-			user:             []string{"*"},
+			user:             []string{utils.Wildcard},
 			data:             []string{dataEmail},
 			expectIncludeLen: 1,
 		},
@@ -145,7 +146,7 @@ func (suite *ExchangeSuite) TestExchangeBackupCreateSelectors() {
 		},
 		{
 			name:             "all users, events",
-			user:             []string{"*"},
+			user:             []string{utils.Wildcard},
 			data:             []string{dataEvents},
 			expectIncludeLen: 1,
 		},
@@ -157,7 +158,7 @@ func (suite *ExchangeSuite) TestExchangeBackupCreateSelectors() {
 		},
 		{
 			name:             "all users, contacts + email",
-			user:             []string{"*"},
+			user:             []string{utils.Wildcard},
 			data:             []string{dataContacts, dataEmail},
 			expectIncludeLen: 2,
 		},
@@ -169,7 +170,7 @@ func (suite *ExchangeSuite) TestExchangeBackupCreateSelectors() {
 		},
 		{
 			name:             "all users, email + events",
-			user:             []string{"*"},
+			user:             []string{utils.Wildcard},
 			data:             []string{dataEmail, dataEvents},
 			expectIncludeLen: 2,
 		},
@@ -181,7 +182,7 @@ func (suite *ExchangeSuite) TestExchangeBackupCreateSelectors() {
 		},
 		{
 			name:             "all users, events + contacts",
-			user:             []string{"*"},
+			user:             []string{utils.Wildcard},
 			data:             []string{dataEvents, dataContacts},
 			expectIncludeLen: 2,
 		},

--- a/src/cli/restore/exchange.go
+++ b/src/cli/restore/exchange.go
@@ -127,10 +127,10 @@ func validateRestoreFlags(u, f, m, rpid string) error {
 		return errors.New("a restore point ID is requried")
 	}
 	lu, lf, lm := len(u), len(f), len(m)
-	if (lu == 0 || u == "*") && (lf+lm > 0) {
+	if (lu == 0 || u == utils.Wildcard) && (lf+lm > 0) {
 		return errors.New("a specific --user must be provided if --folder or --mail is specified")
 	}
-	if (lf == 0 || f == "*") && lm > 0 {
+	if (lf == 0 || f == utils.Wildcard) && lm > 0 {
 		return errors.New("a specific --folder must be provided if a --mail is specified")
 	}
 	return nil

--- a/src/cli/restore/exchange_test.go
+++ b/src/cli/restore/exchange_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/cli/utils"
 	ctesting "github.com/alcionai/corso/internal/testing"
 )
 
@@ -27,10 +28,10 @@ func (suite *ExchangeSuite) TestValidateRestoreFlags() {
 	}{
 		{"all populated", "u", "f", "m", "rpid", assert.NoError},
 		{"folder missing user", "", "f", "m", "rpid", assert.Error},
-		{"folder with wildcard user", "*", "f", "m", "rpid", assert.Error},
+		{"folder with wildcard user", utils.Wildcard, "f", "m", "rpid", assert.Error},
 		{"mail missing user", "", "", "m", "rpid", assert.Error},
 		{"mail missing folder", "u", "", "m", "rpid", assert.Error},
-		{"mail with wildcard folder", "u", "*", "m", "rpid", assert.Error},
+		{"mail with wildcard folder", "u", utils.Wildcard, "m", "rpid", assert.Error},
 		{"missing backup id", "u", "f", "m", "", assert.Error},
 		{"all missing", "", "", "", "rpid", assert.NoError},
 	}

--- a/src/cli/utils/utils.go
+++ b/src/cli/utils/utils.go
@@ -10,6 +10,10 @@ import (
 	"github.com/spf13/pflag"
 )
 
+const (
+	Wildcard = "*"
+)
+
 // RequireProps validates the existence of the properties
 //  in the map.  Expects the format map[propName]propVal.
 func RequireProps(props map[string]string) error {


### PR DESCRIPTION
Adds flags for backing up all exchange data, and
for isolating the data in the backup by data type.
Introduces validation and selector creation in
backup create.  Switches the --user flag variable
type from a string to a []string.