### PR TITLE
Propagate options to repo and operations

### DIFF
--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -16,7 +16,6 @@ import (
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
-	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/repository"
 	"github.com/alcionai/corso/src/pkg/selectors"
@@ -264,7 +263,7 @@ func createExchangeCmd(cmd *cobra.Command, args []string) error {
 		return Only(ctx, err)
 	}
 
-	r, err := repository.Connect(ctx, acct, s, control.Options{})
+	r, err := repository.Connect(ctx, acct, s, options.Control())
 	if err != nil {
 		return Only(ctx, errors.Wrapf(err, "Failed to connect to the %s repository", s.Provider))
 	}

--- a/src/internal/connector/exchange/data_collections.go
+++ b/src/internal/connector/exchange/data_collections.go
@@ -192,7 +192,7 @@ func DataCollections(
 			acct,
 			scope,
 			dps,
-			control.Options{},
+			ctrlOpts,
 			su)
 		if err != nil {
 			user := scope.Get(selectors.ExchangeUser)

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -125,6 +125,7 @@ func Initialize(
 		Account:    acct,
 		Storage:    s,
 		Bus:        bus,
+		Opts:       opts,
 		dataLayer:  w,
 		modelStore: ms,
 	}
@@ -192,6 +193,7 @@ func Connect(
 		Account:    acct,
 		Storage:    s,
 		Bus:        bus,
+		Opts:       opts,
 		dataLayer:  w,
 		modelStore: ms,
 	}, nil


### PR DESCRIPTION
## Description

Make sure the options struct is passed through the entire stack so we actually have access to flag values.

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [x] :hamster: Trivial/Minor

## Issue(s)

* closes #1931 

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
