### PR TITLE
Prevent Test-Suite-Fork from running on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,10 +144,7 @@ jobs:
     needs: [Precheck, Checkout]
     environment: Testing
     runs-on: ubuntu-latest
-    if: (startsWith(github.ref, 'refs/tags/') ||
-      github.ref == 'refs/heads/main' ||
-      needs.precheck.outputs.srcfileschanged == 'true') &&
-      github.event.pull_request.head.repo.full_name == github.repository
+    if: (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main') || (needs.precheck.outputs.srcfileschanged == 'true' && github.event.pull_request.head.repo.full_name == github.repository)
     defaults:
       run:
         working-directory: src
@@ -205,8 +202,7 @@ jobs:
   Test-Suite-Fork:
     needs: [Precheck]
     environment: Testing
-    if: (needs.precheck.outputs.srcfileschanged == 'true' &&
-      github.event.pull_request.head.repo.full_name != github.repository) # only run when repo is forked
+    if: (!startsWith(github.ref , 'refs/tags/') && github.ref != 'refs/heads/main') && (needs.precheck.outputs.srcfileschanged == 'true' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Description

As of now, it looks like we are running `Test-Suite-Fork` in `main` instead of `Test-Suite-Trusted`. This tweaks the conditions so as to restrict the `Test-Suite-Fork` to just fork PRs.

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
