### PR TITLE
Add support for pulling Corso version in Docusorus pages

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -28,6 +28,10 @@ const config = {
   },
   staticDirectories: ['static', 'public'],
 
+  customFields: {
+    corsoVersion: process.env.CORSO_VERSION
+  },
+
   plugins: [
     'docusaurus-plugin-sass',
     require.resolve('docusaurus-plugin-image-zoom')

--- a/docs/src/components/CorsoVersion/index.js
+++ b/docs/src/components/CorsoVersion/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
+export default function CorsoVersion() {
+  const { siteConfig } = useDocusaurusContext();
+
+  return (
+    <span>{siteConfig.customFields.corsoVersion}</span>
+  );
+}


### PR DESCRIPTION
## Description

To use this you can do 

```
import CorsoVersion from '@site/src/components/CorsoVersion';

<CorsoVersion/>
```

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [x] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
