### PR TITLE
Revert "temporarily skip e2e smoke tests"

### DIFF
--- a/src/cli/backup/exchange_integration_test.go
+++ b/src/cli/backup/exchange_integration_test.go
@@ -50,8 +50,6 @@ type NoBackupExchangeIntegrationSuite struct {
 }
 
 func TestNoBackupExchangeIntegrationSuite(t *testing.T) {
-	t.Skip("temporary skip on e2e smoke tests")
-
 	if err := tester.RunOnAny(
 		tester.CorsoCITests,
 		tester.CorsoCLITests,
@@ -141,8 +139,6 @@ type BackupExchangeIntegrationSuite struct {
 }
 
 func TestBackupExchangeIntegrationSuite(t *testing.T) {
-	t.Skip("temporary skip on e2e smoke tests")
-
 	if err := tester.RunOnAny(
 		tester.CorsoCITests,
 		tester.CorsoCLITests,
@@ -240,8 +236,6 @@ type PreparedBackupExchangeIntegrationSuite struct {
 }
 
 func TestPreparedBackupExchangeIntegrationSuite(t *testing.T) {
-	t.Skip("temporary skip on e2e smoke tests")
-
 	if err := tester.RunOnAny(
 		tester.CorsoCITests,
 		tester.CorsoCLITests,
@@ -478,8 +472,6 @@ type BackupDeleteExchangeIntegrationSuite struct {
 }
 
 func TestBackupDeleteExchangeIntegrationSuite(t *testing.T) {
-	t.Skip("temporary skip on e2e smoke tests")
-
 	if err := tester.RunOnAny(
 		tester.CorsoCITests,
 		tester.CorsoCLITests,

--- a/src/cli/backup/onedrive_integration_test.go
+++ b/src/cli/backup/onedrive_integration_test.go
@@ -40,8 +40,6 @@ type NoBackupOneDriveIntegrationSuite struct {
 }
 
 func TestNoBackupOneDriveIntegrationSuite(t *testing.T) {
-	t.Skip("temporary skip on e2e smoke tests")
-
 	if err := tester.RunOnAny(
 		tester.CorsoCITests,
 		tester.CorsoCLITests,
@@ -131,8 +129,6 @@ type BackupDeleteOneDriveIntegrationSuite struct {
 }
 
 func TestBackupDeleteOneDriveIntegrationSuite(t *testing.T) {
-	t.Skip("temporary skip on e2e smoke tests")
-
 	if err := tester.RunOnAny(
 		tester.CorsoCITests,
 		tester.CorsoCLITests,

--- a/src/cli/backup/sharepoint_integration_test.go
+++ b/src/cli/backup/sharepoint_integration_test.go
@@ -40,8 +40,6 @@ type NoBackupSharePointIntegrationSuite struct {
 }
 
 func TestNoBackupSharePointIntegrationSuite(t *testing.T) {
-	t.Skip("temporary skip on e2e smoke tests")
-
 	if err := tester.RunOnAny(
 		tester.CorsoCITests,
 		tester.CorsoCLITests,
@@ -131,8 +129,6 @@ type BackupDeleteSharePointIntegrationSuite struct {
 }
 
 func TestBackupDeleteSharePointIntegrationSuite(t *testing.T) {
-	t.Skip("temporary skip on e2e smoke tests")
-
 	if err := tester.RunOnAny(
 		tester.CorsoCITests,
 		tester.CorsoCLITests,

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -316,8 +316,6 @@ func (suite *BackupOpIntegrationSuite) TestNewBackupOperation() {
 // TestBackup_Run ensures that Integration Testing works
 // for the following scopes: Contacts, Events, and Mail
 func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchange() {
-	suite.T().Skip("temporary skip on e2e smoke tests")
-
 	ctx, flush := tester.NewContext()
 	defer flush()
 
@@ -463,8 +461,6 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchange() {
 }
 
 func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDrive() {
-	suite.T().Skip("temporary skip on e2e smoke tests")
-
 	ctx, flush := tester.NewContext()
 	defer flush()
 
@@ -498,8 +494,6 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDrive() {
 }
 
 func (suite *BackupOpIntegrationSuite) TestBackup_Run_sharePoint() {
-	suite.T().Skip("temporary skip on e2e smoke tests")
-
 	ctx, flush := tester.NewContext()
 	defer flush()
 

--- a/src/internal/operations/restore_test.go
+++ b/src/internal/operations/restore_test.go
@@ -260,8 +260,6 @@ func (suite *RestoreOpIntegrationSuite) TestNewRestoreOperation() {
 }
 
 func (suite *RestoreOpIntegrationSuite) TestRestore_Run() {
-	suite.T().Skip("temporary skip on e2e smoke tests")
-
 	ctx, flush := tester.NewContext()
 	defer flush()
 


### PR DESCRIPTION
Reverts alcionai/corso#1835 now that #1841 is in. That should help with the flakiness.

I will follow up with another PR after though that moves these tests to a post-CI job (we don't need to run these on every commit)