### PR TITLE
Helper to fetch backups by ID

### DIFF
--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -373,7 +373,7 @@ func listExchangeCmd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	bs, err := r.Backups(ctx, store.Service(path.ExchangeService))
+	bs, err := r.BackupsByTag(ctx, store.Service(path.ExchangeService))
 	if err != nil {
 		return Only(ctx, errors.Wrap(err, "Failed to list backups in the repository"))
 	}

--- a/src/cli/backup/onedrive.go
+++ b/src/cli/backup/onedrive.go
@@ -272,7 +272,7 @@ func listOneDriveCmd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	bs, err := r.Backups(ctx, store.Service(path.OneDriveService))
+	bs, err := r.BackupsByTag(ctx, store.Service(path.OneDriveService))
 	if err != nil {
 		return Only(ctx, errors.Wrap(err, "Failed to list backups in the repository"))
 	}

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -229,7 +229,7 @@ func listSharePointCmd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	bs, err := r.Backups(ctx, store.Service(path.SharePointService))
+	bs, err := r.BackupsByTag(ctx, store.Service(path.SharePointService))
 	if err != nil {
 		return Only(ctx, errors.Wrap(err, "Failed to list backups in the repository"))
 	}

--- a/src/cli/utils/testdata/opts.go
+++ b/src/cli/utils/testdata/opts.go
@@ -408,6 +408,10 @@ func (MockBackupGetter) Backup(
 	return nil, errors.New("unexpected call to mock")
 }
 
+func (MockBackupGetter) BackupsByID(context.Context, []model.StableID) ([]*backup.Backup, error) {
+	return nil, errors.New("unexpected call to mock")
+}
+
 func (MockBackupGetter) Backups(context.Context, ...store.FilterOption) ([]*backup.Backup, error) {
 	return nil, errors.New("unexpected call to mock")
 }

--- a/src/cli/utils/testdata/opts.go
+++ b/src/cli/utils/testdata/opts.go
@@ -408,11 +408,14 @@ func (MockBackupGetter) Backup(
 	return nil, errors.New("unexpected call to mock")
 }
 
-func (MockBackupGetter) BackupsByID(context.Context, []model.StableID) ([]*backup.Backup, error) {
+func (MockBackupGetter) Backups(context.Context, []model.StableID) ([]*backup.Backup, error) {
 	return nil, errors.New("unexpected call to mock")
 }
 
-func (MockBackupGetter) Backups(context.Context, ...store.FilterOption) ([]*backup.Backup, error) {
+func (MockBackupGetter) BackupsByTag(
+	context.Context,
+	...store.FilterOption,
+) ([]*backup.Backup, error) {
 	return nil, errors.New("unexpected call to mock")
 }
 

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -29,8 +29,8 @@ var ErrorRepoAlreadyExists = errors.New("a repository was already initialized wi
 // repository.
 type BackupGetter interface {
 	Backup(ctx context.Context, id model.StableID) (*backup.Backup, error)
-	BackupsByID(ctx context.Context, ids []model.StableID) ([]*backup.Backup, error)
-	Backups(ctx context.Context, fs ...store.FilterOption) ([]*backup.Backup, error)
+	Backups(ctx context.Context, ids []model.StableID) ([]*backup.Backup, error)
+	BackupsByTag(ctx context.Context, fs ...store.FilterOption) ([]*backup.Backup, error)
 	BackupDetails(
 		ctx context.Context,
 		backupID string,
@@ -242,7 +242,7 @@ func (r repository) Backup(ctx context.Context, id model.StableID) (*backup.Back
 
 // BackupsByID lists backups by ID. Returns as many backups as possible with
 // errors for the backups it was unable to retrieve.
-func (r repository) BackupsByID(ctx context.Context, ids []model.StableID) ([]*backup.Backup, error) {
+func (r repository) Backups(ctx context.Context, ids []model.StableID) ([]*backup.Backup, error) {
 	var (
 		errs *multierror.Error
 		bups []*backup.Backup
@@ -262,7 +262,7 @@ func (r repository) BackupsByID(ctx context.Context, ids []model.StableID) ([]*b
 }
 
 // backups lists backups in a repository
-func (r repository) Backups(ctx context.Context, fs ...store.FilterOption) ([]*backup.Backup, error) {
+func (r repository) BackupsByTag(ctx context.Context, fs ...store.FilterOption) ([]*backup.Backup, error) {
 	sw := store.NewKopiaStore(r.modelStore)
 	return sw.GetBackups(ctx, fs...)
 }

--- a/src/pkg/repository/repository_load_test.go
+++ b/src/pkg/repository/repository_load_test.go
@@ -181,7 +181,7 @@ func runBackupListLoadTest(
 		)
 
 		pprof.Do(ctx, labels, func(ctx context.Context) {
-			bs, err = r.Backups(ctx)
+			bs, err = r.BackupsByTag(ctx)
 		})
 
 		require.NoError(t, err, "retrieving backups")


### PR DESCRIPTION
## Description

Helper function to fetch backup models by ID. Also renames `Backups` to `BackupsByTag`

## Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* #1505

separated from
* #1609 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
