### PR TITLE
Speed up Windows Powershell download

### DIFF
--- a/website/docs/setup/_download_binary.md
+++ b/website/docs/setup/_download_binary.md
@@ -10,7 +10,8 @@ import {Version} from '@site/src/corsoEnv';
 <TabItem value="win" label="Windows (Powershell)">
 
 <CodeBlock language="powershell">{
-`Invoke-WebRequest \`
+`$ProgressPreference = 'SilentlyContinue'
+Invoke-WebRequest \`
   -Uri https://github.com/alcionai/corso/releases/download/${Version()}/corso_${Version()}_Windows_x86_64.zip \`
   -UseBasicParsing -Outfile corso_${Version()}_Windows_x86_64.zip
 Expand-Archive .\\corso_${Version()}_Windows_x86_64.zip`


### PR DESCRIPTION
## Description

Don't count downloaded bytes when using Powershell's Invoke-WebRequest. This speeds up
downloads.

## Type of change

- [x] :bug: Bugfix
- [x] :world_map: Documentation

## Issue(s)

* Closes #1746 

## Test Plan

- [x] :muscle: Manual
