### PR TITLE
Disable kopia-assisted incrementals for OneDrive

### DIFF
--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -31,10 +31,11 @@ const (
 )
 
 var (
-	_ data.Collection    = &Collection{}
-	_ data.Stream        = &Item{}
-	_ data.StreamInfo    = &Item{}
-	_ data.StreamModTime = &Item{}
+	_ data.Collection = &Collection{}
+	_ data.Stream     = &Item{}
+	_ data.StreamInfo = &Item{}
+	// TODO(ashmrtn): Uncomment when #1702 is resolved.
+	//_ data.StreamModTime = &Item{}
 )
 
 // Collection represents a set of OneDrive objects retreived from M365
@@ -116,9 +117,10 @@ func (od *Item) Info() details.ItemInfo {
 	return details.ItemInfo{OneDrive: od.info}
 }
 
-func (od *Item) ModTime() time.Time {
-	return od.info.Modified
-}
+// TODO(ashmrtn): Uncomment when #1702 is resolved.
+//func (od *Item) ModTime() time.Time {
+//	return od.info.Modified
+//}
 
 // populateItems iterates through items added to the collection
 // and uses the collection `itemReader` to read the item

--- a/src/internal/connector/onedrive/collection_test.go
+++ b/src/internal/connector/onedrive/collection_test.go
@@ -107,9 +107,10 @@ func (suite *OneDriveCollectionSuite) TestOneDriveCollection() {
 
 	assert.Equal(t, testItemName, readItem.UUID())
 
-	require.Implements(t, (*data.StreamModTime)(nil), readItem)
-	mt := readItem.(data.StreamModTime)
-	assert.Equal(t, now, mt.ModTime())
+	// TODO(ashmrtn): Uncomment when #1702 is resolved.
+	// require.Implements(t, (*data.StreamModTime)(nil), readItem)
+	// mt := readItem.(data.StreamModTime)
+	// assert.Equal(t, now, mt.ModTime())
 
 	readData, err := io.ReadAll(readItem.ToReader())
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

Do not implement the StreamModTime interface so kopia-assisted incrementals cannot be used for OneDrive.

Feature should be reenabled when the following are resolved:
* #1702 

## Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [x] :hamster: Trivial/Minor

## Issue(s)

* closes #1723 

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
