### PR TITLE
Simplify exchange path constructors

### DIFF
--- a/src/internal/path/path.go
+++ b/src/internal/path/path.go
@@ -176,28 +176,6 @@ func (pb Builder) withPrefix(elements ...string) *Builder {
 	return res
 }
 
-// ToDataLayerExchangeMailFolder returns a Path for an Exchange mail folder or item
-// resource with information useful to the data layer. This includes prefix
-// elements of the path such as the tenant ID, user ID, service, and service
-// category.
-func (pb Builder) ToDataLayerExchangeMailPath(tenant, user string, isItem bool) (Path, error) {
-	if err := pb.verifyPrefix(tenant, user); err != nil {
-		return nil, err
-	}
-
-	return &dataLayerResourcePath{
-		Builder: *pb.withPrefix(
-			tenant,
-			ExchangeService.String(),
-			user,
-			EmailCategory.String(),
-		),
-		service:  ExchangeService,
-		category: EmailCategory,
-		hasItem:  isItem,
-	}, nil
-}
-
 func (pb Builder) ToDataLayerExchangePathForCategory(
 	tenant, user string,
 	category CategoryType,
@@ -207,12 +185,21 @@ func (pb Builder) ToDataLayerExchangePathForCategory(
 		return nil, err
 	}
 
-	switch category {
-	case EmailCategory:
-		return pb.ToDataLayerExchangeMailPath(tenant, user, isItem)
-	default:
-		return nil, errors.New("not implemented")
+	if err := pb.verifyPrefix(tenant, user); err != nil {
+		return nil, err
 	}
+
+	return &dataLayerResourcePath{
+		Builder: *pb.withPrefix(
+			tenant,
+			ExchangeService.String(),
+			user,
+			category.String(),
+		),
+		service:  ExchangeService,
+		category: category,
+		hasItem:  isItem,
+	}, nil
 }
 
 // FromDataLayerPath parses the escaped path p, validates the elements in p


### PR DESCRIPTION
## Description

Allows constructing Contacts and Events category type paths for Exchange.
They all need user and tenant filled in and only differ in the category given.
This makes it easier to call them in more generic situations, so long as the
category is known. It also consolidates code for constructing the paths of those
types.

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [x] :hamster: Trivial/Minor

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #671 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
