### PR TITLE
Track more info about collections during backup

### DIFF
--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -228,6 +228,11 @@ func collectionEntries(
 			// the data (if it exists in the base) if we fail uploading the new
 			// version. If so, we should split this call into where we check for the
 			// item being deleted and then again after we do the kopia callback.
+			//
+			// TODO(ashmrtn): With a little more info, we could reduce the number of
+			// items we need to track. Namely, we can track the created time of the
+			// item and if it's after the base snapshot was finalized we can skip it
+			// because it's not possible for the base snapshot to contain that item.
 			seen[e.UUID()] = struct{}{}
 
 			// For now assuming that item IDs don't need escaping.


### PR DESCRIPTION
## Description

Track additional information about collections and their items during backup so we can properly merge directories and items in directories when doing incremental backups

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [x] :hamster: Trivial/Minor

## Issue(s)

* #1740 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
