### PR TITLE
Use pull_request_target instead of pull_request for ci trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,7 @@
 name: Build/Release Corso
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [main]
+  pull_request_target:
   push:
     branches: [main]
     tags: ["v*.*.*"]


### PR DESCRIPTION
## Description

Ref: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
