### PR TITLE
add a cartesian product func to scopes

### DIFF
--- a/src/pkg/filters/filters.go
+++ b/src/pkg/filters/filters.go
@@ -181,6 +181,15 @@ func in(target, input string) bool {
 // Helpers
 // ----------------------------------------------------------------------------------------------------
 
+// Clone returns a copy of the Filter
+func (f Filter) Clone() Filter {
+	return Filter{
+		Comparator: f.Comparator,
+		Target:     f.Target,
+		Negate:     f.Negate,
+	}
+}
+
 // Targets returns the Target value split into a slice.
 func (f Filter) Targets() []string {
 	return split(f.Target)

--- a/src/pkg/selectors/exchange.go
+++ b/src/pkg/selectors/exchange.go
@@ -495,6 +495,14 @@ type ExchangeScope scope
 // interface compliance checks
 var _ scoper = &ExchangeScope{}
 
+// Cartesian produces the cartesian product of all the values
+// held in the scope.  Ie: if the scope expresses two distinct users
+// (and the same values otherwise), it will return two scopes: one for
+// each individual user.
+func (s ExchangeScope) Cartesian() []ExchangeScope {
+	return cartesian(s)
+}
+
 // Category describes the type of the data in scope.
 func (s ExchangeScope) Category() exchangeCategory {
 	return exchangeCategory(getCategory(s))

--- a/src/pkg/selectors/helpers_test.go
+++ b/src/pkg/selectors/helpers_test.go
@@ -3,6 +3,7 @@ package selectors
 import (
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/alcionai/corso/pkg/backup/details"
@@ -139,4 +140,26 @@ func scopeMustHave[T scopeT](t *testing.T, sc T, m map[categorizer]string) {
 			assert.Equal(t, getCatValue(sc, k), split(v))
 		})
 	}
+}
+
+// returns nil if the scopes are equal length and contain equal values.
+func scopesEqual[T scopeT](a, b T) error {
+	if len(a) != len(b) {
+		return errors.New("inequal scope lengths")
+	}
+
+	for k, v := range a {
+		at := v.Target
+
+		bv, ok := b[k]
+		if !ok {
+			return errors.Errorf("key [%s] not found in scope b", k)
+		}
+
+		if at != bv.Target {
+			return errors.Errorf("inequal value at [%s]: a [%s] b [%s]", k, at, bv.Target)
+		}
+	}
+
+	return nil
 }

--- a/src/pkg/selectors/onedrive.go
+++ b/src/pkg/selectors/onedrive.go
@@ -221,6 +221,14 @@ type OneDriveScope scope
 // interface compliance checks
 var _ scoper = &OneDriveScope{}
 
+// Cartesian produces the cartesian product of all the values
+// held in the scope.  Ie: if the scope expresses two distinct users
+// (and the same values otherwise), it will return two scopes: one for
+// each individual user.
+func (s OneDriveScope) Cartesian() []OneDriveScope {
+	return cartesian(s)
+}
+
 // Category describes the type of the data in scope.
 func (s OneDriveScope) Category() oneDriveCategory {
 	return oneDriveCategory(getCategory(s))


### PR DESCRIPTION
## Description

Adds the Cartesian() func to scopes so that users can
produce cartesian products of the scope target values
as needed.

## Type of change

Please check the type of change your PR introduces:
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :hamster: Trivial/Minor

## Issue(s)

#288

## Test Plan

<!-- How will this be tested prior to merging.-->

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
