### PR TITLE
chore: turn off dependabot rebase on prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     reviewers:
       - "corso-maintainers"
     open-pull-requests-limit: 50
+    rebase-strategy: "disabled"
 
   # Maintain dependencies for npm - website
   - package-ecosystem: "npm"
@@ -19,6 +20,7 @@ updates:
     reviewers:
       - "corso-maintainers"
     open-pull-requests-limit: 50
+    rebase-strategy: "disabled"
 
   # Maintain dependencies for npm - docs
   - package-ecosystem: "npm"
@@ -28,6 +30,7 @@ updates:
     reviewers:
       - "corso-maintainers"
     open-pull-requests-limit: 50
+    rebase-strategy: "disabled"
 
   # Maintain dependencies for go - src
   - package-ecosystem: "gomod"
@@ -37,3 +40,4 @@ updates:
     reviewers:
       - "corso-maintainers"
     open-pull-requests-limit: 50
+    rebase-strategy: "disabled"


### PR DESCRIPTION
## Description

* dependabot PRs that are constantly being rebased chews up tons of CI time, this PR will prevent dependabot from rebasing (will require manual intervention).

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
