### PR TITLE
move graphService to graph as Service

### DIFF
--- a/src/cmd/getM365/getItem.go
+++ b/src/cmd/getM365/getItem.go
@@ -81,7 +81,7 @@ func handleGetCommand(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = runDisplayM365JSON(ctx, gc.Service())
+	err = runDisplayM365JSON(ctx, gc.Service)
 	if err != nil {
 		return Only(ctx, errors.Wrapf(err, "unable to create mock from M365: %s", m365ID))
 	}

--- a/src/cmd/purge/purge.go
+++ b/src/cmd/purge/purge.go
@@ -195,7 +195,7 @@ func purgeFolders(
 	Infof(ctx, "Container: %s", data)
 
 	// get them folders
-	fs, err := getter(gc.Service(), uid, prefix)
+	fs, err := getter(gc.Service, uid, prefix)
 	if err != nil {
 		return Only(ctx, errors.Wrapf(err, "retrieving %s folders", data))
 	}
@@ -227,7 +227,7 @@ func purgeFolders(
 
 		Infof(ctx, "∙ Deleting [%s]", displayName)
 
-		err = deleter(gc.Service(), uid, fld)
+		err = deleter(gc.Service, uid, fld)
 		if err != nil {
 			err = errors.Wrapf(err, "!! Error")
 			errs = multierror.Append(errs, err)

--- a/src/internal/connector/data_collections.go
+++ b/src/internal/connector/data_collections.go
@@ -55,7 +55,7 @@ func (gc *GraphConnector) DataCollections(
 			sels,
 			gc.GetSiteIDs(),
 			gc.credentials.AzureTenantID,
-			gc,
+			gc.Service,
 			gc,
 			ctrlOpts)
 		if err != nil {
@@ -265,7 +265,7 @@ func (gc *GraphConnector) OneDriveDataCollections(
 				user,
 				onedrive.OneDriveSource,
 				odFolderMatcher{scope},
-				gc,
+				gc.Service,
 				gc.UpdateStatus,
 				ctrlOpts,
 			).Get(ctx)

--- a/src/internal/connector/data_collections_test.go
+++ b/src/internal/connector/data_collections_test.go
@@ -195,7 +195,7 @@ func (suite *ConnectorDataCollectionIntegrationSuite) TestSharePointDataCollecti
 				test.getSelector(t),
 				[]string{suite.site},
 				connector.credentials.AzureTenantID,
-				connector,
+				connector.Service,
 				connector,
 				control.Options{})
 			require.NoError(t, err)

--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -25,6 +25,28 @@ type QueryParams struct {
 	Credentials   account.M365Config
 }
 
+var _ Servicer = &Service{}
+
+type Service struct {
+	adapter msgraphsdk.GraphRequestAdapter
+	client  msgraphsdk.GraphServiceClient
+}
+
+func NewService(adapter *msgraphsdk.GraphRequestAdapter) Service {
+	return Service{
+		adapter: *adapter,
+		client:  *msgraphsdk.NewGraphServiceClient(adapter),
+	}
+}
+
+func (s Service) Adapter() *msgraphsdk.GraphRequestAdapter {
+	return &s.adapter
+}
+
+func (s Service) Client() *msgraphsdk.GraphServiceClient {
+	return &s.client
+}
+
 type Servicer interface {
 	// Client() returns msgraph Service client that can be used to process and execute
 	// the majority of the queries to the M365 Backstore

--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -28,23 +28,23 @@ type QueryParams struct {
 var _ Servicer = &Service{}
 
 type Service struct {
-	adapter msgraphsdk.GraphRequestAdapter
-	client  msgraphsdk.GraphServiceClient
+	adapter *msgraphsdk.GraphRequestAdapter
+	client  *msgraphsdk.GraphServiceClient
 }
 
-func NewService(adapter *msgraphsdk.GraphRequestAdapter) Service {
-	return Service{
-		adapter: *adapter,
-		client:  *msgraphsdk.NewGraphServiceClient(adapter),
+func NewService(adapter *msgraphsdk.GraphRequestAdapter) *Service {
+	return &Service{
+		adapter: adapter,
+		client:  msgraphsdk.NewGraphServiceClient(adapter),
 	}
 }
 
 func (s Service) Adapter() *msgraphsdk.GraphRequestAdapter {
-	return &s.adapter
+	return s.adapter
 }
 
 func (s Service) Client() *msgraphsdk.GraphServiceClient {
-	return &s.client
+	return s.client
 }
 
 type Servicer interface {

--- a/src/internal/connector/graph_connector.go
+++ b/src/internal/connector/graph_connector.go
@@ -100,14 +100,14 @@ func NewGraphConnector(ctx context.Context, acct account.Account, r resource) (*
 }
 
 // createService constructor for graphService component
-func (gc *GraphConnector) createService() (graph.Service, error) {
+func (gc *GraphConnector) createService() (*graph.Service, error) {
 	adapter, err := graph.CreateAdapter(
 		gc.credentials.AzureTenantID,
 		gc.credentials.AzureClientID,
 		gc.credentials.AzureClientSecret,
 	)
 	if err != nil {
-		return graph.Service{}, err
+		return &graph.Service{}, err
 	}
 
 	return graph.NewService(adapter), nil

--- a/src/internal/connector/graph_connector.go
+++ b/src/internal/connector/graph_connector.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 
 	"github.com/microsoft/kiota-abstractions-go/serialization"
-	msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
 	msgraphgocore "github.com/microsoftgraph/msgraph-sdk-go-core"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/pkg/errors"
@@ -37,7 +36,7 @@ import (
 // GraphRequestAdapter from the msgraph-sdk-go. Additional fields are for
 // bookkeeping and interfacing with other component.
 type GraphConnector struct {
-	graphService
+	Service     graph.Servicer
 	tenant      string
 	Users       map[string]string // key<email> value<id>
 	Sites       map[string]string // key<???> value<???>
@@ -50,27 +49,6 @@ type GraphConnector struct {
 	// mutex used to synchronize updates to `status`
 	mu     sync.Mutex
 	status support.ConnectorOperationStatus // contains the status of the last run status
-}
-
-// Service returns the GC's embedded graph.Servicer
-func (gc *GraphConnector) Service() graph.Servicer {
-	return gc.graphService
-}
-
-var _ graph.Servicer = &graphService{}
-
-type graphService struct {
-	client   msgraphsdk.GraphServiceClient
-	adapter  msgraphsdk.GraphRequestAdapter
-	failFast bool // if true service will exit sequence upon encountering an error
-}
-
-func (gs graphService) Client() *msgraphsdk.GraphServiceClient {
-	return &gs.client
-}
-
-func (gs graphService) Adapter() *msgraphsdk.GraphRequestAdapter {
-	return &gs.adapter
 }
 
 type resource int
@@ -95,12 +73,12 @@ func NewGraphConnector(ctx context.Context, acct account.Account, r resource) (*
 		credentials: m365,
 	}
 
-	aService, err := gc.createService()
+	gService, err := gc.createService()
 	if err != nil {
 		return nil, errors.Wrap(err, "creating service connection")
 	}
 
-	gc.graphService = *aService
+	gc.Service = gService
 
 	// TODO(ashmrtn): When selectors only encapsulate a single resource owner that
 	// is not a wildcard don't populate users or sites when making the connector.
@@ -122,26 +100,17 @@ func NewGraphConnector(ctx context.Context, acct account.Account, r resource) (*
 }
 
 // createService constructor for graphService component
-func (gc *GraphConnector) createService() (*graphService, error) {
+func (gc *GraphConnector) createService() (graph.Service, error) {
 	adapter, err := graph.CreateAdapter(
 		gc.credentials.AzureTenantID,
 		gc.credentials.AzureClientID,
 		gc.credentials.AzureClientSecret,
 	)
 	if err != nil {
-		return nil, err
+		return graph.Service{}, err
 	}
 
-	connector := graphService{
-		adapter: *adapter,
-		client:  *msgraphsdk.NewGraphServiceClient(adapter),
-	}
-
-	return &connector, nil
-}
-
-func (gs *graphService) EnableFailFast() {
-	gs.failFast = true
+	return graph.NewService(adapter), nil
 }
 
 // setTenantUsers queries the M365 to identify the users in the
@@ -151,7 +120,7 @@ func (gc *GraphConnector) setTenantUsers(ctx context.Context) error {
 	ctx, end := D.Span(ctx, "gc:setTenantUsers")
 	defer end()
 
-	users, err := discovery.Users(ctx, gc, gc.tenant)
+	users, err := discovery.Users(ctx, gc.Service, gc.tenant)
 	if err != nil {
 		return err
 	}
@@ -186,7 +155,7 @@ func (gc *GraphConnector) setTenantSites(ctx context.Context) error {
 
 	sites, err := getResources(
 		ctx,
-		gc.graphService,
+		gc.Service,
 		gc.tenant,
 		sharepoint.GetAllSitesForTenant,
 		models.CreateSiteCollectionResponseFromDiscriminatorValue,
@@ -315,11 +284,11 @@ func (gc *GraphConnector) RestoreDataCollections(
 
 	switch selector.Service {
 	case selectors.ServiceExchange:
-		status, err = exchange.RestoreExchangeDataCollections(ctx, gc.graphService, dest, dcs, deets)
+		status, err = exchange.RestoreExchangeDataCollections(ctx, gc.Service, dest, dcs, deets)
 	case selectors.ServiceOneDrive:
-		status, err = onedrive.RestoreCollections(ctx, gc, dest, dcs, deets)
+		status, err = onedrive.RestoreCollections(ctx, gc.Service, dest, dcs, deets)
 	case selectors.ServiceSharePoint:
-		status, err = sharepoint.RestoreCollections(ctx, gc, dest, dcs, deets)
+		status, err = sharepoint.RestoreCollections(ctx, gc.Service, dest, dcs, deets)
 	default:
 		err = errors.Errorf("restore data from service %s not supported", selector.Service.String())
 	}

--- a/src/internal/connector/graph_connector_test.go
+++ b/src/internal/connector/graph_connector_test.go
@@ -174,7 +174,7 @@ func (suite *GraphConnectorIntegrationSuite) TestSetTenantUsers() {
 	service, err := newConnector.createService()
 	require.NoError(suite.T(), err)
 
-	newConnector.graphService = *service
+	newConnector.Service = service
 
 	suite.Empty(len(newConnector.Users))
 	err = newConnector.setTenantUsers(ctx)
@@ -197,7 +197,7 @@ func (suite *GraphConnectorIntegrationSuite) TestSetTenantSites() {
 	service, err := newConnector.createService()
 	require.NoError(suite.T(), err)
 
-	newConnector.graphService = *service
+	newConnector.Service = service
 
 	suite.Equal(0, len(newConnector.Sites))
 	err = newConnector.setTenantSites(ctx)
@@ -413,7 +413,7 @@ func (suite *GraphConnectorIntegrationSuite) TestRestoreAndBackup() {
 	driveID := mustGetDefaultDriveID(
 		suite.T(),
 		ctx,
-		suite.connector,
+		suite.connector.Service,
 		suite.user,
 	)
 

--- a/src/pkg/services/m365/m365.go
+++ b/src/pkg/services/m365/m365.go
@@ -25,7 +25,7 @@ func Users(ctx context.Context, m365Account account.Account) ([]*User, error) {
 		return nil, errors.Wrap(err, "could not initialize M365 graph connection")
 	}
 
-	users, err := discovery.Users(ctx, gc.Service(), m365Account.ID())
+	users, err := discovery.Users(ctx, gc.Service, m365Account.ID())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Relocates the graphService struct to graph as
the Service struct.  Replaces GC's embedded
graphService with a graph.Servicer reference.

## Type of change

- [x] :hamster: Trivial/Minor

## Issue(s)

* #1725

## Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
