### PR TITLE
Directory resolver for remote objects

### DIFF
--- a/src/internal/connector/graph/container_resolver.go
+++ b/src/internal/connector/graph/container_resolver.go
@@ -1,4 +1,4 @@
-package exchange
+package graph
 
 import (
 	"context"

--- a/src/internal/connector/graph/container_resolver_test.go
+++ b/src/internal/connector/graph/container_resolver_test.go
@@ -1,4 +1,4 @@
-package exchange
+package graph
 
 import (
 	"context"


### PR DESCRIPTION
Struct that allows resolving the path of objects given the object ID of the final element in the path. This is a step towards being able to backup the full directory path for an item in M365.

The resolver itself caches results as it goes along so it can reduce calls to the remote API. It also makes use of provided objects to abstract actually fetching data from looking up information in the cache, making it suitable for use in other parts of the code if needed.

Code to actually fetch Exchange email folders to come in another PR

Code can be moved to another package and package-public/-private stuff can be adjusted if needed

part of #456 