### PR TITLE
rename /internal/testing to /tester

### DIFF
--- a/src/cli/backup/exchange_test.go
+++ b/src/cli/backup/exchange_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/cli/utils"
-	ctesting "github.com/alcionai/corso/internal/testing"
+	"github.com/alcionai/corso/internal/tester"
 	"github.com/alcionai/corso/pkg/selectors"
 )
 
@@ -47,7 +47,7 @@ func (suite *ExchangeSuite) TestAddExchangeCommands() {
 			child := cmds[0]
 			assert.Equal(t, test.expectUse, child.Use)
 			assert.Equal(t, test.expectShort, child.Short)
-			ctesting.AreSameFunc(t, test.expectRunE, child.RunE)
+			tester.AreSameFunc(t, test.expectRunE, child.RunE)
 		})
 	}
 }

--- a/src/cli/config/config_test.go
+++ b/src/cli/config/config_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	ctesting "github.com/alcionai/corso/internal/testing"
+	"github.com/alcionai/corso/internal/tester"
 	"github.com/alcionai/corso/pkg/account"
 	"github.com/alcionai/corso/pkg/credentials"
 	"github.com/alcionai/corso/pkg/storage"
@@ -184,9 +184,9 @@ type ConfigIntegrationSuite struct {
 }
 
 func TestConfigIntegrationSuite(t *testing.T) {
-	if err := ctesting.RunOnAny(
-		ctesting.CorsoCITests,
-		ctesting.CorsoCLIConfigTests,
+	if err := tester.RunOnAny(
+		tester.CorsoCITests,
+		tester.CorsoCLIConfigTests,
 	); err != nil {
 		t.Skip(err)
 	}
@@ -194,10 +194,10 @@ func TestConfigIntegrationSuite(t *testing.T) {
 }
 
 func (suite *ConfigIntegrationSuite) SetupSuite() {
-	_, err := ctesting.GetRequiredEnvVars(
+	_, err := tester.GetRequiredEnvVars(
 		append(
-			ctesting.AWSStorageCredEnvs,
-			ctesting.M365AcctCredEnvs...,
+			tester.AWSStorageCredEnvs,
+			tester.M365AcctCredEnvs...,
 		)...,
 	)
 	require.NoError(suite.T(), err)

--- a/src/cli/repo/s3_test.go
+++ b/src/cli/repo/s3_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	ctesting "github.com/alcionai/corso/internal/testing"
+	"github.com/alcionai/corso/internal/tester"
 )
 
 type S3Suite struct {
@@ -44,7 +44,7 @@ func (suite *S3Suite) TestAddS3Commands() {
 			child := cmds[0]
 			assert.Equal(t, test.expectUse, child.Use)
 			assert.Equal(t, test.expectShort, child.Short)
-			ctesting.AreSameFunc(t, test.expectRunE, child.RunE)
+			tester.AreSameFunc(t, test.expectRunE, child.RunE)
 		})
 	}
 }

--- a/src/cli/restore/exchange_test.go
+++ b/src/cli/restore/exchange_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/cli/utils"
-	ctesting "github.com/alcionai/corso/internal/testing"
+	"github.com/alcionai/corso/internal/tester"
 	"github.com/alcionai/corso/pkg/selectors"
 )
 
@@ -45,7 +45,7 @@ func (suite *ExchangeSuite) TestAddExchangeCommands() {
 			child := cmds[0]
 			assert.Equal(t, test.expectUse, child.Use)
 			assert.Equal(t, test.expectShort, child.Short)
-			ctesting.AreSameFunc(t, test.expectRunE, child.RunE)
+			tester.AreSameFunc(t, test.expectRunE, child.RunE)
 		})
 	}
 }

