### PR TITLE
Use npm install instead of ci in Dockerfile

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get -y update && apt-get -y install gpg emacs curl git make \
 
 WORKDIR /usr/src
 COPY package.json package-lock.json* ./
-RUN npm ci \
+RUN npm install \
   && npm cache clean --force \
   && rm -f package.json package-lock.json*
 ENV PATH /usr/src/node_modules/.bin:$PATH

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,7 +7,7 @@ CORSO_BUILD_MOD := ${CORSO_BUILD_DIR}/mod
 CORSO_BUILD_BIN := ${CORSO_BUILD_DIR}/bin
 CORSO_REPO := /go/src/github.com/alcionai/corso
 CORSO_LOCAL_PATH := $(shell git rev-parse --show-toplevel)
-DOCSC := docker run --rm -it -p 3000:3000 -v ${PWD}:/usr/src/docs alcion/docs
+DOCSC := docker run --rm -it -p 3000:3000 -v ${PWD}:/usr/src/docs alcion/docs:latest
 DOCSE := ${DOCSC} # for enforcing docker container as environment
 GOC :=  docker run --rm -it \
 		-v ${CORSO_LOCAL_PATH}:${CORSO_REPO} -v ${CORSO_BUILD_DIR}:${CORSO_BUILD_DIR} \


### PR DESCRIPTION
## Description

`install` is better for local development than [`ci`](https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable)

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [x] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
