### PR TITLE
Replace src/ README

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,20 +1,3 @@
-# SRC Directory
+# Corso documentation
 
-## /pkg
-API and Components which are exposed for external usage.
-
-* /pkg/repository  
-Control layer for coordinating connections and communication with storage provider repositories.
-
-* /pkg/storage  
-Manages compilation and validation of repository configuration and consts.  Both those that are specific to storage providers, and those that are provider-agnostic.
-
------
-
-## /cli
-Command Line Interface controller.  Utilizes /pkg/repository as an exernal dependency.
-
------
-
-## /internal
-Packages which are only intended for use within Corso.
+Please refer to the [Corso docs](https://docs.corsobackup.io/) for help.


### PR DESCRIPTION
## Description

The src README is being included with our binary artifacts. We should either prevent that
or replace it with something more relevant to an end-user.

## Type of change

- [x] :world_map: Documentation
