### PR TITLE
Set file mod time in KopiaWrapper

### DIFF
--- a/src/internal/connector/mockconnector/mock_data_collection.go
+++ b/src/internal/connector/mockconnector/mock_data_collection.go
@@ -19,6 +19,7 @@ type MockExchangeDataCollection struct {
 	messageCount int
 	Data         [][]byte
 	Names        []string
+	ModTimes     []time.Time
 }
 
 var (
@@ -36,12 +37,15 @@ func NewMockExchangeCollection(pathRepresentation path.Path, numMessagesToReturn
 		messageCount: numMessagesToReturn,
 		Data:         [][]byte{},
 		Names:        []string{},
+		ModTimes:     []time.Time{},
 	}
+	baseTime := time.Now()
 
 	for i := 0; i < c.messageCount; i++ {
 		// We can plug in whatever data we want here (can be an io.Reader to a test data file if needed)
 		c.Data = append(c.Data, GetMockMessageBytes("From: NewMockExchangeCollection"))
 		c.Names = append(c.Names, uuid.NewString())
+		c.ModTimes = append(c.ModTimes, baseTime.Add(1*time.Hour))
 	}
 
 	return c
@@ -100,7 +104,7 @@ func (medc *MockExchangeDataCollection) Items() <-chan data.Stream {
 				ID:           medc.Names[i],
 				Reader:       io.NopCloser(bytes.NewReader(medc.Data[i])),
 				size:         int64(len(medc.Data[i])),
-				ModifiedTime: time.Now(),
+				modifiedTime: medc.ModTimes[i],
 			}
 		}
 	}()
@@ -114,7 +118,7 @@ type MockExchangeData struct {
 	Reader       io.ReadCloser
 	ReadErr      error
 	size         int64
-	ModifiedTime time.Time
+	modifiedTime time.Time
 }
 
 func (med *MockExchangeData) UUID() string {
@@ -144,7 +148,7 @@ func (med *MockExchangeData) Size() int64 {
 }
 
 func (med *MockExchangeData) ModTime() time.Time {
-	return med.ModifiedTime
+	return med.modifiedTime
 }
 
 type errReader struct {

--- a/src/internal/connector/mockconnector/mock_data_collection.go
+++ b/src/internal/connector/mockconnector/mock_data_collection.go
@@ -109,10 +109,11 @@ func (medc *MockExchangeDataCollection) Items() <-chan data.Stream {
 
 // ExchangeData represents a single item retrieved from exchange
 type MockExchangeData struct {
-	ID      string
-	Reader  io.ReadCloser
-	ReadErr error
-	size    int64
+	ID           string
+	Reader       io.ReadCloser
+	ReadErr      error
+	size         int64
+	ModifiedTime time.Time
 }
 
 func (med *MockExchangeData) UUID() string {
@@ -139,6 +140,10 @@ func (med *MockExchangeData) Info() details.ItemInfo {
 
 func (med *MockExchangeData) Size() int64 {
 	return med.size
+}
+
+func (med *MockExchangeData) ModTime() time.Time {
+	return med.ModifiedTime
 }
 
 type errReader struct {

--- a/src/internal/connector/mockconnector/mock_data_collection.go
+++ b/src/internal/connector/mockconnector/mock_data_collection.go
@@ -97,9 +97,10 @@ func (medc *MockExchangeDataCollection) Items() <-chan data.Stream {
 
 		for i := 0; i < medc.messageCount; i++ {
 			res <- &MockExchangeData{
-				ID:     medc.Names[i],
-				Reader: io.NopCloser(bytes.NewReader(medc.Data[i])),
-				size:   int64(len(medc.Data[i])),
+				ID:           medc.Names[i],
+				Reader:       io.NopCloser(bytes.NewReader(medc.Data[i])),
+				size:         int64(len(medc.Data[i])),
+				ModifiedTime: time.Now(),
 			}
 		}
 	}()

--- a/src/internal/data/data_collection.go
+++ b/src/internal/data/data_collection.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"io"
+	"time"
 
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -45,6 +46,11 @@ type StreamInfo interface {
 // information about the Stream
 type StreamSize interface {
 	Size() int64
+}
+
+// StreamModTime is used to provide the modified time of the stream's data.
+type StreamModTime interface {
+	ModTime() time.Time
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -128,6 +128,8 @@ type BackupStats struct {
 	TotalUploadedBytes int64
 
 	TotalFileCount      int
+	CachedFileCount     int
+	UncachedFileCount   int
 	TotalDirectoryCount int
 	IgnoredErrorCount   int
 	ErrorCount          int
@@ -148,6 +150,8 @@ func manifestToStats(
 		TotalUploadedBytes: uploadCount.NumBytes,
 
 		TotalFileCount:      int(man.Stats.TotalFileCount),
+		CachedFileCount:     int(man.Stats.CachedFiles),
+		UncachedFileCount:   int(man.Stats.NonCachedFiles),
 		TotalDirectoryCount: int(man.Stats.TotalDirectoryCount),
 		IgnoredErrorCount:   int(man.Stats.IgnoredErrorCount),
 		ErrorCount:          int(man.Stats.ErrorCount),

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -7,6 +7,7 @@ import (
 	"runtime/trace"
 	"sync"
 	"sync/atomic"
+	"time"
 	"unsafe"
 
 	"github.com/hashicorp/go-multierror"
@@ -340,8 +341,14 @@ func getStreamItemFunc(
 				d := &itemDetails{info: ei.Info(), repoPath: itemPath}
 				progress.put(encodeAsPath(itemPath.PopFront().Elements()...), d)
 
-				entry := virtualfs.StreamingFileFromReader(
+				modTime := time.Now()
+				if smt, ok := e.(data.StreamModTime); ok {
+					modTime = smt.ModTime()
+				}
+
+				entry := virtualfs.StreamingFileWithModTimeFromReader(
 					encodeAsPath(e.UUID()),
+					modTime,
 					&backupStreamReader{
 						version:    serializationVersion,
 						ReadCloser: e.ToReader(),

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -885,12 +885,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 			stats, deets, err := suite.w.BackupCollections(suite.ctx, collections, path.ExchangeService)
 			assert.NoError(t, err)
 
-			assert.Equal(
-				t,
-				test.expectedUploadedFiles+test.expectedCachedFiles,
-				stats.TotalFileCount,
-				"total files",
-			)
+			assert.Equal(t, test.expectedUploadedFiles, stats.TotalFileCount, "total files")
 			assert.Equal(t, test.expectedUploadedFiles, stats.UncachedFileCount, "uncached files")
 			assert.Equal(t, test.expectedCachedFiles, stats.CachedFileCount, "cached files")
 			assert.Equal(t, 6, stats.TotalDirectoryCount)


### PR DESCRIPTION
## Description

Set the mod time of uploaded files to either the mod time of the item (if it has one) or the current time (if it does not have one). Also add tests to check caching in kopia works properly.

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* closes #621 

part of:
* #547 

merge after:
* #1427 
* #1430

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
