### PR TITLE
purge onedrive folders on gh action

### DIFF
--- a/.github/actions/purge-m365-user-data/action.yml
+++ b/.github/actions/purge-m365-user-data/action.yml
@@ -59,5 +59,15 @@ runs:
         ./foldersAndItems.ps1 -WellKnownRoot recoverableitemsroot -User ${{ inputs.user }} -FolderNamePurge Purges
         ./foldersAndItems.ps1 -WellKnownRoot recoverableitemsroot -User ${{ inputs.user }} -FolderNamePurge Deletions
 
-# possible future extensions
-# ./foldersAndItems.ps1 -WellKnownRoot recoverableitemsroot -User ${{ inputs.user }} -FolderNamePurge "Calendar Logging"
+    - name: Run the old purge script to clear out onedrive buildup
+      working-directory: ./src
+      if: ${{ inputs.folder-prefix != '' }}
+      env:
+        AZURE_CLIENT_ID: ${{ inputs.azure-client-id }}
+        AZURE_CLIENT_SECRET: ${{ inputs.azure-client-secret }}
+        AZURE_TENANT_ID: ${{ inputs.azure-tenant-id }}
+      run: >
+        go run ./cmd/purge/purge.go onedrive
+        --user ${{ inputs.user }}
+        --prefix ${{ inputs.folder-prefix }}
+        --before ${{ inputs.older-than }}


### PR DESCRIPTION
## Description

runs the golang purge script for onedrive folders
when running the pwsh purge scripts.  This will
move test-generated folders in onedrive into
a recycle bin.  However, that recycle bin cannot
be purged via api, and must be manually emptied
periodically for each user.

## Type of change

- [x] :computer: CI/Deployment

## Issue(s)

* #1525

## Test Plan

- [x] :green_heart: E2E
