### PR TITLE
Add FAQ to address if Corso works with consumer M365 subscriptions

### DIFF
--- a/docs/docs/support/faq.md
+++ b/docs/docs/support/faq.md
@@ -20,3 +20,11 @@ Telemetry reporting can be turned off by using the `--no-stats` flag. See the [C
 section for more information.
 
 </details>
+
+<details>
+    <summary>Does Corso work with Microsoft 365 Personal or Family subscriptions?</summary>
+
+Unfortunately, Corso leverages the Microsoft Graph API and that's only accessible to organizations with paid
+subscriptions to Microsoft 365 (for example, Business, Enterprise, or Education plans).
+
+</details>


### PR DESCRIPTION
## Description

Addresses questions on Corso consumer use

## Type of change

- [x] :world_map: Documentation
