### PR TITLE
add sharepoint to testVerifyBackupinputs

### DIFF
--- a/src/internal/connector/data_collections.go
+++ b/src/internal/connector/data_collections.go
@@ -29,7 +29,7 @@ func (gc *GraphConnector) DataCollections(ctx context.Context, sels selectors.Se
 	ctx, end := D.Span(ctx, "gc:dataCollections", D.Index("service", sels.Service.String()))
 	defer end()
 
-	err := verifyBackupInputs(sels, gc.GetUsersIds(), gc.GetSiteIds())
+	err := verifyBackupInputs(sels, gc.GetUsers(), gc.GetSiteIds())
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func (gc *GraphConnector) DataCollections(ctx context.Context, sels selectors.Se
 	}
 }
 
-func verifyBackupInputs(sels selectors.Selector, userIDs, siteIDs []string) error {
+func verifyBackupInputs(sels selectors.Selector, userPNs, siteIDs []string) error {
 	var ids []string
 
 	resourceOwners, err := sels.ResourceOwners()
@@ -65,7 +65,7 @@ func verifyBackupInputs(sels selectors.Selector, userIDs, siteIDs []string) erro
 
 	switch sels.Service {
 	case selectors.ServiceExchange, selectors.ServiceOneDrive:
-		ids = userIDs
+		ids = userPNs
 
 	case selectors.ServiceSharePoint:
 		ids = siteIDs

--- a/src/internal/connector/data_collections_test.go
+++ b/src/internal/connector/data_collections_test.go
@@ -504,13 +504,13 @@ func (suite *ConnectorCreateSharePointCollectionIntegrationSuite) TestCreateShar
 
 	var (
 		t      = suite.T()
-		userID = tester.M365UserID(t)
+		siteID = tester.M365SiteID(t)
 		gc     = loadConnector(ctx, t, Sites)
 		sel    = selectors.NewSharePointBackup()
 	)
 
 	sel.Include(sel.Folders(
-		[]string{userID},
+		[]string{siteID},
 		[]string{"foo"},
 		selectors.PrefixMatch(),
 	))

--- a/src/internal/connector/graph_connector_disconnected_test.go
+++ b/src/internal/connector/graph_connector_disconnected_test.go
@@ -18,7 +18,7 @@ import (
 
 // ---------------------------------------------------------------
 // Disconnected Test Section
-// -------------------------
+// ---------------------------------------------------------------
 type DisconnectedGraphConnectorSuite struct {
 	suite.Suite
 }
@@ -206,12 +206,18 @@ func (suite *DisconnectedGraphConnectorSuite) TestRestoreFailsBadService() {
 }
 
 func (suite *DisconnectedGraphConnectorSuite) TestVerifyBackupInputs() {
-	users := make(map[string]string)
-	users["elliotReid@someHospital.org"] = ""
-	users["chrisTurk@someHospital.org"] = ""
-	users["carlaEspinosa@someHospital.org"] = ""
-	users["bobKelso@someHospital.org"] = ""
-	users["johnDorian@someHospital.org"] = ""
+	users := []string{
+		"elliotReid@someHospital.org",
+		"chrisTurk@someHospital.org",
+		"carlaEspinosa@someHospital.org",
+		"bobKelso@someHospital.org",
+		"johnDorian@someHospital.org",
+	}
+
+	sites := []string{
+		"abc.site.foo",
+		"bar.site.baz",
+	}
 
 	tests := []struct {
 		name        string
@@ -256,11 +262,29 @@ func (suite *DisconnectedGraphConnectorSuite) TestVerifyBackupInputs() {
 				return sel.Selector
 			},
 		},
+		{
+			name:       "valid sites",
+			checkError: assert.NoError,
+			getSelector: func(t *testing.T) selectors.Selector {
+				sel := selectors.NewSharePointBackup()
+				sel.Include(sel.Sites([]string{"abc.site.foo", "bar.site.baz"}))
+				return sel.Selector
+			},
+		},
+		{
+			name:       "invalid sites",
+			checkError: assert.Error,
+			getSelector: func(t *testing.T) selectors.Selector {
+				sel := selectors.NewSharePointBackup()
+				sel.Include(sel.Sites([]string{"fnords.smarfs.brawnhilda"}))
+				return sel.Selector
+			},
+		},
 	}
 
 	for _, test := range tests {
 		suite.T().Run(test.name, func(t *testing.T) {
-			err := verifyBackupInputs(test.getSelector(t), users)
+			err := verifyBackupInputs(test.getSelector(t), users, sites)
 			test.checkError(t, err)
 		})
 	}

--- a/src/pkg/selectors/exchange.go
+++ b/src/pkg/selectors/exchange.go
@@ -36,7 +36,11 @@ type (
 	}
 )
 
-var _ Reducer = &ExchangeRestore{}
+var (
+	_ Reducer         = &ExchangeRestore{}
+	_ printabler      = &ExchangeRestore{}
+	_ resourceOwnerer = &ExchangeRestore{}
+)
 
 // NewExchange produces a new Selector with the service set to ServiceExchange.
 func NewExchangeBackup() *ExchangeBackup {
@@ -87,6 +91,16 @@ func (s Selector) ToExchangeRestore() (*ExchangeRestore, error) {
 // Printable creates the minimized display of a selector, formatted for human readability.
 func (s exchange) Printable() Printable {
 	return toPrintable[ExchangeScope](s.Selector)
+}
+
+// ResourceOwners produces the aggregation of discrete users described by each type of scope.
+// Any and None values are omitted.
+func (s exchange) ResourceOwners() selectorResourceOwners {
+	return selectorResourceOwners{
+		Excludes: resourceOwnersIn(s.Excludes, ExchangeUser.String()),
+		Filters:  resourceOwnersIn(s.Filters, ExchangeUser.String()),
+		Includes: resourceOwnersIn(s.Includes, ExchangeUser.String()),
+	}
 }
 
 // -------------------

--- a/src/pkg/selectors/onedrive.go
+++ b/src/pkg/selectors/onedrive.go
@@ -35,7 +35,11 @@ type (
 	}
 )
 
-var _ Reducer = &OneDriveRestore{}
+var (
+	_ Reducer         = &OneDriveRestore{}
+	_ printabler      = &OneDriveRestore{}
+	_ resourceOwnerer = &OneDriveRestore{}
+)
 
 // NewOneDriveBackup produces a new Selector with the service set to ServiceOneDrive.
 func NewOneDriveBackup() *OneDriveBackup {
@@ -86,6 +90,16 @@ func (s Selector) ToOneDriveRestore() (*OneDriveRestore, error) {
 // Printable creates the minimized display of a selector, formatted for human readability.
 func (s oneDrive) Printable() Printable {
 	return toPrintable[OneDriveScope](s.Selector)
+}
+
+// ResourceOwners produces the aggregation of discrete users described by each type of scope.
+// Any and None values are omitted.
+func (s oneDrive) ResourceOwners() selectorResourceOwners {
+	return selectorResourceOwners{
+		Excludes: resourceOwnersIn(s.Excludes, OneDriveUser.String()),
+		Filters:  resourceOwnersIn(s.Filters, OneDriveUser.String()),
+		Includes: resourceOwnersIn(s.Includes, OneDriveUser.String()),
+	}
 }
 
 // -------------------

--- a/src/pkg/selectors/selectors.go
+++ b/src/pkg/selectors/selectors.go
@@ -71,6 +71,19 @@ type Reducer interface {
 	Reduce(context.Context, *details.Details) *details.Details
 }
 
+// selectorResourceOwners aggregates all discrete resource owner ids described
+// in the selector.  Any and None values are ignored.  ResourceOwner sets are
+// grouped by their scope type (includes, excludes, filters).
+type selectorResourceOwners struct {
+	Includes []string
+	Excludes []string
+	Filters  []string
+}
+
+type resourceOwnerer interface {
+	ResourceOwners() selectorResourceOwners
+}
+
 // ---------------------------------------------------------------------------
 // Selector
 // ---------------------------------------------------------------------------
@@ -184,27 +197,46 @@ func (s Selector) PathService() path.ServiceType {
 // than have the caller make that interpretation.  Returns an error if the
 // service is unsupported.
 func (s Selector) Reduce(ctx context.Context, deets *details.Details) (*details.Details, error) {
-	var (
-		r   Reducer
-		err error
-	)
-
-	switch s.Service {
-	case ServiceExchange:
-		r, err = s.ToExchangeRestore()
-	case ServiceOneDrive:
-		r, err = s.ToOneDriveRestore()
-	case ServiceSharePoint:
-		r, err = s.ToSharePointRestore()
-	default:
-		return nil, errors.New("service not supported: " + s.Service.String())
-	}
-
+	r, err := selectorAsIface[Reducer](s)
 	if err != nil {
 		return nil, err
 	}
 
 	return r.Reduce(ctx, deets), nil
+}
+
+func (s Selector) ResourceOwners() (selectorResourceOwners, error) {
+	ro, err := selectorAsIface[resourceOwnerer](s)
+	if err != nil {
+		return selectorResourceOwners{}, err
+	}
+
+	return ro.ResourceOwners(), nil
+}
+
+// transformer for arbitrary selector interfaces
+func selectorAsIface[T any](s Selector) (T, error) {
+	var (
+		a   any
+		t   T
+		err error
+	)
+
+	switch s.Service {
+	case ServiceExchange:
+		a, err = func() (any, error) { return s.ToExchangeRestore() }()
+		t = a.(T)
+	case ServiceOneDrive:
+		a, err = func() (any, error) { return s.ToOneDriveRestore() }()
+		t = a.(T)
+	case ServiceSharePoint:
+		a, err = func() (any, error) { return s.ToSharePointRestore() }()
+		t = a.(T)
+	default:
+		err = errors.New("service not supported: " + s.Service.String())
+	}
+
+	return t, err
 }
 
 // ---------------------------------------------------------------------------
@@ -218,35 +250,18 @@ type Printable struct {
 	Includes map[string][]string `json:"includes,omitempty"`
 }
 
+type printabler interface {
+	Printable() Printable
+}
+
 // ToPrintable creates the minimized display of a selector, formatted for human readability.
 func (s Selector) ToPrintable() Printable {
-	switch s.Service {
-	case ServiceExchange:
-		r, err := s.ToExchangeRestore()
-		if err != nil {
-			return Printable{}
-		}
-
-		return r.Printable()
-
-	case ServiceOneDrive:
-		r, err := s.ToOneDriveBackup()
-		if err != nil {
-			return Printable{}
-		}
-
-		return r.Printable()
-
-	case ServiceSharePoint:
-		r, err := s.ToSharePointBackup()
-		if err != nil {
-			return Printable{}
-		}
-
-		return r.Printable()
+	p, err := selectorAsIface[printabler](s)
+	if err != nil {
+		return Printable{}
 	}
 
-	return Printable{}
+	return p.Printable()
 }
 
 // toPrintable creates the minimized display of a selector, formatted for human readability.
@@ -349,6 +364,32 @@ func addToSet(set []string, v []string) []string {
 // helpers
 // ---------------------------------------------------------------------------
 
+// produces the discrete set of resource owners in the slice of scopes.
+// Any and None values are discarded.
+func resourceOwnersIn(s []scope, rootCat string) []string {
+	rm := map[string]struct{}{}
+
+	for _, sc := range s {
+		for _, v := range split(sc[rootCat].Target) {
+			rm[v] = struct{}{}
+		}
+	}
+
+	rs := []string{}
+
+	for k := range rm {
+		if k != AnyTgt && k != NoneTgt {
+			rs = append(rs, k)
+		}
+	}
+
+	return rs
+}
+
+// ---------------------------------------------------------------------------
+// scope helpers
+// ---------------------------------------------------------------------------
+
 type scopeConfig struct {
 	usePathFilter   bool
 	usePrefixFilter bool
@@ -379,10 +420,6 @@ func pathType() option {
 		sc.usePathFilter = true
 	}
 }
-
-// ---------------------------------------------------------------------------
-// helpers
-// ---------------------------------------------------------------------------
 
 func badCastErr(cast, is service) error {
 	return errors.Wrapf(ErrorBadSelectorCast, "%s service is not %s", cast, is)

--- a/src/pkg/selectors/selectors_test.go
+++ b/src/pkg/selectors/selectors_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/pkg/filters"
 )
 
 type SelectorSuite struct {
@@ -124,6 +126,69 @@ func (suite *SelectorSuite) TestToResourceTypeMap() {
 		suite.T().Run(test.name, func(t *testing.T) {
 			rtm := toResourceTypeMap[mockScope](test.input)
 			assert.Equal(t, test.expect, rtm)
+		})
+	}
+}
+
+func (suite *SelectorSuite) TestResourceOwnersIn() {
+	rootCat := rootCatStub.String()
+
+	table := []struct {
+		name   string
+		input  []scope
+		expect []string
+	}{
+		{
+			name:   "nil",
+			input:  nil,
+			expect: []string{},
+		},
+		{
+			name:   "empty",
+			input:  []scope{},
+			expect: []string{},
+		},
+		{
+			name:   "single",
+			input:  []scope{{rootCat: filters.Identity("foo")}},
+			expect: []string{"foo"},
+		},
+		{
+			name:   "multiple values",
+			input:  []scope{{rootCat: filters.Identity(join("foo", "bar"))}},
+			expect: []string{"foo", "bar"},
+		},
+		{
+			name:   "with any",
+			input:  []scope{{rootCat: filters.Identity(join("foo", "bar", AnyTgt))}},
+			expect: []string{"foo", "bar"},
+		},
+		{
+			name:   "with none",
+			input:  []scope{{rootCat: filters.Identity(join("foo", "bar", NoneTgt))}},
+			expect: []string{"foo", "bar"},
+		},
+		{
+			name: "multiple scopes",
+			input: []scope{
+				{rootCat: filters.Identity(join("foo", "bar"))},
+				{rootCat: filters.Identity(join("baz"))},
+			},
+			expect: []string{"foo", "bar", "baz"},
+		},
+		{
+			name: "multiple scopes with duplicates",
+			input: []scope{
+				{rootCat: filters.Identity(join("foo", "bar"))},
+				{rootCat: filters.Identity(join("baz", "foo"))},
+			},
+			expect: []string{"foo", "bar", "baz"},
+		},
+	}
+	for _, test := range table {
+		suite.T().Run(test.name, func(t *testing.T) {
+			result := resourceOwnersIn(test.input, rootCat)
+			assert.ElementsMatch(t, test.expect, result)
 		})
 	}
 }

--- a/src/pkg/selectors/sharepoint.go
+++ b/src/pkg/selectors/sharepoint.go
@@ -34,7 +34,11 @@ type (
 	}
 )
 
-var _ Reducer = &SharePointRestore{}
+var (
+	_ Reducer         = &SharePointRestore{}
+	_ printabler      = &SharePointRestore{}
+	_ resourceOwnerer = &SharePointRestore{}
+)
 
 // NewSharePointBackup produces a new Selector with the service set to ServiceSharePoint.
 func NewSharePointBackup() *SharePointBackup {
@@ -85,6 +89,16 @@ func (s Selector) ToSharePointRestore() (*SharePointRestore, error) {
 // Printable creates the minimized display of a selector, formatted for human readability.
 func (s sharePoint) Printable() Printable {
 	return toPrintable[SharePointScope](s.Selector)
+}
+
+// ResourceOwners produces the aggregation of discrete sitets described by each type of scope.
+// Any and None values are omitted.
+func (s sharePoint) ResourceOwners() selectorResourceOwners {
+	return selectorResourceOwners{
+		Excludes: resourceOwnersIn(s.Excludes, SharePointSite.String()),
+		Filters:  resourceOwnersIn(s.Filters, SharePointSite.String()),
+		Includes: resourceOwnersIn(s.Includes, SharePointSite.String()),
+	}
 }
 
 // -------------------


### PR DESCRIPTION
## Description

adds sharepoint to testVerifyBackupInputs, with
some additional refactors to selectors for either
convenience or case coverage.

❗ This branch needs to be merged before [issue-1506-collects](https://github.com/alcionai/corso/pull/1536)
can merge. ❗ 

## Type of change

- [x] :sunflower: Feature
- [x] :bug: Bugfix

## Issue(s)

* #1506

## Test Plan

- [x] :zap: Unit test
