### PR TITLE
Function to get only folders from backup details

### DIFF
--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -102,6 +102,21 @@ func (dm DetailsModel) Items() []*DetailsEntry {
 	return res
 }
 
+// Folders returns a slice of *ItemInfo that contains only FolderInfo entries.
+func (dm DetailsModel) Folders() []*DetailsEntry {
+	res := []*DetailsEntry{}
+
+	for i := 0; i < len(dm.Entries); i++ {
+		if dm.Entries[i].Folder == nil {
+			continue
+		}
+
+		res = append(res, &dm.Entries[i])
+	}
+
+	return res
+}
+
 // --------------------------------------------------------------------------------
 // Details
 // --------------------------------------------------------------------------------

--- a/src/pkg/backup/details/details_test.go
+++ b/src/pkg/backup/details/details_test.go
@@ -136,9 +136,10 @@ func (suite *DetailsUnitSuite) TestDetailsEntry_HeadersValues() {
 }
 
 var pathItemsTable = []struct {
-	name       string
-	ents       []details.DetailsEntry
-	expectRefs []string
+	name             string
+	ents             []details.DetailsEntry
+	expectRefs       []string
+	expectFolderRefs []string
 }{
 	{
 		name:       "nil entries",
@@ -174,7 +175,8 @@ var pathItemsTable = []struct {
 				},
 			},
 		},
-		expectRefs: []string{"abcde", "12345"},
+		expectRefs:       []string{"abcde", "12345"},
+		expectFolderRefs: []string{"deadbeef"},
 	},
 }
 
@@ -205,6 +207,25 @@ func (suite *DetailsUnitSuite) TestDetailsModel_Items() {
 
 			for _, e := range ents {
 				assert.Contains(t, test.expectRefs, e.RepoRef)
+			}
+		})
+	}
+}
+
+func (suite *DetailsUnitSuite) TestDetailsModel_Folders() {
+	for _, test := range pathItemsTable {
+		suite.T().Run(test.name, func(t *testing.T) {
+			d := details.Details{
+				DetailsModel: details.DetailsModel{
+					Entries: test.ents,
+				},
+			}
+
+			ents := d.Folders()
+			assert.Len(t, ents, len(test.expectFolderRefs))
+
+			for _, e := range ents {
+				assert.Contains(t, test.expectFolderRefs, e.RepoRef)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

Mirror of Items() function but returns only folders entries.

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* #1216 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
