### PR TITLE
Return interface values instead of concrete type

### DIFF
--- a/src/internal/connector/data_collections.go
+++ b/src/internal/connector/data_collections.go
@@ -109,16 +109,16 @@ func verifyBackupInputs(sels selectors.Selector, userPNs, siteIDs []string) erro
 func (gc *GraphConnector) createExchangeCollections(
 	ctx context.Context,
 	scope selectors.ExchangeScope,
-) ([]*exchange.Collection, error) {
+) ([]data.Collection, error) {
 	var (
 		errs           *multierror.Error
 		users          = scope.Get(selectors.ExchangeUser)
-		allCollections = make([]*exchange.Collection, 0)
+		allCollections = make([]data.Collection, 0)
 	)
 
 	// Create collection of ExchangeDataCollection
 	for _, user := range users {
-		collections := make(map[string]*exchange.Collection)
+		collections := make(map[string]data.Collection)
 
 		qp := graph.QueryParams{
 			Category:      scope.Category().PathType(),
@@ -188,9 +188,7 @@ func (gc *GraphConnector) ExchangeDataCollection(
 			return nil, support.WrapAndAppend(user[0], err, errs)
 		}
 
-		for _, collection := range dcs {
-			collections = append(collections, collection)
-		}
+		collections = append(collections, dcs...)
 	}
 
 	return collections, errs

--- a/src/internal/connector/data_collections_test.go
+++ b/src/internal/connector/data_collections_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alcionai/corso/src/internal/connector/exchange"
 	"github.com/alcionai/corso/src/internal/connector/sharepoint"
 	"github.com/alcionai/corso/src/internal/connector/support"
+	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/selectors"
 )
@@ -336,11 +337,11 @@ func (suite *ConnectorCreateExchangeCollectionIntegrationSuite) TestContactSeria
 
 	tests := []struct {
 		name          string
-		getCollection func(t *testing.T) []*exchange.Collection
+		getCollection func(t *testing.T) []data.Collection
 	}{
 		{
 			name: "Default Contact Folder",
-			getCollection: func(t *testing.T) []*exchange.Collection {
+			getCollection: func(t *testing.T) []data.Collection {
 				scope := selectors.
 					NewExchangeBackup().
 					ContactFolders([]string{suite.user}, []string{exchange.DefaultContactFolder}, selectors.PrefixMatch())[0]
@@ -389,12 +390,12 @@ func (suite *ConnectorCreateExchangeCollectionIntegrationSuite) TestEventsSerial
 
 	tests := []struct {
 		name, expected string
-		getCollection  func(t *testing.T) []*exchange.Collection
+		getCollection  func(t *testing.T) []data.Collection
 	}{
 		{
 			name:     "Default Event Calendar",
 			expected: exchange.DefaultCalendar,
-			getCollection: func(t *testing.T) []*exchange.Collection {
+			getCollection: func(t *testing.T) []data.Collection {
 				sel := selectors.NewExchangeBackup()
 				sel.Include(sel.EventCalendars([]string{suite.user}, []string{exchange.DefaultCalendar}, selectors.PrefixMatch()))
 				collections, err := connector.createExchangeCollections(ctx, sel.Scopes()[0])
@@ -406,7 +407,7 @@ func (suite *ConnectorCreateExchangeCollectionIntegrationSuite) TestEventsSerial
 		{
 			name:     "Birthday Calendar",
 			expected: "Birthdays",
-			getCollection: func(t *testing.T) []*exchange.Collection {
+			getCollection: func(t *testing.T) []data.Collection {
 				sel := selectors.NewExchangeBackup()
 				sel.Include(sel.EventCalendars([]string{suite.user}, []string{"Birthdays"}, selectors.PrefixMatch()))
 				collections, err := connector.createExchangeCollections(ctx, sel.Scopes()[0])

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -25,9 +25,9 @@ const nextLinkKey = "@odata.nextLink"
 // the value is not in the map returns an empty string.
 func getAdditionalDataString(
 	key string,
-	data map[string]any,
+	addtlData map[string]any,
 ) string {
-	iface := data[key]
+	iface := addtlData[key]
 	if iface == nil {
 		return ""
 	}


### PR DESCRIPTION
## Description

Having a map of interface values instead of concrete structs allows adding collection implementations via different structs. This will be useful to inject a new collection that contains metadata information like delta links.

Also refactors the code for creating collections in Exchange so that it follows golang patterns of exiting early a bit better.

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [x] :hamster: Trivial/Minor

## Issue(s)

* #1685

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
