### PR TITLE
Implement ModTime interface in service streams

### DIFF
--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -28,9 +28,10 @@ import (
 )
 
 var (
-	_ data.Collection = &Collection{}
-	_ data.Stream     = &Stream{}
-	_ data.StreamInfo = &Stream{}
+	_ data.Collection    = &Collection{}
+	_ data.Stream        = &Stream{}
+	_ data.StreamInfo    = &Stream{}
+	_ data.StreamModTime = &Stream{}
 )
 
 const (
@@ -222,6 +223,20 @@ func (col *Collection) finishPopulation(ctx context.Context, success int, totalB
 	col.statusUpdater(status)
 }
 
+type modTimer interface {
+	GetLastModifiedDateTime() *time.Time
+}
+
+func getModTime(mt modTimer) time.Time {
+	res := time.Now()
+
+	if t := mt.GetLastModifiedDateTime(); t != nil {
+		res = *t
+	}
+
+	return res
+}
+
 // GraphSerializeFunc are class of functions that are used by Collections to transform GraphRetrievalFunc
 // responses into data.Stream items contained within the Collection
 type GraphSerializeFunc func(
@@ -290,7 +305,12 @@ func eventToDataCollection(
 	}
 
 	if len(byteArray) > 0 {
-		dataChannel <- &Stream{id: *event.GetId(), message: byteArray, info: EventInfo(event, int64(len(byteArray)))}
+		dataChannel <- &Stream{
+			id:      *event.GetId(),
+			message: byteArray,
+			info:    EventInfo(event, int64(len(byteArray))),
+			modTime: getModTime(event),
+		}
 	}
 
 	return len(byteArray), nil
@@ -323,7 +343,12 @@ func contactToDataCollection(
 	}
 
 	if len(byteArray) > 0 {
-		dataChannel <- &Stream{id: *contact.GetId(), message: byteArray, info: ContactInfo(contact, int64(len(byteArray)))}
+		dataChannel <- &Stream{
+			id:      *contact.GetId(),
+			message: byteArray,
+			info:    ContactInfo(contact, int64(len(byteArray))),
+			modTime: getModTime(contact),
+		}
 	}
 
 	return len(byteArray), nil
@@ -390,7 +415,12 @@ func messageToDataCollection(
 		return 0, support.SetNonRecoverableError(err)
 	}
 
-	dataChannel <- &Stream{id: *aMessage.GetId(), message: byteArray, info: MessageInfo(aMessage, int64(len(byteArray)))}
+	dataChannel <- &Stream{
+		id:      *aMessage.GetId(),
+		message: byteArray,
+		info:    MessageInfo(aMessage, int64(len(byteArray))),
+		modTime: getModTime(aMessage),
+	}
 
 	return len(byteArray), nil
 }
@@ -403,6 +433,9 @@ type Stream struct {
 	// some structured type in here (serialization to []byte can be done in `Read`)
 	message []byte
 	info    *details.ExchangeInfo // temporary change to bring populate function into directory
+	// TODO(ashmrtn): Can probably eventually be sourced from info as there's a
+	// request to provide modtime in ItemInfo structs.
+	modTime time.Time
 }
 
 func (od *Stream) UUID() string {
@@ -417,11 +450,16 @@ func (od *Stream) Info() details.ItemInfo {
 	return details.ItemInfo{Exchange: od.info}
 }
 
+func (od *Stream) ModTime() time.Time {
+	return od.modTime
+}
+
 // NewStream constructor for exchange.Stream object
-func NewStream(identifier string, dataBytes []byte, detail details.ExchangeInfo) Stream {
+func NewStream(identifier string, dataBytes []byte, detail details.ExchangeInfo, modTime time.Time) Stream {
 	return Stream{
 		id:      identifier,
 		message: dataBytes,
 		info:    &detail,
+		modTime: modTime,
 	}
 }

--- a/src/internal/connector/graph_connector_helper_test.go
+++ b/src/internal/connector/graph_connector_helper_test.go
@@ -633,6 +633,10 @@ func compareItem(
 	category path.CategoryType,
 	item data.Stream,
 ) {
+	if mt, ok := item.(data.StreamModTime); ok {
+		assert.NotZero(t, mt.ModTime())
+	}
+
 	switch service {
 	case path.ExchangeService:
 		switch category {

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -31,9 +31,10 @@ const (
 )
 
 var (
-	_ data.Collection = &Collection{}
-	_ data.Stream     = &Item{}
-	_ data.StreamInfo = &Item{}
+	_ data.Collection    = &Collection{}
+	_ data.Stream        = &Item{}
+	_ data.StreamInfo    = &Item{}
+	_ data.StreamModTime = &Item{}
 )
 
 // Collection represents a set of OneDrive objects retreived from M365
@@ -113,6 +114,10 @@ func (od *Item) ToReader() io.ReadCloser {
 
 func (od *Item) Info() details.ItemInfo {
 	return details.ItemInfo{OneDrive: od.info}
+}
+
+func (od *Item) ModTime() time.Time {
+	return od.info.Modified
 }
 
 // populateItems iterates through items added to the collection


### PR DESCRIPTION
## Description

Add ModTime to Exchange, OneDrive and SharePoint list stream items. This enables kopia-assisted incrementals for those items. Backup details still contains a complete set of information for all items in the backup regardless of if kopia uploaded data for the item or not.

Kopia-assisted incrementals does come with some caveats though. If changes are made to an item in M365 and that change does not cause the modified time reported by M365 to update, then the change will not be backed up. Currently, only marking an email as read/unread is known to hit this edge case.

This patch does not lazily fetch data from Graph API. This means that kopia may upload less data, but the same amount of data will still be pulled from Graph

## Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* closes #622 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
