### PR TITLE
Speed up Exchange backup by parallelizing url fetch

### DIFF
--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -152,7 +152,7 @@ func (col *Collection) populateByOptionIdentifier(
 		err  error
 	}
 
-	errCh := make(chan uerr)
+	errCh := make(chan uerr, len(col.jobs))
 	defer close(errCh)
 
 	ffail := int64(0)
@@ -179,7 +179,9 @@ func (col *Collection) populateByOptionIdentifier(
 					break
 				}
 				// TODO: Tweak sleep times
-				time.Sleep(time.Duration(3*(i+1)) * time.Second)
+				if i != numberOfRetries-1 {
+					time.Sleep(time.Duration(3*(i+1)) * time.Second)
+				}
 			}
 
 			if err != nil {

--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -34,9 +34,12 @@ var (
 )
 
 const (
-	collectionChannelBufferSize  = 1000
-	numberOfRetries              = 4
-	urlPrefetchChannelBufferSize = 50
+	collectionChannelBufferSize = 1000
+	numberOfRetries             = 4
+
+	// Outlooks expects max 4 concurrent requests
+	// https://learn.microsoft.com/en-us/graph/throttling-limits#outlook-service-limits
+	urlPrefetchChannelBufferSize = 4
 )
 
 // Collection implements the interface from data.Collection


### PR DESCRIPTION
## Description

From rough numbers we can speedup an account with ~3000 emails, ~1000 contacts and ~1000 events from ~18m to <3m.

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* https://github.com/alcionai/corso/issues/362
* https://github.com/alcionai/corso/issues/1595
* https://github.com/alcionai/corso/pull/1607

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
