### PR TITLE
Have BackupOp pass in OwnersCats to kopia.BackupCollections

### DIFF
--- a/src/internal/kopia/snapshot_manager.go
+++ b/src/internal/kopia/snapshot_manager.go
@@ -71,6 +71,10 @@ func MakeTagKV(k string) (string, string) {
 // passed in. Currently uses placeholder values for each tag because there can
 // be multiple instances of resource owners and categories in a single snapshot.
 func tagsFromStrings(oc *OwnersCats) map[string]string {
+	if oc == nil {
+		return map[string]string{}
+	}
+
 	res := make(map[string]string, len(oc.ServiceCats)+len(oc.ResourceOwners))
 
 	for k := range oc.ServiceCats {
@@ -218,6 +222,10 @@ func fetchPrevSnapshotManifests(
 	oc *OwnersCats,
 	tags map[string]string,
 ) []*snapshot.Manifest {
+	if oc == nil {
+		return nil
+	}
+
 	mans := map[manifest.ID]*snapshot.Manifest{}
 	tags = normalizeTagKVs(tags)
 

--- a/src/internal/kopia/upload_test.go
+++ b/src/internal/kopia/upload_test.go
@@ -439,14 +439,6 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree() {
 		user1Encoded: 5,
 		user2Encoded: 42,
 	}
-	expectedServiceCats := map[string]ServiceCat{
-		serviceCatTag(suite.testPath): {},
-		serviceCatTag(p2):             {},
-	}
-	expectedResourceOwners := map[string]struct{}{
-		suite.testPath.ResourceOwner(): {},
-		p2.ResourceOwner():             {},
-	}
 
 	progress := &corsoProgress{pending: map[string]*itemDetails{}}
 
@@ -472,11 +464,8 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree() {
 	//       - emails
 	//         - Inbox
 	//           - 42 separate files
-	dirTree, oc, err := inflateDirTree(ctx, collections, progress)
+	dirTree, err := inflateDirTree(ctx, collections, progress)
 	require.NoError(t, err)
-
-	assert.Equal(t, expectedServiceCats, oc.ServiceCats)
-	assert.Equal(t, expectedResourceOwners, oc.ResourceOwners)
 
 	assert.Equal(t, encodeAsPath(testTenant), dirTree.Name())
 
@@ -517,15 +506,6 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_MixedDirectory() 
 
 	p2, err := suite.testPath.Append(subdir, false)
 	require.NoError(suite.T(), err)
-
-	expectedServiceCats := map[string]ServiceCat{
-		serviceCatTag(suite.testPath): {},
-		serviceCatTag(p2):             {},
-	}
-	expectedResourceOwners := map[string]struct{}{
-		suite.testPath.ResourceOwner(): {},
-		p2.ResourceOwner():             {},
-	}
 
 	// Test multiple orders of items because right now order can matter. Both
 	// orders result in a directory structure like:
@@ -573,11 +553,8 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_MixedDirectory() 
 		suite.T().Run(test.name, func(t *testing.T) {
 			progress := &corsoProgress{pending: map[string]*itemDetails{}}
 
-			dirTree, oc, err := inflateDirTree(ctx, test.layout, progress)
+			dirTree, err := inflateDirTree(ctx, test.layout, progress)
 			require.NoError(t, err)
-
-			assert.Equal(t, expectedServiceCats, oc.ServiceCats)
-			assert.Equal(t, expectedResourceOwners, oc.ResourceOwners)
 
 			assert.Equal(t, encodeAsPath(testTenant), dirTree.Name())
 
@@ -674,7 +651,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_Fails() {
 		defer flush()
 
 		suite.T().Run(test.name, func(t *testing.T) {
-			_, _, err := inflateDirTree(ctx, test.layout, nil)
+			_, err := inflateDirTree(ctx, test.layout, nil)
 			assert.Error(t, err)
 		})
 	}

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -135,7 +135,7 @@ func (w Wrapper) BackupCollections(
 		deets:   &details.Details{},
 	}
 
-	dirTree, oc, err := inflateDirTree(ctx, collections, progress)
+	dirTree, err := inflateDirTree(ctx, collections, progress)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "building kopia directories")
 	}

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -116,6 +116,7 @@ func (w Wrapper) BackupCollections(
 	previousSnapshots []*snapshot.Manifest,
 	collections []data.Collection,
 	service path.ServiceType,
+	oc *OwnersCats,
 	tags map[string]string,
 ) (*BackupStats, *details.Details, error) {
 	if w.c == nil {
@@ -411,12 +412,12 @@ func (w Wrapper) DeleteSnapshot(
 // normalized inside the func using MakeTagKV.
 func (w Wrapper) FetchPrevSnapshotManifests(
 	ctx context.Context,
-	oc OwnersCats,
+	oc *OwnersCats,
 	tags map[string]string,
 ) ([]*snapshot.Manifest, error) {
 	if w.c == nil {
 		return nil, errors.WithStack(errNotConnected)
 	}
 
-	return fetchPrevSnapshotManifests(ctx, w.c, &oc, tags), nil
+	return fetchPrevSnapshotManifests(ctx, w.c, oc, tags), nil
 }

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -210,6 +210,16 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 		),
 	}
 
+	k, v := MakeServiceCat(path.ExchangeService, path.EmailCategory)
+	oc := &OwnersCats{
+		ResourceOwners: map[string]struct{}{
+			testUser: {},
+		},
+		ServiceCats: map[string]ServiceCat{
+			k: v,
+		},
+	}
+
 	// tags that are expected to populate as a side effect
 	// of the backup process.
 	baseTagKeys := []string{
@@ -260,6 +270,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 				nil,
 				collections,
 				path.ExchangeService,
+				oc,
 				customTags,
 			)
 			assert.NoError(t, err)
@@ -302,6 +313,16 @@ func (suite *KopiaIntegrationSuite) TestRestoreAfterCompressionChange() {
 
 	w := &Wrapper{k}
 
+	mapK, mapV := MakeServiceCat(path.ExchangeService, path.EmailCategory)
+	oc := &OwnersCats{
+		ResourceOwners: map[string]struct{}{
+			testUser: {},
+		},
+		ServiceCats: map[string]ServiceCat{
+			mapK: mapV,
+		},
+	}
+
 	dc1 := mockconnector.NewMockExchangeCollection(suite.testPath1, 1)
 	dc2 := mockconnector.NewMockExchangeCollection(suite.testPath2, 1)
 
@@ -316,6 +337,7 @@ func (suite *KopiaIntegrationSuite) TestRestoreAfterCompressionChange() {
 		nil,
 		[]data.Collection{dc1, dc2},
 		path.ExchangeService,
+		oc,
 		nil,
 	)
 	require.NoError(t, err)
@@ -344,6 +366,16 @@ func (suite *KopiaIntegrationSuite) TestRestoreAfterCompressionChange() {
 
 func (suite *KopiaIntegrationSuite) TestBackupCollections_ReaderError() {
 	t := suite.T()
+
+	k, v := MakeServiceCat(path.ExchangeService, path.EmailCategory)
+	oc := &OwnersCats{
+		ResourceOwners: map[string]struct{}{
+			testUser: {},
+		},
+		ServiceCats: map[string]ServiceCat{
+			k: v,
+		},
+	}
 
 	collections := []data.Collection{
 		&kopiaDataCollection{
@@ -387,6 +419,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_ReaderError() {
 		nil,
 		collections,
 		path.ExchangeService,
+		oc,
 		nil,
 	)
 	require.NoError(t, err)
@@ -431,6 +464,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollectionsHandlesNoCollections() 
 				nil,
 				test.collections,
 				path.UnknownService,
+				&OwnersCats{},
 				nil,
 			)
 			require.NoError(t, err)
@@ -576,11 +610,22 @@ func (suite *KopiaSimpleRepoIntegrationSuite) SetupTest() {
 		collections = append(collections, collection)
 	}
 
+	k, v := MakeServiceCat(path.ExchangeService, path.EmailCategory)
+	oc := &OwnersCats{
+		ResourceOwners: map[string]struct{}{
+			testUser: {},
+		},
+		ServiceCats: map[string]ServiceCat{
+			k: v,
+		},
+	}
+
 	stats, deets, err := suite.w.BackupCollections(
 		suite.ctx,
 		nil,
 		collections,
 		path.ExchangeService,
+		oc,
 		nil,
 	)
 	require.NoError(t, err)

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -405,7 +405,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchange() {
 			// verify that we can find the new backup id in the manifests
 			var (
 				sck, scv = kopia.MakeServiceCat(sel.PathService(), test.category)
-				oc       = kopia.OwnersCats{
+				oc       = &kopia.OwnersCats{
 					ResourceOwners: map[string]struct{}{test.resourceOwner: {}},
 					ServiceCats:    map[string]kopia.ServiceCat{sck: scv},
 				}

--- a/src/internal/streamstore/streamstore.go
+++ b/src/internal/streamstore/streamstore.go
@@ -73,7 +73,7 @@ func (ss *streamStore) WriteBackupDetails(
 		},
 	}
 
-	backupStats, _, err := ss.kw.BackupCollections(ctx, nil, []data.Collection{dc}, ss.service, nil)
+	backupStats, _, err := ss.kw.BackupCollections(ctx, nil, []data.Collection{dc}, ss.service, nil, nil)
 	if err != nil {
 		return "", nil
 	}


### PR DESCRIPTION
## Description

Instead of relying on KopiaWrapper to create the OwnersCats for a
backup, have BackupOp create them from the selector and pass them in.

This is necessary as incremental backups will no longer see all the data
in the backup, meaning it cannot accurately create the OwnersCats
because some data categories or owners in the backup may not have had
changes.

OwnersCats are eventually converted to tags on a kopia snpashot and used
to lookup snapshots when trying to find base snapshots for incrementals.

Additional minor changes:
* use pointers instead of values when passing parameters
* set backup details OwnersCats to nil

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* #1740 

## Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
