### PR TITLE
Check if a string matches shortref pattern

### DIFF
--- a/src/pkg/path/path.go
+++ b/src/pkg/path/path.go
@@ -39,6 +39,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -57,6 +58,8 @@ var charactersToEscape = map[rune]struct{}{
 	pathSeparator:   {},
 	escapeCharacter: {},
 }
+
+var shortRefRegex = regexp.MustCompile("^[a-fA-F0-9]*$")
 
 var errMissingSegment = errors.New("missing required path element")
 
@@ -94,6 +97,25 @@ type Path interface {
 	ShortRef() string
 	// ToBuilder returns a Builder instance that represents the current Path.
 	ToBuilder() *Builder
+}
+
+// MaybeShortRef takes a stirng and returns true if this string could possibly
+// be a ShortRef. Otherwise it returns false. A return value of true does not
+// absolutely mean the string is a ShortRef returned by some item, only that it
+// fits the pattern ShortRefs use.
+func MaybeShortRef(ref string) bool {
+	// Keep separate from regex match below in case we start supporting multiple
+	// sizes. Also avoids having to change multiple bits of code if we do update
+	// the size.
+	if len(ref) != shortRefCharacters {
+		return false
+	}
+
+	if !shortRefRegex.MatchString(ref) {
+		return false
+	}
+
+	return true
 }
 
 // Builder is a simple path representation that only tracks path elements. It

--- a/src/pkg/path/path_test.go
+++ b/src/pkg/path/path_test.go
@@ -426,6 +426,50 @@ func (suite *PathUnitSuite) TestShortRefUniqueWithEscaping() {
 	assert.NotEqual(suite.T(), pb1.ShortRef(), pb2.ShortRef())
 }
 
+func (suite *PathUnitSuite) TestMaybeShortRef() {
+	table := []struct {
+		name  string
+		input string
+		check assert.BoolAssertionFunc
+	}{
+		{
+			name:  "FromPath",
+			input: Builder{}.Append(`this`, `is/a`, `path`).ShortRef(),
+			check: assert.True,
+		},
+		{
+			name:  "TooShort",
+			input: Builder{}.Append(`this`, `is/a`, `path`).ShortRef()[:shortRefCharacters-1],
+			check: assert.False,
+		},
+		{
+			name:  "TooLong",
+			input: Builder{}.Append(`this`, `is/a`, `path`).ShortRef() + "a",
+			check: assert.False,
+		},
+		{
+			name:  "WrongStartingCharacter",
+			input: "z0123456789ab",
+			check: assert.False,
+		},
+		{
+			name:  "WrongEndingCharacter",
+			input: "0123456789abz",
+			check: assert.False,
+		},
+		{
+			name:  "WrongCharacter",
+			input: "0123z456789ab",
+			check: assert.False,
+		},
+	}
+	for _, test := range table {
+		suite.T().Run(test.name, func(t *testing.T) {
+			test.check(t, MaybeShortRef(test.input))
+		})
+	}
+}
+
 func (suite *PathUnitSuite) TestFromStringErrors() {
 	table := []struct {
 		name        string


### PR DESCRIPTION
## Description

Function to see if a given string matches the pattern of a shortref. Can help infer if something is a shortref or not.

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* #1216 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
