### PR TITLE
Windows container image builds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Build/Release Corso
+env:
+  IMAGE_NAME: ghcr.io/alcionai/corso
 on:
   workflow_dispatch:
   pull_request:
@@ -201,6 +203,7 @@ jobs:
     outputs:
       environment: ${{ steps.environment.outputs.environment }}
       version: ${{ steps.version.outputs.version }}
+      imgtag: ${{ steps.imgtag.outputs.imgtag }}
     steps:
       - uses: actions/checkout@v3
 
@@ -224,6 +227,17 @@ jobs:
           else
             echo "set-output name=version::$(echo unreleased-$(git rev-parse --short HEAD))"
             echo "::set-output name=version::$(echo unreleased-$(git rev-parse --short HEAD))"
+          fi
+
+      - name: Get image tag
+        id: imgtag
+        run: |
+          if ${{ startsWith(github.ref, 'refs/tags/') }}; then
+            echo "set-output name=imgtag::$(git describe --exact-match --tags $(git rev-parse HEAD))"
+            echo "::set-output name=imgtag::$(git describe --exact-match --tags $(git rev-parse HEAD))"
+          else
+            echo "set-output name=imgtag::$(git rev-parse --short HEAD)"
+            echo "::set-output name=imgtag::$(git rev-parse --short HEAD)"
           fi
 
   Publish-Binary:
@@ -311,8 +325,9 @@ jobs:
         run: |
           aws cloudfront create-invalidation --distribution-id ${{ secrets.DOCS_CF_DISTRIBUTION }} --paths "/*"
 
-  Publish-Image:
-    needs: [Test-Suite, Linting, Docs-Linting, SetEnv]
+  Publish-Image-Linux:
+    name: Build and Publish Containers (Linux)
+    needs: [ Linting, Docs-Linting, SetEnv]
     environment: ${{ needs.SetEnv.outputs.environment }}
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
@@ -320,7 +335,6 @@ jobs:
       run:
         working-directory: build
     env:
-      imageName: ghcr.io/alcionai/corso
       PLATFORMS: linux/amd64,linux/arm64
     steps:
       - uses: actions/checkout@v3
@@ -339,16 +353,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ env.imageName }}
-          tags: |
-            type=ref,event=tag
-            type=sha,format=short,prefix=
-            type=raw,value=nightly
-
       # deploy the image
       - name: Build image and push to GitHub Container Registry
         uses: docker/build-push-action@v3
@@ -357,10 +361,89 @@ jobs:
           file: ./build/Dockerfile
           platforms: ${{ env.PLATFORMS }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ env.IMAGE_NAME }}:${{ needs.SetEnv.outputs.imgtag }}-linux
           build-args: |
