### PR TITLE
Add docs/rn question to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,12 @@
 
 <!-- Insert PR description-->
 
+## Does this PR need a docs update or release note?
+
+- [ ] :white_check_mark: Yes, it's included
+- [ ] :clock1: Yes, but in a later PR
+- [ ] :no_entry: No 
+
 ## Type of change
 
 <!--- Please check the type of change your PR introduces: --->


### PR DESCRIPTION
## Description

This PR template change will remind folks to include release notes or documentation
updates as we start adding or updating features and will prevent things from falling
through the cracks.

## Type of change

- [x] :world_map: Documentation
