### PR TITLE
Update gotestfmt package repo in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
 
       # Install gotestfmt
       - name: Set up gotestfmt
-        run: go install github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
+        run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
 
       # AWS creds
       - name: Configure AWS credentials from Test account


### PR DESCRIPTION
## Description

The package was moved to gotesttools org with the original one being deleted soon.

Warning from CI:
>  Warning: You are using the deprecated haveyoudebuggedit/gotestfmt. Please switch to installing gotestfmt by running go install github.com/gotesttools/gotestfmt . This repository will be deleted on January 1, 2023.

**Waiting on https://github.com/alcionai/corso/pull/1102**

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
