### PR TITLE
require complete previous data for increment

### DIFF
--- a/src/internal/connector/exchange/data_collections.go
+++ b/src/internal/connector/exchange/data_collections.go
@@ -65,7 +65,7 @@ func ParseMetadataCollections(
 	}
 
 	// found tracks the metadata we've loaded, to make sure we don't
-	// fetch overlapping opies.
+	// fetch overlapping copies.
 	found := map[path.CategoryType]map[string]struct{}{
 		path.ContactsCategory: {},
 		path.EmailCategory:    {},

--- a/src/internal/connector/exchange/data_collections.go
+++ b/src/internal/connector/exchange/data_collections.go
@@ -24,16 +24,31 @@ func MetadataFileNames(cat path.CategoryType) []string {
 
 type CatDeltaPaths map[path.CategoryType]DeltaPaths
 
-type DeltaPaths struct {
-	deltas map[string]string
-	paths  map[string]string
+type DeltaPaths map[string]DeltaPath
+
+func (dps DeltaPaths) AddDelta(k, d string) {
+	dp, ok := dps[k]
+	if !ok {
+		dp = DeltaPath{}
+	}
+
+	dp.delta = d
+	dps[k] = dp
 }
 
-func makeDeltaPaths() DeltaPaths {
-	return DeltaPaths{
-		deltas: map[string]string{},
-		paths:  map[string]string{},
+func (dps DeltaPaths) AddPath(k, p string) {
+	dp, ok := dps[k]
+	if !ok {
+		dp = DeltaPath{}
 	}
+
+	dp.path = p
+	dps[k] = dp
+}
+
+type DeltaPath struct {
+	delta string
+	path  string
 }
 
 // ParseMetadataCollections produces a map of structs holding delta
@@ -42,10 +57,19 @@ func ParseMetadataCollections(
 	ctx context.Context,
 	colls []data.Collection,
 ) (CatDeltaPaths, error) {
+	// cdp stores metadata
 	cdp := CatDeltaPaths{
-		path.ContactsCategory: makeDeltaPaths(),
-		path.EmailCategory:    makeDeltaPaths(),
-		path.EventsCategory:   makeDeltaPaths(),
+		path.ContactsCategory: {},
+		path.EmailCategory:    {},
+		path.EventsCategory:   {},
+	}
+
+	// found tracks the metadata we've loaded, to make sure we don't
+	// fetch overlapping opies.
+	found := map[path.CategoryType]map[string]struct{}{
+		path.ContactsCategory: {},
+		path.EmailCategory:    {},
+		path.EventsCategory:   {},
 	}
 
 	for _, coll := range colls {
@@ -66,8 +90,10 @@ func ParseMetadataCollections(
 					break
 				}
 
-				m := map[string]string{}
-				cdps := cdp[category]
+				var (
+					m    = map[string]string{}
+					cdps = cdp[category]
+				)
 
 				err := json.NewDecoder(item.ToReader()).Decode(&m)
 				if err != nil {
@@ -76,18 +102,26 @@ func ParseMetadataCollections(
 
 				switch item.UUID() {
 				case graph.PreviousPathFileName:
-					if len(cdps.paths) > 0 {
+					if _, ok := found[category]["path"]; ok {
 						return nil, errors.Errorf("multiple versions of %s path metadata", category)
 					}
 
-					cdps.paths = m
+					for k, p := range m {
+						cdps.AddPath(k, p)
+					}
+
+					found[category]["path"] = struct{}{}
 
 				case graph.DeltaURLsFileName:
-					if len(cdps.deltas) > 0 {
+					if _, ok := found[category]["delta"]; ok {
 						return nil, errors.Errorf("multiple versions of %s delta metadata", category)
 					}
 
-					cdps.deltas = m
+					for k, d := range m {
+						cdps.AddDelta(k, d)
+					}
+
+					found[category]["delta"] = struct{}{}
 				}
 
 				cdp[category] = cdps
@@ -95,6 +129,17 @@ func ParseMetadataCollections(
 
 			if breakLoop {
 				break
+			}
+		}
+	}
+
+	// Remove any entries that contain a path or a delta, but not both.
+	// That metadata is considered incomplete, and needs to incur a
+	// complete backup on the next run.
+	for _, dps := range cdp {
+		for k, dp := range dps {
+			if len(dp.delta) == 0 || len(dp.path) == 0 {
+				delete(dps, k)
 			}
 		}
 	}

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -133,7 +133,7 @@ func FilterContainersAndFillCollections(
 		)
 		collections[cID] = &edc
 
-		if edc.state == data.DeletedState {
+		if edc.State() == data.DeletedState {
 			continue
 		}
 


### PR DESCRIPTION
## Description

If an exchange collection only has previous
delta info, or only previous path info, and not
the other, remove that entry from the parsed
metadata map, causing a full backup of the
containere.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :sunflower: Feature

## Issue(s)

* #1804

## Test Plan

- [x] :zap: Unit test
