### PR TITLE
split Corso backups by resource owner, service, and category

### DIFF
--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -280,12 +280,12 @@ func createExchangeCmd(cmd *cobra.Command, args []string) error {
 		return Only(ctx, errors.Wrap(err, "Failed to run Exchange backup"))
 	}
 
-	bu, err := r.Backup(ctx, bo.Results.BackupID)
+	bups, err := r.BackupsByID(ctx, bo.BackupIDs)
 	if err != nil {
 		return Only(ctx, errors.Wrap(err, "Unable to retrieve backup results from storage"))
 	}
 
-	bu.Print(ctx)
+	backup.PrintAll(ctx, bups)
 
 	return nil
 }

--- a/src/cli/backup/onedrive.go
+++ b/src/cli/backup/onedrive.go
@@ -202,12 +202,12 @@ func createOneDriveCmd(cmd *cobra.Command, args []string) error {
 		return Only(ctx, errors.Wrap(err, "Failed to run OneDrive backup"))
 	}
 
-	bu, err := r.Backup(ctx, bo.Results.BackupID)
+	bups, err := r.BackupsByID(ctx, bo.BackupIDs)
 	if err != nil {
 		return errors.Wrap(err, "Unable to retrieve backup results from storage")
 	}
 
-	bu.Print(ctx)
+	backup.PrintAll(ctx, bups)
 
 	return nil
 }

--- a/src/cli/utils/testdata/opts.go
+++ b/src/cli/utils/testdata/opts.go
@@ -408,7 +408,7 @@ func (MockBackupGetter) Backup(
 	return nil, errors.New("unexpected call to mock")
 }
 
