### PR TITLE
Regression test for kopia sharing local config

### DIFF
--- a/src/internal/kopia/model_store_test.go
+++ b/src/internal/kopia/model_store_test.go
@@ -2,6 +2,8 @@ package kopia
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
@@ -13,6 +15,7 @@ import (
 
 	"github.com/alcionai/corso/internal/model"
 	"github.com/alcionai/corso/internal/tester"
+	"github.com/alcionai/corso/pkg/backup/details"
 )
 
 type fooModel struct {
@@ -512,4 +515,126 @@ func (suite *ModelStoreRegressionSuite) TestFailDuringWriteSessionHasNoVisibleEf
 	require.NoError(
 		t, m.GetWithModelStoreID(ctx, theModelType, foo.ModelStoreID, returned))
 	assert.Equal(t, foo, returned)
+}
+
+func openConnAndModelStore(
+	t *testing.T,
+	ctx context.Context,
+) (*conn, *ModelStore) {
+	st := tester.NewPrefixedS3Storage(t)
+	c := NewConn(st)
+
+	require.NoError(t, c.Initialize(ctx))
+
+	defer func() {
+		require.NoError(t, c.Close(ctx))
+	}()
+
+	ms, err := NewModelStore(c)
+	require.NoError(t, err)
+
+	return c, ms
+}
+
+func reconnectToModelStore(
+	t *testing.T,
+	ctx context.Context,
+	c *conn,
+) *ModelStore {
+	require.NoError(t, c.Connect(ctx))
+
+	defer func() {
+		assert.NoError(t, c.Close(ctx))
+	}()
+
+	ms, err := NewModelStore(c)
+	require.NoError(t, err)
+
+	return ms
+}
+
+// Ensures there's no shared configuration state between different instances of
+// the ModelStore (and consequently the underlying kopia instances).
+func (suite *ModelStoreRegressionSuite) TestMultipleConfigs() {
+	ctx := context.Background()
+	t := suite.T()
+	numEntries := 10
+	deets := details.DetailsModel{
+		Entries: make([]details.DetailsEntry, 0, numEntries),
+	}
+
+	for i := 0; i < numEntries; i++ {
+		deets.Entries = append(
+			deets.Entries,
+			details.DetailsEntry{
+				RepoRef: fmt.Sprintf("exchange/user1/mail/inbox/mail%v", i),
+				ItemInfo: details.ItemInfo{
+					Exchange: &details.ExchangeInfo{
+						Sender:  "John Doe",
+						Subject: fmt.Sprintf("Hola mundo %v", i),
+					},
+				},
+			},
+		)
+	}
+
+	conn1, ms1 := openConnAndModelStore(t, ctx)
+
+	require.NoError(t, ms1.Put(ctx, model.BackupDetailsSchema, &deets))
+	require.NoError(t, ms1.Close(ctx))
+
+	start := make(chan struct{})
+	ready := sync.WaitGroup{}
+	ready.Add(2)
+
+	var ms2 *ModelStore
+
+	// These need to be opened in parallel because it's a race writing the kopia
+	// config file.
+	go func() {
+		defer ready.Done()
+
+		<-start
+
+		_, ms2 = openConnAndModelStore(t, ctx)
+	}()
+
+	go func() {
+		defer ready.Done()
+
+		<-start
+
+		ms1 = reconnectToModelStore(t, ctx, conn1)
+	}()
+
+	close(start)
+	ready.Wait()
+
+	defer func() {
+		assert.NoError(t, ms2.Close(ctx))
+	}()
+
+	defer func() {
+		assert.NoError(t, ms1.Close(ctx))
+	}()
+
+	// New instance should not have model we added.
+	gotDeets := details.Details{}
+	err := ms2.GetWithModelStoreID(
+		ctx,
+		model.BackupDetailsSchema,
+		deets.ModelStoreID,
+		&gotDeets,
+	)
+	assert.Error(t, err)
+
+	// Old instance should still be able to access added model.
+	gotDeets = details.Details{}
+	err = ms1.GetWithModelStoreID(
+		ctx,
+		model.BackupDetailsSchema,
+		deets.ModelStoreID,
+		&gotDeets,
+	)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
Adding smoke test for #601 

Ensure that kopia is not sharing the local config and that different
instances of kopia reconnect to the proper remote repo.

Local test output without fix for #601:
```text
=== RUN   TestModelStoreRegressionSuite                                                                                                                                                                                                                                       
=== RUN   TestModelStoreRegressionSuite/TestMultipleConfigs
    integration_runners.go:54: TestModelStoreRegressionSuite/TestMultipleConfigs run at 2022-08-19T19:55:09.47958Z
    integration_runners.go:54: TestModelStoreRegressionSuite/TestMultipleConfigs run at 2022-08-19T19:55:15.938808Z
    model_store_test.go:638: 
                Error Trace:    /Users/ashmrtnz/go/src/github.com/alcionai/corso/internal/kopia/model_store_test.go:638
                Error:          Received unexpected error:
                                not found
                                github.com/kopia/kopia/repo/manifest.init
                                        /Users/ashmrtnz/go/pkg/mod/github.com/kopia/kopia@v0.11.4-0.20220811233840-5fd7c62ecabc/repo/manifest/manifest_manager.go:30
                                runtime.doInit
                                        /opt/homebrew/Cellar/go/1.18.5/libexec/src/runtime/proc.go:6222
                                runtime.doInit
                                        /opt/homebrew/Cellar/go/1.18.5/libexec/src/runtime/proc.go:6199
                                runtime.doInit
                                        /opt/homebrew/Cellar/go/1.18.5/libexec/src/runtime/proc.go:6199
                                runtime.doInit
                                        /opt/homebrew/Cellar/go/1.18.5/libexec/src/runtime/proc.go:6199
                                runtime.doInit
                                        /opt/homebrew/Cellar/go/1.18.5/libexec/src/runtime/proc.go:6199
                                runtime.main
                                        /opt/homebrew/Cellar/go/1.18.5/libexec/src/runtime/proc.go:233
                                runtime.goexit
                                        /opt/homebrew/Cellar/go/1.18.5/libexec/src/runtime/asm_arm64.s:1263
                                manifest 3cd7537176220a0aad69426797932bcc
                                github.com/kopia/kopia/repo/manifest.(*Manager).getPendingOrCommitted
                                        /Users/ashmrtnz/go/pkg/mod/github.com/kopia/kopia@v0.11.4-0.20220811233840-5fd7c62ecabc/repo/manifest/manifest_manager.go:140
                                github.com/kopia/kopia/repo/manifest.(*Manager).Get
                                        /Users/ashmrtnz/go/pkg/mod/github.com/kopia/kopia@v0.11.4-0.20220811233840-5fd7c62ecabc/repo/manifest/manifest_manager.go:111
                                github.com/kopia/kopia/repo.(*directRepository).GetManifest
                                        /Users/ashmrtnz/go/pkg/mod/github.com/kopia/kopia@v0.11.4-0.20220811233840-5fd7c62ecabc/repo/repository.go:181
                                github.com/alcionai/corso/internal/kopia.(*ModelStore).GetWithModelStoreID
                                        /Users/ashmrtnz/go/src/github.com/alcionai/corso/internal/kopia/model_store.go:291
                                github.com/alcionai/corso/internal/kopia.(*ModelStoreRegressionSuite).TestMultipleConfigs
                                        /Users/ashmrtnz/go/src/github.com/alcionai/corso/internal/kopia/model_store_test.go:632
                                reflect.Value.call
                                        /opt/homebrew/Cellar/go/1.18.5/libexec/src/reflect/value.go:556
                                reflect.Value.Call
                                        /opt/homebrew/Cellar/go/1.18.5/libexec/src/reflect/value.go:339
                                github.com/stretchr/testify/suite.Run.func1
                                        /Users/ashmrtnz/go/pkg/mod/github.com/stretchr/testify@v1.8.0/suite/suite.go:175
                                testing.tRunner
                                        /opt/homebrew/Cellar/go/1.18.5/libexec/src/testing/testing.go:1439
                                runtime.goexit
                                        /opt/homebrew/Cellar/go/1.18.5/libexec/src/runtime/asm_arm64.s:1263
                                getting model data
                                github.com/alcionai/corso/internal/kopia.(*ModelStore).GetWithModelStoreID
                                        /Users/ashmrtnz/go/src/github.com/alcionai/corso/internal/kopia/model_store.go:295
                                github.com/alcionai/corso/internal/kopia.(*ModelStoreRegressionSuite).TestMultipleConfigs
                                        /Users/ashmrtnz/go/src/github.com/alcionai/corso/internal/kopia/model_store_test.go:632
                                reflect.Value.call
                                        /opt/homebrew/Cellar/go/1.18.5/libexec/src/reflect/value.go:556
                                reflect.Value.Call
                                        /opt/homebrew/Cellar/go/1.18.5/libexec/src/reflect/value.go:339
                                github.com/stretchr/testify/suite.Run.func1
                                        /Users/ashmrtnz/go/pkg/mod/github.com/stretchr/testify@v1.8.0/suite/suite.go:175
                                testing.tRunner
                                        /opt/homebrew/Cellar/go/1.18.5/libexec/src/testing/testing.go:1439
                                runtime.goexit
                                        /opt/homebrew/Cellar/go/1.18.5/libexec/src/runtime/asm_arm64.s:1263
                Test:           TestModelStoreRegressionSuite/TestMultipleConfigs
--- FAIL: TestModelStoreRegressionSuite (11.57s)
    --- FAIL: TestModelStoreRegressionSuite/TestMultipleConfigs (11.57s)
FAIL
FAIL    github.com/alcionai/corso/internal/kopia        11.772s
?       github.com/alcionai/corso/internal/kopia/mockkopia      [no test files]
FAIL
```

closes #616 