### PR TITLE
Say reasons why a base snapshot was selected

### DIFF
--- a/src/internal/kopia/snapshot_manager.go
+++ b/src/internal/kopia/snapshot_manager.go
@@ -25,6 +25,24 @@ const (
 	userTagPrefix = "tag:"
 )
 
+type Reason struct {
+	ResourceOwner string
+	Service       path.ServiceType
+	Category      path.CategoryType
+}
+
+type ManifestEntry struct {
+	*snapshot.Manifest
+	// Reason contains the ResourceOwners and Service/Categories that caused this
+	// snapshot to be selected as a base. We can't reuse OwnersCats here because
+	// it's possible some ResourceOwners will have a subset of the Categories as
+	// the reason for selecting a snapshot. For example:
+	// 1. backup user1 email,contacts -> B1
+	// 2. backup user1 contacts -> B2 (uses B1 as base)
+	// 3. backup user1 email,contacts,events (uses B1 for email, B2 for contacts)
+	Reasons []Reason
+}
+
 type snapshotManager interface {
 	FindManifests(
 		ctx context.Context,

--- a/src/internal/kopia/snapshot_manager.go
+++ b/src/internal/kopia/snapshot_manager.go
@@ -253,7 +253,7 @@ func fetchPrevManifests(
 		})
 	}
 
