### PR TITLE
migrate containerCache to graph pkg

### DIFF
--- a/src/internal/connector/exchange/cache_container.go
+++ b/src/internal/connector/exchange/cache_container.go
@@ -2,65 +2,7 @@ package exchange
 
 import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
-	"github.com/pkg/errors"
-
-	"github.com/alcionai/corso/src/internal/connector/graph"
-	"github.com/alcionai/corso/src/pkg/path"
 )
-
-// checkIDAndName is a helper function to ensure that
-// the ID and name pointers are set prior to being called.
-func checkIDAndName(c graph.Container) error {
-	idPtr := c.GetId()
-	if idPtr == nil || len(*idPtr) == 0 {
-		return errors.New("folder without ID")
-	}
-
-	ptr := c.GetDisplayName()
-	if ptr == nil || len(*ptr) == 0 {
-		return errors.Errorf("folder %s without display name", *idPtr)
-	}
-
-	return nil
-}
-
-// checkRequiredValues is a helper function to ensure that
-// all the pointers are set prior to being called.
-func checkRequiredValues(c graph.Container) error {
-	if err := checkIDAndName(c); err != nil {
-		return err
-	}
-
-	ptr := c.GetParentFolderId()
-	if ptr == nil || len(*ptr) == 0 {
-		return errors.Errorf("folder %s without parent ID", *c.GetId())
-	}
-
-	return nil
-}
-
-//======================================
-// cachedContainer Implementations
-//======================
-
-var _ graph.CachedContainer = &cacheFolder{}
-
-type cacheFolder struct {
-	graph.Container
-	p *path.Builder
-}
-
-//=========================================
-// Required Functions to satisfy interfaces
-//=====================================
-
-func (cf cacheFolder) Path() *path.Builder {
-	return cf.p
-}
-
-func (cf *cacheFolder) SetPath(newPath *path.Builder) {
-	cf.p = newPath
-}
 
 // CalendarDisplayable is a transformative struct that aligns
 // models.Calendarable interface with the container interface.

