### PR TITLE
add doNotMerge func to collections

### DIFF
--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -69,6 +69,9 @@ type Collection struct {
 	prevPath path.Path
 
 	state data.CollectionState
+
+	// doNotMergeItems should only be true if the old delta token expired.
+	doNotMergeItems bool
 }
 
 // NewExchangeDataCollection creates an ExchangeDataCollection.
@@ -156,10 +159,12 @@ func (col Collection) PreviousPath() path.Path {
 	return nil
 }
 
-// TODO(ashmrtn): Fill in once GraphConnector compares old and new folder
-// hierarchies.
 func (col Collection) State() data.CollectionState {
 	return col.state
+}
+
+func (col Collection) DoNotMergeItems() bool {
+	return col.doNotMergeItems
 }
 
 // populateByOptionIdentifier is a utility function that uses col.collectionType to be able to serialize

--- a/src/internal/connector/graph/metadata_collection.go
+++ b/src/internal/connector/graph/metadata_collection.go
@@ -127,6 +127,10 @@ func (md MetadataCollection) State() data.CollectionState {
 	return data.NewState
 }
 
+func (md MetadataCollection) DoNotMergeItems() bool {
+	return false
+}
+
 func (md MetadataCollection) Items() <-chan data.Stream {
 	res := make(chan data.Stream)
 

--- a/src/internal/connector/mockconnector/mock_data_collection.go
+++ b/src/internal/connector/mockconnector/mock_data_collection.go
@@ -15,15 +15,15 @@ import (
 
 // MockExchangeDataCollection represents a mock exchange mailbox
 type MockExchangeDataCollection struct {
-	fullPath        path.Path
-	messageCount    int
-	Data            [][]byte
-	Names           []string
-	ModTimes        []time.Time
-	ColState        data.CollectionState
-	PrevPath        path.Path
-	DeletedItems    []bool
-	doNotMergeItems bool
+	fullPath     path.Path
+	messageCount int
+	Data         [][]byte
+	Names        []string
+	ModTimes     []time.Time
+	ColState     data.CollectionState
+	PrevPath     path.Path
+	DeletedItems []bool
+	DoNotMerge   bool
 }
 
 var (
@@ -106,7 +106,7 @@ func (medc MockExchangeDataCollection) State() data.CollectionState {
 }
 
 func (medc MockExchangeDataCollection) DoNotMergeItems() bool {
-	return medc.doNotMergeItems
+	return medc.DoNotMerge
 }
 
 // Items returns a channel that has the next items in the collection. The

--- a/src/internal/connector/mockconnector/mock_data_collection.go
+++ b/src/internal/connector/mockconnector/mock_data_collection.go
@@ -15,14 +15,15 @@ import (
 
 // MockExchangeDataCollection represents a mock exchange mailbox
 type MockExchangeDataCollection struct {
-	fullPath     path.Path
-	messageCount int
-	Data         [][]byte
-	Names        []string
-	ModTimes     []time.Time
-	ColState     data.CollectionState
-	PrevPath     path.Path
-	DeletedItems []bool
+	fullPath        path.Path
+	messageCount    int
+	Data            [][]byte
+	Names           []string
+	ModTimes        []time.Time
+	ColState        data.CollectionState
+	PrevPath        path.Path
+	DeletedItems    []bool
+	doNotMergeItems bool
 }
 
 var (
@@ -102,6 +103,10 @@ func (medc MockExchangeDataCollection) PreviousPath() path.Path {
 
 func (medc MockExchangeDataCollection) State() data.CollectionState {
 	return medc.ColState
+}
+
+func (medc MockExchangeDataCollection) DoNotMergeItems() bool {
+	return medc.doNotMergeItems
 }
 
 // Items returns a channel that has the next items in the collection. The

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -57,6 +57,9 @@ type Collection struct {
 	statusUpdater support.StatusUpdater
 	itemReader    itemReaderFunc
 	ctrl          control.Options
+
+	// should only be true if the old delta token expired
+	doNotMergeItems bool
 }
 
 // itemReadFunc returns a reader for the specified item
@@ -121,6 +124,10 @@ func (oc Collection) PreviousPath() path.Path {
 // hierarchies.
 func (oc Collection) State() data.CollectionState {
 	return data.NewState
+}
+
+func (oc Collection) DoNotMergeItems() bool {
+	return oc.doNotMergeItems
 }
 
 // Item represents a single item retrieved from OneDrive

--- a/src/internal/connector/sharepoint/collection.go
+++ b/src/internal/connector/sharepoint/collection.go
@@ -81,10 +81,12 @@ func (sc Collection) PreviousPath() path.Path {
 	return nil
 }
 
-// TODO(ashmrtn): Fill in once GraphConnector compares old and new folder
-// hierarchies.
 func (sc Collection) State() data.CollectionState {
 	return data.NewState
+}
+
+func (sc Collection) DoNotMergeItems() bool {
+	return false
 }
 
 func (sc *Collection) Items() <-chan data.Stream {

--- a/src/internal/data/data_collection.go
+++ b/src/internal/data/data_collection.go
@@ -48,7 +48,7 @@ type Collection interface {
 	// unless said items/Collections were moved.
 	State() CollectionState
 	// DoNotMergeItems informs kopia that the collection is rebuilding its contents
-	// from scratch, and that any items currently stored in that collection should
+	// from scratch, and that any items currently stored at the previousPath should
 	// be skipped during the process of merging historical data into the new backup.
 	// This flag is normally expected to be false.  It should only be flagged under
 	// specific circumstances.  Example: if the link token used for incremental queries

--- a/src/internal/data/data_collection.go
+++ b/src/internal/data/data_collection.go
@@ -47,6 +47,15 @@ type Collection interface {
 	// backup along with all items and Collections below them in the hierarchy
 	// unless said items/Collections were moved.
 	State() CollectionState
+	// DoNotMergeItems informs kopia that the collection is rebuilding its contents
+	// from scratch, and that any items currently stored in that collection should
+	// be skipped during the process of merging historical data into the new backup.
+	// This flag is normally expected to be false.  It should only be flagged under
+	// specific circumstances.  Example: if the link token used for incremental queries
+	// expires or otherwise becomes unusable, thus requiring the backup producer to
+	// re-discover all data in the container.  This flag only affects the path of the
+	// collection, and does not cascade to subfolders.
+	DoNotMergeItems() bool
 }
 
 // Stream represents a single item within a Collection

--- a/src/internal/data/data_collection_test.go
+++ b/src/internal/data/data_collection_test.go
@@ -30,6 +30,10 @@ func (mc mockColl) State() CollectionState {
 	return NewState
 }
 
+func (mc mockColl) DoNotMergeItems() bool {
+	return false
+}
+
 type CollectionSuite struct {
 	suite.Suite
 }

--- a/src/internal/kopia/data_collection.go
+++ b/src/internal/kopia/data_collection.go
@@ -43,6 +43,10 @@ func (kdc kopiaDataCollection) State() data.CollectionState {
 	return data.NewState
 }
 
+func (kdc kopiaDataCollection) DoNotMergeItems() bool {
+	return false
+}
+
 type kopiaDataStream struct {
 	reader io.ReadCloser
 	uuid   string

--- a/src/internal/streamstore/streamstore.go
+++ b/src/internal/streamstore/streamstore.go
@@ -177,6 +177,10 @@ func (dc *streamCollection) State() data.CollectionState {
 	return data.NewState
 }
 
+func (dc *streamCollection) DoNotMergeItems() bool {
+	return false
+}
+
 // Items() always returns a channel with a single data.Stream
 // representing the object to be persisted
 func (dc *streamCollection) Items() <-chan data.Stream {


### PR DESCRIPTION
## Description

Adds a new func to the data.Collection iface:
DoNotMergeItems() tells kopia to skip the
retention of items from prior snapshots when
generating the new snapshot for this collection.
A primary use case for this flag is when a delta
token expires, preventing an incremental lookup
and forcing gc to re-discover all items in the
container.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :sunflower: Feature

## Issue(s)

* #1914

## Test Plan

- [x] :zap: Unit test
