### PR TITLE
Select subtrees of data from base snapshots based on reason snapshot was picked

### DIFF
--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -650,6 +650,29 @@ func traverseBaseDir(
 	return nil
 }
 
+// TODO(ashmrtn): We may want to move this to BackupOp and pass in
+// (Manifest, path) to kopia.BackupCollections() instead of passing in
+// ManifestEntry. That would keep kopia from having to know anything about how
+// paths are formed. It would just encode/decode them and do basic manipulations
+// like pushing/popping elements on a path based on location in the hierarchy.
+func encodedElementsForPath(tenant string, r Reason) (*path.Builder, error) {
+	// This is hacky, but we want the path package to format the path the right
+	// way (e.x. proper order for service, category, etc), but we don't care about
+	// the folders after the prefix.
+	p, err := path.Builder{}.Append("tmp").ToDataLayerPath(
+		tenant,
+		r.ResourceOwner,
+		r.Service,
+		r.Category,
+		false,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "building path")
+	}
+
+	return p.ToBuilder().Dir(), nil
+}
+
 func inflateBaseTree(
 	ctx context.Context,
 	loader snapshotLoader,

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/kopia/kopia/fs"
 	"github.com/kopia/kopia/fs/virtualfs"
-	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/snapshotfs"
 	"github.com/pkg/errors"
 
@@ -676,7 +675,7 @@ func encodedElementsForPath(tenant string, r Reason) (*path.Builder, error) {
 func inflateBaseTree(
 	ctx context.Context,
 	loader snapshotLoader,
-	snap *snapshot.Manifest,
+	snap *ManifestEntry,
 	updatedPaths map[string]path.Path,
 	roots map[string]*treeMap,
 ) error {
@@ -687,7 +686,7 @@ func inflateBaseTree(
 		return nil
 	}
 
-	root, err := loader.SnapshotRoot(snap)
+	root, err := loader.SnapshotRoot(snap.Manifest)
 	if err != nil {
 		return errors.Wrapf(err, "getting snapshot %s root directory", snap.ID)
 	}
@@ -727,7 +726,7 @@ func inflateBaseTree(
 func inflateDirTree(
 	ctx context.Context,
 	loader snapshotLoader,
-	baseSnaps []*snapshot.Manifest,
+	baseSnaps []*ManifestEntry,
 	collections []data.Collection,
 	progress *corsoProgress,
 ) (fs.Directory, error) {

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -710,8 +710,7 @@ func inflateBaseTree(
 			return errors.Wrapf(err, "snapshot %s getting path elements", snap.ID)
 		}
 
-		// Root directory is not included in the lookup path we give kopia as we're
-		// starting from the root.
+		// We're starting from the root directory so don't need it in the path.
 		pathElems := encodeElements(pb.PopFront().Elements()...)
 
 		ent, err := snapshotfs.GetNestedEntry(ctx, dir, pathElems)

--- a/src/internal/kopia/upload_test.go
+++ b/src/internal/kopia/upload_test.go
@@ -1545,3 +1545,248 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSkipsDeletedSubtre
 
 	expectTree(t, ctx, expected, dirTree)
 }
+
+type mockMultiSnapshotWalker struct {
+	snaps map[string]fs.Entry
+}
+
+func (msw *mockMultiSnapshotWalker) SnapshotRoot(man *snapshot.Manifest) (fs.Entry, error) {
+	if snap := msw.snaps[string(man.ID)]; snap != nil {
+		return snap, nil
+	}
+
+	return nil, errors.New("snapshot not found")
+}
+
+func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSelectsCorrectSubtrees() {
+	tester.LogTimeOfTest(suite.T())
+	t := suite.T()
+
+	ctx, flush := tester.NewContext()
+	defer flush()
+
+	const contactsDir = "contacts"
+
+	inboxPath := makePath(
+		suite.T(),
+		[]string{testTenant, service, testUser, category, testInboxDir},
+	)
+
+	inboxFileName1 := testFileName
+	inboxFileName2 := testFileName2
+
+	inboxFileData1 := testFileData
+	inboxFileData1v2 := testFileData5
+	inboxFileData2 := testFileData2
+
+	contactsFileName1 := testFileName3
+	contactsFileData1 := testFileData3
+
+	eventsFileName1 := testFileName5
+	eventsFileData1 := testFileData
+
+	// Must be a function that returns a new instance each time as StreamingFile
+	// can only return its Reader once.
+	// baseSnapshot with the following layout:
+	// - a-tenant
+	//   - exchange
+	//     - user1
+	//       - email
+	//         - Inbox
+	//           - file1
+	//       - contacts
+	//         - contacts
+	//           - file2
+	getBaseSnapshot1 := func() fs.Entry {
+		return baseWithChildren(
+			[]string{
+				testTenant,
+				service,
+				testUser,
+			},
+			[]fs.Entry{
+				virtualfs.NewStaticDirectory(
+					encodeElements(category)[0],
+					[]fs.Entry{
+						virtualfs.NewStaticDirectory(
+							encodeElements(testInboxDir)[0],
+							[]fs.Entry{
+								virtualfs.StreamingFileWithModTimeFromReader(
+									encodeElements(inboxFileName1)[0],
+									time.Time{},
+									bytes.NewReader(inboxFileData1),
+								),
+							},
+						),
+					},
+				),
+				virtualfs.NewStaticDirectory(
+					encodeElements(path.ContactsCategory.String())[0],
+					[]fs.Entry{
+						virtualfs.NewStaticDirectory(
+							encodeElements(contactsDir)[0],
+							[]fs.Entry{
+								virtualfs.StreamingFileWithModTimeFromReader(
+									encodeElements(contactsFileName1)[0],
+									time.Time{},
+									bytes.NewReader(contactsFileData1),
+								),
+							},
+						),
+					},
+				),
+			},
+		)
+	}
+
+	// Must be a function that returns a new instance each time as StreamingFile
+	// can only return its Reader once.
+	// baseSnapshot with the following layout:
+	// - a-tenant
+	//   - exchange
+	//     - user1
+	//       - email
+	//         - Inbox
+	//           - file1 <- has different data version
+	//       - events
+	//         - events
+	//           - file3
+	getBaseSnapshot2 := func() fs.Entry {
+		return baseWithChildren(
+			[]string{
+				testTenant,
+				service,
+				testUser,
+			},
+			[]fs.Entry{
+				virtualfs.NewStaticDirectory(
+					encodeElements(category)[0],
+					[]fs.Entry{
+						virtualfs.NewStaticDirectory(
+							encodeElements(testInboxDir)[0],
+							[]fs.Entry{
+								virtualfs.StreamingFileWithModTimeFromReader(
+									encodeElements(inboxFileName1)[0],
+									time.Time{},
+									// Wrap with a backup reader so it gets the version injected.
+									newBackupStreamReader(
+										serializationVersion,
+										io.NopCloser(bytes.NewReader(inboxFileData1v2)),
+									),
+								),
+							},
+						),
+					},
+				),
+				virtualfs.NewStaticDirectory(
+					encodeElements(path.EventsCategory.String())[0],
+					[]fs.Entry{
+						virtualfs.NewStaticDirectory(
+							encodeElements("events")[0],
+							[]fs.Entry{
+								virtualfs.StreamingFileWithModTimeFromReader(
+									encodeElements(eventsFileName1)[0],
+									time.Time{},
+									bytes.NewReader(eventsFileData1),
+								),
+							},
+						),
+					},
+				),
+			},
+		)
+	}
+
+	// Check the following:
+	//   * contacts pulled from base1 unchanged even if no collections reference
+	//     it
+	//   * email pulled from base2
+	//   * new email added
+	//   * events not pulled from base2 as it's not listed as a Reason
+	//
+	// Expected output:
+	// - a-tenant
+	//   - exchange
+	//     - user1
+	//       - email
+	//         - Inbox
+	//           - file1 <- version of data from second base
+	//           - file2
+	//       - contacts
+	//         - contacts
+	//           - file2
+	expected := expectedTreeWithChildren(
+		[]string{
+			testTenant,
+			service,
+			testUser,
+		},
+		[]*expectedNode{
+			{
+				name: category,
+				children: []*expectedNode{
+					{
+						name: testInboxDir,
+						children: []*expectedNode{
+							{
+								name:     inboxFileName1,
+								children: []*expectedNode{},
+								data:     inboxFileData1v2,
+							},
+							{
+								name:     inboxFileName2,
+								children: []*expectedNode{},
+								data:     inboxFileData2,
+							},
+						},
+					},
+				},
+			},
+			{
+				name: path.ContactsCategory.String(),
+				children: []*expectedNode{
+					{
+						name: contactsDir,
+						children: []*expectedNode{
+							{
+								name:     contactsFileName1,
+								children: []*expectedNode{},
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+
+	progress := &corsoProgress{pending: map[string]*itemDetails{}}
+
+	mc := mockconnector.NewMockExchangeCollection(inboxPath, 1)
+	mc.PrevPath = mc.FullPath()
+	mc.ColState = data.NotMovedState
+	mc.Names[0] = inboxFileName2
+	mc.Data[0] = inboxFileData2
+
+	msw := &mockMultiSnapshotWalker{
+		snaps: map[string]fs.Entry{
+			"id1": getBaseSnapshot1(),
+			"id2": getBaseSnapshot2(),
+		},
+	}
+
+	collections := []data.Collection{mc}
+
+	dirTree, err := inflateDirTree(
+		ctx,
+		msw,
+		[]*ManifestEntry{
+			mockSnapshotEntry("id1", testUser, path.ExchangeService, path.ContactsCategory),
+			mockSnapshotEntry("id2", testUser, path.ExchangeService, path.EmailCategory),
+		},
+		collections,
+		progress,
+	)
+	require.NoError(t, err)
+
+	expectTree(t, ctx, expected, dirTree)
+}

--- a/src/internal/kopia/upload_test.go
+++ b/src/internal/kopia/upload_test.go
@@ -34,7 +34,7 @@ func makePath(t *testing.T, elements []string) path.Path {
 
 // baseWithChildren returns an fs.Entry hierarchy where the first len(basic)
 // levels are the encoded values of basic in order. All items in children are
-// made a direct descendent of the final entry in basic.
+// used as the direct descendents of the final entry in basic.
 func baseWithChildren(
 	basic []string,
 	children []fs.Entry,

--- a/src/internal/kopia/upload_test.go
+++ b/src/internal/kopia/upload_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kopia/kopia/fs"
 	"github.com/kopia/kopia/fs/virtualfs"
+	"github.com/kopia/kopia/repo/manifest"
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/snapshotfs"
 	"github.com/pkg/errors"
@@ -798,6 +799,25 @@ func (msw *mockSnapshotWalker) SnapshotRoot(*snapshot.Manifest) (fs.Entry, error
 	return msw.snapshotRoot, nil
 }
 
+func mockSnapshotEntry(
+	id, resourceOwner string,
+	service path.ServiceType,
+	category path.CategoryType,
+) *ManifestEntry {
+	return &ManifestEntry{
+		Manifest: &snapshot.Manifest{
+			ID: manifest.ID(id),
+		},
+		Reasons: []Reason{
+			{
+				ResourceOwner: resourceOwner,
+				Service:       service,
+				Category:      category,
+			},
+		},
+	}
+}
+
 func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
 	dirPath := makePath(
 		suite.T(),
@@ -941,7 +961,9 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
 			dirTree, err := inflateDirTree(
 				ctx,
 				msw,
-				[]*snapshot.Manifest{{}},
+				[]*ManifestEntry{
+					mockSnapshotEntry("", testUser, path.ExchangeService, path.EmailCategory),
+				},
 				test.inputCollections(),
 				progress,
 			)
@@ -1353,7 +1375,9 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 			dirTree, err := inflateDirTree(
 				ctx,
 				msw,
-				[]*snapshot.Manifest{{}},
+				[]*ManifestEntry{
+					mockSnapshotEntry("", testUser, path.ExchangeService, path.EmailCategory),
+				},
 				test.inputCollections(t),
 				progress,
 			)
@@ -1511,7 +1535,9 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSkipsDeletedSubtre
 	dirTree, err := inflateDirTree(
 		ctx,
 		msw,
-		[]*snapshot.Manifest{{}},
+		[]*ManifestEntry{
+			mockSnapshotEntry("", testUser, path.ExchangeService, path.EmailCategory),
+		},
 		collections,
 		progress,
 	)

--- a/src/pkg/path/path.go
+++ b/src/pkg/path/path.go
@@ -360,12 +360,13 @@ func (pb Builder) ToServiceCategoryMetadataPath(
 	}, nil
 }
 
-func (pb Builder) ToDataLayerExchangePathForCategory(
+func (pb Builder) ToDataLayerPath(
 	tenant, user string,
+	service ServiceType,
 	category CategoryType,
 	isItem bool,
 ) (Path, error) {
-	if err := validateServiceAndCategory(ExchangeService, category); err != nil {
+	if err := validateServiceAndCategory(service, category); err != nil {
 		return nil, err
 	}
 
@@ -376,35 +377,29 @@ func (pb Builder) ToDataLayerExchangePathForCategory(
 	return &dataLayerResourcePath{
 		Builder: *pb.withPrefix(
 			tenant,
-			ExchangeService.String(),
+			service.String(),
 			user,
 			category.String(),
 		),
-		service:  ExchangeService,
+		service:  service,
 		category: category,
 		hasItem:  isItem,
 	}, nil
+}
+
+func (pb Builder) ToDataLayerExchangePathForCategory(
+	tenant, user string,
+	category CategoryType,
+	isItem bool,
+) (Path, error) {
+	return pb.ToDataLayerPath(tenant, user, ExchangeService, category, isItem)
 }
 
 func (pb Builder) ToDataLayerOneDrivePath(
 	tenant, user string,
 	isItem bool,
 ) (Path, error) {
-	if err := pb.verifyPrefix(tenant, user); err != nil {
-		return nil, err
-	}
-
-	return &dataLayerResourcePath{
-		Builder: *pb.withPrefix(
-			tenant,
-			OneDriveService.String(),
-			user,
-			FilesCategory.String(),
-		),
-		service:  OneDriveService,
-		category: FilesCategory,
-		hasItem:  isItem,
-	}, nil
+	return pb.ToDataLayerPath(tenant, user, OneDriveService, FilesCategory, isItem)
 }
 
 func (pb Builder) ToDataLayerSharePointPath(
@@ -412,21 +407,7 @@ func (pb Builder) ToDataLayerSharePointPath(
 	category CategoryType,
 	isItem bool,
 ) (Path, error) {
-	if err := pb.verifyPrefix(tenant, site); err != nil {
-		return nil, err
-	}
-
-	return &dataLayerResourcePath{
-		Builder: *pb.withPrefix(
-			tenant,
-			SharePointService.String(),
-			site,
-			category.String(),
-		),
-		service:  SharePointService,
-		category: category,
-		hasItem:  isItem,
-	}, nil
+	return pb.ToDataLayerPath(tenant, site, SharePointService, category, isItem)
 }
 
 // FromDataLayerPath parses the escaped path p, validates the elements in p


### PR DESCRIPTION
## Description

Pick what data to source from a base snapshot by examining the reason the snapshot was selected as a base. This helps avoid two issues:
* pulling in unwanted data when the base has a superset of what is being backed up. Example: pulling in contacts from the base when only email is being backed up
* clobbering already selected data from a different base with data in the base currently being examined. Example: two snapshots, one with contacts and emails and the other with just emails. Second snapshot is newer than the first. The email items in the first snapshot should not clobber those in the first when building the hierarchy

This PR also has the effect of, under some conditions, reducing the amount of data that is pulled from the remote kopia repo when building the hierarchy. This occurs because only the subtrees that will be used in the new backup are traversed instead of traversing the entire snapshot

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* #1740 

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
