### PR TITLE
retain kopia-assist when not on incrementals

### DIFF
--- a/src/internal/connector/exchange/data_collections_test.go
+++ b/src/internal/connector/exchange/data_collections_test.go
@@ -532,14 +532,14 @@ func (suite *DataCollectionsIntegrationSuite) TestEventsSerializationRegression(
 				[]string{DefaultCalendar},
 				selectors.PrefixMatch())[0],
 		},
-		// {
-		// 	name:     "Birthday Calendar",
-		// 	expected: "Birthdays",
-		// 	scope: selectors.NewExchangeBackup(users).EventCalendars(
-		// 		users,
-		// 		[]string{"Birthdays"},
-		// 		selectors.PrefixMatch())[0],
-		// },
+		{
+			name:     "Birthday Calendar",
+			expected: "Birthdays",
+			scope: selectors.NewExchangeBackup(users).EventCalendars(
+				users,
+				[]string{"Birthdays"},
+				selectors.PrefixMatch())[0],
+		},
 	}
 
 	for _, test := range tests {

--- a/src/internal/connector/exchange/data_collections_test.go
+++ b/src/internal/connector/exchange/data_collections_test.go
@@ -532,14 +532,14 @@ func (suite *DataCollectionsIntegrationSuite) TestEventsSerializationRegression(
 				[]string{DefaultCalendar},
 				selectors.PrefixMatch())[0],
 		},
-		{
-			name:     "Birthday Calendar",
-			expected: "Birthdays",
-			scope: selectors.NewExchangeBackup(users).EventCalendars(
-				users,
-				[]string{"Birthdays"},
-				selectors.PrefixMatch())[0],
-		},
+		// {
+		// 	name:     "Birthday Calendar",
+		// 	expected: "Birthdays",
+		// 	scope: selectors.NewExchangeBackup(users).EventCalendars(
+		// 		users,
+		// 		[]string{"Birthdays"},
+		// 		selectors.PrefixMatch())[0],
+		// },
 	}
 
 	for _, test := range tests {
@@ -554,7 +554,7 @@ func (suite *DataCollectionsIntegrationSuite) TestEventsSerializationRegression(
 				control.Options{},
 				newStatusUpdater(t, &wg))
 			require.NoError(t, err)
-			require.Equal(t, len(collections), 2)
+			require.Len(t, collections, 2)
 
 			wg.Add(len(collections))
 

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -122,6 +122,7 @@ func (w Wrapper) BackupCollections(
 	service path.ServiceType,
 	oc *OwnersCats,
 	tags map[string]string,
+	buildTreeWithBase bool,
 ) (*BackupStats, *details.Builder, map[string]path.Path, error) {
 	if w.c == nil {
 		return nil, nil, nil, errNotConnected
@@ -140,7 +141,15 @@ func (w Wrapper) BackupCollections(
 		toMerge: map[string]path.Path{},
 	}
 
-	dirTree, err := inflateDirTree(ctx, w.c, previousSnapshots, collections, progress)
+	// When running an incremental backup, we need to pass the prior
+	// snapshot bases into inflateDirTree so that the new snapshot
+	// includes historical data.
+	var base []IncrementalBase
+	if buildTreeWithBase {
+		base = previousSnapshots
+	}
+
+	dirTree, err := inflateDirTree(ctx, w.c, base, collections, progress)
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(err, "building kopia directories")
 	}

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -272,6 +272,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 				path.ExchangeService,
 				oc,
 				customTags,
+				true,
 			)
 			assert.NoError(t, err)
 
@@ -353,6 +354,7 @@ func (suite *KopiaIntegrationSuite) TestRestoreAfterCompressionChange() {
 		path.ExchangeService,
 		oc,
 		nil,
+		true,
 	)
 	require.NoError(t, err)
 
@@ -435,6 +437,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_ReaderError() {
 		path.ExchangeService,
 		oc,
 		nil,
+		true,
 	)
 	require.NoError(t, err)
 
@@ -480,6 +483,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollectionsHandlesNoCollections() 
 				path.UnknownService,
 				&OwnersCats{},
 				nil,
+				true,
 			)
 			require.NoError(t, err)
 
@@ -641,6 +645,7 @@ func (suite *KopiaSimpleRepoIntegrationSuite) SetupTest() {
 		path.ExchangeService,
 		oc,
 		nil,
+		false,
 	)
 	require.NoError(t, err)
 	require.Equal(t, stats.ErrorCount, 0)

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -89,7 +89,7 @@ type backupStats struct {
 }
 
 type detailsWriter interface {
-	WriteBackupDetails(context.Context, *details.Details, bool) (string, error)
+	WriteBackupDetails(context.Context, *details.Details) (string, error)
 }
 
 // ---------------------------------------------------------------------------
@@ -138,8 +138,7 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 			ctx,
 			detailsStore,
 			opStats.k.SnapshotID,
-			backupDetails.Details(),
-			uib)
+			backupDetails.Details())
 		if err != nil {
 			opStats.writeErr = err
 		}
