### PR TITLE
Run docs dev without regenerating CLI docs

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -24,6 +24,9 @@ buildimage:
 dev: genclidocs
 	$(WEBC) npm start -- --host 0.0.0.0
 
+noclidev:
+	$(WEBC) npm start -- --host 0.0.0.0
+
 VALE_TARGET ?= docs README.md
 
 check: genclidocs


### PR DESCRIPTION
## Description

Hack to prevent long waits for go code to build 

## Type of change

- [x] :world_map: Documentation
