### PR TITLE
add rolling data production to load test

### DIFF
--- a/.github/workflows/load_test.yml
+++ b/.github/workflows/load_test.yml
@@ -52,6 +52,7 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           AZURE_TENANT_ID: ${{ secrets.TENANT_ID }}
           CORSO_PASSPHRASE: ${{ secrets.INTEGRATION_TEST_CORSO_PASSPHRASE }}
+          CORSO_M356_LOAD_TEST_USER_ID: ${{ secrets.CORSO_M356_LOAD_TEST_USER_ID }}
           CORSO_LOAD_TESTS: true 
         run: |
           set -euo pipefail
@@ -78,6 +79,37 @@ jobs:
           path: src/test_results/*
           if-no-files-found: error
           retention-days: 14
+        
+      # currently, we're required to generate a unique folder for each factory
+      # production.  Whenever possible, this should be reverted to increasing the
+      # item count of a single folder instead, to prevent overproduction of folders
+      # during restore.
+      - name: Set folder destination date
+        run: |
+          echo "NOW=$(date -u +"%Y-%m-%d_%H-%M-%S")" >> $GITHUB_ENV
+
+      # generate new entries to roll into the next load test
+      # only runs if the test was successful
+      - name: New Data Creation
+        working-directory: ./src/cmd/factory
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+          AZURE_TENANT_ID: ${{ secrets.TENANT_ID }}
+          CORSO_M356_LOAD_TEST_USER_ID: ${{ secrets.CORSO_M356_LOAD_TEST_USER_ID }}
+        run: |
+          go run . exchange emails \
+          --user ${{ env.CORSO_M356_LOAD_TEST_USER_ID }} \
+          --destination lt_${{ env.NOW }} \
+          --count 10
+          go run . exchange contacts \
+          --user ${{ env.CORSO_M356_LOAD_TEST_USER_ID }} \
+          --destination lt_${{ env.NOW }} \
+          --count 10
+          go run . exchange events \
+          --user ${{ env.CORSO_M356_LOAD_TEST_USER_ID }} \
+          --destination lt_${{ env.NOW }} \
+          --count 10
 
       # cleanup folders produced by load test
       - name: Restored Folder Purge
@@ -92,4 +124,3 @@ jobs:
           go run ./cmd/purge/purge.go
           --user '*'
           --prefix ${{ env.DELETE_FOLDER_PREFIX }}
-        

--- a/src/internal/tester/config.go
+++ b/src/internal/tester/config.go
@@ -23,6 +23,7 @@ const (
 	TestCfgAzureTenantID   = "azure_tenantid"
 	TestCfgUserID          = "m365userid"
 	TestCfgSecondaryUserID = "secondarym365userid"
+	TestCfgLoadTestUserID  = "loadttestm365userid"
 	TestCfgAccountProvider = "account_provider"
 )
 
@@ -30,6 +31,7 @@ const (
 const (
 	EnvCorsoM365TestUserID          = "CORSO_M356_TEST_USER_ID"
 	EnvCorsoSecondaryM365TestUserID = "CORSO_SECONDARY_M356_TEST_USER_ID"
+	EnvCorsoM365LoadTestUserID      = "CORSO_M356_LOAD_TEST_USER_ID"
 	EnvCorsoTestConfigFilePath      = "CORSO_TEST_CONFIG_FILE"
 )
 
@@ -118,6 +120,13 @@ func readTestConfig() (map[string]string, error) {
 		vpr.GetString(TestCfgSecondaryUserID),
 		"lidiah@8qzvrj.onmicrosoft.com",
 		//"lynner@8qzvrj.onmicrosoft.com",
+	)
+	fallbackTo(
+		testEnv,
+		TestCfgLoadTestUserID,
+		os.Getenv(EnvCorsoM365LoadTestUserID),
+		vpr.GetString(TestCfgLoadTestUserID),
+		"leeg@8qzvrj.onmicrosoft.com",
 	)
 
 	testEnv[EnvCorsoTestConfigFilePath] = os.Getenv(EnvCorsoTestConfigFilePath)

--- a/src/internal/tester/users.go
+++ b/src/internal/tester/users.go
@@ -28,3 +28,15 @@ func SecondaryM365UserID(t *testing.T) string {
 
 	return cfg[TestCfgSecondaryUserID]
 }
+
+// LoadTestM365UserID returns an userID string representing the m365UserID
+// described by either the env var CORSO_M356_LOAD_TEST_USER_ID, the
+// corso_test.toml config file or the default value (in that order of priority).
+// The default is a last-attempt fallback that will only work on alcion's
+// testing org.
+func LoadTestM365UserID(t *testing.T) string {
+	cfg, err := readTestConfig()
+	require.NoError(t, err, "retrieving load test m365 user id from test configuration")
+
+	return cfg[TestCfgLoadTestUserID]
+}


### PR DESCRIPTION
## Description

Adds production of 10 exchange items of each type, only for the load_test user, every time the load tests succeed.  Also migrates that user ID out to a secret value stored in github.

## Type of change

- [x] :robot: Test

## Issue(s)

* #902

## Test Plan

- [x] :green_heart: E2E
