### PR TITLE
Add an `updated` flag to backup details

### DIFF
--- a/src/internal/connector/exchange/service_restore.go
+++ b/src/internal/connector/exchange/service_restore.go
@@ -415,6 +415,7 @@ func restoreCollection(
 				itemPath.String(),
 				itemPath.ShortRef(),
 				"",
+				true,
 				details.ItemInfo{
 					Exchange: info,
 				})

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -171,6 +171,7 @@ func RestoreCollection(
 				itemPath.String(),
 				itemPath.ShortRef(),
 				"",
+				true,
 				itemInfo)
 
 			metrics.Successes++

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -157,6 +157,7 @@ func (cp *corsoProgress) FinishedFile(relativePath string, err error) {
 		d.repoPath.String(),
 		d.repoPath.ShortRef(),
 		parent.ShortRef(),
+		true,
 		d.info,
 	)
 

--- a/src/internal/streamstore/streamstore_test.go
+++ b/src/internal/streamstore/streamstore_test.go
@@ -48,7 +48,7 @@ func (suite *StreamStoreIntegrationSuite) TestDetails() {
 
 	deets := &details.Details{}
 
-	deets.Add("ref", "shortref", "parentref",
+	deets.Add("ref", "shortref", "parentref", true,
 		details.ItemInfo{
 			Exchange: &details.ExchangeInfo{
 				Subject: "hello world",
@@ -69,6 +69,7 @@ func (suite *StreamStoreIntegrationSuite) TestDetails() {
 	assert.Equal(t, deets.Entries[0].ParentRef, readDeets.Entries[0].ParentRef)
 	assert.Equal(t, deets.Entries[0].ShortRef, readDeets.Entries[0].ShortRef)
 	assert.Equal(t, deets.Entries[0].RepoRef, readDeets.Entries[0].RepoRef)
+	assert.Equal(t, deets.Entries[0].Updated, readDeets.Entries[0].Updated)
 	assert.NotNil(t, readDeets.Entries[0].Exchange)
 	assert.Equal(t, *deets.Entries[0].Exchange, *readDeets.Entries[0].Exchange)
 }

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -115,13 +115,14 @@ type Details struct {
 	knownFolders map[string]struct{} `json:"-"`
 }
 
-func (d *Details) Add(repoRef, shortRef, parentRef string, info ItemInfo) {
+func (d *Details) Add(repoRef, shortRef, parentRef string, updated bool, info ItemInfo) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.Entries = append(d.Entries, DetailsEntry{
 		RepoRef:   repoRef,
 		ShortRef:  shortRef,
 		ParentRef: parentRef,
+		Updated:   updated,
 		ItemInfo:  info,
 	})
 }
@@ -163,6 +164,9 @@ type DetailsEntry struct {
 	RepoRef   string `json:"repoRef"`
 	ShortRef  string `json:"shortRef"`
 	ParentRef string `json:"parentRef,omitempty"`
+	// Indicates the item was added or updated in this backup
+	// Always `true` for full backups
+	Updated bool `json:"updated"`
 	ItemInfo
 }
 


### PR DESCRIPTION
## Description

Adds a flag in backup details that indicates whether the item in that backup is new/updated.

Currently always set to `true` but once we implement #1800 - we will set this to false for existing items from
base snapshots.

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #1812 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
