### PR TITLE
Source resource owner from prev path if needed

### DIFF
--- a/src/internal/data/data_collection.go
+++ b/src/internal/data/data_collection.go
@@ -98,6 +98,18 @@ func ResourceOwnerSet(cs []Collection) []string {
 
 	for _, c := range cs {
 		fp := c.FullPath()
+		if fp == nil {
+			// Deleted collections have their full path set to nil but the previous
+			// path will be populated.
+			fp = c.PreviousPath()
+		}
+
+		if fp == nil {
+			// This should not happen, but keep us from hitting a nil pointer
+			// exception if it does somehow occur. Statistics will be off though.
+			continue
+		}
+
 		rs[fp.ResourceOwner()] = struct{}{}
 	}
 


### PR DESCRIPTION
## Description

Deleted collections have full path set to nil but have their previous path populated. When gathering information for statistics reporting, check that we have a non-nil value to get resource owner from.

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

* closes #1948 

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
