### PR TITLE
deduplicate cache folders

### DIFF
--- a/src/internal/connector/data_collections_test.go
+++ b/src/internal/connector/data_collections_test.go
@@ -551,9 +551,11 @@ func (suite *ConnectorCreateExchangeCollectionIntegrationSuite) TestEventsSerial
 
 				for stream := range streamChannel {
 					buf := &bytes.Buffer{}
+
 					read, err := buf.ReadFrom(stream.ToReader())
 					assert.NoError(t, err)
 					assert.NotZero(t, read)
+
 					event, err := support.CreateEventFromBytes(buf.Bytes())
 					assert.NotNil(t, event)
 					assert.NoError(t, err, "creating event from bytes: "+buf.String())

--- a/src/internal/connector/exchange/cache_container.go
+++ b/src/internal/connector/exchange/cache_container.go
@@ -5,7 +5,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/alcionai/corso/src/internal/connector/graph"
-	"github.com/alcionai/corso/src/pkg/path"
 )
 
 // checkIDAndName is a helper function to ensure that
@@ -37,29 +36,6 @@ func checkRequiredValues(c graph.Container) error {
 	}
 
 	return nil
-}
-
-// =========================================
-// cachedContainer Implementations
-// =========================================
-
-var _ graph.CachedContainer = &cacheFolder{}
-
-type cacheFolder struct {
-	graph.Container
-	p *path.Builder
-}
-
-// =========================================
-// Required Functions to satisfy interfaces
-// =========================================
-
-func (cf cacheFolder) Path() *path.Builder {
-	return cf.p
-}
-
-func (cf *cacheFolder) SetPath(newPath *path.Builder) {
-	cf.p = newPath
 }
 
 // CalendarDisplayable is a transformative struct that aligns

--- a/src/internal/connector/exchange/contact_folder_cache.go
+++ b/src/internal/connector/exchange/contact_folder_cache.go
@@ -43,10 +43,7 @@ func (cfc *contactFolderCache) populateContactRoot(
 			"fetching root contact folder: "+support.ConnectorStackErrorTrace(err))
 	}
 
