### PR TITLE
adds tenant site lookup on new graph conn

### DIFF
--- a/src/cmd/factory/factory.go
+++ b/src/cmd/factory/factory.go
@@ -176,7 +176,7 @@ func getGCAndVerifyUser(ctx context.Context, userID string) (*connector.GraphCon
 	}
 
 	// build a graph connector
-	gc, err := connector.NewGraphConnector(ctx, acct)
+	gc, err := connector.NewGraphConnector(ctx, acct, connector.Users)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "connecting to graph api")
 	}

--- a/src/cmd/getM365/getItem.go
+++ b/src/cmd/getM365/getItem.go
@@ -44,7 +44,8 @@ var (
 // Supports:
 // - exchange (contacts, email, and events)
 // Input: go run ./getItem.go     --user <user>
-//   --m365ID <m365ID> --category <oneof: contacts, email, events>
+//
+//	--m365ID <m365ID> --category <oneof: contacts, email, events>
 func main() {
 	ctx, _ := logger.SeedLevel(context.Background(), logger.Development)
 	ctx = SetRootCmd(ctx, getCmd)
@@ -170,7 +171,7 @@ func getGC(ctx context.Context) (*connector.GraphConnector, error) {
 		return nil, Only(ctx, errors.Wrap(err, "finding m365 account details"))
 	}
 
-	gc, err := connector.NewGraphConnector(ctx, acct)
+	gc, err := connector.NewGraphConnector(ctx, acct, connector.Users)
 	if err != nil {
 		return nil, Only(ctx, errors.Wrap(err, "connecting to graph API"))
 	}

--- a/src/cmd/purge/purge.go
+++ b/src/cmd/purge/purge.go
@@ -255,7 +255,7 @@ func getGC(ctx context.Context) (*connector.GraphConnector, error) {
 	}
 
 	// build a graph connector
-	gc, err := connector.NewGraphConnector(ctx, acct)
+	gc, err := connector.NewGraphConnector(ctx, acct, connector.Users)
 	if err != nil {
 		return nil, Only(ctx, errors.Wrap(err, "connecting to graph api"))
 	}

--- a/src/internal/connector/data_collections_test.go
+++ b/src/internal/connector/data_collections_test.go
@@ -42,7 +42,7 @@ func (suite *ConnectorDataCollectionIntegrationSuite) SetupSuite() {
 
 	_, err := tester.GetRequiredEnvVars(tester.M365AcctCredEnvs...)
 	require.NoError(suite.T(), err)
-	suite.connector = loadConnector(ctx, suite.T())
+	suite.connector = loadConnector(ctx, suite.T(), AllResources)
 	suite.user = tester.M365UserID(suite.T())
 	suite.site = tester.M365SiteID(suite.T())
 	tester.LogTimeOfTest(suite.T())
@@ -58,7 +58,7 @@ func (suite *ConnectorDataCollectionIntegrationSuite) TestExchangeDataCollection
 	ctx, flush := tester.NewContext()
 	defer flush()
 
-	connector := loadConnector(ctx, suite.T())
+	connector := loadConnector(ctx, suite.T(), Users)
 	tests := []struct {
 		name        string
 		getSelector func(t *testing.T) selectors.Selector
@@ -123,7 +123,7 @@ func (suite *ConnectorDataCollectionIntegrationSuite) TestInvalidUserForDataColl
 	defer flush()
 
 	invalidUser := "foo@example.com"
-	connector := loadConnector(ctx, suite.T())
+	connector := loadConnector(ctx, suite.T(), Users)
 	tests := []struct {
 		name        string
 		getSelector func(t *testing.T) selectors.Selector
@@ -162,7 +162,7 @@ func (suite *ConnectorDataCollectionIntegrationSuite) TestSharePointDataCollecti
 	ctx, flush := tester.NewContext()
 	defer flush()
 
-	connector := loadConnector(ctx, suite.T())
+	connector := loadConnector(ctx, suite.T(), Users)
 	tests := []struct {
 		name        string
 		getSelector func(t *testing.T) selectors.Selector
@@ -230,7 +230,7 @@ func (suite *ConnectorCreateExchangeCollectionIntegrationSuite) SetupSuite() {
 
 	_, err := tester.GetRequiredEnvVars(tester.M365AcctCredEnvs...)
 	require.NoError(suite.T(), err)
-	suite.connector = loadConnector(ctx, suite.T())
+	suite.connector = loadConnector(ctx, suite.T(), Users)
 	suite.user = tester.M365UserID(suite.T())
 	suite.site = tester.M365SiteID(suite.T())
 	tester.LogTimeOfTest(suite.T())
@@ -263,7 +263,7 @@ func (suite *ConnectorCreateExchangeCollectionIntegrationSuite) TestMailFetch() 
 		},
 	}
 
-	gc := loadConnector(ctx, t)
+	gc := loadConnector(ctx, t, Users)
 
 	for _, test := range tests {
 		suite.T().Run(test.name, func(t *testing.T) {
@@ -292,7 +292,7 @@ func (suite *ConnectorCreateExchangeCollectionIntegrationSuite) TestMailSerializ
 	defer flush()
 
 	t := suite.T()
-	connector := loadConnector(ctx, t)
+	connector := loadConnector(ctx, t, Users)
 	sel := selectors.NewExchangeBackup()
 	sel.Include(sel.MailFolders([]string{suite.user}, []string{exchange.DefaultMailFolder}, selectors.PrefixMatch()))
 	collection, err := connector.createExchangeCollections(ctx, sel.Scopes()[0])
@@ -326,7 +326,7 @@ func (suite *ConnectorCreateExchangeCollectionIntegrationSuite) TestContactSeria
 	ctx, flush := tester.NewContext()
 	defer flush()
 
-	connector := loadConnector(ctx, suite.T())
+	connector := loadConnector(ctx, suite.T(), Users)
 
 	tests := []struct {
 		name          string
@@ -379,7 +379,7 @@ func (suite *ConnectorCreateExchangeCollectionIntegrationSuite) TestEventsSerial
 	ctx, flush := tester.NewContext()
 	defer flush()
 
-	connector := loadConnector(ctx, suite.T())
+	connector := loadConnector(ctx, suite.T(), Users)
 
 	tests := []struct {
 		name, expected string
@@ -447,7 +447,7 @@ func (suite *ConnectorCreateExchangeCollectionIntegrationSuite) TestAccessOfInbo
 	defer flush()
 
 	t := suite.T()
-	connector := loadConnector(ctx, t)
+	connector := loadConnector(ctx, t, Users)
 	sel := selectors.NewExchangeBackup()
 	sel.Include(sel.MailFolders(selectors.Any(), []string{exchange.DefaultMailFolder}, selectors.PrefixMatch()))
 	scopes := sel.DiscreteScopes(connector.GetUsers())
@@ -488,7 +488,7 @@ func (suite *ConnectorCreateSharePointCollectionIntegrationSuite) SetupSuite() {
 
 	_, err := tester.GetRequiredEnvVars(tester.M365AcctCredEnvs...)
 	require.NoError(suite.T(), err)
-	suite.connector = loadConnector(ctx, suite.T())
+	suite.connector = loadConnector(ctx, suite.T(), Sites)
 	suite.user = tester.M365UserID(suite.T())
 	tester.LogTimeOfTest(suite.T())
 }
@@ -502,7 +502,7 @@ func (suite *ConnectorCreateSharePointCollectionIntegrationSuite) TestCreateShar
 		userID = tester.M365UserID(t)
 	)
 
-	gc := loadConnector(ctx, t)
+	gc := loadConnector(ctx, t, Sites)
 	scope := selectors.NewSharePointBackup().Folders(
 		[]string{userID},
 		[]string{"foo"},

--- a/src/internal/connector/exchange/cache_container.go
+++ b/src/internal/connector/exchange/cache_container.go
@@ -39,9 +39,9 @@ func checkRequiredValues(c graph.Container) error {
 	return nil
 }
 
-//======================================
+// =========================================
 // cachedContainer Implementations
-//======================
+// =========================================
 
 var _ graph.CachedContainer = &cacheFolder{}
 
@@ -50,9 +50,9 @@ type cacheFolder struct {
 	p *path.Builder
 }
 
-//=========================================
+// =========================================
 // Required Functions to satisfy interfaces
-//=====================================
+// =========================================
 
 func (cf cacheFolder) Path() *path.Builder {
 	return cf.p
@@ -79,6 +79,7 @@ func (c CalendarDisplayable) GetDisplayName() *string {
 // GetParentFolderId returns the default calendar name address
 // EventCalendars have a flat hierarchy and Calendars are rooted
 // at the default
+//
 //nolint:revive
 func (c CalendarDisplayable) GetParentFolderId() *string {
 	return nil

--- a/src/internal/connector/exchange/exchange_service_test.go
+++ b/src/internal/connector/exchange/exchange_service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	absser "github.com/microsoft/kiota-abstractions-go/serialization"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -252,8 +253,10 @@ func (suite *ExchangeServiceSuite) TestGraphQueryFunctions() {
 			function: GetAllFolderNamesForUser,
 		},
 		{
-			name:     "GraphQuery: Get All Users",
-			function: GetAllUsersForTenant,
+			name: "GraphQuery: Get All Users",
+			function: func(ctx context.Context, gs graph.Service, toss string) (absser.Parsable, error) {
+				return GetAllUsersForTenant(ctx, gs)
+			},
 		},
 		{
 			name:     "GraphQuery: Get All ContactFolders",

--- a/src/internal/connector/exchange/exchange_vars.go
+++ b/src/internal/connector/exchange/exchange_vars.go
@@ -6,7 +6,8 @@ package exchange
 // Legacy Value Tags and constants are used to override certain values within
 // M365 objects.
 // Master Property Value Document:
-//  https://interoperability.blob.core.windows.net/files/MS-OXPROPS/%5bMS-OXPROPS%5d.pdf
+//
+//	https://interoperability.blob.core.windows.net/files/MS-OXPROPS/%5bMS-OXPROPS%5d.pdf
 const (
 	// MailRestorePropertyTag inhibits exchange.Mail.Message from being "resent" through the server.
 	// DEFINED: Section 2.791 PidTagMessageFlags
@@ -27,9 +28,9 @@ const (
 	// Section: 2.789 PidTagMessageDeliveryTime
 	MailReceiveDateTimeOverriveProperty = "SystemTime 0x0E06"
 
-	//----------------------------------
+	// ----------------------------------
 	// Default Folder Names
-	//------------------------
+	// ----------------------------------
 	// Mail Definitions: https://docs.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0
 
 	// inbox and root
@@ -38,9 +39,9 @@ const (
 	DefaultContactFolder = "Contacts"
 	DefaultCalendar      = "Calendar"
 
-	//---------------------
+	// ----------------------------------
 	// Paging
-	//-----------------
+	// ----------------------------------
 	// nextDataLink definition https://docs.microsoft.com/en-us/graph/paging
 	nextDataLink = "@odata.nextLink"
 )

--- a/src/internal/connector/exchange/query_options.go
+++ b/src/internal/connector/exchange/query_options.go
@@ -21,11 +21,11 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
-//-----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // Constant Section
 // Defines the allowable strings that can be passed into
 // selectors for M365 objects
-//------------------------------------------------------------
+// -----------------------------------------------------------------------
 var (
 	fieldsForCalendars = map[string]int{
 		"changeKey":         1,
@@ -118,12 +118,12 @@ func CategoryToOptionIdentifier(category path.CategoryType) optionIdentifier {
 	}
 }
 
-//---------------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // exchange.Query Option Section
 // These functions can be used to filter a response on M365
 // Graph queries and reduce / filter the amount of data returned
 // which reduces the overall latency of complex calls
-//----------------------------------------------------------------
+// -----------------------------------------------------------------------
 
 func optionsForFolderMessages(moreOps []string) (*msmfmessage.MessagesRequestBuilderGetRequestConfiguration, error) {
 	selecting, err := buildOptions(moreOps, messages)

--- a/src/internal/connector/exchange/service_functions.go
+++ b/src/internal/connector/exchange/service_functions.go
@@ -23,9 +23,10 @@ type exchangeService struct {
 	credentials account.M365Config
 }
 
-// /------------------------------------------------------------
+// ------------------------------------------------------------
 // Functions to comply with graph.Service Interface
-// -------------------------------------------------------
+// ------------------------------------------------------------
+
 func (es *exchangeService) Client() *msgraphsdk.GraphServiceClient {
 	return &es.client
 }

--- a/src/internal/connector/exchange/service_query.go
+++ b/src/internal/connector/exchange/service_query.go
@@ -74,9 +74,8 @@ func GetAllContactFolderNamesForUser(ctx context.Context, gs graph.Service, user
 	return gs.Client().UsersById(user).ContactFolders().Get(ctx, options)
 }
 
-// GetAllUsersForTenant is a GraphQuery for retrieving all the UserCollectionResponse with
-// that contains the UserID and email for each user. All other information is omitted
-func GetAllUsersForTenant(ctx context.Context, gs graph.Service, user string) (absser.Parsable, error) {
+// GetAllUsersForTenant makes a GraphQuery request retrieving all the users in the tenant.
+func GetAllUsersForTenant(ctx context.Context, gs graph.Service) (absser.Parsable, error) {
 	selecting := []string{"userPrincipalName"}
 
 	options, err := optionsForUsers(selecting)

--- a/src/internal/connector/graph/cache_container.go
+++ b/src/internal/connector/graph/cache_container.go
@@ -37,9 +37,9 @@ func CheckRequiredValues(c Container) error {
 	return nil
 }
 
-//======================================
+// ======================================
 // cachedContainer Implementations
-//======================================
+// ======================================
 
 var _ CachedContainer = &CacheFolder{}
 
@@ -58,9 +58,9 @@ func NewCacheFolder(c Container, pb *path.Builder) CacheFolder {
 	return cf
 }
 
-//=========================================
+// =========================================
 // Required Functions to satisfy interfaces
-//=========================================
+// =========================================
 
 func (cf CacheFolder) Path() *path.Builder {
 	return cf.p
@@ -86,6 +86,7 @@ func (c CalendarDisplayable) GetDisplayName() *string {
 // GetParentFolderId returns the default calendar name address
 // EventCalendars have a flat hierarchy and Calendars are rooted
 // at the default
+//
 //nolint:revive
 func (c CalendarDisplayable) GetParentFolderId() *string {
 	return &c.parentID

--- a/src/internal/connector/graph_connector.go
+++ b/src/internal/connector/graph_connector.go
@@ -229,7 +229,6 @@ func identifySite(item any) (string, string, error) {
 	}
 
 	if m.GetName() == nil {
-
 		// the built-in site at "htps://{tenant-domain}/search" never has a name.
 		if m.GetWebUrl() != nil && strings.HasSuffix(*m.GetWebUrl(), "/search") {
 			return "", "", errKnownSkippableCase
@@ -380,6 +379,7 @@ func getResources(
 			}
 
 			iterErrs = support.WrapAndAppend(gs.Adapter().GetBaseUrl(), err, iterErrs)
+
 			return true
 		}
 

--- a/src/internal/connector/graph_connector_disconnected_test.go
+++ b/src/internal/connector/graph_connector_disconnected_test.go
@@ -65,7 +65,7 @@ func (suite *DisconnectedGraphConnectorSuite) TestBadConnection() {
 
 	for _, test := range table {
 		suite.T().Run(test.name, func(t *testing.T) {
-			gc, err := NewGraphConnector(ctx, test.acct(t))
+			gc, err := NewGraphConnector(ctx, test.acct(t), Users)
 			assert.Nil(t, gc, test.name+" failed")
 			assert.NotNil(t, err, test.name+"failed")
 		})

--- a/src/internal/connector/graph_connector_helper_test.go
+++ b/src/internal/connector/graph_connector_helper_test.go
@@ -162,6 +162,7 @@ type restoreBackupInfo struct {
 	name        string
 	service     path.ServiceType
 	collections []colInfo
+	resource    resource
 }
 
 func attachmentEqual(
@@ -858,15 +859,16 @@ func getSelectorWith(service path.ServiceType) selectors.Selector {
 	case path.OneDriveService:
 		s = selectors.ServiceOneDrive
 	}
+	// TODO: ^ sharepoint
 
 	return selectors.Selector{
 		Service: s,
 	}
 }
 
-func loadConnector(ctx context.Context, t *testing.T) *GraphConnector {
+func loadConnector(ctx context.Context, t *testing.T, r resource) *GraphConnector {
 	a := tester.NewM365Account(t)
-	connector, err := NewGraphConnector(ctx, a)
+	connector, err := NewGraphConnector(ctx, a, r)
 	require.NoError(t, err)
 
 	return connector

--- a/src/internal/connector/graph_connector_test.go
+++ b/src/internal/connector/graph_connector_test.go
@@ -87,7 +87,7 @@ func (suite *GraphConnectorIntegrationSuite) TestSetTenantSites() {
 	suite.Equal(0, len(newConnector.Sites))
 	err = newConnector.setTenantSites(ctx)
 	suite.NoError(err)
-	suite.Less(0, len(newConnector.Users))
+	suite.Less(0, len(newConnector.Sites))
 }
 
 func (suite *GraphConnectorIntegrationSuite) TestEmptyCollections() {

--- a/src/internal/connector/graph_connector_test.go
+++ b/src/internal/connector/graph_connector_test.go
@@ -39,7 +39,7 @@ func (suite *GraphConnectorIntegrationSuite) SetupSuite() {
 
 	_, err := tester.GetRequiredEnvVars(tester.M365AcctCredEnvs...)
 	require.NoError(suite.T(), err)
-	suite.connector = loadConnector(ctx, suite.T())
+	suite.connector = loadConnector(ctx, suite.T(), Users)
 	suite.user = tester.M365UserID(suite.T())
 	tester.LogTimeOfTest(suite.T())
 }
@@ -63,8 +63,8 @@ func (suite *GraphConnectorIntegrationSuite) TestSetTenantUsers() {
 
 	suite.Equal(len(newConnector.Users), 0)
 	err = newConnector.setTenantUsers(ctx)
-	assert.NoError(suite.T(), err)
-	suite.Greater(len(newConnector.Users), 0)
+	suite.NoError(err)
+	suite.Less(0, len(newConnector.Users))
 }
 
 // TestSetTenantUsers verifies GraphConnector's ability to query
@@ -86,10 +86,8 @@ func (suite *GraphConnectorIntegrationSuite) TestSetTenantSites() {
 
 	suite.Equal(0, len(newConnector.Sites))
 	err = newConnector.setTenantSites(ctx)
-	assert.NoError(suite.T(), err)
-	// TODO: should be non-zero once implemented.
-	// suite.Greater(len(newConnector.Users), 0)
-	suite.Equal(0, len(newConnector.Sites))
+	suite.NoError(err)
+	suite.Less(0, len(newConnector.Users))
 }
 
 func (suite *GraphConnectorIntegrationSuite) TestEmptyCollections() {
@@ -194,7 +192,7 @@ func runRestoreBackupTest(
 
 	start := time.Now()
 
-	restoreGC := loadConnector(ctx, t)
+	restoreGC := loadConnector(ctx, t, test.resource)
 	restoreSel := getSelectorWith(test.service)
 	deets, err := restoreGC.RestoreDataCollections(ctx, restoreSel, dest, collections)
 	require.NoError(t, err)
@@ -228,7 +226,7 @@ func runRestoreBackupTest(
 		})
 	}
 
-	backupGC := loadConnector(ctx, t)
+	backupGC := loadConnector(ctx, t, test.resource)
 	backupSel := backupSelectorForExpected(t, test.service, expectedDests)
 	t.Logf("Selective backup of %s\n", backupSel)
 
@@ -253,8 +251,9 @@ func (suite *GraphConnectorIntegrationSuite) TestRestoreAndBackup() {
 
 	table := []restoreBackupInfo{
 		{
-			name:    "EmailsWithAttachments",
-			service: path.ExchangeService,
+			name:     "EmailsWithAttachments",
+			service:  path.ExchangeService,
+			resource: Users,
 			collections: []colInfo{
 				{
 					pathElements: []string{"Inbox"},
@@ -279,8 +278,9 @@ func (suite *GraphConnectorIntegrationSuite) TestRestoreAndBackup() {
 			},
 		},
 		{
-			name:    "MultipleEmailsMultipleFolders",
-			service: path.ExchangeService,
+			name:     "MultipleEmailsMultipleFolders",
+			service:  path.ExchangeService,
+			resource: Users,
 			collections: []colInfo{
 				{
 					pathElements: []string{"Inbox"},
@@ -324,8 +324,9 @@ func (suite *GraphConnectorIntegrationSuite) TestRestoreAndBackup() {
 			},
 		},
 		{
-			name:    "MultipleContactsSingleFolder",
-			service: path.ExchangeService,
+			name:     "MultipleContactsSingleFolder",
+			service:  path.ExchangeService,
+			resource: Users,
 			collections: []colInfo{
 				{
 					pathElements: []string{"Contacts"},
@@ -351,8 +352,9 @@ func (suite *GraphConnectorIntegrationSuite) TestRestoreAndBackup() {
 			},
 		},
 		{
-			name:    "MultipleContactsMutlipleFolders",
-			service: path.ExchangeService,
+			name:     "MultipleContactsMutlipleFolders",
+			service:  path.ExchangeService,
+			resource: Users,
 			collections: []colInfo{
 				{
 					pathElements: []string{"Work"},
@@ -475,8 +477,9 @@ func (suite *GraphConnectorIntegrationSuite) TestRestoreAndBackup() {
 func (suite *GraphConnectorIntegrationSuite) TestMultiFolderBackupDifferentNames() {
 	table := []restoreBackupInfo{
 		{
-			name:    "Contacts",
-			service: path.ExchangeService,
+			name:     "Contacts",
+			service:  path.ExchangeService,
+			resource: Users,
 			collections: []colInfo{
 				{
 					pathElements: []string{"Work"},
@@ -574,7 +577,7 @@ func (suite *GraphConnectorIntegrationSuite) TestMultiFolderBackupDifferentNames
 					dest.ContainerName,
 				)
 
-				restoreGC := loadConnector(ctx, t)
+				restoreGC := loadConnector(ctx, t, test.resource)
 				deets, err := restoreGC.RestoreDataCollections(ctx, restoreSel, dest, collections)
 				require.NoError(t, err)
 				require.NotNil(t, deets)
@@ -592,7 +595,7 @@ func (suite *GraphConnectorIntegrationSuite) TestMultiFolderBackupDifferentNames
 
 			// Run a backup and compare its output with what we put in.
 
-			backupGC := loadConnector(ctx, t)
+			backupGC := loadConnector(ctx, t, test.resource)
 			backupSel := backupSelectorForExpected(t, test.service, expectedDests)
 			t.Log("Selective backup of", backupSel)
 
@@ -622,8 +625,9 @@ func (suite *GraphConnectorIntegrationSuite) TestMultiuserRestoreAndBackup() {
 	}
 	table := []restoreBackupInfo{
 		{
-			name:    "Email",
-			service: path.ExchangeService,
+			name:     "Email",
+			service:  path.ExchangeService,
+			resource: Users,
 			collections: []colInfo{
 				{
 					pathElements: []string{"Inbox"},
@@ -658,8 +662,9 @@ func (suite *GraphConnectorIntegrationSuite) TestMultiuserRestoreAndBackup() {
 			},
 		},
 		{
-			name:    "Contacts",
-			service: path.ExchangeService,
+			name:     "Contacts",
+			service:  path.ExchangeService,
+			resource: Users,
 			collections: []colInfo{
 				{
 					pathElements: []string{"Work"},

--- a/src/internal/connector/sharepoint/queries.go
+++ b/src/internal/connector/sharepoint/queries.go
@@ -1,0 +1,21 @@
+package sharepoint
+
+import (
+	"context"
+
+	absser "github.com/microsoft/kiota-abstractions-go/serialization"
+	mssite "github.com/microsoftgraph/msgraph-sdk-go/sites"
+
+	"github.com/alcionai/corso/src/internal/connector/graph"
+)
+
+// GetAllSitesForTenant makes a GraphQuery request retrieving all sites in the tenant.
+func GetAllSitesForTenant(ctx context.Context, gs graph.Service) (absser.Parsable, error) {
+	options := &mssite.SitesRequestBuilderGetRequestConfiguration{
+		QueryParameters: &mssite.SitesRequestBuilderGetQueryParameters{
+			Select: []string{"id", "name"},
+		},
+	}
+
+	return gs.Client().Sites().Get(ctx, options)
+}

--- a/src/internal/connector/sharepoint/queries.go
+++ b/src/internal/connector/sharepoint/queries.go
@@ -13,7 +13,7 @@ import (
 func GetAllSitesForTenant(ctx context.Context, gs graph.Service) (absser.Parsable, error) {
 	options := &mssite.SitesRequestBuilderGetRequestConfiguration{
 		QueryParameters: &mssite.SitesRequestBuilderGetQueryParameters{
-			Select: []string{"id", "name"},
+			Select: []string{"id", "name", "weburl"},
 		},
 	}
 

--- a/src/internal/connector/support/m365Transform.go
+++ b/src/internal/connector/support/m365Transform.go
@@ -406,9 +406,9 @@ func SetAdditionalDataToEventMessage(
 
 // ToEventSimplified transforms an event to simplifed restore format
 // To overcome some of the MS Graph API challenges, the event object is modified in the following ways:
-// * Instead of adding attendees and generating spurious notifications,
+//   - Instead of adding attendees and generating spurious notifications,
 //     add a summary of attendees at the beginning to the event before the original body content
-// * event.attendees is set to an empty list
+//   - event.attendees is set to an empty list
 func ToEventSimplified(orig models.Eventable) models.Eventable {
 	attendees := FormatAttendees(orig, *orig.GetBody().GetContentType() == models.HTML_BODYTYPE)
 	orig.SetAttendees([]models.Attendeeable{})

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -128,7 +128,12 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 	defer close(complete)
 
 	// retrieve data from the producer
-	gc, err := connector.NewGraphConnector(ctx, op.account)
+	resource := connector.Users
+	if op.Selectors.Service == selectors.ServiceSharePoint {
+		resource = connector.Sites
+	}
+
+	gc, err := connector.NewGraphConnector(ctx, op.account, resource)
 	if err != nil {
 		err = errors.Wrap(err, "connecting to graph api")
 		opStats.readErr = err

--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -166,7 +166,12 @@ func (op *RestoreOperation) Run(ctx context.Context) (restoreDetails *details.De
 	defer close(gcComplete)
 
 	// restore those collections using graph
-	gc, err := connector.NewGraphConnector(ctx, op.account)
+	resource := connector.Users
+	if op.Selectors.Service == selectors.ServiceSharePoint {
+		resource = connector.Sites
+	}
+
+	gc, err := connector.NewGraphConnector(ctx, op.account, resource)
 	if err != nil {
 		err = errors.Wrap(err, "connecting to microsoft servers")
 		opStats.writeErr = err

--- a/src/pkg/services/m365/m365.go
+++ b/src/pkg/services/m365/m365.go
@@ -12,7 +12,7 @@ import (
 // Users returns a list of users in the specified M365 tenant
 // TODO: Implement paging support
 func Users(ctx context.Context, m365Account account.Account) ([]string, error) {
-	gc, err := connector.NewGraphConnector(ctx, m365Account)
+	gc, err := connector.NewGraphConnector(ctx, m365Account, connector.Users)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not initialize M365 graph connection")
 	}
@@ -23,7 +23,7 @@ func Users(ctx context.Context, m365Account account.Account) ([]string, error) {
 // UserIDs returns a list of user IDs for the specified M365 tenant
 // TODO: Implement paging support
 func UserIDs(ctx context.Context, m365Account account.Account) ([]string, error) {
-	gc, err := connector.NewGraphConnector(ctx, m365Account)
+	gc, err := connector.NewGraphConnector(ctx, m365Account, connector.Users)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not initialize M365 graph connection")
 	}
@@ -32,7 +32,7 @@ func UserIDs(ctx context.Context, m365Account account.Account) ([]string, error)
 }
 
 func GetEmailAndUserID(ctx context.Context, m365Account account.Account) (map[string]string, error) {
-	gc, err := connector.NewGraphConnector(ctx, m365Account)
+	gc, err := connector.NewGraphConnector(ctx, m365Account, connector.Users)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not initialize M365 graph connection")
 	}


### PR DESCRIPTION
## Description

Adds a lookup for all tenant site ids when a new
graph connector is created.  Also adds an enum
to flag which resource set (users, sites, or all)
that the connector should initialize.

## Type of change

- [x] :sunflower: Feature

## Issue(s)

* #1506

## Test Plan

- [x] :green_heart: E2E
