### PR TITLE
produce previousPaths metadata

### DIFF
--- a/src/internal/connector/data_collections_test.go
+++ b/src/internal/connector/data_collections_test.go
@@ -520,9 +520,11 @@ func (suite *ConnectorCreateExchangeCollectionIntegrationSuite) TestEventsSerial
 	for _, test := range tests {
 		suite.T().Run(test.name, func(t *testing.T) {
 			collections := test.getCollection(t)
-			require.Equal(t, len(collections), 1)
+			require.Equal(t, len(collections), 2)
+
 			edc := collections[0]
 			assert.Equal(t, edc.FullPath().Folder(), test.expected)
+
 			streamChannel := edc.Items()
 
 			for stream := range streamChannel {

--- a/src/internal/connector/data_collections_test.go
+++ b/src/internal/connector/data_collections_test.go
@@ -522,19 +522,24 @@ func (suite *ConnectorCreateExchangeCollectionIntegrationSuite) TestEventsSerial
 			collections := test.getCollection(t)
 			require.Equal(t, len(collections), 2)
 
-			edc := collections[0]
-			assert.Equal(t, edc.FullPath().Folder(), test.expected)
+			for _, edc := range collections {
+				if edc.FullPath().Service() != path.ExchangeMetadataService {
+					assert.Equal(t, test.expected, edc.FullPath().Folder())
+				} else {
+					assert.Equal(t, "", edc.FullPath().Folder())
+				}
 
-			streamChannel := edc.Items()
+				streamChannel := edc.Items()
 
-			for stream := range streamChannel {
-				buf := &bytes.Buffer{}
-				read, err := buf.ReadFrom(stream.ToReader())
-				assert.NoError(t, err)
-				assert.NotZero(t, read)
-				event, err := support.CreateEventFromBytes(buf.Bytes())
-				assert.NotNil(t, event)
-				assert.NoError(t, err, "experienced error parsing event bytes: "+buf.String())
+				for stream := range streamChannel {
+					buf := &bytes.Buffer{}
+					read, err := buf.ReadFrom(stream.ToReader())
+					assert.NoError(t, err)
+					assert.NotZero(t, read)
+					event, err := support.CreateEventFromBytes(buf.Bytes())
+					assert.NotNil(t, event)
+					assert.NoError(t, err, "experienced error parsing event bytes: "+buf.String())
+				}
 			}
 
 			status := connector.AwaitStatus()

--- a/src/internal/connector/exchange/data_collections.go
+++ b/src/internal/connector/exchange/data_collections.go
@@ -8,7 +8,19 @@ import (
 
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/data"
+	"github.com/alcionai/corso/src/pkg/path"
 )
+
+// MetadataFileNames produces the category-specific set of filenames used to
+// store graph metadata such as delta tokens and folderID->path references.
+func MetadataFileNames(cat path.CategoryType) []string {
+	switch cat {
+	case path.EmailCategory, path.ContactsCategory:
+		return []string{graph.DeltaTokenFileName, graph.PreviousPathFileName}
+	default:
+		return []string{graph.PreviousPathFileName}
+	}
+}
 
 // ParseMetadataCollections produces two maps:
 // 1- paths: folderID->filePath, used to look up previous folder pathing

--- a/src/internal/connector/exchange/data_collections_test.go
+++ b/src/internal/connector/exchange/data_collections_test.go
@@ -56,6 +56,15 @@ func (suite *DataCollectionsUnitSuite) TestParseMetadataCollections() {
 				"key": "`!@#$%^&*()_[]{}/\"\\",
 			},
 		},
+		{
+			name: "delta urls with escaped chars",
+			data: []fileValues{
+				{graph.DeltaTokenFileName, `\n\r\t\b\f\v\0\\`},
+			},
+			expectDeltas: map[string]string{
+				"key": "\\n\\r\\t\\b\\f\\v\\0\\\\",
+			},
+		},
 	}
 	for _, test := range table {
 		suite.T().Run(test.name, func(t *testing.T) {

--- a/src/internal/connector/exchange/data_collections_test.go
+++ b/src/internal/connector/exchange/data_collections_test.go
@@ -68,9 +68,9 @@ func (suite *DataCollectionsUnitSuite) TestParseMetadataCollections() {
 		{
 			name: "delta urls with newline char runes",
 			data: []fileValues{
-				// rune(92) = \, rune(110) = n.  If a parsing error were possible
-				// by serializing/deserializing those two runes and producing a
-				// single newline character, this would produce it.
+				// rune(92) = \, rune(110) = n.  Ensuring it's not possible to
+				// error in serializing/deserializing and produce a single newline
+				// character from those two runes.
 				{graph.DeltaTokenFileName, string([]rune{rune(92), rune(110)})},
 			},
 			expectDeltas: map[string]string{

--- a/src/internal/connector/exchange/data_collections_test.go
+++ b/src/internal/connector/exchange/data_collections_test.go
@@ -65,6 +65,18 @@ func (suite *DataCollectionsUnitSuite) TestParseMetadataCollections() {
 				"key": "\\n\\r\\t\\b\\f\\v\\0\\\\",
 			},
 		},
+		{
+			name: "delta urls with newline char runes",
+			data: []fileValues{
+				// rune(92) = \, rune(110) = n.  If a parsing error were possible
+				// by serializing/deserializing those two runes and producing a
+				// single newline character, this would produce it.
+				{graph.DeltaTokenFileName, string([]rune{rune(92), rune(110)})},
+			},
+			expectDeltas: map[string]string{
+				"key": "\\n",
+			},
+		},
 	}
 	for _, test := range table {
 		suite.T().Run(test.name, func(t *testing.T) {

--- a/src/internal/connector/exchange/iterators_test.go
+++ b/src/internal/connector/exchange/iterators_test.go
@@ -1,7 +1,6 @@
 package exchange
 
 import (
-	"encoding/json"
 	"testing"
 
 	absser "github.com/microsoft/kiota-abstractions-go/serialization"
@@ -15,96 +14,8 @@ import (
 	"github.com/alcionai/corso/src/internal/connector/mockconnector"
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 )
-
-type ExchangeIteratorUnitSuite struct {
-	suite.Suite
-}
-
-func TestExchangeIteratorUnitSuite(t *testing.T) {
-	suite.Run(t, new(ExchangeIteratorUnitSuite))
-}
-
-func (suite *ExchangeIteratorUnitSuite) TestMakeMetadataCollection() {
-	tenant := "a-tenant"
-	user := "a-user"
-
-	table := []struct {
-		name            string
-		cat             path.CategoryType
-		tokens          map[string]string
-		collectionCheck assert.ValueAssertionFunc
-		errCheck        assert.ErrorAssertionFunc
-	}{
-		{
-			name:            "EmptyTokens",
-			cat:             path.EmailCategory,
-			tokens:          nil,
-			collectionCheck: assert.Nil,
-			errCheck:        assert.NoError,
-		},
-		{
-			name: "Tokens",
-			cat:  path.EmailCategory,
-			tokens: map[string]string{
-				"hello": "world",
-				"hola":  "mundo",
-			},
-			collectionCheck: assert.NotNil,
-			errCheck:        assert.NoError,
-		},
-		{
-			name: "BadCategory",
-			cat:  path.FilesCategory,
-			tokens: map[string]string{
-				"hello": "world",
-				"hola":  "mundo",
-			},
-			collectionCheck: assert.Nil,
-			errCheck:        assert.Error,
-		},
-	}
-
-	for _, test := range table {
-		suite.T().Run(test.name, func(t *testing.T) {
-			col, err := makeMetadataCollection(
-				tenant,
-				user,
-				test.cat,
-				test.tokens,
-				func(*support.ConnectorOperationStatus) {},
-			)
-
-			test.errCheck(t, err)
-			if err != nil {
-				return
-			}
-
-			test.collectionCheck(t, col)
-			if col == nil {
-				return
-			}
-
-			itemCount := 0
-			for item := range col.Items() {
-				gotMap := map[string]string{}
-				decoder := json.NewDecoder(item.ToReader())
-				itemCount++
-
-				err := decoder.Decode(&gotMap)
-				if !assert.NoError(t, err) {
-					continue
-				}
-
-				assert.Equal(t, test.tokens, gotMap)
-			}
-
-			assert.Equal(t, 1, itemCount)
-		})
-	}
-}
 
 type ExchangeIteratorSuite struct {
 	suite.Suite

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -92,15 +92,20 @@ func FilterContainersAndFillCollections(
 		prevPaths[cID] = dirPath.Folder()
 	}
 
+	entries := []graph.MetadataCollectionEntry{
+		graph.NewMetadataEntry(graph.PreviousPathFileName, prevPaths),
+	}
+
+	if len(deltaURLs) > 0 {
+		entries = append(entries, graph.NewMetadataEntry(graph.DeltaTokenFileName, deltaURLs))
+	}
+
 	if col, err := graph.MakeMetadataCollection(
 		qp.Credentials.AzureTenantID,
 		qp.ResourceOwner,
 		path.ExchangeService,
 		qp.Category,
-		[]graph.MetadataCollectionEntry{
-			graph.NewMetadataEntry(graph.DeltaTokenFileName, deltaURLs),
-			graph.NewMetadataEntry(graph.PreviousPathFileName, prevPaths),
-		},
+		entries,
 		statusUpdater,
 	); err != nil {
 		errs = support.WrapAndAppend("making metadata collection", err, errs)

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -1,9 +1,7 @@
 package exchange
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -19,53 +17,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 )
-
-const (
-	metadataKey = "metadata"
-)
-
-// makeMetadataCollection creates a metadata collection that has a file
-// containing all the delta tokens in tokens. Returns nil if the map does not
-// have any entries.
-//
-// TODO(ashmrtn): Expand this/break it out into multiple functions so that we
-// can also store map[container ID]->full container path in a file in the
-// metadata collection.
-func makeMetadataCollection(
-	tenant string,
-	user string,
-	cat path.CategoryType,
-	tokens map[string]string,
-	statusUpdater support.StatusUpdater,
-) (data.Collection, error) {
-	if len(tokens) == 0 {
-		return nil, nil
-	}
-
-	buf := &bytes.Buffer{}
-	encoder := json.NewEncoder(buf)
-
-	if err := encoder.Encode(tokens); err != nil {
-		return nil, errors.Wrap(err, "serializing delta tokens")
-	}
-
-	p, err := path.Builder{}.ToServiceCategoryMetadataPath(
-		tenant,
-		user,
-		path.ExchangeService,
-		cat,
-		false,
-	)
-	if err != nil {
-		return nil, errors.Wrap(err, "making path")
-	}
-
-	return graph.NewMetadataCollection(
-		p,
-		[]graph.MetadataItem{graph.NewMetadataItem(graph.DeltaTokenFileName, buf.Bytes())},
-		statusUpdater,
-	), nil
-}
 
 // FilterContainersAndFillCollections is a utility function
 // that places the M365 object ids belonging to specific directories
@@ -83,85 +34,111 @@ func FilterContainersAndFillCollections(
 	ctrlOpts control.Options,
 ) error {
 	var (
-		errs           error
-		collectionType = CategoryToOptionIdentifier(qp.Category)
+		errs error
+		oi   = CategoryToOptionIdentifier(qp.Category)
 		// folder ID -> delta url for folder.
 		deltaURLs = map[string]string{}
+		prevPaths = map[string]string{}
 	)
 
 	for _, c := range resolver.Items() {
+		if ctrlOpts.FailFast && errs != nil {
+			return errs
+		}
+
 		dirPath, ok := pathAndMatch(qp, c, scope)
 		if !ok {
 			continue
 		}
 
+		cID := *c.GetId()
+
 		// Create only those that match
 		service, err := createService(qp.Credentials)
 		if err != nil {
-			errs = support.WrapAndAppend(
-				qp.ResourceOwner+" FilterContainerAndFillCollection",
-				err,
-				errs)
-
-			if ctrlOpts.FailFast {
-				return errs
-			}
+			errs = support.WrapAndAppend(qp.ResourceOwner, err, errs)
+			continue
 		}
 
 		edc := NewCollection(
 			qp.ResourceOwner,
 			dirPath,
-			collectionType,
+			oi,
 			service,
 			statusUpdater,
 			ctrlOpts,
 		)
-		collections[*c.GetId()] = &edc
+		collections[cID] = &edc
 
 		fetchFunc, err := getFetchIDFunc(qp.Category)
 		if err != nil {
-			errs = support.WrapAndAppend(
-				qp.ResourceOwner,
-				err,
-				errs)
-
-			if ctrlOpts.FailFast {
-				return errs
-			}
-
+			errs = support.WrapAndAppend(qp.ResourceOwner, err, errs)
 			continue
 		}
 
-		dirID := *c.GetId()
-		oldDelta := oldDeltas[dirID]
-
-		jobs, delta, err := fetchFunc(ctx, edc.service, qp.ResourceOwner, dirID, oldDelta)
+		jobs, delta, err := fetchFunc(ctx, edc.service, qp.ResourceOwner, cID, oldDeltas[cID])
 		if err != nil {
-			errs = support.WrapAndAppend(
-				qp.ResourceOwner,
-				err,
-				errs,
-			)
+			errs = support.WrapAndAppend(qp.ResourceOwner, err, errs)
 		}
 
 		edc.jobs = append(edc.jobs, jobs...)
 
 		if len(delta) > 0 {
-			deltaURLs[dirID] = delta
+			deltaURLs[cID] = delta
+		}
+
+		// add the current path for the container ID to be used in the next backup
+		// as the "previous path", for reference in case of a rename or relocation.
+		if itp, err := resolver.IDToPath(ctx, cID); err != nil {
+			errs = support.WrapAndAppend(qp.ResourceOwner, err, errs)
+		} else {
+			// Some root folders have no display name. The exchange path will
+			// fail without that, so we inject a fallback here just for
+			// the previousPaths handling.
+			els := itp.Elements()
+			if len(els) == 0 || len(els[len(els)-1]) == 0 {
+				itp = itp.Append(rootFolderAlias)
+			}
+
+			p, err := itp.ToDataLayerExchangePathForCategory(
+				qp.Credentials.AzureTenantID,
+				qp.ResourceOwner,
+				qp.Category,
+				false)
+			if err != nil {
+				errs = support.WrapAndAppend(qp.ResourceOwner, err, errs)
+			} else {
+				prevPaths[cID] = p.Folder()
+			}
 		}
 	}
 
-	col, err := makeMetadataCollection(
+	if col, err := graph.MakeMetadataCollection(
 		qp.Credentials.AzureTenantID,
 		qp.ResourceOwner,
+		graph.DeltaTokenFileName,
+		path.ExchangeService,
 		qp.Category,
 		deltaURLs,
 		statusUpdater,
-	)
-	if err != nil {
-		errs = support.WrapAndAppend("making metadata collection", err, errs)
+	); err != nil {
+		errs = support.WrapAndAppend("making delta metadata collection", err, errs)
 	} else if col != nil {
-		collections[metadataKey] = col
+		collections[graph.DeltaMetadataCollectionKey] = col
+	}
+
+	if col, err := graph.MakeMetadataCollection(
+		qp.Credentials.AzureTenantID,
+		qp.ResourceOwner,
+		graph.PreviousPathFileName,
+		path.ExchangeService,
+		qp.Category,
+		prevPaths,
+		statusUpdater,
+	); err != nil {
+		errs = support.WrapAndAppend("making paths metadata collection", err, errs)
+	} else if col != nil {
+		collections[graph.PathsMetadataCollectionKey] = col
 	}
 
 	return errs

--- a/src/internal/connector/graph/metadata_collection.go
+++ b/src/internal/connector/graph/metadata_collection.go
@@ -163,7 +163,7 @@ func (md MetadataCollection) Items() <-chan data.Stream {
 	return res
 }
 
-// metadataItem is an in-memory data.Stream implementation. MetadataItem does
+// MetadataItem is an in-memory data.Stream implementation. MetadataItem does
 // not implement additional interfaces like data.StreamInfo, so it should only
 // be used for items with a small amount of content that don't need to be added
 // to backup details.

--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -9,9 +9,23 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
-// DeltaTokenFileName is the name of the file containing delta token(s) for a
-// given endpoint. The endpoint granularity varies by service.
-const DeltaTokenFileName = "delta"
+const (
+	// DeltaTokenFileName is the name of the file containing delta token(s) for a
+	// given endpoint. The endpoint granularity varies by service.
+	DeltaTokenFileName = "delta"
+	// PreviousPathFileName is the name of the file containing previous path(s) for a
+	// given endpoint.
+	PreviousPathFileName = "previouspath"
+)
+
+const (
+	// DeltaMetadataCollectionKey is the name of the collection holding the delta
+	// url lookups inside a collection map otherwise keyed by folder ids.
+	DeltaMetadataCollectionKey = "delta-metadata"
+	// PathsMetadataCollectionKey is the name of the collection holding the previous
+	// paths lookups inside a collection map otherwise keyed by folder ids.
+	PathsMetadataCollectionKey = "paths-metadata"
+)
 
 // MetadataFileNames produces the standard set of filenames used to store graph
 // metadata such as delta tokens and folderID->path references.

--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -24,17 +24,6 @@ func AllMetadataFileNames() []string {
 	return []string{DeltaTokenFileName, PreviousPathFileName}
 }
 
-// MetadataFileNames produces the category-specific set of filenames used to
-// store graph metadata such as delta tokens and folderID->path references.
-func MetadataFileNames(cat path.CategoryType) []string {
-	switch cat {
-	case path.EmailCategory, path.ContactsCategory:
-		return []string{DeltaTokenFileName, PreviousPathFileName}
-	default:
-		return []string{PreviousPathFileName}
-	}
-}
-
 type QueryParams struct {
 	Category      path.CategoryType
 	ResourceOwner string

--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -18,19 +18,21 @@ const (
 	PreviousPathFileName = "previouspath"
 )
 
-const (
-	// DeltaMetadataCollectionKey is the name of the collection holding the delta
-	// url lookups inside a collection map otherwise keyed by folder ids.
-	DeltaMetadataCollectionKey = "delta-metadata"
-	// PathsMetadataCollectionKey is the name of the collection holding the previous
-	// paths lookups inside a collection map otherwise keyed by folder ids.
-	PathsMetadataCollectionKey = "paths-metadata"
-)
-
-// MetadataFileNames produces the standard set of filenames used to store graph
+// AllMetadataFileNames produces the standard set of filenames used to store graph
 // metadata such as delta tokens and folderID->path references.
-func MetadataFileNames() []string {
-	return []string{DeltaTokenFileName}
+func AllMetadataFileNames() []string {
+	return []string{DeltaTokenFileName, PreviousPathFileName}
+}
+
+// MetadataFileNames produces the category-specific set of filenames used to
+// store graph metadata such as delta tokens and folderID->path references.
+func MetadataFileNames(cat path.CategoryType) []string {
+	switch cat {
+	case path.EmailCategory, path.ContactsCategory:
+		return []string{DeltaTokenFileName, PreviousPathFileName}
+	default:
+		return []string{PreviousPathFileName}
+	}
 }
 
 type QueryParams struct {

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -219,7 +219,7 @@ func produceManifestsAndMetadata(
 			return nil, nil, err
 		}
 
-		colls, err := collectMetadata(ctx, kw, graph.MetadataFileNames(), oc, tid, bup.SnapshotID)
+		colls, err := collectMetadata(ctx, kw, graph.AllMetadataFileNames(), oc, tid, bup.SnapshotID)
 		if err != nil && !errors.Is(err, kopia.ErrNotFound) {
 			// prior metadata isn't guaranteed to exist.
 			// if it doesn't, we'll just have to do a

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -342,7 +342,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchange() {
 			},
 			resourceOwner: m365UserID,
 			category:      path.EmailCategory,
-			metadataFiles: []string{graph.DeltaTokenFileName, graph.PreviousPathFileName},
+			metadataFiles: graph.MetadataFileNames(path.EmailCategory),
 		},
 		{
 			name: "Contacts",
@@ -357,7 +357,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchange() {
 			},
 			resourceOwner: m365UserID,
 			category:      path.ContactsCategory,
-			metadataFiles: []string{graph.DeltaTokenFileName, graph.PreviousPathFileName},
+			metadataFiles: graph.MetadataFileNames(path.ContactsCategory),
 		},
 		{
 			name: "Calendar Events",
@@ -372,7 +372,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchange() {
 			},
 			resourceOwner: m365UserID,
 			category:      path.EventsCategory,
-			metadataFiles: []string{graph.PreviousPathFileName},
+			metadataFiles: graph.MetadataFileNames(path.EventsCategory),
 		},
 	}
 	for _, test := range tests {

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -2,7 +2,6 @@ package operations
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -230,8 +229,6 @@ func checkMetadataFilesExist(
 
 		for item := range col.Items() {
 			assert.Implements(t, (*data.StreamSize)(nil), item)
-
-			fmt.Printf("\n-----\nrestored %v %v\n-----\n", item.UUID(), col.FullPath())
 
 			s := item.(data.StreamSize)
 			assert.Greaterf(

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/connector/exchange"
-	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/events"
@@ -342,7 +341,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchange() {
 			},
 			resourceOwner: m365UserID,
 			category:      path.EmailCategory,
-			metadataFiles: graph.MetadataFileNames(path.EmailCategory),
+			metadataFiles: exchange.MetadataFileNames(path.EmailCategory),
 		},
 		{
 			name: "Contacts",
@@ -357,7 +356,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchange() {
 			},
 			resourceOwner: m365UserID,
 			category:      path.ContactsCategory,
-			metadataFiles: graph.MetadataFileNames(path.ContactsCategory),
+			metadataFiles: exchange.MetadataFileNames(path.ContactsCategory),
 		},
 		{
 			name: "Calendar Events",
@@ -372,7 +371,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchange() {
 			},
 			resourceOwner: m365UserID,
 			category:      path.EventsCategory,
-			metadataFiles: graph.MetadataFileNames(path.EventsCategory),
+			metadataFiles: exchange.MetadataFileNames(path.EventsCategory),
 		},
 	}
 	for _, test := range tests {

--- a/src/internal/operations/restore_test.go
+++ b/src/internal/operations/restore_test.go
@@ -198,9 +198,9 @@ func (suite *RestoreOpIntegrationSuite) SetupSuite() {
 	require.NotEmpty(t, bo.Results.BackupID)
 
 	suite.backupID = bo.Results.BackupID
-	// Remove delta metadata files for contacts and email as they are not part of
-	// the data restored.
-	suite.numItems = bo.Results.ItemsWritten - 2
+	// Discount delta and paths metadata files as
+	// they are not part of the data restored.
+	suite.numItems = bo.Results.ItemsWritten - 5
 }
 
 func (suite *RestoreOpIntegrationSuite) TearDownSuite() {

--- a/src/internal/operations/restore_test.go
+++ b/src/internal/operations/restore_test.go
@@ -198,7 +198,7 @@ func (suite *RestoreOpIntegrationSuite) SetupSuite() {
 	require.NotEmpty(t, bo.Results.BackupID)
 
 	suite.backupID = bo.Results.BackupID
-	// Discount delta and paths metadata files as
+	// Discount metadata files (3 paths, 2 deltas) as
 	// they are not part of the data restored.
 	suite.numItems = bo.Results.ItemsWritten - 5
 }


### PR DESCRIPTION
## Description

Adds an additional metadata collection: a folder
id to path string mapping.  This collection is
created on backup, and retrieved along with
the delta metadata on the next backup, but is
not yet parsed or utilzed downstream.

## Type of change

- [x] :sunflower: Feature

## Issue(s)

* #1726

## Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