--- a/src/go.sum
+++ b/src/go.sum
@@ -482,8 +482,6 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.0.0-20220630215102-69896b714898 h1:K7wO6V1IrczY9QOQ2WkVpw4JQSwCd52UsxVEirZUfiw=
-golang.org/x/net v0.0.0-20220630215102-69896b714898/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b h1:PxfKdU9lEEDYjdIzOtC4qFWgkU2rGHdKlKowJSMN9h0=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -508,8 +506,6 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=
-golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -564,8 +560,6 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e h1:CsOuNlbOuf0mzxJIefr6Q4uAUetRUwZE4qt7VfzP+xo=
-golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220727055044-e65921a090b8 h1:dyU22nBWzrmTQxtNrr4dzVOvaw35nUYE279vF9UmsI8=
 golang.org/x/sys v0.0.0-20220727055044-e65921a090b8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -631,8 +625,6 @@ golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.11 h1:loJ25fNOEhSXfHrpoGj91eCUThwdNX6u24rO1xnNteY=
-golang.org/x/tools v0.1.11/go.mod h1:SgwaegtQh8clINPpECJMqnxLv9I09HLqnW3RMqW0CA4=
 golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/src/internal/connector/graph_connector_test.go
+++ b/src/internal/connector/graph_connector_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/alcionai/corso/internal/connector/mockconnector"
 	"github.com/alcionai/corso/internal/connector/support"
 	"github.com/alcionai/corso/internal/data"
-	ctesting "github.com/alcionai/corso/internal/testing"
+	"github.com/alcionai/corso/internal/tester"
 	"github.com/alcionai/corso/pkg/selectors"
 )
 
