### PR TITLE
Use previous snapshots to allow kopia to find previous versions of files

### DIFF
--- a/src/internal/kopia/conn.go
+++ b/src/internal/kopia/conn.go
@@ -383,16 +383,9 @@ func checkCompressor(compressor compression.Name) error {
 	return errors.Errorf("unknown compressor type %s", compressor)
 }
 
-func (w *conn) FindManifests(
-	ctx context.Context,
-	tags map[string]string,
-) ([]*manifest.EntryMetadata, error) {
-	return w.FindManifests(ctx, tags)
-}
-
 func (w *conn) LoadSnapshots(
 	ctx context.Context,
 	ids []manifest.ID,
 ) ([]*snapshot.Manifest, error) {
-	return snapshot.LoadSnapshots(ctx, w, ids)
+	return snapshot.LoadSnapshots(ctx, w.Repository, ids)
 }

--- a/src/internal/kopia/conn.go
+++ b/src/internal/kopia/conn.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/compression"
 	"github.com/kopia/kopia/repo/content"
+	"github.com/kopia/kopia/repo/manifest"
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/policy"
 	"github.com/pkg/errors"
@@ -58,6 +59,8 @@ func IsRepoAlreadyExistsError(e error) bool {
 	var erae ErrorRepoAlreadyExists
 	return errors.As(e, &erae)
 }
+
+var _ snapshotManager = &conn{}
 
 type conn struct {
 	storage storage.Storage
@@ -378,4 +381,18 @@ func checkCompressor(compressor compression.Name) error {
 	}
 
 	return errors.Errorf("unknown compressor type %s", compressor)
+}
+
+func (w *conn) FindManifests(
+	ctx context.Context,
+	tags map[string]string,
+) ([]*manifest.EntryMetadata, error) {
+	return w.FindManifests(ctx, tags)
+}
+
+func (w *conn) LoadSnapshots(
+	ctx context.Context,
+	ids []manifest.ID,
+) ([]*snapshot.Manifest, error) {
+	return snapshot.LoadSnapshots(ctx, w, ids)
 }

--- a/src/internal/kopia/snapshot_manager.go
+++ b/src/internal/kopia/snapshot_manager.go
@@ -187,9 +187,6 @@ func fetchPrevManifests(
 // incomplete. An incomplete manifest may be returned if it is newer than the
 // newest complete manifest for the tuple. Manifests are deduped such that if
 // multiple tuples match the same manifest it will only be returned once.
-//
-// TODO(ashmrtn): Use to get previous manifests so backup can find previously
-// uploaded versions of a file.
 func fetchPrevSnapshotManifests(
 	ctx context.Context,
 	sm snapshotManager,

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -530,6 +530,8 @@ func (w Wrapper) makeSnapshotWithRoot(
 ) (*BackupStats, error) {
 	var man *snapshot.Manifest
 
+	prevSnaps := fetchPrevSnapshotManifests(ctx, w.c, oc)
+
 	bc := &stats.ByteCounter{}
 
 	err := repo.WriteSession(
@@ -569,7 +571,7 @@ func (w Wrapper) makeSnapshotWithRoot(
 			progress.UploadProgress = u.Progress
 			u.Progress = progress
 
-			man, err = u.Upload(innerCtx, root, policyTree, si)
+			man, err = u.Upload(innerCtx, root, policyTree, si, prevSnaps...)
 			if err != nil {
 				err = errors.Wrap(err, "uploading data")
 				logger.Ctx(innerCtx).Errorw("kopia backup", err)


### PR DESCRIPTION
## Description

Tell kopia about previous snapshots during the backup
so it can make use of them to skip uploading some data.

Currently only selects the most recent completed snapshot
and most recent incomplete snapshot that contains the
information being backed up. This can be tuned later if
it is not working good enough. However, increasing the
number of previous snapshots passed in may increase memory
usage during backup

## Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* closes #1404

merge after:
* #1427 

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
