### PR TITLE
GC: Backup: Sharepoint: Mock Support

### DIFF
--- a/src/internal/connector/mockconnector/mock_data_collection_test.go
+++ b/src/internal/connector/mockconnector/mock_data_collection_test.go
@@ -156,6 +156,14 @@ func (suite *MockExchangeDataSuite) TestMockByteHydration() {
 				_, err := support.CreateEventFromBytes(bytes)
 				return err
 			},
+		}, {
+			name: "Sharepoint: List",
+			transformation: func(t *testing.T) error {
+				bytes, err := mockconnector.GetMockListBytes(subject)
+				require.NoError(suite.T(), err)
+				_, err = support.CreateListFromBytes(bytes)
+				return err
+			},
 		},
 	}
 

--- a/src/internal/connector/mockconnector/mock_data_list.go
+++ b/src/internal/connector/mockconnector/mock_data_list.go
@@ -1,0 +1,56 @@
+package mockconnector
+
+import (
+	kw "github.com/microsoft/kiota-serialization-json-go"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+)
+
+// GetMockList returns a Listable object with generic
+// information.
+// Source: https://learn.microsoft.com/en-us/graph/api/list-create?view=graph-rest-1.0&tabs=go
+func GetMockList(title string) models.Listable {
+	requestBody := models.NewList()
+	requestBody.SetDisplayName(&title)
+
+	columnDef := models.NewColumnDefinition()
+	name := "Author"
+	text := models.NewTextColumn()
+
+	columnDef.SetName(&name)
+	columnDef.SetText(text)
+
+	columnDef2 := models.NewColumnDefinition()
+	name2 := "PageCount"
+	number := models.NewNumberColumn()
+
+	columnDef2.SetName(&name2)
+	columnDef2.SetNumber(number)
+
+	columns := []models.ColumnDefinitionable{
+		columnDef,
+		columnDef2,
+	}
+	requestBody.SetColumns(columns)
+
+	aList := models.NewListInfo()
+	template := "genericList"
+	aList.SetTemplate(&template)
+	requestBody.SetList(aList)
+
+	return requestBody
+}
+
+// GetMockListBytes returns the byte representation of GetMockList
+func GetMockListBytes(title string) ([]byte, error) {
+	list := GetMockList(title)
+
+	objectWriter := kw.NewJsonSerializationWriter()
+	defer objectWriter.Close()
+
+	err := objectWriter.WriteObjectValue("", list)
+	if err != nil {
+		return nil, err
+	}
+
+	return objectWriter.GetSerializedContent()
+}

--- a/src/internal/connector/support/m365Support.go
+++ b/src/internal/connector/support/m365Support.go
@@ -59,3 +59,15 @@ func CreateEventFromBytes(bytes []byte) (models.Eventable, error) {
 
 	return event, nil
 }
+
+// CreateListFromBytes transforms given bytes into models.Listable object
+func CreateListFromBytes(bytes []byte) (models.Listable, error) {
+	parsable, err := CreateFromBytes(bytes, models.CreateListFromDiscriminatorValue)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating m365 sharepoint.List object from provided bytes")
+	}
+
+	list := parsable.(models.Listable)
+
+	return list, nil
+}

--- a/src/internal/connector/support/m365Support_test.go
+++ b/src/internal/connector/support/m365Support_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/connector/mockconnector"
@@ -114,6 +115,45 @@ func (suite *DataSupportSuite) TestCreateEventFromBytes() {
 	for _, test := range tests {
 		suite.T().Run(test.name, func(t *testing.T) {
 			result, err := CreateEventFromBytes(test.byteArray)
+			test.checkError(t, err)
+			test.isNil(t, result)
+		})
+	}
+}
+
+func (suite *DataSupportSuite) TestCreateListFromBytes() {
+	listBytes, err := mockconnector.GetMockListBytes("DataSupportSuite")
+	require.NoError(suite.T(), err)
+
+	tests := []struct {
+		name       string
+		byteArray  []byte
+		checkError assert.ErrorAssertionFunc
+		isNil      assert.ValueAssertionFunc
+	}{
+		{
+			name:       "Empty Byes",
+			byteArray:  make([]byte, 0),
+			checkError: assert.Error,
+			isNil:      assert.Nil,
+		},
+		{
+			name:       "Invalid Bytes",
+			byteArray:  []byte("Invalid byte stream \"subject:\" Not going to work"),
+			checkError: assert.Error,
+			isNil:      assert.Nil,
+		},
+		{
+			name:       "Valid List",
+			byteArray:  listBytes,
+			checkError: assert.NoError,
+			isNil:      assert.NotNil,
+		},
+	}
+
+	for _, test := range tests {
+		suite.T().Run(test.name, func(t *testing.T) {
+			result, err := CreateListFromBytes(test.byteArray)
 			test.checkError(t, err)
 			test.isNil(t, result)
 		})


### PR DESCRIPTION
## Description
Creates Sharepoint.List mock object. Tests support the creation and hydration of objects. 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature

## Issue(s)
*closes  #1457<issue>

## Test Plan
- [x] :zap: Unit test

