### PR TITLE
populate sharepoint itemInfo

### DIFF
--- a/src/internal/connector/onedrive/collection_test.go
+++ b/src/internal/connector/onedrive/collection_test.go
@@ -145,33 +145,6 @@ func (suite *CollectionUnitTestSuite) TestCollection() {
 			assert.Equal(t, driveFolderPath, parentPath)
 		})
 	}
-
-	wg.Wait()
-
-	// Expect only 1 item
-	require.Len(t, readItems, 1)
-	require.Equal(t, 1, collStatus.ObjectCount)
-	require.Equal(t, 1, collStatus.Successful)
-
-	// Validate item info and data
-	readItem := readItems[0]
-	readItemInfo := readItem.(data.StreamInfo)
-
-	assert.Equal(t, testItemName, readItem.UUID())
-
-	// TODO(ashmrtn): Uncomment when #1702 is resolved.
-	// require.Implements(t, (*data.StreamModTime)(nil), readItem)
-	// mt := readItem.(data.StreamModTime)
-	// assert.Equal(t, now, mt.ModTime())
-
-	readData, err := io.ReadAll(readItem.ToReader())
-	require.NoError(t, err)
-
-	assert.Equal(t, testItemData, readData)
-	require.NotNil(t, readItemInfo.Info())
-	require.NotNil(t, readItemInfo.Info().OneDrive)
-	assert.Equal(t, testItemName, readItemInfo.Info().OneDrive.ItemName)
-	assert.Equal(t, driveFolderPath, readItemInfo.Info().OneDrive.ParentPath)
 }
 
 func (suite *CollectionUnitTestSuite) TestCollectionReadError() {

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -138,6 +138,7 @@ func (c *Collections) UpdateCollections(ctx context.Context, driveID string, ite
 					driveID,
 					c.service,
 					c.statusUpdater,
+					c.source,
 				)
 
 				c.CollectionMap[collectionPath.String()] = col

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -133,12 +133,11 @@ func oneDriveItemInfo(di models.DriveItemable, itemSize int64) *details.OneDrive
 // and kiota drops any SetSize update.
 func sharePointItemInfo(di models.DriveItemable, itemSize int64) *details.SharePointInfo {
 	var (
-		id  string
-		url string
+		id   string
+		url  string
+		idp  = di.GetSharepointIds().GetSiteId()
+		urlp = di.GetSharepointIds().GetSiteUrl()
 	)
-
-	idp := di.GetSharepointIds().GetSiteId()
-	urlp := di.GetSharepointIds().GetSiteUrl()
 
 	if idp != nil {
 		id = *idp

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -11,7 +11,6 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/pkg/errors"
 
-	"github.com/alcionai/corso/src/internal/common"
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/connector/uploadsession"
@@ -25,22 +24,60 @@ const (
 	downloadURLKey = "@microsoft.graph.downloadUrl"
 )
 
-// itemReader will return a io.ReadCloser for the specified item
+// sharePointItemReader will return a io.ReadCloser for the specified item
+// It crafts this by querying M365 for a download URL for the item
+// and using a http client to initialize a reader
+func sharePointItemReader(
+	ctx context.Context,
+	service graph.Service,
+	driveID, itemID string,
+) (details.ItemInfo, io.ReadCloser, error) {
+	item, rc, err := driveItemReader(ctx, service, driveID, itemID)
+	if err != nil {
+		return details.ItemInfo{}, nil, err
+	}
+
+	dii := details.ItemInfo{
+		SharePoint: sharePointItemInfo(item, *item.GetSize()),
+	}
+
+	return dii, rc, nil
+}
+
+// oneDriveItemReader will return a io.ReadCloser for the specified item
+// It crafts this by querying M365 for a download URL for the item
+// and using a http client to initialize a reader
+func oneDriveItemReader(
+	ctx context.Context,
+	service graph.Service,
+	driveID, itemID string,
+) (details.ItemInfo, io.ReadCloser, error) {
+	item, rc, err := driveItemReader(ctx, service, driveID, itemID)
+	if err != nil {
+		return details.ItemInfo{}, nil, err
+	}
+
+	dii := details.ItemInfo{
+		OneDrive: oneDriveItemInfo(item, *item.GetSize()),
+	}
+
+	return dii, rc, nil
+}
+
+// driveItemReader will return a io.ReadCloser for the specified item
 // It crafts this by querying M365 for a download URL for the item
 // and using a http client to initialize a reader
 func driveItemReader(
 	ctx context.Context,
 	service graph.Service,
 	driveID, itemID string,
-) (*details.OneDriveInfo, io.ReadCloser, error) {
-	logger.Ctx(ctx).Debugf("Reading Item %s at %s", itemID, time.Now())
+) (models.DriveItemable, io.ReadCloser, error) {
+	logger.Ctx(ctx).Debugw("Reading Item", "id", itemID, "time", time.Now())
 
 	item, err := service.Client().DrivesById(driveID).ItemsById(itemID).Get(ctx, nil)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to get item %s", itemID)
 	}
-
-	logger.Ctx(ctx).Debugw("reading item", "name", *item.GetName(), "time", common.Now())
 
 	// Get the download URL - https://docs.microsoft.com/en-us/graph/api/driveitem-get-content
 	// These URLs are pre-authenticated and can be used to download the data using the standard
@@ -63,15 +100,15 @@ func driveItemReader(
 		return nil, nil, errors.Wrapf(err, "failed to download file from %s", *downloadURL)
 	}
 
-	return driveItemInfo(item, *item.GetSize()), resp.Body, nil
+	return item, resp.Body, nil
 }
 
-// driveItemInfo will populate a details.OneDriveInfo struct
+// oneDriveItemInfo will populate a details.OneDriveInfo struct
 // with properties from the drive item.  ItemSize is specified
 // separately for restore processes because the local itemable
 // doesn't have its size value updated as a side effect of creation,
 // and kiota drops any SetSize update.
-func driveItemInfo(di models.DriveItemable, itemSize int64) *details.OneDriveInfo {
+func oneDriveItemInfo(di models.DriveItemable, itemSize int64) *details.OneDriveInfo {
 	ed, ok := di.GetCreatedBy().GetUser().GetAdditionalData()["email"]
 
 	email := ""
@@ -86,6 +123,39 @@ func driveItemInfo(di models.DriveItemable, itemSize int64) *details.OneDriveInf
 		Modified: *di.GetLastModifiedDateTime(),
 		Size:     itemSize,
 		Owner:    email,
+	}
+}
+
+// sharePointItemInfo will populate a details.SharePointInfo struct
+// with properties from the drive item.  ItemSize is specified
+// separately for restore processes because the local itemable
+// doesn't have its size value updated as a side effect of creation,
+// and kiota drops any SetSize update.
+func sharePointItemInfo(di models.DriveItemable, itemSize int64) *details.SharePointInfo {
+	var (
+		id  string
+		url string
+	)
+
+	idp := di.GetSharepointIds().GetSiteId()
+	urlp := di.GetSharepointIds().GetSiteUrl()
+
+	if idp != nil {
+		id = *idp
+	}
+
+	if urlp != nil {
+		url = *urlp
+	}
+
+	return &details.SharePointInfo{
+		ItemType: details.OneDriveItem,
+		ItemName: *di.GetName(),
+		Created:  *di.GetCreatedDateTime(),
+		Modified: *di.GetLastModifiedDateTime(),
+		Size:     itemSize,
+		Owner:    id,
+		WebURL:   url,
 	}
 }
 

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -133,18 +133,19 @@ func oneDriveItemInfo(di models.DriveItemable, itemSize int64) *details.OneDrive
 // and kiota drops any SetSize update.
 func sharePointItemInfo(di models.DriveItemable, itemSize int64) *details.SharePointInfo {
 	var (
-		id   string
-		url  string
-		idp  = di.GetSharepointIds().GetSiteId()
-		urlp = di.GetSharepointIds().GetSiteUrl()
+		id  string
+		url string
 	)
 
-	if idp != nil {
-		id = *idp
-	}
+	gsi := di.GetSharepointIds()
+	if gsi != nil {
+		if gsi.GetSiteId() != nil {
+			id = *gsi.GetSiteId()
+		}
 
-	if urlp != nil {
-		url = *urlp
+		if gsi.GetSiteUrl() != nil {
+			url = *gsi.GetSiteUrl()
+		}
 	}
 
 	return &details.SharePointInfo{

--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -18,8 +18,8 @@ import (
 
 type ItemIntegrationSuite struct {
 	suite.Suite
-	site        string
-	siteDriveID string
+	// site        string
+	// siteDriveID string
 	user        string
 	userDriveID string
 	client      *msgraphsdk.GraphServiceClient

--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -18,10 +18,12 @@ import (
 
 type ItemIntegrationSuite struct {
 	suite.Suite
-	user    string
-	driveID string
-	client  *msgraphsdk.GraphServiceClient
-	adapter *msgraphsdk.GraphRequestAdapter
+	site        string
+	siteDriveID string
+	user        string
+	userDriveID string
+	client      *msgraphsdk.GraphServiceClient
+	adapter     *msgraphsdk.GraphRequestAdapter
 }
 
 func (suite *ItemIntegrationSuite) Client() *msgraphsdk.GraphServiceClient {
@@ -49,31 +51,45 @@ func TestItemIntegrationSuite(t *testing.T) {
 }
 
 func (suite *ItemIntegrationSuite) SetupSuite() {
+	t := suite.T()
+
 	ctx, flush := tester.NewContext()
 	defer flush()
 
 	_, err := tester.GetRequiredEnvVars(tester.M365AcctCredEnvs...)
-	require.NoError(suite.T(), err)
+	require.NoError(t, err)
 
-	a := tester.NewM365Account(suite.T())
+	a := tester.NewM365Account(t)
 
 	m365, err := a.M365Config()
-	require.NoError(suite.T(), err)
+	require.NoError(t, err)
 
 	adapter, err := graph.CreateAdapter(m365.AzureTenantID, m365.AzureClientID, m365.AzureClientSecret)
-	require.NoError(suite.T(), err)
+	require.NoError(t, err)
+
 	suite.client = msgraphsdk.NewGraphServiceClient(adapter)
 	suite.adapter = adapter
 
-	suite.user = tester.SecondaryM365UserID(suite.T())
+	// TODO: fulfill file preconditions required for testing (expected files w/in drive)
+	// spDrives, err := drives(ctx, suite, suite.site, SharePointSource)
+	// require.NoError(t, err)
+	// // Test Requirement 1: Need a drive
+	// require.Greaterf(t, len(spDrives), 0, "site %s does not have a drive", suite.site)
 
-	drives, err := drives(ctx, suite, suite.user, OneDriveSource)
-	require.NoError(suite.T(), err)
+	// // Pick the first drive
+	// suite.siteDriveID = *spDrives[0].GetId()
+
+	suite.user = tester.SecondaryM365UserID(t)
+
+	odDrives, err := drives(ctx, suite, suite.user, OneDriveSource)
+	require.NoError(t, err)
 	// Test Requirement 1: Need a drive
-	require.Greaterf(suite.T(), len(drives), 0, "user %s does not have a drive", suite.user)
+	require.Greaterf(t, len(odDrives), 0, "user %s does not have a drive", suite.user)
 
 	// Pick the first drive
-	suite.driveID = *drives[0].GetId()
+	suite.userDriveID = *odDrives[0].GetId()
+
+	suite.site = tester.M365SiteID(t)
 }
 
 // TestItemReader is an integration test that makes a few assumptions
@@ -81,7 +97,7 @@ func (suite *ItemIntegrationSuite) SetupSuite() {
 // 1) It assumes the test user has a drive
 // 2) It assumes the drive has a file it can use to test `driveItemReader`
 // The test checks these in below
-func (suite *ItemIntegrationSuite) TestItemReader() {
+func (suite *ItemIntegrationSuite) TestItemReader_oneDrive() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 
@@ -97,7 +113,7 @@ func (suite *ItemIntegrationSuite) TestItemReader() {
 
 		return nil
 	}
-	err := collectItems(ctx, suite, suite.driveID, itemCollector)
+	err := collectItems(ctx, suite, suite.userDriveID, itemCollector)
 	require.NoError(suite.T(), err)
 
 	// Test Requirement 2: Need a file
@@ -106,41 +122,41 @@ func (suite *ItemIntegrationSuite) TestItemReader() {
 		driveItemID,
 		"no file item found for user %s drive %s",
 		suite.user,
-		suite.driveID,
+		suite.userDriveID,
 	)
 
 	// Read data for the file
 
-	itemInfo, itemData, err := driveItemReader(ctx, suite, suite.driveID, driveItemID)
+	itemInfo, itemData, err := oneDriveItemReader(ctx, suite, suite.userDriveID, driveItemID)
 	require.NoError(suite.T(), err)
-	require.NotNil(suite.T(), itemInfo)
-	require.NotEmpty(suite.T(), itemInfo.ItemName)
+	require.NotNil(suite.T(), itemInfo.OneDrive)
+	require.NotEmpty(suite.T(), itemInfo.OneDrive.ItemName)
 
 	size, err := io.Copy(io.Discard, itemData)
 	require.NoError(suite.T(), err)
 	require.NotZero(suite.T(), size)
-	require.Equal(suite.T(), size, itemInfo.Size)
-	suite.T().Logf("Read %d bytes from file %s.", size, itemInfo.ItemName)
+	require.Equal(suite.T(), size, itemInfo.OneDrive.Size)
+	suite.T().Logf("Read %d bytes from file %s.", size, itemInfo.OneDrive.ItemName)
 }
 
 // TestItemWriter is an integration test for uploading data to OneDrive
 // It creates a new `testfolder_<timestamp` folder with a new
 // testitem_<timestamp> item and writes data to it
-func (suite *ItemIntegrationSuite) TestItemWriter() {
+func (suite *ItemIntegrationSuite) TestItemWriter_oneDrive() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 
-	root, err := suite.Client().DrivesById(suite.driveID).Root().Get(ctx, nil)
+	root, err := suite.Client().DrivesById(suite.userDriveID).Root().Get(ctx, nil)
 	require.NoError(suite.T(), err)
 
 	// Test Requirement 2: "Test Folder" should exist
-	folder, err := getFolder(ctx, suite, suite.driveID, *root.GetId(), "Test Folder")
+	folder, err := getFolder(ctx, suite, suite.userDriveID, *root.GetId(), "Test Folder")
 	require.NoError(suite.T(), err)
 
 	newFolderName := "testfolder_" + time.Now().Format("2006-01-02T15-04-05")
 	suite.T().Logf("Test will create folder %s", newFolderName)
 
-	newFolder, err := createItem(ctx, suite, suite.driveID, *folder.GetId(), newItem(newFolderName, true))
+	newFolder, err := createItem(ctx, suite, suite.userDriveID, *folder.GetId(), newItem(newFolderName, true))
 	require.NoError(suite.T(), err)
 
 	require.NotNil(suite.T(), newFolder.GetId())
@@ -148,20 +164,20 @@ func (suite *ItemIntegrationSuite) TestItemWriter() {
 	newItemName := "testItem_" + time.Now().Format("2006-01-02T15-04-05")
 	suite.T().Logf("Test will create item %s", newItemName)
 
-	newItem, err := createItem(ctx, suite, suite.driveID, *newFolder.GetId(), newItem(newItemName, false))
+	newItem, err := createItem(ctx, suite, suite.userDriveID, *newFolder.GetId(), newItem(newItemName, false))
 	require.NoError(suite.T(), err)
 
 	require.NotNil(suite.T(), newItem.GetId())
 
 	// HACK: Leveraging this to test getFolder behavior for a file. `getFolder()` on the
 	// newly created item should fail because it's a file not a folder
-	_, err = getFolder(ctx, suite, suite.driveID, *newFolder.GetId(), newItemName)
+	_, err = getFolder(ctx, suite, suite.userDriveID, *newFolder.GetId(), newItemName)
 	require.ErrorIs(suite.T(), err, errFolderNotFound)
 
 	// Initialize a 100KB mockDataProvider
 	td, writeSize := mockDataReader(int64(100 * 1024))
 
-	w, err := driveItemWriter(ctx, suite, suite.driveID, *newItem.GetId(), writeSize)
+	w, err := driveItemWriter(ctx, suite, suite.userDriveID, *newItem.GetId(), writeSize)
 	require.NoError(suite.T(), err)
 
 	// Using a 32 KB buffer for the copy allows us to validate the
@@ -180,18 +196,18 @@ func mockDataReader(size int64) (io.Reader, int64) {
 	return bytes.NewReader(data), size
 }
 
-func (suite *ItemIntegrationSuite) TestDriveGetFolder() {
+func (suite *ItemIntegrationSuite) TestDriveGetFolder_oneDrive() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 
-	root, err := suite.Client().DrivesById(suite.driveID).Root().Get(ctx, nil)
+	root, err := suite.Client().DrivesById(suite.userDriveID).Root().Get(ctx, nil)
 	require.NoError(suite.T(), err)
 
 	// Lookup a folder that doesn't exist
-	_, err = getFolder(ctx, suite, suite.driveID, *root.GetId(), "FolderDoesNotExist")
+	_, err = getFolder(ctx, suite, suite.userDriveID, *root.GetId(), "FolderDoesNotExist")
 	require.ErrorIs(suite.T(), err, errFolderNotFound)
 
 	// Lookup a folder that does exist
-	_, err = getFolder(ctx, suite, suite.driveID, *root.GetId(), "")
+	_, err = getFolder(ctx, suite, suite.userDriveID, *root.GetId(), "")
 	require.NoError(suite.T(), err)
 }

--- a/src/internal/connector/sharepoint/restore.go
+++ b/src/internal/connector/sharepoint/restore.go
@@ -40,7 +40,14 @@ func RestoreCollections(
 
 		switch dc.FullPath().Category() {
 		case path.LibrariesCategory:
-			metrics, canceled = onedrive.RestoreCollection(ctx, service, dc, onedrive.OneDriveSource, dest.ContainerName, deets, errUpdater)
+			metrics, canceled = onedrive.RestoreCollection(
+				ctx,
+				service,
+				dc,
+				onedrive.OneDriveSource,
+				dest.ContainerName,
+				deets,
+				errUpdater)
 		default:
 			return nil, errors.Errorf("category %s not supported", dc.FullPath().Category())
 		}

--- a/src/internal/connector/sharepoint/restore.go
+++ b/src/internal/connector/sharepoint/restore.go
@@ -40,7 +40,7 @@ func RestoreCollections(
 
 		switch dc.FullPath().Category() {
 		case path.LibrariesCategory:
-			metrics, canceled = onedrive.RestoreCollection(ctx, service, dc, dest.ContainerName, deets, errUpdater)
+			metrics, canceled = onedrive.RestoreCollection(ctx, service, dc, onedrive.OneDriveSource, dest.ContainerName, deets, errUpdater)
 		default:
 			return nil, errors.Errorf("category %s not supported", dc.FullPath().Category())
 		}


### PR DESCRIPTION
## Description

Currently, all drive backup and restore actions
populatet a details.OneDriveInfo struct.  This
change branches that struct between one-
drive and sharepoint info, depending on the
current source.

## Type of change

- [x] :sunflower: Feature

## Issue(s)

* #1616

## Test Plan

- [x] :zap: Unit test
