### PR TITLE
Update folder size and modified time in details

### DIFF
--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -143,11 +143,29 @@ func (b *Builder) AddFoldersForItem(folders []FolderEntry, itemInfo ItemInfo) {
 		}
 
 		// Update the folder's size and modified time
+		var (
+			itemSize     int64
+			itemModified time.Time
+		)
 
-		folder.Info.Folder.Size += itemInfo.Exchange.Size
+		switch {
+		case itemInfo.Exchange != nil:
+			itemSize = itemInfo.Exchange.Size
+			itemModified = itemInfo.Exchange.Modified
 
-		if folder.Info.Folder.Modified.Before(itemInfo.Exchange.Modified) {
-			folder.Info.Folder.Modified = itemInfo.Exchange.Modified
+		case itemInfo.OneDrive != nil:
+			itemSize = itemInfo.OneDrive.Size
+			itemModified = itemInfo.OneDrive.Modified
+
+		case itemInfo.SharePoint != nil:
+			itemSize = itemInfo.SharePoint.Size
+			itemModified = itemInfo.SharePoint.Modified
+		}
+
+		folder.Info.Folder.Size += itemSize
+
+		if folder.Info.Folder.Modified.Before(itemModified) {
+			folder.Info.Folder.Modified = itemModified
 		}
 
 		b.knownFolders[folder.ShortRef] = folder

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -103,8 +103,8 @@ func (dm DetailsModel) Items() []*DetailsEntry {
 // Builder should be used to create a details model.
 type Builder struct {
 	d            Details
-	mu           sync.Mutex          `json:"-"`
-	knownFolders map[string]struct{} `json:"-"`
+	mu           sync.Mutex             `json:"-"`
+	knownFolders map[string]FolderEntry `json:"-"`
 }
 
 func (b *Builder) Add(repoRef, shortRef, parentRef string, updated bool, info ItemInfo) {
@@ -114,6 +114,14 @@ func (b *Builder) Add(repoRef, shortRef, parentRef string, updated bool, info It
 }
 
 func (b *Builder) Details() *Details {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// Write the cached folder entries to details
+	for _, folder := range b.knownFolders {
+		b.d.addFolder(folder)
+	}
+
 	return &b.d
 }
 
@@ -124,17 +132,25 @@ func (b *Builder) AddFoldersForItem(folders []FolderEntry, itemInfo ItemInfo) {
 	defer b.mu.Unlock()
 
 	if b.knownFolders == nil {
-		b.knownFolders = map[string]struct{}{}
+		b.knownFolders = map[string]FolderEntry{}
 	}
 
 	for _, folder := range folders {
-		if _, ok := b.knownFolders[folder.ShortRef]; ok {
-			// Entry already exists, nothing to do.
-			continue
+		if existing, ok := b.knownFolders[folder.ShortRef]; ok {
+			// We've seen this folder before for a different item.
+			// Update the "cached" folder entry
+			folder = existing
 		}
 
-		b.knownFolders[folder.ShortRef] = struct{}{}
-		b.d.addFolder(folder)
+		// Update the folder's size and modified time
+
+		folder.Info.Folder.Size += itemInfo.Exchange.Size
+
+		if folder.Info.Folder.Modified.Before(itemInfo.Exchange.Modified) {
+			folder.Info.Folder.Modified = itemInfo.Exchange.Modified
+		}
+
+		b.knownFolders[folder.ShortRef] = folder
 	}
 }
 

--- a/src/pkg/backup/details/details_test.go
+++ b/src/pkg/backup/details/details_test.go
@@ -337,3 +337,78 @@ func (suite *DetailsUnitSuite) TestDetails_AddFolders() {
 		})
 	}
 }
+
+func (suite *DetailsUnitSuite) TestDetails_AddFoldersDifferentServices() {
+	itemTime := time.Date(2022, 10, 21, 10, 0, 0, 0, time.UTC)
+	folderTimeOlderThanItem := time.Date(2022, 9, 21, 10, 0, 0, 0, time.UTC)
+
+	table := []struct {
+		name               string
+		item               details.ItemInfo
+		expectedFolderInfo details.FolderInfo
+	}{
+		{
+			name: "Exchange",
+			item: details.ItemInfo{
+				Exchange: &details.ExchangeInfo{
+					Size:     20,
+					Modified: itemTime,
+				},
+			},
+			expectedFolderInfo: details.FolderInfo{
+				Size:     20,
+				Modified: itemTime,
+			},
+		},
+		{
+			name: "OneDrive",
+			item: details.ItemInfo{
+				OneDrive: &details.OneDriveInfo{
+					Size:     20,
+					Modified: itemTime,
+				},
+			},
+			expectedFolderInfo: details.FolderInfo{
+				Size:     20,
+				Modified: itemTime,
+			},
+		},
+		{
+			name: "SharePoint",
+			item: details.ItemInfo{
+				SharePoint: &details.SharePointInfo{
+					Size:     20,
+					Modified: itemTime,
+				},
+			},
+			expectedFolderInfo: details.FolderInfo{
+				Size:     20,
+				Modified: itemTime,
+			},
+		},
+	}
+	for _, test := range table {
+		suite.T().Run(test.name, func(t *testing.T) {
+			folderEntry := details.FolderEntry{
+				RepoRef:   "rr1",
+				ShortRef:  "sr1",
+				ParentRef: "pr1",
+				Info: details.ItemInfo{
+					Folder: &details.FolderInfo{
+						Modified: folderTimeOlderThanItem,
+					},
+				},
+			}
+
+			builder := details.Builder{}
+			builder.AddFoldersForItem([]details.FolderEntry{folderEntry}, test.item)
+			deets := builder.Details()
+			require.Len(t, deets.Entries, 1)
+
+			got := deets.Entries[0].Folder
+
+			assert.Equal(t, test.expectedFolderInfo, *got)
+		})
+	}
+
+}

--- a/src/pkg/backup/details/details_test.go
+++ b/src/pkg/backup/details/details_test.go
@@ -222,16 +222,22 @@ func (suite *DetailsUnitSuite) TestDetailsModel_Items() {
 }
 
 func (suite *DetailsUnitSuite) TestDetails_AddFolders() {
+	itemTime := time.Date(2022, 10, 21, 10, 0, 0, 0, time.UTC)
+	folderTimeOlderThanItem := time.Date(2022, 9, 21, 10, 0, 0, 0, time.UTC)
+	folderTimeNewerThanItem := time.Date(2022, 11, 21, 10, 0, 0, 0, time.UTC)
+
 	itemInfo := details.ItemInfo{
 		Exchange: &details.ExchangeInfo{
-			Size: 1,
+			Size:     20,
+			Modified: itemTime,
 		},
 	}
 
 	table := []struct {
-		name              string
-		folders           []details.FolderEntry
-		expectedShortRefs []string
+		name               string
+		folders            []details.FolderEntry
+		expectedShortRefs  []string
+		expectedFolderInfo map[string]details.FolderInfo
 	}{
 		{
 			name: "MultipleFolders",
@@ -241,7 +247,9 @@ func (suite *DetailsUnitSuite) TestDetails_AddFolders() {
 					ShortRef:  "sr1",
 					ParentRef: "pr1",
 					Info: details.ItemInfo{
-						Folder: &details.FolderInfo{},
+						Folder: &details.FolderInfo{
+							Modified: folderTimeOlderThanItem,
+						},
 					},
 				},
 				{
@@ -249,11 +257,17 @@ func (suite *DetailsUnitSuite) TestDetails_AddFolders() {
 					ShortRef:  "sr2",
 					ParentRef: "pr2",
 					Info: details.ItemInfo{
-						Folder: &details.FolderInfo{},
+						Folder: &details.FolderInfo{
+							Modified: folderTimeNewerThanItem,
+						},
 					},
 				},
 			},
 			expectedShortRefs: []string{"sr1", "sr2"},
+			expectedFolderInfo: map[string]details.FolderInfo{
+				"sr1": {Size: 20, Modified: itemTime},
+				"sr2": {Size: 20, Modified: folderTimeNewerThanItem},
+			},
 		},
 		{
 			name: "MultipleFoldersWithRepeats",
@@ -263,7 +277,9 @@ func (suite *DetailsUnitSuite) TestDetails_AddFolders() {
 					ShortRef:  "sr1",
 					ParentRef: "pr1",
 					Info: details.ItemInfo{
-						Folder: &details.FolderInfo{},
+						Folder: &details.FolderInfo{
+							Modified: folderTimeOlderThanItem,
+						},
 					},
 				},
 				{
@@ -271,7 +287,9 @@ func (suite *DetailsUnitSuite) TestDetails_AddFolders() {
 					ShortRef:  "sr2",
 					ParentRef: "pr2",
 					Info: details.ItemInfo{
-						Folder: &details.FolderInfo{},
+						Folder: &details.FolderInfo{
+							Modified: folderTimeOlderThanItem,
+						},
 					},
 				},
 				{
@@ -279,7 +297,9 @@ func (suite *DetailsUnitSuite) TestDetails_AddFolders() {
 					ShortRef:  "sr1",
 					ParentRef: "pr1",
 					Info: details.ItemInfo{
-						Folder: &details.FolderInfo{},
+						Folder: &details.FolderInfo{
+							Modified: folderTimeOlderThanItem,
+						},
 					},
 				},
 				{
@@ -287,11 +307,19 @@ func (suite *DetailsUnitSuite) TestDetails_AddFolders() {
 					ShortRef:  "sr3",
 					ParentRef: "pr3",
 					Info: details.ItemInfo{
-						Folder: &details.FolderInfo{},
+						Folder: &details.FolderInfo{
+							Modified: folderTimeNewerThanItem,
+						},
 					},
 				},
 			},
 			expectedShortRefs: []string{"sr1", "sr2", "sr3"},
+			expectedFolderInfo: map[string]details.FolderInfo{
+				// Two items were added
+				"sr1": {Size: 40, Modified: itemTime},
+				"sr2": {Size: 20, Modified: itemTime},
+				"sr3": {Size: 20, Modified: folderTimeNewerThanItem},
+			},
 		},
 	}
 	for _, test := range table {
@@ -303,6 +331,8 @@ func (suite *DetailsUnitSuite) TestDetails_AddFolders() {
 
 			for _, e := range deets.Entries {
 				assert.Contains(t, test.expectedShortRefs, e.ShortRef)
+				assert.Equal(t, test.expectedFolderInfo[e.ShortRef].Size, e.Folder.Size)
+				assert.Equal(t, test.expectedFolderInfo[e.ShortRef].Modified, e.Folder.Modified)
 			}
 		})
 	}

--- a/src/pkg/backup/details/details_test.go
+++ b/src/pkg/backup/details/details_test.go
@@ -410,5 +410,4 @@ func (suite *DetailsUnitSuite) TestDetails_AddFoldersDifferentServices() {
 			assert.Equal(t, test.expectedFolderInfo, *got)
 		})
 	}
-
 }


### PR DESCRIPTION
## Description

Caches folder info added during details construction in the details builder and keeps the size/modified time
updated as newer items are added.

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [x] :clock1: Yes, but in a later PR
- [ ] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #1850 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
