### PR TITLE
remove extraneous debug logs from cli

### DIFF
--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -11,7 +11,6 @@ import (
 	"github.com/alcionai/corso/cli/utils"
 	"github.com/alcionai/corso/internal/model"
 	"github.com/alcionai/corso/pkg/backup"
-	"github.com/alcionai/corso/pkg/logger"
 	"github.com/alcionai/corso/pkg/repository"
 	"github.com/alcionai/corso/pkg/selectors"
 )
@@ -175,17 +174,6 @@ func createExchangeCmd(cmd *cobra.Command, args []string) error {
 		return Only(ctx, err)
 	}
 
-	m365, err := acct.M365Config()
-	if err != nil {
-		return Only(ctx, errors.Wrap(err, "Failed to parse m365 account config"))
-	}
-
-	logger.Ctx(ctx).Debugw(
-		"Called - "+cmd.CommandPath(),
-		"tenantID", m365.TenantID,
-		"clientID", m365.ClientID,
-		"hasClientSecret", len(m365.ClientSecret) > 0)
-
 	r, err := repository.Connect(ctx, acct, s)
 	if err != nil {
 		return Only(ctx, errors.Wrapf(err, "Failed to connect to the %s repository", s.Provider))
@@ -284,15 +272,6 @@ func listExchangeCmd(cmd *cobra.Command, args []string) error {
 		return Only(ctx, err)
 	}
 
-	m365, err := acct.M365Config()
-	if err != nil {
-		return Only(ctx, errors.Wrap(err, "Failed to parse m365 account config"))
-	}
-
-	logger.Ctx(ctx).Debugw(
-		"Called - "+cmd.CommandPath(),
-		"tenantID", m365.TenantID)
-
 	r, err := repository.Connect(ctx, acct, s)
 	if err != nil {
 		return Only(ctx, errors.Wrapf(err, "Failed to connect to the %s repository", s.Provider))
@@ -348,15 +327,6 @@ func detailsExchangeCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return Only(ctx, err)
 	}
-
-	m365, err := acct.M365Config()
-	if err != nil {
-		return Only(ctx, errors.Wrap(err, "Failed to parse m365 account config"))
-	}
-
-	logger.Ctx(ctx).Debugw(
-		"Called - "+cmd.CommandPath(),
-		"tenantID", m365.TenantID)
 
 	r, err := repository.Connect(ctx, acct, s)
 	if err != nil {
@@ -563,17 +533,6 @@ func deleteExchangeCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return Only(ctx, err)
 	}
-
-	m365, err := acct.M365Config()
-	if err != nil {
-		return Only(ctx, errors.Wrap(err, "Failed to parse m365 account config"))
-	}
-
-	logger.Ctx(ctx).Debugw(
-		"Called - "+cmd.CommandPath(),
-		"tenantID", m365.TenantID,
-		"clientID", m365.ClientID,
-		"hasClientSecret", len(m365.ClientSecret) > 0)
 
 	r, err := repository.Connect(ctx, acct, s)
 	if err != nil {

--- a/src/cli/repo/s3.go
+++ b/src/cli/repo/s3.go
@@ -11,7 +11,6 @@ import (
 	"github.com/alcionai/corso/internal/kopia"
 	"github.com/alcionai/corso/pkg/account"
 	"github.com/alcionai/corso/pkg/credentials"
-	"github.com/alcionai/corso/pkg/logger"
 	"github.com/alcionai/corso/pkg/repository"
 	"github.com/alcionai/corso/pkg/storage"
 )
@@ -72,7 +71,6 @@ func s3InitCmd() *cobra.Command {
 // initializes a s3 repo.
 func initS3Cmd(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	log := logger.Ctx(ctx)
 
 	if utils.HasNoFlagsAndShownHelp(cmd) {
 		return nil
@@ -92,14 +90,6 @@ func initS3Cmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return Only(ctx, errors.Wrap(err, "Failed to parse m365 account config"))
 	}
-
-	log.Debugw(
-		"Called - "+cmd.CommandPath(),
-		"bucket", s3Cfg.Bucket,
-		"clientID", m365.ClientID,
-		"hasClientSecret", len(m365.ClientSecret) > 0,
-		"accessKey", s3Cfg.AccessKey,
-		"hasSecretKey", len(s3Cfg.SecretKey) > 0)
 
 	r, err := repository.Initialize(ctx, a, s)
 	if err != nil {
@@ -139,7 +129,6 @@ func s3ConnectCmd() *cobra.Command {
 // connects to an existing s3 repo.
 func connectS3Cmd(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	log := logger.Ctx(ctx)
 
 	if utils.HasNoFlagsAndShownHelp(cmd) {
 		return nil
@@ -159,14 +148,6 @@ func connectS3Cmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return Only(ctx, errors.Wrap(err, "Failed to parse m365 account config"))
 	}
-
-	log.Debugw(
-		"Called - "+cmd.CommandPath(),
-		"bucket", s3Cfg.Bucket,
-		"clientID", m365.ClientID,
-		"hasClientSecret", len(m365.ClientSecret) > 0,
-		"accessKey", s3Cfg.AccessKey,
-		"hasSecretKey", len(s3Cfg.SecretKey) > 0)
 
 	r, err := repository.Connect(ctx, a, s)
 	if err != nil {

--- a/src/cli/restore/exchange.go
+++ b/src/cli/restore/exchange.go
@@ -9,7 +9,6 @@ import (
 	"github.com/alcionai/corso/cli/options"
 	. "github.com/alcionai/corso/cli/print"
 	"github.com/alcionai/corso/cli/utils"
-	"github.com/alcionai/corso/pkg/logger"
 	"github.com/alcionai/corso/pkg/repository"
 	"github.com/alcionai/corso/pkg/selectors"
 )
@@ -128,18 +127,6 @@ func restoreExchangeCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return Only(ctx, err)
 	}
-
-	m365, err := a.M365Config()
-	if err != nil {
-		return Only(ctx, errors.Wrap(err, "Failed to parse m365 account config"))
-	}
-
-	logger.Ctx(ctx).Debugw(
-		"Called - "+cmd.CommandPath(),
-		"backupID", backupID,
-		"tenantID", m365.TenantID,
-		"clientID", m365.ClientID,
-		"hasClientSecret", len(m365.ClientSecret) > 0)
 
 	r, err := repository.Connect(ctx, a, s)
 	if err != nil {


### PR DESCRIPTION
## Description

Minor cli house cleaning.   Debug logs were put into place as sanity checks before corso had end-to-end functionality.  They're no longer needed.  If debug logging of commands is wanted, we can look at a centralized means of logging those details.

## Type of change

Please check the type of change your PR introduces:
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :hamster: Trivial/Minor

## Issue(s)

filed under #501, unrelated.

## Test Plan

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
