### PR TITLE
Use path struct in recovery of exchange

### DIFF
--- a/src/internal/connector/graph_connector.go
+++ b/src/internal/connector/graph_connector.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"strings"
+	stdpath "path"
 	"sync"
 
 	msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
@@ -260,19 +260,25 @@ func (gc *GraphConnector) RestoreExchangeDataCollection(
 
 	for _, dc := range dcs {
 		var (
-			user      string
-			category  path.CategoryType
-			directory = strings.Join(dc.FullPath(), "")
-			items     = dc.Items()
-			// TODO(ashmrtn): Update this when we have path struct support in collections.
-			exit bool
+			items = dc.Items()
+			exit  bool
 		)
 
-		category = path.ToCategoryType(dc.FullPath()[3])
-		user = dc.FullPath()[2]
+		// TODO(ashmrtn): Remove this when data.Collection.FullPath supports path.Path
+		directory, err := path.FromDataLayerPath(
+			stdpath.Join(dc.FullPath()...),
+			false,
+		)
+		if err != nil {
+			errs = support.WrapAndAppend("parsing Collection path", err, errs)
+			continue
+		}
 
-		if _, ok := pathCounter[directory]; !ok {
-			pathCounter[directory] = true
+		category := directory.Category()
+		user := directory.ResourceOwner()
+
+		if _, ok := pathCounter[directory.String()]; !ok {
+			pathCounter[directory.String()] = true
 			folderID, errs = exchange.GetRestoreContainer(&gc.graphService, user, category)
 
 			if errs != nil {


### PR DESCRIPTION
## Description

Preparation for data.Collection.FullPath returning path.Path instead of []string.

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #554 

merge after:
* #820 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
