### PR TITLE
silence config folder lookup error

### DIFF
--- a/src/cli/config/config.go
+++ b/src/cli/config/config.go
@@ -38,11 +38,6 @@ var (
 func AddConfigFlags(cmd *cobra.Command) {
 	fs := cmd.PersistentFlags()
 
-	_, err := os.Stat(defaultDir)
-	if err != nil {
-		Err(cmd.Context(), "finding "+defaultDir+" directory (default) for config file")
-	}
-
 	fs.StringVar(
 		&configFilePath,
 		"config-file",


### PR DESCRIPTION
## Description

It's not necessary to find the default config file folder when setting up the config flag.

## Type of change

- [x] :bug: Bugfix

## Issue(s)

* #718

## Test Plan

- [x] :muscle: Manual
