### PR TITLE
Fixes the resource-not-found-fix

### DIFF
--- a/src/internal/tester/config.go
+++ b/src/internal/tester/config.go
@@ -102,7 +102,7 @@ func readTestConfig() (map[string]string, error) {
 		testEnv,
 		TestCfgUserID,
 		os.Getenv(EnvCorsoM365TestUserID),
-		vpr.GetString(TestCfgTenantID),
+		vpr.GetString(TestCfgUserID),
 		"lidiah@8qzvrj.onmicrosoft.com",
 	)
 	testEnv[EnvCorsoTestConfigFilePath] = os.Getenv(EnvCorsoTestConfigFilePath)


### PR DESCRIPTION
This is the fix from August 17th where the tenantID was being passed instead of the userID. 