### PR TITLE
export repoExists error from repository

### DIFF
--- a/src/cli/repo/s3.go
+++ b/src/cli/repo/s3.go
@@ -9,7 +9,6 @@ import (
 	"github.com/alcionai/corso/src/cli/options"
 	. "github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/cli/utils"
-	"github.com/alcionai/corso/src/internal/kopia"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/repository"
 	"github.com/alcionai/corso/src/pkg/storage"
@@ -121,7 +120,7 @@ func initS3Cmd(cmd *cobra.Command, args []string) error {
 
 	r, err := repository.Initialize(ctx, a, s, options.Control())
 	if err != nil {
-		if succeedIfExists && kopia.IsRepoAlreadyExistsError(err) {
+		if succeedIfExists && errors.Is(err, repository.ErrorRepoAlreadyExists) {
 			return nil
 		}
 

--- a/src/cli/repo/s3_integration_test.go
+++ b/src/cli/repo/s3_integration_test.go
@@ -76,6 +76,11 @@ func (suite *S3IntegrationSuite) TestInitS3Cmd() {
 
 			// run the command
 			require.NoError(t, cmd.ExecuteContext(ctx))
+
+			// a second initialization should result in an error
+			err = cmd.ExecuteContext(ctx)
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, repository.ErrorRepoAlreadyExists)
 		})
 	}
 }


### PR DESCRIPTION
## Description

Intercept the lower-level RepoAlreadyExists error, and field a repository package version of the same error for sdk consumers to identify when initializing corso repos.

## Type of change

- [x] :sunflower: Feature

## Issue(s)

* #1136

## Test Plan

- [x] :muscle: Manual
- [x] :green_heart: E2E
