### PR TITLE
Fix bad comparison due to timezone mismatch

### DIFF
--- a/src/internal/connector/exchange/event_test.go
+++ b/src/internal/connector/exchange/event_test.go
@@ -26,7 +26,9 @@ func TestEventSuite(t *testing.T) {
 // TestEventInfo verifies that searchable event metadata
 // can be properly retrieved from a models.Eventable object
 func (suite *EventSuite) TestEventInfo() {
-	initial := time.Now()
+	// Exchange stores start/end times in UTC and the below compares hours
+	// directly so we need to "normalize" the timezone here.
+	initial := time.Now().UTC()
 	now := common.FormatTimeWith(initial, common.M365DateTimeTimeZone)
 
 	suite.T().Logf("Initial: %v\nFormatted: %v\n", initial, now)


### PR DESCRIPTION
## Description

Exchange stores start/end times for events in UTC time. This fixes test failures due to comparing hours extracted from time structs directly. Without the normalization to UTC, the initial time may be different.

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* closes #1625 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
