### PR TITLE
1216 exchange folder refs

### DIFF
--- a/src/pkg/path/path.go
+++ b/src/pkg/path/path.go
@@ -39,6 +39,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -57,6 +58,8 @@ var charactersToEscape = map[rune]struct{}{
 	pathSeparator:   {},
 	escapeCharacter: {},
 }
+
+var shortRefRegex = regexp.MustCompile("^[a-fA-F0-9]*$")
 
 var errMissingSegment = errors.New("missing required path element")
 
@@ -94,6 +97,25 @@ type Path interface {
 	ShortRef() string
 	// ToBuilder returns a Builder instance that represents the current Path.
 	ToBuilder() *Builder
+}
+
+// MaybeShortRef takes a stirng and returns true if this string could possibly
+// be a ShortRef. Otherwise it returns false. A return value of true does not
+// absolutely mean the string is a ShortRef returned by some item, only that it
+// fits the pattern ShortRefs use.
+func MaybeShortRef(ref string) bool {
+	// Keep separate from regex match below in case we start supporting multiple
+	// sizes. Also avoids having to change multiple bits of code if we do update
+	// the size.
+	if len(ref) != shortRefCharacters {
+		return false
+	}
+
+	if !shortRefRegex.MatchString(ref) {
+		return false
+	}
+
+	return true
 }
 
 // Builder is a simple path representation that only tracks path elements. It

--- a/src/pkg/path/path_test.go
+++ b/src/pkg/path/path_test.go
@@ -426,6 +426,50 @@ func (suite *PathUnitSuite) TestShortRefUniqueWithEscaping() {
 	assert.NotEqual(suite.T(), pb1.ShortRef(), pb2.ShortRef())
 }
 
+func (suite *PathUnitSuite) TestMaybeShortRef() {
+	table := []struct {
+		name  string
+		input string
+		check assert.BoolAssertionFunc
+	}{
+		{
+			name:  "FromPath",
+			input: Builder{}.Append(`this`, `is/a`, `path`).ShortRef(),
+			check: assert.True,
+		},
+		{
+			name:  "TooShort",
+			input: Builder{}.Append(`this`, `is/a`, `path`).ShortRef()[:shortRefCharacters-1],
+			check: assert.False,
+		},
+		{
+			name:  "TooLong",
+			input: Builder{}.Append(`this`, `is/a`, `path`).ShortRef() + "a",
+			check: assert.False,
+		},
+		{
+			name:  "WrongStartingCharacter",
+			input: "z0123456789ab",
+			check: assert.False,
+		},
+		{
+			name:  "WrongEndingCharacter",
+			input: "0123456789abz",
+			check: assert.False,
+		},
+		{
+			name:  "WrongCharacter",
+			input: "0123z456789ab",
+			check: assert.False,
+		},
+	}
+	for _, test := range table {
+		suite.T().Run(test.name, func(t *testing.T) {
+			test.check(t, MaybeShortRef(test.input))
+		})
+	}
+}
+
 func (suite *PathUnitSuite) TestFromStringErrors() {
 	table := []struct {
 		name        string

--- a/src/pkg/selectors/exchange.go
+++ b/src/pkg/selectors/exchange.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"strconv"
 
+	"github.com/pkg/errors"
+
 	"github.com/alcionai/corso/src/internal/common"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/filters"
@@ -638,6 +640,15 @@ func (s ExchangeScope) setDefaults() {
 // ---------------------------------------------------------------------------
 // Backup Details Filtering
 // ---------------------------------------------------------------------------
+
+func (s exchange) FolderRefToPath(ref string, deets *details.Details) (string, error) {
+	p, err := folderRefToPath(ref, deets)
+	if err != nil {
+		return "", errors.Wrap(err, "resolving Exchange folder ref")
+	}
+
+	return p.Folder(), nil
+}
 
 // Reduce filters the entries in a details struct to only those that match the
 // inclusions, filters, and exclusions in the selector.

--- a/src/pkg/selectors/exchange_test.go
+++ b/src/pkg/selectors/exchange_test.go
@@ -1,6 +1,7 @@
 package selectors
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -1391,6 +1392,106 @@ func (suite *ExchangeSelectorSuite) TestCategoryFromItemType() {
 		suite.T().Run(test.name, func(t *testing.T) {
 			result := categoryFromItemType(test.input)
 			assert.Equal(t, test.expect, result)
+		})
+	}
+}
+
+func (suite *ExchangeSelectorSuite) TestFolderRefToPath() {
+	folder1 := path.Builder{}.Append(
+		"a-tenant",
+		path.ExchangeService.String(),
+		"a-user",
+		path.EmailCategory.String(),
+		"Inbox",
+	)
+	folder2 := folder1.Append("Work")
+	email1 := folder1.Append("email1")
+	email2 := folder2.Append("email2")
+
+	deets := &details.Details{
+		DetailsModel: details.DetailsModel{
+			Entries: []details.DetailsEntry{
+				{
+					RepoRef:  folder1.String(),
+					ShortRef: folder1.ShortRef(),
+					ItemInfo: details.ItemInfo{
+						Folder: &details.FolderInfo{},
+					},
+				},
+				{
+					RepoRef:   folder2.String(),
+					ShortRef:  folder2.ShortRef(),
+					ParentRef: folder1.ShortRef(),
+					ItemInfo: details.ItemInfo{
+						Folder: &details.FolderInfo{},
+					},
+				},
+				{
+					RepoRef:   email1.String(),
+					ShortRef:  email1.ShortRef(),
+					ParentRef: folder1.ShortRef(),
+					ItemInfo: details.ItemInfo{
+						Exchange: &details.ExchangeInfo{},
+					},
+				},
+				{
+					RepoRef:   email2.String(),
+					ShortRef:  email2.ShortRef(),
+					ParentRef: folder2.ShortRef(),
+					ItemInfo: details.ItemInfo{
+						Exchange: &details.ExchangeInfo{},
+					},
+				},
+			},
+		},
+	}
+	table := []struct {
+		name     string
+		ref      string
+		expected string
+		errCheck assert.ErrorAssertionFunc
+	}{
+		{
+			name:     "RefTooShort",
+			ref:      folder1.ShortRef()[:len(folder1.ShortRef())-1],
+			errCheck: assert.Error,
+		},
+		{
+			name:     "RefTooLong",
+			ref:      folder1.ShortRef() + "a",
+			errCheck: assert.Error,
+		},
+		{
+			name:     "NotFound",
+			ref:      strings.Repeat("a", len(folder1.ShortRef())),
+			errCheck: assert.Error,
+		},
+		{
+			name:     "TopLevelFolder",
+			ref:      folder1.ShortRef(),
+			errCheck: assert.NoError,
+			expected: "Inbox",
+		},
+		{
+			name:     "SubFolder",
+			ref:      folder2.ShortRef(),
+			errCheck: assert.NoError,
+			expected: "Inbox/Work",
+		},
+	}
+
+	for _, test := range table {
+		suite.T().Run(test.name, func(t *testing.T) {
+			sel := NewExchangeBackup()
+
+			p, err := sel.FolderRefToPath(test.ref, deets)
+			test.errCheck(t, err)
+
+			if err != nil {
+				return
+			}
+
+			assert.Equal(t, test.expected, p)
 		})
 	}
 }


### PR DESCRIPTION
## Description

Translate exchange folder ShortRef into a folder path that can be used in a selector.

#1341 is cherry-picked into this branch as the first commit so it compiles, but will be removed once it merges

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* #1216 

merge after:
* #1342 
* #1341 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
