### PR TITLE
Add note about email isRead marker with kopia-assisted incrementals

### DIFF
--- a/website/docs/support/known_issues.md
+++ b/website/docs/support/known_issues.md
@@ -5,6 +5,9 @@ Below is a list of known Corso issues and limitations:
 * Only supports Exchange (email, calendars, contact) and OneDrive (files) M365 data. Additional
   data types and services will be added in subsequent releases.
 
+* Backups of Exchange email may not include changes to whether an email is marked as read or not if no other changes
+  to the email have been made since the previous backup.
+
 * Restores are non-destructive to a dedicated restore folder in the original Exchange mailbox or OneDrive account.
   Advanced restore options such as in-place restore, or restore to a specific folder or to a different account aren't
   yet supported.

--- a/website/docs/support/known_issues.md
+++ b/website/docs/support/known_issues.md
@@ -5,7 +5,7 @@ Below is a list of known Corso issues and limitations:
 * Only supports Exchange (email, calendars, contact) and OneDrive (files) M365 data. Additional
   data types and services will be added in subsequent releases.
 
-* Backups of Exchange email may not include changes to whether an email is marked as read or not if no other changes
+* Backups of Exchange email may not include changes to the read status of an email if no other changes
   to the email have been made since the previous backup.
 
 * Restores are non-destructive to a dedicated restore folder in the original Exchange mailbox or OneDrive account.


### PR DESCRIPTION
## Description

Kopia-assisted incrementals will not find changes to emails being marked/unmarked as read because that operation does not update the mod time in Exchange.

## Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [x] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* closes #1693 

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
