### PR TITLE
GC: Restore: `exchange.Mail` Cache Resolver Change

### DIFF
--- a/src/internal/connector/exchange/service_restore.go
+++ b/src/internal/connector/exchange/service_restore.go
@@ -524,8 +524,8 @@ func establishMailRestoreLocation(
 
 	for _, folder := range folders {
 		pb = *pb.Append(folder)
-		cached, ok := mfc.PathInCache(pb.String())
 
+		cached, ok := mfc.PathInCache(pb.String())
 		if ok {
 			folderID = cached
 			continue
@@ -544,7 +544,7 @@ func establishMailRestoreLocation(
 		// newCache to false in this we'll only try to populate it once per function
 		// call even if we make a new cache.
 		if isNewCache {
-			if err := mfc.Populate(ctx, folderID, folder); err != nil {
+			if err := mfc.Populate(ctx, rootFolderAlias); err != nil {
 				return "", errors.Wrap(err, "populating folder cache")
 			}
 


### PR DESCRIPTION
## Description
For the upgrade for the `msgraph-sdk-go`, there were side effects to the Delta Queries. We are no longer able to build a truncated tree for Restore. The `gs.Client().UsersById(user).MailFoldersById(root).ChildFolders().Delta().Get()` no longer returns the Inbox for `exchange.Mail`. Therefore, the call is changed to `gs.Client().UsersById(user).MailFolders().Delta().Get()` is now used. 

Result: These changes will create a larger container resolver for Mail during restore. 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

## Test Plan


- [x] :zap: Unit test
