### PR TITLE
Return delta tokens from fetch functions

### DIFF
--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -166,8 +166,9 @@ func IterativeCollectCalendarContainers(
 	}
 }
 
-// FetchIDFunc collection of helper functions which return a list of strings
-// from a response.
+// FetchIDFunc collection of helper functions which return a list of all item
+// IDs in the given container and a delta token for future requests if the
+// container supports fetching delta records.
 type FetchIDFunc func(
 	ctx context.Context,
 	gs graph.Service,


### PR DESCRIPTION
## Description

When fetching Exchange items, return the resulting delta token from the query so it can be reused later.

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* #1685 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
