### PR TITLE
Functions to merge a set of backup details

### DIFF
--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -420,7 +420,7 @@ func mergeDetails(
 	detailsStore detailsReader,
 	mans []*kopia.ManifestEntry,
 	toMerge map[string]path.Path,
-	deets *details.Details,
+	deets *details.Builder,
 ) error {
 	// Don't bother loading any of the base details if there's nothing we need to
 	// merge.

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -419,12 +419,12 @@ func mergeDetails(
 	ms *store.Wrapper,
 	detailsStore detailsReader,
 	mans []*kopia.ManifestEntry,
-	toMerge map[string]path.Path,
+	shortRefsFromPrevBackup map[string]path.Path,
 	deets *details.Builder,
 ) error {
 	// Don't bother loading any of the base details if there's nothing we need to
 	// merge.
-	if len(toMerge) == 0 {
+	if len(shortRefsFromPrevBackup) == 0 {
 		return nil
 	}
 
@@ -455,9 +455,9 @@ func mergeDetails(
 			if err != nil {
 				return errors.Wrapf(
 					err,
-					"parsing base item info in backup %s at path %s",
-					bID,
+					"parsing base item info path %s in backup %s",
 					entry.RepoRef,
+					bID,
 				)
 			}
 
@@ -471,7 +471,7 @@ func mergeDetails(
 				continue
 			}
 
-			newPath := toMerge[rr.ShortRef()]
+			newPath := shortRefsFromPrevBackup[rr.ShortRef()]
 			if newPath == nil {
 				// This entry was not sourced from a base snapshot or cached from a
 				// previous backup, skip it.
@@ -504,11 +504,11 @@ func mergeDetails(
 		}
 	}
 
-	if addedEntries != len(toMerge) {
+	if addedEntries != len(shortRefsFromPrevBackup) {
 		return errors.Errorf(
-			"merging details: wanted %v entries but added %v",
-			len(toMerge),
+			"incomplete migration of backup details: found %v of %v expected items",
 			addedEntries,
+			len(shortRefsFromPrevBackup),
 		)
 	}
 

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -697,31 +697,31 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 	require.NoError(suite.T(), err)
 
 	table := []struct {
-		name             string
-		populatedModels  map[model.StableID]backup.Backup
-		populatedDetails map[string]*details.Details
-		inputMans        []*kopia.ManifestEntry
-		inputToMerge     map[string]path.Path
+		name                         string
+		populatedModels              map[model.StableID]backup.Backup
+		populatedDetails             map[string]*details.Details
+		inputMans                    []*kopia.ManifestEntry
+		inputShortRefsFromPrevBackup map[string]path.Path
 
 		errCheck        assert.ErrorAssertionFunc
 		expectedEntries []*details.DetailsEntry
 	}{
 		{
-			name:     "NilToMerge",
+			name:     "NilShortRefsFromPrevBackup",
 			errCheck: assert.NoError,
 			// Use empty slice so we don't error out on nil != empty.
 			expectedEntries: []*details.DetailsEntry{},
 		},
 		{
-			name:         "EmptyToMerge",
-			inputToMerge: map[string]path.Path{},
-			errCheck:     assert.NoError,
+			name:                         "EmptyShortRefsFromPrevBackup",
+			inputShortRefsFromPrevBackup: map[string]path.Path{},
+			errCheck:                     assert.NoError,
 			// Use empty slice so we don't error out on nil != empty.
 			expectedEntries: []*details.DetailsEntry{},
 		},
 		{
 			name: "BackupIDNotFound",
-			inputToMerge: map[string]path.Path{
+			inputShortRefsFromPrevBackup: map[string]path.Path{
 				itemPath1.ShortRef(): itemPath1,
 			},
 			inputMans: []*kopia.ManifestEntry{
@@ -736,7 +736,7 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 		},
 		{
 			name: "DetailsIDNotFound",
-			inputToMerge: map[string]path.Path{
+			inputShortRefsFromPrevBackup: map[string]path.Path{
 				itemPath1.ShortRef(): itemPath1,
 			},
 			inputMans: []*kopia.ManifestEntry{
@@ -759,7 +759,7 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 		},
 		{
 			name: "BaseMissingItems",
-			inputToMerge: map[string]path.Path{
+			inputShortRefsFromPrevBackup: map[string]path.Path{
 				itemPath1.ShortRef(): itemPath1,
 				itemPath2.ShortRef(): itemPath2,
 			},
@@ -787,7 +787,7 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 		},
 		{
 			name: "TooManyItems",
-			inputToMerge: map[string]path.Path{
+			inputShortRefsFromPrevBackup: map[string]path.Path{
 				itemPath1.ShortRef(): itemPath1,
 			},
 			inputMans: []*kopia.ManifestEntry{
@@ -820,7 +820,7 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 		},
 		{
 			name: "BadBaseRepoRef",
-			inputToMerge: map[string]path.Path{
+			inputShortRefsFromPrevBackup: map[string]path.Path{
 				itemPath1.ShortRef(): itemPath1,
 			},
 			inputMans: []*kopia.ManifestEntry{
@@ -866,7 +866,7 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 		},
 		{
 			name: "BadOneDrivePath",
-			inputToMerge: map[string]path.Path{
+			inputShortRefsFromPrevBackup: map[string]path.Path{
 				itemPath1.ShortRef(): makePath(
 					suite.T(),
 					[]string{
@@ -904,7 +904,7 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 		},
 		{
 			name: "ItemMerged",
-			inputToMerge: map[string]path.Path{
+			inputShortRefsFromPrevBackup: map[string]path.Path{
 				itemPath1.ShortRef(): itemPath1,
 			},
 			inputMans: []*kopia.ManifestEntry{
@@ -934,7 +934,7 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 		},
 		{
 			name: "ItemMergedExtraItemsInBase",
-			inputToMerge: map[string]path.Path{
+			inputShortRefsFromPrevBackup: map[string]path.Path{
 				itemPath1.ShortRef(): itemPath1,
 			},
 			inputMans: []*kopia.ManifestEntry{
@@ -965,7 +965,7 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 		},
 		{
 			name: "ItemMoved",
-			inputToMerge: map[string]path.Path{
+			inputShortRefsFromPrevBackup: map[string]path.Path{
 				itemPath1.ShortRef(): itemPath2,
 			},
 			inputMans: []*kopia.ManifestEntry{
@@ -995,7 +995,7 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 		},
 		{
 			name: "MultipleBases",
-			inputToMerge: map[string]path.Path{
+			inputShortRefsFromPrevBackup: map[string]path.Path{
 				itemPath1.ShortRef(): itemPath1,
 				itemPath3.ShortRef(): itemPath3,
 			},
@@ -1044,7 +1044,7 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 		},
 		{
 			name: "SomeBasesIncomplete",
-			inputToMerge: map[string]path.Path{
+			inputShortRefsFromPrevBackup: map[string]path.Path{
 				itemPath1.ShortRef(): itemPath1,
 			},
 			inputMans: []*kopia.ManifestEntry{
@@ -1104,7 +1104,7 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 				w,
 				mdr,
 				test.inputMans,
-				test.inputToMerge,
+				test.inputShortRefsFromPrevBackup,
 				&deets,
 			)
 

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -561,10 +561,10 @@ func makeDetailsEntry(
 	p path.Path,
 	size int,
 	updated bool,
-) details.DetailsEntry {
+) *details.DetailsEntry {
 	t.Helper()
 
-	res := details.DetailsEntry{
+	res := &details.DetailsEntry{
 		RepoRef:   p.String(),
 		ShortRef:  p.ShortRef(),
 		ParentRef: p.ToBuilder().Dir().ShortRef(),
@@ -704,20 +704,20 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 		inputToMerge     map[string]path.Path
 
 		errCheck        assert.ErrorAssertionFunc
-		expectedEntries []details.DetailsEntry
+		expectedEntries []*details.DetailsEntry
 	}{
 		{
 			name:     "NilToMerge",
 			errCheck: assert.NoError,
 			// Use empty slice so we don't error out on nil != empty.
-			expectedEntries: []details.DetailsEntry{},
+			expectedEntries: []*details.DetailsEntry{},
 		},
 		{
 			name:         "EmptyToMerge",
 			inputToMerge: map[string]path.Path{},
 			errCheck:     assert.NoError,
 			// Use empty slice so we don't error out on nil != empty.
-			expectedEntries: []details.DetailsEntry{},
+			expectedEntries: []*details.DetailsEntry{},
 		},
 		{
 			name: "BackupIDNotFound",
@@ -778,7 +778,7 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 				backup1.DetailsID: {
 					DetailsModel: details.DetailsModel{
 						Entries: []details.DetailsEntry{
-							makeDetailsEntry(suite.T(), itemPath1, 42, false),
+							*makeDetailsEntry(suite.T(), itemPath1, 42, false),
 						},
 					},
 				},
@@ -811,7 +811,7 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 				backup1.DetailsID: {
 					DetailsModel: details.DetailsModel{
 						Entries: []details.DetailsEntry{
-							makeDetailsEntry(suite.T(), itemPath1, 42, false),
+							*makeDetailsEntry(suite.T(), itemPath1, 42, false),
 						},
 					},
 				},
@@ -895,7 +895,7 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 				backup1.DetailsID: {
 					DetailsModel: details.DetailsModel{
 						Entries: []details.DetailsEntry{
-							makeDetailsEntry(suite.T(), itemPath1, 42, false),
+							*makeDetailsEntry(suite.T(), itemPath1, 42, false),
 						},
 					},
 				},
@@ -922,13 +922,13 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 				backup1.DetailsID: {
 					DetailsModel: details.DetailsModel{
 						Entries: []details.DetailsEntry{
-							makeDetailsEntry(suite.T(), itemPath1, 42, false),
+							*makeDetailsEntry(suite.T(), itemPath1, 42, false),
 						},
 					},
 				},
 			},
 			errCheck: assert.NoError,
-			expectedEntries: []details.DetailsEntry{
+			expectedEntries: []*details.DetailsEntry{
 				makeDetailsEntry(suite.T(), itemPath1, 42, false),
 			},
 		},
@@ -952,14 +952,14 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 				backup1.DetailsID: {
 					DetailsModel: details.DetailsModel{
 						Entries: []details.DetailsEntry{
-							makeDetailsEntry(suite.T(), itemPath1, 42, false),
-							makeDetailsEntry(suite.T(), itemPath2, 84, false),
+							*makeDetailsEntry(suite.T(), itemPath1, 42, false),
+							*makeDetailsEntry(suite.T(), itemPath2, 84, false),
 						},
 					},
 				},
 			},
 			errCheck: assert.NoError,
-			expectedEntries: []details.DetailsEntry{
+			expectedEntries: []*details.DetailsEntry{
 				makeDetailsEntry(suite.T(), itemPath1, 42, false),
 			},
 		},
@@ -983,13 +983,13 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 				backup1.DetailsID: {
 					DetailsModel: details.DetailsModel{
 						Entries: []details.DetailsEntry{
-							makeDetailsEntry(suite.T(), itemPath1, 42, false),
+							*makeDetailsEntry(suite.T(), itemPath1, 42, false),
 						},
 					},
 				},
 			},
 			errCheck: assert.NoError,
-			expectedEntries: []details.DetailsEntry{
+			expectedEntries: []*details.DetailsEntry{
 				makeDetailsEntry(suite.T(), itemPath2, 42, true),
 			},
 		},
@@ -1021,7 +1021,7 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 				backup1.DetailsID: {
 					DetailsModel: details.DetailsModel{
 						Entries: []details.DetailsEntry{
-							makeDetailsEntry(suite.T(), itemPath1, 42, false),
+							*makeDetailsEntry(suite.T(), itemPath1, 42, false),
 						},
 					},
 				},
@@ -1029,15 +1029,15 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 					DetailsModel: details.DetailsModel{
 						Entries: []details.DetailsEntry{
 							// This entry should not be picked due to a mismatch on Reasons.
-							makeDetailsEntry(suite.T(), itemPath1, 84, false),
+							*makeDetailsEntry(suite.T(), itemPath1, 84, false),
 							// This item should be picked.
-							makeDetailsEntry(suite.T(), itemPath3, 37, false),
+							*makeDetailsEntry(suite.T(), itemPath3, 37, false),
 						},
 					},
 				},
 			},
 			errCheck: assert.NoError,
-			expectedEntries: []details.DetailsEntry{
+			expectedEntries: []*details.DetailsEntry{
 				makeDetailsEntry(suite.T(), itemPath1, 42, false),
 				makeDetailsEntry(suite.T(), itemPath3, 37, false),
 			},
@@ -1069,7 +1069,7 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 				backup1.DetailsID: {
 					DetailsModel: details.DetailsModel{
 						Entries: []details.DetailsEntry{
-							makeDetailsEntry(suite.T(), itemPath1, 42, false),
+							*makeDetailsEntry(suite.T(), itemPath1, 42, false),
 						},
 					},
 				},
@@ -1077,13 +1077,13 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 					DetailsModel: details.DetailsModel{
 						Entries: []details.DetailsEntry{
 							// This entry should not be picked due to being incomplete.
-							makeDetailsEntry(suite.T(), itemPath1, 84, false),
+							*makeDetailsEntry(suite.T(), itemPath1, 84, false),
 						},
 					},
 				},
 			},
 			errCheck: assert.NoError,
-			expectedEntries: []details.DetailsEntry{
+			expectedEntries: []*details.DetailsEntry{
 				makeDetailsEntry(suite.T(), itemPath1, 42, false),
 			},
 		},
@@ -1097,7 +1097,7 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 			mdr := mockDetailsReader{entries: test.populatedDetails}
 			w := &store.Wrapper{Storer: mockBackupStorer{entries: test.populatedModels}}
 
-			deets := details.Details{}
+			deets := details.Builder{}
 
 			err := mergeDetails(
 				ctx,
@@ -1113,7 +1113,7 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails() {
 				return
 			}
 
-			assert.ElementsMatch(t, test.expectedEntries, deets.Entries)
+			assert.ElementsMatch(t, test.expectedEntries, deets.Details().Items())
 		})
 	}
 }

--- a/src/internal/operations/common.go
+++ b/src/internal/operations/common.go
@@ -5,31 +5,28 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/alcionai/corso/src/internal/kopia"
 	"github.com/alcionai/corso/src/internal/model"
-	"github.com/alcionai/corso/src/internal/streamstore"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
-	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/store"
 )
 
+type detailsReader interface {
+	ReadBackupDetails(ctx context.Context, detailsID string) (*details.Details, error)
+}
+
 func getBackupAndDetailsFromID(
 	ctx context.Context,
-	tenant string,
 	backupID model.StableID,
-	service path.ServiceType,
 	ms *store.Wrapper,
-	kw *kopia.Wrapper,
+	detailsStore detailsReader,
 ) (*backup.Backup, *details.Details, error) {
 	dID, bup, err := ms.GetDetailsIDFromBackupID(ctx, backupID)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "getting backup details ID")
 	}
 
-	deets, err := streamstore.
-		New(kw, tenant, service).
-		ReadBackupDetails(ctx, dID)
+	deets, err := detailsStore.ReadBackupDetails(ctx, dID)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "getting backup details data")
 	}

--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -18,6 +18,7 @@ import (
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/internal/observe"
 	"github.com/alcionai/corso/src/internal/stats"
+	"github.com/alcionai/corso/src/internal/streamstore"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control"
@@ -117,13 +118,13 @@ func (op *RestoreOperation) Run(ctx context.Context) (restoreDetails *details.De
 		}
 	}()
 
+	detailsStore := streamstore.New(op.kopia, op.account.ID(), op.Selectors.PathService())
+
 	bup, deets, err := getBackupAndDetailsFromID(
 		ctx,
-		op.account.ID(),
 		op.BackupID,
-		op.Selectors.PathService(),
 		op.store,
-		op.kopia,
+		detailsStore,
 	)
 	if err != nil {
 		err = errors.Wrap(err, "restore")


### PR DESCRIPTION
## Description

Go through the provided bases, load their backup details, and check if
any of the items in them need to be merged into the details for the
current backup.

Has a small amount of logic to treat moved items as updated.

Also include all the tests

Viewing by commit may be useful

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* #1800 

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
