### PR TITLE
DO NOT MERGE -- alternate folder ref matching

### DIFF
--- a/src/pkg/selectors/exchange_test.go
+++ b/src/pkg/selectors/exchange_test.go
@@ -817,7 +817,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeScope_MatchesPath() {
 			var aMatch bool
 			for _, scope := range scopes {
 				pv := ExchangeMail.pathValues(pth)
-				if matchesPathValues(scope, ExchangeMail, pv, short) {
+				if matchesPathValues(scope, ExchangeMail, pv, short, nil) {
 					aMatch = true
 					break
 				}

--- a/src/pkg/selectors/scopes_test.go
+++ b/src/pkg/selectors/scopes_test.go
@@ -371,7 +371,7 @@ func (suite *SelectorScopesSuite) TestMatchesPathValues() {
 			sc[rootCatStub.String()] = filterize(scopeConfig{}, test.rootVal)
 			sc[leafCatStub.String()] = filterize(scopeConfig{}, test.leafVal)
 
-			test.expect(t, matchesPathValues(sc, cat, pvs, test.shortRef))
+			test.expect(t, matchesPathValues(sc, cat, pvs, test.shortRef, nil))
 		})
 	}
 }

--- a/src/pkg/selectors/selectors_reduce_test.go
+++ b/src/pkg/selectors/selectors_reduce_test.go
@@ -278,6 +278,85 @@ func (suite *SelectorReduceSuite) TestReduce() {
 			},
 			expected: testdata.ExchangeEventsItems,
 		},
+		{
+			name: "ExchangeMailFolderRefPrefixMatch",
+			selFunc: func() selectors.Reducer {
+				sel := selectors.NewExchangeRestore()
+				sel.Include(sel.MailFolders(
+					selectors.Any(),
+					[]string{testdata.ExchangeEmailInboxPath.ShortRef()},
+				))
+
+				return sel
+			},
+			expected: testdata.ExchangeEmailItems,
+		},
+		{
+			name: "ExchangeMailByFolderRef",
+			selFunc: func() selectors.Reducer {
+				sel := selectors.NewExchangeRestore()
+				sel.Include(sel.MailFolders(
+					selectors.Any(),
+					[]string{testdata.ExchangeEmailBasePath.ShortRef()},
+				))
+
+				return sel
+			},
+			expected: []details.DetailsEntry{testdata.ExchangeEmailItems[0]},
+		},
+		{
+			name: "ExchangeContactByFolderRef",
+			selFunc: func() selectors.Reducer {
+				sel := selectors.NewExchangeRestore()
+				sel.Include(sel.ContactFolders(
+					selectors.Any(),
+					[]string{testdata.ExchangeContactsBasePath.ShortRef()},
+				))
+
+				return sel
+			},
+			expected: []details.DetailsEntry{testdata.ExchangeContactsItems[0]},
+		},
+		{
+			name: "ExchangeContactByFolderRefRoot",
+			selFunc: func() selectors.Reducer {
+				sel := selectors.NewExchangeRestore()
+				sel.Include(sel.ContactFolders(
+					selectors.Any(),
+					[]string{testdata.ExchangeContactsRootPath.ShortRef()},
+				))
+
+				return sel
+			},
+			expected: testdata.ExchangeContactsItems,
+		},
+
+		{
+			name: "ExchangeEventsByFolderRef",
+			selFunc: func() selectors.Reducer {
+				sel := selectors.NewExchangeRestore()
+				sel.Include(sel.EventCalendars(
+					selectors.Any(),
+					[]string{testdata.ExchangeEventsBasePath.ShortRef()},
+				))
+
+				return sel
+			},
+			expected: []details.DetailsEntry{testdata.ExchangeEventsItems[0]},
+		},
+		{
+			name: "ExchangeEventsByFolderRefRoot",
+			selFunc: func() selectors.Reducer {
+				sel := selectors.NewExchangeRestore()
+				sel.Include(sel.EventCalendars(
+					selectors.Any(),
+					[]string{testdata.ExchangeEventsRootPath.ShortRef()},
+				))
+
+				return sel
+			},
+			expected: testdata.ExchangeEventsItems,
+		},
 	}
 
 	for _, test := range table {


### PR DESCRIPTION
## Description

Alternate way of selecting folders if given a ShortRef as the argument. Assumes prefix matching. Not super efficient as it has no caching and always tries to match to all folder elements, even if some are hidden from the user like with OneDrive

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* #1216 

merge after
* #1341 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
