### PR TITLE
rename graph.Service to Servicer

### DIFF
--- a/src/cmd/getM365/getItem.go
+++ b/src/cmd/getM365/getItem.go
@@ -93,7 +93,7 @@ func handleGetCommand(cmd *cobra.Command, args []string) error {
 
 func runDisplayM365JSON(
 	ctx context.Context,
-	gs graph.Service,
+	gs graph.Servicer,
 ) error {
 	var (
 		get           exchange.GraphRetrievalFunc

--- a/src/cmd/purge/purge.go
+++ b/src/cmd/purge/purge.go
@@ -150,7 +150,7 @@ func purgeOneDriveFolders(
 	boundary time.Time,
 	uid string,
 ) error {
-	getter := func(gs graph.Service, uid, prefix string) ([]purgable, error) {
+	getter := func(gs graph.Servicer, uid, prefix string) ([]purgable, error) {
 		cfs, err := onedrive.GetAllFolders(ctx, gs, uid, prefix)
 		if err != nil {
 			return nil, err
@@ -165,7 +165,7 @@ func purgeOneDriveFolders(
 		return purgables, nil
 	}
 
-	deleter := func(gs graph.Service, uid string, f purgable) error {
+	deleter := func(gs graph.Servicer, uid string, f purgable) error {
 		driveFolder, ok := f.(*onedrive.Displayable)
 		if !ok {
 			return errors.New("non-OneDrive item")
@@ -189,8 +189,8 @@ func purgeFolders(
 	gc *connector.GraphConnector,
 	boundary time.Time,
 	data, uid string,
-	getter func(graph.Service, string, string) ([]purgable, error),
-	deleter func(graph.Service, string, purgable) error,
+	getter func(graph.Servicer, string, string) ([]purgable, error),
+	deleter func(graph.Servicer, string, purgable) error,
 ) error {
 	Infof(ctx, "Container: %s", data)
 

--- a/src/internal/connector/discovery/discovery.go
+++ b/src/internal/connector/discovery/discovery.go
@@ -18,7 +18,7 @@ const (
 	userSelectDisplayName   = "displayName"
 )
 
-func Users(ctx context.Context, gs graph.Service, tenantID string) ([]models.Userable, error) {
+func Users(ctx context.Context, gs graph.Servicer, tenantID string) ([]models.Userable, error) {
 	users := make([]models.Userable, 0)
 
 	options := &msuser.UsersRequestBuilderGetRequestConfiguration{

--- a/src/internal/connector/exchange/attachment_uploadable.go
+++ b/src/internal/connector/exchange/attachment_uploadable.go
@@ -29,7 +29,7 @@ type mailAttachmentUploader struct {
 	userID   string
 	folderID string
 	itemID   string
-	service  graph.Service
+	service  graph.Servicer
 }
 
 func (mau *mailAttachmentUploader) getItemID() string {
@@ -77,7 +77,7 @@ type eventAttachmentUploader struct {
 	userID     string
 	calendarID string
 	itemID     string
-	service    graph.Service
+	service    graph.Servicer
 }
 
 func (eau *eventAttachmentUploader) getItemID() string {

--- a/src/internal/connector/exchange/contact_folder_cache.go
+++ b/src/internal/connector/exchange/contact_folder_cache.go
@@ -15,7 +15,7 @@ var _ graph.ContainerResolver = &contactFolderCache{}
 
 type contactFolderCache struct {
 	*containerResolver
-	gs     graph.Service
+	gs     graph.Servicer
 	userID string
 }
 

--- a/src/internal/connector/exchange/event_calendar_cache.go
+++ b/src/internal/connector/exchange/event_calendar_cache.go
@@ -15,7 +15,7 @@ var _ graph.ContainerResolver = &eventCalendarCache{}
 
 type eventCalendarCache struct {
 	*containerResolver
-	gs     graph.Service
+	gs     graph.Servicer
 	userID string
 }
 

--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -53,7 +53,7 @@ type Collection struct {
 	// is desired to be sent through the data channel for eventual storage
 	jobs []string
 	// service - client/adapter pair used to access M365 back store
-	service graph.Service
+	service graph.Servicer
 
 	collectionType optionIdentifier
 	statusUpdater  support.StatusUpdater
@@ -67,7 +67,7 @@ func NewCollection(
 	user string,
 	fullPath path.Path,
 	collectionType optionIdentifier,
-	service graph.Service,
+	service graph.Servicer,
 	statusUpdater support.StatusUpdater,
 ) Collection {
 	collection := Collection{

--- a/src/internal/connector/exchange/exchange_service_test.go
+++ b/src/internal/connector/exchange/exchange_service_test.go
@@ -324,7 +324,7 @@ func (suite *ExchangeServiceSuite) TestRestoreExchangeObject() {
 		name        string
 		bytes       []byte
 		category    path.CategoryType
-		cleanupFunc func(context.Context, graph.Service, string, string) error
+		cleanupFunc func(context.Context, graph.Servicer, string, string) error
 		destination func(context.Context) string
 	}{
 		{

--- a/src/internal/connector/exchange/folder_resolver_test.go
+++ b/src/internal/connector/exchange/folder_resolver_test.go
@@ -13,7 +13,7 @@ import (
 
 type CacheResolverSuite struct {
 	suite.Suite
-	gs graph.Service
+	gs graph.Servicer
 }
 
 func TestCacheResolverIntegrationSuite(t *testing.T) {

--- a/src/internal/connector/exchange/mail_folder_cache.go
+++ b/src/internal/connector/exchange/mail_folder_cache.go
@@ -19,7 +19,7 @@ var _ graph.ContainerResolver = &mailFolderCache{}
 // nameLookup map: Key: DisplayName Value: ID
 type mailFolderCache struct {
 	*containerResolver
-	gs     graph.Service
+	gs     graph.Servicer
 	userID string
 }
 

--- a/src/internal/connector/exchange/mail_folder_cache_test.go
+++ b/src/internal/connector/exchange/mail_folder_cache_test.go
@@ -26,7 +26,7 @@ const (
 
 type MailFolderCacheIntegrationSuite struct {
 	suite.Suite
-	gs graph.Service
+	gs graph.Servicer
 }
 
 func (suite *MailFolderCacheIntegrationSuite) SetupSuite() {

--- a/src/internal/connector/exchange/service_functions.go
+++ b/src/internal/connector/exchange/service_functions.go
@@ -24,7 +24,7 @@ type exchangeService struct {
 }
 
 // ------------------------------------------------------------
-// Functions to comply with graph.Service Interface
+// Functions to comply with graph.Servicer Interface
 // ------------------------------------------------------------
 
 func (es *exchangeService) Client() *msgraphsdk.GraphServiceClient {
@@ -64,7 +64,7 @@ func createService(credentials account.M365Config, shouldFailFast bool) (*exchan
 
 // CreateMailFolder makes a mail folder iff a folder of the same name does not exist
 // Reference: https://docs.microsoft.com/en-us/graph/api/user-post-mailfolders?view=graph-rest-1.0&tabs=http
-func CreateMailFolder(ctx context.Context, gs graph.Service, user, folder string) (models.MailFolderable, error) {
+func CreateMailFolder(ctx context.Context, gs graph.Servicer, user, folder string) (models.MailFolderable, error) {
 	isHidden := false
 	requestBody := models.NewMailFolder()
 	requestBody.SetDisplayName(&folder)
@@ -75,7 +75,7 @@ func CreateMailFolder(ctx context.Context, gs graph.Service, user, folder string
 
 func CreateMailFolderWithParent(
 	ctx context.Context,
-	gs graph.Service,
+	gs graph.Servicer,
 	user, folder, parentID string,
 ) (models.MailFolderable, error) {
 	isHidden := false
@@ -92,13 +92,13 @@ func CreateMailFolderWithParent(
 
 // DeleteMailFolder removes a mail folder with the corresponding M365 ID  from the user's M365 Exchange account
 // Reference: https://docs.microsoft.com/en-us/graph/api/mailfolder-delete?view=graph-rest-1.0&tabs=http
-func DeleteMailFolder(ctx context.Context, gs graph.Service, user, folderID string) error {
+func DeleteMailFolder(ctx context.Context, gs graph.Servicer, user, folderID string) error {
 	return gs.Client().UsersById(user).MailFoldersById(folderID).Delete(ctx, nil)
 }
 
 // CreateCalendar makes an event Calendar with the name in the user's M365 exchange account
 // Reference: https://docs.microsoft.com/en-us/graph/api/user-post-calendars?view=graph-rest-1.0&tabs=go
-func CreateCalendar(ctx context.Context, gs graph.Service, user, calendarName string) (models.Calendarable, error) {
+func CreateCalendar(ctx context.Context, gs graph.Servicer, user, calendarName string) (models.Calendarable, error) {
 	requestbody := models.NewCalendar()
 	requestbody.SetName(&calendarName)
 
@@ -107,7 +107,7 @@ func CreateCalendar(ctx context.Context, gs graph.Service, user, calendarName st
 
 // DeleteCalendar removes calendar from user's M365 account
 // Reference: https://docs.microsoft.com/en-us/graph/api/calendar-delete?view=graph-rest-1.0&tabs=go
-func DeleteCalendar(ctx context.Context, gs graph.Service, user, calendarID string) error {
+func DeleteCalendar(ctx context.Context, gs graph.Servicer, user, calendarID string) error {
 	return gs.Client().UsersById(user).CalendarsById(calendarID).Delete(ctx, nil)
 }
 
@@ -115,7 +115,7 @@ func DeleteCalendar(ctx context.Context, gs graph.Service, user, calendarID stri
 // If successful, returns the created folder object.
 func CreateContactFolder(
 	ctx context.Context,
-	gs graph.Service,
+	gs graph.Servicer,
 	user, folderName string,
 ) (models.ContactFolderable, error) {
 	requestBody := models.NewContactFolder()
@@ -127,7 +127,7 @@ func CreateContactFolder(
 
 // DeleteContactFolder deletes the ContactFolder associated with the M365 ID if permissions are valid.
 // Errors returned if the function call was not successful.
-func DeleteContactFolder(ctx context.Context, gs graph.Service, user, folderID string) error {
+func DeleteContactFolder(ctx context.Context, gs graph.Servicer, user, folderID string) error {
 	return gs.Client().UsersById(user).ContactFoldersById(folderID).Delete(ctx, nil)
 }
 

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -213,7 +213,7 @@ func IterativeCollectCalendarContainers(
 // container supports fetching delta records.
 type FetchIDFunc func(
 	ctx context.Context,
-	gs graph.Service,
+	gs graph.Servicer,
 	user, containerID string,
 ) ([]string, string, error)
 
@@ -233,7 +233,7 @@ func getFetchIDFunc(category path.CategoryType) (FetchIDFunc, error) {
 // FetchEventIDsFromCalendar returns a list of all M365IDs of events of the targeted Calendar.
 func FetchEventIDsFromCalendar(
 	ctx context.Context,
-	gs graph.Service,
+	gs graph.Servicer,
 	user, calendarID string,
 ) ([]string, string, error) {
 	var (
@@ -287,7 +287,7 @@ func FetchEventIDsFromCalendar(
 // of the targeted directory
 func FetchContactIDsFromDirectory(
 	ctx context.Context,
-	gs graph.Service,
+	gs graph.Servicer,
 	user, directoryID string,
 ) ([]string, string, error) {
 	var (
@@ -347,7 +347,7 @@ func FetchContactIDsFromDirectory(
 // of the targeted directory
 func FetchMessageIDsFromDirectory(
 	ctx context.Context,
-	gs graph.Service,
+	gs graph.Servicer,
 	user, directoryID string,
 ) ([]string, string, error) {
 	var (

--- a/src/internal/connector/exchange/service_query.go
+++ b/src/internal/connector/exchange/service_query.go
@@ -12,10 +12,10 @@ import (
 // into M365 backstore. Responses -> returned items will only contain the information
 // that is included in the options
 // TODO: use selector or path for granularity into specific folders or specific date ranges
-type GraphQuery func(ctx context.Context, gs graph.Service, userID string) (absser.Parsable, error)
+type GraphQuery func(ctx context.Context, gs graph.Servicer, userID string) (absser.Parsable, error)
 
 // GetAllContactsForUser is a GraphQuery function for querying all the contacts in a user's account
-func GetAllContactsForUser(ctx context.Context, gs graph.Service, user string) (absser.Parsable, error) {
+func GetAllContactsForUser(ctx context.Context, gs graph.Servicer, user string) (absser.Parsable, error) {
 	selecting := []string{"parentFolderId"}
 
 	options, err := optionsForContacts(selecting)
@@ -28,7 +28,7 @@ func GetAllContactsForUser(ctx context.Context, gs graph.Service, user string) (
 
 // GetAllFolderDisplayNamesForUser is a GraphQuery function for getting FolderId and display
 // names for Mail Folder. All other information for the MailFolder object is omitted.
-func GetAllFolderNamesForUser(ctx context.Context, gs graph.Service, user string) (absser.Parsable, error) {
+func GetAllFolderNamesForUser(ctx context.Context, gs graph.Servicer, user string) (absser.Parsable, error) {
 	options, err := optionsForMailFolders([]string{"displayName"})
 	if err != nil {
 		return nil, err
@@ -37,7 +37,7 @@ func GetAllFolderNamesForUser(ctx context.Context, gs graph.Service, user string
 	return gs.Client().UsersById(user).MailFolders().Get(ctx, options)
 }
 
-func GetAllCalendarNamesForUser(ctx context.Context, gs graph.Service, user string) (absser.Parsable, error) {
+func GetAllCalendarNamesForUser(ctx context.Context, gs graph.Servicer, user string) (absser.Parsable, error) {
 	options, err := optionsForCalendars([]string{"name", "owner"})
 	if err != nil {
 		return nil, err
@@ -49,7 +49,7 @@ func GetAllCalendarNamesForUser(ctx context.Context, gs graph.Service, user stri
 // GetDefaultContactFolderForUser is a GraphQuery function for getting the ContactFolderId
 // and display names for the default "Contacts" folder.
 // Only returns the default Contact Folder
-func GetDefaultContactFolderForUser(ctx context.Context, gs graph.Service, user string) (absser.Parsable, error) {
+func GetDefaultContactFolderForUser(ctx context.Context, gs graph.Servicer, user string) (absser.Parsable, error) {
 	options, err := optionsForContactChildFolders([]string{"displayName", "parentFolderId"})
 	if err != nil {
 		return nil, err
@@ -65,7 +65,7 @@ func GetDefaultContactFolderForUser(ctx context.Context, gs graph.Service, user 
 // GetAllContactFolderNamesForUser is a GraphQuery function for getting ContactFolderId
 // and display names for contacts. All other information is omitted.
 // Does not return the default Contact Folder
-func GetAllContactFolderNamesForUser(ctx context.Context, gs graph.Service, user string) (absser.Parsable, error) {
+func GetAllContactFolderNamesForUser(ctx context.Context, gs graph.Servicer, user string) (absser.Parsable, error) {
 	options, err := optionsForContactFolders([]string{"displayName", "parentFolderId"})
 	if err != nil {
 		return nil, err
@@ -77,7 +77,7 @@ func GetAllContactFolderNamesForUser(ctx context.Context, gs graph.Service, user
 // GetAllEvents for User. Default returns EventResponseCollection for future events.
 // of the time that the call was made. 'calendar' option must be present to gain
 // access to additional data map in future calls.
-func GetAllEventsForUser(ctx context.Context, gs graph.Service, user string) (absser.Parsable, error) {
+func GetAllEventsForUser(ctx context.Context, gs graph.Servicer, user string) (absser.Parsable, error) {
 	options, err := optionsForEvents([]string{"id", "calendar"})
 	if err != nil {
 		return nil, err
@@ -89,21 +89,21 @@ func GetAllEventsForUser(ctx context.Context, gs graph.Service, user string) (ab
 // GraphRetrievalFunctions are functions from the Microsoft Graph API that retrieve
 // the default associated data of a M365 object. This varies by object. Additional
 // Queries must be run to obtain the omitted fields.
-type GraphRetrievalFunc func(ctx context.Context, gs graph.Service, user, m365ID string) (absser.Parsable, error)
+type GraphRetrievalFunc func(ctx context.Context, gs graph.Servicer, user, m365ID string) (absser.Parsable, error)
 
 // RetrieveContactDataForUser is a GraphRetrievalFun that returns all associated fields.
-func RetrieveContactDataForUser(ctx context.Context, gs graph.Service, user, m365ID string) (absser.Parsable, error) {
+func RetrieveContactDataForUser(ctx context.Context, gs graph.Servicer, user, m365ID string) (absser.Parsable, error) {
 	return gs.Client().UsersById(user).ContactsById(m365ID).Get(ctx, nil)
 }
 
 // RetrieveEventDataForUser is a GraphRetrievalFunc that returns event data.
 // Calendarable and attachment fields are omitted due to size
-func RetrieveEventDataForUser(ctx context.Context, gs graph.Service, user, m365ID string) (absser.Parsable, error) {
+func RetrieveEventDataForUser(ctx context.Context, gs graph.Servicer, user, m365ID string) (absser.Parsable, error) {
 	return gs.Client().UsersById(user).EventsById(m365ID).Get(ctx, nil)
 }
 
 // RetrieveMessageDataForUser is a GraphRetrievalFunc that returns message data.
 // Attachment field is omitted due to size.
-func RetrieveMessageDataForUser(ctx context.Context, gs graph.Service, user, m365ID string) (absser.Parsable, error) {
+func RetrieveMessageDataForUser(ctx context.Context, gs graph.Servicer, user, m365ID string) (absser.Parsable, error) {
 	return gs.Client().UsersById(user).MessagesById(m365ID).Get(ctx, nil)
 }

--- a/src/internal/connector/exchange/service_restore.go
+++ b/src/internal/connector/exchange/service_restore.go
@@ -30,7 +30,7 @@ func RestoreExchangeObject(
 	bits []byte,
 	category path.CategoryType,
 	policy control.CollisionPolicy,
-	service graph.Service,
+	service graph.Servicer,
 	destination, user string,
 ) (*details.ExchangeInfo, error) {
 	if policy != control.Copy {
@@ -60,7 +60,7 @@ func RestoreExchangeObject(
 func RestoreExchangeContact(
 	ctx context.Context,
 	bits []byte,
-	service graph.Service,
+	service graph.Servicer,
 	cp control.CollisionPolicy,
 	destination, user string,
 ) (*details.ExchangeInfo, error) {
@@ -96,7 +96,7 @@ func RestoreExchangeContact(
 func RestoreExchangeEvent(
 	ctx context.Context,
 	bits []byte,
-	service graph.Service,
+	service graph.Servicer,
 	cp control.CollisionPolicy,
 	destination, user string,
 ) (*details.ExchangeInfo, error) {
@@ -165,7 +165,7 @@ func RestoreExchangeEvent(
 func RestoreMailMessage(
 	ctx context.Context,
 	bits []byte,
-	service graph.Service,
+	service graph.Servicer,
 	cp control.CollisionPolicy,
 	destination, user string,
 ) (*details.ExchangeInfo, error) {
@@ -230,7 +230,7 @@ func attachmentBytes(attachment models.Attachmentable) []byte {
 // @param message is a models.Messageable interface from "github.com/microsoftgraph/msgraph-sdk-go/models"
 func SendMailToBackStore(
 	ctx context.Context,
-	service graph.Service,
+	service graph.Servicer,
 	user, destination string,
 	message models.Messageable,
 ) error {
@@ -285,7 +285,7 @@ func SendMailToBackStore(
 // @param dest:  container destination to M365
 func RestoreExchangeDataCollections(
 	ctx context.Context,
-	gs graph.Service,
+	gs graph.Servicer,
 	dest control.RestoreDestination,
 	dcs []data.Collection,
 	deets *details.Details,
@@ -345,7 +345,7 @@ func RestoreExchangeDataCollections(
 // restoreCollection handles restoration of an individual collection.
 func restoreCollection(
 	ctx context.Context,
-	gs graph.Service,
+	gs graph.Servicer,
 	dc data.Collection,
 	folderID string,
 	policy control.CollisionPolicy,
@@ -429,7 +429,7 @@ func restoreCollection(
 // Assumption: collisionPolicy == COPY
 func GetContainerIDFromCache(
 	ctx context.Context,
-	gs graph.Service,
+	gs graph.Servicer,
 	directory path.Path,
 	destination string,
 	caches map[path.CategoryType]graph.ContainerResolver,
@@ -514,7 +514,7 @@ func establishMailRestoreLocation(
 	folders []string,
 	mfc graph.ContainerResolver,
 	user string,
-	service graph.Service,
+	service graph.Servicer,
 	isNewCache bool,
 ) (string, error) {
 	// Process starts with the root folder in order to recreate
@@ -571,7 +571,7 @@ func establishContactsRestoreLocation(
 	folders []string,
 	cfc graph.ContainerResolver,
 	user string,
-	gs graph.Service,
+	gs graph.Servicer,
 	isNewCache bool,
 ) (string, error) {
 	cached, ok := cfc.PathInCache(folders[0])
@@ -604,7 +604,7 @@ func establishEventsRestoreLocation(
 	folders []string,
 	ecc graph.ContainerResolver, // eventCalendarCache
 	user string,
-	gs graph.Service,
+	gs graph.Servicer,
 	isNewCache bool,
 ) (string, error) {
 	cached, ok := ecc.PathInCache(folders[0])

--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -26,7 +26,7 @@ type QueryParams struct {
 	FailFast      bool
 }
 
-type Service interface {
+type Servicer interface {
 	// Client() returns msgraph Service client that can be used to process and execute
 	// the majority of the queries to the M365 Backstore
 	Client() *msgraphsdk.GraphServiceClient

--- a/src/internal/connector/graph_connector.go
+++ b/src/internal/connector/graph_connector.go
@@ -52,12 +52,12 @@ type GraphConnector struct {
 	status support.ConnectorOperationStatus // contains the status of the last run status
 }
 
-// Service returns the GC's embedded graph.Service
-func (gc *GraphConnector) Service() graph.Service {
+// Service returns the GC's embedded graph.Servicer
+func (gc *GraphConnector) Service() graph.Servicer {
 	return gc.graphService
 }
 
-var _ graph.Service = &graphService{}
+var _ graph.Servicer = &graphService{}
 
 type graphService struct {
 	client   msgraphsdk.GraphServiceClient
@@ -380,9 +380,9 @@ func (gc *GraphConnector) incrementAwaitingMessages() {
 
 func getResources(
 	ctx context.Context,
-	gs graph.Service,
+	gs graph.Servicer,
 	tenantID string,
-	query func(context.Context, graph.Service) (serialization.Parsable, error),
+	query func(context.Context, graph.Servicer) (serialization.Parsable, error),
 	parser func(parseNode serialization.ParseNode) (serialization.Parsable, error),
 	identify func(any) (string, string, error),
 ) (map[string]string, error) {

--- a/src/internal/connector/graph_connector_test.go
+++ b/src/internal/connector/graph_connector_test.go
@@ -284,7 +284,7 @@ func (suite *GraphConnectorIntegrationSuite) TestEmptyCollections() {
 func mustGetDefaultDriveID(
 	t *testing.T,
 	ctx context.Context,
-	service graph.Service,
+	service graph.Servicer,
 	userID string,
 ) string {
 	//revive:enable:context-as-argument

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -51,7 +51,7 @@ type Collection struct {
 	// M365 ID of the drive this collection was created from
 	driveID       string
 	source        driveSource
-	service       graph.Service
+	service       graph.Servicer
 	statusUpdater support.StatusUpdater
 	itemReader    itemReaderFunc
 }
@@ -59,7 +59,7 @@ type Collection struct {
 // itemReadFunc returns a reader for the specified item
 type itemReaderFunc func(
 	ctx context.Context,
-	service graph.Service,
+	service graph.Servicer,
 	driveID, itemID string,
 ) (itemInfo details.ItemInfo, itemData io.ReadCloser, err error)
 
@@ -67,7 +67,7 @@ type itemReaderFunc func(
 func NewCollection(
 	folderPath path.Path,
 	driveID string,
-	service graph.Service,
+	service graph.Servicer,
 	statusUpdater support.StatusUpdater,
 	source driveSource,
 ) *Collection {

--- a/src/internal/connector/onedrive/collection_test.go
+++ b/src/internal/connector/onedrive/collection_test.go
@@ -23,7 +23,7 @@ type CollectionUnitTestSuite struct {
 	suite.Suite
 }
 
-// Allows `*CollectionUnitTestSuite` to be used as a graph.Service
+// Allows `*CollectionUnitTestSuite` to be used as a graph.Servicer
 // TODO: Implement these methods
 
 func (suite *CollectionUnitTestSuite) Client() *msgraphsdk.GraphServiceClient {
@@ -71,7 +71,7 @@ func (suite *CollectionUnitTestSuite) TestCollection() {
 		{
 			name:   "oneDrive",
 			source: OneDriveSource,
-			itemReader: func(context.Context, graph.Service, string, string) (details.ItemInfo, io.ReadCloser, error) {
+			itemReader: func(context.Context, graph.Servicer, string, string) (details.ItemInfo, io.ReadCloser, error) {
 				return details.ItemInfo{OneDrive: &details.OneDriveInfo{ItemName: testItemName}},
 					io.NopCloser(bytes.NewReader(testItemData)),
 					nil
@@ -84,7 +84,7 @@ func (suite *CollectionUnitTestSuite) TestCollection() {
 		{
 			name:   "sharePoint",
 			source: SharePointSource,
-			itemReader: func(context.Context, graph.Service, string, string) (details.ItemInfo, io.ReadCloser, error) {
+			itemReader: func(context.Context, graph.Servicer, string, string) (details.ItemInfo, io.ReadCloser, error) {
 				return details.ItemInfo{SharePoint: &details.SharePointInfo{ItemName: testItemName}},
 					io.NopCloser(bytes.NewReader(testItemData)),
 					nil
@@ -178,7 +178,7 @@ func (suite *CollectionUnitTestSuite) TestCollectionReadError() {
 
 			readError := errors.New("Test error")
 
-			coll.itemReader = func(context.Context, graph.Service, string, string) (details.ItemInfo, io.ReadCloser, error) {
+			coll.itemReader = func(context.Context, graph.Servicer, string, string) (details.ItemInfo, io.ReadCloser, error) {
 				return details.ItemInfo{}, nil, readError
 			}
 

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -36,7 +36,7 @@ type Collections struct {
 	resourceOwner string
 	source        driveSource
 	matcher       folderMatcher
-	service       graph.Service
+	service       graph.Servicer
 	statusUpdater support.StatusUpdater
 
 	// collectionMap allows lookup of the data.Collection
@@ -54,7 +54,7 @@ func NewCollections(
 	resourceOwner string,
 	source driveSource,
 	matcher folderMatcher,
-	service graph.Service,
+	service graph.Servicer,
 	statusUpdater support.StatusUpdater,
 ) *Collections {
 	return &Collections{

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -69,7 +69,7 @@ const (
 // Enumerates the drives for the specified user
 func drives(
 	ctx context.Context,
-	service graph.Service,
+	service graph.Servicer,
 	resourceOwner string,
 	source driveSource,
 ) ([]models.Driveable, error) {
@@ -83,7 +83,7 @@ func drives(
 	}
 }
 
-func siteDrives(ctx context.Context, service graph.Service, site string) ([]models.Driveable, error) {
+func siteDrives(ctx context.Context, service graph.Servicer, site string) ([]models.Driveable, error) {
 	options := &sites.SitesItemDrivesRequestBuilderGetRequestConfiguration{
 		QueryParameters: &sites.SitesItemDrivesRequestBuilderGetQueryParameters{
 			Select: []string{"id", "name", "weburl", "system"},
@@ -99,7 +99,7 @@ func siteDrives(ctx context.Context, service graph.Service, site string) ([]mode
 	return r.GetValue(), nil
 }
 
-func userDrives(ctx context.Context, service graph.Service, user string) ([]models.Driveable, error) {
+func userDrives(ctx context.Context, service graph.Servicer, user string) ([]models.Driveable, error) {
 	var hasDrive bool
 
 	hasDrive, err := hasDriveLicense(ctx, service, user)
@@ -135,7 +135,7 @@ type itemCollector func(ctx context.Context, driveID string, driveItems []models
 // provided `collector` method
 func collectItems(
 	ctx context.Context,
-	service graph.Service,
+	service graph.Servicer,
 	driveID string,
 	collector itemCollector,
 ) error {
@@ -175,7 +175,7 @@ func collectItems(
 // getFolder will lookup the specified folder name under `parentFolderID`
 func getFolder(
 	ctx context.Context,
-	service graph.Service,
+	service graph.Servicer,
 	driveID, parentFolderID, folderName string,
 ) (models.DriveItemable, error) {
 	// The `Children().Get()` API doesn't yet support $filter, so using that to find a folder
@@ -215,7 +215,7 @@ func getFolder(
 // Create a new item in the specified folder
 func createItem(
 	ctx context.Context,
-	service graph.Service,
+	service graph.Servicer,
 	driveID, parentFolderID string,
 	newItem models.DriveItemable,
 ) (models.DriveItemable, error) {
@@ -264,7 +264,7 @@ func (op *Displayable) GetDisplayName() *string {
 // are a subfolder or top-level folder in the hierarchy.
 func GetAllFolders(
 	ctx context.Context,
-	gs graph.Service,
+	gs graph.Servicer,
 	userID string,
 	prefix string,
 ) ([]*Displayable, error) {
@@ -325,7 +325,7 @@ func GetAllFolders(
 
 func DeleteItem(
 	ctx context.Context,
-	gs graph.Service,
+	gs graph.Servicer,
 	driveID string,
 	itemID string,
 ) error {
@@ -341,7 +341,7 @@ func DeleteItem(
 // to investigate the user's includes access to OneDrive.
 func hasDriveLicense(
 	ctx context.Context,
-	service graph.Service,
+	service graph.Servicer,
 	user string,
 ) (bool, error) {
 	var hasDrive bool

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -26,7 +26,7 @@ const (
 // and using a http client to initialize a reader
 func sharePointItemReader(
 	ctx context.Context,
-	service graph.Service,
+	service graph.Servicer,
 	driveID, itemID string,
 ) (details.ItemInfo, io.ReadCloser, error) {
 	item, rc, err := driveItemReader(ctx, service, driveID, itemID)
@@ -46,7 +46,7 @@ func sharePointItemReader(
 // and using a http client to initialize a reader
 func oneDriveItemReader(
 	ctx context.Context,
-	service graph.Service,
+	service graph.Servicer,
 	driveID, itemID string,
 ) (details.ItemInfo, io.ReadCloser, error) {
 	item, rc, err := driveItemReader(ctx, service, driveID, itemID)
@@ -66,7 +66,7 @@ func oneDriveItemReader(
 // and using a http client to initialize a reader
 func driveItemReader(
 	ctx context.Context,
-	service graph.Service,
+	service graph.Servicer,
 	driveID, itemID string,
 ) (models.DriveItemable, io.ReadCloser, error) {
 	logger.Ctx(ctx).Debugw("Reading Item", "id", itemID, "time", time.Now())
@@ -161,7 +161,7 @@ func sharePointItemInfo(di models.DriveItemable, itemSize int64) *details.ShareP
 // TODO: @vkamra verify if var session is the desired input
 func driveItemWriter(
 	ctx context.Context,
-	service graph.Service,
+	service graph.Servicer,
 	driveID, itemID string,
 	itemSize int64,
 ) (io.Writer, error) {

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -50,7 +50,7 @@ func toOneDrivePath(p path.Path) (*drivePath, error) {
 // RestoreCollections will restore the specified data collections into OneDrive
 func RestoreCollections(
 	ctx context.Context,
-	service graph.Service,
+	service graph.Servicer,
 	dest control.RestoreDestination,
 	dcs []data.Collection,
 	deets *details.Details,
@@ -91,7 +91,7 @@ func RestoreCollections(
 // - the context cancellation state (true if the context is cancelled)
 func RestoreCollection(
 	ctx context.Context,
-	service graph.Service,
+	service graph.Servicer,
 	dc data.Collection,
 	source driveSource,
 	restoreContainerName string,
@@ -180,7 +180,7 @@ func RestoreCollection(
 
 // createRestoreFolders creates the restore folder hieararchy in the specified drive and returns the folder ID
 // of the last folder entry in the hiearchy
-func createRestoreFolders(ctx context.Context, service graph.Service, driveID string, restoreFolders []string,
+func createRestoreFolders(ctx context.Context, service graph.Servicer, driveID string, restoreFolders []string,
 ) (string, error) {
 	driveRoot, err := service.Client().DrivesById(driveID).Root().Get(ctx, nil)
 	if err != nil {
@@ -226,7 +226,7 @@ func createRestoreFolders(ctx context.Context, service graph.Service, driveID st
 // restoreItem will create a new item in the specified `parentFolderID` and upload the data.Stream
 func restoreItem(
 	ctx context.Context,
-	service graph.Service,
+	service graph.Servicer,
 	itemData data.Stream,
 	driveID, parentFolderID string,
 	copyBuffer []byte,

--- a/src/internal/connector/sharepoint/collection.go
+++ b/src/internal/connector/sharepoint/collection.go
@@ -40,13 +40,13 @@ type Collection struct {
 	// fullPath indicates the hierarchy within the collection
 	fullPath path.Path
 	// M365 IDs of the items of this collection
-	service       graph.Service
+	service       graph.Servicer
 	statusUpdater support.StatusUpdater
 }
 
 func NewCollection(
 	folderPath path.Path,
-	service graph.Service,
+	service graph.Servicer,
 	statusUpdater support.StatusUpdater,
 ) *Collection {
 	c := &Collection{

--- a/src/internal/connector/sharepoint/data_collections.go
+++ b/src/internal/connector/sharepoint/data_collections.go
@@ -23,7 +23,7 @@ type statusUpdater interface {
 type connector interface {
 	statusUpdater
 
-	Service() graph.Service
+	Service() graph.Servicer
 }
 
 // DataCollections returns a set of DataCollection which represents the SharePoint data
@@ -89,7 +89,7 @@ func DataCollections(
 // all the drives associated with the site.
 func collectLibraries(
 	ctx context.Context,
-	serv graph.Service,
+	serv graph.Servicer,
 	tenantID, siteID string,
 	scope selectors.SharePointScope,
 	updater statusUpdater,

--- a/src/internal/connector/sharepoint/list.go
+++ b/src/internal/connector/sharepoint/list.go
@@ -26,7 +26,7 @@ import (
 // - List Items
 func loadLists(
 	ctx context.Context,
-	gs graph.Service,
+	gs graph.Servicer,
 	siteID string,
 ) ([]models.Listable, error) {
 	var (
@@ -92,7 +92,7 @@ func loadLists(
 // * Fields
 func fetchListItems(
 	ctx context.Context,
-	gs graph.Service,
+	gs graph.Servicer,
 	siteID, listID string,
 ) ([]models.ListItemable, error) {
 	var (
@@ -141,7 +141,7 @@ func fetchListItems(
 // TODO: Refactor on if/else (dadams39)
 func fetchColumns(
 	ctx context.Context,
-	gs graph.Service,
+	gs graph.Servicer,
 	siteID, listID, cTypeID string,
 ) ([]models.ColumnDefinitionable, error) {
 	cs := make([]models.ColumnDefinitionable, 0)
@@ -198,7 +198,7 @@ func fetchColumns(
 // TODO: Verify functionality after version upgrade or remove (dadams39) Check Stubs
 func fetchContentTypes(
 	ctx context.Context,
-	gs graph.Service,
+	gs graph.Servicer,
 	siteID, listID string,
 ) ([]models.ContentTypeable, error) {
 	var (
@@ -252,7 +252,7 @@ func fetchContentTypes(
 
 func fetchColumnLinks(
 	ctx context.Context,
-	gs graph.Service,
+	gs graph.Servicer,
 	siteID, listID, cTypeID string,
 ) ([]models.ColumnLinkable, error) {
 	var (

--- a/src/internal/connector/sharepoint/queries.go
+++ b/src/internal/connector/sharepoint/queries.go
@@ -12,7 +12,7 @@ import (
 // GetAllSitesForTenant makes a GraphQuery request retrieving all sites in the tenant.
 // Due to restrictions in filter capabilities for site queries, the returned iterable
 // will contain all personal sites for all users in the org.
-func GetAllSitesForTenant(ctx context.Context, gs graph.Service) (absser.Parsable, error) {
+func GetAllSitesForTenant(ctx context.Context, gs graph.Servicer) (absser.Parsable, error) {
 	options := &mssite.SitesRequestBuilderGetRequestConfiguration{
 		QueryParameters: &mssite.SitesRequestBuilderGetQueryParameters{
 			Select: []string{"id", "name", "weburl"},

--- a/src/internal/connector/sharepoint/restore.go
+++ b/src/internal/connector/sharepoint/restore.go
@@ -17,7 +17,7 @@ import (
 // RestoreCollections will restore the specified data collections into OneDrive
 func RestoreCollections(
 	ctx context.Context,
-	service graph.Service,
+	service graph.Servicer,
 	dest control.RestoreDestination,
 	dcs []data.Collection,
 	deets *details.Details,


### PR DESCRIPTION
## Description

`graph.Service -> graph.Servicer`,  no other changes.

More compliant with golang naming standards,
and will allow us to eventually migrate the
Service struct out of connector and into graph.

## Type of change

- [x] :hamster: Trivial/Minor

## Issue(s)

* #1725
