### PR TITLE
add flag to retain all progress bars

### DIFF
--- a/src/internal/observe/observe.go
+++ b/src/internal/observe/observe.go
@@ -14,9 +14,9 @@ import (
 )
 
 const (
-	noProgressBarsFN   = "no-progress-bars"
-	saveProgressBarsFN = "save-progress-bars"
-	progressBarWidth   = 32
+	hideProgressBarsFN   = "hide-progress"
+	retainProgressBarsFN = "retain-progress"
+	progressBarWidth     = 32
 )
 
 var (
@@ -35,13 +35,13 @@ func init() {
 	makeSpinFrames(progressBarWidth)
 }
 
-// adds the persistent boolean flag --no-progress-bars to the provided command.
+// adds the persistent boolean flag --hide-progress to the provided command.
 // This is a hack for help displays.  Due to seeding the context, we also
 // need to parse the configuration before we execute the command.
 func AddProgressBarFlags(parent *cobra.Command) {
 	fs := parent.PersistentFlags()
-	fs.Bool(noProgressBarsFN, false, "turn off the progress bar displays")
-	fs.Bool(saveProgressBarsFN, false, "preserve progress bars after completion")
+	fs.Bool(hideProgressBarsFN, false, "turn off the progress bar displays")
+	fs.Bool(retainProgressBarsFN, false, "retain the progress bar displays after completion")
 }
 
 // Due to races between the lazy evaluation of flags in cobra and the need to init observer
@@ -50,8 +50,8 @@ func AddProgressBarFlags(parent *cobra.Command) {
 func PreloadFlags() *config {
 	fs := pflag.NewFlagSet("seed-observer", pflag.ContinueOnError)
 	fs.ParseErrorsWhitelist.UnknownFlags = true
-	fs.Bool(noProgressBarsFN, false, "turn off the progress bar displays")
-	fs.Bool(saveProgressBarsFN, false, "preserve progress bars after completion")
+	fs.Bool(hideProgressBarsFN, false, "turn off the progress bar displays")
+	fs.Bool(retainProgressBarsFN, false, "retain the progress bar displays after completion")
 	// prevents overriding the corso/cobra help processor
 	fs.BoolP("help", "h", false, "")
 
@@ -62,14 +62,14 @@ func PreloadFlags() *config {
 
 	// retrieve the user's preferred display
 	// automatically defaults to "info"
-	shouldHide, err := fs.GetBool(noProgressBarsFN)
+	shouldHide, err := fs.GetBool(hideProgressBarsFN)
 	if err != nil {
 		return nil
 	}
 
 	// retrieve the user's preferred display
 	// automatically defaults to "info"
-	shouldAlwaysShow, err := fs.GetBool(saveProgressBarsFN)
+	shouldAlwaysShow, err := fs.GetBool(retainProgressBarsFN)
 	if err != nil {
 		return nil
 	}

--- a/src/internal/observe/observe_test.go
+++ b/src/internal/observe/observe_test.go
@@ -33,13 +33,13 @@ func (suite *ObserveProgressUnitSuite) TestItemProgress() {
 	t := suite.T()
 
 	recorder := strings.Builder{}
-	observe.SeedWriter(ctx, &recorder, false)
+	observe.SeedWriter(ctx, &recorder, nil)
 
 	defer func() {
 		// don't cross-contaminate other tests.
 		observe.Complete()
 		//nolint:forbidigo
-		observe.SeedWriter(context.Background(), nil, false)
+		observe.SeedWriter(context.Background(), nil, nil)
 	}()
 
 	from := make([]byte, 100)
@@ -87,13 +87,13 @@ func (suite *ObserveProgressUnitSuite) TestCollectionProgress_unblockOnCtxCancel
 	t := suite.T()
 
 	recorder := strings.Builder{}
-	observe.SeedWriter(ctx, &recorder, false)
+	observe.SeedWriter(ctx, &recorder, nil)
 
 	defer func() {
 		// don't cross-contaminate other tests.
 		observe.Complete()
 		//nolint:forbidigo
-		observe.SeedWriter(context.Background(), nil, false)
+		observe.SeedWriter(context.Background(), nil, nil)
 	}()
 
 	progCh, closer := observe.CollectionProgress("test", "testcat", "testertons")
@@ -122,13 +122,13 @@ func (suite *ObserveProgressUnitSuite) TestCollectionProgress_unblockOnChannelCl
 	t := suite.T()
 
 	recorder := strings.Builder{}
-	observe.SeedWriter(ctx, &recorder, false)
+	observe.SeedWriter(ctx, &recorder, nil)
 
 	defer func() {
 		// don't cross-contaminate other tests.
 		observe.Complete()
 		//nolint:forbidigo
-		observe.SeedWriter(context.Background(), nil, false)
+		observe.SeedWriter(context.Background(), nil, nil)
 	}()
 
 	progCh, closer := observe.CollectionProgress("test", "testcat", "testertons")
@@ -153,12 +153,12 @@ func (suite *ObserveProgressUnitSuite) TestObserveProgress() {
 	defer flush()
 
 	recorder := strings.Builder{}
-	observe.SeedWriter(ctx, &recorder, false)
+	observe.SeedWriter(ctx, &recorder, nil)
 
 	defer func() {
 		// don't cross-contaminate other tests.
 		//nolint:forbidigo
-		observe.SeedWriter(context.Background(), nil, false)
+		observe.SeedWriter(context.Background(), nil, nil)
 	}()
 
 	message := "Test Message"
@@ -174,12 +174,12 @@ func (suite *ObserveProgressUnitSuite) TestObserveProgressWithCompletion() {
 	defer flush()
 
 	recorder := strings.Builder{}
-	observe.SeedWriter(ctx, &recorder, false)
+	observe.SeedWriter(ctx, &recorder, nil)
 
 	defer func() {
 		// don't cross-contaminate other tests.
 		//nolint:forbidigo
-		observe.SeedWriter(context.Background(), nil, false)
+		observe.SeedWriter(context.Background(), nil, nil)
 	}()
 
 	message := "Test Message"
@@ -204,12 +204,12 @@ func (suite *ObserveProgressUnitSuite) TestObserveProgressWithChannelClosed() {
 	defer flush()
 
 	recorder := strings.Builder{}
-	observe.SeedWriter(ctx, &recorder, false)
+	observe.SeedWriter(ctx, &recorder, nil)
 
 	defer func() {
 		// don't cross-contaminate other tests.
 		//nolint:forbidigo
-		observe.SeedWriter(context.Background(), nil, false)
+		observe.SeedWriter(context.Background(), nil, nil)
 	}()
 
 	message := "Test Message"
@@ -236,12 +236,12 @@ func (suite *ObserveProgressUnitSuite) TestObserveProgressWithContextCancelled()
 	ctx, cancel := context.WithCancel(ctx)
 
 	recorder := strings.Builder{}
-	observe.SeedWriter(ctx, &recorder, false)
+	observe.SeedWriter(ctx, &recorder, nil)
 
 	defer func() {
 		// don't cross-contaminate other tests.
 		//nolint:forbidigo
-		observe.SeedWriter(context.Background(), nil, false)
+		observe.SeedWriter(context.Background(), nil, nil)
 	}()
 
 	message := "Test Message"
@@ -265,12 +265,12 @@ func (suite *ObserveProgressUnitSuite) TestObserveProgressWithCount() {
 	defer flush()
 
 	recorder := strings.Builder{}
-	observe.SeedWriter(ctx, &recorder, false)
+	observe.SeedWriter(ctx, &recorder, nil)
 
 	defer func() {
 		// don't cross-contaminate other tests.
 		//nolint:forbidigo
-		observe.SeedWriter(context.Background(), nil, false)
+		observe.SeedWriter(context.Background(), nil, nil)
 	}()
 
 	header := "Header"
@@ -298,12 +298,12 @@ func (suite *ObserveProgressUnitSuite) TestObserveProgressWithCountChannelClosed
 	defer flush()
 
 	recorder := strings.Builder{}
-	observe.SeedWriter(ctx, &recorder, false)
+	observe.SeedWriter(ctx, &recorder, nil)
 
 	defer func() {
 		// don't cross-contaminate other tests.
 		//nolint:forbidigo
-		observe.SeedWriter(context.Background(), nil, false)
+		observe.SeedWriter(context.Background(), nil, nil)
 	}()
 
 	header := "Header"


### PR DESCRIPTION
## Description

Adds the --save-progress-bars flag, which
prevents the observe package from removing
completed progress bars.

## Type of change

- [x] :sunflower: Feature

## Issue(s)

* #1581

## Test Plan

- [x] :muscle: Manual
