### PR TITLE
add recurs to event info

### DIFF
--- a/src/internal/connector/exchange/event.go
+++ b/src/internal/connector/exchange/event.go
@@ -40,8 +40,9 @@ func EventInfo(evt models.Eventable) *details.ExchangeInfo {
 	}
 
 	return &details.ExchangeInfo{
-		Organizer:  organizer,
-		Subject:    subject,
-		EventStart: start,
+		EventRecurs: evt.GetSeriesMasterId() != nil,
+		EventStart:  start,
+		Organizer:   organizer,
+		Subject:     subject,
 	}
 }

--- a/src/internal/connector/exchange/query_options.go
+++ b/src/internal/connector/exchange/query_options.go
@@ -27,6 +27,7 @@ var (
 		"responseRequested": 7,
 		"showAs":            8,
 		"subject":           9,
+		"seriesMasterId":    10,
 	}
 
 	fieldsForFolders = map[string]int{

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -136,12 +136,13 @@ type ItemInfo struct {
 
 // ExchangeInfo describes an exchange item
 type ExchangeInfo struct {
-	Sender      string    `json:"sender,omitempty"`
-	Subject     string    `json:"subject,omitempty"`
-	Received    time.Time `json:"received,omitempty"`
+	ContactName string    `json:"contactName,omitempty"`
+	EventRecurs bool      `json:"eventRecurs,omitempty"`
 	EventStart  time.Time `json:"eventStart,omitempty"`
 	Organizer   string    `json:"organizer,omitempty"`
-	ContactName string    `json:"contactName,omitempty"`
+	Received    time.Time `json:"received,omitempty"`
+	Sender      string    `json:"sender,omitempty"`
+	Subject     string    `json:"subject,omitempty"`
 }
 
 // Headers returns the human-readable names of properties in an ExchangeInfo


### PR DESCRIPTION
## Description

Graph event objects provide a seriesMasterId
property which is only populated if the event
is part of a recurring set.  This is used to populate
the ExchangeInfo event property `recurs`.

## Type of change

Please check the type of change your PR introduces:
- [x] :sunflower: Feature

## Issue(s)

#501 

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
