### PR TITLE
Wire details merging during BackupOp.Run

### DIFF
--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -140,9 +140,7 @@ func (w Wrapper) BackupCollections(
 		toMerge: map[string]path.Path{},
 	}
 
-	// TODO(ashmrtn): Pass previousSnapshots here to enable building the directory
-	// hierarchy with them.
-	dirTree, err := inflateDirTree(ctx, w.c, nil, collections, progress)
+	dirTree, err := inflateDirTree(ctx, w.c, previousSnapshots, collections, progress)
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(err, "building kopia directories")
 	}

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -122,7 +122,7 @@ func (w Wrapper) BackupCollections(
 	service path.ServiceType,
 	oc *OwnersCats,
 	tags map[string]string,
-) (*BackupStats, *details.Details, map[string]path.Path, error) {
+) (*BackupStats, *details.Builder, map[string]path.Path, error) {
 	if w.c == nil {
 		return nil, nil, nil, errNotConnected
 	}
@@ -131,7 +131,7 @@ func (w Wrapper) BackupCollections(
 	defer end()
 
 	if len(collections) == 0 {
-		return &BackupStats{}, (&details.Builder{}).Details(), nil, nil
+		return &BackupStats{}, &details.Builder{}, nil, nil
 	}
 
 	progress := &corsoProgress{
@@ -159,7 +159,7 @@ func (w Wrapper) BackupCollections(
 		return nil, nil, nil, err
 	}
 
-	return s, progress.deets.Details(), progress.toMerge, nil
+	return s, progress.deets, progress.toMerge, nil
 }
 
 func (w Wrapper) makeSnapshotWithRoot(

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -285,7 +285,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 			// 47 file and 6 folder entries.
 			assert.Len(
 				t,
-				deets.Entries,
+				deets.Details().Entries,
 				test.expectedUploadedFiles+test.expectedCachedFiles+6,
 			)
 
@@ -444,7 +444,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_ReaderError() {
 	assert.Equal(t, 1, stats.IgnoredErrorCount)
 	assert.False(t, stats.Incomplete)
 	// 5 file and 6 folder entries.
-	assert.Len(t, deets.Entries, 5+6)
+	assert.Len(t, deets.Details().Entries, 5+6)
 }
 
 type backedupFile struct {
@@ -484,7 +484,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollectionsHandlesNoCollections() 
 			require.NoError(t, err)
 
 			assert.Equal(t, BackupStats{}, *s)
-			assert.Empty(t, d.Entries)
+			assert.Empty(t, d.Details().Entries)
 		})
 	}
 }
@@ -649,7 +649,7 @@ func (suite *KopiaSimpleRepoIntegrationSuite) SetupTest() {
 	require.Equal(t, stats.IgnoredErrorCount, 0)
 	require.False(t, stats.Incomplete)
 	// 6 file and 6 folder entries.
-	assert.Len(t, deets.Entries, expectedFiles+expectedDirs)
+	assert.Len(t, deets.Details().Entries, expectedFiles+expectedDirs)
 
 	suite.snapshotID = manifest.ID(stats.SnapshotID)
 }

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -299,12 +299,12 @@ func (mbu mockBackuper) BackupCollections(
 	service path.ServiceType,
 	oc *kopia.OwnersCats,
 	tags map[string]string,
-) (*kopia.BackupStats, *details.Details, map[string]path.Path, error) {
+) (*kopia.BackupStats, *details.Builder, map[string]path.Path, error) {
 	if mbu.checkFunc != nil {
 		mbu.checkFunc(bases, cs, service, oc, tags)
 	}
 
-	return &kopia.BackupStats{}, &details.Details{}, nil, nil
+	return &kopia.BackupStats{}, &details.Builder{}, nil, nil
 }
 
 func (suite *BackupOpSuite) TestBackupOperation_ConsumeBackupDataCollections_Paths() {


### PR DESCRIPTION
## Description

Actually call the details merge function while performing a backup. If no base snapshots or `len(toMerge) == 0` then turns into a noop.

This PR contains a little extra refactoring to keep from initializing a struct multiple times. However, long-term we should probably refactor BackupOp to better fit the fact that we are now using interfaces as inputs to many functions for the sake of testing

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* closes #1800 

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
