### PR TITLE
add sharepoint fullcontrol permission to docs

### DIFF
--- a/website/docs/setup/m365_access.md
+++ b/website/docs/setup/m365_access.md
@@ -56,6 +56,8 @@ then click **Add permissions**.
 | Files.ReadWrite.All | Application | Read and write files in all site collections |
 | Mail.ReadWrite | Application | Read and write mail in all mailboxes |
 | User.Read.All | Application | Read all users' full profiles |
+| Sites.FullControl.All | Application | Have full control of all site collections |
+
 <!-- vale Microsoft.Spacing = YES -->
 
 ### Grant admin consent


### PR DESCRIPTION
## Description

`Sites.FullControl.All` should provide permission to all sites
and site-related things (site lists, site list items, etc).  This is
just going off of microsoft documentation, not actual testing.

## Type of change

- [x] :world_map: Documentation
