### PR TITLE
Make rules to check for linter and run it

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,24 @@
+# This must match the version defined in .github/workflows/lint.yaml.
+WANTED_LINT_VERSION := 1.45.2
+LINT_VERSION := $(shell golangci-lint version | cut -d' ' -f4)
+HAS_LINT := $(shell which golangci-lint)
+
+INSTALL_LINT_PAGE := "https://golangci-lint.run/usage/install/"
+BAD_LINT_MSG := "Missing golangci-lint version $(WANTED_LINT_VERSION). Visit $(INSTALL_LINT_PAGE) for instructions on how to install"
+
+.PHONY: check-lint check-lint-version lint
+
+lint: check-lint-version
+	golangci-lint run
+
+check-lint-version: check-lint
+	@if [ "$(LINT_VERSION)" != "$(WANTED_LINT_VERSION)" ]; then \
+		echo >&2 $(BAD_LINT_MSG); \
+		false; \
+	fi
+
+check-lint:
+	@if [ -z "$(HAS_LINT)" ]; then \
+		echo >&2 $(BAD_LINT_MSG); \
+		false; \
+	fi


### PR DESCRIPTION
Explicitly check for the linter version as different versions can return
different results. Currently the desired version is hard-coded, but may
be sourced from the github workflow file in the future.

Linter can be run with `make` or `make lint` from the `src` directory.
May not be the default rule in the future so `make lint` is safest
option.

closes #510 