### PR TITLE
Enable wsl linter for most of codebase

### DIFF
--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - lll
     - misspell
     - revive
+    - wsl
 
 linters-settings:
   gci:
@@ -78,3 +79,6 @@ issues:
       linters:
       - revive
       text: "import-shadowing:.*'suite' shadows"
+    # Temporarily skip linting wsl on `connector` package until fixes are merged.
+    - path: internal/connector/
+      linters: wsl


### PR DESCRIPTION
## Description

Does not enable wsl for `internal/connector` package right now.
Turn on for other code now to keep from cycle of fixing most code, waiting for some PRs
in other packages, and then needing to do more fixups. Will slowly
enable on various files in connector package until we get full coverage.

## Type of change

Please check the type of change your PR introduces:
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :hamster: Trivial/Minor

## Issue(s)
<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->

part of #481 
merge after #678 

## Test Plan

<!-- How will this be tested prior to merging.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
