### PR TITLE
Weaken test assertions so the test doesn't flake

### DIFF
--- a/src/internal/kopia/snapshot_manager_test.go
+++ b/src/internal/kopia/snapshot_manager_test.go
@@ -526,8 +526,6 @@ func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshotsWorksWithErrors() {
 		),
 	}
 
-	expected := []*snapshot.Manifest{mockData[2].man}
-
 	msm := &mockErrorSnapshotManager{
 		sm: &mockSnapshotManager{
 			data: mockData,
@@ -536,5 +534,7 @@ func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshotsWorksWithErrors() {
 
 	snaps := fetchPrevSnapshotManifests(ctx, msm, input)
 
-	assert.ElementsMatch(t, expected, snaps)
+	// Only 1 snapshot should be chosen because the other two attempts fail.
+	// However, which one is returned is non-deterministic because maps are used.
+	assert.Len(t, snaps, 1)
 }


### PR DESCRIPTION
## Description

Just check number of items returned instead of checking for specific items.

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* #1657 
 
## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
