### PR TITLE
Implement a logging middleware to log Graph requests

### DIFF
--- a/src/internal/connector/graph/service_helper.go
+++ b/src/internal/connector/graph/service_helper.go
@@ -1,9 +1,22 @@
 package graph
 
 import (
+	"context"
+	nethttp "net/http"
+	"net/http/httputil"
+	"os"
+
 	az "github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	ka "github.com/microsoft/kiota-authentication-azure-go"
+	khttp "github.com/microsoft/kiota-http-go"
 	msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
+	msgraphgocore "github.com/microsoftgraph/msgraph-sdk-go-core"
+
+	"github.com/alcionai/corso/src/pkg/logger"
+)
+
+const (
+	logGraphRequestsEnvKey = "LOG_GRAPH_REQUESTS"
 )
 
 // CreateAdapter uses provided credentials to log into M365 using Kiota Azure Library
@@ -23,7 +36,32 @@ func CreateAdapter(tenant, client, secret string) (*msgraphsdk.GraphRequestAdapt
 		return nil, err
 	}
 
-	adapter, err := msgraphsdk.NewGraphRequestAdapter(auth)
+	// If the "LOG_GRAPH_REQUESTS" environment variable is not set, return
+	// the default client
+	if os.Getenv(logGraphRequestsEnvKey) == "" {
+		return msgraphsdk.NewGraphRequestAdapter(auth)
+	}
 
-	return adapter, err
+	// Create a client with logging middleware
+	clientOptions := msgraphsdk.GetDefaultClientOptions()
+	defaultMiddlewares := msgraphgocore.GetDefaultMiddlewaresWithOptions(&clientOptions)
+	middlewares := []khttp.Middleware{&LoggingMiddleware{}}
+	middlewares = append(middlewares, defaultMiddlewares...)
+	httpClient := msgraphgocore.GetDefaultClient(&clientOptions, middlewares...)
+
+	return msgraphsdk.NewGraphRequestAdapterWithParseNodeFactoryAndSerializationWriterFactoryAndHttpClient(
+		auth, nil, nil, httpClient)
+}
+
+// LoggingMiddleware can be used to log the http request sent by the graph client
+type LoggingMiddleware struct{}
+
+// Intercept implements the RequestInterceptor interface and decodes the parameters name
+func (handler *LoggingMiddleware) Intercept(
+	pipeline khttp.Pipeline, middlewareIndex int, req *nethttp.Request,
+) (*nethttp.Response, error) {
+	requestDump, _ := httputil.DumpRequest(req, true)
+	logger.Ctx(context.TODO()).Infof("REQUEST: %s", string(requestDump))
+
+	return pipeline.Next(req, middlewareIndex)
 }


### PR DESCRIPTION
## Description

Enables a logging middleware that will log the Graph http calls if the `LOG_GRAPH_REQUESTS` environment variable
is set

## Type of change

Please check the type of change your PR introduces:
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :hamster: Trivial/Minor

## Test Plan

<!-- How will this be tested prior to merging.-->

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E

```$ LOG_GRAPH_REQUESTS=true CORSO_CI_TESTS=true go test -v .
...
=== RUN   TestGraphConnectorIntegrationSuite
2022-09-08T13:39:25.556-0700	INFO	graph/service_helper.go:61	REQUEST: GET /v1.0/users?%24select=id%2CuserPrincipalName HTTP/1.1
Host: graph.microsoft.com
Accept: application/json
Authorization: Bearer <REDACTED>


    integration_runners.go:58: TestGraphConnectorIntegrationSuite run at 2022-09-08T20:39:25.967824Z
=== RUN   TestGraphConnectorIntegrationSuite/TestAccessOfInboxAllUsers
2022-09-08T13:39:26.398-0700	INFO	graph/service_helper.go:61	REQUEST: GET /v1.0/users?%24select=id%2CuserPrincipalName HTTP/1.1
Host: graph.microsoft.com
Accept: application/json
Authorization: Bearer <REDACTED>
```