### PR TITLE
consume prevPath on next backup

### DIFF
--- a/src/internal/common/maps.go
+++ b/src/internal/common/maps.go
@@ -1,0 +1,16 @@
+package common
+
+// UnionMaps produces a new map containing all the values of the other
+// maps.  The last maps have the highes priority.  Key collisions with
+// earlier maps will favor the last map with that key.
+func UnionMaps[K comparable, V any](ms ...map[K]V) map[K]V {
+	r := map[K]V{}
+
+	for _, m := range ms {
+		for k, v := range m {
+			r[k] = v
+		}
+	}
+
+	return r
+}

--- a/src/internal/connector/data_collections.go
+++ b/src/internal/connector/data_collections.go
@@ -126,7 +126,7 @@ func verifyBackupInputs(sels selectors.Selector, userPNs, siteIDs []string) erro
 func (gc *GraphConnector) createExchangeCollections(
 	ctx context.Context,
 	scope selectors.ExchangeScope,
-	deltas map[string]string,
+	dps exchange.DeltaPaths,
 	ctrlOpts control.Options,
 ) ([]data.Collection, error) {
 	var (
@@ -161,7 +161,7 @@ func (gc *GraphConnector) createExchangeCollections(
 			gc.UpdateStatus,
 			resolver,
 			scope,
-			deltas,
+			dps,
 			ctrlOpts)
 
 		if err != nil {
@@ -202,14 +202,15 @@ func (gc *GraphConnector) ExchangeDataCollection(
 		errs        error
 	)
 
-	_, deltas, err := exchange.ParseMetadataCollections(ctx, metadata)
+	cdps, err := exchange.ParseMetadataCollections(ctx, metadata)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, scope := range scopes {
-		// Creates a map of collections based on scope
-		dcs, err := gc.createExchangeCollections(ctx, scope, deltas, control.Options{})
+		dps := cdps[scope.Category().PathType()]
+
+		dcs, err := gc.createExchangeCollections(ctx, scope, dps, control.Options{})
 		if err != nil {
 			user := scope.Get(selectors.ExchangeUser)
 			return nil, support.WrapAndAppend(user[0], err, errs)

--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -58,17 +58,21 @@ type Collection struct {
 
 	collectionType optionIdentifier
 	statusUpdater  support.StatusUpdater
-	// FullPath is the slice representation of the action context passed down through the hierarchy.
-	// The original request can be gleaned from the slice. (e.g. {<tenant ID>, <user ID>, "emails"})
+	ctrl           control.Options
+
+	// FullPath is the current hierarchical path used by this collection.
 	fullPath path.Path
 
-	ctrl control.Options
+	// PrevPath is the previous hierarchical path used by this collection.
+	// It may be the same as fullPath, if the folder was not renamed or
+	// moved.  It will be empty on its first retrieval.
+	prevPath path.Path
 }
 
 // NewExchangeDataCollection creates an ExchangeDataCollection with fullPath is annotated
 func NewCollection(
 	user string,
-	fullPath path.Path,
+	fullPath, prevPath path.Path,
 	collectionType optionIdentifier,
 	service graph.Servicer,
 	statusUpdater support.StatusUpdater,
@@ -81,6 +85,7 @@ func NewCollection(
 		service:        service,
 		statusUpdater:  statusUpdater,
 		fullPath:       fullPath,
+		prevPath:       prevPath,
 		collectionType: collectionType,
 		ctrl:           ctrlOpts,
 	}

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -2,6 +2,7 @@ package operations
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -228,6 +229,8 @@ func checkMetadataFilesExist(
 
 		for item := range col.Items() {
 			assert.Implements(t, (*data.StreamSize)(nil), item)
+
+			fmt.Printf("\n-----\nrestored %v %v\n-----\n", item.UUID(), col.FullPath())
 
 			s := item.(data.StreamSize)
 			assert.Greaterf(

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -2,7 +2,6 @@ package operations
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -229,8 +228,6 @@ func checkMetadataFilesExist(
 
 		for item := range col.Items() {
 			assert.Implements(t, (*data.StreamSize)(nil), item)
-
-			fmt.Printf("\n-----\nrestored %v %v\n-----\n", item.UUID(), col.FullPath())
 
 			s := item.(data.StreamSize)
 			assert.Greaterf(


### PR DESCRIPTION
## Description

Parses the previousPaths metadata collections
along with deltas, and hands paths down to
exchange backup collection producers.  Does
not yet scrutinize previous/current path diffs.

## Type of change

- [x] :sunflower: Feature

## Issue(s)

* #1726

## Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
