### PR TITLE
Add a make clean step for the website

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -1,9 +1,9 @@
-.PHONY: buildimage dev shell build publish sync
+.PHONY: buildimage dev shell build publish sync clean
 
 WEBC := docker run --rm -it --init -p 5050:3000 -p 5051:3001 \
 		-v ${PWD}:/usr/src/website corso/website:latest
 
-buildimage:
+buildimage: clean
 	docker build -t "corso/website:latest" .
 
 dev:
@@ -23,3 +23,6 @@ publish: build
 sync:
 	aws s3 sync /usr/src/website/dist/ s3://corsobackup.io/ --exclude ".git/*" --delete
 	aws cloudfront create-invalidation --distribution-id E1W9NGI9YTVZ1A --paths "/*"
+
+clean:
+	rm -rf node_modules


### PR DESCRIPTION
## Description

`make clean` will now be executed before a Docker image is built. While it technically has no impact on the Docker image, it will ensure that there are no stale Node modules lying around when a build is executed after the creation of a new image.

While running a Docker build without a cache is an additional option, it does not prevent stale local node_modules directories and suffers from the overhead of having to pull down a large Ubuntu base image every time.

## Type of change

- [x] :bug: Bugfix