-	// If we didn't find another complete manifest then we need to make the
+	// If we didn't find another complete manifest then we need to mark the
 	// previous complete manifest as having this ResourceOwner, Service, Category
 	// as the reason as well.
 	if !hasCompleted && man != nil {

--- a/src/internal/kopia/snapshot_manager_test.go
+++ b/src/internal/kopia/snapshot_manager_test.go
@@ -29,11 +29,19 @@ var (
 	testID2 = manifest.ID("snap2")
 	testID3 = manifest.ID("snap3")
 
-	testMail   = path.ExchangeService.String() + path.EmailCategory.String()
-	testEvents = path.ExchangeService.String() + path.EventsCategory.String()
-	testUser1  = "user1"
-	testUser2  = "user2"
-	testUser3  = "user3"
+	testMail           = path.ExchangeService.String() + path.EmailCategory.String()
+	testMailServiceCat = ServiceCat{
+		Service:  path.ExchangeService,
+		Category: path.EmailCategory,
+	}
+	testEvents           = path.ExchangeService.String() + path.EventsCategory.String()
+	testEventsServiceCat = ServiceCat{
+		Service:  path.ExchangeService,
+		Category: path.EventsCategory,
+	}
+	testUser1 = "user1"
+	testUser2 = "user2"
+	testUser3 = "user3"
 
 	testAllUsersAllCats = &OwnersCats{
 		ResourceOwners: map[string]struct{}{
@@ -42,8 +50,8 @@ var (
 			testUser3: {},
 		},
 		ServiceCats: map[string]ServiceCat{
-			testMail:   {},
-			testEvents: {},
+			testMail:   testMailServiceCat,
+			testEvents: testEventsServiceCat,
 		},
 	}
 	testAllUsersMail = &OwnersCats{
@@ -53,7 +61,7 @@ var (
 			testUser3: {},
 		},
 		ServiceCats: map[string]ServiceCat{
-			testMail: {},
+			testMail: testMailServiceCat,
 		},
 	}
 )
@@ -174,6 +182,9 @@ func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshots() {
 		// defining data in a table while not repeating things between data and
 		// expected.
 		expectedIdxs []int
+		// Use this to denote the Reasons a manifest is selected. The int maps to
+		// the index of the manifest in data.
+		expectedReasons map[int][]Reason
 		// Expected number of times a manifest should try to be loaded from kopia.
 		// Used to check that caching is functioning properly.
 		expectedLoadCounts map[manifest.ID]int
@@ -194,6 +205,40 @@ func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshots() {
 				),
 			},
 			expectedIdxs: []int{0},
+			expectedReasons: map[int][]Reason{
+				0: {
+					Reason{
+						ResourceOwner: testUser1,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+					Reason{
+						ResourceOwner: testUser2,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+					Reason{
+						ResourceOwner: testUser3,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+					Reason{
+						ResourceOwner: testUser1,
+						Service:       path.ExchangeService,
+						Category:      path.EventsCategory,
+					},
+					Reason{
+						ResourceOwner: testUser2,
+						Service:       path.ExchangeService,
+						Category:      path.EventsCategory,
+					},
+					Reason{
+						ResourceOwner: testUser3,
+						Service:       path.ExchangeService,
+						Category:      path.EventsCategory,
+					},
+				},
+			},
 			expectedLoadCounts: map[manifest.ID]int{
 				testID1: 1,
 			},
@@ -222,6 +267,42 @@ func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshots() {
 				),
 			},
 			expectedIdxs: []int{0, 1},
+			expectedReasons: map[int][]Reason{
+				0: {
+					{
+						ResourceOwner: testUser1,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+					{
+						ResourceOwner: testUser2,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+					{
+						ResourceOwner: testUser3,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+				},
+				1: {
+					Reason{
+						ResourceOwner: testUser1,
+						Service:       path.ExchangeService,
+						Category:      path.EventsCategory,
+					},
+					Reason{
+						ResourceOwner: testUser2,
+						Service:       path.ExchangeService,
+						Category:      path.EventsCategory,
+					},
+					Reason{
+						ResourceOwner: testUser3,
+						Service:       path.ExchangeService,
+						Category:      path.EventsCategory,
+					},
+				},
+			},
 			expectedLoadCounts: map[manifest.ID]int{
 				testID1: 1,
 				testID2: 1,
@@ -251,6 +332,42 @@ func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshots() {
 				),
 			},
 			expectedIdxs: []int{0, 1},
+			expectedReasons: map[int][]Reason{
+				0: {
+					Reason{
+						ResourceOwner: testUser1,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+					Reason{
+						ResourceOwner: testUser2,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+					Reason{
+						ResourceOwner: testUser3,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+				},
+				1: {
+					Reason{
+						ResourceOwner: testUser1,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+					Reason{
+						ResourceOwner: testUser2,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+					Reason{
+						ResourceOwner: testUser3,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+				},
+			},
 			expectedLoadCounts: map[manifest.ID]int{
 				testID1: 1,
 				testID2: 3,
@@ -280,6 +397,25 @@ func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshots() {
 				),
 			},
 			expectedIdxs: []int{1},
+			expectedReasons: map[int][]Reason{
+				1: {
+					Reason{
+						ResourceOwner: testUser1,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+					Reason{
+						ResourceOwner: testUser2,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+					Reason{
+						ResourceOwner: testUser3,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+				},
+			},
 			expectedLoadCounts: map[manifest.ID]int{
 				testID1: 1,
 				testID2: 1,
@@ -300,6 +436,25 @@ func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshots() {
 				),
 			},
 			expectedIdxs: []int{0},
+			expectedReasons: map[int][]Reason{
+				0: {
+					Reason{
+						ResourceOwner: testUser1,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+					Reason{
+						ResourceOwner: testUser2,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+					Reason{
+						ResourceOwner: testUser3,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+				},
+			},
 			expectedLoadCounts: map[manifest.ID]int{
 				testID1: 3,
 			},
@@ -328,6 +483,25 @@ func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshots() {
 				),
 			},
 			expectedIdxs: []int{1},
+			expectedReasons: map[int][]Reason{
+				1: {
+					Reason{
+						ResourceOwner: testUser1,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+					Reason{
+						ResourceOwner: testUser2,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+					Reason{
+						ResourceOwner: testUser3,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+				},
+			},
 			expectedLoadCounts: map[manifest.ID]int{
 				testID1: 1,
 				testID2: 1,
@@ -357,6 +531,25 @@ func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshots() {
 				),
 			},
 			expectedIdxs: []int{1},
+			expectedReasons: map[int][]Reason{
+				1: {
+					Reason{
+						ResourceOwner: testUser1,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+					Reason{
+						ResourceOwner: testUser2,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+					Reason{
+						ResourceOwner: testUser3,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+				},
+			},
 			expectedLoadCounts: map[manifest.ID]int{
 				testID1: 3,
 				testID2: 3,
@@ -384,6 +577,91 @@ func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshots() {
 				),
 			},
 			expectedIdxs: []int{0, 1},
+			expectedReasons: map[int][]Reason{
+				0: {
+					Reason{
+						ResourceOwner: testUser1,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+					Reason{
+						ResourceOwner: testUser2,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+				},
+				1: {
+					Reason{
+						ResourceOwner: testUser3,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+				},
+			},
+			expectedLoadCounts: map[manifest.ID]int{
+				testID1: 2,
+				testID2: 1,
+			},
+		},
+		{
+			name:  "SomeCachedSomeNewerDifferentCategories",
+			input: testAllUsersAllCats,
+			data: []manifestInfo{
+				newManifestInfo(
+					testID1,
+					testT1,
+					testCompleteMan,
+					testMail,
+					testEvents,
+					testUser1,
+					testUser2,
+					testUser3,
+				),
+				newManifestInfo(
+					testID2,
+					testT2,
+					testCompleteMan,
+					testMail,
+					testUser3,
+				),
+			},
+			expectedIdxs: []int{0, 1},
+			expectedReasons: map[int][]Reason{
+				0: {
+					Reason{
+						ResourceOwner: testUser1,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+					Reason{
+						ResourceOwner: testUser2,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+					Reason{
+						ResourceOwner: testUser1,
+						Service:       path.ExchangeService,
+						Category:      path.EventsCategory,
+					},
+					Reason{
+						ResourceOwner: testUser2,
+						Service:       path.ExchangeService,
+						Category:      path.EventsCategory,
+					},
+					Reason{
+						ResourceOwner: testUser3,
+						Service:       path.ExchangeService,
+						Category:      path.EventsCategory,
+					},
+				},
+				1: {
+					Reason{
+						ResourceOwner: testUser3,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+				},
+			},
 			expectedLoadCounts: map[manifest.ID]int{
 				testID1: 2,
 				testID2: 1,
@@ -411,6 +689,32 @@ func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshots() {
 				),
 			},
 			expectedIdxs: []int{0, 1},
+			expectedReasons: map[int][]Reason{
+				0: {
+					Reason{
+						ResourceOwner: testUser1,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+					Reason{
+						ResourceOwner: testUser2,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+					Reason{
+						ResourceOwner: testUser3,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+				},
+				1: {
+					Reason{
+						ResourceOwner: testUser3,
+						Service:       path.ExchangeService,
+						Category:      path.EmailCategory,
+					},
+				},
+			},
 			expectedLoadCounts: map[manifest.ID]int{
 				testID1: 1,
 				testID2: 1,
@@ -444,13 +748,42 @@ func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshots() {
 
 			snaps := fetchPrevSnapshotManifests(ctx, msm, test.input, nil)
 
+			// Check the proper snapshot manifests were returned.
 			expected := make([]*snapshot.Manifest, 0, len(test.expectedIdxs))
 			for _, i := range test.expectedIdxs {
 				expected = append(expected, test.data[i].man)
 			}
 
-			assert.ElementsMatch(t, expected, snaps)
+			got := make([]*snapshot.Manifest, 0, len(snaps))
+			for _, s := range snaps {
+				got = append(got, s.Manifest)
+			}
 
+			assert.ElementsMatch(t, expected, got)
+
+			// Check the resons for selecting each manifest are correct.
+			expectedReasons := make(map[manifest.ID][]Reason, len(test.expectedReasons))
+			for idx, reason := range test.expectedReasons {
+				expectedReasons[test.data[idx].man.ID] = reason
+			}
+
+			for _, found := range snaps {
+				reason, ok := expectedReasons[found.ID]
+				if !ok {
+					// Missing or extra snapshots will be reported by earlier checks.
+					continue
+				}
+
+				assert.ElementsMatch(
+					t,
+					reason,
+					found.Reasons,
+					"incorrect reasons for snapshot with ID %s",
+					found.ID,
+				)
+			}
+
+			// Check number of loads to make sure caching is working properly.
 			// Need to manually check because we don't know the order the
 			// user/service/category labels will be iterated over. For some tests this
 			// could cause more loads than the ideal case.
@@ -542,7 +875,12 @@ func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshots_customTags() {
 				expected = append(expected, data[i].man)
 			}
 
-			assert.ElementsMatch(t, expected, snaps)
+			got := make([]*snapshot.Manifest, 0, len(snaps))
+			for _, s := range snaps {
+				got = append(got, s.Manifest)
+			}
+
+			assert.ElementsMatch(t, expected, got)
 
 			// Need to manually check because we don't know the order the
 			// user/service/category labels will be iterated over. For some tests this

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/uuid"
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/kopia/kopia/snapshot"
 	"github.com/pkg/errors"
 
 	"github.com/alcionai/corso/src/internal/common"
@@ -181,7 +180,7 @@ func produceManifestsAndMetadata(
 	sw *store.Wrapper,
 	oc *kopia.OwnersCats,
 	acct account.Account,
-) ([]*snapshot.Manifest, []data.Collection, error) {
+) ([]*kopia.ManifestEntry, []data.Collection, error) {
 	complete, closer := observe.MessageWithCompletion("Fetching backup heuristics:")
 	defer func() {
 		complete <- struct{}{}
@@ -337,7 +336,7 @@ func consumeBackupDataCollections(
 	kw *kopia.Wrapper,
 	sel selectors.Selector,
 	oc *kopia.OwnersCats,
-	mans []*snapshot.Manifest,
+	mans []*kopia.ManifestEntry,
 	cs []data.Collection,
 	backupID model.StableID,
 ) (*kopia.BackupStats, *details.Details, error) {


### PR DESCRIPTION
## Description

For each snapshot manifest returned when looking for previous snapshots for a given set of owners cats, return the reason the snapshot was selected. This will allow other code to select the correct metadata and base snapshot subtree(s) when making incremental backups.

An example of when all metadata and directories in a base snapshot may not be needed is
```text
backup create exchange --data email,contacts --users user1 -> B1

// uses B1 as the base
backup create exchange --data email --users user1 -> B2

// uses B1 as the base for contacts and B2 as the base for email
backup create exchange --data email,contacts --users user1 -> B3
```

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* closes #1779

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
