### PR TITLE
GC: Populate Refactor (Contacts)

### DIFF
--- a/src/internal/connector/exchange/contact_folder_cache.go
+++ b/src/internal/connector/exchange/contact_folder_cache.go
@@ -3,8 +3,7 @@ package exchange
 import (
 	"context"
 
-	msgraphgocore "github.com/microsoftgraph/msgraph-sdk-go-core"
-	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	cf "github.com/microsoftgraph/msgraph-sdk-go/users/item/contactfolders/item/childfolders"
 	"github.com/pkg/errors"
 
 	"github.com/alcionai/corso/src/internal/connector/graph"
@@ -70,52 +69,55 @@ func (cfc *contactFolderCache) Populate(
 	}
 
 	var (
-		containers = make(map[string]graph.Container)
-		errs       error
-		errUpdater = func(s string, e error) {
-			errs = support.WrapAndAppend(s, e, errs)
-		}
+		errs         error
+		options, err = optionsForContactChildFolders([]string{"displayName", "parentFolderId"})
 	)
 
-	query, err := cfc.
+	if err != nil {
+		return errors.Wrap(err, "contact cache resolver option")
+	}
+
+	builder := cfc.
 		gs.Client().
 		UsersById(cfc.userID).
 		ContactFoldersById(baseID).
-		ChildFolders().
-		Get(ctx, nil)
-	if err != nil {
-		return errors.Wrap(err, support.ConnectorStackErrorTrace(err))
-	}
+		ChildFolders()
 
-	iter, err := msgraphgocore.NewPageIterator(query, cfc.gs.Adapter(),
-		models.CreateContactFolderCollectionResponseFromDiscriminatorValue)
-	if err != nil {
-		return errors.Wrap(err, support.ConnectorStackErrorTrace(err))
-	}
-
-	cb := IterativeCollectContactContainers(containers,
-		"",
-		errUpdater)
-	if err := iter.Iterate(ctx, cb); err != nil {
-		return errors.Wrap(err, support.ConnectorStackErrorTrace(err))
-	}
-
-	if errs != nil {
-		return errs
-	}
-
-	for _, entry := range containers {
-		temp := cacheFolder{
-			Container: entry,
-		}
-
-		err = cfc.addFolder(temp)
+	for {
+		resp, err := builder.Get(ctx, options)
 		if err != nil {
-			errs = support.WrapAndAppend(
-				"cache build in cfc.Populate",
-				err,
-				errs)
+			return errors.Wrap(err, support.ConnectorStackErrorTrace(err))
 		}
+
+		for _, fold := range resp.GetValue() {
+			if err := checkIDAndName(fold); err != nil {
+				errs = support.WrapAndAppend(
+					"adding folder to contact resolver",
+					err,
+					errs,
+				)
+
+				continue
+			}
+
+			temp := cacheFolder{
+				Container: fold,
+			}
+
+			err = cfc.addFolder(temp)
+			if err != nil {
+				errs = support.WrapAndAppend(
+					"cache build in cfc.Populate",
+					err,
+					errs)
+			}
+		}
+
+		if resp.GetOdataNextLink() == nil {
+			break
+		}
+
+		builder = cf.NewChildFoldersRequestBuilder(*resp.GetOdataNextLink(), cfc.gs.Adapter())
 	}
 
 	if err := cfc.populatePaths(ctx); err != nil {


### PR DESCRIPTION
## Description

Iterator Removal from Cache Folder Resolver.
The iterator overhead contributes to the complexities of the GC backup pipeline. Issue 1486's goal is to remove errors that are populated from non-error scenarios (e.g. container no longer exists).

Stage 1: Reduce the number of error clauses in Populate() function
Stage 2: Update the M365ID retrieval process per resolver
PR introduces the `Iterate` approach used in delta functionality to populate the contact folder cache resolver. Reduces the number of calls and variable creation during the populate function. The increase in efficiency will reduce the amount of time concurrent Mailbox queries are being made (application throttling).

## Type of change
- [x] :hamster: Trivial/Minor

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

## Test Plan

- [x] :zap: Unit test
