### PR TITLE
Refactor restore helper

### DIFF
--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -139,7 +139,7 @@ func (op *RestoreOperation) Run(ctx context.Context) (err error) {
 		return err
 	}
 
-	err = gc.RestoreExchangeDataCollection(ctx, dcs)
+	err = gc.RestoreDataCollections(ctx, dcs)
 	if err != nil {
 		err = errors.Wrap(err, "restoring service data")
 		opStats.writeErr = err


### PR DESCRIPTION
## Description

Small refactor of the data collection restore helper so that we can plug-in the OneDrive helpers in a 
follow-up PR

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [x] :hamster: Trivial/Minor

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
