### PR TITLE
CLI and selectors tests for folder prefix match

### DIFF
--- a/src/cli/utils/testdata/opts.go
+++ b/src/cli/utils/testdata/opts.go
@@ -72,6 +72,13 @@ var (
 			},
 		},
 		{
+			Name:     "EmailsFolderPrefixMatch",
+			Expected: testdata.ExchangeEmailItems,
+			Opts: utils.ExchangeOpts{
+				EmailFolders: []string{testdata.ExchangeEmailInboxPath.Folder()},
+			},
+		},
+		{
 			Name:     "EmailsBySubject",
 			Expected: testdata.ExchangeEmailItems,
 			Opts: utils.ExchangeOpts{

--- a/src/pkg/selectors/selectors_reduce_test.go
+++ b/src/pkg/selectors/selectors_reduce_test.go
@@ -45,6 +45,19 @@ func (suite *SelectorReduceSuite) TestReduce() {
 			expected: testdata.ExchangeEmailItems,
 		},
 		{
+			name: "ExchangeMailFolderPrefixMatch",
+			selFunc: func() selectors.Reducer {
+				sel := selectors.NewExchangeRestore()
+				sel.Include(sel.MailFolders(
+					selectors.Any(),
+					[]string{testdata.ExchangeEmailInboxPath.Folder()},
+				))
+
+				return sel
+			},
+			expected: testdata.ExchangeEmailItems,
+		},
+		{
 			name: "ExchangeMailSubject",
 			selFunc: func() selectors.Reducer {
 				sel := selectors.NewExchangeRestore()


### PR DESCRIPTION
## Description

Specifying a folder on the CLI should cause the system to do a prefix match on that folder when doing a restore, backup details, or selector reduce operation.

Recently updated behavior, adjusting tests to match new expectations.

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* #913 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
