### PR TITLE
add missing any/none target check for paths

### DIFF
--- a/src/pkg/selectors/sharepoint_test.go
+++ b/src/pkg/selectors/sharepoint_test.go
@@ -140,6 +140,41 @@ func (suite *SharePointSelectorSuite) TestSharePointSelector_Include_WebURLs() {
 	}
 }
 
+func (suite *SharePointSelectorSuite) TestSharePointSelector_Include_WebURLs_anyNone() {
+	table := []struct {
+		name   string
+		in     []string
+		expect string
+	}{
+		{
+			name:   "any",
+			in:     []string{AnyTgt},
+			expect: AnyTgt,
+		},
+		{
+			name:   "none",
+			in:     []string{NoneTgt},
+			expect: NoneTgt,
+		},
+	}
+	for _, test := range table {
+		suite.T().Run(test.name, func(t *testing.T) {
+			sel := NewSharePointRestore()
+			sel.Include(sel.WebURL(test.in))
+			scopes := sel.Includes
+			require.Len(t, scopes, 1)
+
+			for _, sc := range scopes {
+				scopeMustHave(
+					t,
+					SharePointScope(sc),
+					map[categorizer]string{SharePointWebURL: test.expect},
+				)
+			}
+		})
+	}
+}
+
 func (suite *SharePointSelectorSuite) TestSharePointSelector_Exclude_WebURLs() {
 	t := suite.T()
 	sel := NewSharePointRestore()


### PR DESCRIPTION
## Description

the new pathFilterFactory now properly cleans
the inputs and checks for all-pass and all-fail
conditions.

## Type of change

- [x] :bug: Bugfix

## Issue(s)

* #1616

## Test Plan

- [x] :zap: Unit test
