### PR TITLE
Don't merge directories if they're marked as new

### DIFF
--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -764,7 +764,8 @@ func traverseBaseDir(
 		// in the node. That allows us to propagate subtree operations (e.x. move)
 		// while selectively skipping merging old and new versions for some
 		// directories. The expected usecase for this is delta token expiry in M365.
-		if node.collection != nil && node.collection.DoNotMergeItems() {
+		if node.collection != nil &&
+			(node.collection.DoNotMergeItems() || node.collection.State() == data.NewState) {
 			return nil
 		}
 

--- a/src/internal/kopia/upload_test.go
+++ b/src/internal/kopia/upload_test.go
@@ -1148,6 +1148,37 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
 				},
 			),
 		},
+		{
+			name: "NewDoesntMerge",
+			inputCollections: func() []data.Collection {
+				mc1 := mockconnector.NewMockExchangeCollection(dirPath, 1)
+				mc1.ColState = data.NewState
+				mc1.Names[0] = testFileName2
+				mc1.Data[0] = testFileData2
+
+				return []data.Collection{mc1}
+			},
+			expected: expectedTreeWithChildren(
+				[]string{
+					testTenant,
+					service,
+					testUser,
+					category,
+				},
+				[]*expectedNode{
+					{
+						name: testInboxDir,
+						children: []*expectedNode{
+							{
+								name:     testFileName2,
+								children: []*expectedNode{},
+								data:     testFileData2,
+							},
+						},
+					},
+				},
+			),
+		},
 	}
 
 	for _, test := range table {


### PR DESCRIPTION
## Description

If we have a collection marked as new and we have a base directory, do not merge the base with the collection.

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* #1740 

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
