### PR TITLE
Refactor service failfast

### DIFF
--- a/src/cmd/getM365/getItem.go
+++ b/src/cmd/getM365/getItem.go
@@ -81,9 +81,7 @@ func handleGetCommand(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = runDisplayM365JSON(
-		ctx,
-		gc)
+	err = runDisplayM365JSON(ctx, gc.Service())
 	if err != nil {
 		return Only(ctx, errors.Wrapf(err, "unable to create mock from M365: %s", m365ID))
 	}

--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -23,6 +23,7 @@ import (
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/observe"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
 )
@@ -60,6 +61,8 @@ type Collection struct {
 	// FullPath is the slice representation of the action context passed down through the hierarchy.
 	// The original request can be gleaned from the slice. (e.g. {<tenant ID>, <user ID>, "emails"})
 	fullPath path.Path
+
+	ctrl control.Options
 }
 
 // NewExchangeDataCollection creates an ExchangeDataCollection with fullPath is annotated
@@ -69,6 +72,7 @@ func NewCollection(
 	collectionType optionIdentifier,
 	service graph.Servicer,
 	statusUpdater support.StatusUpdater,
+	ctrlOpts control.Options,
 ) Collection {
 	collection := Collection{
 		user:           user,
@@ -78,6 +82,7 @@ func NewCollection(
 		statusUpdater:  statusUpdater,
 		fullPath:       fullPath,
 		collectionType: collectionType,
+		ctrl:           ctrlOpts,
 	}
 
 	return collection
@@ -168,7 +173,7 @@ func (col *Collection) populateByOptionIdentifier(
 	}
 
 	for _, identifier := range col.jobs {
-		if col.service.ErrPolicy() && errs != nil {
+		if col.ctrl.FailFast && errs != nil {
 			break
 		}
 		semaphoreCh <- struct{}{}

--- a/src/internal/connector/exchange/exchange_service_test.go
+++ b/src/internal/connector/exchange/exchange_service_test.go
@@ -45,7 +45,7 @@ func (suite *ExchangeServiceSuite) SetupSuite() {
 	require.NoError(t, err)
 	m365, err := a.M365Config()
 	require.NoError(t, err)
-	service, err := createService(m365, false)
+	service, err := createService(m365)
 	require.NoError(t, err)
 
 	suite.es = service
@@ -79,7 +79,7 @@ func (suite *ExchangeServiceSuite) TestCreateService() {
 	for _, test := range tests {
 		suite.T().Run(test.name, func(t *testing.T) {
 			t.Log(test.credentials.AzureClientSecret)
-			_, err := createService(test.credentials, false)
+			_, err := createService(test.credentials)
 			test.checkErr(t, err)
 		})
 	}

--- a/src/internal/connector/exchange/folder_resolver_test.go
+++ b/src/internal/connector/exchange/folder_resolver_test.go
@@ -40,7 +40,7 @@ func (suite *CacheResolverSuite) SetupSuite() {
 	m365, err := a.M365Config()
 	require.NoError(t, err)
 
-	service, err := createService(m365, false)
+	service, err := createService(m365)
 	require.NoError(t, err)
 
 	suite.gs = service

--- a/src/internal/connector/exchange/iterators_test.go
+++ b/src/internal/connector/exchange/iterators_test.go
@@ -151,7 +151,7 @@ func loadService(t *testing.T) *exchangeService {
 	m365, err := a.M365Config()
 	require.NoError(t, err)
 
-	service, err := createService(m365, false)
+	service, err := createService(m365)
 	require.NoError(t, err)
 
 	return service

--- a/src/internal/connector/exchange/mail_folder_cache_test.go
+++ b/src/internal/connector/exchange/mail_folder_cache_test.go
@@ -41,7 +41,7 @@ func (suite *MailFolderCacheIntegrationSuite) SetupSuite() {
 	m365, err := a.M365Config()
 	require.NoError(t, err)
 
-	service, err := createService(m365, false)
+	service, err := createService(m365)
 	require.NoError(t, err)
 
 	suite.gs = service

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -15,6 +15,7 @@ import (
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/data"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 )
@@ -79,6 +80,7 @@ func FilterContainersAndFillCollections(
 	resolver graph.ContainerResolver,
 	scope selectors.ExchangeScope,
 	oldDeltas map[string]string,
+	ctrlOpts control.Options,
 ) error {
 	var (
 		errs           error
@@ -94,14 +96,14 @@ func FilterContainersAndFillCollections(
 		}
 
 		// Create only those that match
-		service, err := createService(qp.Credentials, qp.FailFast)
+		service, err := createService(qp.Credentials)
 		if err != nil {
 			errs = support.WrapAndAppend(
 				qp.ResourceOwner+" FilterContainerAndFillCollection",
 				err,
 				errs)
 
-			if qp.FailFast {
+			if ctrlOpts.FailFast {
 				return errs
 			}
 		}
@@ -112,6 +114,7 @@ func FilterContainersAndFillCollections(
 			collectionType,
 			service,
 			statusUpdater,
+			ctrlOpts,
 		)
 		collections[*c.GetId()] = &edc
 
@@ -122,7 +125,7 @@ func FilterContainersAndFillCollections(
 				err,
 				errs)
 
-			if qp.FailFast {
+			if ctrlOpts.FailFast {
 				return errs
 			}
 

--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -23,7 +23,6 @@ type QueryParams struct {
 	Category      path.CategoryType
 	ResourceOwner string
 	Credentials   account.M365Config
-	FailFast      bool
 }
 
 type Servicer interface {
@@ -33,8 +32,6 @@ type Servicer interface {
 	// Adapter() returns GraphRequest adapter used to process large requests, create batches
 	// and page iterators
 	Adapter() *msgraphsdk.GraphRequestAdapter
-	// ErrPolicy returns if the service is implementing a Fast-Fail policy or not
-	ErrPolicy() bool
 }
 
 // Idable represents objects that implement msgraph-sdk-go/models.entityable

--- a/src/internal/connector/graph_connector_test.go
+++ b/src/internal/connector/graph_connector_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 )
@@ -170,7 +171,7 @@ func (suite *GraphConnectorIntegrationSuite) TestSetTenantUsers() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 
-	service, err := newConnector.createService(false)
+	service, err := newConnector.createService()
 	require.NoError(suite.T(), err)
 
 	newConnector.graphService = *service
@@ -193,7 +194,7 @@ func (suite *GraphConnectorIntegrationSuite) TestSetTenantSites() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 
-	service, err := newConnector.createService(false)
+	service, err := newConnector.createService()
 	require.NoError(suite.T(), err)
 
 	newConnector.graphService = *service
@@ -387,7 +388,7 @@ func runRestoreBackupTest(
 	t.Logf("Selective backup of %s\n", backupSel)
 
 	start = time.Now()
-	dcs, err := backupGC.DataCollections(ctx, backupSel, nil)
+	dcs, err := backupGC.DataCollections(ctx, backupSel, nil, control.Options{})
 	require.NoError(t, err)
 
 	t.Logf("Backup enumeration complete in %v\n", time.Since(start))
@@ -412,7 +413,7 @@ func (suite *GraphConnectorIntegrationSuite) TestRestoreAndBackup() {
 	driveID := mustGetDefaultDriveID(
 		suite.T(),
 		ctx,
-		suite.connector.Service(),
+		suite.connector,
 		suite.user,
 	)
 
@@ -855,7 +856,7 @@ func (suite *GraphConnectorIntegrationSuite) TestMultiFolderBackupDifferentNames
 			backupSel := backupSelectorForExpected(t, test.service, expectedDests)
 			t.Log("Selective backup of", backupSel)
 
-			dcs, err := backupGC.DataCollections(ctx, backupSel, nil)
+			dcs, err := backupGC.DataCollections(ctx, backupSel, nil, control.Options{})
 			require.NoError(t, err)
 
 			t.Log("Backup enumeration complete")

--- a/src/internal/connector/onedrive/collection_test.go
+++ b/src/internal/connector/onedrive/collection_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/control"
 )
 
 type CollectionUnitTestSuite struct {
@@ -32,10 +33,6 @@ func (suite *CollectionUnitTestSuite) Client() *msgraphsdk.GraphServiceClient {
 
 func (suite *CollectionUnitTestSuite) Adapter() *msgraphsdk.GraphRequestAdapter {
 	return nil
-}
-
-func (suite *CollectionUnitTestSuite) ErrPolicy() bool {
-	return false
 }
 
 func TestCollectionUnitTestSuite(t *testing.T) {
@@ -108,7 +105,13 @@ func (suite *CollectionUnitTestSuite) TestCollection() {
 			driveFolderPath, err := getDriveFolderPath(folderPath)
 			require.NoError(t, err)
 
-			coll := NewCollection(folderPath, "drive-id", suite, suite.testStatusUpdater(&wg, &collStatus), test.source)
+			coll := NewCollection(
+				folderPath,
+				"drive-id",
+				suite,
+				suite.testStatusUpdater(&wg, &collStatus),
+				test.source,
+				control.Options{})
 			require.NotNil(t, coll)
 			assert.Equal(t, folderPath, coll.FullPath())
 
@@ -173,7 +176,13 @@ func (suite *CollectionUnitTestSuite) TestCollectionReadError() {
 			folderPath, err := GetCanonicalPath("drive/driveID1/root:/folderPath", "a-tenant", "a-user", test.source)
 			require.NoError(t, err)
 
-			coll := NewCollection(folderPath, "fakeDriveID", suite, suite.testStatusUpdater(&wg, &collStatus), test.source)
+			coll := NewCollection(
+				folderPath,
+				"fakeDriveID",
+				suite,
+				suite.testStatusUpdater(&wg, &collStatus),
+				test.source,
+				control.Options{})
 			coll.Add("testItemID")
 
 			readError := errors.New("Test error")

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/observe"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
 )
@@ -39,6 +40,8 @@ type Collections struct {
 	service       graph.Servicer
 	statusUpdater support.StatusUpdater
 
+	ctrl control.Options
+
 	// collectionMap allows lookup of the data.Collection
 	// for a OneDrive folder
 	CollectionMap map[string]data.Collection
@@ -56,6 +59,7 @@ func NewCollections(
 	matcher folderMatcher,
 	service graph.Servicer,
 	statusUpdater support.StatusUpdater,
+	ctrlOpts control.Options,
 ) *Collections {
 	return &Collections{
 		tenant:        tenant,
@@ -65,6 +69,7 @@ func NewCollections(
 		CollectionMap: map[string]data.Collection{},
 		service:       service,
 		statusUpdater: statusUpdater,
+		ctrl:          ctrlOpts,
 	}
 }
 
@@ -139,6 +144,7 @@ func (c *Collections) UpdateCollections(ctx context.Context, driveID string, ite
 					c.service,
 					c.statusUpdater,
 					c.source,
+					c.ctrl,
 				)
 
 				c.CollectionMap[collectionPath.String()] = col

--- a/src/internal/connector/onedrive/collections_test.go
+++ b/src/internal/connector/onedrive/collections_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/selectors"
 )
 
@@ -255,7 +256,14 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			ctx, flush := tester.NewContext()
 			defer flush()
 
-			c := NewCollections(tenant, user, OneDriveSource, testFolderMatcher{tt.scope}, &MockGraphService{}, nil)
+			c := NewCollections(
+				tenant,
+				user,
+				OneDriveSource,
+				testFolderMatcher{tt.scope},
+				&MockGraphService{},
+				nil,
+				control.Options{})
 
 			err := c.UpdateCollections(ctx, "driveID", tt.items)
 			tt.expect(t, err)

--- a/src/internal/connector/onedrive/drive_test.go
+++ b/src/internal/connector/onedrive/drive_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/selectors"
 )
@@ -153,6 +154,7 @@ func (suite *OneDriveSuite) TestOneDriveNewCollections() {
 				testFolderMatcher{scope},
 				service,
 				service.updateStatus,
+				control.Options{},
 			).Get(ctx)
 			assert.NoError(t, err)
 

--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -34,10 +34,6 @@ func (suite *ItemIntegrationSuite) Adapter() *msgraphsdk.GraphRequestAdapter {
 	return suite.adapter
 }
 
-func (suite *ItemIntegrationSuite) ErrPolicy() bool {
-	return false
-}
-
 func TestItemIntegrationSuite(t *testing.T) {
 	if err := tester.RunOnAny(
 		tester.CorsoCITests,

--- a/src/internal/connector/onedrive/service_test.go
+++ b/src/internal/connector/onedrive/service_test.go
@@ -22,10 +22,6 @@ func (ms *MockGraphService) Adapter() *msgraphsdk.GraphRequestAdapter {
 	return nil
 }
 
-func (ms *MockGraphService) ErrPolicy() bool {
-	return false
-}
-
 // TODO(ashmrtn): Merge with similar structs in graph and exchange packages.
 type oneDriveService struct {
 	client      msgraphsdk.GraphServiceClient
@@ -40,10 +36,6 @@ func (ods *oneDriveService) Client() *msgraphsdk.GraphServiceClient {
 
 func (ods *oneDriveService) Adapter() *msgraphsdk.GraphRequestAdapter {
 	return &ods.adapter
-}
-
-func (ods *oneDriveService) ErrPolicy() bool {
-	return false
 }
 
 func NewOneDriveService(credentials account.M365Config) (*oneDriveService, error) {

--- a/src/internal/connector/sharepoint/data_collections_test.go
+++ b/src/internal/connector/sharepoint/data_collections_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/connector/onedrive"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/selectors"
 )
 
@@ -92,7 +93,8 @@ func (suite *SharePointLibrariesSuite) TestUpdateCollections() {
 				onedrive.SharePointSource,
 				testFolderMatcher{test.scope},
 				&MockGraphService{},
-				nil)
+				nil,
+				control.Options{})
 			err := c.UpdateCollections(ctx, "driveID", test.items)
 			test.expect(t, err)
 			assert.Equal(t, len(test.expectedCollectionPaths), len(c.CollectionMap), "collection paths")

--- a/src/internal/connector/sharepoint/helper_test.go
+++ b/src/internal/connector/sharepoint/helper_test.go
@@ -35,20 +35,12 @@ func (ms *MockGraphService) Adapter() *msgraphsdk.GraphRequestAdapter {
 	return nil
 }
 
-func (ms *MockGraphService) ErrPolicy() bool {
-	return false
-}
-
 func (ts *testService) Client() *msgraphsdk.GraphServiceClient {
 	return &ts.client
 }
 
 func (ts *testService) Adapter() *msgraphsdk.GraphRequestAdapter {
 	return &ts.adapter
-}
-
-func (ts *testService) ErrPolicy() bool {
-	return false
 }
 
 // ---------------------------------------------------------------------------

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -139,7 +139,7 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 		return opStats.readErr
 	}
 
-	cs, err := produceBackupDataCollections(ctx, gc, op.Selectors, mdColls)
+	cs, err := produceBackupDataCollections(ctx, gc, op.Selectors, mdColls, control.Options{})
 	if err != nil {
 		opStats.readErr = errors.Wrap(err, "retrieving data to backup")
 		return opStats.readErr
@@ -316,6 +316,7 @@ func produceBackupDataCollections(
 	gc *connector.GraphConnector,
 	sel selectors.Selector,
 	metadata []data.Collection,
+	ctrlOpts control.Options,
 ) ([]data.Collection, error) {
 	complete, closer := observe.MessageWithCompletion("Discovering items to backup:")
 	defer func() {
@@ -324,7 +325,7 @@ func produceBackupDataCollections(
 		closer()
 	}()
 
-	return gc.DataCollections(ctx, sel, metadata)
+	return gc.DataCollections(ctx, sel, metadata, ctrlOpts)
 }
 
 // calls kopia to backup the collections of data


### PR DESCRIPTION
## Description

Configuration and attenion to the graphService
failFast is haphazard and has shared ownership.
This change removes that property from the
service, along with the ErrPolicy func, in favor of passing around a control.Options struct.

## Type of change

- [x] :hamster: Trivial/Minor

## Issue(s)

* #1725
* #302

## Test Plan

- [x] :zap: Unit test
