### PR TITLE
Lift'n'shift of existing code

### DIFF
--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -183,25 +183,7 @@ func (cp *corsoProgress) FinishedFile(relativePath string, err error) {
 		*d.info,
 	)
 
-	folders := []details.FolderEntry{}
-
-	for len(parent.Elements()) > 0 {
-		nextParent := parent.Dir()
-
-		folders = append(folders, details.FolderEntry{
-			RepoRef:   parent.String(),
-			ShortRef:  parent.ShortRef(),
-			ParentRef: nextParent.ShortRef(),
-			Info: details.ItemInfo{
-				Folder: &details.FolderInfo{
-					DisplayName: parent.Elements()[len(parent.Elements())-1],
-				},
-			},
-		})
-
-		parent = nextParent
-	}
-
+	folders := details.FolderEntriesForPath(parent)
 	cp.deets.AddFoldersForItem(folders, *d.info)
 }
 

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -127,6 +127,32 @@ func (b *Builder) Details() *Details {
 	return &b.d
 }
 
+// TODO(ashmrtn): If we never need to pre-populate the modified time of a folder
+// we should just merge this with AddFoldersForItem, have Add call
+// AddFoldersForItem, and unexport AddFoldersForItem.
+func FolderEntriesForPath(parent *path.Builder) []FolderEntry {
+	folders := []FolderEntry{}
+
+	for len(parent.Elements()) > 0 {
+		nextParent := parent.Dir()
+
+		folders = append(folders, FolderEntry{
+			RepoRef:   parent.String(),
+			ShortRef:  parent.ShortRef(),
+			ParentRef: nextParent.ShortRef(),
+			Info: ItemInfo{
+				Folder: &FolderInfo{
+					DisplayName: parent.Elements()[len(parent.Elements())-1],
+				},
+			},
+		})
+
+		parent = nextParent
+	}
+
+	return folders
+}
+
 // AddFoldersForItem adds entries for the given folders. It skips adding entries that
 // have been added by previous calls.
 func (b *Builder) AddFoldersForItem(folders []FolderEntry, itemInfo ItemInfo) {


### PR DESCRIPTION
## Description

Factor out code to get a set of FolderEntries based on some path information. This code will be used in BackupOp when merging item details.

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [x] :hamster: Trivial/Minor

## Issue(s)

* #1800 

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
