### PR TITLE
set nomerge on delta reset

### DIFF
--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -87,18 +87,20 @@ func NewCollection(
 	service graph.Servicer,
 	statusUpdater support.StatusUpdater,
 	ctrlOpts control.Options,
+	doNotMergeItems bool,
 ) Collection {
 	collection := Collection{
-		user:           user,
-		data:           make(chan data.Stream, collectionChannelBufferSize),
-		jobs:           make([]string, 0),
-		service:        service,
-		statusUpdater:  statusUpdater,
-		fullPath:       curr,
-		prevPath:       prev,
-		collectionType: collectionType,
-		ctrl:           ctrlOpts,
-		state:          stateOf(prev, curr),
+		collectionType:  collectionType,
+		ctrl:            ctrlOpts,
+		data:            make(chan data.Stream, collectionChannelBufferSize),
+		doNotMergeItems: doNotMergeItems,
+		fullPath:        curr,
+		jobs:            make([]string, 0),
+		prevPath:        prev,
+		service:         service,
+		state:           stateOf(prev, curr),
+		statusUpdater:   statusUpdater,
+		user:            user,
 	}
 
 	return collection

--- a/src/internal/connector/exchange/exchange_data_collection_test.go
+++ b/src/internal/connector/exchange/exchange_data_collection_test.go
@@ -151,7 +151,8 @@ func (suite *ExchangeDataCollectionSuite) TestNewCollection_state() {
 			c := NewCollection(
 				"u",
 				test.curr, test.prev,
-				0, nil, nil, control.Options{})
+				0, nil, nil, control.Options{},
+				false)
 			assert.Equal(t, test.expect, c.State())
 		})
 	}

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -117,14 +117,6 @@ func filterContainersAndFillCollections(
 			deltaURLs[cID] = newDelta.url
 		}
 
-		if newDelta.reset {
-			// the previous delta was invalid or otherwise unusable.
-			// We need to mark the collection as New, and tombstone
-			// the path to clear out any data for a clean refresh.
-			prevPath = nil
-			tombstones[currPath.String()] = struct{}{}
-		}
-
 		edc := NewCollection(
 			qp.ResourceOwner,
 			currPath,
@@ -133,6 +125,7 @@ func filterContainersAndFillCollections(
 			service,
 			statusUpdater,
 			ctrlOpts,
+			newDelta.reset,
 		)
 
 		collections[cID] = &edc
@@ -171,6 +164,7 @@ func filterContainersAndFillCollections(
 			service,
 			statusUpdater,
 			ctrlOpts,
+			false,
 		)
 		collections[p] = &edc
 	}


### PR DESCRIPTION
## Description

Flag doNotMergeItems for exchange collections
where the delta token was marked as reset (ie,
expired or otherwise unusable).  Do this instead
of making a (delete, new) collection tuple for
that path.


## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :sunflower: Feature

## Issue(s)

* #1914

## Test Plan

- [x] :green_heart: E2E
