### PR TITLE
generate events

### DIFF
--- a/src/internal/events/events_test.go
+++ b/src/internal/events/events_test.go
@@ -8,6 +8,9 @@ import (
 
 	"github.com/alcionai/corso/src/internal/events"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/account"
+	"github.com/alcionai/corso/src/pkg/credentials"
+	"github.com/alcionai/corso/src/pkg/storage"
 )
 
 type EventsIntegrationSuite struct {
@@ -25,7 +28,28 @@ func TestMetricsIntegrationSuite(t *testing.T) {
 func (suite *EventsIntegrationSuite) TestNewBus() {
 	t := suite.T()
 
-	b := events.NewBus("s3", "bckt", "prfx", "tenid")
+	s, err := storage.NewStorage(
+		storage.ProviderS3,
+		storage.S3Config{
+			Bucket: "bckt",
+			Prefix: "prfx",
+		},
+	)
+	require.NoError(t, err)
+
+	a, err := account.NewAccount(
+		account.ProviderM365,
+		account.M365Config{
+			M365: credentials.M365{
+				ClientID:     "id",
+				ClientSecret: "secret",
+			},
+			TenantID: "tid",
+		},
+	)
+	require.NoError(t, err)
+
+	b := events.NewBus(s, a)
 	require.NotEmpty(t, b)
 
 	require.NoError(t, b.Close())

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/connector/support"
+	"github.com/alcionai/corso/src/internal/events"
 	"github.com/alcionai/corso/src/internal/kopia"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/account"
@@ -53,7 +54,14 @@ func (suite *BackupOpSuite) TestBackupOperation_PersistResults() {
 		}
 	)
 
-	op, err := NewBackupOperation(ctx, control.Options{}, kw, sw, acct, selectors.Selector{})
+	op, err := NewBackupOperation(
+		ctx,
+		control.Options{},
+		kw,
+		sw,
+		acct,
+		selectors.Selector{},
+		events.Bus{})
 	require.NoError(t, err)
 
 	require.NoError(t, op.persistResults(now, &stats))
@@ -119,7 +127,8 @@ func (suite *BackupOpIntegrationSuite) TestNewBackupOperation() {
 				test.kw,
 				test.sw,
 				test.acct,
-				selectors.Selector{})
+				selectors.Selector{},
+				events.Bus{})
 			test.errCheck(t, err)
 		})
 	}
@@ -193,7 +202,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run() {
 				sw,
 				acct,
 				*selected,
-			)
+				events.Bus{})
 			require.NoError(t, err)
 
 			require.NoError(t, bo.Run(ctx))
@@ -246,7 +255,8 @@ func (suite *BackupOpIntegrationSuite) TestBackupOneDrive_Run() {
 		kw,
 		sw,
 		acct,
-		sel.Selector)
+		sel.Selector,
+		events.Bus{})
 	require.NoError(t, err)
 
 	require.NoError(t, bo.Run(ctx))

--- a/src/internal/operations/operation.go
+++ b/src/internal/operations/operation.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/alcionai/corso/src/internal/events"
 	"github.com/alcionai/corso/src/internal/kopia"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/store"
@@ -41,18 +42,21 @@ type operation struct {
 	Options   control.Options `json:"options"`
 	Status    opStatus        `json:"status"`
 
+	bus   events.Bus
 	kopia *kopia.Wrapper
 	store *store.Wrapper
 }
 
 func newOperation(
 	opts control.Options,
+	bus events.Bus,
 	kw *kopia.Wrapper,
 	sw *store.Wrapper,
 ) operation {
 	return operation{
 		CreatedAt: time.Now(),
 		Options:   opts,
+		bus:       bus,
 		kopia:     kw,
 		store:     sw,
 		Status:    InProgress,

--- a/src/internal/operations/operation_test.go
+++ b/src/internal/operations/operation_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/events"
 	"github.com/alcionai/corso/src/internal/kopia"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/store"
@@ -22,7 +23,7 @@ func TestOperationSuite(t *testing.T) {
 
 func (suite *OperationSuite) TestNewOperation() {
 	t := suite.T()
-	op := newOperation(control.Options{}, nil, nil)
+	op := newOperation(control.Options{}, events.Bus{}, nil, nil)
 	assert.Greater(t, op.CreatedAt, time.Time{})
 }
 
@@ -42,7 +43,7 @@ func (suite *OperationSuite) TestOperation_Validate() {
 	}
 	for _, test := range table {
 		suite.T().Run(test.name, func(t *testing.T) {
-			op := newOperation(control.Options{}, test.kw, test.sw)
+			op := newOperation(control.Options{}, events.Bus{}, test.kw, test.sw)
 			test.errCheck(t, op.validate())
 		})
 	}

--- a/src/internal/operations/restore_test.go
+++ b/src/internal/operations/restore_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alcionai/corso/src/internal/connector/exchange"
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/data"
+	"github.com/alcionai/corso/src/internal/events"
 	"github.com/alcionai/corso/src/internal/kopia"
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/internal/tester"
@@ -56,10 +57,18 @@ func (suite *RestoreOpSuite) TestRestoreOperation_PersistResults() {
 		}
 	)
 
-	op, err := NewRestoreOperation(ctx, control.Options{}, kw, sw, acct, "foo", selectors.Selector{})
+	op, err := NewRestoreOperation(
+		ctx,
+		control.Options{},
+		kw,
+		sw,
+		acct,
+		"foo",
+		selectors.Selector{},
+		events.Bus{})
 	require.NoError(t, err)
 
-	require.NoError(t, op.persistResults(now, &stats))
+	require.NoError(t, op.persistResults(ctx, now, &stats))
 
 	assert.Equal(t, op.Status.String(), Completed.String(), "status")
 	assert.Equal(t, op.Results.ItemsRead, len(stats.cs), "items read")
@@ -138,7 +147,8 @@ func (suite *RestoreOpIntegrationSuite) SetupSuite() {
 		kw,
 		sw,
 		acct,
-		bsel.Selector)
+		bsel.Selector,
+		events.Bus{})
 	require.NoError(t, err)
 	require.NoError(t, bo.Run(ctx))
 	require.NotEmpty(t, bo.Results.BackupID)
@@ -189,7 +199,8 @@ func (suite *RestoreOpIntegrationSuite) TestNewRestoreOperation() {
 				test.sw,
 				test.acct,
 				"backup-id",
-				selectors.Selector{})
+				selectors.Selector{},
+				events.Bus{})
 			test.errCheck(t, err)
 		})
 	}
@@ -209,7 +220,8 @@ func (suite *RestoreOpIntegrationSuite) TestRestore_Run() {
 		suite.sw,
 		tester.NewM365Account(t),
 		suite.backupID,
-		rsel.Selector)
+		rsel.Selector,
+		events.Bus{})
 	require.NoError(t, err)
 
 	require.NoError(t, ro.Run(ctx), "restoreOp.Run()")
@@ -236,7 +248,8 @@ func (suite *RestoreOpIntegrationSuite) TestRestore_Run_ErrorNoResults() {
 		suite.sw,
 		tester.NewM365Account(t),
 		suite.backupID,
-		rsel.Selector)
+		rsel.Selector,
+		events.Bus{})
 	require.NoError(t, err)
 	require.Error(t, ro.Run(ctx), "restoreOp.Run() should have 0 results")
 }


### PR DESCRIPTION
## Description

Adds events for repo init, backup start and end,
and restore start and end.  Not all expected
values are available.  TODOs have been marked
for values that need future implementation.

## Type of change

- [x] :sunflower: Feature

## Issue(s)

* #741

## Test Plan

- [x] :zap: Unit test
