### PR TITLE
Path: Category expanded to include SharePoint Lists

### DIFF
--- a/src/pkg/path/categorytype_string.go
+++ b/src/pkg/path/categorytype_string.go
@@ -13,12 +13,13 @@ func _() {
 	_ = x[ContactsCategory-2]
 	_ = x[EventsCategory-3]
 	_ = x[FilesCategory-4]
-	_ = x[LibrariesCategory-5]
+	_ = x[ListsCategory-5]
+	_ = x[LibrariesCategory-6]
 }
 
-const _CategoryType_name = "UnknownCategoryemailcontactseventsfileslibraries"
+const _CategoryType_name = "UnknownCategoryemailcontactseventsfileslistslibraries"
 
-var _CategoryType_index = [...]uint8{0, 15, 20, 28, 34, 39, 48}
+var _CategoryType_index = [...]uint8{0, 15, 20, 28, 34, 39, 44, 53}
 
 func (i CategoryType) String() string {
 	if i < 0 || i >= CategoryType(len(_CategoryType_index)-1) {

--- a/src/pkg/path/resource_path.go
+++ b/src/pkg/path/resource_path.go
@@ -40,6 +40,7 @@ const (
 	ContactsCategory               // contacts
 	EventsCategory                 // events
 	FilesCategory                  // files
+	ListsCategory                  // lists
 	LibrariesCategory              // libraries
 )
 
@@ -55,6 +56,8 @@ func ToCategoryType(category string) CategoryType {
 		return FilesCategory
 	case LibrariesCategory.String():
 		return LibrariesCategory
+	case ListsCategory.String():
+		return ListsCategory
 	default:
 		return UnknownCategory
 	}
@@ -72,7 +75,7 @@ var serviceCategories = map[ServiceType]map[CategoryType]struct{}{
 	},
 	SharePointService: {
 		LibrariesCategory: {},
-		// TODO: Lists
+		ListsCategory:     {},
 	},
 }
 

--- a/src/pkg/path/resource_path_test.go
+++ b/src/pkg/path/resource_path_test.go
@@ -109,6 +109,13 @@ var (
 				return pb.ToDataLayerSharePointPath(tenant, site, path.LibrariesCategory, isItem)
 			},
 		},
+		{
+			service:  path.SharePointService,
+			category: path.ListsCategory,
+			pathFunc: func(pb *path.Builder, tenant, site string, isItem bool) (path.Path, error) {
+				return pb.ToDataLayerSharePointPath(tenant, site, path.ListsCategory, isItem)
+			},
+		},
 	}
 )
 


### PR DESCRIPTION
## Description
Backup of SharePoint requires the extension of `path.CategoryType` to be able to support the creation of `data.Collections` for `SharePoint.Lists`. 
## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature


## Test Plan

- [x] :zap: Unit test

