### PR TITLE
Fix repo connect progress bar clobbering output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed issue where repository connect progress bar was clobbering backup/restore operation output.
+
 ## [v0.0.4] (alpha)
 
 ### Added

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -150,6 +150,10 @@ func Connect(
 	s storage.Storage,
 	opts control.Options,
 ) (Repository, error) {
+	// Close/Reset the progress bar. This ensures callers don't have to worry about
+	// their output getting clobbered (#1720)
+	defer observe.Complete()
+
 	complete, closer := observe.MessageWithCompletion("Connecting to repository:")
 	defer closer()
 	defer close(complete)


### PR DESCRIPTION
## Description

The Backup/Restore operations ensure progress bars are completed before logging to stdout.
When a progress bar was added to repo connect - this is outside of that scope and ends up not getting
shutdown correctly.

This fixes that by adding a `observe.Complete()` in `Connect`.

## Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :hamster: Trivial/Minor

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #1720 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
