### PR TITLE
Select specific metadata from base snapshot by Reasons base snapshot was picked

### DIFF
--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -265,7 +265,7 @@ func getItemStream(
 	ctx context.Context,
 	itemPath path.Path,
 	snapshotRoot fs.Entry,
-	bcounter byteCounter,
+	bcounter ByteCounter,
 ) (data.Stream, error) {
 	if itemPath == nil {
 		return nil, errors.WithStack(errNoRestorePath)
@@ -314,7 +314,7 @@ func getItemStream(
 	}, nil
 }
 
-type byteCounter interface {
+type ByteCounter interface {
 	Count(numBytes int64)
 }
 
@@ -329,7 +329,7 @@ func (w Wrapper) RestoreMultipleItems(
 	ctx context.Context,
 	snapshotID string,
 	paths []path.Path,
-	bcounter byteCounter,
+	bcounter ByteCounter,
 ) ([]data.Collection, error) {
 	ctx, end := D.Span(ctx, "kopia:restoreMultipleItems")
 	defer end()

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -194,8 +194,9 @@ func produceManifestsAndMetadata(
 	}
 
 	var (
-		tid         = m365.AzureTenantID
-		collections []data.Collection
+		tid           = m365.AzureTenantID
+		metadataFiles = graph.AllMetadataFileNames()
+		collections   []data.Collection
 	)
 
 	ms, err := kw.FetchPrevSnapshotManifests(
@@ -211,15 +212,17 @@ func produceManifestsAndMetadata(
 			continue
 		}
 
-		k, _ := kopia.MakeTagKV(kopia.TagBackupID)
-		bupID := man.Tags[k]
+		// TODO(ashmrtn): Uncomment this again when we need to fetch and merge
+		// backup details from previous snapshots.
+		// k, _ := kopia.MakeTagKV(kopia.TagBackupID)
+		// bupID := man.Tags[k]
 
-		bup, err := sw.GetBackup(ctx, model.StableID(bupID))
-		if err != nil {
-			return nil, nil, err
-		}
+		// bup, err := sw.GetBackup(ctx, model.StableID(bupID))
+		// if err != nil {
+		// 	return nil, nil, err
+		// }
 
-		colls, err := collectMetadata(ctx, kw, graph.AllMetadataFileNames(), tid, man)
+		colls, err := collectMetadata(ctx, kw, man, metadataFiles, tid)
 		if err != nil && !errors.Is(err, kopia.ErrNotFound) {
 			// prior metadata isn't guaranteed to exist.
 			// if it doesn't, we'll just have to do a
@@ -236,9 +239,9 @@ func produceManifestsAndMetadata(
 func collectMetadata(
 	ctx context.Context,
 	kw *kopia.Wrapper,
+	man *kopia.ManifestEntry,
 	fileNames []string,
 	tenantID string,
-	man *kopia.ManifestEntry,
 ) ([]data.Collection, error) {
 	paths := []path.Path{}
 

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -236,9 +236,18 @@ func produceManifestsAndMetadata(
 	return ms, collections, err
 }
 
+type restorer interface {
+	RestoreMultipleItems(
+		ctx context.Context,
+		snapshotID string,
+		paths []path.Path,
+		bc kopia.ByteCounter,
+	) ([]data.Collection, error)
+}
+
 func collectMetadata(
 	ctx context.Context,
-	kw *kopia.Wrapper,
+	kw restorer,
 	man *kopia.ManifestEntry,
 	fileNames []string,
 	tenantID string,

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -247,7 +247,7 @@ type restorer interface {
 
 func collectMetadata(
 	ctx context.Context,
-	kw restorer,
+	r restorer,
 	man *kopia.ManifestEntry,
 	fileNames []string,
 	tenantID string,
@@ -272,7 +272,7 @@ func collectMetadata(
 		}
 	}
 
-	dcs, err := kw.RestoreMultipleItems(ctx, string(man.ID), paths, nil)
+	dcs, err := r.RestoreMultipleItems(ctx, string(man.ID), paths, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "collecting prior metadata")
 	}


### PR DESCRIPTION
## Description

Use the Reasons a snapshot was selected to retrieve only the metadata
corresponding to those reasons. This will avoid having multiple versions
of metadata for the same (resource owner, service, category) tuple as
well as pulling in more metadata than required for some backups.

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* closes #1829 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
