### PR TITLE
add suffix and pathSuffix filters

### DIFF
--- a/src/pkg/filters/filters_test.go
+++ b/src/pkg/filters/filters_test.go
@@ -206,6 +206,31 @@ func (suite *FiltersSuite) TestPrefixes() {
 	}
 }
 
+func (suite *FiltersSuite) TestSuffixes() {
+	target := "folderB"
+	f := filters.Suffix(target)
+	nf := filters.NotSuffix(target)
+
+	table := []struct {
+		name     string
+		input    string
+		expectF  assert.BoolAssertionFunc
+		expectNF assert.BoolAssertionFunc
+	}{
+		{"Exact match - same case", "folderB", assert.True, assert.False},
+		{"Exact match - different case", "Folderb", assert.True, assert.False},
+		{"Suffix match - same case", "folderA/folderB", assert.True, assert.False},
+		{"Suffix match - different case", "Foldera/folderb", assert.True, assert.False},
+		{"Should not match substring", "folderB/folder1", assert.False, assert.True},
+	}
+	for _, test := range table {
+		suite.T().Run(test.name, func(t *testing.T) {
+			test.expectF(t, f.Compare(test.input), "filter")
+			test.expectNF(t, nf.Compare(test.input), "negated filter")
+		})
+	}
+}
+
 func (suite *FiltersSuite) TestPathPrefix() {
 	table := []struct {
 		name     string
@@ -356,6 +381,82 @@ func (suite *FiltersSuite) TestPathContains_NormalizedTargets() {
 	for _, test := range table {
 		suite.T().Run(test.name, func(t *testing.T) {
 			f := filters.PathContains(test.targets)
+			assert.Equal(t, test.expect, f.NormalizedTargets)
+		})
+	}
+}
+
+func (suite *FiltersSuite) TestPathSuffix() {
+	table := []struct {
+		name     string
+		targets  []string
+		input    string
+		expectF  assert.BoolAssertionFunc
+		expectNF assert.BoolAssertionFunc
+	}{
+		{"Exact - same case", []string{"fA"}, "/fA", assert.True, assert.False},
+		{"Exact - different case", []string{"fa"}, "/fA", assert.True, assert.False},
+		{"Suffix - same case", []string{"fB"}, "/fA/fB", assert.True, assert.False},
+		{"Suffix - different case", []string{"fb"}, "/fA/fB", assert.True, assert.False},
+		{"Exact - multiple folders", []string{"fA/fB"}, "/fA/fB", assert.True, assert.False},
+		{"Suffix - single folder partial", []string{"f"}, "/fA/fB", assert.False, assert.True},
+		{"Suffix - multi folder partial", []string{"A/fB"}, "/fA/fB", assert.False, assert.True},
+		{"Target Longer - single folder", []string{"fA"}, "/f", assert.False, assert.True},
+		{"Target Longer - multi folder", []string{"fA/fB"}, "/fA/f", assert.False, assert.True},
+		{"Not suffix - single folder", []string{"fA"}, "/af", assert.False, assert.True},
+		{"Not suffix - multi folder", []string{"fA/fB"}, "/Af/fB", assert.False, assert.True},
+		{"Exact - target variations - none", []string{"fA"}, "/fA", assert.True, assert.False},
+		{"Exact - target variations - prefix", []string{"/fA"}, "/fA", assert.True, assert.False},
+		{"Exact - target variations - suffix", []string{"fA/"}, "/fA", assert.True, assert.False},
+		{"Exact - target variations - both", []string{"/fA/"}, "/fA", assert.True, assert.False},
+		{"Exact - input variations - none", []string{"fA"}, "fA", assert.True, assert.False},
+		{"Exact - input variations - prefix", []string{"fA"}, "/fA", assert.True, assert.False},
+		{"Exact - input variations - suffix", []string{"fA"}, "fA/", assert.True, assert.False},
+		{"Exact - input variations - both", []string{"fA"}, "/fA/", assert.True, assert.False},
+		{"Suffix - target variations - none", []string{"fb"}, "/fA/fb", assert.True, assert.False},
+		{"Suffix - target variations - prefix", []string{"/fb"}, "/fA/fb", assert.True, assert.False},
+		{"Suffix - target variations - suffix", []string{"fb/"}, "/fA/fb", assert.True, assert.False},
+		{"Suffix - target variations - both", []string{"/fb/"}, "/fA/fb", assert.True, assert.False},
+		{"Suffix - input variations - none", []string{"fb"}, "fA/fb", assert.True, assert.False},
+		{"Suffix - input variations - prefix", []string{"fb"}, "/fA/fb", assert.True, assert.False},
+		{"Suffix - input variations - suffix", []string{"fb"}, "fA/fb/", assert.True, assert.False},
+		{"Suffix - input variations - both", []string{"fb"}, "/fA/fb/", assert.True, assert.False},
+		{"Slice - one matches", []string{"foo", "fa/f", "fb"}, "/fA/fb", assert.True, assert.True},
+		{"Slice - none match", []string{"foo", "fa/f", "f"}, "/fA/fb", assert.False, assert.True},
+	}
+	for _, test := range table {
+		suite.T().Run(test.name, func(t *testing.T) {
+			f := filters.PathSuffix(test.targets)
+			nf := filters.NotPathSuffix(test.targets)
+
+			test.expectF(t, f.Compare(test.input), "filter")
+			test.expectNF(t, nf.Compare(test.input), "negated filter")
+		})
+	}
+}
+
+func (suite *FiltersSuite) TestPathSuffix_NormalizedTargets() {
+	table := []struct {
+		name    string
+		targets []string
+		expect  []string
+	}{
+		{"Single - no slash", []string{"fA"}, []string{"/fA/"}},
+		{"Single - pre slash", []string{"/fA"}, []string{"/fA/"}},
+		{"Single - suff slash", []string{"fA/"}, []string{"/fA/"}},
+		{"Single - both slashes", []string{"/fA/"}, []string{"/fA/"}},
+		{"Multipath - no slash", []string{"fA/fB"}, []string{"/fA/fB/"}},
+		{"Multipath - pre slash", []string{"/fA/fB"}, []string{"/fA/fB/"}},
+		{"Multipath - suff slash", []string{"fA/fB/"}, []string{"/fA/fB/"}},
+		{"Multipath - both slashes", []string{"/fA/fB/"}, []string{"/fA/fB/"}},
+		{"Multi input - no slash", []string{"fA", "fB"}, []string{"/fA/", "/fB/"}},
+		{"Multi input - pre slash", []string{"/fA", "/fB"}, []string{"/fA/", "/fB/"}},
+		{"Multi input - suff slash", []string{"fA/", "fB/"}, []string{"/fA/", "/fB/"}},
+		{"Multi input - both slashes", []string{"/fA/", "/fB/"}, []string{"/fA/", "/fB/"}},
+	}
+	for _, test := range table {
+		suite.T().Run(test.name, func(t *testing.T) {
+			f := filters.PathSuffix(test.targets)
 			assert.Equal(t, test.expect, f.NormalizedTargets)
 		})
 	}


### PR DESCRIPTION
## Description

Preparing for handling sharepoint webUrl
selectors, we will need suffix-matching filters.

## Type of change

- [x] :sunflower: Feature

## Issue(s)

* #1616

## Test Plan

- [x] :zap: Unit test
