### PR TITLE
fix: tag corso maintainers properly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
-      - "corso-maintainers"
+      - "alcionai/corso-maintainers"
     open-pull-requests-limit: 50
     rebase-strategy: "disabled"
 
@@ -18,7 +18,7 @@ updates:
     schedule:
       interval: "daily"
     reviewers:
-      - "corso-maintainers"
+      - "alcionai/corso-maintainers"
     open-pull-requests-limit: 50
     rebase-strategy: "disabled"
 
@@ -28,7 +28,7 @@ updates:
     schedule:
       interval: "daily"
     reviewers:
-      - "corso-maintainers"
+      - "alcionai/corso-maintainers"
     open-pull-requests-limit: 50
     rebase-strategy: "disabled"
 
@@ -38,6 +38,6 @@ updates:
     schedule:
       interval: "daily"
     reviewers:
-      - "corso-maintainers"
+      - "alcionai/corso-maintainers"
     open-pull-requests-limit: 50
     rebase-strategy: "disabled"


### PR DESCRIPTION
## Description

* fix reference to `corso-maintainers` for dependabot reviewers 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [X] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Test Plan

<!-- How will this be tested prior to merging.-->
- [X] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
