### PR TITLE
Merge items in a single directory during snapshot

### DIFF
--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -234,6 +234,8 @@ func collectionEntries(
 				return seen, errs
 			}
 
+			encodedName := encodeAsPath(e.UUID())
+
 			// Even if this item has been deleted and should not appear at all in
 			// the new snapshot we need to record that we've seen it here so we know
 			// to skip it if it's also present in the base snapshot.
@@ -247,7 +249,7 @@ func collectionEntries(
 			// items we need to track. Namely, we can track the created time of the
 			// item and if it's after the base snapshot was finalized we can skip it
 			// because it's not possible for the base snapshot to contain that item.
-			seen[e.UUID()] = struct{}{}
+			seen[encodedName] = struct{}{}
 
 			// For now assuming that item IDs don't need escaping.
 			itemPath, err := streamedEnts.FullPath().Append(e.UUID(), true)
@@ -287,7 +289,7 @@ func collectionEntries(
 			}
 
 			entry := virtualfs.StreamingFileWithModTimeFromReader(
-				encodeAsPath(e.UUID()),
+				encodedName,
 				modTime,
 				newBackupStreamReader(serializationVersion, e.ToReader()),
 			)

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -420,9 +420,12 @@ type treeMap struct {
 	// Reference to data pulled from the external service. Contains only items in
 	// this directory. Does not contain references to subdirectories.
 	collection data.Collection
-	// Reference to directory in base snapshot. Can contain items and
-	// subdirectories but the subdirectories should be added to childDirs and
-	// ignored when handing items to kopia during the upload process.
+	// Reference to directory in base snapshot. The referenced directory itself
+	// may contain files and subdirectories, but the subdirectories should
+	// eventually be added when walking the base snapshot to build the hierarchy,
+	// not when handing items to kopia for the new snapshot. Subdirectories should
+	// be added to childDirs while building the hierarchy. They will be ignored
+	// when iterating through the directory to hand items to kopia.
 	baseDir fs.Directory
 }
 


### PR DESCRIPTION
## Description

Create and wire up a helper function that merges items in the base snapshot with items that have been seen from the collection

Will not change the output of execution at all since the base snapshot directory will always be nil at the moment

Will require further modifications to properly handle deleted items where only a single delta endpoint is used to fetch changes (e.x. OneDrive file deletions)

## Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* #1740

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
