### PR TITLE
Remove some dead code in upload.go

### DIFF
--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -526,10 +526,6 @@ func inflateCollectionTree(
 	// Temporary variable just to track the things that have been marked as
 	// changed while keeping a reference to their path.
 	changedPaths := []path.Path{}
-	ownerCats := &OwnersCats{
-		ResourceOwners: make(map[string]struct{}),
-		ServiceCats:    make(map[string]ServiceCat),
-	}
 
 	for _, s := range collections {
 		switch s.State() {
@@ -571,10 +567,6 @@ func inflateCollectionTree(
 				s.FullPath(),
 			)
 		}
-
-		serviceCat := serviceCatTag(s.FullPath())
-		ownerCats.ServiceCats[serviceCat] = ServiceCat{}
-		ownerCats.ResourceOwners[s.FullPath().ResourceOwner()] = struct{}{}
 
 		// Make sure there's only a single collection adding items for any given
 		// path in the new hierarchy.


### PR DESCRIPTION
## Description

Code was missed when switching to having BackupOp supply the OwnersCats for a backup.

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [x] :hamster: Trivial/Minor

## Issue(s)

* #1781 

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
