### PR TITLE
Small fix in build/Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.18-alpine as builder
 WORKDIR /go/src/app
 COPY src .
 
-ARG CORSO_BUILD_LDFLAGS="" # ldflags
+ARG CORSO_BUILD_LDFLAGS=""
 RUN go build -o corso -ldflags "$CORSO_BUILD_LDFLAGS"
 
 FROM alpine:3.16


### PR DESCRIPTION
## Description

The `#` symbol not at the beginning is technically not valid and fails in podman.
ref: https://docs.docker.com/engine/reference/builder/#format

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
