### PR TITLE
GC: Resolver: `exchange.Mail` versioning mail bug fix

### DIFF
--- a/src/internal/connector/exchange/mail_folder_cache.go
+++ b/src/internal/connector/exchange/mail_folder_cache.go
@@ -23,16 +23,13 @@ type mailFolderCache struct {
 	userID string
 }
 
-// populateMailRoot fetches and populates the "base" directory from user's inbox.
+// populateMailRoot manually fetches directories that are not returned during Graph for msgraph-sdk-go v. 40+
+// rootFolderAlias is the top-level directory for exchange.Mail.
+// DefaultMailFolder is the traditional "Inbox" for exchange.Mail
 // Action ensures that cache will stop at appropriate level.
-// @param directory: M365 ID of the root all intended inquiries.
-// Function should only be used directly when it is known that all
-// folder inquiries are going to a specific node. In all other cases
 // @error iff the struct is not properly instantiated
 func (mc *mailFolderCache) populateMailRoot(
 	ctx context.Context,
-	directoryID string,
-	baseContainerPath []string,
 ) error {
 	wantedOpts := []string{"displayName", "parentFolderId"}
 
@@ -41,23 +38,31 @@ func (mc *mailFolderCache) populateMailRoot(
 		return errors.Wrapf(err, "getting options for mail folders %v", wantedOpts)
 	}
 
-	f, err := mc.
-		gs.
-		Client().
-		UsersById(mc.userID).
-		MailFoldersById(directoryID).
-		Get(ctx, opts)
-	if err != nil {
-		return errors.Wrap(err, "fetching root folder"+support.ConnectorStackErrorTrace(err))
-	}
+	for _, fldr := range []string{rootFolderAlias, DefaultMailFolder} {
+		var directory string
 
-	temp := cacheFolder{
-		Container: f,
-		p:         path.Builder{}.Append(baseContainerPath...),
-	}
+		f, err := mc.
+			gs.
+			Client().
+			UsersById(mc.userID).
+			MailFoldersById(fldr).
+			Get(ctx, opts)
+		if err != nil {
+			return errors.Wrap(err, "fetching root folder"+support.ConnectorStackErrorTrace(err))
+		}
 
-	if err := mc.addFolder(temp); err != nil {
-		return errors.Wrap(err, "initializing mail resolver")
+		if fldr == DefaultMailFolder {
+			directory = DefaultMailFolder
+		}
+
+		temp := cacheFolder{
+			Container: f,
+			p:         path.Builder{}.Append(directory),
+		}
+
+		if err := mc.addFolder(temp); err != nil {
+			return errors.Wrap(err, "initializing mail resolver")
+		}
 	}
 
 	return nil
@@ -73,7 +78,7 @@ func (mc *mailFolderCache) Populate(
 	baseID string,
 	baseContainerPath ...string,
 ) error {
-	if err := mc.init(ctx, baseID, baseContainerPath); err != nil {
+	if err := mc.init(ctx); err != nil {
 		return err
 	}
 
@@ -129,16 +134,10 @@ func (mc *mailFolderCache) Populate(
 // [mc.cache]
 func (mc *mailFolderCache) init(
 	ctx context.Context,
-	baseNode string,
-	baseContainerPath []string,
 ) error {
-	if len(baseNode) == 0 {
-		return errors.New("m365 folder ID required for base folder")
-	}
-
 	if mc.containerResolver == nil {
 		mc.containerResolver = newContainerResolver()
 	}
 
-	return mc.populateMailRoot(ctx, baseNode, baseContainerPath)
+	return mc.populateMailRoot(ctx)
 }

--- a/src/internal/connector/exchange/service_functions.go
+++ b/src/internal/connector/exchange/service_functions.go
@@ -204,12 +204,9 @@ func pathAndMatch(
 		category,
 		false,
 	)
+	// Only true for containers without a path e.g. Root mail folder
 	if err != nil {
 		return nil, false
-	}
-
-	if dirPath == nil && category == path.EmailCategory {
-		return nil, false // Only true for root mail folder
 	}
 
 	directory = pb.String()

--- a/src/internal/connector/exchange/service_functions.go
+++ b/src/internal/connector/exchange/service_functions.go
@@ -204,7 +204,7 @@ func pathAndMatch(
 		category,
 		false,
 	)
-	// Only true for containers without a path e.g. Root mail folder
+	// Containers without a path (e.g. Root mail folder) always err here.
 	if err != nil {
 		return nil, false
 	}


### PR DESCRIPTION
## Description
The changes in `msgraph-sdk-go` version 40+  causes the `Inbox` not to be returned with the `gs.Client().UsersById(user).MailFolders().Get()` call.  The solution is to manually populate Inbox with the initialization. 

This is in addition to the previous change for the GetContainerID. 

## Type of change

- [x] :bug: Bugfix

## Test Plan

- [x] :zap: Unit test
