### PR TITLE
retrieve manifests and metadata from kopia

### DIFF
--- a/src/cli/repo/s3.go
+++ b/src/cli/repo/s3.go
@@ -200,9 +200,14 @@ func connectS3Cmd(cmd *cobra.Command, args []string) error {
 }
 
 func s3Overrides() map[string]string {
+	var (
+		prvM365 = account.ProviderM365.String()
+		prvS3   = storage.ProviderS3.String()
+	)
+
 	return map[string]string{
-		config.AccountProviderTypeKey: account.ProviderM365.String(),
-		config.StorageProviderTypeKey: storage.ProviderS3.String(),
+		config.AccountProviderTypeKey: prvM365,
+		config.StorageProviderTypeKey: prvS3,
 		storage.Bucket:                bucket,
 		storage.Endpoint:              endpoint,
 		storage.Prefix:                prefix,

--- a/src/internal/connector/data_collections.go
+++ b/src/internal/connector/data_collections.go
@@ -42,6 +42,8 @@ func (gc *GraphConnector) DataCollections(
 		return nil, err
 	}
 
+	// serialize metadata into maps here
+
 	switch sels.Service {
 	case selectors.ServiceExchange:
 		return gc.ExchangeDataCollection(ctx, sels)

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -66,49 +66,6 @@ func makeMetadataCollection(
 	), nil
 }
 
-// makeMetadataCollection creates a metadata collection that has a file
-// containing all the delta tokens in tokens. Returns nil if the map does not
-// have any entries.
-//
-// TODO(ashmrtn): Expand this/break it out into multiple functions so that we
-// can also store map[container ID]->full container path in a file in the
-// metadata collection.
-func makeMetadataCollection(
-	tenant string,
-	user string,
-	cat path.CategoryType,
-	tokens map[string]string,
-	statusUpdater support.StatusUpdater,
-) (data.Collection, error) {
-	if len(tokens) == 0 {
-		return nil, nil
-	}
-
-	buf := &bytes.Buffer{}
-	encoder := json.NewEncoder(buf)
-
-	if err := encoder.Encode(tokens); err != nil {
-		return nil, errors.Wrap(err, "serializing delta tokens")
-	}
-
-	p, err := path.Builder{}.ToServiceCategoryMetadataPath(
-		tenant,
-		user,
-		path.ExchangeService,
-		cat,
-		false,
-	)
-	if err != nil {
-		return nil, errors.Wrap(err, "making path")
-	}
-
-	return graph.NewMetadataCollection(
-		p,
-		[]graph.MetadataItem{graph.NewMetadataItem(graph.DeltaTokenFileName, buf.Bytes())},
-		statusUpdater,
-	), nil
-}
-
 // FilterContainersAndFillCollections is a utility function
 // that places the M365 object ids belonging to specific directories
 // into a Collection. Messages outside of those directories are omitted.

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -66,6 +66,49 @@ func makeMetadataCollection(
 	), nil
 }
 
+// makeMetadataCollection creates a metadata collection that has a file
+// containing all the delta tokens in tokens. Returns nil if the map does not
+// have any entries.
+//
+// TODO(ashmrtn): Expand this/break it out into multiple functions so that we
+// can also store map[container ID]->full container path in a file in the
+// metadata collection.
+func makeMetadataCollection(
+	tenant string,
+	user string,
+	cat path.CategoryType,
+	tokens map[string]string,
+	statusUpdater support.StatusUpdater,
+) (data.Collection, error) {
+	if len(tokens) == 0 {
+		return nil, nil
+	}
+
+	buf := &bytes.Buffer{}
+	encoder := json.NewEncoder(buf)
+
+	if err := encoder.Encode(tokens); err != nil {
+		return nil, errors.Wrap(err, "serializing delta tokens")
+	}
+
+	p, err := path.Builder{}.ToServiceCategoryMetadataPath(
+		tenant,
+		user,
+		path.ExchangeService,
+		cat,
+		false,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "making path")
+	}
+
+	return graph.NewMetadataCollection(
+		p,
+		[]graph.MetadataItem{graph.NewMetadataItem(graph.DeltaTokenFileName, buf.Bytes())},
+		statusUpdater,
+	), nil
+}
+
 // FilterContainersAndFillCollections is a utility function
 // that places the M365 object ids belonging to specific directories
 // into a Collection. Messages outside of those directories are omitted.

