### PR TITLE
Stricter checking for how hierarchies are merged

### DIFF
--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -576,8 +576,8 @@ func inflateCollectionTree(
 		ownerCats.ServiceCats[serviceCat] = ServiceCat{}
 		ownerCats.ResourceOwners[s.FullPath().ResourceOwner()] = struct{}{}
 
-		// Make sure we haven't moved and made a new instance of the collection at
-		// this path.
+		// Make sure there's only a single collection adding items for any given
+		// path in the new hierarchy.
 		if node.collection != nil {
 			return nil, nil, errors.Errorf("multiple instances of collection at %s", s.FullPath())
 		}

--- a/src/internal/kopia/upload_test.go
+++ b/src/internal/kopia/upload_test.go
@@ -899,6 +899,10 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
 		suite.T(),
 		[]string{testTenant, service, testUser, category, testInboxDir},
 	)
+	dirPath2 := makePath(
+		suite.T(),
+		[]string{testTenant, service, testUser, category, testArchiveDir},
+	)
 
 	// Must be a function that returns a new instance each time as StreamingFile
 	// can only return its Reader once.
@@ -1014,6 +1018,85 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
 								name:     testFileName,
 								children: []*expectedNode{},
 								data:     testFileData2,
+							},
+						},
+					},
+				},
+			),
+		},
+		{
+			name: "DeleteAndNew",
+			inputCollections: func() []data.Collection {
+				mc1 := mockconnector.NewMockExchangeCollection(dirPath, 0)
+				mc1.ColState = data.DeletedState
+				mc1.PrevPath = dirPath
+
+				mc2 := mockconnector.NewMockExchangeCollection(dirPath, 1)
+				mc2.ColState = data.NewState
+				mc2.Names[0] = testFileName2
+				mc2.Data[0] = testFileData2
+
+				return []data.Collection{mc1, mc2}
+			},
+			expected: expectedTreeWithChildren(
+				[]string{
+					testTenant,
+					service,
+					testUser,
+					category,
+				},
+				[]*expectedNode{
+					{
+						name: testInboxDir,
+						children: []*expectedNode{
+							{
+								name:     testFileName2,
+								children: []*expectedNode{},
+								data:     testFileData2,
+							},
+						},
+					},
+				},
+			),
+		},
+		{
+			name: "MovedAndNew",
+			inputCollections: func() []data.Collection {
+				mc1 := mockconnector.NewMockExchangeCollection(dirPath2, 0)
+				mc1.ColState = data.MovedState
+				mc1.PrevPath = dirPath
+
+				mc2 := mockconnector.NewMockExchangeCollection(dirPath, 1)
+				mc2.ColState = data.NewState
+				mc2.Names[0] = testFileName2
+				mc2.Data[0] = testFileData2
+
+				return []data.Collection{mc1, mc2}
+			},
+			expected: expectedTreeWithChildren(
+				[]string{
+					testTenant,
+					service,
+					testUser,
+					category,
+				},
+				[]*expectedNode{
+					{
+						name: testInboxDir,
+						children: []*expectedNode{
+							{
+								name:     testFileName2,
+								children: []*expectedNode{},
+								data:     testFileData2,
+							},
+						},
+					},
+					{
+						name: testArchiveDir,
+						children: []*expectedNode{
+							{
+								name:     testFileName,
+								children: []*expectedNode{},
 							},
 						},
 					},


### PR DESCRIPTION
## Description

Add some extra error checking for how the hierarchy can evolve during merging in kopia.Wrapper. Add more tests to solidify this behavior as well.

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* closes #1884 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
