### PR TITLE
Speedup OneDrive backup by pulling urls in delta API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- *Breaking Change*:
+- **Breaking Change**:
   Changed how backup details are stored in the repository to
   improve memory usage (#1735) from [vkamra](https://github.com/vkamra)
+- Improve OneDrive backup speed (#1842) from [meain](https://github.com/meain)
 
 ## [v0.0.3] (alpha) - 2022-12-05
 

--- a/src/internal/connector/graph/service_helper.go
+++ b/src/internal/connector/graph/service_helper.go
@@ -3,7 +3,6 @@ package graph
 import (
 	"context"
 	nethttp "net/http"
-	"net/http/httputil"
 	"os"
 	"strings"
 	"time"
@@ -70,8 +69,8 @@ type LoggingMiddleware struct{}
 func (handler *LoggingMiddleware) Intercept(
 	pipeline khttp.Pipeline, middlewareIndex int, req *nethttp.Request,
 ) (*nethttp.Response, error) {
-	requestDump, _ := httputil.DumpRequest(req, true)
-	logger.Ctx(context.TODO()).Infof("REQUEST: %s", string(requestDump))
+	// requestDump, _ := httputil.DumpRequest(req, true)
+	logger.Ctx(context.TODO()).Infof("REQUEST: %s", req.URL.String())
 
 	return pipeline.Next(req, middlewareIndex)
 }

--- a/src/internal/connector/graph/service_helper.go
+++ b/src/internal/connector/graph/service_helper.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"context"
 	nethttp "net/http"
+	"net/http/httputil"
 	"os"
 	"strings"
 	"time"
@@ -69,8 +70,8 @@ type LoggingMiddleware struct{}
 func (handler *LoggingMiddleware) Intercept(
 	pipeline khttp.Pipeline, middlewareIndex int, req *nethttp.Request,
 ) (*nethttp.Response, error) {
-	// requestDump, _ := httputil.DumpRequest(req, true)
-	logger.Ctx(context.TODO()).Infof("REQUEST: %s", req.URL.String())
+	requestDump, _ := httputil.DumpRequest(req, true)
+	logger.Ctx(context.TODO()).Infof("REQUEST: %s", string(requestDump))
 
 	return pipeline.Next(req, middlewareIndex)
 }

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/data"
@@ -17,7 +19,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
-	"github.com/microsoftgraph/msgraph-sdk-go/models"
 )
 
 const (

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -225,7 +225,7 @@ func (oc *Collection) populateItems(ctx context.Context) {
 			)
 
 			for i := 1; i <= maxRetries; i++ {
-				itemInfo, itemData, err = oc.itemReader(ctx, oc.service, oc.driveID, itemID)
+				itemInfo, itemData, err = oc.itemReader(ctx, item)
 
 				// We only retry if it is a timeout error. Other
 				// errors like throttling are already handled within

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -22,10 +22,10 @@ import (
 const (
 	// TODO: This number needs to be tuned
 	// Consider max open file limit `ulimit -n`, usually 1024 when setting this value
-	collectionChannelBufferSize = 50
+	collectionChannelBufferSize = 5
 
 	// TODO: Tune this later along with collectionChannelBufferSize
-	urlPrefetchChannelBufferSize = 25
+	urlPrefetchChannelBufferSize = 5
 
 	// Max number of retries to get doc from M365
 	// Seems to timeout at times because of multiple requests

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -224,22 +224,7 @@ func (oc *Collection) populateItems(ctx context.Context) {
 				err      error
 			)
 
-			for i := 1; i <= maxRetries; i++ {
-				itemInfo, itemData, err = oc.itemReader(ctx, item)
-
-				// We only retry if it is a timeout error. Other
-				// errors like throttling are already handled within
-				// the graph client via a retry middleware.
-				// https://github.com/microsoftgraph/msgraph-sdk-go/issues/302
-				if err == nil || !isTimeoutErr(err) {
-					break
-				}
-
-				if i < maxRetries {
-					time.Sleep(1 * time.Second)
-				}
-			}
-
+			itemInfo, itemData, err = oc.itemReader(ctx, item)
 			if err != nil {
 				errUpdater(*item.GetId(), err)
 				return

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/support"
@@ -275,8 +274,8 @@ func (oc *Collection) reportAsCompleted(ctx context.Context, itemsRead int, byte
 		1, // num folders (always 1)
 		support.CollectionMetrics{
 			Objects:    len(oc.driveItems), // items to read,
-			Successes:  itemsRead,            // items read successfully,
-			TotalBytes: byteCount,            // Number of bytes read in the operation,
+			Successes:  itemsRead,          // items read successfully,
+			TotalBytes: byteCount,          // Number of bytes read in the operation,
 		},
 		errs,
 		oc.folderPath.Folder(), // Additional details

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -153,7 +153,7 @@ func (c *Collections) UpdateCollections(ctx context.Context, driveID string, ite
 			}
 
 			collection := col.(*Collection)
-			collection.Add(*item.GetId())
+			collection.Add(item)
 			c.NumFiles++
 			c.NumItems++
 

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/alcionai/corso/src/internal/connector/graph"
+	"github.com/alcionai/corso/src/internal/connector/support"
+	"github.com/alcionai/corso/src/pkg/logger"
 	msgraphgocore "github.com/microsoftgraph/msgraph-sdk-go-core"
 	msdrive "github.com/microsoftgraph/msgraph-sdk-go/drive"
 	msdrives "github.com/microsoftgraph/msgraph-sdk-go/drives"
@@ -12,10 +15,6 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 	"github.com/microsoftgraph/msgraph-sdk-go/sites"
 	"github.com/pkg/errors"
-
-	"github.com/alcionai/corso/src/internal/connector/graph"
-	"github.com/alcionai/corso/src/internal/connector/support"
-	"github.com/alcionai/corso/src/pkg/logger"
 )
 
 var (
@@ -143,7 +142,7 @@ func collectItems(
 	// https://docs.microsoft.com/en-us/graph/api/driveitem-delta?
 	// view=graph-rest-1.0&tabs=http#example-4-retrieving-delta-results-using-a-timestamp
 	builder := service.Client().DrivesById(driveID).Root().Delta()
-	pageCount := int32(999)    // max we can do is 999
+	pageCount := int32(999) // max we can do is 999
 	requestFields := []string{
 		"content.downloadUrl",
 		"createdBy",

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -152,6 +152,7 @@ func collectItems(
 		"id",
 		"lastModifiedDateTime",
 		"name",
+		"package",
 		"parentReference",
 		"root",
 		"size",

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -5,17 +5,17 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
-
-	"github.com/alcionai/corso/src/internal/connector/graph"
-	"github.com/alcionai/corso/src/internal/connector/support"
-	"github.com/alcionai/corso/src/pkg/logger"
 	msgraphgocore "github.com/microsoftgraph/msgraph-sdk-go-core"
 	msdrive "github.com/microsoftgraph/msgraph-sdk-go/drive"
 	msdrives "github.com/microsoftgraph/msgraph-sdk-go/drives"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 	"github.com/microsoftgraph/msgraph-sdk-go/sites"
+	"github.com/pkg/errors"
+
+	"github.com/alcionai/corso/src/internal/connector/graph"
+	"github.com/alcionai/corso/src/internal/connector/support"
+	"github.com/alcionai/corso/src/pkg/logger"
 )
 
 var (

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -143,10 +143,10 @@ func collectItems(
 	// https://docs.microsoft.com/en-us/graph/api/driveitem-delta?
 	// view=graph-rest-1.0&tabs=http#example-4-retrieving-delta-results-using-a-timestamp
 	builder := service.Client().DrivesById(driveID).Root().Delta()
-	pageCount := int32(999) // max we can do is 999
+	pageCount := int32(999)    // max we can do is 999
 	requestFields := []string{ // TODO(meain): shrink this list to only needed ones
 		"id",
-		"@content.downloadUrl",
+		"content.downloadUrl",
 		"createdBy",
 		"createdDateTime",
 		"cTag",

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -143,9 +143,34 @@ func collectItems(
 	// https://docs.microsoft.com/en-us/graph/api/driveitem-delta?
 	// view=graph-rest-1.0&tabs=http#example-4-retrieving-delta-results-using-a-timestamp
 	builder := service.Client().DrivesById(driveID).Root().Delta()
+	pageCount := int32(999) // max we can do is 999
+	requestFields := []string{ // TODO(meain): shrink this list to only needed ones
+		"id",
+		"@content.downloadUrl",
+		"createdBy",
+		"createdDateTime",
+		"cTag",
+		"eTag",
+		"file",
+		"fileSystemInfo",
+		"folder",
+		"lastModifiedBy",
+		"lastModifiedDateTime",
+		"name",
+		"parentReference",
+		"root",
+		"size",
+		"webUrl",
+	}
+	requestConfig := &msdrives.DrivesItemRootDeltaRequestBuilderGetRequestConfiguration{
+		QueryParameters: &msdrives.DrivesItemRootDeltaRequestBuilderGetQueryParameters{
+			Top:    &pageCount,
+			Select: requestFields,
+		},
+	}
 
 	for {
-		r, err := builder.Get(ctx, nil)
+		r, err := builder.Get(ctx, requestConfig)
 		if err != nil {
 			return errors.Wrapf(
 				err,

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/pkg/logger"
@@ -14,7 +16,6 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 	"github.com/microsoftgraph/msgraph-sdk-go/sites"
-	"github.com/pkg/errors"
 )
 
 var (

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -158,8 +158,8 @@ func collectItems(
 		"root",
 		"size",
 	}
-	requestConfig := &msdrives.DrivesItemRootDeltaRequestBuilderGetRequestConfiguration{
-		QueryParameters: &msdrives.DrivesItemRootDeltaRequestBuilderGetQueryParameters{
+	requestConfig := &msdrives.ItemRootDeltaRequestBuilderGetRequestConfiguration{
+		QueryParameters: &msdrives.ItemRootDeltaRequestBuilderGetQueryParameters{
 			Top:    &pageCount,
 			Select: requestFields,
 		},

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -144,23 +144,18 @@ func collectItems(
 	// view=graph-rest-1.0&tabs=http#example-4-retrieving-delta-results-using-a-timestamp
 	builder := service.Client().DrivesById(driveID).Root().Delta()
 	pageCount := int32(999)    // max we can do is 999
-	requestFields := []string{ // TODO(meain): shrink this list to only needed ones
-		"id",
+	requestFields := []string{
 		"content.downloadUrl",
 		"createdBy",
 		"createdDateTime",
-		"cTag",
-		"eTag",
 		"file",
-		"fileSystemInfo",
 		"folder",
-		"lastModifiedBy",
+		"id",
 		"lastModifiedDateTime",
 		"name",
 		"parentReference",
 		"root",
 		"size",
-		"webUrl",
 	}
 	requestConfig := &msdrives.DrivesItemRootDeltaRequestBuilderGetRequestConfiguration{
 		QueryParameters: &msdrives.DrivesItemRootDeltaRequestBuilderGetQueryParameters{

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -50,7 +50,11 @@ func oneDriveItemReader(
 	item models.DriveItemable,
 ) (details.ItemInfo, io.ReadCloser, error) {
 	fmt.Println("src/internal/connector/onedrive/item.go:50 item.GetAdditionalData():", item.GetAdditionalData())
-	rc, err := driveItemReader(ctx, item.GetAdditionalData()["@content.downloadUrl"].(string))
+	url, ok := item.GetAdditionalData()["@content.downloadUrl"].(string)
+	if !ok {
+		return details.ItemInfo{}, nil, fmt.Errorf("failed to get url for %s", *item.GetName())
+	}
+	rc, err := driveItemReader(ctx, url)
 	if err != nil {
 		return details.ItemInfo{}, nil, err
 	}

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -53,6 +53,7 @@ func oneDriveItemReader(
 	if !ok {
 		return details.ItemInfo{}, nil, fmt.Errorf("failed to get url for %s", *item.GetName())
 	}
+
 	rc, err := driveItemReader(ctx, *url)
 	if err != nil {
 		return details.ItemInfo{}, nil, err
@@ -90,6 +91,7 @@ func driveItemReader(
 // and kiota drops any SetSize update.
 func oneDriveItemInfo(di models.DriveItemable, itemSize int64) *details.OneDriveInfo {
 	email := ""
+
 	if di.GetCreatedBy().GetUser() != nil {
 		// User is sometimes not available when created via some
 		// external applications (like backup/restore solutions)

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -89,11 +89,14 @@ func driveItemReader(
 // doesn't have its size value updated as a side effect of creation,
 // and kiota drops any SetSize update.
 func oneDriveItemInfo(di models.DriveItemable, itemSize int64) *details.OneDriveInfo {
-	ed, ok := di.GetCreatedBy().GetUser().GetAdditionalData()["email"]
-
 	email := ""
-	if ok {
-		email = *ed.(*string)
+	if di.GetCreatedBy().GetUser() != nil {
+		// User is sometimes not available when created via some
+		// external applications (like backup/restore solutions)
+		ed, ok := di.GetCreatedBy().GetUser().GetAdditionalData()["email"]
+		if ok {
+			email = *ed.(*string)
+		}
 	}
 
 	return &details.OneDriveInfo{

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -30,7 +30,7 @@ func sharePointItemReader(
 	item models.DriveItemable,
 ) (details.ItemInfo, io.ReadCloser, error) {
 	// TODO(meain): make sure the url is available here
-	rc, err := driveItemReader(ctx, item.GetAdditionalData()["@content.downloadUrl"].(string))
+	rc, err := driveItemReader(ctx, item.GetAdditionalData()[downloadURLKey].(string))
 	if err != nil {
 		return details.ItemInfo{}, nil, err
 	}
@@ -49,12 +49,11 @@ func oneDriveItemReader(
 	ctx context.Context,
 	item models.DriveItemable,
 ) (details.ItemInfo, io.ReadCloser, error) {
-	fmt.Println("src/internal/connector/onedrive/item.go:50 item.GetAdditionalData():", item.GetAdditionalData())
-	url, ok := item.GetAdditionalData()["@content.downloadUrl"].(string)
+	url, ok := item.GetAdditionalData()[downloadURLKey].(*string)
 	if !ok {
 		return details.ItemInfo{}, nil, fmt.Errorf("failed to get url for %s", *item.GetName())
 	}
-	rc, err := driveItemReader(ctx, url)
+	rc, err := driveItemReader(ctx, *url)
 	if err != nil {
 		return details.ItemInfo{}, nil, err
 	}

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -29,8 +29,12 @@ func sharePointItemReader(
 	ctx context.Context,
 	item models.DriveItemable,
 ) (details.ItemInfo, io.ReadCloser, error) {
-	// TODO(meain): make sure the url is available here
-	rc, err := driveItemReader(ctx, item.GetAdditionalData()[downloadURLKey].(string))
+	url, ok := item.GetAdditionalData()[downloadURLKey].(*string)
+	if !ok {
+		return details.ItemInfo{}, nil, fmt.Errorf("failed to get url for %s", *item.GetName())
+	}
+
+	rc, err := driveItemReader(ctx, *url)
 	if err != nil {
 		return details.ItemInfo{}, nil, err
 	}

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -2,6 +2,7 @@ package onedrive
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	msdrives "github.com/microsoftgraph/msgraph-sdk-go/drives"
@@ -24,22 +25,22 @@ const (
 // sharePointItemReader will return a io.ReadCloser for the specified item
 // It crafts this by querying M365 for a download URL for the item
 // and using a http client to initialize a reader
-// func sharePointItemReader(
-// 	ctx context.Context,
-// 	service graph.Servicer,
-// 	driveID, itemID string,
-// ) (details.ItemInfo, io.ReadCloser, error) {
-// 	item, rc, err := driveItemReader(ctx, service, driveID, itemID)
-// 	if err != nil {
-// 		return details.ItemInfo{}, nil, err
-// 	}
+func sharePointItemReader(
+	ctx context.Context,
+	item models.DriveItemable,
+) (details.ItemInfo, io.ReadCloser, error) {
+	// TODO(meain): make sure the url is available here
+	rc, err := driveItemReader(ctx, item.GetAdditionalData()["@content.downloadUrl"].(string))
+	if err != nil {
+		return details.ItemInfo{}, nil, err
+	}
 
-// 	dii := details.ItemInfo{
-// 		SharePoint: sharePointItemInfo(item, *item.GetSize()),
-// 	}
+	dii := details.ItemInfo{
+		SharePoint: sharePointItemInfo(item, *item.GetSize()),
+	}
 
-// 	return dii, rc, nil
-// }
+	return dii, rc, nil
+}
 
 // oneDriveItemReader will return a io.ReadCloser for the specified item
 // It crafts this by querying M365 for a download URL for the item
@@ -48,6 +49,7 @@ func oneDriveItemReader(
 	ctx context.Context,
 	item models.DriveItemable,
 ) (details.ItemInfo, io.ReadCloser, error) {
+	fmt.Println("src/internal/connector/onedrive/item.go:50 item.GetAdditionalData():", item.GetAdditionalData())
 	rc, err := driveItemReader(ctx, item.GetAdditionalData()["@content.downloadUrl"].(string))
 	if err != nil {
 		return details.ItemInfo{}, nil, err

--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -97,12 +97,12 @@ func (suite *ItemIntegrationSuite) TestItemReader_oneDrive() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 
-	var driveItemID string
+	var driveItem models.DriveItemable
 	// This item collector tries to find "a" drive item that is a file to test the reader function
 	itemCollector := func(ctx context.Context, driveID string, items []models.DriveItemable) error {
 		for _, item := range items {
 			if item.GetFile() != nil {
-				driveItemID = *item.GetId()
+				driveItem = item
 				break
 			}
 		}
@@ -115,7 +115,7 @@ func (suite *ItemIntegrationSuite) TestItemReader_oneDrive() {
 	// Test Requirement 2: Need a file
 	require.NotEmpty(
 		suite.T(),
-		driveItemID,
+		driveItem,
 		"no file item found for user %s drive %s",
 		suite.user,
 		suite.userDriveID,
@@ -123,7 +123,7 @@ func (suite *ItemIntegrationSuite) TestItemReader_oneDrive() {
 
 	// Read data for the file
 
-	itemInfo, itemData, err := oneDriveItemReader(ctx, suite, suite.userDriveID, driveItemID)
+	itemInfo, itemData, err := oneDriveItemReader(ctx, driveItem)
 	require.NoError(suite.T(), err)
 	require.NotNil(suite.T(), itemInfo.OneDrive)
 	require.NotEmpty(suite.T(), itemInfo.OneDrive.ItemName)


### PR DESCRIPTION
## Description

This brings in another huge improvement in the backup speed dropping from ~15m to ~1.5m for an account with ~5000 files. This one also drastically reduces the number of requests we have to make for the same account from 5505 to just ~55. This also means that we don't get throttled anymore and we can easily run multiple backup jobs in parallel before we hit the 1024 limit.

~The code works as of now, but I have to double check the numbers as well as fix an issue with us opening too many files and causing program to crash with 'too many open files' when we bump up the numbers. With the current numbers, it works, but I wanna double check and optimize them. Plus some code cleanup.~

## Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [x] :hamster: Trivial/Minor

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
