### PR TITLE
refactors the exchange fetchIDs iters

### DIFF
--- a/src/internal/connector/exchange/api/api.go
+++ b/src/internal/connector/exchange/api/api.go
@@ -87,18 +87,6 @@ func newService(creds account.M365Config) (*graph.Service, error) {
 	return graph.NewService(adapter), nil
 }
 
-func (c Client) Contacts() Contacts {
-	return Contacts{c}
-}
-
-func (c Client) Events() Events {
-	return Events{c}
-}
-
-func (c Client) Mail() Mail {
-	return Mail{c}
-}
-
 // ---------------------------------------------------------------------------
 // helper funcs
 // ---------------------------------------------------------------------------

--- a/src/internal/connector/exchange/api/contacts.go
+++ b/src/internal/connector/exchange/api/contacts.go
@@ -40,10 +40,6 @@ func (p *contactPager) setNext(nextLink string) {
 	p.builder = users.NewItemContactFoldersItemContactsDeltaRequestBuilder(nextLink, p.gs.Adapter())
 }
 
-func (p *contactPager) idsIn(pl pageLinker) ([]getIDer, error) {
-	return toIders(pl)
-}
-
 // ---------------------------------------------------------------------------
 // methods
 // ---------------------------------------------------------------------------
@@ -197,7 +193,7 @@ func (c Contacts) GetAddedAndRemovedItemIDs(
 		builder := users.NewItemContactFoldersItemContactsDeltaRequestBuilder(oldDelta, service.Adapter())
 		pgr := &contactPager{service, builder, options}
 
-		added, removed, deltaURL, err := getContainerIDs(ctx, pgr, errUpdater)
+		added, removed, deltaURL, err := getItemsAddedAndRemovedFromContainer(ctx, pgr, errUpdater)
 		// note: happy path, not the error condition
 		if err == nil {
 			return added, removed, DeltaUpdate{deltaURL, false}, errs.ErrorOrNil()
@@ -215,7 +211,7 @@ func (c Contacts) GetAddedAndRemovedItemIDs(
 	builder := service.Client().UsersById(user).ContactFoldersById(directoryID).Contacts().Delta()
 	pgr := &contactPager{service, builder, options}
 
-	added, removed, deltaURL, err := getContainerIDs(ctx, pgr, errUpdater)
+	added, removed, deltaURL, err := getItemsAddedAndRemovedFromContainer(ctx, pgr, errUpdater)
 	if err != nil {
 		return nil, nil, DeltaUpdate{}, err
 	}

--- a/src/internal/connector/exchange/api/contacts.go
+++ b/src/internal/connector/exchange/api/contacts.go
@@ -26,20 +26,6 @@ type Contacts struct {
 	Client
 }
 
-type contactPager struct {
-	gs      graph.Servicer
-	builder *users.ItemContactFoldersItemContactsDeltaRequestBuilder
-	options *users.ItemContactFoldersItemContactsDeltaRequestBuilderGetRequestConfiguration
-}
-
-func (p *contactPager) getPage(ctx context.Context) (pageLinker, error) {
-	return p.builder.Get(ctx, p.options)
-}
-
-func (p *contactPager) setNext(nextLink string) {
-	p.builder = users.NewItemContactFoldersItemContactsDeltaRequestBuilder(nextLink, p.gs.Adapter())
-}
-
 // ---------------------------------------------------------------------------
 // methods
 // ---------------------------------------------------------------------------
@@ -164,6 +150,24 @@ func (c Contacts) EnumerateContainers(
 	}
 
 	return errs.ErrorOrNil()
+}
+
+// ---------------------------------------------------------------------------
+// item pager
+// ---------------------------------------------------------------------------
+
+type contactPager struct {
+	gs      graph.Servicer
+	builder *users.ItemContactFoldersItemContactsDeltaRequestBuilder
+	options *users.ItemContactFoldersItemContactsDeltaRequestBuilderGetRequestConfiguration
+}
+
+func (p *contactPager) getPage(ctx context.Context) (pageLinker, error) {
+	return p.builder.Get(ctx, p.options)
+}
+
+func (p *contactPager) setNext(nextLink string) {
+	p.builder = users.NewItemContactFoldersItemContactsDeltaRequestBuilder(nextLink, p.gs.Adapter())
 }
 
 func (c Contacts) GetAddedAndRemovedItemIDs(

--- a/src/internal/connector/exchange/api/contacts.go
+++ b/src/internal/connector/exchange/api/contacts.go
@@ -170,6 +170,10 @@ func (p *contactPager) setNext(nextLink string) {
 	p.builder = users.NewItemContactFoldersItemContactsDeltaRequestBuilder(nextLink, p.gs.Adapter())
 }
 
+func (p *contactPager) valuesIn(pl pageLinker) ([]getIDAndAddtler, error) {
+	return toValues(pl)
+}
+
 func (c Contacts) GetAddedAndRemovedItemIDs(
 	ctx context.Context,
 	user, directoryID, oldDelta string,

--- a/src/internal/connector/exchange/api/contacts.go
+++ b/src/internal/connector/exchange/api/contacts.go
@@ -156,6 +156,8 @@ func (c Contacts) EnumerateContainers(
 // item pager
 // ---------------------------------------------------------------------------
 
+var _ itemPager = &contactPager{}
+
 type contactPager struct {
 	gs      graph.Servicer
 	builder *users.ItemContactFoldersItemContactsDeltaRequestBuilder
@@ -171,7 +173,7 @@ func (p *contactPager) setNext(nextLink string) {
 }
 
 func (p *contactPager) valuesIn(pl pageLinker) ([]getIDAndAddtler, error) {
-	return toValues(pl)
+	return toValues[models.Contactable](pl)
 }
 
 func (c Contacts) GetAddedAndRemovedItemIDs(

--- a/src/internal/connector/exchange/api/contacts.go
+++ b/src/internal/connector/exchange/api/contacts.go
@@ -190,10 +190,6 @@ func (c Contacts) GetAddedAndRemovedItemIDs(
 		resetDelta bool
 	)
 
-	errUpdater := func(err error) {
-		errs = multierror.Append(errs, errors.Wrap(err, "folder "+directoryID))
-	}
-
 	options, err := optionsForContactFoldersItemDelta([]string{"parentFolderId"})
 	if err != nil {
 		return nil, nil, DeltaUpdate{}, errors.Wrap(err, "getting query options")
@@ -203,7 +199,7 @@ func (c Contacts) GetAddedAndRemovedItemIDs(
 		builder := users.NewItemContactFoldersItemContactsDeltaRequestBuilder(oldDelta, service.Adapter())
 		pgr := &contactPager{service, builder, options}
 
-		added, removed, deltaURL, err := getItemsAddedAndRemovedFromContainer(ctx, pgr, errUpdater)
+		added, removed, deltaURL, err := getItemsAddedAndRemovedFromContainer(ctx, pgr)
 		// note: happy path, not the error condition
 		if err == nil {
 			return added, removed, DeltaUpdate{deltaURL, false}, errs.ErrorOrNil()
@@ -221,7 +217,7 @@ func (c Contacts) GetAddedAndRemovedItemIDs(
 	builder := service.Client().UsersById(user).ContactFoldersById(directoryID).Contacts().Delta()
 	pgr := &contactPager{service, builder, options}
 
-	added, removed, deltaURL, err := getItemsAddedAndRemovedFromContainer(ctx, pgr, errUpdater)
+	added, removed, deltaURL, err := getItemsAddedAndRemovedFromContainer(ctx, pgr)
 	if err != nil {
 		return nil, nil, DeltaUpdate{}, err
 	}

--- a/src/internal/connector/exchange/api/contacts.go
+++ b/src/internal/connector/exchange/api/contacts.go
@@ -17,8 +17,31 @@ import (
 // controller
 // ---------------------------------------------------------------------------
 
+func (c Client) Contacts() Contacts {
+	return Contacts{c}
+}
+
+// Contacts is an interface-compliant provider of the client.
 type Contacts struct {
 	Client
+}
+
+type contactPager struct {
+	gs      graph.Servicer
+	builder *users.ItemContactFoldersItemContactsDeltaRequestBuilder
+	options *users.ItemContactFoldersItemContactsDeltaRequestBuilderGetRequestConfiguration
+}
+
+func (p *contactPager) getPage(ctx context.Context) (pageLinker, error) {
+	return p.builder.Get(ctx, p.options)
+}
+
+func (p *contactPager) setNext(nextLink string) {
+	p.builder = users.NewItemContactFoldersItemContactsDeltaRequestBuilder(nextLink, p.gs.Adapter())
+}
+
+func (p *contactPager) idsIn(pl pageLinker) ([]getIDer, error) {
+	return toIders(pl)
 }
 
 // ---------------------------------------------------------------------------
@@ -158,74 +181,29 @@ func (c Contacts) GetAddedAndRemovedItemIDs(
 
 	var (
 		errs       *multierror.Error
-		ids        []string
-		removedIDs []string
-		deltaURL   string
 		resetDelta bool
 	)
+
+	errUpdater := func(err error) {
+		errs = multierror.Append(errs, errors.Wrap(err, "folder "+directoryID))
+	}
 
 	options, err := optionsForContactFoldersItemDelta([]string{"parentFolderId"})
 	if err != nil {
 		return nil, nil, DeltaUpdate{}, errors.Wrap(err, "getting query options")
 	}
 
-	getIDs := func(builder *users.ItemContactFoldersItemContactsDeltaRequestBuilder) error {
-		for {
-			resp, err := builder.Get(ctx, options)
-			if err != nil {
-				if err := graph.IsErrDeletedInFlight(err); err != nil {
-					return err
-				}
-
-				if err := graph.IsErrInvalidDelta(err); err != nil {
-					return err
-				}
-
-				return errors.Wrap(err, support.ConnectorStackErrorTrace(err))
-			}
-
-			for _, item := range resp.GetValue() {
-				if item.GetId() == nil {
-					errs = multierror.Append(
-						errs,
-						errors.Errorf("item with nil ID in folder %s", directoryID),
-					)
-
-					// TODO(ashmrtn): Handle fail-fast.
-					continue
-				}
-
-				if item.GetAdditionalData()[graph.AddtlDataRemoved] == nil {
-					ids = append(ids, *item.GetId())
-				} else {
-					removedIDs = append(removedIDs, *item.GetId())
-				}
-			}
-
-			delta := resp.GetOdataDeltaLink()
-			if delta != nil && len(*delta) > 0 {
-				deltaURL = *delta
-			}
-
-			nextLink := resp.GetOdataNextLink()
-			if nextLink == nil || len(*nextLink) == 0 {
-				break
-			}
-
-			builder = users.NewItemContactFoldersItemContactsDeltaRequestBuilder(*nextLink, service.Adapter())
-		}
-
-		return nil
-	}
-
 	if len(oldDelta) > 0 {
-		err := getIDs(users.NewItemContactFoldersItemContactsDeltaRequestBuilder(oldDelta, service.Adapter()))
+		builder := users.NewItemContactFoldersItemContactsDeltaRequestBuilder(oldDelta, service.Adapter())
+		pgr := &contactPager{service, builder, options}
+
+		added, removed, deltaURL, err := getContainerIDs(ctx, pgr, errUpdater)
 		// note: happy path, not the error condition
 		if err == nil {
-			return ids, removedIDs, DeltaUpdate{deltaURL, false}, errs.ErrorOrNil()
+			return added, removed, DeltaUpdate{deltaURL, false}, errs.ErrorOrNil()
 		}
 		// only return on error if it is NOT a delta issue.
-		// otherwise we'll retry the call with the regular builder
+		// on bad deltas we retry the call with the regular builder
 		if graph.IsErrInvalidDelta(err) == nil {
 			return nil, nil, DeltaUpdate{}, err
 		}
@@ -234,15 +212,13 @@ func (c Contacts) GetAddedAndRemovedItemIDs(
 		errs = nil
 	}
 
-	builder := service.Client().
-		UsersById(user).
-		ContactFoldersById(directoryID).
-		Contacts().
-		Delta()
+	builder := service.Client().UsersById(user).ContactFoldersById(directoryID).Contacts().Delta()
+	pgr := &contactPager{service, builder, options}
 
-	if err := getIDs(builder); err != nil {
+	added, removed, deltaURL, err := getContainerIDs(ctx, pgr, errUpdater)
+	if err != nil {
 		return nil, nil, DeltaUpdate{}, err
 	}
 
-	return ids, removedIDs, DeltaUpdate{deltaURL, resetDelta}, errs.ErrorOrNil()
+	return added, removed, DeltaUpdate{deltaURL, resetDelta}, errs.ErrorOrNil()
 }

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -173,10 +173,6 @@ func (c Events) GetAddedAndRemovedItemIDs(
 
 	var errs *multierror.Error
 
-	errUpdater := func(err error) {
-		errs = multierror.Append(errs, errors.Wrap(err, "calendar "+calendarID))
-	}
-
 	options, err := optionsForEventsByCalendar([]string{"id"})
 	if err != nil {
 		return nil, nil, DeltaUpdate{}, err
@@ -185,7 +181,7 @@ func (c Events) GetAddedAndRemovedItemIDs(
 	builder := service.Client().UsersById(user).CalendarsById(calendarID).Events()
 	pgr := &eventPager{service, builder, options}
 
-	added, _, _, err := getItemsAddedAndRemovedFromContainer(ctx, pgr, errUpdater)
+	added, _, _, err := getItemsAddedAndRemovedFromContainer(ctx, pgr)
 	if err != nil {
 		return nil, nil, DeltaUpdate{}, err
 	}

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -27,29 +27,6 @@ type Events struct {
 	Client
 }
 
-type eventPager struct {
-	gs      graph.Servicer
-	builder *users.ItemCalendarsItemEventsRequestBuilder
-	options *users.ItemCalendarsItemEventsRequestBuilderGetRequestConfiguration
-}
-
-type eventWrapper struct {
-	models.EventCollectionResponseable
-}
-
-func (ew eventWrapper) GetOdataDeltaLink() *string {
-	return nil
-}
-
-func (p *eventPager) getPage(ctx context.Context) (pageLinker, error) {
-	resp, err := p.builder.Get(ctx, p.options)
-	return eventWrapper{resp}, err
-}
-
-func (p *eventPager) setNext(nextLink string) {
-	p.builder = users.NewItemCalendarsItemEventsRequestBuilder(nextLink, p.gs.Adapter())
-}
-
 // ---------------------------------------------------------------------------
 // methods
 // ---------------------------------------------------------------------------
@@ -150,6 +127,33 @@ func (c Events) EnumerateContainers(
 	}
 
 	return errs.ErrorOrNil()
+}
+
+// ---------------------------------------------------------------------------
+// item pager
+// ---------------------------------------------------------------------------
+
+type eventPager struct {
+	gs      graph.Servicer
+	builder *users.ItemCalendarsItemEventsRequestBuilder
+	options *users.ItemCalendarsItemEventsRequestBuilderGetRequestConfiguration
+}
+
+type eventWrapper struct {
+	models.EventCollectionResponseable
+}
+
+func (ew eventWrapper) GetOdataDeltaLink() *string {
+	return nil
+}
+
+func (p *eventPager) getPage(ctx context.Context) (pageLinker, error) {
+	resp, err := p.builder.Get(ctx, p.options)
+	return eventWrapper{resp}, err
+}
+
+func (p *eventPager) setNext(nextLink string) {
+	p.builder = users.NewItemCalendarsItemEventsRequestBuilder(nextLink, p.gs.Adapter())
 }
 
 func (c Events) GetAddedAndRemovedItemIDs(

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -133,20 +133,20 @@ func (c Events) EnumerateContainers(
 // item pager
 // ---------------------------------------------------------------------------
 
-var _ itemPager = &eventPager{}
-
-type eventPager struct {
-	gs      graph.Servicer
-	builder *users.ItemCalendarsItemEventsRequestBuilder
-	options *users.ItemCalendarsItemEventsRequestBuilderGetRequestConfiguration
-}
-
 type eventWrapper struct {
 	models.EventCollectionResponseable
 }
 
 func (ew eventWrapper) GetOdataDeltaLink() *string {
 	return nil
+}
+
+var _ itemPager = &eventPager{}
+
+type eventPager struct {
+	gs      graph.Servicer
+	builder *users.ItemCalendarsItemEventsRequestBuilder
+	options *users.ItemCalendarsItemEventsRequestBuilderGetRequestConfiguration
 }
 
 func (p *eventPager) getPage(ctx context.Context) (pageLinker, error) {
@@ -159,7 +159,7 @@ func (p *eventPager) setNext(nextLink string) {
 }
 
 func (p *eventPager) valuesIn(pl pageLinker) ([]getIDAndAddtler, error) {
-	return toValues[models.Entityable](pl)
+	return toValues[models.Eventable](pl)
 }
 
 func (c Events) GetAddedAndRemovedItemIDs(

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -133,6 +133,8 @@ func (c Events) EnumerateContainers(
 // item pager
 // ---------------------------------------------------------------------------
 
+var _ itemPager = &eventPager{}
+
 type eventPager struct {
 	gs      graph.Servicer
 	builder *users.ItemCalendarsItemEventsRequestBuilder
@@ -157,7 +159,7 @@ func (p *eventPager) setNext(nextLink string) {
 }
 
 func (p *eventPager) valuesIn(pl pageLinker) ([]getIDAndAddtler, error) {
-	return toValues(pl)
+	return toValues[models.Entityable](pl)
 }
 
 func (c Events) GetAddedAndRemovedItemIDs(

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -50,10 +50,6 @@ func (p *eventPager) setNext(nextLink string) {
 	p.builder = users.NewItemCalendarsItemEventsRequestBuilder(nextLink, p.gs.Adapter())
 }
 
-func (p *eventPager) idsIn(pl pageLinker) ([]getIDer, error) {
-	return toIders(pl)
-}
-
 // ---------------------------------------------------------------------------
 // methods
 // ---------------------------------------------------------------------------
@@ -179,7 +175,7 @@ func (c Events) GetAddedAndRemovedItemIDs(
 	builder := service.Client().UsersById(user).CalendarsById(calendarID).Events()
 	pgr := &eventPager{service, builder, options}
 
-	added, _, _, err := getContainerIDs(ctx, pgr, errUpdater)
+	added, _, _, err := getItemsAddedAndRemovedFromContainer(ctx, pgr, errUpdater)
 	if err != nil {
 		return nil, nil, DeltaUpdate{}, err
 	}

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -156,6 +156,10 @@ func (p *eventPager) setNext(nextLink string) {
 	p.builder = users.NewItemCalendarsItemEventsRequestBuilder(nextLink, p.gs.Adapter())
 }
 
+func (p *eventPager) valuesIn(pl pageLinker) ([]getIDAndAddtler, error) {
+	return toValues(pl)
+}
+
 func (c Events) GetAddedAndRemovedItemIDs(
 	ctx context.Context,
 	user, calendarID, oldDelta string,

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -18,8 +18,40 @@ import (
 // controller
 // ---------------------------------------------------------------------------
 
+func (c Client) Events() Events {
+	return Events{c}
+}
+
+// Events is an interface-compliant provider of the client.
 type Events struct {
 	Client
+}
+
+type eventPager struct {
+	gs      graph.Servicer
+	builder *users.ItemCalendarsItemEventsRequestBuilder
+	options *users.ItemCalendarsItemEventsRequestBuilderGetRequestConfiguration
+}
+
+type eventWrapper struct {
+	models.EventCollectionResponseable
+}
+
+func (ew eventWrapper) GetOdataDeltaLink() *string {
+	return nil
+}
+
+func (p *eventPager) getPage(ctx context.Context) (pageLinker, error) {
+	resp, err := p.builder.Get(ctx, p.options)
+	return eventWrapper{resp}, err
+}
+
+func (p *eventPager) setNext(nextLink string) {
+	p.builder = users.NewItemCalendarsItemEventsRequestBuilder(nextLink, p.gs.Adapter())
+}
+
+func (p *eventPager) idsIn(pl pageLinker) ([]getIDer, error) {
+	return toIders(pl)
 }
 
 // ---------------------------------------------------------------------------
@@ -133,10 +165,11 @@ func (c Events) GetAddedAndRemovedItemIDs(
 		return nil, nil, DeltaUpdate{}, err
 	}
 
-	var (
-		errs *multierror.Error
-		ids  []string
-	)
+	var errs *multierror.Error
+
+	errUpdater := func(err error) {
+		errs = multierror.Append(errs, errors.Wrap(err, "calendar "+calendarID))
+	}
 
 	options, err := optionsForEventsByCalendar([]string{"id"})
 	if err != nil {
@@ -144,41 +177,15 @@ func (c Events) GetAddedAndRemovedItemIDs(
 	}
 
 	builder := service.Client().UsersById(user).CalendarsById(calendarID).Events()
+	pgr := &eventPager{service, builder, options}
 
-	for {
-		resp, err := builder.Get(ctx, options)
-		if err != nil {
-			if err := graph.IsErrDeletedInFlight(err); err != nil {
-				return nil, nil, DeltaUpdate{}, err
-			}
-
-			return nil, nil, DeltaUpdate{}, errors.Wrap(err, support.ConnectorStackErrorTrace(err))
-		}
-
-		for _, item := range resp.GetValue() {
-			if item.GetId() == nil {
-				errs = multierror.Append(
-					errs,
-					errors.Errorf("event with nil ID in calendar %s", calendarID),
-				)
-
-				// TODO(ashmrtn): Handle fail-fast.
-				continue
-			}
-
-			ids = append(ids, *item.GetId())
-		}
-
-		nextLink := resp.GetOdataNextLink()
-		if nextLink == nil || len(*nextLink) == 0 {
-			break
-		}
-
-		builder = users.NewItemCalendarsItemEventsRequestBuilder(*nextLink, service.Adapter())
+	added, _, _, err := getContainerIDs(ctx, pgr, errUpdater)
+	if err != nil {
+		return nil, nil, DeltaUpdate{}, err
 	}
 
 	// Events don't have a delta endpoint so just return an empty string.
-	return ids, nil, DeltaUpdate{}, errs.ErrorOrNil()
+	return added, nil, DeltaUpdate{}, errs.ErrorOrNil()
 }
 
 // ---------------------------------------------------------------------------

--- a/src/internal/connector/exchange/api/mail.go
+++ b/src/internal/connector/exchange/api/mail.go
@@ -189,10 +189,6 @@ func (c Mail) GetAddedAndRemovedItemIDs(
 		resetDelta bool
 	)
 
-	errUpdater := func(err error) {
-		errs = multierror.Append(errs, errors.Wrap(err, "folder "+directoryID))
-	}
-
 	options, err := optionsForFolderMessagesDelta([]string{"isRead"})
 	if err != nil {
 		return nil, nil, DeltaUpdate{}, errors.Wrap(err, "getting query options")
@@ -202,7 +198,7 @@ func (c Mail) GetAddedAndRemovedItemIDs(
 		builder := users.NewItemMailFoldersItemMessagesDeltaRequestBuilder(oldDelta, service.Adapter())
 		pgr := &mailPager{service, builder, options}
 
-		added, removed, deltaURL, err := getItemsAddedAndRemovedFromContainer(ctx, pgr, errUpdater)
+		added, removed, deltaURL, err := getItemsAddedAndRemovedFromContainer(ctx, pgr)
 		// note: happy path, not the error condition
 		if err == nil {
 			return added, removed, DeltaUpdate{deltaURL, false}, errs.ErrorOrNil()
@@ -220,7 +216,7 @@ func (c Mail) GetAddedAndRemovedItemIDs(
 	builder := service.Client().UsersById(user).MailFoldersById(directoryID).Messages().Delta()
 	pgr := &mailPager{service, builder, options}
 
-	added, removed, deltaURL, err := getItemsAddedAndRemovedFromContainer(ctx, pgr, errUpdater)
+	added, removed, deltaURL, err := getItemsAddedAndRemovedFromContainer(ctx, pgr)
 	if err != nil {
 		return nil, nil, DeltaUpdate{}, err
 	}

--- a/src/internal/connector/exchange/api/mail.go
+++ b/src/internal/connector/exchange/api/mail.go
@@ -26,20 +26,6 @@ type Mail struct {
 	Client
 }
 
-type mailPager struct {
-	gs      graph.Servicer
-	builder *users.ItemMailFoldersItemMessagesDeltaRequestBuilder
-	options *users.ItemMailFoldersItemMessagesDeltaRequestBuilderGetRequestConfiguration
-}
-
-func (p *mailPager) getPage(ctx context.Context) (pageLinker, error) {
-	return p.builder.Get(ctx, p.options)
-}
-
-func (p *mailPager) setNext(nextLink string) {
-	p.builder = users.NewItemMailFoldersItemMessagesDeltaRequestBuilder(nextLink, p.gs.Adapter())
-}
-
 // ---------------------------------------------------------------------------
 // methods
 // ---------------------------------------------------------------------------
@@ -162,6 +148,24 @@ func (c Mail) EnumerateContainers(
 	}
 
 	return errs.ErrorOrNil()
+}
+
+// ---------------------------------------------------------------------------
+// item pager
+// ---------------------------------------------------------------------------
+
+type mailPager struct {
+	gs      graph.Servicer
+	builder *users.ItemMailFoldersItemMessagesDeltaRequestBuilder
+	options *users.ItemMailFoldersItemMessagesDeltaRequestBuilderGetRequestConfiguration
+}
+
+func (p *mailPager) getPage(ctx context.Context) (pageLinker, error) {
+	return p.builder.Get(ctx, p.options)
+}
+
+func (p *mailPager) setNext(nextLink string) {
+	p.builder = users.NewItemMailFoldersItemMessagesDeltaRequestBuilder(nextLink, p.gs.Adapter())
 }
 
 func (c Mail) GetAddedAndRemovedItemIDs(

--- a/src/internal/connector/exchange/api/mail.go
+++ b/src/internal/connector/exchange/api/mail.go
@@ -168,6 +168,10 @@ func (p *mailPager) setNext(nextLink string) {
 	p.builder = users.NewItemMailFoldersItemMessagesDeltaRequestBuilder(nextLink, p.gs.Adapter())
 }
 
+func (p *mailPager) valuesIn(pl pageLinker) ([]getIDAndAddtler, error) {
+	return toValues(pl)
+}
+
 func (c Mail) GetAddedAndRemovedItemIDs(
 	ctx context.Context,
 	user, directoryID, oldDelta string,

--- a/src/internal/connector/exchange/api/mail.go
+++ b/src/internal/connector/exchange/api/mail.go
@@ -40,10 +40,6 @@ func (p *mailPager) setNext(nextLink string) {
 	p.builder = users.NewItemMailFoldersItemMessagesDeltaRequestBuilder(nextLink, p.gs.Adapter())
 }
 
-func (p *mailPager) idsIn(pl pageLinker) ([]getIDer, error) {
-	return toIders(pl)
-}
-
 // ---------------------------------------------------------------------------
 // methods
 // ---------------------------------------------------------------------------
@@ -196,7 +192,7 @@ func (c Mail) GetAddedAndRemovedItemIDs(
 		builder := users.NewItemMailFoldersItemMessagesDeltaRequestBuilder(oldDelta, service.Adapter())
 		pgr := &mailPager{service, builder, options}
 
-		added, removed, deltaURL, err := getContainerIDs(ctx, pgr, errUpdater)
+		added, removed, deltaURL, err := getItemsAddedAndRemovedFromContainer(ctx, pgr, errUpdater)
 		// note: happy path, not the error condition
 		if err == nil {
 			return added, removed, DeltaUpdate{deltaURL, false}, errs.ErrorOrNil()
@@ -214,7 +210,7 @@ func (c Mail) GetAddedAndRemovedItemIDs(
 	builder := service.Client().UsersById(user).MailFoldersById(directoryID).Messages().Delta()
 	pgr := &mailPager{service, builder, options}
 
-	added, removed, deltaURL, err := getContainerIDs(ctx, pgr, errUpdater)
+	added, removed, deltaURL, err := getItemsAddedAndRemovedFromContainer(ctx, pgr, errUpdater)
 	if err != nil {
 		return nil, nil, DeltaUpdate{}, err
 	}

--- a/src/internal/connector/exchange/api/mail.go
+++ b/src/internal/connector/exchange/api/mail.go
@@ -17,8 +17,31 @@ import (
 // controller
 // ---------------------------------------------------------------------------
 
+func (c Client) Mail() Mail {
+	return Mail{c}
+}
+
+// Mail is an interface-compliant provider of the client.
 type Mail struct {
 	Client
+}
+
+type mailPager struct {
+	gs      graph.Servicer
+	builder *users.ItemMailFoldersItemMessagesDeltaRequestBuilder
+	options *users.ItemMailFoldersItemMessagesDeltaRequestBuilderGetRequestConfiguration
+}
+
+func (p *mailPager) getPage(ctx context.Context) (pageLinker, error) {
+	return p.builder.Get(ctx, p.options)
+}
+
+func (p *mailPager) setNext(nextLink string) {
+	p.builder = users.NewItemMailFoldersItemMessagesDeltaRequestBuilder(nextLink, p.gs.Adapter())
+}
+
+func (p *mailPager) idsIn(pl pageLinker) ([]getIDer, error) {
+	return toIders(pl)
 }
 
 // ---------------------------------------------------------------------------
@@ -156,74 +179,30 @@ func (c Mail) GetAddedAndRemovedItemIDs(
 
 	var (
 		errs       *multierror.Error
-		ids        []string
-		removedIDs []string
 		deltaURL   string
 		resetDelta bool
 	)
+
+	errUpdater := func(err error) {
+		errs = multierror.Append(errs, errors.Wrap(err, "folder "+directoryID))
+	}
 
 	options, err := optionsForFolderMessagesDelta([]string{"isRead"})
 	if err != nil {
 		return nil, nil, DeltaUpdate{}, errors.Wrap(err, "getting query options")
 	}
 
-	getIDs := func(builder *users.ItemMailFoldersItemMessagesDeltaRequestBuilder) error {
-		for {
-			resp, err := builder.Get(ctx, options)
-			if err != nil {
-				if err := graph.IsErrDeletedInFlight(err); err != nil {
-					return err
-				}
-
-				if err := graph.IsErrInvalidDelta(err); err != nil {
-					return err
-				}
-
-				return errors.Wrap(err, support.ConnectorStackErrorTrace(err))
-			}
-
-			for _, item := range resp.GetValue() {
-				if item.GetId() == nil {
-					errs = multierror.Append(
-						errs,
-						errors.Errorf("item with nil ID in folder %s", directoryID),
-					)
-
-					// TODO(ashmrtn): Handle fail-fast.
-					continue
-				}
-
-				if item.GetAdditionalData()[graph.AddtlDataRemoved] == nil {
-					ids = append(ids, *item.GetId())
-				} else {
-					removedIDs = append(removedIDs, *item.GetId())
-				}
-			}
-
-			delta := resp.GetOdataDeltaLink()
-			if delta != nil && len(*delta) > 0 {
-				deltaURL = *delta
-			}
-
-			nextLink := resp.GetOdataNextLink()
-			if nextLink == nil || len(*nextLink) == 0 {
-				break
-			}
-
-			builder = users.NewItemMailFoldersItemMessagesDeltaRequestBuilder(*nextLink, service.Adapter())
-		}
-
-		return nil
-	}
-
 	if len(oldDelta) > 0 {
-		err := getIDs(users.NewItemMailFoldersItemMessagesDeltaRequestBuilder(oldDelta, service.Adapter()))
+		builder := users.NewItemMailFoldersItemMessagesDeltaRequestBuilder(oldDelta, service.Adapter())
+		pgr := &mailPager{service, builder, options}
+
+		added, removed, deltaURL, err := getContainerIDs(ctx, pgr, errUpdater)
 		// note: happy path, not the error condition
 		if err == nil {
-			return ids, removedIDs, DeltaUpdate{deltaURL, false}, errs.ErrorOrNil()
+			return added, removed, DeltaUpdate{deltaURL, false}, errs.ErrorOrNil()
 		}
 		// only return on error if it is NOT a delta issue.
-		// otherwise we'll retry the call with the regular builder
+		// on bad deltas we retry the call with the regular builder
 		if graph.IsErrInvalidDelta(err) == nil {
 			return nil, nil, DeltaUpdate{}, err
 		}
@@ -233,10 +212,12 @@ func (c Mail) GetAddedAndRemovedItemIDs(
 	}
 
 	builder := service.Client().UsersById(user).MailFoldersById(directoryID).Messages().Delta()
+	pgr := &mailPager{service, builder, options}
 
-	if err := getIDs(builder); err != nil {
+	added, removed, deltaURL, err := getContainerIDs(ctx, pgr, errUpdater)
+	if err != nil {
 		return nil, nil, DeltaUpdate{}, err
 	}
 
-	return ids, removedIDs, DeltaUpdate{deltaURL, resetDelta}, errs.ErrorOrNil()
+	return added, removed, DeltaUpdate{deltaURL, resetDelta}, errs.ErrorOrNil()
 }

--- a/src/internal/connector/exchange/api/mail.go
+++ b/src/internal/connector/exchange/api/mail.go
@@ -154,6 +154,8 @@ func (c Mail) EnumerateContainers(
 // item pager
 // ---------------------------------------------------------------------------
 
+var _ itemPager = &mailPager{}
+
 type mailPager struct {
 	gs      graph.Servicer
 	builder *users.ItemMailFoldersItemMessagesDeltaRequestBuilder
@@ -169,7 +171,7 @@ func (p *mailPager) setNext(nextLink string) {
 }
 
 func (p *mailPager) valuesIn(pl pageLinker) ([]getIDAndAddtler, error) {
-	return toValues(pl)
+	return toValues[models.Messageable](pl)
 }
 
 func (c Mail) GetAddedAndRemovedItemIDs(

--- a/src/internal/connector/exchange/api/shared.go
+++ b/src/internal/connector/exchange/api/shared.go
@@ -3,9 +3,10 @@ package api
 import (
 	"context"
 
+	"github.com/pkg/errors"
+
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/support"
-	"github.com/pkg/errors"
 )
 
 // ---------------------------------------------------------------------------
@@ -14,7 +15,6 @@ import (
 
 type itemPager interface {
 	getPage(context.Context) (pageLinker, error)
-	idsIn(pageLinker) ([]getIDer, error)
 	setNext(string)
 }
 
@@ -23,26 +23,13 @@ type pageLinker interface {
 	GetOdataNextLink() *string
 }
 
-type getIDer interface {
+type getIDAndAddtler interface {
 	GetId() *string
-}
-
-// uses a models interface compliant with { GetValues() []T }
-// to transform its results into a slice of getIDer interfaces.
-// Generics used here to handle the variation of msoft interfaces
-// that all _almost_ comply with GetValue, but all return a different
-// interface.
-func toIders(a any) ([]getIDer, error) {
-	gv, ok := a.(interface{ GetValue() []getIDer })
-	if !ok {
-		return nil, errors.New("response does not comply with GetValue interface")
-	}
-
-	return gv.GetValue(), nil
+	GetAdditionalData() map[string]any
 }
 
 // generic controller for retrieving all item ids in a container.
-func getContainerIDs(
+func getItemsAddedAndRemovedFromContainer(
 	ctx context.Context,
 	pager itemPager,
 	errUpdater func(error),
@@ -54,6 +41,7 @@ func getContainerIDs(
 	)
 
 	for {
+		// get the next page of data, check for standard errors
 		resp, err := pager.getPage(ctx)
 		if err != nil {
 			if err := graph.IsErrDeletedInFlight(err); err != nil {
@@ -67,12 +55,15 @@ func getContainerIDs(
 			return nil, nil, deltaURL, errors.Wrap(err, support.ConnectorStackErrorTrace(err))
 		}
 
-		items, err := pager.idsIn(resp)
-		if err != nil {
-			return nil, nil, "", err
+		// each category type responds with a different interface, but all
+		// of them comply with GetValue, which is where we'll get our item data.
+		gv, ok := resp.(interface{ GetValue() []getIDAndAddtler })
+		if !ok {
+			return nil, nil, deltaURL, errors.New("response does not comply with GetValue interface")
 		}
 
-		for _, item := range items {
+		// iterate through the items in the page
+		for _, item := range gv.GetValue() {
 			if item.GetId() == nil {
 				errUpdater(errors.Errorf("item with nil ID"))
 
@@ -80,6 +71,9 @@ func getContainerIDs(
 				continue
 			}
 
+			// if the additional data conains a `@removed` key, the value will either
+			// be 'changed' or 'deleted'.  We don't really care about the cause: both
+			// cases are handled the same way in storage.
 			if item.GetAdditionalData()[graph.AddtlDataRemoved] == nil {
 				addedIDs = append(addedIDs, *item.GetId())
 			} else {
@@ -87,11 +81,18 @@ func getContainerIDs(
 			}
 		}
 
+		// the deltaLink is kind of like a cursor for overall data state.
+		// once we run through pages of nextLinks, the last query will
+		// produce a deltaLink instead (if supported), which we'll use on
+		// the next backup to only get the changes since this run.
 		delta := resp.GetOdataDeltaLink()
 		if delta != nil && len(*delta) > 0 {
 			deltaURL = *delta
 		}
 
+		// the nextLink is our page cursor within this query.
+		// if we have more data to retrieve, we'll have a
+		// nextLink instead of a deltaLink.
 		nextLink := resp.GetOdataNextLink()
 		if nextLink == nil || len(*nextLink) == 0 {
 			break

--- a/src/internal/connector/exchange/api/shared.go
+++ b/src/internal/connector/exchange/api/shared.go
@@ -1,0 +1,104 @@
+package api
+
+import (
+	"context"
+
+	"github.com/alcionai/corso/src/internal/connector/graph"
+	"github.com/alcionai/corso/src/internal/connector/support"
+	"github.com/pkg/errors"
+)
+
+// ---------------------------------------------------------------------------
+// generic handler for paging item ids in a container
+// ---------------------------------------------------------------------------
+
+type itemPager interface {
+	getPage(context.Context) (pageLinker, error)
+	idsIn(pageLinker) ([]getIDer, error)
+	setNext(string)
+}
+
+type pageLinker interface {
+	GetOdataDeltaLink() *string
+	GetOdataNextLink() *string
+}
+
+type getIDer interface {
+	GetId() *string
+}
+
+// uses a models interface compliant with { GetValues() []T }
+// to transform its results into a slice of getIDer interfaces.
+// Generics used here to handle the variation of msoft interfaces
+// that all _almost_ comply with GetValue, but all return a different
+// interface.
+func toIders(a any) ([]getIDer, error) {
+	gv, ok := a.(interface{ GetValue() []getIDer })
+	if !ok {
+		return nil, errors.New("response does not comply with GetValue interface")
+	}
+
+	return gv.GetValue(), nil
+}
+
+// generic controller for retrieving all item ids in a container.
+func getContainerIDs(
+	ctx context.Context,
+	pager itemPager,
+	errUpdater func(error),
+) ([]string, []string, string, error) {
+	var (
+		addedIDs   = []string{}
+		removedIDs = []string{}
+		deltaURL   string
+	)
+
+	for {
+		resp, err := pager.getPage(ctx)
+		if err != nil {
+			if err := graph.IsErrDeletedInFlight(err); err != nil {
+				return nil, nil, deltaURL, err
+			}
+
+			if err := graph.IsErrInvalidDelta(err); err != nil {
+				return nil, nil, deltaURL, err
+			}
+
+			return nil, nil, deltaURL, errors.Wrap(err, support.ConnectorStackErrorTrace(err))
+		}
+
+		items, err := pager.idsIn(resp)
+		if err != nil {
+			return nil, nil, "", err
+		}
+
+		for _, item := range items {
+			if item.GetId() == nil {
+				errUpdater(errors.Errorf("item with nil ID"))
+
+				// TODO: Handle fail-fast.
+				continue
+			}
+
+			if item.GetAdditionalData()[graph.AddtlDataRemoved] == nil {
+				addedIDs = append(addedIDs, *item.GetId())
+			} else {
+				removedIDs = append(removedIDs, *item.GetId())
+			}
+		}
+
+		delta := resp.GetOdataDeltaLink()
+		if delta != nil && len(*delta) > 0 {
+			deltaURL = *delta
+		}
+
+		nextLink := resp.GetOdataNextLink()
+		if nextLink == nil || len(*nextLink) == 0 {
+			break
+		}
+
+		pager.setNext(*nextLink)
+	}
+
+	return addedIDs, removedIDs, deltaURL, nil
+}

--- a/src/internal/connector/exchange/api/shared.go
+++ b/src/internal/connector/exchange/api/shared.go
@@ -44,6 +44,7 @@ func toValues[T any](a any) ([]getIDAndAddtler, error) {
 	r := make([]getIDAndAddtler, 0, len(items))
 
 	for _, item := range items {
+		//nolint:gosimple
 		var a any
 		a = item
 
@@ -62,7 +63,6 @@ func toValues[T any](a any) ([]getIDAndAddtler, error) {
 func getItemsAddedAndRemovedFromContainer(
 	ctx context.Context,
 	pager itemPager,
-	errUpdater func(error),
 ) ([]string, []string, string, error) {
 	var (
 		addedIDs   = []string{}

--- a/src/internal/connector/exchange/api/shared.go
+++ b/src/internal/connector/exchange/api/shared.go
@@ -44,9 +44,7 @@ func toValues[T any](a any) ([]getIDAndAddtler, error) {
 	r := make([]getIDAndAddtler, 0, len(items))
 
 	for _, item := range items {
-		//nolint:gosimple
-		var a any
-		a = item
+		var a any = item
 
 		ri, ok := a.(getIDAndAddtler)
 		if !ok {


### PR DESCRIPTION
## Description
    
Transitions the fetchIDs service iterators to a
set of interfaces to consolidate code across
multiple nearly identical variations of "fetch id
for directory".

This was originally written in another PR (1780), then
separated out to isolate changes.

## Type of change

- [x] :hamster: Trivial/Minor

## Test Plan

- [x] :green_heart: E2E