-            CORSO_BUILD_LDFLAGS=-X 'github.com/alcionai/corso/src/internal/events.RudderStackWriteKey=${{ secrets.RUDDERSTACK_CORSO_WRITE_KEY }}' -X 'github.com/alcionai/corso/src/internal/events.RudderStackDataPlaneURL=${{ secrets.RUDDERSTACK_CORSO_DATA_PLANE_URL }}' -X 'github.com/alcionai/corso/src/cli.version=$(git describe --exact-match --tags $(git rev-parse HEAD) 2>/dev/null || echo unreleased)-$(git rev-parse --short HEAD)'
+            CORSO_BUILD_LDFLAGS=-X 'github.com/alcionai/corso/src/internal/events.RudderStackWriteKey=${{ secrets.RUDDERSTACK_CORSO_WRITE_KEY }}' -X 'github.com/alcionai/corso/src/internal/events.RudderStackDataPlaneURL=${{ secrets.RUDDERSTACK_CORSO_DATA_PLANE_URL }}' -X 'github.com/alcionai/corso/src/cli.version=${{ needs.SetEnv.outputs.version }}'
           # use the github cache
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  Publish-Image-Windows:
+    name: Build and Publish Containers (Windows)
+    needs: [ Linting, Docs-Linting, SetEnv]
+    environment: ${{ needs.SetEnv.outputs.environment }}
+    runs-on: windows-2022
+    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # retrieve credentials for ghcr.io
+      - name: Login to Github Packages
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker Build
+        run: |
+          docker build -f docker/Dockerfile-windows --build-arg CORSO_BUILD_LDFLAGS="-X 'github.com/alcionai/corso/src/internal/events.RudderStackWriteKey=${{ secrets.RUDDERSTACK_CORSO_WRITE_KEY }}' -X 'github.com/alcionai/corso/src/internal/events.RudderStackDataPlaneURL=${{ secrets.RUDDERSTACK_CORSO_DATA_PLANE_URL }}' -X 'github.com/alcionai/corso/src/cli.version=${{ needs.SetEnv.outputs.version }}'" -t ${{ env.IMAGE_NAME }}:${{ needs.SetEnv.outputs.imgtag }}-windows .
+
+      - name: Docker Push
+        run: |
+          docker push ${{ env.IMAGE_NAME }}:${{ needs.SetEnv.outputs.imgtag }}-windows
+
+  Publish-Image-Manifest:
+    name: Publish manifest for images
+    needs: [Publish-Image-Linux, Publish-Image-Windows, SetEnv]
+    environment: ${{ needs.SetEnv.outputs.environment }}
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      # retrieve credentials for ghcr.io
+      - name: Login to Github Packages
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=sha,format=short,prefix=
+            type=raw,value=nightly
+
+      - name: Docker Manifest create
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.IMAGE_NAME }}:${{ needs.SetEnv.outputs.imgtag }} \
+            ${{ env.IMAGE_NAME }}:${{ needs.SetEnv.outputs.imgtag }}-linux \
+            ${{ env.IMAGE_NAME }}:${{ needs.SetEnv.outputs.imgtag }}-windows
+
+      - name: Docker Manifest create nightly
+        if: github.ref == 'refs/heads/main'
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.IMAGE_NAME }}:nightly \
+            ${{ env.IMAGE_NAME }}:${{ needs.SetEnv.outputs.imgtag }}-linux \
+            ${{ env.IMAGE_NAME }}:${{ needs.SetEnv.outputs.imgtag }}-windows
+
+      - name: Docker Manifest create latest
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.IMAGE_NAME }}:latest \
+            ${{ env.IMAGE_NAME }}:${{ needs.SetEnv.outputs.imgtag }}-linux \
+            ${{ env.IMAGE_NAME }}:${{ needs.SetEnv.outputs.imgtag }}-windows

--- a/docker/Dockerfile-windows
+++ b/docker/Dockerfile-windows
@@ -1,0 +1,28 @@
+FROM golang:windowsservercore-ltsc2022 as builder
+
+WORKDIR /go/src/app
+COPY src .
+
+ARG CORSO_BUILD_LDFLAGS="" # ldflags
+RUN go build -o corso -ldflags $env:CORSO_BUILD_LDFLAGS
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
+
+LABEL org.opencontainers.image.title="Corso"
+LABEL org.opencontainers.image.description="Free, Secure, and Open-Source Backup for Microsoft 365"
+LABEL org.opencontainers.image.url="https://github.com/alcionai/corso"
+LABEL org.opencontainers.image.source="https://github.com/alcionai/corso"
+LABEL org.opencontainers.image.vendor="Alcion, Inc."
+
+COPY --from=builder /go/src/app/corso /corso
+
+ENV CORSO_HOME=/app/corso
+ENV CORSO_CONFIG_DIR=$CORSO_HOME \
+	KOPIA_CONFIG_PATH=$CORSO_HOME/kopia/config/repository.config \
+	KOPIA_LOG_DIR=$CORSO_HOME/kopia/logs \
+	KOPIA_CACHE_DIRECTORY=$CORSO_HOME/kopia/cache \
+	RCLONE_CONFIG=$CORSO_HOME/kopia/rclone/rclone.conf \
+	KOPIA_PERSIST_CREDENTIALS_ON_CONNECT=false \
+	KOPIA_CHECK_FOR_UPDATES=false
+
+ENTRYPOINT ["/corso"]


### PR DESCRIPTION
## Description

Enabled Windows container image builds in CI.

> As of now there is a small caveat in that we have to publish intermediate images to `ghcr`. For example, when publishing `v0.0.1`, it will first publish `v0.0.1-linux` and `v0.0.1-windows` and then create a combined version `v0.0.1`. At the end all 3 will be available on ghcr. I have tried quite a few things to avoid it, but could get anything working reliably.

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* fixes https://github.com/alcionai/corso/issues/1322

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
