### PR TITLE
Revert "⬆️ Bump @mdx-js/react from 1.6.22 to 2.1.5 in /docs"

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -11,7 +11,7 @@
         "@docusaurus/core": "2.2.0",
         "@docusaurus/plugin-google-gtag": "^2.2.0",
         "@docusaurus/preset-classic": "2.2.0",
-        "@mdx-js/react": "^2.1.5",
+        "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "docusaurus-plugin-image-zoom": "^0.1.1",
         "docusaurus-plugin-sass": "^0.2.2",
@@ -2677,18 +2677,6 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-classic/node_modules/@mdx-js/react": {
-      "version": "1.6.22",
-      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
-      "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      },
-      "peerDependencies": {
-        "react": "^16.13.1 || ^17.0.0"
-      }
-    },
     "node_modules/@docusaurus/theme-common": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.2.0.tgz",
@@ -3071,19 +3059,15 @@
       }
     },
     "node_modules/@mdx-js/react": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-2.1.5.tgz",
-      "integrity": "sha512-3Az1I6SAWA9R38rYjz5rXBrGKeZhq96CSSyQtqY+maPj8stBsoUH5pNcmIixuGkufYsh8F5+ka2CVPo2fycWZw==",
-      "dependencies": {
-        "@types/mdx": "^2.0.0",
-        "@types/react": ">=16"
-      },
+      "version": "1.6.22",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
+      "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       },
       "peerDependencies": {
-        "react": ">=16"
+        "react": "^16.13.1 || ^17.0.0"
       }
     },
     "node_modules/@mdx-js/util": {
@@ -3547,11 +3531,6 @@
       "dependencies": {
         "@types/unist": "*"
       }
-    },
-    "node_modules/@types/mdx": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.3.tgz",
-      "integrity": "sha512-IgHxcT3RC8LzFLhKwP3gbMPeaK7BM9eBH46OdapPA7yvuIUJ8H6zHZV53J8hGZcTSnt95jANt+rTBNUUc22ACQ=="
     },
     "node_modules/@types/mime": {
       "version": "3.0.1",
@@ -15884,12 +15863,6 @@
             "webpack": "^5.73.0",
             "webpack-merge": "^5.8.0"
           }
-        },
-        "@mdx-js/react": {
-          "version": "1.6.22",
-          "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
-          "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
-          "requires": {}
         }
       }
     },
@@ -16191,13 +16164,10 @@
       }
     },
     "@mdx-js/react": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-2.1.5.tgz",
-      "integrity": "sha512-3Az1I6SAWA9R38rYjz5rXBrGKeZhq96CSSyQtqY+maPj8stBsoUH5pNcmIixuGkufYsh8F5+ka2CVPo2fycWZw==",
-      "requires": {
-        "@types/mdx": "^2.0.0",
-        "@types/react": ">=16"
-      }
+      "version": "1.6.22",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
+      "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
+      "requires": {}
     },
     "@mdx-js/util": {
       "version": "1.6.22",
@@ -16512,11 +16482,6 @@
       "requires": {
         "@types/unist": "*"
       }
-    },
-    "@types/mdx": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.3.tgz",
-      "integrity": "sha512-IgHxcT3RC8LzFLhKwP3gbMPeaK7BM9eBH46OdapPA7yvuIUJ8H6zHZV53J8hGZcTSnt95jANt+rTBNUUc22ACQ=="
     },
     "@types/mime": {
       "version": "3.0.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,7 +17,7 @@
     "@docusaurus/core": "2.2.0",
     "@docusaurus/plugin-google-gtag": "^2.2.0",
     "@docusaurus/preset-classic": "2.2.0",
-    "@mdx-js/react": "^2.1.5",
+    "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
     "docusaurus-plugin-image-zoom": "^0.1.1",
     "docusaurus-plugin-sass": "^0.2.2",


### PR DESCRIPTION
Reverts alcionai/corso#1381. This is breaking the docs build but CI was only catching this post-merge.