### PR TITLE
retrieve all drives in each site

### DIFF
--- a/src/internal/connector/data_collections_test.go
+++ b/src/internal/connector/data_collections_test.go
@@ -169,7 +169,7 @@ func (suite *ConnectorDataCollectionIntegrationSuite) TestSharePointDataCollecti
 		getSelector func(t *testing.T) selectors.Selector
 	}{
 		{
-			name: "Items - TODO: actual sharepoint categories",
+			name: "Libraries",
 			getSelector: func(t *testing.T) selectors.Selector {
 				sel := selectors.NewSharePointBackup()
 				sel.Include(sel.Libraries([]string{suite.site}, selectors.Any()))
@@ -188,7 +188,10 @@ func (suite *ConnectorDataCollectionIntegrationSuite) TestSharePointDataCollecti
 				connector.credentials.AzureTenantID,
 				connector)
 			require.NoError(t, err)
-			assert.Equal(t, 1, len(collection))
+
+			// we don't know an exact count of drives this will produce,
+			// but it should be more than one.
+			assert.Less(t, 1, len(collection))
 
 			// the test only reads the firstt collection
 			connector.incrementAwaitingMessages()

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -123,7 +123,7 @@ func (oc *Collection) populateItems(ctx context.Context) {
 
 	folderProgress, colCloser := observe.ProgressWithCount(
 		observe.ItemQueueMsg,
-		"Folder: /"+parentPathString,
+		"/"+parentPathString,
 		int64(len(oc.driveItemIDs)),
 	)
 	defer colCloser()

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -11,6 +11,7 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/drives/item/root/delta"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
+	mssitedrives "github.com/microsoftgraph/msgraph-sdk-go/sites/item/drives"
 	"github.com/pkg/errors"
 
 	"github.com/alcionai/corso/src/internal/connector/graph"
@@ -84,7 +85,13 @@ func drives(
 }
 
 func siteDrives(ctx context.Context, service graph.Service, site string) ([]models.Driveable, error) {
-	r, err := service.Client().SitesById(site).Drives().Get(ctx, nil)
+	options := &mssitedrives.DrivesRequestBuilderGetRequestConfiguration{
+		QueryParameters: &mssitedrives.DrivesRequestBuilderGetQueryParameters{
+			Select: []string{"id", "name", "weburl", "system"},
+		},
+	}
+
+	r, err := service.Client().SitesById(site).Drives().Get(ctx, options)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to retrieve site drives. site: %s, details: %s",
 			site, support.ConnectorStackErrorTrace(err))

--- a/src/internal/observe/observe.go
+++ b/src/internal/observe/observe.go
@@ -252,8 +252,8 @@ func ProgressWithCount(header, message string, count int64) (chan<- struct{}, fu
 	barOpts := []mpb.BarOption{
 		mpb.PrependDecorators(
 			decor.Name(header, decor.WCSyncSpaceR),
-			decor.Counters(0, " %d/%d "),
 			decor.Name(message),
+			decor.Counters(0, " %d/%d "),
 		),
 	}
 


### PR DESCRIPTION
## Description

Extends the site drive query to include a selector
for 'system' properties, which causes graph to
return an expanded set of drives including many
which are not normally visible to end users.

## Type of change

- [x] :sunflower: Feature

## Issue(s)

* #1506

## Test Plan

- [x] :green_heart: E2E