-	temp := cacheFolder{
-		Container: f,
-		p:         path.Builder{}.Append(baseContainerPath...),
-	}
+	temp := graph.NewCacheFolder(f, path.Builder{}.Append(baseContainerPath...))
 
 	if err := cfc.addFolder(temp); err != nil {
 		return errors.Wrap(err, "adding cache root")
@@ -100,9 +97,7 @@ func (cfc *contactFolderCache) Populate(
 				continue
 			}
 
-			temp := cacheFolder{
-				Container: fold,
-			}
+			temp := graph.NewCacheFolder(fold, nil)
 
 			err = cfc.addFolder(temp)
 			if err != nil {

--- a/src/internal/connector/exchange/container_resolver.go
+++ b/src/internal/connector/exchange/container_resolver.go
@@ -85,10 +85,10 @@ func (cr *containerResolver) PathInCache(pathString string) (string, bool) {
 
 // addFolder adds a folder to the cache with the given ID. If the item is
 // already in the cache does nothing. The path for the item is not modified.
-func (cr *containerResolver) addFolder(cf cacheFolder) error {
+func (cr *containerResolver) addFolder(cf graph.CacheFolder) error {
 	// Only require a non-nil non-empty parent if the path isn't already
 	// populated.
-	if cf.p != nil {
+	if cf.Path() != nil {
 		if err := checkIDAndName(cf.Container); err != nil {
 			return errors.Wrap(err, "adding item to cache")
 		}
@@ -120,7 +120,7 @@ func (cr *containerResolver) Items() []graph.CachedContainer {
 // AddToCache adds container to map in field 'cache'
 // @returns error iff the required values are not accessible.
 func (cr *containerResolver) AddToCache(ctx context.Context, f graph.Container) error {
-	temp := cacheFolder{
+	temp := graph.CacheFolder{
 		Container: f,
 	}
 

--- a/src/internal/connector/exchange/container_resolver_test.go
+++ b/src/internal/connector/exchange/container_resolver_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/path"
 )
@@ -144,67 +145,67 @@ func (suite *FolderCacheUnitSuite) TestCheckRequiredValues() {
 func (suite *FolderCacheUnitSuite) TestAddFolder() {
 	table := []struct {
 		name  string
-		cf    cacheFolder
+		cf    graph.CacheFolder
 		check assert.ErrorAssertionFunc
 	}{
 		{
 			name: "NoParentNoPath",
-			cf: cacheFolder{
-				Container: &mockContainer{
+			cf: graph.NewCacheFolder(
+				&mockContainer{
 					id:       &testID,
 					name:     &testName,
 					parentID: nil,
 				},
-				p: nil,
-			},
+				nil,
+			),
 			check: assert.Error,
 		},
 		{
 			name: "NoParentPath",
-			cf: cacheFolder{
-				Container: &mockContainer{
+			cf: graph.NewCacheFolder(
+				&mockContainer{
 					id:       &testID,
 					name:     &testName,
 					parentID: nil,
 				},
-				p: path.Builder{}.Append("foo"),
-			},
+				path.Builder{}.Append("foo"),
+			),
 			check: assert.NoError,
 		},
 		{
 			name: "NoName",
-			cf: cacheFolder{
-				Container: &mockContainer{
+			cf: graph.NewCacheFolder(
+				&mockContainer{
 					id:       &testID,
 					name:     nil,
 					parentID: &testParentID,
 				},
-				p: path.Builder{}.Append("foo"),
-			},
+				path.Builder{}.Append("foo"),
+			),
 			check: assert.Error,
 		},
 		{
 			name: "NoID",
-			cf: cacheFolder{
-				Container: &mockContainer{
+			cf: graph.NewCacheFolder(
+				&mockContainer{
 					id:       nil,
 					name:     &testName,
 					parentID: &testParentID,
 				},
-				p: path.Builder{}.Append("foo"),
-			},
+				path.Builder{}.Append("foo"),
+			),
 			check: assert.Error,
 		},
 		{
 			name: "NoPath",
-			cf: cacheFolder{
-				Container: &mockContainer{
+			cf: graph.NewCacheFolder(
+				&mockContainer{
 					id:       &testID,
 					name:     &testName,
 					parentID: &testParentID,
 				},
-				p: nil,
-			},
+				nil,
+			),
 			check: assert.NoError,
 		},
 	}

--- a/src/internal/connector/exchange/data_collections.go
+++ b/src/internal/connector/exchange/data_collections.go
@@ -16,7 +16,7 @@ import (
 func MetadataFileNames(cat path.CategoryType) []string {
 	switch cat {
 	case path.EmailCategory, path.ContactsCategory:
-		return []string{graph.DeltaTokenFileName, graph.PreviousPathFileName}
+		return []string{graph.DeltaURLsFileName, graph.PreviousPathFileName}
 	default:
 		return []string{graph.PreviousPathFileName}
 	}
@@ -82,7 +82,7 @@ func ParseMetadataCollections(
 
 					cdps.paths = m
 
-				case graph.DeltaTokenFileName:
+				case graph.DeltaURLsFileName:
 					if len(cdps.deltas) > 0 {
 						return nil, errors.Errorf("multiple versions of %s delta metadata", category)
 					}

--- a/src/internal/connector/exchange/data_collections_test.go
+++ b/src/internal/connector/exchange/data_collections_test.go
@@ -123,27 +123,6 @@ func (suite *DataCollectionsUnitSuite) TestParseMetadataCollections() {
 			},
 			expectError: assert.NoError,
 		},
-		{
-			name: "delta urls with escaped chars",
-			data: []fileValues{
-				{graph.DeltaTokenFileName, `\n\r\t\b\f\v\0\\`},
-			},
-			expectDeltas: map[string]string{
-				"key": "\\n\\r\\t\\b\\f\\v\\0\\\\",
-			},
-		},
-		{
-			name: "delta urls with newline char runes",
-			data: []fileValues{
-				// rune(92) = \, rune(110) = n.  Ensuring it's not possible to
-				// error in serializing/deserializing and produce a single newline
-				// character from those two runes.
-				{graph.DeltaTokenFileName, string([]rune{rune(92), rune(110)})},
-			},
-			expectDeltas: map[string]string{
-				"key": "\\n",
-			},
-		},
 	}
 	for _, test := range table {
 		suite.T().Run(test.name, func(t *testing.T) {

--- a/src/internal/connector/exchange/data_collections_test.go
+++ b/src/internal/connector/exchange/data_collections_test.go
@@ -187,9 +187,6 @@ func (suite *DataCollectionsUnitSuite) TestParseMetadataCollections() {
 			emails := cdps[path.EmailCategory]
 			deltas, paths := emails.deltas, emails.paths
 
-			deltas := cdps[path.EmailCategory].deltas
-			paths := cdps[path.EmailCategory].paths
-
 			if len(test.expectDeltas) > 0 {
 				assert.NotEmpty(t, deltas, "deltas")
 			}

--- a/src/internal/connector/exchange/data_collections_test.go
+++ b/src/internal/connector/exchange/data_collections_test.go
@@ -123,39 +123,6 @@ func (suite *DataCollectionsUnitSuite) TestParseMetadataCollections() {
 			},
 			expectError: assert.NoError,
 		},
-		{
-			name: "previous paths",
-			data: []fileValues{
-				{graph.PreviousPathFileName, "previous-path"},
-			},
-			expectPaths: map[string]string{
-				"key": "previous-path",
-			},
-		},
-		{
-			name: "delas and paths",
-			data: []fileValues{
-				{graph.PreviousPathFileName, "previous-path"},
-				{graph.DeltaURLsFileName, "delta-link"},
-			},
-			expectDeltas: map[string]string{
-				"key": "delta-link",
-			},
-			expectPaths: map[string]string{
-				"key": "previous-path",
-			},
-		},
-		{
-			name: "multiple paths files",
-			data: []fileValues{
-				{graph.PreviousPathFileName, "previous-path"},
-				{graph.PreviousPathFileName, "previous-path-2"},
-			},
-			expectPaths: map[string]string{
-				// the second collection clobbers the first on union.
-				"key": "previous-path-2",
-			},
-		},
 	}
 	for _, test := range table {
 		suite.T().Run(test.name, func(t *testing.T) {

--- a/src/internal/connector/exchange/data_collections_test.go
+++ b/src/internal/connector/exchange/data_collections_test.go
@@ -135,9 +135,9 @@ func (suite *DataCollectionsUnitSuite) TestParseMetadataCollections() {
 		{
 			name: "delta urls with newline char runes",
 			data: []fileValues{
-				// rune(92) = \, rune(110) = n.  If a parsing error were possible
-				// by serializing/deserializing those two runes and producing a
-				// single newline character, this would produce it.
+				// rune(92) = \, rune(110) = n.  Ensuring it's not possible to
+				// error in serializing/deserializing and produce a single newline
+				// character from those two runes.
 				{graph.DeltaTokenFileName, string([]rune{rune(92), rune(110)})},
 			},
 			expectDeltas: map[string]string{

--- a/src/internal/connector/exchange/data_collections_test.go
+++ b/src/internal/connector/exchange/data_collections_test.go
@@ -123,6 +123,15 @@ func (suite *DataCollectionsUnitSuite) TestParseMetadataCollections() {
 			},
 			expectError: assert.NoError,
 		},
+		{
+			name: "delta urls with escaped chars",
+			data: []fileValues{
+				{graph.DeltaTokenFileName, `\n\r\t\b\f\v\0\\`},
+			},
+			expectDeltas: map[string]string{
+				"key": "\\n\\r\\t\\b\\f\\v\\0\\\\",
+			},
+		},
 	}
 	for _, test := range table {
 		suite.T().Run(test.name, func(t *testing.T) {

--- a/src/internal/connector/exchange/data_collections_test.go
+++ b/src/internal/connector/exchange/data_collections_test.go
@@ -132,6 +132,18 @@ func (suite *DataCollectionsUnitSuite) TestParseMetadataCollections() {
 				"key": "\\n\\r\\t\\b\\f\\v\\0\\\\",
 			},
 		},
+		{
+			name: "delta urls with newline char runes",
+			data: []fileValues{
+				// rune(92) = \, rune(110) = n.  If a parsing error were possible
+				// by serializing/deserializing those two runes and producing a
+				// single newline character, this would produce it.
+				{graph.DeltaTokenFileName, string([]rune{rune(92), rune(110)})},
+			},
+			expectDeltas: map[string]string{
+				"key": "\\n",
+			},
+		},
 	}
 	for _, test := range table {
 		suite.T().Run(test.name, func(t *testing.T) {

--- a/src/internal/connector/exchange/event_calendar_cache.go
+++ b/src/internal/connector/exchange/event_calendar_cache.go
@@ -72,10 +72,7 @@ func (ecc *eventCalendarCache) Populate(
 	}
 
 	for _, container := range directories {
-		temp := cacheFolder{
-			Container: container,
-			p:         path.Builder{}.Append(*container.GetDisplayName()),
-		}
+		temp := graph.NewCacheFolder(container, path.Builder{}.Append(*container.GetDisplayName()))
 
 		if err := ecc.addFolder(temp); err != nil {
 			errs = support.WrapAndAppend(
@@ -95,10 +92,7 @@ func (ecc *eventCalendarCache) AddToCache(ctx context.Context, f graph.Container
 		return errors.Wrap(err, "adding cache folder")
 	}
 
-	temp := cacheFolder{
-		Container: f,
-		p:         path.Builder{}.Append(*f.GetDisplayName()),
-	}
+	temp := graph.NewCacheFolder(f, path.Builder{}.Append(*f.GetDisplayName()))
 
 	if err := ecc.addFolder(temp); err != nil {
 		return errors.Wrap(err, "adding cache folder")

--- a/src/internal/connector/exchange/mail_folder_cache.go
+++ b/src/internal/connector/exchange/mail_folder_cache.go
@@ -55,10 +55,7 @@ func (mc *mailFolderCache) populateMailRoot(
 			directory = DefaultMailFolder
 		}
 
-		temp := cacheFolder{
-			Container: f,
-			p:         path.Builder{}.Append(directory),
-		}
+		temp := graph.NewCacheFolder(f, path.Builder{}.Append(directory))
 
 		if err := mc.addFolder(temp); err != nil {
 			return errors.Wrap(err, "initializing mail resolver")
@@ -98,9 +95,7 @@ func (mc *mailFolderCache) Populate(
 		}
 
 		for _, f := range resp.GetValue() {
-			temp := cacheFolder{
-				Container: f,
-			}
+			temp := graph.NewCacheFolder(f, nil)
 
 			// Use addFolder instead of AddToCache to be conservative about path
 			// population. The fetch order of the folders could cause failures while

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -113,7 +113,7 @@ func FilterContainersAndFillCollections(
 	}
 
 	if len(deltaURLs) > 0 {
-		entries = append(entries, graph.NewMetadataEntry(graph.DeltaTokenFileName, deltaURLs))
+		entries = append(entries, graph.NewMetadataEntry(graph.DeltaURLsFileName, deltaURLs))
 	}
 
 	if col, err := graph.MakeMetadataCollection(

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -116,14 +116,6 @@ func FilterContainersAndFillCollections(
 		entries = append(entries, graph.NewMetadataEntry(graph.DeltaTokenFileName, deltaURLs))
 	}
 
-	entries := []graph.MetadataCollectionEntry{
-		graph.NewMetadataEntry(graph.PreviousPathFileName, prevPaths),
-	}
-
-	if len(deltaURLs) > 0 {
-		entries = append(entries, graph.NewMetadataEntry(graph.DeltaTokenFileName, deltaURLs))
-	}
-
 	if col, err := graph.MakeMetadataCollection(
 		qp.Credentials.AzureTenantID,
 		qp.ResourceOwner,

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -116,6 +116,14 @@ func FilterContainersAndFillCollections(
 		entries = append(entries, graph.NewMetadataEntry(graph.DeltaTokenFileName, deltaURLs))
 	}
 
+	entries := []graph.MetadataCollectionEntry{
+		graph.NewMetadataEntry(graph.PreviousPathFileName, prevPaths),
+	}
+
+	if len(deltaURLs) > 0 {
+		entries = append(entries, graph.NewMetadataEntry(graph.DeltaTokenFileName, deltaURLs))
+	}
+
 	if col, err := graph.MakeMetadataCollection(
 		qp.Credentials.AzureTenantID,
 		qp.ResourceOwner,

--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -10,9 +10,9 @@ import (
 )
 
 const (
-	// DeltaTokenFileName is the name of the file containing delta token(s) for a
+	// DeltaURLsFileName is the name of the file containing delta token(s) for a
 	// given endpoint. The endpoint granularity varies by service.
-	DeltaTokenFileName = "delta"
+	DeltaURLsFileName = "delta"
 	// PreviousPathFileName is the name of the file containing previous path(s) for a
 	// given endpoint.
 	PreviousPathFileName = "previouspath"
@@ -21,7 +21,7 @@ const (
 // AllMetadataFileNames produces the standard set of filenames used to store graph
 // metadata such as delta tokens and folderID->path references.
 func AllMetadataFileNames() []string {
-	return []string{DeltaTokenFileName, PreviousPathFileName}
+	return []string{DeltaURLsFileName, PreviousPathFileName}
 }
 
 type QueryParams struct {

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -2,6 +2,7 @@ package operations
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -228,6 +229,8 @@ func checkMetadataFilesExist(
 
 		for item := range col.Items() {
 			assert.Implements(t, (*data.StreamSize)(nil), item)
+
+			fmt.Printf("\n-----\nrestored %v %v\n-----\n", item.UUID(), col.FullPath())
 
 			s := item.(data.StreamSize)
 			assert.Greaterf(

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -2,7 +2,6 @@ package operations
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -229,8 +228,6 @@ func checkMetadataFilesExist(
 
 		for item := range col.Items() {
 			assert.Implements(t, (*data.StreamSize)(nil), item)
-
-			fmt.Printf("\n-----\nrestored %v %v\n-----\n", item.UUID(), col.FullPath())
 
 			s := item.(data.StreamSize)
 			assert.Greaterf(


### PR DESCRIPTION
## Description

These two structures are effectively identical.
This refactor deferrs to the graph version since
services may still wrap that for more specific
behavior as needed.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :hamster: Trivial/Minor

## Issue(s)

* #1727

## Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
