### PR TITLE
Add git shortref to docs build

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,7 +7,8 @@ CORSO_BUILD_MOD := ${CORSO_BUILD_DIR}/mod
 CORSO_BUILD_BIN := ${CORSO_BUILD_DIR}/bin
 CORSO_REPO := /go/src/github.com/alcionai/corso
 CORSO_LOCAL_PATH := $(shell git rev-parse --show-toplevel)
-DOCSC := docker run --rm -it -p 3000:3000 -v ${PWD}:/usr/src/docs corso/docs
+CORSO_VERSION := $(shell git rev-parse --short HEAD)
+DOCSC := docker run --rm -it -p 3000:3000 -v ${PWD}:/usr/src/docs --env CORSO_VERSION=${CORSO_VERSION} corso/docs
 DOCSE := ${DOCSC} # for enforcing docker container as environment
 GOC :=  docker run --rm -it \
 		-v ${CORSO_LOCAL_PATH}:${CORSO_REPO} -v ${CORSO_BUILD_DIR}:${CORSO_BUILD_DIR} \

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -129,7 +129,7 @@ const config = {
             ],
           },
         ],
-        copyright: `Copyright © ${new Date().getFullYear()}`,
+        copyright: `Copyright © ${new Date().getFullYear()} | Version ${process.env.CORSO_VERSION}`,
       },
       colorMode: {
         defaultMode: 'dark',


### PR DESCRIPTION
## Description

Add git version to docs build

This will help us verify what version of docs has been published. This should be replaced by the git tag for production builds.

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