-func (MockBackupGetter) Backups(context.Context, ...store.FilterOption) ([]backup.Backup, error) {
+func (MockBackupGetter) Backups(context.Context, ...store.FilterOption) ([]*backup.Backup, error) {
 	return nil, errors.New("unexpected call to mock")
 }
 

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -25,11 +25,15 @@ import (
 	"github.com/alcionai/corso/src/pkg/store"
 )
 
+var (
+	errBackupNotStarted = errors.New("errors prevented the operation from processing")
+)
+
 // BackupOperation wraps an operation with backup-specific props.
 type BackupOperation struct {
 	operation
 
-	Results   BackupResults      `json:"results"`
+	BackupIDs []model.StableID
 	Selectors selectors.Selector `json:"selectors"`
 	Version   string             `json:"version"`
 
@@ -42,6 +46,7 @@ type BackupResults struct {
 	stats.ReadWrites
 	stats.StartAndEndTime
 	BackupID model.StableID `json:"backupID"`
+	Status   opStatus
 }
 
 // NewBackupOperation constructs and validates a backup operation.
@@ -88,40 +93,8 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 	ctx, end := D.Span(ctx, "operations:backup:run")
 	defer end()
 
-	var (
-		opStats       backupStats
-		backupDetails *details.Details
-		startTime     = time.Now()
-	)
-
-	op.Results.BackupID = model.StableID(uuid.NewString())
-
-	op.bus.Event(
-		ctx,
-		events.BackupStart,
-		map[string]any{
-			events.StartTime: startTime,
-			events.Service:   op.Selectors.Service.String(),
-			events.BackupID:  op.Results.BackupID,
-		},
-	)
-
-	// persist operation results to the model store on exit
-	defer func() {
-		// wait for the progress display to clean up
-		observe.Complete()
-
-		err = op.persistResults(startTime, &opStats)
-		if err != nil {
-			return
-		}
-
-		err = op.createBackupModels(ctx, opStats.k.SnapshotID, backupDetails)
-		if err != nil {
-			// todo: we're not persisting this yet, except for the error shown to the user.
-			opStats.writeErr = err
-		}
-	}()
+	// wait for the progress display to clean up
+	defer observe.Complete()
 
 	complete, closer := observe.MessageWithCompletion("Connecting to M365:")
 	defer closer()
@@ -131,9 +104,12 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 	gc, err := connector.NewGraphConnector(ctx, op.account)
 	if err != nil {
 		err = errors.Wrap(err, "connecting to graph api")
-		opStats.readErr = err
 
-		return err
+		// Errors here don't cause anything to be persisted.
+		return multierror.Append(
+			errBackupNotStarted,
+			err,
+		)
 	}
 	complete <- struct{}{}
 
@@ -144,18 +120,103 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 	cs, err := gc.DataCollections(ctx, op.Selectors)
 	if err != nil {
 		err = errors.Wrap(err, "retrieving service data")
-		opStats.readErr = err
-
 		return err
 	}
 
 	discoverCh <- struct{}{}
 
-	opStats.resourceCount = len(data.ResourceOwnerSet(cs))
-
 	backupCh, closer := observe.MessageWithCompletion("Backing up data:")
 	defer closer()
 	defer close(backupCh)
+
+	// Group items by (resource owner, service, category) tuple and create a
+	// separate backup for each tuple.
+	groups := map[string][]data.Collection{}
+
+	for _, c := range cs {
+		fp := c.FullPath()
+		idx := fp.ResourceOwner() + fp.Service().String() + fp.Category().String()
+
+		groups[idx] = append(groups[idx], c)
+	}
+
+	allFailed := true
+	allNoData := true
+
+	for _, cols := range groups {
+		results := op.backupCollectionsGroup(ctx, cols)
+
+		if results.Status != Failed {
+			op.BackupIDs = append(op.BackupIDs, results.BackupID)
+		}
+
+		allFailed = allFailed && results.Status == Failed
+		allNoData = allNoData && results.Status == NoData
+	}
+
+	backupCh <- struct{}{}
+
+	// Wait at the end so any individual backup doesn't deadlock. Seems like the
+	// total items read is not reported or persisted anywhere.
+	gcStats := gc.AwaitStatus()
+
+	// Check before checking for failures so we pick up when the loop doesn't run
+	// because there were no collections.
+	if allNoData && gcStats.Successful == 0 {
+		op.Status = NoData
+	} else if allFailed {
+		op.Status = Failed
+	} else {
+		op.Status = Completed
+	}
+
+	return err
+}
+
+// backupCollectionsGroup backs up a single set of collections and makes a
+// BackupModel for the collections. Each set should correspond to a single
+// (resource owner, service, category) tuple.
+func (op *BackupOperation) backupCollectionsGroup(
+	ctx context.Context,
+	cs []data.Collection,
+) *BackupResults {
+	var (
+		err           error
+		opStats       backupStats
+		backupDetails *details.Details
+		results       = &BackupResults{}
+		startTime     = time.Now()
+		hadData       = len(cs) > 0
+	)
+
+	// persist operation results to the model store on exit
+	// TODO(ashmrtn): Find some error handling method for this.
+	defer func() {
+		err = op.persistResults(startTime, &opStats, hadData, results)
+		if err != nil {
+			return
+		}
+
+		err = op.createBackupModels(ctx, results, opStats.k.SnapshotID, backupDetails)
+		if err != nil {
+			// todo: we're not persisting this yet, except for the error shown to the user.
+			opStats.writeErr = err
+		}
+	}()
+
+	results.BackupID = model.StableID(uuid.NewString())
+
+	op.bus.Event(
+		ctx,
+		events.BackupStart,
+		map[string]any{
+			events.StartTime: startTime,
+			events.Service:   op.Selectors.Service.String(),
+			events.BackupID:  results.BackupID,
+		},
+	)
+
+	opStats.resourceCount = len(cs)
 
 	// hand the results to the consumer
 	opStats.k, backupDetails, err = op.kopia.BackupCollections(ctx, cs, op.Selectors.PathService())
@@ -163,14 +224,12 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 		err = errors.Wrap(err, "backing up service data")
 		opStats.writeErr = err
 
-		return err
+		return results
 	}
-	backupCh <- struct{}{}
 
 	opStats.started = true
-	opStats.gc = gc.AwaitStatus()
 
-	return err
+	return results
 }
 
 // writes the results metrics to the operation results.