--- a/src/internal/connector/exchange/exchange_service_test.go
+++ b/src/internal/connector/exchange/exchange_service_test.go
@@ -494,7 +494,7 @@ func (suite *ExchangeServiceSuite) TestGetContainerIDFromCache() {
 		t               = suite.T()
 		user            = tester.M365UserID(t)
 		connector       = loadService(t)
-		directoryCaches = make(map[path.CategoryType]graph.ContainerResolver)
+		directoryCaches = make(map[path.CategoryType]graph.ContainerPopulater)
 		folderName      = tester.DefaultTestRestoreDestination().ContainerName
 		tests           = []struct {
 			name      string

--- a/src/internal/connector/exchange/folder_resolver_test.go
+++ b/src/internal/connector/exchange/folder_resolver_test.go
@@ -50,14 +50,14 @@ func (suite *CacheResolverSuite) TestPopulate() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 
-	eventFunc := func(t *testing.T) graph.ContainerResolver {
+	eventFunc := func(t *testing.T) graph.ContainerPopulater {
 		return &eventCalendarCache{
 			userID: tester.M365UserID(t),
 			gs:     suite.gs,
 		}
 	}
 
-	contactFunc := func(t *testing.T) graph.ContainerResolver {
+	contactFunc := func(t *testing.T) graph.ContainerPopulater {
 		return &contactFolderCache{
 			userID: tester.M365UserID(t),
 			gs:     suite.gs,
@@ -66,7 +66,7 @@ func (suite *CacheResolverSuite) TestPopulate() {
 
 	tests := []struct {
 		name, folderName, root, basePath string
-		resolverFunc                     func(t *testing.T) graph.ContainerResolver
+		resolverFunc                     func(t *testing.T) graph.ContainerPopulater
 		canFind                          assert.BoolAssertionFunc
 	}{
 		{

--- a/src/internal/connector/exchange/service_functions.go
+++ b/src/internal/connector/exchange/service_functions.go
@@ -26,6 +26,7 @@ type exchangeService struct {
 ///------------------------------------------------------------
 // Functions to comply with graph.Service Interface
 //-------------------------------------------------------
+
 func (es *exchangeService) Client() *msgraphsdk.GraphServiceClient {
 	return &es.client
 }
@@ -232,7 +233,7 @@ func PopulateExchangeContainerResolver(
 	qp graph.QueryParams,
 ) (graph.ContainerResolver, error) {
 	var (
-		res          graph.ContainerResolver
+		res          graph.ContainerPopulater
 		cacheRoot    string
 		service, err = createService(qp.Credentials, qp.FailFast)
 	)

--- a/src/internal/connector/exchange/service_restore.go
+++ b/src/internal/connector/exchange/service_restore.go
@@ -292,7 +292,7 @@ func RestoreExchangeDataCollections(
 ) (*support.ConnectorOperationStatus, error) {
 	var (
 		// map of caches... but not yet...
-		directoryCaches = make(map[string]map[path.CategoryType]graph.ContainerResolver)
+		directoryCaches = make(map[string]map[path.CategoryType]graph.ContainerPopulater)
 		metrics         support.CollectionMetrics
 		errs            error
 		// TODO policy to be updated from external source after completion of refactoring
@@ -308,7 +308,7 @@ func RestoreExchangeDataCollections(
 
 		userCaches := directoryCaches[userID]
 		if userCaches == nil {
-			directoryCaches[userID] = make(map[path.CategoryType]graph.ContainerResolver)
+			directoryCaches[userID] = make(map[path.CategoryType]graph.ContainerPopulater)
 			userCaches = directoryCaches[userID]
 		}
 
@@ -432,7 +432,7 @@ func GetContainerIDFromCache(
 	gs graph.Service,
 	directory path.Path,
 	destination string,
-	caches map[path.CategoryType]graph.ContainerResolver,
+	caches map[path.CategoryType]graph.ContainerPopulater,
 ) (string, error) {
 	var (
 		newCache       = false
@@ -512,7 +512,7 @@ func GetContainerIDFromCache(
 func establishMailRestoreLocation(
 	ctx context.Context,
 	folders []string,
-	mfc graph.ContainerResolver,
+	mfc graph.ContainerPopulater,
 	user string,
 	service graph.Service,
 	isNewCache bool,
@@ -569,7 +569,7 @@ func establishMailRestoreLocation(
 func establishContactsRestoreLocation(
 	ctx context.Context,
 	folders []string,
-	cfc graph.ContainerResolver,
+	cfc graph.ContainerPopulater,
 	user string,
 	gs graph.Service,
 	isNewCache bool,
@@ -602,7 +602,7 @@ func establishContactsRestoreLocation(
 func establishEventsRestoreLocation(
 	ctx context.Context,
 	folders []string,
-	ecc graph.ContainerResolver, // eventCalendarCache
+	ecc graph.ContainerPopulater, // eventCalendarCache
 	user string,
 	gs graph.Service,
 	isNewCache bool,

--- a/src/internal/connector/graph/cache_container.go
+++ b/src/internal/connector/graph/cache_container.go
@@ -1,7 +1,6 @@
 package graph
 
 import (
-	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/pkg/errors"
 
 	"github.com/alcionai/corso/src/pkg/path"
@@ -16,9 +15,9 @@ type CachedContainer interface {
 	SetPath(*path.Builder)
 }
 
-// checkRequiredValues is a helper function to ensure that
-// all the pointers are set prior to being called.
-func CheckRequiredValues(c Container) error {
+// CheckIDAndName is a helper function to ensure that
+// the ID and name pointers are set prior to being called.
+func CheckIDAndName(c Container) error {
 	idPtr := c.GetId()
 	if idPtr == nil || len(*idPtr) == 0 {
 		return errors.New("folder without ID")
@@ -29,9 +28,19 @@ func CheckRequiredValues(c Container) error {
 		return errors.Errorf("folder %s without display name", *idPtr)
 	}
 
-	ptr = c.GetParentFolderId()
+	return nil
+}
+
+// CheckRequiredValues is a helper function to ensure that
+// all the pointers are set prior to being called.
+func CheckRequiredValues(c Container) error {
+	if err := CheckIDAndName(c); err != nil {
+		return err
+	}
+
+	ptr := c.GetParentFolderId()
 	if ptr == nil || len(*ptr) == 0 {
-		return errors.Errorf("folder %s without parent ID", *idPtr)
+		return errors.Errorf("folder %s without parent ID", *c.GetId())
 	}
 
 	return nil
@@ -58,52 +67,10 @@ func NewCacheFolder(c Container, pb *path.Builder) CacheFolder {
 	return cf
 }
 
-//=========================================
-// Required Functions to satisfy interfaces
-//=========================================
-
 func (cf CacheFolder) Path() *path.Builder {
 	return cf.p
 }
 
 func (cf *CacheFolder) SetPath(newPath *path.Builder) {
 	cf.p = newPath
-}
-
-// CalendarDisplayable is a transformative struct that aligns
-// models.Calendarable interface with the container interface.
-// Calendars do not have the 2 of the
-type CalendarDisplayable struct {
-	models.Calendarable
-	parentID string
-}
-
-// GetDisplayName returns the *string of the calendar name
-func (c CalendarDisplayable) GetDisplayName() *string {
-	return c.GetName()
-}
-
-// GetParentFolderId returns the default calendar name address
-// EventCalendars have a flat hierarchy and Calendars are rooted
-// at the default
-//nolint:revive
-func (c CalendarDisplayable) GetParentFolderId() *string {
-	return &c.parentID
-}
-
-// CreateCalendarDisplayable helper function to create the
-// calendarDisplayable during msgraph-sdk-go iterative process
-// @param entry is the input supplied by pageIterator.Iterate()
-// @param parentID of Calendar sets. Only populate when used with
-// EventCalendarCache
-func CreateCalendarDisplayable(entry any, parentID string) *CalendarDisplayable {
-	calendar, ok := entry.(models.Calendarable)
-	if !ok {
-		return nil
-	}
-
-	return &CalendarDisplayable{
-		Calendarable: calendar,
-		parentID:     parentID,
-	}
 }

--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -60,11 +60,6 @@ type ContainerResolver interface {
 	// to that container. The path has a similar format to paths on the local
 	// file system.
 	IDToPath(ctx context.Context, m365ID string) (*path.Builder, error)
-	// Populate performs initialization steps for the resolver
-	// @param ctx is necessary param for Graph API tracing
-	// @param baseFolderID represents the M365ID base that the resolver will
-	// conclude its search. Default input is "".
-	Populate(ctx context.Context, baseFolderID string, baseContainerPather ...string) error
 
 	// PathInCache performs a look up of a path reprensentation
 	// and returns the m365ID of directory iff the pathString
@@ -76,4 +71,17 @@ type ContainerResolver interface {
 
 	// Items returns the containers in the cache.
 	Items() []CachedContainer
+}
+
+// ContainerPopulater houses functions for populating and retrieving info
+// about containers from remote APIs (i.e. resolve folder paths with Graph
+// API). Populaters may cache information about containers.
+type ContainerPopulater interface {
+	ContainerResolver
+
+	// Populate performs initialization steps for the populater
+	// @param ctx is necessary param for Graph API tracing
+	// @param baseFolderID represents the M365ID base that the
+	// populater will conclude its search. Default input is "".
+	Populate(ctx context.Context, baseFolderID string, baseContainerPather ...string) error
 }


### PR DESCRIPTION
## Description

ContainerCache is a generic resource that can
be moved to the graph package.  Service-
specific code is tied to the `populate` func,
which remains in each service/category.  This
change is a prepatory refactoring to reduce
boilerplate for sharepoint implementation.

## Type of change

- [x] :hamster: Trivial/Minor

## Issue(s)

* #1506

## Test Plan

- [x] :zap: Unit test
