### PR TITLE
add happy-path incremental tests to operations

### DIFF
--- a/src/internal/tester/cli.go
+++ b/src/internal/tester/cli.go
@@ -36,7 +36,6 @@ func StubRootCmd(args ...string) *cobra.Command {
 func NewContext() (context.Context, func()) {
 	level := logger.Info
 
-	fmt.Printf("\n-----\nargs %v\n-----\n", os.Args)
 	for _, a := range os.Args {
 		if a == "-test.v=true" {
 			level = logger.Development

--- a/src/internal/tester/cli.go
+++ b/src/internal/tester/cli.go
@@ -36,6 +36,7 @@ func StubRootCmd(args ...string) *cobra.Command {
 func NewContext() (context.Context, func()) {
 	level := logger.Info
 
+	fmt.Printf("\n-----\nargs %v\n-----\n", os.Args)
 	for _, a := range os.Args {
 		if a == "-test.v=true" {
 			level = logger.Development


### PR DESCRIPTION
## Description

Add a simple happy-path integration test to
operations backups.  This test only attemps to
assert the most basic expectations: that
incrementals are runnable, and that they involve
less data than the initial backup.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :robot: Test

## Issue(s)

* #1966

## Test Plan

- [x] :green_heart: E2E