@@ -25,9 +25,9 @@ type GraphConnectorIntegrationSuite struct {
 }
 
 func TestGraphConnectorIntegrationSuite(t *testing.T) {
-	if err := ctesting.RunOnAny(
-		ctesting.CorsoCITests,
-		ctesting.CorsoGraphConnectorTests,
+	if err := tester.RunOnAny(
+		tester.CorsoCITests,
+		tester.CorsoGraphConnectorTests,
 	); err != nil {
 		t.Skip(err)
 	}
@@ -35,14 +35,14 @@ func TestGraphConnectorIntegrationSuite(t *testing.T) {
 }
 
 func (suite *GraphConnectorIntegrationSuite) SetupSuite() {
-	if err := ctesting.RunOnAny(ctesting.CorsoCITests); err != nil {
+	if err := tester.RunOnAny(tester.CorsoCITests); err != nil {
 		suite.T().Skip(err)
 	}
 
-	_, err := ctesting.GetRequiredEnvVars(ctesting.M365AcctCredEnvs...)
+	_, err := tester.GetRequiredEnvVars(tester.M365AcctCredEnvs...)
 	require.NoError(suite.T(), err)
 
-	a, err := ctesting.NewM365Account()
+	a, err := tester.NewM365Account()
 	require.NoError(suite.T(), err)
 
 	suite.connector, err = NewGraphConnector(a)
@@ -50,7 +50,7 @@ func (suite *GraphConnectorIntegrationSuite) SetupSuite() {
 }
 
 func (suite *GraphConnectorIntegrationSuite) TestGraphConnector() {
-	ctesting.LogTimeOfTest(suite.T())
+	tester.LogTimeOfTest(suite.T())
 	suite.NotNil(suite.connector)
 }
 
@@ -86,7 +86,7 @@ func (suite *GraphConnectorIntegrationSuite) TestGraphConnector_ExchangeDataColl
 // is able to restore a messageable item to a Mailbox.
 func (suite *GraphConnectorIntegrationSuite) TestGraphConnector_restoreMessages() {
 	user := "TEST_GRAPH_USER" // user.GetId()
-	evs, err := ctesting.GetRequiredEnvVars(user)
+	evs, err := tester.GetRequiredEnvVars(user)
 	if err != nil {
 		suite.T().Skipf("Environment not configured: %v\n", err)
 	}

--- a/src/internal/connector/support/m365Support_test.go
+++ b/src/internal/connector/support/m365Support_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
-	ctesting "github.com/alcionai/corso/internal/testing"
+	"github.com/alcionai/corso/internal/tester"
 )
 
 type DataSupportSuite struct {
@@ -21,7 +21,7 @@ const (
 )
 
 func TestDataSupportSuite(t *testing.T) {
-	err := ctesting.RunOnAny(support_file)
+	err := tester.RunOnAny(support_file)
 	if err != nil {
 		t.Skipf("Skipping: %v\n", err)
 	}
@@ -29,7 +29,7 @@ func TestDataSupportSuite(t *testing.T) {
 }
 
 func (suite *DataSupportSuite) TestCreateMessageFromBytes() {
-	bytes, err := ctesting.LoadAFile(os.Getenv(SUPPORT_FILE))
+	bytes, err := tester.LoadAFile(os.Getenv(SUPPORT_FILE))
 	if err != nil {
 		suite.T().Errorf("Failed with %v\n", err)
 	}

--- a/src/internal/connector/support/m365Transform_test.go
+++ b/src/internal/connector/support/m365Transform_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	ctesting "github.com/alcionai/corso/internal/testing"
+	"github.com/alcionai/corso/internal/tester"
 )
 
 type SupportTestSuite struct {
@@ -21,7 +21,7 @@ const (
 )
 
 func TestSupportTestSuite(t *testing.T) {
-	evs, err := ctesting.GetRequiredEnvVars(SUPPORT_FILE)
+	evs, err := tester.GetRequiredEnvVars(SUPPORT_FILE)
 	if err != nil {
 		t.Skipf("Env not configured: %v\n", err)
 	}
@@ -33,7 +33,7 @@ func TestSupportTestSuite(t *testing.T) {
 }
 
 func (suite *SupportTestSuite) TestToMessage() {
-	bytes, err := ctesting.LoadAFile(os.Getenv(SUPPORT_FILE))
+	bytes, err := tester.LoadAFile(os.Getenv(SUPPORT_FILE))
 	if err != nil {
 		suite.T().Errorf("Failed with %v\n", err)
 	}

--- a/src/internal/kopia/conn_test.go
+++ b/src/internal/kopia/conn_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	ctesting "github.com/alcionai/corso/internal/testing"
+	"github.com/alcionai/corso/internal/tester"
 )
 
 func openKopiaRepo(t *testing.T, ctx context.Context) (*conn, error) {
-	storage, err := ctesting.NewPrefixedS3Storage(t)
+	storage, err := tester.NewPrefixedS3Storage(t)
 	if err != nil {
 		return nil, err
 	}
@@ -53,9 +53,9 @@ type WrapperIntegrationSuite struct {
 }
 
 func TestWrapperIntegrationSuite(t *testing.T) {
-	if err := ctesting.RunOnAny(
-		ctesting.CorsoCITests,
-		ctesting.CorsoKopiaWrapperTests,
+	if err := tester.RunOnAny(
+		tester.CorsoCITests,
+		tester.CorsoKopiaWrapperTests,
 	); err != nil {
 		t.Skip()
 	}
@@ -64,7 +64,7 @@ func TestWrapperIntegrationSuite(t *testing.T) {
 }
 
 func (suite *WrapperIntegrationSuite) SetupSuite() {
-	_, err := ctesting.GetRequiredEnvVars(ctesting.AWSStorageCredEnvs...)
+	_, err := tester.GetRequiredEnvVars(tester.AWSStorageCredEnvs...)
 	require.NoError(suite.T(), err)
 }
 

--- a/src/internal/kopia/model_store_test.go
+++ b/src/internal/kopia/model_store_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/internal/model"
-	ctesting "github.com/alcionai/corso/internal/testing"
+	"github.com/alcionai/corso/internal/tester"
 )
 
 type fooModel struct {
@@ -54,9 +54,9 @@ type ModelStoreIntegrationSuite struct {
 }
 
 func TestModelStoreIntegrationSuite(t *testing.T) {
-	if err := ctesting.RunOnAny(
-		ctesting.CorsoCITests,
-		ctesting.CorsoModelStoreTests,
+	if err := tester.RunOnAny(
+		tester.CorsoCITests,
+		tester.CorsoModelStoreTests,
 	); err != nil {
 		t.Skip()
 	}
@@ -65,7 +65,7 @@ func TestModelStoreIntegrationSuite(t *testing.T) {
 }
 
 func (suite *ModelStoreIntegrationSuite) SetupSuite() {
-	_, err := ctesting.GetRequiredEnvVars(ctesting.AWSStorageCredEnvs...)
+	_, err := tester.GetRequiredEnvVars(tester.AWSStorageCredEnvs...)
 	require.NoError(suite.T(), err)
 }
 
@@ -437,9 +437,9 @@ type ModelStoreRegressionSuite struct {
 }
 
 func TestModelStoreRegressionSuite(t *testing.T) {
-	if err := ctesting.RunOnAny(
-		ctesting.CorsoCITests,
-		ctesting.CorsoModelStoreTests,
+	if err := tester.RunOnAny(
+		tester.CorsoCITests,
+		tester.CorsoModelStoreTests,
 	); err != nil {
 		t.Skip()
 	}
@@ -448,7 +448,7 @@ func TestModelStoreRegressionSuite(t *testing.T) {
 }
 
 func (suite *ModelStoreRegressionSuite) SetupSuite() {
-	_, err := ctesting.GetRequiredEnvVars(ctesting.AWSStorageCredEnvs...)
+	_, err := tester.GetRequiredEnvVars(tester.AWSStorageCredEnvs...)
 	require.NoError(suite.T(), err)
 }
 

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/alcionai/corso/internal/connector/mockconnector"
 	"github.com/alcionai/corso/internal/data"
 	"github.com/alcionai/corso/internal/kopia/mockkopia"
-	ctesting "github.com/alcionai/corso/internal/testing"
+	"github.com/alcionai/corso/internal/tester"
 	"github.com/alcionai/corso/pkg/backup/details"
 )
 
@@ -104,7 +104,7 @@ func (suite *KopiaUnitSuite) TestCloseWithoutInitDoesNotPanic() {
 }
 
 func (suite *KopiaUnitSuite) TestBuildDirectoryTree() {
-	ctesting.LogTimeOfTest(suite.T())
+	tester.LogTimeOfTest(suite.T())
 
 	ctx := context.Background()
 	tenant := "a-tenant"
@@ -173,7 +173,7 @@ func (suite *KopiaUnitSuite) TestBuildDirectoryTree() {
 }
 
 func (suite *KopiaUnitSuite) TestBuildDirectoryTree_NoAncestorDirs() {
-	ctesting.LogTimeOfTest(suite.T())
+	tester.LogTimeOfTest(suite.T())
 
 	ctx := context.Background()
 	emails := "emails"
@@ -372,9 +372,9 @@ type KopiaIntegrationSuite struct {
 }
 
 func TestKopiaIntegrationSuite(t *testing.T) {
-	if err := ctesting.RunOnAny(
-		ctesting.CorsoCITests,
-		ctesting.CorsoKopiaWrapperTests,
+	if err := tester.RunOnAny(
+		tester.CorsoCITests,
+		tester.CorsoKopiaWrapperTests,
 	); err != nil {
 		t.Skip()
 	}
@@ -383,7 +383,7 @@ func TestKopiaIntegrationSuite(t *testing.T) {
 }
 
 func (suite *KopiaIntegrationSuite) SetupSuite() {
-	_, err := ctesting.GetRequiredEnvVars(ctesting.AWSStorageCredEnvs...)
+	_, err := tester.GetRequiredEnvVars(tester.AWSStorageCredEnvs...)
 	require.NoError(suite.T(), err)
 }
 
@@ -433,9 +433,9 @@ type KopiaSimpleRepoIntegrationSuite struct {
 }
 
 func TestKopiaSimpleRepoIntegrationSuite(t *testing.T) {
-	if err := ctesting.RunOnAny(
-		ctesting.CorsoCITests,
-		ctesting.CorsoKopiaWrapperTests,
+	if err := tester.RunOnAny(
+		tester.CorsoCITests,
+		tester.CorsoKopiaWrapperTests,
 	); err != nil {
 		t.Skip()
 	}
@@ -444,7 +444,7 @@ func TestKopiaSimpleRepoIntegrationSuite(t *testing.T) {
 }
 
 func (suite *KopiaSimpleRepoIntegrationSuite) SetupSuite() {
-	_, err := ctesting.GetRequiredEnvVars(ctesting.AWSStorageCredEnvs...)
+	_, err := tester.GetRequiredEnvVars(tester.AWSStorageCredEnvs...)
 	require.NoError(suite.T(), err)
 }
 

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/alcionai/corso/internal/connector/support"
 	"github.com/alcionai/corso/internal/kopia"
-	ctesting "github.com/alcionai/corso/internal/testing"
+	"github.com/alcionai/corso/internal/tester"
 	"github.com/alcionai/corso/pkg/account"
 	"github.com/alcionai/corso/pkg/control"
 	"github.com/alcionai/corso/pkg/selectors"
@@ -75,9 +75,9 @@ type BackupOpIntegrationSuite struct {
 }
 
 func TestBackupOpIntegrationSuite(t *testing.T) {
-	if err := ctesting.RunOnAny(
-		ctesting.CorsoCITests,
-		ctesting.CorsoOperationTests,
+	if err := tester.RunOnAny(
+		tester.CorsoCITests,
+		tester.CorsoOperationTests,
 	); err != nil {
 		t.Skip(err)
 	}
@@ -85,10 +85,10 @@ func TestBackupOpIntegrationSuite(t *testing.T) {
 }
 
 func (suite *BackupOpIntegrationSuite) SetupSuite() {
-	_, err := ctesting.GetRequiredEnvVars(
+	_, err := tester.GetRequiredEnvVars(
 		append(
-			ctesting.AWSStorageCredEnvs,
-			ctesting.M365AcctCredEnvs...,
+			tester.AWSStorageCredEnvs,
+			tester.M365AcctCredEnvs...,
 		)...,
 	)
 	require.NoError(suite.T(), err)
@@ -97,7 +97,7 @@ func (suite *BackupOpIntegrationSuite) SetupSuite() {
 func (suite *BackupOpIntegrationSuite) TestNewBackupOperation() {
 	kw := &kopia.Wrapper{}
 	sw := &store.Wrapper{}
-	acct, err := ctesting.NewM365Account()
+	acct, err := tester.NewM365Account()
 	require.NoError(suite.T(), err)
 
 	table := []struct {
@@ -132,11 +132,11 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run() {
 	ctx := context.Background()
 
 	m365User := "lidiah@8qzvrj.onmicrosoft.com"
-	acct, err := ctesting.NewM365Account()
+	acct, err := tester.NewM365Account()
 	require.NoError(t, err)
 
 	// need to initialize the repository before we can test connecting to it.
-	st, err := ctesting.NewPrefixedS3Storage(t)
+	st, err := tester.NewPrefixedS3Storage(t)
 	require.NoError(t, err)
 
 	k := kopia.NewConn(st)

--- a/src/internal/operations/restore_test.go
+++ b/src/internal/operations/restore_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/alcionai/corso/internal/connector/support"
 	"github.com/alcionai/corso/internal/data"
 	"github.com/alcionai/corso/internal/kopia"
-	ctesting "github.com/alcionai/corso/internal/testing"
+	"github.com/alcionai/corso/internal/tester"
 	"github.com/alcionai/corso/pkg/account"
 	"github.com/alcionai/corso/pkg/control"
 	"github.com/alcionai/corso/pkg/selectors"
@@ -77,9 +77,9 @@ type RestoreOpIntegrationSuite struct {
 }
 
 func TestRestoreOpIntegrationSuite(t *testing.T) {
-	if err := ctesting.RunOnAny(
-		ctesting.CorsoCITests,
-		ctesting.CorsoOperationTests,
+	if err := tester.RunOnAny(
+		tester.CorsoCITests,
+		tester.CorsoOperationTests,
 	); err != nil {
 		t.Skip(err)
 	}
@@ -87,14 +87,14 @@ func TestRestoreOpIntegrationSuite(t *testing.T) {
 }
 
 func (suite *RestoreOpIntegrationSuite) SetupSuite() {
-	_, err := ctesting.GetRequiredEnvVars(ctesting.M365AcctCredEnvs...)
+	_, err := tester.GetRequiredEnvVars(tester.M365AcctCredEnvs...)
 	require.NoError(suite.T(), err)
 }
 
 func (suite *RestoreOpIntegrationSuite) TestNewRestoreOperation() {
 	kw := &kopia.Wrapper{}
 	sw := &store.Wrapper{}
-	acct, err := ctesting.NewM365Account()
+	acct, err := tester.NewM365Account()
 	require.NoError(suite.T(), err)
 
 	table := []struct {
@@ -130,11 +130,11 @@ func (suite *RestoreOpIntegrationSuite) TestRestore_Run() {
 	ctx := context.Background()
 
 	m365User := "lidiah@8qzvrj.onmicrosoft.com"
-	acct, err := ctesting.NewM365Account()
+	acct, err := tester.NewM365Account()
 	require.NoError(t, err)
 
 	// need to initialize the repository before we can test connecting to it.
-	st, err := ctesting.NewPrefixedS3Storage(t)
+	st, err := tester.NewPrefixedS3Storage(t)
 	require.NoError(t, err)
 
 	k := kopia.NewConn(st)
@@ -193,11 +193,11 @@ func (suite *RestoreOpIntegrationSuite) TestRestore_Run_ErrorNoResults() {
 	ctx := context.Background()
 
 	m365User := "lidiah@8qzvrj.onmicrosoft.com"
-	acct, err := ctesting.NewM365Account()
+	acct, err := tester.NewM365Account()
 	require.NoError(t, err)
 
 	// need to initialize the repository before we can test connecting to it.
-	st, err := ctesting.NewPrefixedS3Storage(t)
+	st, err := tester.NewPrefixedS3Storage(t)
 	require.NoError(t, err)
 
 	k := kopia.NewConn(st)

--- a/src/internal/tester/account.go
+++ b/src/internal/tester/account.go
@@ -1,4 +1,4 @@
-package testing
+package tester
 
 import (
 	"github.com/alcionai/corso/pkg/account"

--- a/src/internal/tester/config.go
+++ b/src/internal/tester/config.go
@@ -1,4 +1,4 @@
-package testing
+package tester
 
 import (
 	"os"

--- a/src/internal/tester/envvars.go
+++ b/src/internal/tester/envvars.go
@@ -1,4 +1,4 @@
-package testing
+package tester
 
 import (
 	"errors"

--- a/src/internal/tester/envvars_test.go
+++ b/src/internal/tester/envvars_test.go
@@ -1,4 +1,4 @@
-package testing
+package tester
 
 import (
 	"os"

--- a/src/internal/tester/integration_runners.go
+++ b/src/internal/tester/integration_runners.go
@@ -1,4 +1,4 @@
-package testing
+package tester
 
 import (
 	"fmt"

--- a/src/internal/tester/loader.go
+++ b/src/internal/tester/loader.go
@@ -1,4 +1,4 @@
-package testing
+package tester
 
 import (
 	"bufio"

--- a/src/internal/tester/storage.go
+++ b/src/internal/tester/storage.go
@@ -1,4 +1,4 @@
-package testing
+package tester
 
 import (
 	"testing"

--- a/src/internal/tester/testing.go
+++ b/src/internal/tester/testing.go
@@ -1,4 +1,4 @@
-package testing
+package tester
 
 import (
 	"reflect"

--- a/src/pkg/repository/repository_test.go
+++ b/src/pkg/repository/repository_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	ctesting "github.com/alcionai/corso/internal/testing"
+	"github.com/alcionai/corso/internal/tester"
 	"github.com/alcionai/corso/pkg/account"
 	"github.com/alcionai/corso/pkg/control"
 	"github.com/alcionai/corso/pkg/repository"
@@ -91,9 +91,9 @@ type RepositoryIntegrationSuite struct {
 }
 
 func TestRepositoryIntegrationSuite(t *testing.T) {
-	if err := ctesting.RunOnAny(
-		ctesting.CorsoCITests,
-		ctesting.CorsoRepositoryTests,
+	if err := tester.RunOnAny(
+		tester.CorsoCITests,
+		tester.CorsoRepositoryTests,
 	); err != nil {
 		t.Skip(err)
 	}
@@ -102,10 +102,10 @@ func TestRepositoryIntegrationSuite(t *testing.T) {
 
 // ensure all required env values are populated
 func (suite *RepositoryIntegrationSuite) SetupSuite() {
-	_, err := ctesting.GetRequiredEnvVars(
+	_, err := tester.GetRequiredEnvVars(
 		append(
-			ctesting.AWSStorageCredEnvs,
-			ctesting.M365AcctCredEnvs...,
+			tester.AWSStorageCredEnvs,
+			tester.M365AcctCredEnvs...,
 		)...,
 	)
 	require.NoError(suite.T(), err)
@@ -122,7 +122,7 @@ func (suite *RepositoryIntegrationSuite) TestInitialize() {
 	}{
 		{
 			name:     "success",
-			storage:  ctesting.NewPrefixedS3Storage,
+			storage:  tester.NewPrefixedS3Storage,
 			errCheck: assert.NoError,
 		},
 	}
@@ -147,7 +147,7 @@ func (suite *RepositoryIntegrationSuite) TestConnect() {
 	ctx := context.Background()
 
 	// need to initialize the repository before we can test connecting to it.
-	st, err := ctesting.NewPrefixedS3Storage(t)
+	st, err := tester.NewPrefixedS3Storage(t)
 	require.NoError(t, err)
 
 	_, err = repository.Initialize(ctx, account.Account{}, st)
@@ -162,11 +162,11 @@ func (suite *RepositoryIntegrationSuite) TestNewBackup() {
 	t := suite.T()
 	ctx := context.Background()
 
-	acct, err := ctesting.NewM365Account()
+	acct, err := tester.NewM365Account()
 	require.NoError(t, err)
 
 	// need to initialize the repository before we can test connecting to it.
-	st, err := ctesting.NewPrefixedS3Storage(t)
+	st, err := tester.NewPrefixedS3Storage(t)
 	require.NoError(t, err)
 
 	r, err := repository.Initialize(ctx, acct, st)
@@ -181,11 +181,11 @@ func (suite *RepositoryIntegrationSuite) TestNewRestore() {
 	t := suite.T()
 	ctx := context.Background()
 
-	acct, err := ctesting.NewM365Account()
+	acct, err := tester.NewM365Account()
 	require.NoError(t, err)
 
 	// need to initialize the repository before we can test connecting to it.
-	st, err := ctesting.NewPrefixedS3Storage(t)
+	st, err := tester.NewPrefixedS3Storage(t)
 	require.NoError(t, err)
 
 	r, err := repository.Initialize(ctx, acct, st)


### PR DESCRIPTION
The alias of testing to ctesting prevented auto-importing
of the testing library.  This change (arbitrarily) renames
the package so that it doesn't collide with the core pkg
for "testing".

Changes are entirely a rename of ctesting -> tester, and
the package migration.