### PR TITLE
populate sharepoint selectors with scopes

### DIFF
--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -273,9 +273,15 @@ func sharePointBackupCreateSelectors(
 	sites, weburls []string,
 	gc *connector.GraphConnector,
 ) (*selectors.SharePointBackup, error) {
+	if len(sites) == 0 && len(weburls) == 0 {
+		return selectors.NewSharePointBackup(selectors.None()), nil
+	}
+
 	for _, site := range sites {
 		if site == utils.Wildcard {
 			sel := selectors.NewSharePointBackup(selectors.Any())
+			sel.Include(sel.Sites(selectors.Any()))
+
 			return sel, nil
 		}
 	}
@@ -283,6 +289,8 @@ func sharePointBackupCreateSelectors(
 	for _, wURL := range weburls {
 		if wURL == utils.Wildcard {
 			sel := selectors.NewSharePointBackup(selectors.Any())
+			sel.Include(sel.Sites(selectors.Any()))
+
 			return sel, nil
 		}
 	}
@@ -292,7 +300,10 @@ func sharePointBackupCreateSelectors(
 		return nil, err
 	}
 
-	return selectors.NewSharePointBackup(union), nil
+	sel := selectors.NewSharePointBackup(union)
+	sel.Include(sel.Sites(union))
+
+	return sel, nil
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/src/cli/backup/sharepoint_test.go
+++ b/src/cli/backup/sharepoint_test.go
@@ -112,10 +112,11 @@ func (suite *SharePointSuite) TestSharePointBackupCreateSelectors() {
 	}
 
 	table := []struct {
-		name   string
-		site   []string
-		weburl []string
-		expect []string
+		name            string
+		site            []string
+		weburl          []string
+		expect          []string
+		expectScopesLen int
 	}{
 		{
 			name:   "no sites or urls",
@@ -128,48 +129,56 @@ func (suite *SharePointSuite) TestSharePointBackupCreateSelectors() {
 			expect: selectors.None(),
 		},
 		{
-			name:   "site wildcard",
-			site:   []string{utils.Wildcard},
-			expect: selectors.Any(),
+			name:            "site wildcard",
+			site:            []string{utils.Wildcard},
+			expect:          selectors.Any(),
+			expectScopesLen: 2,
 		},
 		{
-			name:   "url wildcard",
-			weburl: []string{utils.Wildcard},
-			expect: selectors.Any(),
+			name:            "url wildcard",
+			weburl:          []string{utils.Wildcard},
+			expect:          selectors.Any(),
+			expectScopesLen: 2,
 		},
 		{
-			name:   "sites",
-			site:   []string{"id_1", "id_2"},
-			expect: []string{"id_1", "id_2"},
+			name:            "sites",
+			site:            []string{"id_1", "id_2"},
+			expect:          []string{"id_1", "id_2"},
+			expectScopesLen: 2,
 		},
 		{
-			name:   "urls",
-			weburl: []string{"url_1", "url_2"},
-			expect: []string{"id_1", "id_2"},
+			name:            "urls",
+			weburl:          []string{"url_1", "url_2"},
+			expect:          []string{"id_1", "id_2"},
+			expectScopesLen: 2,
 		},
 		{
-			name:   "mix sites and urls",
-			site:   []string{"id_1"},
-			weburl: []string{"url_2"},
-			expect: []string{"id_1", "id_2"},
+			name:            "mix sites and urls",
+			site:            []string{"id_1"},
+			weburl:          []string{"url_2"},
+			expect:          []string{"id_1", "id_2"},
+			expectScopesLen: 2,
 		},
 		{
-			name:   "duplicate sites and urls",
-			site:   []string{"id_1", "id_2"},
-			weburl: []string{"url_1", "url_2"},
-			expect: []string{"id_1", "id_2"},
+			name:            "duplicate sites and urls",
+			site:            []string{"id_1", "id_2"},
+			weburl:          []string{"url_1", "url_2"},
+			expect:          []string{"id_1", "id_2"},
+			expectScopesLen: 2,
 		},
 		{
-			name:   "unnecessary site wildcard",
-			site:   []string{"id_1", utils.Wildcard},
-			weburl: []string{"url_1", "url_2"},
-			expect: selectors.Any(),
+			name:            "unnecessary site wildcard",
+			site:            []string{"id_1", utils.Wildcard},
+			weburl:          []string{"url_1", "url_2"},
+			expect:          selectors.Any(),
+			expectScopesLen: 2,
 		},
 		{
-			name:   "unnecessary url wildcard",
-			site:   []string{"id_1", "id_2"},
-			weburl: []string{"url_1", utils.Wildcard},
-			expect: selectors.Any(),
+			name:            "unnecessary url wildcard",
+			site:            []string{"id_1", "id_2"},
+			weburl:          []string{"url_1", utils.Wildcard},
+			expect:          selectors.Any(),
+			expectScopesLen: 2,
 		},
 	}
 	for _, test := range table {
@@ -180,13 +189,14 @@ func (suite *SharePointSuite) TestSharePointBackupCreateSelectors() {
 			sel, err := sharePointBackupCreateSelectors(ctx, test.site, test.weburl, gc)
 			require.NoError(t, err)
 
-			if len(sel.Scopes()) == 0 {
+			scopes := sel.Scopes()
+			assert.Len(t, scopes, test.expectScopesLen)
+
+			if test.expectScopesLen == 0 {
 				return
 			}
 
-			scope := sel.Scopes()[0]
-			targetSites := scope.Get(selectors.SharePointSite)
-
+			targetSites := scopes[0].Get(selectors.SharePointSite)
 			assert.ElementsMatch(t, test.expect, targetSites)
 		})
 	}


### PR DESCRIPTION
## Description

On backup create, sharepoint selectors also
need scopes, or else they do nothing.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :bug: Bugfix

## Issue(s)

* #1908

## Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
