### PR TITLE
Custom function to send get requests on delta queries

### DIFF
--- a/src/internal/connector/exchange/delta_get.go
+++ b/src/internal/connector/exchange/delta_get.go
@@ -9,17 +9,26 @@ import (
 	msmaildelta "github.com/microsoftgraph/msgraph-sdk-go/users/item/mailfolders/item/messages/delta"
 )
 
+//nolint:lll
+const (
+	mailURLTemplate     = "{+baseurl}/users/{user%2Did}/mailFolders/{mailFolder%2Did}/messages/microsoft.graph.delta(){?%24top,%24skip,%24search,%24filter,%24count,%24select,%24orderby}"
+	contactsURLTemplate = "{+baseurl}/users/{user%2Did}/contactFolders/{contactFolder%2Did}/contacts/microsoft.graph.delta(){?%24top,%24skip,%24search,%24filter,%24count,%24select,%24orderby}"
+)
+
 // The following functions are based off the code in v0.41.0 of msgraph-sdk-go
 // for sending delta requests with query parameters.
 
 func createGetRequestInformationWithRequestConfiguration(
 	baseRequestInfoFunc func() (*abs.RequestInformation, error),
 	requestConfig *DeltaRequestBuilderGetRequestConfiguration,
+	template string,
 ) (*abs.RequestInformation, error) {
 	requestInfo, err := baseRequestInfoFunc()
 	if err != nil {
 		return nil, err
 	}
+
+	requestInfo.UrlTemplate = template
 
 	if requestConfig != nil {
 		if requestConfig.QueryParameters != nil {
@@ -45,6 +54,7 @@ func sendMessagesDeltaGet(
 			return m.CreateGetRequestInformationWithRequestConfiguration(nil)
 		},
 		requestConfiguration,
+		mailURLTemplate,
 	)
 	if err != nil {
 		return nil, err
@@ -84,6 +94,7 @@ func sendContactsDeltaGet(
 			return m.CreateGetRequestInformationWithRequestConfiguration(nil)
 		},
 		requestConfiguration,
+		contactsURLTemplate,
 	)
 	if err != nil {
 		return nil, err

--- a/src/internal/connector/exchange/delta_get.go
+++ b/src/internal/connector/exchange/delta_get.go
@@ -1,0 +1,112 @@
+package exchange
+
+import (
+	"context"
+
+	abs "github.com/microsoft/kiota-abstractions-go"
+	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
+	mscontactdelta "github.com/microsoftgraph/msgraph-sdk-go/users/item/contactfolders/item/contacts/delta"
+	msmaildelta "github.com/microsoftgraph/msgraph-sdk-go/users/item/mailfolders/item/messages/delta"
+)
+
+// The following functions are based off the code in v0.41.0 of msgraph-sdk-go
+// for sending delta requests with query parameters.
+
+func createGetRequestInformationWithRequestConfiguration(
+	baseRequestInfoFunc func() (*abs.RequestInformation, error),
+	requestConfig *DeltaRequestBuilderGetRequestConfiguration,
+) (*abs.RequestInformation, error) {
+	requestInfo, err := baseRequestInfoFunc()
+	if err != nil {
+		return nil, err
+	}
+
+	if requestConfig != nil {
+		if requestConfig.QueryParameters != nil {
+			requestInfo.AddQueryParameters(*(requestConfig.QueryParameters))
+		}
+
+		requestInfo.AddRequestHeaders(requestConfig.Headers)
+		requestInfo.AddRequestOptions(requestConfig.Options)
+	}
+
+	return requestInfo, nil
+}
+
+//nolint:deadcode
+func sendMessagesDeltaGet(
+	ctx context.Context,
+	m *msmaildelta.DeltaRequestBuilder,
+	requestConfiguration *DeltaRequestBuilderGetRequestConfiguration,
+	adapter abs.RequestAdapter,
+) (msmaildelta.DeltaResponseable, error) {
+	requestInfo, err := createGetRequestInformationWithRequestConfiguration(
+		func() (*abs.RequestInformation, error) {
+			return m.CreateGetRequestInformationWithRequestConfiguration(nil)
+		},
+		requestConfiguration,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	errorMapping := abs.ErrorMappings{
+		"4XX": odataerrors.CreateODataErrorFromDiscriminatorValue,
+		"5XX": odataerrors.CreateODataErrorFromDiscriminatorValue,
+	}
+
+	res, err := adapter.SendAsync(
+		ctx,
+		requestInfo,
+		msmaildelta.CreateDeltaResponseFromDiscriminatorValue,
+		errorMapping,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if res == nil {
+		return nil, nil
+	}
+
+	return res.(msmaildelta.DeltaResponseable), nil
+}
+
+//nolint:deadcode
+func sendContactsDeltaGet(
+	ctx context.Context,
+	m *mscontactdelta.DeltaRequestBuilder,
+	requestConfiguration *DeltaRequestBuilderGetRequestConfiguration,
+	adapter abs.RequestAdapter,
+) (mscontactdelta.DeltaResponseable, error) {
+	requestInfo, err := createGetRequestInformationWithRequestConfiguration(
+		func() (*abs.RequestInformation, error) {
+			return m.CreateGetRequestInformationWithRequestConfiguration(nil)
+		},
+		requestConfiguration,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	errorMapping := abs.ErrorMappings{
+		"4XX": odataerrors.CreateODataErrorFromDiscriminatorValue,
+		"5XX": odataerrors.CreateODataErrorFromDiscriminatorValue,
+	}
+
+	res, err := adapter.SendAsync(
+		ctx,
+		requestInfo,
+		mscontactdelta.CreateDeltaResponseFromDiscriminatorValue,
+		errorMapping,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if res == nil {
+		return nil, nil
+	}
+
+	return res.(mscontactdelta.DeltaResponseable), nil
+}

--- a/src/internal/connector/exchange/query_options.go
+++ b/src/internal/connector/exchange/query_options.go
@@ -3,6 +3,7 @@ package exchange
 import (
 	"fmt"
 
+	abs "github.com/microsoft/kiota-abstractions-go"
 	msuser "github.com/microsoftgraph/msgraph-sdk-go/users"
 	mscalendars "github.com/microsoftgraph/msgraph-sdk-go/users/item/calendars"
 	mscontactfolder "github.com/microsoftgraph/msgraph-sdk-go/users/item/contactfolders"
@@ -124,6 +125,24 @@ func CategoryToOptionIdentifier(category path.CategoryType) optionIdentifier {
 // Graph queries and reduce / filter the amount of data returned
 // which reduces the overall latency of complex calls
 // -----------------------------------------------------------------------
+
+// Delta requests for mail and contacts have the same parameters and config
+// structs.
+type DeltaRequestBuilderGetQueryParameters struct {
+	Count   *bool    `uriparametername:"%24count"`
+	Filter  *string  `uriparametername:"%24filter"`
+	Orderby []string `uriparametername:"%24orderby"`
+	Search  *string  `uriparametername:"%24search"`
+	Select  []string `uriparametername:"%24select"`
+	Skip    *int32   `uriparametername:"%24skip"`
+	Top     *int32   `uriparametername:"%24top"`
+}
+
+type DeltaRequestBuilderGetRequestConfiguration struct {
+	Headers         map[string]string
+	Options         []abs.RequestOption
+	QueryParameters *DeltaRequestBuilderGetQueryParameters
+}
 
 func optionsForFolderMessages(moreOps []string) (*msmfmessage.MessagesRequestBuilderGetRequestConfiguration, error) {
 	selecting, err := buildOptions(moreOps, messages)


### PR DESCRIPTION
## Description

The current version of graph SDK (v0.40.0) Corso uses does not support adding query parameters to delta requests on exchange mail folder messages or contact folder contacts. This reimplements the logic from a newer version of graph SDK so that we can add those parameters. Much of the code is lifted from the updated version of the SDK, with some combining of types that have the same fields.

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* #1612 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
