### PR TITLE
Update details merge function for details Builder and new location of folder population

### DIFF
--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -498,6 +498,9 @@ func mergeDetails(
 				item,
 			)
 
+			folders := details.FolderEntriesForPath(newPath.ToBuilder().Dir())
+			deets.AddFoldersForItem(folders, item)
+
 			// Track how many entries we added so that we know if we got them all when
 			// we're done.
 			addedEntries++

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -142,6 +142,7 @@ func FolderEntriesForPath(parent *path.Builder) []FolderEntry {
 			ParentRef: nextParent.ShortRef(),
 			Info: ItemInfo{
 				Folder: &FolderInfo{
+					ItemType:    FolderItem,
 					DisplayName: parent.Elements()[len(parent.Elements())-1],
 				},
 			},


### PR DESCRIPTION
## Description

Folder population now done when merging items in BackupOp. Also add more tests to make sure folders are actually populated properly in Details

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* #1800 

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
