### PR TITLE
Store/Retrieve owner info for OneDrive files

### DIFF
--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -67,11 +67,13 @@ func driveItemReader(
 // doesn't have its size value updated as a side effect of creation,
 // and kiota drops any SetSize update.
 func driveItemInfo(di models.DriveItemable, itemSize int64) *details.OneDriveInfo {
-	email := ""
 	ed, ok := di.GetCreatedBy().GetUser().GetAdditionalData()["email"]
+
+	email := ""
 	if ok {
 		email = *ed.(*string)
 	}
+
 	return &details.OneDriveInfo{
 		ItemType: details.OneDriveItem,
 		ItemName: *di.GetName(),

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -67,12 +67,14 @@ func driveItemReader(
 // doesn't have its size value updated as a side effect of creation,
 // and kiota drops any SetSize update.
 func driveItemInfo(di models.DriveItemable, itemSize int64) *details.OneDriveInfo {
+	adata := di.GetCreatedBy().GetUser().GetAdditionalData()
 	return &details.OneDriveInfo{
 		ItemType: details.OneDriveItem,
 		ItemName: *di.GetName(),
 		Created:  *di.GetCreatedDateTime(),
 		Modified: *di.GetLastModifiedDateTime(),
 		Size:     itemSize,
+		Owner:    *adata["email"].(*string),
 	}
 }
 

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -67,8 +67,8 @@ func driveItemReader(
 // doesn't have its size value updated as a side effect of creation,
 // and kiota drops any SetSize update.
 func driveItemInfo(di models.DriveItemable, itemSize int64) *details.OneDriveInfo {
-	ed, ok := di.GetCreatedBy().GetUser().GetAdditionalData()["email"]
 	email := ""
+	ed, ok := di.GetCreatedBy().GetUser().GetAdditionalData()["email"]
 	if ok {
 		email = *ed.(*string)
 	}

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -67,14 +67,18 @@ func driveItemReader(
 // doesn't have its size value updated as a side effect of creation,
 // and kiota drops any SetSize update.
 func driveItemInfo(di models.DriveItemable, itemSize int64) *details.OneDriveInfo {
-	adata := di.GetCreatedBy().GetUser().GetAdditionalData()
+	ed, ok := di.GetCreatedBy().GetUser().GetAdditionalData()["email"]
+	email := ""
+	if ok {
+		email = *ed.(*string)
+	}
 	return &details.OneDriveInfo{
 		ItemType: details.OneDriveItem,
 		ItemName: *di.GetName(),
 		Created:  *di.GetCreatedDateTime(),
 		Modified: *di.GetLastModifiedDateTime(),
 		Size:     itemSize,
-		Owner:    *adata["email"].(*string),
+		Owner:    email,
 	}
 }
 

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -367,6 +367,7 @@ type OneDriveInfo struct {
 	ParentPath string    `json:"parentPath"`
 	ItemName   string    `json:"itemName"`
 	Size       int64     `json:"size,omitempty"`
+	Owner      string    `json:"owner,omitempty"`
 	Created    time.Time `json:"created,omitempty"`
 	Modified   time.Time `json:"modified,omitempty"`
 }
@@ -374,14 +375,14 @@ type OneDriveInfo struct {
 // Headers returns the human-readable names of properties in a OneDriveInfo
 // for printing out to a terminal in a columnar display.
 func (i OneDriveInfo) Headers() []string {
-	return []string{"ItemName", "ParentPath", "Size", "Created", "Modified"}
+	return []string{"ItemName", "ParentPath", "Size", "Owner", "Created", "Modified"}
 }
 
 // Values returns the values matching the Headers list for printing
 // out to a terminal in a columnar display.
 func (i OneDriveInfo) Values() []string {
 	return []string{
-		i.ItemName, i.ParentPath, humanize.Bytes(uint64(i.Size)),
+		i.ItemName, i.ParentPath, humanize.Bytes(uint64(i.Size)), i.Owner,
 		common.FormatTabularDisplayTime(i.Created), common.FormatTabularDisplayTime(i.Modified),
 	}
 }

--- a/src/pkg/backup/details/details_test.go
+++ b/src/pkg/backup/details/details_test.go
@@ -115,13 +115,14 @@ func (suite *DetailsUnitSuite) TestDetailsEntry_HeadersValues() {
 						ItemName:   "itemName",
 						ParentPath: "parentPath",
 						Size:       1000,
+						Owner:      "user@email.com",
 						Created:    now,
 						Modified:   now,
 					},
 				},
 			},
-			expectHs: []string{"ID", "ItemName", "ParentPath", "Size", "Created", "Modified"},
-			expectVs: []string{"deadbeef", "itemName", "parentPath", "1.0 kB", nowStr, nowStr},
+			expectHs: []string{"ID", "ItemName", "ParentPath", "Size", "Owner", "Created", "Modified"},
+			expectVs: []string{"deadbeef", "itemName", "parentPath", "1.0 kB", "user@email.com", nowStr, nowStr},
 		},
 	}
 

--- a/src/pkg/selectors/onedrive_test.go
+++ b/src/pkg/selectors/onedrive_test.go
@@ -304,6 +304,7 @@ func (suite *OneDriveSelectorSuite) TestOneDriveScope_MatchesInfo() {
 			ParentPath: "folder1/folder2",
 			ItemName:   "file1",
 			Size:       10,
+			Owner:      "user@email.com",
 			Created:    now,
 			Modified:   now,
 		},

--- a/src/pkg/selectors/testdata/details.go
+++ b/src/pkg/selectors/testdata/details.go
@@ -34,9 +34,11 @@ func mustAppendPath(p path.Path, newElement string, isItem bool) path.Path {
 }
 
 const (
-	ItemName1 = "item1"
-	ItemName2 = "item2"
-	ItemName3 = "item3"
+	ItemName1  = "item1"
+	ItemName2  = "item2"
+	ItemName3  = "item3"
+	UserEmail1 = "user1@email.com"
+	UserEmail2 = "user2@email.com"
 )
 
 var (
@@ -187,6 +189,7 @@ var (
 					ParentPath: OneDriveFolderFolder,
 					ItemName:   OneDriveItemPath1.Item() + "name",
 					Size:       int64(23),
+					Owner:      UserEmail1,
 					Created:    Time2,
 					Modified:   Time4,
 				},
@@ -202,6 +205,7 @@ var (
 					ParentPath: OneDriveParentFolder1,
 					ItemName:   OneDriveItemPath2.Item() + "name",
 					Size:       int64(42),
+					Owner:      UserEmail1,
 					Created:    Time1,
 					Modified:   Time3,
 				},
@@ -217,6 +221,7 @@ var (
 					ParentPath: OneDriveParentFolder2,
 					ItemName:   OneDriveItemPath3.Item() + "name",
 					Size:       int64(19),
+					Owner:      UserEmail2,
 					Created:    Time2,
 					Modified:   Time4,
 				},


### PR DESCRIPTION
## Description

Store and retrieve owner info for onedrive files.

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* https://github.com/alcionai/corso/issues/1366

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
