### PR TITLE
Reuse base snapshots

### DIFF
--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -262,11 +262,13 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 		},
 	}
 
+	prevSnaps := []*ManifestEntry{}
+
 	for _, test := range table {
 		suite.T().Run(test.name, func(t *testing.T) {
 			stats, deets, err := suite.w.BackupCollections(
 				suite.ctx,
-				nil,
+				prevSnaps,
 				collections,
 				path.ExchangeService,
 				oc,
@@ -295,6 +297,19 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 				expectedTags,
 				stats.SnapshotID,
 			)
+
+			snap, err := snapshot.LoadSnapshot(
+				suite.ctx,
+				suite.w.c,
+				manifest.ID(stats.SnapshotID),
+			)
+			require.NoError(t, err)
+
+			prevSnaps = append(prevSnaps, &ManifestEntry{
+				// Will need to fill out reason if/when we use this test with
+				// incrementals.
+				Manifest: snap,
+			})
 		})
 	}
 }


### PR DESCRIPTION
## Description

During BackupCollections, use the base snapshots that were passed in
from the BackupOp in the kopia uploader instead of fetching our own set
of base snapshots. This will ensure the set of base snapshots is
consistent throughout the backup.

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* #1740 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
