### PR TITLE
Store backup details in a separate snapshot

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/tidwall/pretty v1.2.1
 	github.com/tomlazar/table v0.1.2
 	github.com/vbauerster/mpb/v8 v8.1.4
+	github.com/zeebo/assert v1.1.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/tools v0.4.0
 	gopkg.in/resty.v1 v1.12.0
@@ -82,7 +83,7 @@ require (
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/microsoft/kiota-serialization-text-go v0.6.0 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect
-	github.com/minio/minio-go/v7 v7.0.39 // indirect
+	github.com/minio/minio-go/v7 v7.0.39
 	github.com/minio/sha256-simd v1.0.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/alcionai/corso/src/internal/data"
 	D "github.com/alcionai/corso/src/internal/diagnostics"
-	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/internal/stats"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/logger"
@@ -521,10 +520,6 @@ func (w Wrapper) BackupCollections(
 	progress := &corsoProgress{
 		pending: map[string]*itemDetails{},
 		deets:   &details.Details{},
-	}
-
-	progress.deets.Tags = map[string]string{
-		model.ServiceTag: service.String(),
 	}
 
 	dirTree, oc, err := inflateDirTree(ctx, collections, progress)

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/alcionai/corso/src/internal/connector/mockconnector"
 	"github.com/alcionai/corso/src/internal/data"
-	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/logger"
@@ -897,7 +896,6 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 			assert.Equal(t, 0, stats.IgnoredErrorCount)
 			assert.Equal(t, 0, stats.ErrorCount)
 			assert.False(t, stats.Incomplete)
-			assert.Equal(t, path.ExchangeService.String(), deets.Tags[model.ServiceTag])
 			// 47 file and 6 folder entries.
 			assert.Len(
 				t,
@@ -938,14 +936,13 @@ func (suite *KopiaIntegrationSuite) TestRestoreAfterCompressionChange() {
 	fp2, err := suite.testPath2.Append(dc2.Names[0], true)
 	require.NoError(t, err)
 
-	stats, deets, err := w.BackupCollections(
+	stats, _, err := w.BackupCollections(
 		ctx,
 		nil,
 		[]data.Collection{dc1, dc2},
 		path.ExchangeService,
 	)
 	require.NoError(t, err)
-	assert.Equal(t, path.ExchangeService.String(), deets.Tags[model.ServiceTag])
 
 	require.NoError(t, k.Compression(ctx, "gzip"))
 
@@ -1022,7 +1019,6 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_ReaderError() {
 	assert.Equal(t, 6, stats.TotalDirectoryCount)
 	assert.Equal(t, 1, stats.IgnoredErrorCount)
 	assert.False(t, stats.Incomplete)
-	assert.Equal(t, path.ExchangeService.String(), deets.Tags[model.ServiceTag])
 	// 5 file and 6 folder entries.
 	assert.Len(t, deets.Entries, 5+6)
 }
@@ -1063,8 +1059,6 @@ func (suite *KopiaIntegrationSuite) TestBackupCollectionsHandlesNoCollections() 
 
 			assert.Equal(t, BackupStats{}, *s)
 			assert.Empty(t, d.Entries)
-			// unknownService resolves to an empty string here.
-			assert.Equal(t, "", d.Tags[model.ServiceTag])
 		})
 	}
 }
@@ -1216,7 +1210,6 @@ func (suite *KopiaSimpleRepoIntegrationSuite) SetupTest() {
 	require.Equal(t, stats.TotalDirectoryCount, expectedDirs)
 	require.Equal(t, stats.IgnoredErrorCount, 0)
 	require.False(t, stats.Incomplete)
-	assert.Equal(t, path.ExchangeService.String(), deets.Tags[model.ServiceTag])
 	// 6 file and 6 folder entries.
 	assert.Len(t, deets.Entries, expectedFiles+expectedDirs)
 

--- a/src/internal/model/model.go
+++ b/src/internal/model/model.go
@@ -17,7 +17,6 @@ const (
 	BackupOpSchema
 	RestoreOpSchema
 	BackupSchema
-	BackupDetailsSchema
 )
 
 // common tags for filtering
@@ -27,7 +26,7 @@ const (
 
 // Valid returns true if the ModelType value fits within the iota range.
 func (mt Schema) Valid() bool {
-	return mt > 0 && mt < BackupDetailsSchema+1
+	return mt > 0 && mt < BackupSchema+1
 }
 
 type Model interface {

--- a/src/internal/model/model_test.go
+++ b/src/internal/model/model_test.go
@@ -27,7 +27,6 @@ func (suite *ModelUnitSuite) TestValid() {
 		{model.BackupOpSchema, assert.True},
 		{model.RestoreOpSchema, assert.True},
 		{model.BackupSchema, assert.True},
-		{model.BackupDetailsSchema, assert.True},
 		{model.Schema(-1), assert.False},
 		{model.Schema(100), assert.False},
 	}

--- a/src/internal/model/schema_string.go
+++ b/src/internal/model/schema_string.go
@@ -12,12 +12,11 @@ func _() {
 	_ = x[BackupOpSchema-1]
 	_ = x[RestoreOpSchema-2]
 	_ = x[BackupSchema-3]
-	_ = x[BackupDetailsSchema-4]
 }
 
-const _Schema_name = "UnknownSchemaBackupOpSchemaRestoreOpSchemaBackupSchemaBackupDetailsSchema"
+const _Schema_name = "UnknownSchemaBackupOpSchemaRestoreOpSchemaBackupSchema"
 
-var _Schema_index = [...]uint8{0, 13, 27, 42, 54, 73}
+var _Schema_index = [...]uint8{0, 13, 27, 42, 54}
 
 func (i Schema) String() string {
 	if i < 0 || i >= Schema(len(_Schema_index)-1) {

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -17,6 +17,7 @@ import (
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/internal/observe"
 	"github.com/alcionai/corso/src/internal/stats"
+	"github.com/alcionai/corso/src/internal/streamstore"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
@@ -242,13 +243,16 @@ func (op *BackupOperation) createBackupModels(
 		return errors.New("no backup details to record")
 	}
 
-	err := op.store.Put(ctx, model.BackupDetailsSchema, &backupDetails.DetailsModel)
+	detailsID, err := streamstore.New(
+		op.kopia,
+		op.account.ID(),
+		op.Selectors.PathService()).WriteBackupDetails(ctx, backupDetails)
 	if err != nil {
 		return errors.Wrap(err, "creating backupdetails model")
 	}
 
 	b := backup.New(
-		snapID, string(backupDetails.ModelStoreID), op.Status.String(),
+		snapID, detailsID, op.Status.String(),
 		op.Results.BackupID,
 		op.Selectors,
 		op.Results.ReadWrites,

--- a/src/internal/streamstore/streamstore.go
+++ b/src/internal/streamstore/streamstore.go
@@ -1,0 +1,194 @@
+// streamstore implements helpers to store large
+// data streams in a repository
+package streamstore
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+
+	"github.com/pkg/errors"
+
+	"github.com/alcionai/corso/src/internal/data"
+	"github.com/alcionai/corso/src/internal/kopia"
+	"github.com/alcionai/corso/src/internal/stats"
+	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/path"
+)
+
+type streamStore struct {
+	kw       *kopia.Wrapper
+	resource string
+	tenant   string
+	service  path.ServiceType
+}
+
+func New(
+	kw *kopia.Wrapper,
+	tenant string,
+	service path.ServiceType,
+) *streamStore {
+	return &streamStore{kw: kw, resource: "metadata", tenant: tenant, service: service}
+}
+
+const detailsItemName = "details"
+
+// WriteBackupDetails persists a `details.Details`
+// object in the stream store
+func (ss *streamStore) WriteBackupDetails(
+	ctx context.Context,
+	backupDetails *details.Details,
+) (string, error) {
+	// construct the path of the container for the `details` item
+	p, err := path.Builder{}.
+		ToServiceCategoryMetadataPath(
+			ss.tenant,
+			ss.resource,
+			ss.service,
+			path.DetailsCategory,
+			false,
+		)
+	if err != nil {
+		return "", err
+	}
+
+	// TODO: We could use an io.Pipe here to avoid a double copy but that
+	// makes error handling a bit complicated
+	dbytes, err := json.Marshal(backupDetails)
+	if err != nil {
+		return "", errors.Wrap(err, "marshalling backup details")
+	}
+
+	dc := &streamCollection{
+		folderPath: p,
+		item: &streamItem{
+			name: detailsItemName,
+			data: dbytes,
+		},
+	}
+
+	backupStats, _, err := ss.kw.BackupCollections(ctx, nil, []data.Collection{dc}, ss.service)
+	if err != nil {
+		return "", nil
+	}
+
+	return backupStats.SnapshotID, nil
+}
+
+// ReadBackupDetails reads the specified details object
+// from the kopia repository
+func (ss *streamStore) ReadBackupDetails(
+	ctx context.Context,
+	detailsID string,
+) (*details.Details, error) {
+	// construct the path for the `details` item
+	detailsPath, err := path.Builder{}.
+		Append("details").
+		ToServiceCategoryMetadataPath(
+			ss.tenant,
+			ss.resource,
+			ss.service,
+			path.DetailsCategory,
+			true,
+		)
+	if err != nil {
+		return nil, err
+	}
+
+	var bc stats.ByteCounter
+
+	dcs, err := ss.kw.RestoreMultipleItems(ctx, detailsID, []path.Path{detailsPath}, &bc)
+	if err != nil {
+		return nil, errors.Wrap(err, "retrieving backup details data")
+	}
+
+	// Expect only 1 data collection
+	if len(dcs) != 1 {
+		return nil, errors.Errorf("expected 1 details data collection: %d", len(dcs))
+	}
+
+	dc := dcs[0]
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, errors.New("context cancelled waiting for backup details data")
+
+		case itemData, ok := <-dc.Items():
+			if !ok {
+				return nil, errors.New("no backup details found")
+			}
+
+			var d details.Details
+
+			err := json.NewDecoder(itemData.ToReader()).Decode(&d)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to decode details data from repository")
+			}
+
+			return &d, nil
+		}
+	}
+}
+
+// DeleteBackupDetails deletes the specified details object from the kopia repository
+func (ss *streamStore) DeleteBackupDetails(
+	ctx context.Context,
+	detailsID string,
+) error {
+	err := ss.kw.DeleteSnapshot(ctx, detailsID)
+	if err != nil {
+		return errors.Wrap(err, "deleting backup details failed")
+	}
+
+	return nil
+}
+
+// streamCollection is a data.Collection used to persist
+// a single data stream
+type streamCollection struct {
+	// folderPath indicates what level in the hierarchy this collection
+	// represents
+	folderPath path.Path
+	item       *streamItem
+}
+
+func (dc *streamCollection) FullPath() path.Path {
+	return dc.folderPath
+}
+
+func (dc *streamCollection) PreviousPath() path.Path {
+	return nil
+}
+
+func (dc *streamCollection) State() data.CollectionState {
+	return data.NewState
+}
+
+// Items() always returns a channel with a single data.Stream
+// representing the object to be persisted
+func (dc *streamCollection) Items() <-chan data.Stream {
+	items := make(chan data.Stream, 1)
+	defer close(items)
+	items <- dc.item
+
+	return items
+}
+
+type streamItem struct {
+	name string
+	data []byte
+}
+
+func (di *streamItem) UUID() string {
+	return di.name
+}
+
+func (di *streamItem) ToReader() io.ReadCloser {
+	return io.NopCloser(bytes.NewReader(di.data))
+}
+
+func (di *streamItem) Deleted() bool {
+	return false
+}

--- a/src/internal/streamstore/streamstore_test.go
+++ b/src/internal/streamstore/streamstore_test.go
@@ -1,0 +1,74 @@
+package streamstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"github.com/zeebo/assert"
+
+	"github.com/alcionai/corso/src/internal/kopia"
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/path"
+)
+
+type StreamStoreIntegrationSuite struct {
+	suite.Suite
+}
+
+func TestKopiaIntegrationSuite(t *testing.T) {
+	if err := tester.RunOnAny(
+		tester.CorsoCITests,
+	); err != nil {
+		t.Skip(err)
+	}
+
+	suite.Run(t, new(StreamStoreIntegrationSuite))
+}
+
+func (suite *StreamStoreIntegrationSuite) TestDetails() {
+	t := suite.T()
+
+	ctx, flush := tester.NewContext()
+	defer flush()
+
+	// need to initialize the repository before we can test connecting to it.
+	st := tester.NewPrefixedS3Storage(t)
+
+	k := kopia.NewConn(st)
+	require.NoError(t, k.Initialize(ctx))
+
+	defer k.Close(ctx)
+
+	kw, err := kopia.NewWrapper(k)
+	require.NoError(t, err)
+
+	defer kw.Close(ctx)
+
+	deets := &details.Details{}
+
+	deets.Add("ref", "shortref", "parentref",
+		details.ItemInfo{
+			Exchange: &details.ExchangeInfo{
+				Subject: "hello world",
+			},
+		})
+
+	ss := New(kw, "tenant", path.ExchangeService)
+
+	id, err := ss.WriteBackupDetails(ctx, deets)
+	require.NoError(t, err)
+	require.NotNil(t, id)
+
+	readDeets, err := ss.ReadBackupDetails(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, readDeets)
+
+	assert.Equal(t, len(deets.Entries), len(readDeets.Entries))
+	assert.Equal(t, deets.Entries[0].ParentRef, readDeets.Entries[0].ParentRef)
+	assert.Equal(t, deets.Entries[0].ShortRef, readDeets.Entries[0].ShortRef)
+	assert.Equal(t, deets.Entries[0].RepoRef, readDeets.Entries[0].RepoRef)
+	assert.NotNil(t, readDeets.Entries[0].Exchange)
+	assert.Equal(t, *deets.Entries[0].Exchange, *readDeets.Entries[0].Exchange)
+}

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/internal/common"
-	"github.com/alcionai/corso/src/internal/model"
 )
 
 type FolderEntry struct {
@@ -26,7 +25,6 @@ type FolderEntry struct {
 
 // DetailsModel describes what was stored in a Backup
 type DetailsModel struct {
-	model.BaseModel
 	Entries []DetailsEntry `json:"entries"`
 }
 

--- a/src/pkg/path/categorytype_string.go
+++ b/src/pkg/path/categorytype_string.go
@@ -15,11 +15,12 @@ func _() {
 	_ = x[FilesCategory-4]
 	_ = x[ListsCategory-5]
 	_ = x[LibrariesCategory-6]
+	_ = x[DetailsCategory-7]
 }
 
-const _CategoryType_name = "UnknownCategoryemailcontactseventsfileslistslibraries"
+const _CategoryType_name = "UnknownCategoryemailcontactseventsfileslistslibrariesdetails"
 
-var _CategoryType_index = [...]uint8{0, 15, 20, 28, 34, 39, 44, 53}
+var _CategoryType_index = [...]uint8{0, 15, 20, 28, 34, 39, 44, 53, 60}
 
 func (i CategoryType) String() string {
 	if i < 0 || i >= CategoryType(len(_CategoryType_index)-1) {

--- a/src/pkg/path/resource_path.go
+++ b/src/pkg/path/resource_path.go
@@ -65,6 +65,7 @@ const (
 	FilesCategory                  // files
 	ListsCategory                  // lists
 	LibrariesCategory              // libraries
+	DetailsCategory                // details
 )
 
 func ToCategoryType(category string) CategoryType {
@@ -81,6 +82,8 @@ func ToCategoryType(category string) CategoryType {
 		return LibrariesCategory
 	case ListsCategory.String():
 		return ListsCategory
+	case DetailsCategory.String():
+		return DetailsCategory
 	default:
 		return UnknownCategory
 	}
@@ -93,13 +96,16 @@ var serviceCategories = map[ServiceType]map[CategoryType]struct{}{
 		EmailCategory:    {},
 		ContactsCategory: {},
 		EventsCategory:   {},
+		DetailsCategory:  {},
 	},
 	OneDriveService: {
-		FilesCategory: {},
+		FilesCategory:   {},
+		DetailsCategory: {},
 	},
 	SharePointService: {
 		LibrariesCategory: {},
 		ListsCategory:     {},
+		DetailsCategory:   {},
 	},
 }
 

--- a/src/pkg/store/mock/store_mock.go
+++ b/src/pkg/store/mock/store_mock.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/pkg/backup"
-	"github.com/alcionai/corso/src/pkg/backup/details"
 )
 
 // ------------------------------------------------------------
@@ -16,16 +15,14 @@ import (
 // ------------------------------------------------------------
 
 type MockModelStore struct {
-	backup  *backup.Backup
-	details *details.Details
-	err     error
+	backup *backup.Backup
+	err    error
 }
 
-func NewMock(b *backup.Backup, d *details.Details, err error) *MockModelStore {
+func NewMock(b *backup.Backup, err error) *MockModelStore {
 	return &MockModelStore{
-		backup:  b,
-		details: d,
-		err:     err,
+		backup: b,
+		err:    err,
 	}
 }
 
@@ -60,10 +57,6 @@ func (mms *MockModelStore) Get(
 		bm := data.(*backup.Backup)
 		*bm = *mms.backup
 
-	case model.BackupDetailsSchema:
-		dm := data.(*details.Details)
-		dm.DetailsModel = mms.details.DetailsModel
-
 	default:
 		return errors.Errorf("schema %s not supported by mock Get", s)
 	}
@@ -84,12 +77,6 @@ func (mms *MockModelStore) GetIDsForType(
 	case model.BackupSchema:
 		b := *mms.backup
 		return []*model.BaseModel{&b.BaseModel}, nil
-
-	case model.BackupDetailsSchema:
-		d := details.Details{}
-		d.DetailsModel = mms.details.DetailsModel
-
-		return []*model.BaseModel{&d.BaseModel}, nil
 	}
 
 	return nil, errors.Errorf("schema %s not supported by mock GetIDsForType", s)
@@ -110,10 +97,6 @@ func (mms *MockModelStore) GetWithModelStoreID(
 		bm := data.(*backup.Backup)
 		*bm = *mms.backup
 
-	case model.BackupDetailsSchema:
-		dm := data.(*details.Details)
-		dm.DetailsModel = mms.details.DetailsModel
-
 	default:
 		return errors.Errorf("schema %s not supported by mock GetWithModelStoreID", s)
 	}
@@ -131,10 +114,6 @@ func (mms *MockModelStore) Put(ctx context.Context, s model.Schema, m model.Mode
 		bm := m.(*backup.Backup)
 		mms.backup = bm
 
-	case model.BackupDetailsSchema:
-		dm := m.(*details.Details)
-		mms.details = dm
-
 	default:
 		return errors.Errorf("schema %s not supported by mock Put", s)
 	}
@@ -147,10 +126,6 @@ func (mms *MockModelStore) Update(ctx context.Context, s model.Schema, m model.M
 	case model.BackupSchema:
 		bm := m.(*backup.Backup)
 		mms.backup = bm
-
-	case model.BackupDetailsSchema:
-		dm := m.(*details.Details)
-		mms.details = dm
 
 	default:
 		return errors.Errorf("schema %s not supported by mock Update", s)


### PR DESCRIPTION
## Description

This PR uses a separate snapshot to store backup details instead of a Corso model (i.e. a kopia manifest).

Introduces a `StreamStore` that can be leveraged to store larger metadata objects. We can also leverage this
for incrementals or restartable backups going forward.

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #1735 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
