### PR TITLE
Clean up more in docs Makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -55,5 +55,5 @@ ${MDGEN_BINARY}: $(shell find ${CORSO_LOCAL_PATH}/src -type f -name *.go) $(shel
 		$(GOC) go build -o ${MDGEN_BINARY} ${MDGEN_SRC}
 
 clean:
-	$(DOCSC) rm -rf docs/cli
+	$(DOCSC) rm -rf docs/cli build node_modules
 	$(GOC) rm -rf ${CORSO_BUILD_DIR}/*


### PR DESCRIPTION
## Description

Nuke the auto-generated build and node_modules directory during clean.
Note that this won't affect the docs container image because the container's
node_modules are stored in the (internal) root directory of the mounted docs
folder.

## Type of change

- [x] :world_map: Documentation
- [x] :hamster: Trivial/Minor
