### PR TITLE
split users scope into per-type scopes

### DIFF
--- a/src/cli/backup/exchange_test.go
+++ b/src/cli/backup/exchange_test.go
@@ -109,7 +109,7 @@ func (suite *ExchangeSuite) TestExchangeBackupCreateSelectors() {
 		{
 			name:             "any",
 			any:              true,
-			expectIncludeLen: 1,
+			expectIncludeLen: 3,
 		},
 		{
 			name:             "any users, no data",
@@ -313,17 +313,17 @@ func (suite *ExchangeSuite) TestIncludeExchangeBackupDetailDataSelectors() {
 		{
 			name:             "any users",
 			users:            any,
-			expectIncludeLen: 1,
+			expectIncludeLen: 3,
 		},
 		{
 			name:             "single user",
 			users:            stub,
-			expectIncludeLen: 1,
+			expectIncludeLen: 3,
 		},
 		{
 			name:             "multiple users",
 			users:            []string{"fnord", "smarf"},
-			expectIncludeLen: 1,
+			expectIncludeLen: 6,
 		},
 		{
 			name:             "any users, any data",

--- a/src/cli/restore/exchange_test.go
+++ b/src/cli/restore/exchange_test.go
@@ -149,17 +149,17 @@ func (suite *ExchangeSuite) TestIncludeExchangeRestoreDataSelectors() {
 		{
 			name:             "any users",
 			users:            any,
-			expectIncludeLen: 1,
+			expectIncludeLen: 3,
 		},
 		{
 			name:             "single user",
 			users:            stub,
-			expectIncludeLen: 1,
+			expectIncludeLen: 3,
 		},
 		{
 			name:             "multiple users",
 			users:            []string{"fnord", "smarf"},
-			expectIncludeLen: 1,
+			expectIncludeLen: 6,
 		},
 		{
 			name:             "any users, any data",

--- a/src/pkg/selectors/exchange.go
+++ b/src/pkg/selectors/exchange.go
@@ -265,10 +265,11 @@ func (s *exchange) MailFolders(users, folders []string) []ExchangeScope {
 func (s *exchange) Users(users []string) []ExchangeScope {
 	users = normalize(users)
 	scopes := []ExchangeScope{}
-	scopes = append(
-		scopes,
-		makeExchangeScope(Group, ExchangeUser, users),
-	)
+	for _, u := range users {
+		scopes = append(scopes, makeExchangeUserScope(u, Group, ExchangeContactFolder, Any()))
+		scopes = append(scopes, makeExchangeUserScope(u, Item, ExchangeEvent, Any()))
+		scopes = append(scopes, makeExchangeUserScope(u, Group, ExchangeMailFolder, Any()))
+	}
 	return scopes
 }
 

--- a/src/pkg/selectors/exchange_test.go
+++ b/src/pkg/selectors/exchange_test.go
@@ -276,15 +276,22 @@ func (suite *ExchangeSourceSuite) TestExchangeSelector_Exclude_Users() {
 
 	sel.Exclude(sel.Users([]string{u1, u2}))
 	scopes := sel.Excludes
-	require.Equal(t, 1, len(scopes))
+	require.Equal(t, 6, len(scopes))
 
-	scope := scopes[0]
-	assert.Equal(t, scope[ExchangeUser.String()], join(u1, u2))
-	assert.Equal(t, scope[ExchangeContact.String()], AnyTgt)
-	assert.Equal(t, scope[ExchangeContactFolder.String()], AnyTgt)
-	assert.Equal(t, scope[ExchangeEvent.String()], AnyTgt)
-	assert.Equal(t, scope[ExchangeMail.String()], AnyTgt)
-	assert.Equal(t, scope[ExchangeMailFolder.String()], AnyTgt)
+	for _, scope := range scopes {
+		assert.Contains(t, join(u1, u2), scope[ExchangeUser.String()])
+		if scope[scopeKeyCategory] == ExchangeContactFolder.String() {
+			assert.Equal(t, scope[ExchangeContact.String()], AnyTgt)
+			assert.Equal(t, scope[ExchangeContactFolder.String()], AnyTgt)
+		}
+		if scope[scopeKeyCategory] == ExchangeEvent.String() {
+			assert.Equal(t, scope[ExchangeEvent.String()], AnyTgt)
+		}
+		if scope[scopeKeyCategory] == ExchangeMailFolder.String() {
+			assert.Equal(t, scope[ExchangeMail.String()], AnyTgt)
+			assert.Equal(t, scope[ExchangeMailFolder.String()], AnyTgt)
+		}
+	}
 }
 
 func (suite *ExchangeSourceSuite) TestExchangeSelector_Include_Users() {
@@ -298,17 +305,22 @@ func (suite *ExchangeSourceSuite) TestExchangeSelector_Include_Users() {
 
 	sel.Include(sel.Users([]string{u1, u2}))
 	scopes := sel.Includes
-	require.Equal(t, 1, len(scopes))
+	require.Equal(t, 6, len(scopes))
 
-	scope := scopes[0]
-	assert.Equal(t, scope[ExchangeUser.String()], join(u1, u2))
-	assert.Equal(t, scope[ExchangeContact.String()], AnyTgt)
-	assert.Equal(t, scope[ExchangeContactFolder.String()], AnyTgt)
-	assert.Equal(t, scope[ExchangeEvent.String()], AnyTgt)
-	assert.Equal(t, scope[ExchangeMail.String()], AnyTgt)
-	assert.Equal(t, scope[ExchangeMailFolder.String()], AnyTgt)
-
-	assert.Equal(t, sel.Scopes()[0].Category(), ExchangeUser)
+	for _, scope := range scopes {
+		assert.Contains(t, join(u1, u2), scope[ExchangeUser.String()])
+		if scope[scopeKeyCategory] == ExchangeContactFolder.String() {
+			assert.Equal(t, scope[ExchangeContact.String()], AnyTgt)
+			assert.Equal(t, scope[ExchangeContactFolder.String()], AnyTgt)
+		}
+		if scope[scopeKeyCategory] == ExchangeEvent.String() {
+			assert.Equal(t, scope[ExchangeEvent.String()], AnyTgt)
+		}
+		if scope[scopeKeyCategory] == ExchangeMailFolder.String() {
+			assert.Equal(t, scope[ExchangeMail.String()], AnyTgt)
+			assert.Equal(t, scope[ExchangeMailFolder.String()], AnyTgt)
+		}
+	}
 }
 
 func (suite *ExchangeSourceSuite) TestNewExchangeDestination() {
@@ -559,9 +571,14 @@ func (suite *ExchangeSourceSuite) TestExchangeScope_MatchesPath() {
 	for _, test := range table {
 		suite.T().Run(test.name, func(t *testing.T) {
 			scopes := extendExchangeScopeValues(test.scope)
+			var aMatch bool
 			for _, scope := range scopes {
-				test.expect(t, scope.matchesPath(ExchangeMail, path))
+				if scope.matchesPath(ExchangeMail, path) {
+					aMatch = true
+					break
+				}
 			}
+			test.expect(t, aMatch)
 		})
 	}
 }


### PR DESCRIPTION
When a caller constructs an Users() exchange scope,
instead of building a single scope that contains all of the
provided users and all of the data beneath, follow the
pattern of the other scopes and generate one scope per
user-category pair.