### PR TITLE
protect against prevPath nil panic

### DIFF
--- a/src/internal/data/data_collection.go
+++ b/src/internal/data/data_collection.go
@@ -36,7 +36,7 @@ type Collection interface {
 	FullPath() path.Path
 	// PreviousPath returns the path.Path this collection used to reside at
 	// (according to the M365 ID for the container) if the collection was moved or
-	// renamed. Returns nil if the collection is new or has been deleted.
+	// renamed. Returns nil if the collection is new.
 	PreviousPath() path.Path
 	// State represents changes to the Collection compared to the last backup
 	// involving the Collection. State changes are based on the M365 ID of the

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -579,13 +579,16 @@ func inflateCollectionTree(
 	for _, s := range collections {
 		switch s.State() {
 		case data.DeletedState:
+			if s.PreviousPath() == nil {
+				return nil, nil, errors.Errorf("nil previous path on deleted collection")
+			}
+
 			changedPaths = append(changedPaths, s.PreviousPath())
 
 			if _, ok := updatedPaths[s.PreviousPath().String()]; ok {
 				return nil, nil, errors.Errorf(
 					"multiple previous state changes to collection %s",
-					s.PreviousPath(),
-				)
+					s.PreviousPath())
 			}
 
 			updatedPaths[s.PreviousPath().String()] = nil


### PR DESCRIPTION
## Description

Return an error if a collection in a deleted state has a nil previousPath.  This technically should
never occur, but we'll prefer an error over a panic.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :bug: Bugfix

## Issue(s)

* #1999

## Test Plan

- [x] :green_heart: E2E
