### PR TITLE
use selector owners, not scope owners

### DIFF
--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -284,31 +284,29 @@ func createExchangeCmd(cmd *cobra.Command, args []string) error {
 
 	for _, sel := range sel.SplitByResourceOwner(users) {
 		// TODO: pass in entire selector, not individual scopes
-		for _, scope := range sel.Scopes() {
-			bo, err := r.NewBackup(ctx, sel.Selector)
-			if err != nil {
-				errs = multierror.Append(errs, errors.Wrapf(
-					err,
-					"Failed to initialize Exchange backup for user %s",
-					scope.Get(selectors.ExchangeUser),
-				))
+		bo, err := r.NewBackup(ctx, sel.Selector)
+		if err != nil {
+			errs = multierror.Append(errs, errors.Wrapf(
+				err,
+				"Failed to initialize Exchange backup for user %s",
+				sel.DiscreteOwner,
+			))
 
-				continue
-			}
-
-			err = bo.Run(ctx)
-			if err != nil {
-				errs = multierror.Append(errs, errors.Wrapf(
-					err,
-					"Failed to run Exchange backup for user %s",
-					scope.Get(selectors.ExchangeUser),
-				))
-
-				continue
-			}
-
-			bIDs = append(bIDs, bo.Results.BackupID)
+			continue
 		}
+
+		err = bo.Run(ctx)
+		if err != nil {
+			errs = multierror.Append(errs, errors.Wrapf(
+				err,
+				"Failed to run Exchange backup for user %s",
+				sel.DiscreteOwner,
+			))
+
+			continue
+		}
+
+		bIDs = append(bIDs, bo.Results.BackupID)
 	}
 
 	bups, err := r.Backups(ctx, bIDs)

--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -282,14 +282,13 @@ func createExchangeCmd(cmd *cobra.Command, args []string) error {
 		bIDs []model.StableID
 	)
 
-	for _, sel := range sel.SplitByResourceOwner(users) {
-		// TODO: pass in entire selector, not individual scopes
-		bo, err := r.NewBackup(ctx, sel.Selector)
+	for _, discSel := range sel.SplitByResourceOwner(users) {
+		bo, err := r.NewBackup(ctx, discSel.Selector)
 		if err != nil {
 			errs = multierror.Append(errs, errors.Wrapf(
 				err,
 				"Failed to initialize Exchange backup for user %s",
-				sel.DiscreteOwner,
+				discSel.DiscreteOwner,
 			))
 
 			continue
@@ -300,7 +299,7 @@ func createExchangeCmd(cmd *cobra.Command, args []string) error {
 			errs = multierror.Append(errs, errors.Wrapf(
 				err,
 				"Failed to run Exchange backup for user %s",
-				sel.DiscreteOwner,
+				discSel.DiscreteOwner,
 			))
 
 			continue

--- a/src/cli/backup/onedrive.go
+++ b/src/cli/backup/onedrive.go
@@ -204,13 +204,13 @@ func createOneDriveCmd(cmd *cobra.Command, args []string) error {
 		bIDs []model.StableID
 	)
 
-	for _, sel := range sel.SplitByResourceOwner(users) {
-		bo, err := r.NewBackup(ctx, sel.Selector)
+	for _, discSel := range sel.SplitByResourceOwner(users) {
+		bo, err := r.NewBackup(ctx, discSel.Selector)
 		if err != nil {
 			errs = multierror.Append(errs, errors.Wrapf(
 				err,
 				"Failed to initialize OneDrive backup for user %s",
-				sel.DiscreteOwner,
+				discSel.DiscreteOwner,
 			))
 
 			continue
@@ -221,7 +221,7 @@ func createOneDriveCmd(cmd *cobra.Command, args []string) error {
 			errs = multierror.Append(errs, errors.Wrapf(
 				err,
 				"Failed to run OneDrive backup for user %s",
-				sel.DiscreteOwner,
+				discSel.DiscreteOwner,
 			))
 
 			continue

--- a/src/cli/backup/onedrive.go
+++ b/src/cli/backup/onedrive.go
@@ -205,32 +205,29 @@ func createOneDriveCmd(cmd *cobra.Command, args []string) error {
 	)
 
 	for _, sel := range sel.SplitByResourceOwner(users) {
-		// TODO: pass in entire selector, not individual scopes
-		for _, scope := range sel.Scopes() {
-			bo, err := r.NewBackup(ctx, sel.Selector)
-			if err != nil {
-				errs = multierror.Append(errs, errors.Wrapf(
-					err,
-					"Failed to initialize OneDrive backup for user %s",
-					scope.Get(selectors.OneDriveUser),
-				))
+		bo, err := r.NewBackup(ctx, sel.Selector)
+		if err != nil {
+			errs = multierror.Append(errs, errors.Wrapf(
+				err,
+				"Failed to initialize OneDrive backup for user %s",
+				sel.DiscreteOwner,
+			))
 
-				continue
-			}
-
-			err = bo.Run(ctx)
-			if err != nil {
-				errs = multierror.Append(errs, errors.Wrapf(
-					err,
-					"Failed to run OneDrive backup for user %s",
-					scope.Get(selectors.OneDriveUser),
-				))
-
-				continue
-			}
-
-			bIDs = append(bIDs, bo.Results.BackupID)
+			continue
 		}
+
+		err = bo.Run(ctx)
+		if err != nil {
+			errs = multierror.Append(errs, errors.Wrapf(
+				err,
+				"Failed to run OneDrive backup for user %s",
+				sel.DiscreteOwner,
+			))
+
+			continue
+		}
+
+		bIDs = append(bIDs, bo.Results.BackupID)
 	}
 
 	bups, err := r.Backups(ctx, bIDs)

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -210,13 +210,13 @@ func createSharePointCmd(cmd *cobra.Command, args []string) error {
 		bIDs []model.StableID
 	)
 
-	for _, sel := range sel.SplitByResourceOwner(gc.GetSiteIDs()) {
-		bo, err := r.NewBackup(ctx, sel.Selector)
+	for _, discSel := range sel.SplitByResourceOwner(gc.GetSiteIDs()) {
+		bo, err := r.NewBackup(ctx, discSel.Selector)
 		if err != nil {
 			errs = multierror.Append(errs, errors.Wrapf(
 				err,
 				"Failed to initialize SharePoint backup for site %s",
-				sel.DiscreteOwner,
+				discSel.DiscreteOwner,
 			))
 
 			continue
@@ -227,7 +227,7 @@ func createSharePointCmd(cmd *cobra.Command, args []string) error {
 			errs = multierror.Append(errs, errors.Wrapf(
 				err,
 				"Failed to run SharePoint backup for site %s",
-				sel.DiscreteOwner,
+				discSel.DiscreteOwner,
 			))
 
 			continue

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -211,32 +211,29 @@ func createSharePointCmd(cmd *cobra.Command, args []string) error {
 	)
 
 	for _, sel := range sel.SplitByResourceOwner(gc.GetSiteIDs()) {
-		// TODO: pass in entire selector, not individual scopes
-		for _, scope := range sel.Scopes() {
-			bo, err := r.NewBackup(ctx, sel.Selector)
-			if err != nil {
-				errs = multierror.Append(errs, errors.Wrapf(
-					err,
-					"Failed to initialize SharePoint backup for site %s",
-					scope.Get(selectors.SharePointSite),
-				))
+		bo, err := r.NewBackup(ctx, sel.Selector)
+		if err != nil {
+			errs = multierror.Append(errs, errors.Wrapf(
+				err,
+				"Failed to initialize SharePoint backup for site %s",
+				sel.DiscreteOwner,
+			))
 
-				continue
-			}
-
-			err = bo.Run(ctx)
-			if err != nil {
-				errs = multierror.Append(errs, errors.Wrapf(
-					err,
-					"Failed to run SharePoint backup for site %s",
-					scope.Get(selectors.SharePointSite),
-				))
-
-				continue
-			}
-
-			bIDs = append(bIDs, bo.Results.BackupID)
+			continue
 		}
+
+		err = bo.Run(ctx)
+		if err != nil {
+			errs = multierror.Append(errs, errors.Wrapf(
+				err,
+				"Failed to run SharePoint backup for site %s",
+				sel.DiscreteOwner,
+			))
+
+			continue
+		}
+
+		bIDs = append(bIDs, bo.Results.BackupID)
 	}
 
 	bups, err := r.Backups(ctx, bIDs)

--- a/src/internal/connector/data_collections_test.go
+++ b/src/internal/connector/data_collections_test.go
@@ -71,7 +71,7 @@ func (suite *ConnectorDataCollectionIntegrationSuite) TestExchangeDataCollection
 			getSelector: func(t *testing.T) selectors.Selector {
 				sel := selectors.NewExchangeBackup(selUsers)
 				sel.Include(sel.MailFolders(selUsers, []string{exchange.DefaultMailFolder}, selectors.PrefixMatch()))
-
+				sel.DiscreteOwner = suite.user
 				return sel.Selector
 			},
 		},
@@ -79,11 +79,8 @@ func (suite *ConnectorDataCollectionIntegrationSuite) TestExchangeDataCollection
 			name: suite.user + " Contacts",
 			getSelector: func(t *testing.T) selectors.Selector {
 				sel := selectors.NewExchangeBackup(selUsers)
-				sel.Include(sel.ContactFolders(
-					selUsers,
-					[]string{exchange.DefaultContactFolder},
-					selectors.PrefixMatch()))
-
+				sel.Include(sel.ContactFolders(selUsers, []string{exchange.DefaultContactFolder}, selectors.PrefixMatch()))
+				sel.DiscreteOwner = suite.user
 				return sel.Selector
 			},
 		},
@@ -91,12 +88,8 @@ func (suite *ConnectorDataCollectionIntegrationSuite) TestExchangeDataCollection
 		// 	name: suite.user + " Events",
 		// 	getSelector: func(t *testing.T) selectors.Selector {
 		// 		sel := selectors.NewExchangeBackup(selUsers)
-		// 		sel.Include(sel.EventCalendars(
-		// 			selUsers,
-		// 			[]string{exchange.DefaultCalendar},
-		// 			selectors.PrefixMatch(),
-		// 		))
-
+		// 		sel.Include(sel.EventCalendars(selUsers, []string{exchange.DefaultCalendar}, selectors.PrefixMatch()))
+		// 		sel.DiscreteOwner = suite.user
 		// 		return sel.Selector
 		// 	},
 		// },
@@ -108,7 +101,6 @@ func (suite *ConnectorDataCollectionIntegrationSuite) TestExchangeDataCollection
 				ctx,
 				test.getSelector(t),
 				nil,
-				[]string{suite.user},
 				connector.credentials,
 				connector.UpdateStatus,
 				control.Options{})

--- a/src/internal/connector/data_collections_test.go
+++ b/src/internal/connector/data_collections_test.go
@@ -199,6 +199,7 @@ func (suite *ConnectorDataCollectionIntegrationSuite) TestSharePointDataCollecti
 				sel := selectors.NewSharePointBackup(selSites)
 				sel.Include(sel.Libraries(selSites, selectors.Any()))
 				sel.DiscreteOwner = suite.site
+
 				return sel.Selector
 			},
 		},
@@ -209,6 +210,7 @@ func (suite *ConnectorDataCollectionIntegrationSuite) TestSharePointDataCollecti
 				sel := selectors.NewSharePointBackup(selSites)
 				sel.Include(sel.Lists(selSites, selectors.Any()))
 				sel.DiscreteOwner = suite.site
+
 				return sel.Selector
 			},
 		},

--- a/src/internal/connector/exchange/data_collections.go
+++ b/src/internal/connector/exchange/data_collections.go
@@ -174,7 +174,7 @@ func DataCollections(
 	}
 
 	var (
-		scopes      = eb.DiscreteScopes(userPNs)
+		scopes      = eb.DiscreteScopes([]string{selector.DiscreteOwner})
 		collections = []data.Collection{}
 		errs        error
 	)

--- a/src/internal/connector/exchange/data_collections.go
+++ b/src/internal/connector/exchange/data_collections.go
@@ -163,7 +163,6 @@ func DataCollections(
 	ctx context.Context,
 	selector selectors.Selector,
 	metadata []data.Collection,
-	userPNs []string,
 	acct account.M365Config,
 	su support.StatusUpdater,
 	ctrlOpts control.Options,
@@ -174,7 +173,8 @@ func DataCollections(
 	}
 
 	var (
-		scopes      = eb.DiscreteScopes([]string{selector.DiscreteOwner})
+		user        = selector.DiscreteOwner
+		scopes      = eb.DiscreteScopes([]string{user})
 		collections = []data.Collection{}
 		errs        error
 	)
@@ -190,13 +190,13 @@ func DataCollections(
 		dcs, err := createCollections(
 			ctx,
 			acct,
+			user,
 			scope,
 			dps,
 			ctrlOpts,
 			su)
 		if err != nil {
-			user := scope.Get(selectors.ExchangeUser)
-			return nil, support.WrapAndAppend(user[0], err, errs)
+			return nil, support.WrapAndAppend(user, err, errs)
 		}
 
 		collections = append(collections, dcs...)
@@ -211,6 +211,7 @@ func DataCollections(
 func createCollections(
 	ctx context.Context,
 	acct account.M365Config,
+	user string,
 	scope selectors.ExchangeScope,
 	dps DeltaPaths,
 	ctrlOpts control.Options,
@@ -218,48 +219,45 @@ func createCollections(
 ) ([]data.Collection, error) {
 	var (
 		errs           *multierror.Error
-		users          = scope.Get(selectors.ExchangeUser)
 		allCollections = make([]data.Collection, 0)
 	)
 
 	// Create collection of ExchangeDataCollection
-	for _, user := range users {
-		collections := make(map[string]data.Collection)
+	collections := make(map[string]data.Collection)
 
-		qp := graph.QueryParams{
-			Category:      scope.Category().PathType(),
-			ResourceOwner: user,
-			Credentials:   acct,
-		}
+	qp := graph.QueryParams{
+		Category:      scope.Category().PathType(),
+		ResourceOwner: user,
+		Credentials:   acct,
+	}
 
-		foldersComplete, closer := observe.MessageWithCompletion(fmt.Sprintf("∙ %s - %s:", qp.Category, user))
-		defer closer()
-		defer close(foldersComplete)
+	foldersComplete, closer := observe.MessageWithCompletion(fmt.Sprintf("∙ %s - %s:", qp.Category, user))
+	defer closer()
+	defer close(foldersComplete)
 
-		resolver, err := PopulateExchangeContainerResolver(ctx, qp)
-		if err != nil {
-			return nil, errors.Wrap(err, "getting folder cache")
-		}
+	resolver, err := PopulateExchangeContainerResolver(ctx, qp)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting folder cache")
+	}
 
-		err = filterContainersAndFillCollections(
-			ctx,
-			qp,
-			collections,
-			su,
-			resolver,
-			scope,
-			dps,
-			ctrlOpts)
+	err = filterContainersAndFillCollections(
+		ctx,
+		qp,
+		collections,
+		su,
+		resolver,
+		scope,
+		dps,
+		ctrlOpts)
 
-		if err != nil {
-			return nil, errors.Wrap(err, "filling collections")
-		}
+	if err != nil {
+		return nil, errors.Wrap(err, "filling collections")
+	}
 
-		foldersComplete <- struct{}{}
+	foldersComplete <- struct{}{}
 
-		for _, coll := range collections {
-			allCollections = append(allCollections, coll)
-		}
+	for _, coll := range collections {
+		allCollections = append(allCollections, coll)
 	}
 
 	return allCollections, errs.ErrorOrNil()

--- a/src/internal/connector/exchange/data_collections_test.go
+++ b/src/internal/connector/exchange/data_collections_test.go
@@ -256,13 +256,12 @@ func (suite *DataCollectionsIntegrationSuite) TestMailFetch() {
 		},
 	}
 
-	// gc := loadConnector(ctx, t, Users)
-
 	for _, test := range tests {
 		suite.T().Run(test.name, func(t *testing.T) {
 			collections, err := createCollections(
 				ctx,
 				acct,
+				userID,
 				test.scope,
 				DeltaPaths{},
 				control.Options{},
@@ -324,6 +323,7 @@ func (suite *DataCollectionsIntegrationSuite) TestDelta() {
 			collections, err := createCollections(
 				ctx,
 				acct,
+				userID,
 				test.scope,
 				DeltaPaths{},
 				control.Options{},
@@ -351,6 +351,7 @@ func (suite *DataCollectionsIntegrationSuite) TestDelta() {
 			collections, err = createCollections(
 				ctx,
 				acct,
+				userID,
 				test.scope,
 				dps,
 				control.Options{},
@@ -395,6 +396,7 @@ func (suite *DataCollectionsIntegrationSuite) TestMailSerializationRegression() 
 	collections, err := createCollections(
 		ctx,
 		acct,
+		suite.user,
 		sel.Scopes()[0],
 		DeltaPaths{},
 		control.Options{},
@@ -462,6 +464,7 @@ func (suite *DataCollectionsIntegrationSuite) TestContactSerializationRegression
 			edcs, err := createCollections(
 				ctx,
 				acct,
+				suite.user,
 				test.scope,
 				DeltaPaths{},
 				control.Options{},
@@ -546,6 +549,7 @@ func (suite *DataCollectionsIntegrationSuite) TestEventsSerializationRegression(
 			collections, err := createCollections(
 				ctx,
 				acct,
+				suite.user,
 				test.scope,
 				DeltaPaths{},
 				control.Options{},

--- a/src/internal/connector/graph_connector_helper_test.go
+++ b/src/internal/connector/graph_connector_helper_test.go
@@ -939,20 +939,37 @@ func collectionsForInfo(
 }
 
 //nolint:deadcode
-func getSelectorWith(service path.ServiceType) selectors.Selector {
-	s := selectors.ServiceUnknown
-
+func getSelectorWith(
+	t *testing.T,
+	service path.ServiceType,
+	resourceOwners []string,
+	forRestore bool,
+) selectors.Selector {
 	switch service {
 	case path.ExchangeService:
-		s = selectors.ServiceExchange
-	case path.OneDriveService:
-		s = selectors.ServiceOneDrive
-	case path.SharePointService:
-		s = selectors.ServiceSharePoint
-	}
+		if forRestore {
+			return selectors.NewExchangeRestore(resourceOwners).Selector
+		}
 
-	return selectors.Selector{
-		Service: s,
+		return selectors.NewExchangeBackup(resourceOwners).Selector
+
+	case path.OneDriveService:
+		if forRestore {
+			return selectors.NewOneDriveRestore(resourceOwners).Selector
+		}
+
+		return selectors.NewOneDriveBackup(resourceOwners).Selector
+
+	case path.SharePointService:
+		if forRestore {
+			return selectors.NewSharePointRestore(resourceOwners).Selector
+		}
+
+		return selectors.NewSharePointBackup(resourceOwners).Selector
+
+	default:
+		require.FailNow(t, "unknown path service")
+		return selectors.Selector{}
 	}
 }
 

--- a/src/internal/connector/graph_connector_helper_test.go
+++ b/src/internal/connector/graph_connector_helper_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
 
 	"github.com/alcionai/corso/src/internal/connector/mockconnector"
 	"github.com/alcionai/corso/src/internal/connector/support"
@@ -777,14 +778,14 @@ func makeExchangeBackupSel(
 	dests []destAndCats,
 ) selectors.Selector {
 	toInclude := [][]selectors.ExchangeScope{}
-	resourceOwners := []string{}
+	resourceOwners := map[string]struct{}{}
 
 	for _, d := range dests {
 		for c := range d.cats {
 			sel := selectors.NewExchangeBackup(nil)
 			builder := sel.MailFolders
 
-			resourceOwners = append(resourceOwners, d.resourceOwner)
+			resourceOwners[d.resourceOwner] = struct{}{}
 
 			switch c {
 			case path.ContactsCategory:
@@ -802,7 +803,7 @@ func makeExchangeBackupSel(
 		}
 	}
 
-	sel := selectors.NewExchangeBackup(resourceOwners)
+	sel := selectors.NewExchangeBackup(maps.Keys(resourceOwners))
 	sel.Include(toInclude...)
 
 	return sel.Selector

--- a/src/internal/connector/sharepoint/data_collections.go
+++ b/src/internal/connector/sharepoint/data_collections.go
@@ -37,55 +37,50 @@ func DataCollections(
 	}
 
 	var (
-		scopes      = b.DiscreteScopes([]string{selector.DiscreteOwner})
+		site        = b.DiscreteOwner
 		collections = []data.Collection{}
 		errs        error
 	)
 
-	for _, scope := range scopes {
-		// due to DiscreteScopes(siteIDs), each range should only contain one site.
-		for _, site := range scope.Get(selectors.SharePointSite) {
-			foldersComplete, closer := observe.MessageWithCompletion(fmt.Sprintf(
-				"∙ %s - %s:",
-				scope.Category().PathType(), site))
-			defer closer()
-			defer close(foldersComplete)
+	for _, scope := range b.Scopes() {
+		foldersComplete, closer := observe.MessageWithCompletion(fmt.Sprintf(
+			"∙ %s - %s:",
+			scope.Category().PathType(), site))
+		defer closer()
+		defer close(foldersComplete)
 
-			var spcs []data.Collection
+		var spcs []data.Collection
 
-			switch scope.Category().PathType() {
-			case path.ListsCategory:
-				spcs, err = collectLists(
-					ctx,
-					serv,
-					tenantID,
-					site,
-					scope,
-					su,
-					ctrlOpts,
-				)
-				if err != nil {
-					return nil, support.WrapAndAppend(site, err, errs)
-				}
-
-			case path.LibrariesCategory:
-				spcs, err = collectLibraries(
-					ctx,
-					serv,
-					tenantID,
-					site,
-					scope,
-					su,
-					ctrlOpts)
-				if err != nil {
-					return nil, support.WrapAndAppend(site, err, errs)
-				}
+		switch scope.Category().PathType() {
+		case path.ListsCategory:
+			spcs, err = collectLists(
+				ctx,
+				serv,
+				tenantID,
+				site,
+				scope,
+				su,
+				ctrlOpts)
+			if err != nil {
+				return nil, support.WrapAndAppend(site, err, errs)
 			}
 
-			collections = append(collections, spcs...)
-
-			foldersComplete <- struct{}{}
+		case path.LibrariesCategory:
+			spcs, err = collectLibraries(
+				ctx,
+				serv,
+				tenantID,
+				site,
+				scope,
+				su,
+				ctrlOpts)
+			if err != nil {
+				return nil, support.WrapAndAppend(site, err, errs)
+			}
 		}
+
+		collections = append(collections, spcs...)
+		foldersComplete <- struct{}{}
 	}
 
 	return collections, errs

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -34,9 +34,10 @@ import (
 type BackupOperation struct {
 	operation
 
-	Results   BackupResults      `json:"results"`
-	Selectors selectors.Selector `json:"selectors"`
-	Version   string             `json:"version"`
+	ResourceOwner string             `json:"resourceOwner"`
+	Results       BackupResults      `json:"results"`
+	Selectors     selectors.Selector `json:"selectors"`
+	Version       string             `json:"version"`
 
 	account account.Account
 }
@@ -60,10 +61,11 @@ func NewBackupOperation(
 	bus events.Eventer,
 ) (BackupOperation, error) {
 	op := BackupOperation{
-		operation: newOperation(opts, bus, kw, sw),
-		Selectors: selector,
-		Version:   "v0",
-		account:   acct,
+		operation:     newOperation(opts, bus, kw, sw),
+		ResourceOwner: selector.DiscreteOwner,
+		Selectors:     selector,
+		Version:       "v0",
+		account:       acct,
 	}
 	if err := op.validate(); err != nil {
 		return BackupOperation{}, err
@@ -73,6 +75,10 @@ func NewBackupOperation(
 }
 
 func (op BackupOperation) validate() error {
+	if len(op.ResourceOwner) == 0 {
+		return errors.New("backup requires a resource owner")
+	}
+
 	return op.operation.validate()
 }
 
@@ -333,9 +339,7 @@ func selectorToOwnersCats(sel selectors.Selector) *kopia.OwnersCats {
 		ServiceCats:    map[string]kopia.ServiceCat{},
 	}
 
-	for _, ro := range sel.DiscreteResourceOwners() {
-		oc.ResourceOwners[ro] = struct{}{}
-	}
+	oc.ResourceOwners[sel.DiscreteOwner] = struct{}{}
 
 	pcs, err := sel.PathCategories()
 	if err != nil {

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -483,7 +483,7 @@ func (suite *BackupOpIntegrationSuite) TestNewBackupOperation() {
 				test.kw,
 				test.sw,
 				test.acct,
-				selectors.Selector{},
+				selectors.Selector{DiscreteOwner: "test"},
 				evmock.NewBus())
 			test.errCheck(t, err)
 		})
@@ -515,6 +515,8 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchange() {
 			selector: func() *selectors.ExchangeBackup {
 				sel := selectors.NewExchangeBackup(users)
 				sel.Include(sel.MailFolders(users, []string{exchange.DefaultMailFolder}, selectors.PrefixMatch()))
+				sel.DiscreteOwner = suite.user
+
 				return sel
 			},
 			resourceOwner:  suite.user,
@@ -530,6 +532,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchange() {
 					users,
 					[]string{exchange.DefaultContactFolder},
 					selectors.PrefixMatch()))
+				sel.DiscreteOwner = suite.user
 
 				return sel
 			},
@@ -543,6 +546,8 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchange() {
 			selector: func() *selectors.ExchangeBackup {
 				sel := selectors.NewExchangeBackup(users)
 				sel.Include(sel.EventCalendars(users, []string{exchange.DefaultCalendar}, selectors.PrefixMatch()))
+				sel.DiscreteOwner = suite.user
+
 				return sel
 			},
 			resourceOwner: suite.user,
@@ -868,16 +873,20 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchangeIncrementals() {
 					switch category {
 					case path.EmailCategory:
 						cmf := cli.MailFoldersById(containerID)
+
 						body, err := cmf.Get(ctx, nil)
 						require.NoError(t, err, "getting mail folder")
+
 						body.SetDisplayName(&containerRename)
 						_, err = cmf.Patch(ctx, body, nil)
 						require.NoError(t, err, "updating mail folder name")
 
 					case path.ContactsCategory:
 						ccf := cli.ContactFoldersById(containerID)
+
 						body, err := ccf.Get(ctx, nil)
 						require.NoError(t, err, "getting contact folder")
+
 						body.SetDisplayName(&containerRename)
 						_, err = ccf.Patch(ctx, body, nil)
 						require.NoError(t, err, "updating contact folder name")

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -364,7 +364,7 @@ func (suite *BackupOpSuite) TestBackupOperation_PersistResults() {
 				kw,
 				sw,
 				acct,
-				selectors.Selector{},
+				selectors.Selector{DiscreteOwner: "test"},
 				evmock.NewBus())
 			require.NoError(t, err)
 			test.expectErr(t, op.persistResults(now, &test.stats))

--- a/src/internal/operations/restore_test.go
+++ b/src/internal/operations/restore_test.go
@@ -98,7 +98,7 @@ func (suite *RestoreOpSuite) TestRestoreOperation_PersistResults() {
 				sw,
 				acct,
 				"foo",
-				selectors.Selector{},
+				selectors.Selector{DiscreteOwner: "test"},
 				dest,
 				evmock.NewBus())
 			require.NoError(t, err)
@@ -250,7 +250,7 @@ func (suite *RestoreOpIntegrationSuite) TestNewRestoreOperation() {
 				test.sw,
 				test.acct,
 				"backup-id",
-				selectors.Selector{},
+				selectors.Selector{DiscreteOwner: "test"},
 				dest,
 				evmock.NewBus())
 			test.errCheck(t, err)

--- a/src/pkg/repository/repository_test.go
+++ b/src/pkg/repository/repository_test.go
@@ -193,7 +193,7 @@ func (suite *RepositoryIntegrationSuite) TestNewBackup() {
 	r, err := repository.Initialize(ctx, acct, st, control.Options{})
 	require.NoError(t, err)
 
-	bo, err := r.NewBackup(ctx, selectors.Selector{})
+	bo, err := r.NewBackup(ctx, selectors.Selector{DiscreteOwner: "test"})
 	require.NoError(t, err)
 	require.NotNil(t, bo)
 }
@@ -213,7 +213,7 @@ func (suite *RepositoryIntegrationSuite) TestNewRestore() {
 	r, err := repository.Initialize(ctx, acct, st, control.Options{})
 	require.NoError(t, err)
 
-	ro, err := r.NewRestore(ctx, "backup-id", selectors.Selector{}, dest)
+	ro, err := r.NewRestore(ctx, "backup-id", selectors.Selector{DiscreteOwner: "test"}, dest)
 	require.NoError(t, err)
 	require.NotNil(t, ro)
 }

--- a/src/pkg/selectors/selectors.go
+++ b/src/pkg/selectors/selectors.go
@@ -113,9 +113,15 @@ type Selector struct {
 
 // helper for specific selector instance constructors.
 func newSelector(s service, resourceOwners []string) Selector {
+	var owner string
+	if len(resourceOwners) == 1 {
+		owner = resourceOwners[0]
+	}
+
 	return Selector{
 		Service:        s,
 		ResourceOwners: filterize(scopeConfig{}, resourceOwners...),
+		DiscreteOwner:  owner,
 		Excludes:       []scope{},
 		Includes:       []scope{},
 	}


### PR DESCRIPTION
## Description

Migrates code away from pulling the resource
owner from each scope, and instead usees the
selector as the canon identifier of the resource
owner.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :sunflower: Feature

## Issue(s)

* #1617

## Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