@@ -587,13 +586,12 @@ func (op *BackupOperation) createBackupModels(
 	detailsStore detailsWriter,
 	snapID string,
 	backupDetails *details.Details,
-	isIncremental bool,
 ) error {
 	if backupDetails == nil {
 		return errors.New("no backup details to record")
 	}
 
-	detailsID, err := detailsStore.WriteBackupDetails(ctx, backupDetails, isIncremental)
+	detailsID, err := detailsStore.WriteBackupDetails(ctx, backupDetails)
 	if err != nil {
 		return errors.Wrap(err, "creating backupdetails model")
 	}

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -289,6 +289,7 @@ type mockBackuper struct {
 		service path.ServiceType,
 		oc *kopia.OwnersCats,
 		tags map[string]string,
+		buildTreeWithBase bool,
 	)
 }
 
@@ -299,9 +300,10 @@ func (mbu mockBackuper) BackupCollections(
 	service path.ServiceType,
 	oc *kopia.OwnersCats,
 	tags map[string]string,
+	buildTreeWithBase bool,
 ) (*kopia.BackupStats, *details.Builder, map[string]path.Path, error) {
 	if mbu.checkFunc != nil {
-		mbu.checkFunc(bases, cs, service, oc, tags)
+		mbu.checkFunc(bases, cs, service, oc, tags, buildTreeWithBase)
 	}
 
 	return &kopia.BackupStats{}, &details.Builder{}, nil, nil
@@ -440,6 +442,7 @@ func (suite *BackupOpSuite) TestBackupOperation_ConsumeBackupDataCollections_Pat
 					service path.ServiceType,
 					oc *kopia.OwnersCats,
 					tags map[string]string,
+					buildTreeWithBase bool,
 				) {
 					assert.ElementsMatch(t, test.expected, bases)
 				},
@@ -455,6 +458,7 @@ func (suite *BackupOpSuite) TestBackupOperation_ConsumeBackupDataCollections_Pat
 				test.inputMan,
 				nil,
 				model.StableID(""),
+				true,
 			)
 		})
 	}

--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -95,6 +95,15 @@ type restoreStats struct {
 	restoreID string
 }
 
+type restorer interface {
+	RestoreMultipleItems(
+		ctx context.Context,
+		snapshotID string,
+		paths []path.Path,
+		bc kopia.ByteCounter,
+	) ([]data.Collection, error)
+}
+
 // Run begins a synchronous restore operation.
 func (op *RestoreOperation) Run(ctx context.Context) (restoreDetails *details.Details, err error) {
 	ctx, end := D.Span(ctx, "operations:restore:run")

--- a/src/internal/streamstore/streamstore.go
+++ b/src/internal/streamstore/streamstore.go
@@ -45,6 +45,7 @@ const (
 func (ss *streamStore) WriteBackupDetails(
 	ctx context.Context,
 	backupDetails *details.Details,
+	isIncremental bool,
 ) (string, error) {
 	// construct the path of the container for the `details` item
 	p, err := path.Builder{}.
@@ -80,6 +81,7 @@ func (ss *streamStore) WriteBackupDetails(
 		ss.service,
 		nil,
 		nil,
+		isIncremental,
 	)
 	if err != nil {
 		return "", nil

--- a/src/internal/streamstore/streamstore.go
+++ b/src/internal/streamstore/streamstore.go
@@ -45,7 +45,6 @@ const (
 func (ss *streamStore) WriteBackupDetails(
 	ctx context.Context,
 	backupDetails *details.Details,
-	isIncremental bool,
 ) (string, error) {
 	// construct the path of the container for the `details` item
 	p, err := path.Builder{}.
@@ -81,7 +80,7 @@ func (ss *streamStore) WriteBackupDetails(
 		ss.service,
 		nil,
 		nil,
-		isIncremental,
+		false,
 	)
 	if err != nil {
 		return "", nil

--- a/src/internal/streamstore/streamstore_test.go
+++ b/src/internal/streamstore/streamstore_test.go
@@ -59,7 +59,7 @@ func (suite *StreamStoreIntegrationSuite) TestDetails() {
 
 	ss := New(kw, "tenant", path.ExchangeService)
 
-	id, err := ss.WriteBackupDetails(ctx, deets, false)
+	id, err := ss.WriteBackupDetails(ctx, deets)
 	require.NoError(t, err)
 	require.NotNil(t, id)
 

--- a/src/internal/streamstore/streamstore_test.go
+++ b/src/internal/streamstore/streamstore_test.go
@@ -59,7 +59,7 @@ func (suite *StreamStoreIntegrationSuite) TestDetails() {
 
 	ss := New(kw, "tenant", path.ExchangeService)
 
-	id, err := ss.WriteBackupDetails(ctx, deets)
+	id, err := ss.WriteBackupDetails(ctx, deets, false)
 	require.NoError(t, err)
 	require.NotNil(t, id)
 


### PR DESCRIPTION
## Description

Adds a flag to the BackupCollections interface
that identifies whether the caller is running an
incremental backup or not.  If they are, kopia
will utilize the previous base snapshots when
building the directory tree.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :sunflower: Feature

## Issue(s)

* #1901

## Test Plan

- [x] :green_heart: E2E
