### PR TITLE
consume old deltas on exchange mail backup

### DIFF
--- a/src/internal/connector/data_collections.go
+++ b/src/internal/connector/data_collections.go
@@ -118,7 +118,6 @@ func verifyBackupInputs(sels selectors.Selector, userPNs, siteIDs []string) erro
 // in case of a name change or relocation.
 // 2- deltas: folderID->deltaToken, used to look up previous delta token
 // retrievals.
-// Finally
 func parseMetadataCollections(
 	ctx context.Context,
 	colls []data.Collection,
@@ -136,7 +135,7 @@ func parseMetadataCollections(
 
 			select {
 			case <-ctx.Done():
-				return nil, nil, errors.Wrap(context.Canceled, "parsing collection metadata")
+				return nil, nil, errors.Wrap(ctx.Err(), "parsing collection metadata")
 			case item, ok := <-items:
 				if !ok {
 					breakLoop = true

--- a/src/internal/connector/data_collections_test.go
+++ b/src/internal/connector/data_collections_test.go
@@ -2,7 +2,6 @@ package connector
 
 import (
 	"bytes"
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +9,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/connector/exchange"
-	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/sharepoint"
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/data"
@@ -18,45 +16,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 )
-
-// ---------------------------------------------------------------------------
-// Unit tests
-// ---------------------------------------------------------------------------
-
-type DataCollectionsUnitSuite struct {
-	suite.Suite
-}
-
-func TestDataCollectionsUnitSuite(t *testing.T) {
-	suite.Run(t, new(DataCollectionsUnitSuite))
-}
-
-func (suite *DataCollectionsUnitSuite) TestParseMetadataCollections() {
-	t := suite.T()
-	ctx, flush := tester.NewContext()
-
-	defer flush()
-
-	bs, err := json.Marshal(map[string]string{"key": "token"})
-	require.NoError(t, err)
-
-	p, err := path.Builder{}.ToServiceCategoryMetadataPath(
-		"t", "u",
-		path.ExchangeService,
-		path.EmailCategory,
-		false,
-	)
-	require.NoError(t, err)
-
-	item := []graph.MetadataItem{graph.NewMetadataItem(graph.DeltaTokenFileName, bs)}
-	mdcoll := graph.NewMetadataCollection(p, item, func(cos *support.ConnectorOperationStatus) {})
-	colls := []data.Collection{mdcoll}
-
-	_, deltas, err := parseMetadataCollections(ctx, colls)
-	require.NoError(t, err)
-	assert.NotEmpty(t, deltas, "delta urls")
-	assert.Equal(t, "token", deltas["key"])
-}
 
 // ---------------------------------------------------------------------------
 // DataCollection tests
@@ -391,7 +350,7 @@ func (suite *ConnectorCreateExchangeCollectionIntegrationSuite) TestDelta() {
 
 			require.NotNil(t, metadata, "collections contains a metadata collection")
 
-			_, deltas, err := parseMetadataCollections(ctx, []data.Collection{metadata})
+			_, deltas, err := exchange.ParseMetadataCollections(ctx, []data.Collection{metadata})
 			require.NoError(t, err)
 
 			// now do another backup with the previous delta tokens,

--- a/src/internal/connector/data_collections_test.go
+++ b/src/internal/connector/data_collections_test.go
@@ -233,7 +233,6 @@ func TestConnectorCreateExchangeCollectionIntegrationSuite(t *testing.T) {
 	if err := tester.RunOnAny(
 		tester.CorsoCITests,
 		tester.CorsoConnectorCreateExchangeCollectionTests,
-		"flomp",
 	); err != nil {
 		t.Skip(err)
 	}

--- a/src/internal/connector/exchange/data_collections.go
+++ b/src/internal/connector/exchange/data_collections.go
@@ -1,0 +1,61 @@
+package exchange
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/pkg/errors"
+
+	"github.com/alcionai/corso/src/internal/connector/graph"
+	"github.com/alcionai/corso/src/internal/data"
+)
+
+// ParseMetadataCollections produces two maps:
+// 1- paths: folderID->filePath, used to look up previous folder pathing
+// in case of a name change or relocation.
+// 2- deltas: folderID->deltaToken, used to look up previous delta token
+// retrievals.
+func ParseMetadataCollections(
+	ctx context.Context,
+	colls []data.Collection,
+) (map[string]string, map[string]string, error) {
+	var (
+		paths  = map[string]string{}
+		deltas = map[string]string{}
+	)
+
+	for _, coll := range colls {
+		items := coll.Items()
+
+		for {
+			var breakLoop bool
+
+			select {
+			case <-ctx.Done():
+				return nil, nil, errors.Wrap(ctx.Err(), "parsing collection metadata")
+			case item, ok := <-items:
+				if !ok {
+					breakLoop = true
+					break
+				}
+
+				switch item.UUID() {
+				// case graph.PreviousPathFileName:
+				case graph.DeltaTokenFileName:
+					err := json.NewDecoder(item.ToReader()).Decode(&deltas)
+					if err != nil {
+						return nil, nil, errors.New("parsing delta token map")
+					}
+
+					breakLoop = true
+				}
+			}
+
+			if breakLoop {
+				break
+			}
+		}
+	}
+
+	return paths, deltas, nil
+}

--- a/src/internal/connector/exchange/data_collections_test.go
+++ b/src/internal/connector/exchange/data_collections_test.go
@@ -1,0 +1,55 @@
+package exchange
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/connector/graph"
+	"github.com/alcionai/corso/src/internal/connector/support"
+	"github.com/alcionai/corso/src/internal/data"
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/path"
+)
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+type DataCollectionsUnitSuite struct {
+	suite.Suite
+}
+
+func TestDataCollectionsUnitSuite(t *testing.T) {
+	suite.Run(t, new(DataCollectionsUnitSuite))
+}
+
+func (suite *DataCollectionsUnitSuite) TestParseMetadataCollections() {
+	t := suite.T()
+	ctx, flush := tester.NewContext()
+
+	defer flush()
+
+	bs, err := json.Marshal(map[string]string{"key": "token"})
+	require.NoError(t, err)
+
+	p, err := path.Builder{}.ToServiceCategoryMetadataPath(
+		"t", "u",
+		path.ExchangeService,
+		path.EmailCategory,
+		false,
+	)
+	require.NoError(t, err)
+
+	item := []graph.MetadataItem{graph.NewMetadataItem(graph.DeltaTokenFileName, bs)}
+	mdcoll := graph.NewMetadataCollection(p, item, func(cos *support.ConnectorOperationStatus) {})
+	colls := []data.Collection{mdcoll}
+
+	_, deltas, err := ParseMetadataCollections(ctx, colls)
+	require.NoError(t, err)
+	assert.NotEmpty(t, deltas, "delta urls")
+	assert.Equal(t, "token", deltas["key"])
+}

--- a/src/internal/connector/exchange/query_options.go
+++ b/src/internal/connector/exchange/query_options.go
@@ -113,18 +113,6 @@ func CategoryToOptionIdentifier(category path.CategoryType) optionIdentifier {
 // which reduces the overall latency of complex calls
 // -----------------------------------------------------------------------
 
-// Delta requests for mail and contacts have the same parameters and config
-// structs.
-type DeltaRequestBuilderGetQueryParameters struct {
-	Count   *bool    `uriparametername:"%24count"`
-	Filter  *string  `uriparametername:"%24filter"`
-	Orderby []string `uriparametername:"%24orderby"`
-	Search  *string  `uriparametername:"%24search"`
-	Select  []string `uriparametername:"%24select"`
-	Skip    *int32   `uriparametername:"%24skip"`
-	Top     *int32   `uriparametername:"%24top"`
-}
-
 func optionsForFolderMessagesDelta(
 	moreOps []string,
 ) (*msuser.UsersItemMailFoldersItemMessagesDeltaRequestBuilderGetRequestConfiguration, error) {

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -311,9 +311,11 @@ func FetchContactIDsFromDirectory(
 		Contacts().
 		Delta()
 
-	if len(oldDelta) > 0 {
-		builder = msuser.NewUsersItemContactFoldersItemContactsDeltaRequestBuilder(oldDelta, gs.Adapter())
-	}
+		// TODO(rkeepers): Awaiting full integration of incremental support, else this
+		// will cause unexpected behavior/errors.
+	// if len(oldDelta) > 0 {
+	// 	builder = msuser.NewUsersItemContactFoldersItemContactsDeltaRequestBuilder(oldDelta, gs.Adapter())
+	// }
 
 	for {
 		resp, err := builder.Get(ctx, options)
@@ -375,9 +377,11 @@ func FetchMessageIDsFromDirectory(
 		Messages().
 		Delta()
 
-	if len(oldDelta) > 0 {
-		builder = msuser.NewUsersItemMailFoldersItemMessagesDeltaRequestBuilder(oldDelta, gs.Adapter())
-	}
+		// TODO(rkeepers): Awaiting full integration of incremental support, else this
+		// will cause unexpected behavior/errors.
+	// if len(oldDelta) > 0 {
+	// 	builder = msuser.NewUsersItemMailFoldersItemMessagesDeltaRequestBuilder(oldDelta, gs.Adapter())
+	// }
 
 	for {
 		resp, err := builder.Get(ctx, options)

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -66,49 +66,6 @@ func makeMetadataCollection(
 	), nil
 }
 
-// makeMetadataCollection creates a metadata collection that has a file
-// containing all the delta tokens in tokens. Returns nil if the map does not
-// have any entries.
-//
-// TODO(ashmrtn): Expand this/break it out into multiple functions so that we
-// can also store map[container ID]->full container path in a file in the
-// metadata collection.
-func makeMetadataCollection(
-	tenant string,
-	user string,
-	cat path.CategoryType,
-	tokens map[string]string,
-	statusUpdater support.StatusUpdater,
-) (data.Collection, error) {
-	if len(tokens) == 0 {
-		return nil, nil
-	}
-
-	buf := &bytes.Buffer{}
-	encoder := json.NewEncoder(buf)
-
-	if err := encoder.Encode(tokens); err != nil {
-		return nil, errors.Wrap(err, "serializing delta tokens")
-	}
-
-	p, err := path.Builder{}.ToServiceCategoryMetadataPath(
-		tenant,
-		user,
-		path.ExchangeService,
-		cat,
-		false,
-	)
-	if err != nil {
-		return nil, errors.Wrap(err, "making path")
-	}
-
-	return graph.NewMetadataCollection(
-		p,
-		[]graph.MetadataItem{graph.NewMetadataItem(graph.DeltaTokenFileName, buf.Bytes())},
-		statusUpdater,
-	), nil
-}
-
 // FilterContainersAndFillCollections is a utility function
 // that places the M365 object ids belonging to specific directories
 // into a Collection. Messages outside of those directories are omitted.

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -66,6 +66,49 @@ func makeMetadataCollection(
 	), nil
 }
 
+// makeMetadataCollection creates a metadata collection that has a file
+// containing all the delta tokens in tokens. Returns nil if the map does not
+// have any entries.
+//
+// TODO(ashmrtn): Expand this/break it out into multiple functions so that we
+// can also store map[container ID]->full container path in a file in the
+// metadata collection.
+func makeMetadataCollection(
+	tenant string,
+	user string,
+	cat path.CategoryType,
+	tokens map[string]string,
+	statusUpdater support.StatusUpdater,
+) (data.Collection, error) {
+	if len(tokens) == 0 {
+		return nil, nil
+	}
+
+	buf := &bytes.Buffer{}
+	encoder := json.NewEncoder(buf)
+
+	if err := encoder.Encode(tokens); err != nil {
+		return nil, errors.Wrap(err, "serializing delta tokens")
+	}
+
+	p, err := path.Builder{}.ToServiceCategoryMetadataPath(
+		tenant,
+		user,
+		path.ExchangeService,
+		cat,
+		false,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "making path")
+	}
+
+	return graph.NewMetadataCollection(
+		p,
+		[]graph.MetadataItem{graph.NewMetadataItem(graph.DeltaTokenFileName, buf.Bytes())},
+		statusUpdater,
+	), nil
+}
+
 // FilterContainersAndFillCollections is a utility function
 // that places the M365 object ids belonging to specific directories
 // into a Collection. Messages outside of those directories are omitted.

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -78,12 +78,13 @@ func FilterContainersAndFillCollections(
 	statusUpdater support.StatusUpdater,
 	resolver graph.ContainerResolver,
 	scope selectors.ExchangeScope,
+	oldDeltas map[string]string,
 ) error {
 	var (
 		errs           error
 		collectionType = CategoryToOptionIdentifier(qp.Category)
-		// folder ID -> delta token for folder.
-		deltaTokens = map[string]string{}
+		// folder ID -> delta url for folder.
+		deltaURLs = map[string]string{}
 	)
 
 	for _, c := range resolver.Items() {
@@ -128,7 +129,10 @@ func FilterContainersAndFillCollections(
 			continue
 		}
 
-		jobs, token, err := fetchFunc(ctx, edc.service, qp.ResourceOwner, *c.GetId())
+		dirID := *c.GetId()
+		oldDelta := oldDeltas[dirID]
+
+		jobs, delta, err := fetchFunc(ctx, edc.service, qp.ResourceOwner, dirID, oldDelta)
 		if err != nil {
 			errs = support.WrapAndAppend(
 				qp.ResourceOwner,
@@ -139,8 +143,8 @@ func FilterContainersAndFillCollections(
 
 		edc.jobs = append(edc.jobs, jobs...)
 
-		if len(token) > 0 {
-			deltaTokens[*c.GetId()] = token
+		if len(delta) > 0 {
+			deltaURLs[dirID] = delta
 		}
 	}
 
@@ -148,7 +152,7 @@ func FilterContainersAndFillCollections(
 		qp.Credentials.AzureTenantID,
 		qp.ResourceOwner,
 		qp.Category,
-		deltaTokens,
+		deltaURLs,
 		statusUpdater,
 	)
 	if err != nil {
@@ -214,7 +218,7 @@ func IterativeCollectCalendarContainers(
 type FetchIDFunc func(
 	ctx context.Context,
 	gs graph.Servicer,
-	user, containerID string,
+	user, containerID, oldDeltaToken string,
 ) ([]string, string, error)
 
 func getFetchIDFunc(category path.CategoryType) (FetchIDFunc, error) {
@@ -234,7 +238,7 @@ func getFetchIDFunc(category path.CategoryType) (FetchIDFunc, error) {
 func FetchEventIDsFromCalendar(
 	ctx context.Context,
 	gs graph.Servicer,
-	user, calendarID string,
+	user, calendarID, oldDelta string,
 ) ([]string, string, error) {
 	var (
 		errs *multierror.Error
@@ -288,17 +292,17 @@ func FetchEventIDsFromCalendar(
 func FetchContactIDsFromDirectory(
 	ctx context.Context,
 	gs graph.Servicer,
-	user, directoryID string,
+	user, directoryID, oldDelta string,
 ) ([]string, string, error) {
 	var (
-		errs       *multierror.Error
-		ids        []string
-		deltaToken string
+		errs     *multierror.Error
+		ids      []string
+		deltaURL string
 	)
 
 	options, err := optionsForContactFoldersItemDelta([]string{"parentFolderId"})
 	if err != nil {
-		return nil, deltaToken, errors.Wrap(err, "getting query options")
+		return nil, deltaURL, errors.Wrap(err, "getting query options")
 	}
 
 	builder := gs.Client().
@@ -307,10 +311,14 @@ func FetchContactIDsFromDirectory(
 		Contacts().
 		Delta()
 
+	if len(oldDelta) > 0 {
+		builder = msuser.NewUsersItemContactFoldersItemContactsDeltaRequestBuilder(oldDelta, gs.Adapter())
+	}
+
 	for {
 		resp, err := builder.Get(ctx, options)
 		if err != nil {
-			return nil, deltaToken, errors.Wrap(err, support.ConnectorStackErrorTrace(err))
+			return nil, deltaURL, errors.Wrap(err, support.ConnectorStackErrorTrace(err))
 		}
 
 		for _, item := range resp.GetValue() {
@@ -329,7 +337,7 @@ func FetchContactIDsFromDirectory(
 
 		delta := resp.GetOdataDeltaLink()
 		if delta != nil && len(*delta) > 0 {
-			deltaToken = *delta
+			deltaURL = *delta
 		}
 
 		nextLink := resp.GetOdataNextLink()
@@ -340,7 +348,7 @@ func FetchContactIDsFromDirectory(
 		builder = msuser.NewUsersItemContactFoldersItemContactsDeltaRequestBuilder(*nextLink, gs.Adapter())
 	}
 
-	return ids, deltaToken, errs.ErrorOrNil()
+	return ids, deltaURL, errs.ErrorOrNil()
 }
 
 // FetchMessageIDsFromDirectory function that returns a list of  all the m365IDs of the exchange.Mail
@@ -348,17 +356,17 @@ func FetchContactIDsFromDirectory(
 func FetchMessageIDsFromDirectory(
 	ctx context.Context,
 	gs graph.Servicer,
-	user, directoryID string,
+	user, directoryID, oldDelta string,
 ) ([]string, string, error) {
 	var (
-		errs       *multierror.Error
-		ids        []string
-		deltaToken string
+		errs     *multierror.Error
+		ids      []string
+		deltaURL string
 	)
 
 	options, err := optionsForFolderMessagesDelta([]string{"id"})
 	if err != nil {
-		return nil, deltaToken, errors.Wrap(err, "getting query options")
+		return nil, deltaURL, errors.Wrap(err, "getting query options")
 	}
 
 	builder := gs.Client().
@@ -367,10 +375,14 @@ func FetchMessageIDsFromDirectory(
 		Messages().
 		Delta()
 
+	if len(oldDelta) > 0 {
+		builder = msuser.NewUsersItemMailFoldersItemMessagesDeltaRequestBuilder(oldDelta, gs.Adapter())
+	}
+
 	for {
 		resp, err := builder.Get(ctx, options)
 		if err != nil {
-			return nil, deltaToken, errors.Wrap(err, support.ConnectorStackErrorTrace(err))
+			return nil, deltaURL, errors.Wrap(err, support.ConnectorStackErrorTrace(err))
 		}
 
 		for _, item := range resp.GetValue() {
@@ -389,7 +401,7 @@ func FetchMessageIDsFromDirectory(
 
 		delta := resp.GetOdataDeltaLink()
 		if delta != nil && len(*delta) > 0 {
-			deltaToken = *delta
+			deltaURL = *delta
 		}
 
 		nextLink := resp.GetOdataNextLink()
@@ -400,5 +412,5 @@ func FetchMessageIDsFromDirectory(
 		builder = msuser.NewUsersItemMailFoldersItemMessagesDeltaRequestBuilder(*nextLink, gs.Adapter())
 	}
 
-	return ids, deltaToken, errs.ErrorOrNil()
+	return ids, deltaURL, errs.ErrorOrNil()
 }

--- a/src/internal/kopia/snapshot_manager.go
+++ b/src/internal/kopia/snapshot_manager.go
@@ -202,7 +202,7 @@ func fetchPrevManifests(
 	return manifestsSinceLastComplete(mans), nil
 }
 
-// FetchPrevSnapshotManifests returns a set of manifests for complete and maybe
+// fetchPrevSnapshotManifests returns a set of manifests for complete and maybe
 // incomplete snapshots for the given (resource owner, service, category)
 // tuples. Up to two manifests can be returned per tuple: one complete and one
 // incomplete. An incomplete manifest may be returned if it is newer than the

--- a/src/internal/kopia/snapshot_manager.go
+++ b/src/internal/kopia/snapshot_manager.go
@@ -202,7 +202,7 @@ func fetchPrevManifests(
 	return manifestsSinceLastComplete(mans), nil
 }
 
-// fetchPrevSnapshotManifests returns a set of manifests for complete and maybe
+// FetchPrevSnapshotManifests returns a set of manifests for complete and maybe
 // incomplete snapshots for the given (resource owner, service, category)
 // tuples. Up to two manifests can be returned per tuple: one complete and one
 // incomplete. An incomplete manifest may be returned if it is newer than the

--- a/src/pkg/repository/repository_unexported_test.go
+++ b/src/pkg/repository/repository_unexported_test.go
@@ -19,7 +19,6 @@ func TestRepositoryModelSuite(t *testing.T) {
 	if err := tester.RunOnAny(
 		tester.CorsoCITests,
 		tester.CorsoRepositoryTests,
-		"flomp",
 	); err != nil {
 		t.Skip(err)
 	}


### PR DESCRIPTION
## Description

When backing up exchange data, parse the
metadata collection of delta urls from prior runs
(if any exist) and pass those tokens along to the
fetch functions for re-use.

## Type of change

- [x] :sunflower: Feature

## Issue(s)

* #1725

## Test Plan

- [x] :zap: Unit test
