### PR TITLE
reduce load tests, fix purge creation time

### DIFF
--- a/.github/workflows/load_test.yml
+++ b/.github/workflows/load_test.yml
@@ -3,8 +3,8 @@ on:
   schedule:
     # every day at 01:59 (01:59am) UTC
     # - cron: "59 1 * * *"
-    # temp, for testing: every 6 hours
-    - cron: "0 */6 * * *"
+    # temp, for testing: every 4 hours
+    - cron: "0 */4 * * *"
 
 permissions:
   # required to retrieve AWS credentials
@@ -145,7 +145,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set folder boundary datetime
         run: |
-          echo "NOW=$(date -u +"%Y-%m-%d_%H-%M-%S")" >> $GITHUB_ENV
+          echo "NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_ENV
       - name: Purge Load-Test-Produced Folders
         uses: ./.github/actions/purge-m365-user-data
         with:

--- a/src/pkg/repository/repository_load_test.go
+++ b/src/pkg/repository/repository_load_test.go
@@ -425,6 +425,7 @@ func TestRepositoryIndividualLoadTestExchangeSuite(t *testing.T) {
 
 func (suite *RepositoryIndividualLoadTestExchangeSuite) SetupSuite() {
 	t := suite.T()
+	t.Skip("individual user exchange suite tests are on hold until token expiry gets resolved")
 	t.Parallel()
 	suite.ctx, suite.repo, suite.acct, suite.st = initM365Repo(t)
 	suite.usersUnderTest = singleUserSet(t)
@@ -477,7 +478,7 @@ func TestRepositoryLoadTestOneDriveSuite(t *testing.T) {
 
 func (suite *RepositoryLoadTestOneDriveSuite) SetupSuite() {
 	t := suite.T()
-	t.Skip("temp issue-902-live")
+	t.Skip("not running onedrive load tests atm")
 	t.Parallel()
 	suite.ctx, suite.repo, suite.acct, suite.st = initM365Repo(t)
 	suite.usersUnderTest = orgUserSet(t)
@@ -524,7 +525,7 @@ func TestRepositoryIndividualLoadTestOneDriveSuite(t *testing.T) {
 
 func (suite *RepositoryIndividualLoadTestOneDriveSuite) SetupSuite() {
 	t := suite.T()
-	t.Skip("temp issue-902-live")
+	t.Skip("not running onedrive load tests atm")
 	t.Parallel()
 	suite.ctx, suite.repo, suite.acct, suite.st = initM365Repo(t)
 	suite.usersUnderTest = singleUserSet(t)


### PR DESCRIPTION
## Description

Removes the individual user load test set to
focus on backup-restore of the standard org.
Fixes the folder-creation time value provided to
the purge script from load tests.

## Type of change

- [x] :bug: Bugfix
- [x] :robot: Test

## Issue(s)

* #902

## Test Plan

- [x] :green_heart: E2E
