### PR TITLE
More consistent folder cleanup for OneDrive test

### DIFF
--- a/src/internal/connector/onedrive/drive_test.go
+++ b/src/internal/connector/onedrive/drive_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/selectors"
 )
 
@@ -51,7 +52,10 @@ func (suite *OneDriveSuite) TestCreateGetDeleteFolder() {
 
 	defer func() {
 		for _, id := range folderIDs {
-			assert.NoError(t, DeleteItem(ctx, gs, driveID, id))
+			err := DeleteItem(ctx, gs, driveID, id)
+			if err != nil {
+				logger.Ctx(ctx).Warnw("deleting folder", "id", id, "error", err)
+			}
 		}
 	}()
 

--- a/src/internal/connector/onedrive/drive_test.go
+++ b/src/internal/connector/onedrive/drive_test.go
@@ -49,14 +49,16 @@ func (suite *OneDriveSuite) TestCreateGetDeleteFolder() {
 
 	driveID := *drives[0].GetId()
 
+	defer func() {
+		for _, id := range folderIDs {
+			assert.NoError(t, DeleteItem(ctx, gs, driveID, id))
+		}
+	}()
+
 	folderID, err := createRestoreFolders(ctx, gs, driveID, folderElements)
 	require.NoError(t, err)
 
 	folderIDs = append(folderIDs, folderID)
-
-	defer func() {
-		assert.NoError(t, DeleteItem(ctx, gs, driveID, folderIDs[0]))
-	}()
 
 	folderName2 := "Corso_Folder_Test_" + common.FormatNow(common.SimpleTimeTesting)
 	folderElements = append(folderElements, folderName2)


### PR DESCRIPTION
## Description

Cleanup all folders instead of just some of them. Log errors instead of failing test

## Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Test
- [ ] :computer: CI/Deployment
- [x] :hamster: Trivial/Minor

## Issue(s)

* closes #1661

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