--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -13,6 +13,12 @@ import (
 // given endpoint. The endpoint granularity varies by service.
 const DeltaTokenFileName = "delta"
 
+// MetadataFileNames produces the standard set of filenames used to store graph
+// metadata such as delta tokens and folderID->path references.
+func MetadataFileNames() []string {
+	return []string{DeltaTokenFileName}
+}
+
 type QueryParams struct {
 	Category      path.CategoryType
 	ResourceOwner string

--- a/src/internal/kopia/snapshot_manager.go
+++ b/src/internal/kopia/snapshot_manager.go
@@ -187,7 +187,7 @@ func fetchPrevManifests(
 	return manifestsSinceLastComplete(mans), nil
 }
 
-// fetchPrevSnapshotManifests returns a set of manifests for complete and maybe
+// FetchPrevSnapshotManifests returns a set of manifests for complete and maybe
 // incomplete snapshots for the given (resource owner, service, category)
 // tuples. Up to two manifests can be returned per tuple: one complete and one
 // incomplete. An incomplete manifest may be returned if it is newer than the

--- a/src/internal/kopia/snapshot_manager.go
+++ b/src/internal/kopia/snapshot_manager.go
@@ -202,7 +202,7 @@ func fetchPrevManifests(
 	return manifestsSinceLastComplete(mans), nil
 }
 
-// FetchPrevSnapshotManifests returns a set of manifests for complete and maybe
+// fetchPrevSnapshotManifests returns a set of manifests for complete and maybe
 // incomplete snapshots for the given (resource owner, service, category)
 // tuples. Up to two manifests can be returned per tuple: one complete and one
 // incomplete. An incomplete manifest may be returned if it is newer than the

--- a/src/internal/kopia/snapshot_manager.go
+++ b/src/internal/kopia/snapshot_manager.go
@@ -209,29 +209,34 @@ func fetchPrevManifests(
 // newest complete manifest for the tuple. Manifests are deduped such that if
 // multiple tuples match the same manifest it will only be returned once.
 // External callers can access this via wrapper.FetchPrevSnapshotManifests().
+// If tags are provided, manifests must include a superset of the k:v pairs
+// specified by those tags.  Tags should pass their raw values, and will be
+// normalized inside the func using MakeTagKV.
 func fetchPrevSnapshotManifests(
 	ctx context.Context,
 	sm snapshotManager,
 	oc *OwnersCats,
+	tags map[string]string,
 ) []*snapshot.Manifest {
 	mans := map[manifest.ID]*snapshot.Manifest{}
+	tags = normalizeTagKVs(tags)
 
 	// For each serviceCat/resource owner pair that we will be backing up, see if
 	// there's a previous incomplete snapshot and/or a previous complete snapshot
 	// we can pass in. Can be expanded to return more than the most recent
 	// snapshots, but may require more memory at runtime.
 	for serviceCat := range oc.ServiceCats {
-		serviceTagKey, serviceTagValue := MakeTagKV(serviceCat)
-
 		for resourceOwner := range oc.ResourceOwners {
-			resourceOwnerTagKey, resourceOwnerTagValue := MakeTagKV(resourceOwner)
+			allTags := normalizeTagKVs(map[string]string{
+				serviceCat:    "",
+				resourceOwner: "",
+			})
 
-			tags := map[string]string{
-				serviceTagKey:       serviceTagValue,
-				resourceOwnerTagKey: resourceOwnerTagValue,
+			for k, v := range tags {
+				allTags[k] = v
 			}
 
-			found, err := fetchPrevManifests(ctx, sm, mans, tags)
+			found, err := fetchPrevManifests(ctx, sm, mans, allTags)
 			if err != nil {
 				logger.Ctx(ctx).Warnw(
 					"fetching previous snapshot manifests for service/category/resource owner",
@@ -258,4 +263,20 @@ func fetchPrevSnapshotManifests(
 	}
 
 	return res
+}
+
+func normalizeTagKVs(tags map[string]string) map[string]string {
+	t2 := make(map[string]string, len(tags))
+
+	for k, v := range tags {
+		mk, mv := MakeTagKV(k)
+
+		if len(v) == 0 {
+			v = mv
+		}
+
+		t2[mk] = v
+	}
+
+	return t2
 }

--- a/src/internal/kopia/snapshot_manager.go
+++ b/src/internal/kopia/snapshot_manager.go
@@ -44,9 +44,9 @@ type ServiceCat struct {
 }
 
 // MakeServiceCat produces the expected OwnersCats.ServiceCats key from a
-// path service and path category.
-func MakeServiceCat(s path.ServiceType, c path.CategoryType) string {
-	return serviceCatString(s, c)
+// path service and path category, as well as the ServiceCat value.
+func MakeServiceCat(s path.ServiceType, c path.CategoryType) (string, ServiceCat) {
+	return serviceCatString(s, c), ServiceCat{s, c}
 }
 
 func serviceCatTag(p path.Path) string {

--- a/src/internal/kopia/snapshot_manager.go
+++ b/src/internal/kopia/snapshot_manager.go
@@ -35,11 +35,26 @@ type snapshotManager interface {
 
 type OwnersCats struct {
 	ResourceOwners map[string]struct{}
-	ServiceCats    map[string]struct{}
+	ServiceCats    map[string]ServiceCat
+}
+
+type ServiceCat struct {
+	Service  path.ServiceType
+	Category path.CategoryType
+}
+
+// MakeServiceCat produces the expected OwnersCats.ServiceCats key from a
+// path service and path category.
+func MakeServiceCat(s path.ServiceType, c path.CategoryType) string {
+	return serviceCatString(s, c)
 }
 
 func serviceCatTag(p path.Path) string {
-	return p.Service().String() + p.Category().String()
+	return serviceCatString(p.Service(), p.Category())
+}
+
+func serviceCatString(s path.ServiceType, c path.CategoryType) string {
+	return s.String() + c.String()
 }
 
 // MakeTagKV normalizes the provided key to protect it from clobbering

--- a/src/internal/kopia/snapshot_manager_test.go
+++ b/src/internal/kopia/snapshot_manager_test.go
@@ -41,7 +41,7 @@ var (
 			testUser2: {},
 			testUser3: {},
 		},
-		ServiceCats: map[string]struct{}{
+		ServiceCats: map[string]ServiceCat{
 			testMail:   {},
 			testEvents: {},
 		},
@@ -52,7 +52,7 @@ var (
 			testUser2: {},
 			testUser3: {},
 		},
-		ServiceCats: map[string]struct{}{
+		ServiceCats: map[string]ServiceCat{
 			testMail: {},
 		},
 	}

--- a/src/internal/kopia/snapshot_manager_test.go
+++ b/src/internal/kopia/snapshot_manager_test.go
@@ -442,11 +442,104 @@ func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshots() {
 				}
 			}
 
-			snaps := FetchPrevSnapshotManifests(ctx, msm, test.input)
+			snaps := fetchPrevSnapshotManifests(ctx, msm, test.input, nil)
 
 			expected := make([]*snapshot.Manifest, 0, len(test.expectedIdxs))
 			for _, i := range test.expectedIdxs {
 				expected = append(expected, test.data[i].man)
+			}
+
+			assert.ElementsMatch(t, expected, snaps)
+
+			// Need to manually check because we don't know the order the
+			// user/service/category labels will be iterated over. For some tests this
+			// could cause more loads than the ideal case.
+			assert.Len(t, loadCounts, len(test.expectedLoadCounts))
+			for id, count := range loadCounts {
+				assert.GreaterOrEqual(t, test.expectedLoadCounts[id], count)
+			}
+		})
+	}
+}
+
+func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshots_customTags() {
+	data := []manifestInfo{
+		newManifestInfo(
+			testID1,
+			testT1,
+			false,
+			testMail,
+			testUser1,
+			"fnords",
+			"smarf",
+		),
+	}
+	expectLoad1T1 := map[manifest.ID]int{
+		testID1: 1,
+	}
+
+	table := []struct {
+		name  string
+		input *OwnersCats
+		tags  map[string]string
+		// Use this to denote which manifests in data should be expected. Allows
+		// defining data in a table while not repeating things between data and
+		// expected.
+		expectedIdxs []int
+		// Expected number of times a manifest should try to be loaded from kopia.
+		// Used to check that caching is functioning properly.
+		expectedLoadCounts map[manifest.ID]int
+	}{
+		{
+			name:               "no tags specified",
+			tags:               nil,
+			expectedIdxs:       []int{0},
+			expectedLoadCounts: expectLoad1T1,
+		},
+		{
+			name: "all custom tags",
+			tags: map[string]string{
+				"fnords": "",
+				"smarf":  "",
+			},
+			expectedIdxs:       []int{0},
+			expectedLoadCounts: expectLoad1T1,
+		},
+		{
+			name:               "subset of custom tags",
+			tags:               map[string]string{"fnords": ""},
+			expectedIdxs:       []int{0},
+			expectedLoadCounts: expectLoad1T1,
+		},
+		{
+			name:               "custom tag mismatch",
+			tags:               map[string]string{"bojangles": ""},
+			expectedIdxs:       nil,
+			expectedLoadCounts: nil,
+		},
+	}
+
+	for _, test := range table {
+		suite.T().Run(test.name, func(t *testing.T) {
+			ctx, flush := tester.NewContext()
+			defer flush()
+
+			msm := &mockSnapshotManager{
+				data: data,
+			}
+
+			loadCounts := map[manifest.ID]int{}
+			msm.loadCallback = func(ids []manifest.ID) {
+				for _, id := range ids {
+					loadCounts[id]++
+				}
+			}
+
+			snaps := fetchPrevSnapshotManifests(ctx, msm, testAllUsersAllCats, test.tags)
+
+			expected := make([]*snapshot.Manifest, 0, len(test.expectedIdxs))
+			for _, i := range test.expectedIdxs {
+				expected = append(expected, data[i].man)
 			}
 
 			assert.ElementsMatch(t, expected, snaps)
@@ -495,7 +588,7 @@ func (msm *mockErrorSnapshotManager) LoadSnapshots(
 	return msm.sm.LoadSnapshots(ctx, ids)
 }
 
-func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshotsWorksWithErrors() {
+func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshots_withErrors() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 
@@ -532,7 +625,7 @@ func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshotsWorksWithErrors() {
 		},
 	}
 
-	snaps := FetchPrevSnapshotManifests(ctx, msm, input)
+	snaps := fetchPrevSnapshotManifests(ctx, msm, input, nil)
 
 	// Only 1 snapshot should be chosen because the other two attempts fail.
 	// However, which one is returned is non-deterministic because maps are used.

--- a/src/internal/kopia/snapshot_manager_test.go
+++ b/src/internal/kopia/snapshot_manager_test.go
@@ -442,7 +442,7 @@ func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshots() {
 				}
 			}
 
-			snaps := fetchPrevSnapshotManifests(ctx, msm, test.input)
+			snaps := FetchPrevSnapshotManifests(ctx, msm, test.input)
 
 			expected := make([]*snapshot.Manifest, 0, len(test.expectedIdxs))
 			for _, i := range test.expectedIdxs {
@@ -532,7 +532,7 @@ func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshotsWorksWithErrors() {
 		},
 	}
 
-	snaps := fetchPrevSnapshotManifests(ctx, msm, input)
+	snaps := FetchPrevSnapshotManifests(ctx, msm, input)
 
 	// Only 1 snapshot should be chosen because the other two attempts fail.
 	// However, which one is returned is non-deterministic because maps are used.

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -398,7 +398,7 @@ func inflateCollectionTree(
 	updatedPaths := make(map[string]path.Path)
 	ownerCats := &OwnersCats{
 		ResourceOwners: make(map[string]struct{}),
-		ServiceCats:    make(map[string]struct{}),
+		ServiceCats:    make(map[string]ServiceCat),
 	}
 
 	for _, s := range collections {
@@ -424,7 +424,7 @@ func inflateCollectionTree(
 		}
 
 		serviceCat := serviceCatTag(s.FullPath())
-		ownerCats.ServiceCats[serviceCat] = struct{}{}
+		ownerCats.ServiceCats[serviceCat] = ServiceCat{}
 		ownerCats.ResourceOwners[s.FullPath().ResourceOwner()] = struct{}{}
 
 		node.collection = s

--- a/src/internal/kopia/upload_test.go
+++ b/src/internal/kopia/upload_test.go
@@ -443,7 +443,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree() {
 		user1Encoded: 5,
 		user2Encoded: 42,
 	}
-	expectedServiceCats := map[string]struct{}{
+	expectedServiceCats := map[string]ServiceCat{
 		serviceCatTag(suite.testPath): {},
 		serviceCatTag(p2):             {},
 	}

--- a/src/internal/kopia/upload_test.go
+++ b/src/internal/kopia/upload_test.go
@@ -522,7 +522,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_MixedDirectory() 
 	p2, err := suite.testPath.Append(subdir, false)
 	require.NoError(suite.T(), err)
 
-	expectedServiceCats := map[string]struct{}{
+	expectedServiceCats := map[string]ServiceCat{
 		serviceCatTag(suite.testPath): {},
 		serviceCatTag(p2):             {},
 	}

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -210,7 +210,13 @@ func (w Wrapper) makeSnapshotWithRoot(
 
 			man.Tags = tagsFromStrings(oc)
 			for k, v := range addlTags {
-				man.Tags[k] = v
+				mk, mv := MakeTagKV(k)
+
+				if len(v) == 0 {
+					v = mv
+				}
+
+				man.Tags[mk] = v
 			}
 
 			if _, err := snapshot.SaveSnapshot(innerCtx, rw, man); err != nil {

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -148,7 +148,7 @@ func (w Wrapper) makeSnapshotWithRoot(
 ) (*BackupStats, error) {
 	var man *snapshot.Manifest
 
-	prevSnaps := fetchPrevSnapshotManifests(ctx, w.c, oc)
+	prevSnaps := FetchPrevSnapshotManifests(ctx, w.c, oc)
 
 	bc := &stats.ByteCounter{}
 

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -92,10 +92,6 @@ type Wrapper struct {
 	c *conn
 }
 
-func (w *Wrapper) Conn() *conn {
-	return w.c
-}
-
 func (w *Wrapper) Close(ctx context.Context) error {
 	if w.c == nil {
 		return nil

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -210,17 +210,30 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 		),
 	}
 
+	// tags that are expected to populate as a side effect
+	// of the backup process.
 	baseTagKeys := []string{
 		serviceCatTag(suite.testPath1),
 		suite.testPath1.ResourceOwner(),
 		serviceCatTag(suite.testPath2),
 		suite.testPath2.ResourceOwner(),
 	}
+
+	// tags that are supplied by the caller.
+	customTags := map[string]string{
+		"fnords":    "smarf",
+		"brunhilda": "",
+	}
+
 	expectedTags := map[string]string{}
 
 	for _, k := range baseTagKeys {
 		tk, tv := MakeTagKV(k)
 		expectedTags[tk] = tv
+	}
+
+	for k, v := range normalizeTagKVs(customTags) {
+		expectedTags[k] = v
 	}
 
 	table := []struct {
@@ -247,7 +260,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 				nil,
 				collections,
 				path.ExchangeService,
-				"",
+				nil,
 			)
 			assert.NoError(t, err)
 
@@ -303,7 +316,7 @@ func (suite *KopiaIntegrationSuite) TestRestoreAfterCompressionChange() {
 		nil,
 		[]data.Collection{dc1, dc2},
 		path.ExchangeService,
-		"",
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -374,7 +387,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_ReaderError() {
 		nil,
 		collections,
 		path.ExchangeService,
-		"",
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -418,7 +431,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollectionsHandlesNoCollections() 
 				nil,
 				test.collections,
 				path.UnknownService,
-				"",
+				nil,
 			)
 			require.NoError(t, err)
 
@@ -568,7 +581,7 @@ func (suite *KopiaSimpleRepoIntegrationSuite) SetupTest() {
 		nil,
 		collections,
 		path.ExchangeService,
-		"",
+		nil,
 	)
 	require.NoError(t, err)
 	require.Equal(t, stats.ErrorCount, 0)

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -247,6 +247,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 				nil,
 				collections,
 				path.ExchangeService,
+				"",
 			)
 			assert.NoError(t, err)
 
@@ -302,6 +303,7 @@ func (suite *KopiaIntegrationSuite) TestRestoreAfterCompressionChange() {
 		nil,
 		[]data.Collection{dc1, dc2},
 		path.ExchangeService,
+		"",
 	)
 	require.NoError(t, err)
 
@@ -372,6 +374,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_ReaderError() {
 		nil,
 		collections,
 		path.ExchangeService,
+		"",
 	)
 	require.NoError(t, err)
 
@@ -415,6 +418,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollectionsHandlesNoCollections() 
 				nil,
 				test.collections,
 				path.UnknownService,
+				"",
 			)
 			require.NoError(t, err)
 
@@ -564,6 +568,7 @@ func (suite *KopiaSimpleRepoIntegrationSuite) SetupTest() {
 		nil,
 		collections,
 		path.ExchangeService,
+		"",
 	)
 	require.NoError(t, err)
 	require.Equal(t, stats.ErrorCount, 0)

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -260,7 +260,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 				nil,
 				collections,
 				path.ExchangeService,
-				nil,
+				customTags,
 			)
 			assert.NoError(t, err)
 

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -190,7 +190,10 @@ func produceManifestsAndMetadata(
 		collections []data.Collection
 	)
 
-	ms, err := kw.FetchPrevSnapshotManifests(ctx, oc, map[string]string{kopia.TagBackupCategory: ""})
+	ms, err := kw.FetchPrevSnapshotManifests(
+		ctx,
+		oc,
+		map[string]string{kopia.TagBackupCategory: ""})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -288,10 +291,8 @@ func selectorToOwnersCats(sel selectors.Selector) kopia.OwnersCats {
 
 	for _, sl := range [][]path.CategoryType{pcs.Includes, pcs.Filters} {
 		for _, cat := range sl {
-			oc.ServiceCats[kopia.MakeServiceCat(service, cat)] = kopia.ServiceCat{
-				Service:  service,
-				Category: cat,
-			}
+			k, v := kopia.MakeServiceCat(service, cat)
+			oc.ServiceCats[k] = v
 		}
 	}
 

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -190,7 +190,7 @@ func produceManifestsAndMetadata(
 		collections []data.Collection
 	)
 
-	ms, err := kw.FetchPrevSnapshotManifests(ctx, oc)
+	ms, err := kw.FetchPrevSnapshotManifests(ctx, oc, map[string]string{kopia.TagBackupCategory: ""})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -205,7 +205,7 @@ func produceManifestsAndMetadata(
 		if err := sw.Get(
 			ctx,
 			model.BackupSchema,
-			model.StableID(man.Tags[kopia.BackupIDTag]),
+			model.StableID(man.Tags[kopia.TagBackupID]),
 			&bup,
 		); err != nil {
 			return nil, nil, err
@@ -330,7 +330,12 @@ func consumeBackupDataCollections(
 		closer()
 	}()
 
-	return kw.BackupCollections(ctx, nil, cs, sel.PathService(), string(backupID))
+	tags := map[string]string{
+		kopia.TagBackupID:       string(backupID),
+		kopia.TagBackupCategory: "",
+	}
+
+	return kw.BackupCollections(ctx, nil, cs, sel.PathService(), tags)
 }
 
 // writes the results metrics to the operation results.

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -262,7 +262,7 @@ func TestBackupOpIntegrationSuite(t *testing.T) {
 	if err := tester.RunOnAny(
 		tester.CorsoCITests,
 		tester.CorsoOperationTests,
-		"flomp",
+		tester.CorsoOperationBackupTests,
 	); err != nil {
 		t.Skip(err)
 	}
@@ -322,16 +322,21 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchange() {
 	m365UserID := tester.M365UserID(suite.T())
 
 	tests := []struct {
-		name       string
-		selectFunc func() *selectors.ExchangeBackup
+		name          string
+		selectFunc    func() *selectors.ExchangeBackup
+		resourceOwner string
+		category      path.CategoryType
 	}{
 		{
 			name: "Integration Exchange.Mail",
 			selectFunc: func() *selectors.ExchangeBackup {
 				sel := selectors.NewExchangeBackup()
 				sel.Include(sel.MailFolders([]string{m365UserID}, []string{exchange.DefaultMailFolder}, selectors.PrefixMatch()))
+
 				return sel
 			},
+			resourceOwner: m365UserID,
+			category:      path.EmailCategory,
 		},
 		{
 			name: "Integration Exchange.Contacts",
@@ -341,8 +346,11 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchange() {
 					[]string{m365UserID},
 					[]string{exchange.DefaultContactFolder},
 					selectors.PrefixMatch()))
+
 				return sel
 			},
+			resourceOwner: m365UserID,
+			category:      path.ContactsCategory,
 		},
 		{
 			name: "Integration Exchange.Events",
@@ -351,6 +359,8 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchange() {
 				sel.Include(sel.EventCalendars([]string{m365UserID}, []string{exchange.DefaultCalendar}, selectors.PrefixMatch()))
 				return sel
 			},
+			resourceOwner: m365UserID,
+			category:      path.EventsCategory,
 		},
 	}
 	for _, test := range tests {
@@ -392,13 +402,37 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchange() {
 				mb.CalledWith[events.BackupStart][0][events.BackupID],
 				bo.Results.BackupID, "backupID pre-declaration")
 
-			// Check that metadata files with delta tokens were created. Currently
-			// these files will only be made for contacts and email in Exchange if any
-			// items were backed up. Events does not support delta queries.
+			// verify that we can find the new backup id in the manifests
+			var (
+				sck, scv = kopia.MakeServiceCat(sel.PathService(), test.category)
+				oc       = kopia.OwnersCats{
+					ResourceOwners: map[string]struct{}{test.resourceOwner: {}},
+					ServiceCats:    map[string]kopia.ServiceCat{sck: scv},
+				}
+				tags  = map[string]string{kopia.TagBackupCategory: ""}
+				found bool
+			)
+
+			mans, err := kw.FetchPrevSnapshotManifests(ctx, oc, tags)
+			assert.NoError(t, err)
+
+			for _, man := range mans {
+				tk, _ := kopia.MakeTagKV(kopia.TagBackupID)
+				if man.Tags[tk] == string(bo.Results.BackupID) {
+					found = true
+					break
+				}
+			}
+
+			assert.True(t, found, "backup retrieved by previous snapshot manifest")
+
 			if failed {
 				return
 			}
 
+			// Check that metadata files with delta tokens were created. Currently
+			// these files will only be made for contacts and email in Exchange if any
+			// items were backed up. Events does not support delta queries.
 			m365, err := acct.M365Config()
 			require.NoError(t, err)
 

--- a/src/internal/streamstore/streamstore.go
+++ b/src/internal/streamstore/streamstore.go
@@ -73,7 +73,7 @@ func (ss *streamStore) WriteBackupDetails(
 		},
 	}
 
-	backupStats, _, err := ss.kw.BackupCollections(ctx, nil, []data.Collection{dc}, ss.service)
+	backupStats, _, err := ss.kw.BackupCollections(ctx, nil, []data.Collection{dc}, ss.service, nil)
 	if err != nil {
 		return "", nil
 	}

--- a/src/internal/tester/integration_runners.go
+++ b/src/internal/tester/integration_runners.go
@@ -28,6 +28,7 @@ const (
 	CorsoModelStoreTests                          = "CORSO_MODEL_STORE_TESTS"
 	CorsoOneDriveTests                            = "CORSO_ONE_DRIVE_TESTS"
 	CorsoOperationTests                           = "CORSO_OPERATION_TESTS"
+	CorsoOperationBackupTests                     = "CORSO_OPERATION_BACKUP_TESTS"
 	CorsoRepositoryTests                          = "CORSO_REPOSITORY_TESTS"
 )
 


### PR DESCRIPTION
## Description

In a backup operation, begins the operation by
retrieving all backup manifests and metadata
from prior operations.

## Type of change

- [x] :sunflower: Feature

## Issue(s)

* #1725

## Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