@@ -178,32 +237,36 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 func (op *BackupOperation) persistResults(
 	started time.Time,
 	opStats *backupStats,
+	hadData bool,
+	results *BackupResults,
 ) error {
-	op.Results.StartedAt = started
-	op.Results.CompletedAt = time.Now()
+	results.StartedAt = started
+	results.CompletedAt = time.Now()
 
 	op.Status = Completed
 	if !opStats.started {
-		op.Status = Failed
+		results.Status = Failed
 
 		return multierror.Append(
-			errors.New("errors prevented the operation from processing"),
+			errBackupNotStarted,
 			opStats.readErr,
 			opStats.writeErr)
 	}
 
-	if opStats.readErr == nil && opStats.writeErr == nil && opStats.gc.Successful == 0 {
-		op.Status = NoData
+	if opStats.readErr == nil && opStats.writeErr == nil && !hadData {
+		results.Status = NoData
 	}
 
-	op.Results.ReadErrors = opStats.readErr
-	op.Results.WriteErrors = opStats.writeErr
+	results.ReadErrors = opStats.readErr
+	results.WriteErrors = opStats.writeErr
 
-	op.Results.BytesRead = opStats.k.TotalHashedBytes
-	op.Results.BytesUploaded = opStats.k.TotalUploadedBytes
-	op.Results.ItemsRead = opStats.gc.Successful
-	op.Results.ItemsWritten = opStats.k.TotalFileCount
-	op.Results.ResourceOwners = opStats.resourceCount
+	results.BytesRead = opStats.k.TotalHashedBytes
+	results.BytesUploaded = opStats.k.TotalUploadedBytes
+	// TODO(ashmrtn): Bring back if gc starts returning stats associated with each
+	// tuple.
+	//results.ItemsRead = opStats.gc.Successful
+	results.ItemsWritten = opStats.k.TotalFileCount
+	results.ResourceOwners = opStats.resourceCount
 
 	return nil
 }
@@ -211,6 +274,7 @@ func (op *BackupOperation) persistResults(
 // stores the operation details, results, and selectors in the backup manifest.
 func (op *BackupOperation) createBackupModels(
 	ctx context.Context,
+	results *BackupResults,
 	snapID string,
 	backupDetails *details.Details,
 ) error {
@@ -224,11 +288,11 @@ func (op *BackupOperation) createBackupModels(
 	}
 
 	b := backup.New(
-		snapID, string(backupDetails.ModelStoreID), op.Status.String(),
-		op.Results.BackupID,
+		snapID, string(backupDetails.ModelStoreID), results.Status.String(),
+		results.BackupID,
 		op.Selectors,
-		op.Results.ReadWrites,
-		op.Results.StartAndEndTime,
+		results.ReadWrites,
+		results.StartAndEndTime,
 	)
 
 	err = op.store.Put(ctx, model.BackupSchema, b)
@@ -241,12 +305,12 @@ func (op *BackupOperation) createBackupModels(
 		events.BackupEnd,
 		map[string]any{
 			events.BackupID:   b.ID,
-			events.DataStored: op.Results.BytesUploaded,
-			events.Duration:   op.Results.CompletedAt.Sub(op.Results.StartedAt),
-			events.EndTime:    op.Results.CompletedAt,
-			events.Resources:  op.Results.ResourceOwners,
+			events.DataStored: results.BytesUploaded,
+			events.Duration:   results.CompletedAt.Sub(results.StartedAt),
+			events.EndTime:    results.CompletedAt,
+			events.Resources:  results.ResourceOwners,
 			events.Service:    op.Selectors.PathService().String(),
-			events.StartTime:  op.Results.StartedAt,
+			events.StartTime:  results.StartedAt,
 			events.Status:     op.Status,
 		},
 	)

--- a/src/pkg/backup/backup.go
+++ b/src/pkg/backup/backup.go
@@ -74,7 +74,7 @@ func (b Backup) Print(ctx context.Context) {
 }
 
 // PrintAll writes the slice of Backups to StdOut, in the format requested by the caller.
-func PrintAll(ctx context.Context, bs []Backup) {
+func PrintAll(ctx context.Context, bs []*Backup) {
 	if len(bs) == 0 {
 		print.Info(ctx, "No backups available")
 		return

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -27,7 +27,7 @@ var ErrorRepoAlreadyExists = errors.New("a repository was already initialized wi
 // repository.
 type BackupGetter interface {
 	Backup(ctx context.Context, id model.StableID) (*backup.Backup, error)
-	Backups(ctx context.Context, fs ...store.FilterOption) ([]backup.Backup, error)
+	Backups(ctx context.Context, fs ...store.FilterOption) ([]*backup.Backup, error)
 	BackupDetails(
 		ctx context.Context,
 		backupID string,
@@ -232,7 +232,7 @@ func (r repository) Backup(ctx context.Context, id model.StableID) (*backup.Back
 }
 
 // backups lists backups in a repository
-func (r repository) Backups(ctx context.Context, fs ...store.FilterOption) ([]backup.Backup, error) {
+func (r repository) Backups(ctx context.Context, fs ...store.FilterOption) ([]*backup.Backup, error) {
 	sw := store.NewKopiaStore(r.modelStore)
 	return sw.GetBackups(ctx, fs...)
 }

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/alcionai/corso/src/internal/events"
 	"github.com/alcionai/corso/src/internal/kopia"
@@ -27,6 +28,7 @@ var ErrorRepoAlreadyExists = errors.New("a repository was already initialized wi
 // repository.
 type BackupGetter interface {
 	Backup(ctx context.Context, id model.StableID) (*backup.Backup, error)
+	BackupsByID(ctx context.Context, ids []model.StableID) ([]*backup.Backup, error)
 	Backups(ctx context.Context, fs ...store.FilterOption) ([]*backup.Backup, error)
 	BackupDetails(
 		ctx context.Context,
@@ -229,6 +231,27 @@ func (r repository) NewRestore(
 func (r repository) Backup(ctx context.Context, id model.StableID) (*backup.Backup, error) {
 	sw := store.NewKopiaStore(r.modelStore)
 	return sw.GetBackup(ctx, id)
+}
+
+// BackupsByID lists a set of backups by id
+func (r repository) BackupsByID(ctx context.Context, ids []model.StableID) ([]*backup.Backup, error) {
+	var (
+		errs *multierror.Error
+		sw   = store.NewKopiaStore(r.modelStore)
+		bups = []*backup.Backup{}
+	)
+
+	for _, id := range ids {
+		bup, err := sw.GetBackup(ctx, id)
+		if err != nil {
+			errs = multierror.Append(errs, err)
+			continue
+		}
+
+		bups = append(bups, bup)
+	}
+
+	return bups, errs.ErrorOrNil()
 }
 
 // backups lists backups in a repository

--- a/src/pkg/repository/repository_load_test.go
+++ b/src/pkg/repository/repository_load_test.go
@@ -168,7 +168,7 @@ func runBackupListLoadTest(
 	t.Run("backup_list_"+name, func(t *testing.T) {
 		var (
 			err    error
-			bs     []backup.Backup
+			bs     []*backup.Backup
 			labels = pprof.Labels("list_load_test", name)
 		)
 

--- a/src/pkg/store/backup.go
+++ b/src/pkg/store/backup.go
@@ -54,7 +54,7 @@ func (w Wrapper) GetBackup(ctx context.Context, backupID model.StableID) (*backu
 func (w Wrapper) GetBackups(
 	ctx context.Context,
 	filters ...FilterOption,
-) ([]backup.Backup, error) {
+) ([]*backup.Backup, error) {
 	q := &queryFilters{}
 	q.populate(filters...)
 
@@ -63,12 +63,12 @@ func (w Wrapper) GetBackups(
 		return nil, err
 	}
 
-	bs := make([]backup.Backup, len(bms))
+	bs := make([]*backup.Backup, len(bms))
 
 	for i, bm := range bms {
-		b := backup.Backup{}
+		b := &backup.Backup{}
 
-		err := w.GetWithModelStoreID(ctx, model.BackupSchema, bm.ModelStoreID, &b)
+		err := w.GetWithModelStoreID(ctx, model.BackupSchema, bm.ModelStoreID, b)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Description

This is a draft PR to get feedback on the approach. It is not expected to pass tests right now.

Split backups that span multiple (resource owner, service, category)
tuples into discrete corso backups, one per tuple. This shards the
backup details and allows for better parallelism in the future if we
want it. Could also be useful for incremental backups.

Root cause of many issues revolves around the 1:1 mapping we've had
from operation to output data. This pattern changes that though as
there's now subtasks in the backup operation that have notable
results.

Some things that don't fit well with the current patterns in the code:
* same selector saved in each backup making it difficult to determine
  what the backup contains from the summary information
* number of items read by GC is aggregate for all backups so is no
  longer persisted
* many backup IDs now need to be reported to caller
* status handling for the operation vs. individual backups

## Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* #<issue>

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
