### PR TITLE
methodize all api funcs to the Client

### DIFF
--- a/src/cmd/factory/exchange.go
+++ b/src/cmd/factory/exchange.go
@@ -47,7 +47,7 @@ func handleExchangeEmailFactory(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	gc, tenantID, err := getGCAndVerifyUser(ctx, user)
+	gc, acct, err := getGCAndVerifyUser(ctx, user)
 	if err != nil {
 		return Only(ctx, err)
 	}
@@ -55,10 +55,11 @@ func handleExchangeEmailFactory(cmd *cobra.Command, args []string) error {
 	deets, err := generateAndRestoreItems(
 		ctx,
 		gc,
+		acct,
 		service,
 		category,
 		selectors.NewExchangeRestore([]string{user}).Selector,
-		tenantID, user, destination,
+		user, destination,
 		count,
 		func(id, now, subject, body string) []byte {
 			return mockconnector.GetMockMessageWith(
@@ -87,7 +88,7 @@ func handleExchangeCalendarEventFactory(cmd *cobra.Command, args []string) error
 		return nil
 	}
 
-	gc, tenantID, err := getGCAndVerifyUser(ctx, user)
+	gc, acct, err := getGCAndVerifyUser(ctx, user)
 	if err != nil {
 		return Only(ctx, err)
 	}
@@ -95,10 +96,11 @@ func handleExchangeCalendarEventFactory(cmd *cobra.Command, args []string) error
 	deets, err := generateAndRestoreItems(
 		ctx,
 		gc,
+		acct,
 		service,
 		category,
 		selectors.NewExchangeRestore([]string{user}).Selector,
-		tenantID, user, destination,
+		user, destination,
 		count,
 		func(id, now, subject, body string) []byte {
 			return mockconnector.GetMockEventWith(
@@ -126,7 +128,7 @@ func handleExchangeContactFactory(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	gc, tenantID, err := getGCAndVerifyUser(ctx, user)
+	gc, acct, err := getGCAndVerifyUser(ctx, user)
 	if err != nil {
 		return Only(ctx, err)
 	}
@@ -134,10 +136,11 @@ func handleExchangeContactFactory(cmd *cobra.Command, args []string) error {
 	deets, err := generateAndRestoreItems(
 		ctx,
 		gc,
+		acct,
 		service,
 		category,
 		selectors.NewExchangeRestore([]string{user}).Selector,
-		tenantID, user, destination,
+		user, destination,
 		count,
 		func(id, now, subject, body string) []byte {
 			given, mid, sur := id[:8], id[9:13], id[len(id)-12:]

--- a/src/cmd/getM365/getItem.go
+++ b/src/cmd/getM365/getItem.go
@@ -77,12 +77,12 @@ func handleGetCommand(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	gc, err := getGC(ctx)
+	gc, creds, err := getGC(ctx)
 	if err != nil {
 		return err
 	}
 
-	err = runDisplayM365JSON(ctx, gc.Service)
+	err = runDisplayM365JSON(ctx, gc.Service, creds)
 	if err != nil {
 		return Only(ctx, errors.Wrapf(err, "unable to create mock from M365: %s", m365ID))
 	}
@@ -93,6 +93,7 @@ func handleGetCommand(cmd *cobra.Command, args []string) error {
 func runDisplayM365JSON(
 	ctx context.Context,
 	gs graph.Servicer,
+	creds account.M365Config,
 ) error {
 	var (
 		get           api.GraphRetrievalFunc
@@ -100,9 +101,11 @@ func runDisplayM365JSON(
 		cat           = graph.StringToPathCategory(category)
 	)
 
+	ac := api.Client{Credentials: creds}
+
 	switch cat {
 	case path.EmailCategory, path.EventsCategory, path.ContactsCategory:
-		get, serializeFunc = exchange.GetQueryAndSerializeFunc(cat)
+		get, serializeFunc = exchange.GetQueryAndSerializeFunc(ac, cat)
 	default:
 		return fmt.Errorf("unable to process category: %s", cat)
 	}
@@ -111,7 +114,7 @@ func runDisplayM365JSON(
 
 	sw := kw.NewJsonSerializationWriter()
 
-	response, err := get(ctx, gs, user, m365ID)
+	response, err := get(ctx, user, m365ID)
 	if err != nil {
 		return errors.Wrap(err, support.ConnectorStackErrorTrace(err))
 	}
@@ -159,7 +162,7 @@ func runDisplayM365JSON(
 // Helpers
 //-------------------------------------------------------------------------------
 
-func getGC(ctx context.Context) (*connector.GraphConnector, error) {
+func getGC(ctx context.Context) (*connector.GraphConnector, account.M365Config, error) {
 	// get account info
 	m365Cfg := account.M365Config{
 		M365:          credentials.GetM365(),
@@ -168,13 +171,13 @@ func getGC(ctx context.Context) (*connector.GraphConnector, error) {
 
 	acct, err := account.NewAccount(account.ProviderM365, m365Cfg)
 	if err != nil {
-		return nil, Only(ctx, errors.Wrap(err, "finding m365 account details"))
+		return nil, m365Cfg, Only(ctx, errors.Wrap(err, "finding m365 account details"))
 	}
 
 	gc, err := connector.NewGraphConnector(ctx, acct, connector.Users)
 	if err != nil {
-		return nil, Only(ctx, errors.Wrap(err, "connecting to graph API"))
+		return nil, m365Cfg, Only(ctx, errors.Wrap(err, "connecting to graph API"))
 	}
 
-	return gc, nil
+	return gc, m365Cfg, nil
 }

--- a/src/cmd/getM365/getItem.go
+++ b/src/cmd/getM365/getItem.go
@@ -101,7 +101,10 @@ func runDisplayM365JSON(
 		cat           = graph.StringToPathCategory(category)
 	)
 
-	ac := api.Client{Credentials: creds}
+	ac, err := api.NewClient(creds)
+	if err != nil {
+		return err
+	}
 
 	switch cat {
 	case path.EmailCategory, path.EventsCategory, path.ContactsCategory:

--- a/src/internal/connector/exchange/api/api.go
+++ b/src/internal/connector/exchange/api/api.go
@@ -83,5 +83,6 @@ func newService(creds account.M365Config) (*graph.Service, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "generating graph api service client")
 	}
+
 	return graph.NewService(adapter), nil
 }

--- a/src/internal/connector/exchange/api/api.go
+++ b/src/internal/connector/exchange/api/api.go
@@ -4,8 +4,10 @@ import (
 	"context"
 
 	"github.com/microsoft/kiota-abstractions-go/serialization"
+	"github.com/pkg/errors"
 
 	"github.com/alcionai/corso/src/internal/connector/graph"
+	"github.com/alcionai/corso/src/pkg/account"
 )
 
 // ---------------------------------------------------------------------------
@@ -26,14 +28,13 @@ type DeltaUpdate struct {
 // into M365 backstore. Responses -> returned items will only contain the information
 // that is included in the options
 // TODO: use selector or path for granularity into specific folders or specific date ranges
-type GraphQuery func(ctx context.Context, gs graph.Servicer, userID string) (serialization.Parsable, error)
+type GraphQuery func(ctx context.Context, userID string) (serialization.Parsable, error)
 
 // GraphRetrievalFunctions are functions from the Microsoft Graph API that retrieve
 // the default associated data of a M365 object. This varies by object. Additional
 // Queries must be run to obtain the omitted fields.
 type GraphRetrievalFunc func(
 	ctx context.Context,
-	gs graph.Servicer,
 	user, m365ID string,
 ) (serialization.Parsable, error)
 
@@ -41,10 +42,25 @@ type GraphRetrievalFunc func(
 // interfaces
 // ---------------------------------------------------------------------------
 
-// API is a struct used to fulfill the interface for exchange
+// Client is used to fulfill the interface for exchange
 // queries that are traditionally backed by GraphAPI.  A
 // struct is used in this case, instead of deferring to
 // pure function wrappers, so that the boundary separates the
 // granular implementation of the graphAPI and kiota away
 // from the exchange package's broader intents.
-// type API struct{}
+type Client struct {
+	Credentials account.M365Config
+}
+
+func (c Client) service() (*graph.Service, error) {
+	adapter, err := graph.CreateAdapter(
+		c.Credentials.AzureTenantID,
+		c.Credentials.AzureClientID,
+		c.Credentials.AzureClientSecret,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "generating graph api service client")
+	}
+
+	return graph.NewService(adapter), nil
+}

--- a/src/internal/connector/exchange/api/api.go
+++ b/src/internal/connector/exchange/api/api.go
@@ -50,17 +50,38 @@ type GraphRetrievalFunc func(
 // from the exchange package's broader intents.
 type Client struct {
 	Credentials account.M365Config
+
+	// The stable service is re-usable for any non-paged request.
+	// This allows us to maintain performance across async requests.
+	stable graph.Servicer
 }
 
+// NewClient produces a new exchange api client.  Must be used in
+// place of creating an ad-hoc client struct.
+func NewClient(creds account.M365Config) (Client, error) {
+	s, err := newService(creds)
+	if err != nil {
+		return Client{}, err
+	}
+
+	return Client{creds, s}, nil
+}
+
+// service generates a new service.  Used for paged and other long-running
+// requests instead of the client's stable service, so that in-flight state
+// within the adapter doesn't get clobbered
 func (c Client) service() (*graph.Service, error) {
+	return newService(c.Credentials)
+}
+
+func newService(creds account.M365Config) (*graph.Service, error) {
 	adapter, err := graph.CreateAdapter(
-		c.Credentials.AzureTenantID,
-		c.Credentials.AzureClientID,
-		c.Credentials.AzureClientSecret,
+		creds.AzureTenantID,
+		creds.AzureClientID,
+		creds.AzureClientSecret,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "generating graph api service client")
 	}
-
 	return graph.NewService(adapter), nil
 }

--- a/src/internal/connector/exchange/api/api_test.go
+++ b/src/internal/connector/exchange/api/api_test.go
@@ -164,7 +164,8 @@ func (suite *ExchangeServiceSuite) TestGraphQueryFunctions() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 
-	c := Client{suite.credentials}
+	c, err := NewClient(suite.credentials)
+	require.NoError(suite.T(), err)
 
 	userID := tester.M365UserID(suite.T())
 	tests := []struct {

--- a/src/internal/connector/exchange/api/api_test.go
+++ b/src/internal/connector/exchange/api/api_test.go
@@ -164,6 +164,8 @@ func (suite *ExchangeServiceSuite) TestGraphQueryFunctions() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 
+	c := Client{suite.credentials}
+
 	userID := tester.M365UserID(suite.T())
 	tests := []struct {
 		name     string
@@ -171,17 +173,17 @@ func (suite *ExchangeServiceSuite) TestGraphQueryFunctions() {
 	}{
 		{
 			name:     "GraphQuery: Get All ContactFolders",
-			function: GetAllContactFolderNamesForUser,
+			function: c.GetAllContactFolderNamesForUser,
 		},
 		{
 			name:     "GraphQuery: Get All Calendars for User",
-			function: GetAllCalendarNamesForUser,
+			function: c.GetAllCalendarNamesForUser,
 		},
 	}
 
 	for _, test := range tests {
 		suite.T().Run(test.name, func(t *testing.T) {
-			response, err := test.function(ctx, suite.gs, userID)
+			response, err := test.function(ctx, userID)
 			assert.NoError(t, err)
 			assert.NotNil(t, response)
 		})

--- a/src/internal/connector/exchange/api/contacts.go
+++ b/src/internal/connector/exchange/api/contacts.go
@@ -15,55 +15,79 @@ import (
 
 // CreateContactFolder makes a contact folder with the displayName of folderName.
 // If successful, returns the created folder object.
-func CreateContactFolder(
+func (c Client) CreateContactFolder(
 	ctx context.Context,
-	gs graph.Servicer,
 	user, folderName string,
 ) (models.ContactFolderable, error) {
+	service, err := c.service()
+	if err != nil {
+		return nil, err
+	}
+
 	requestBody := models.NewContactFolder()
 	temp := folderName
 	requestBody.SetDisplayName(&temp)
 
-	return gs.Client().UsersById(user).ContactFolders().Post(ctx, requestBody, nil)
+	return service.Client().UsersById(user).ContactFolders().Post(ctx, requestBody, nil)
 }
 
 // DeleteContactFolder deletes the ContactFolder associated with the M365 ID if permissions are valid.
 // Errors returned if the function call was not successful.
-func DeleteContactFolder(ctx context.Context, gs graph.Servicer, user, folderID string) error {
-	return gs.Client().UsersById(user).ContactFoldersById(folderID).Delete(ctx, nil)
+func (c Client) DeleteContactFolder(
+	ctx context.Context,
+	user, folderID string,
+) error {
+	service, err := c.service()
+	if err != nil {
+		return err
+	}
+
+	return service.Client().UsersById(user).ContactFoldersById(folderID).Delete(ctx, nil)
 }
 
 // RetrieveContactDataForUser is a GraphRetrievalFun that returns all associated fields.
-func RetrieveContactDataForUser(
+func (c Client) RetrieveContactDataForUser(
 	ctx context.Context,
-	gs graph.Servicer,
 	user, m365ID string,
 ) (serialization.Parsable, error) {
-	return gs.Client().UsersById(user).ContactsById(m365ID).Get(ctx, nil)
+	service, err := c.service()
+	if err != nil {
+		return nil, err
+	}
+
+	return service.Client().UsersById(user).ContactsById(m365ID).Get(ctx, nil)
 }
 
 // GetAllContactFolderNamesForUser is a GraphQuery function for getting
 // ContactFolderId and display names for contacts. All other information is omitted.
 // Does not return the default Contact Folder
-func GetAllContactFolderNamesForUser(
+func (c Client) GetAllContactFolderNamesForUser(
 	ctx context.Context,
-	gs graph.Servicer,
 	user string,
 ) (serialization.Parsable, error) {
+	service, err := c.service()
+	if err != nil {
+		return nil, err
+	}
+
 	options, err := optionsForContactFolders([]string{"displayName", "parentFolderId"})
 	if err != nil {
 		return nil, err
 	}
 
-	return gs.Client().UsersById(user).ContactFolders().Get(ctx, options)
+	return service.Client().UsersById(user).ContactFolders().Get(ctx, options)
 }
 
-func GetContactFolderByID(
+func (c Client) GetContactFolderByID(
 	ctx context.Context,
-	gs graph.Servicer,
 	userID, dirID string,
 	optionalFields ...string,
 ) (models.ContactFolderable, error) {
+	service, err := c.service()
+	if err != nil {
+		return nil, err
+	}
+
 	fields := append([]string{"displayName", "parentFolderId"}, optionalFields...)
 
 	ofcf, err := optionsForContactFolderByID(fields)
@@ -71,7 +95,7 @@ func GetContactFolderByID(
 		return nil, errors.Wrapf(err, "options for contact folder: %v", fields)
 	}
 
-	return gs.Client().
+	return service.Client().
 		UsersById(userID).
 		ContactFoldersById(dirID).
 		Get(ctx, ofcf)
@@ -79,38 +103,47 @@ func GetContactFolderByID(
 
 // TODO: we want this to be the full handler, not only the builder.
 // but this halfway point minimizes changes for now.
-func GetContactChildFoldersBuilder(
+func (c Client) GetContactChildFoldersBuilder(
 	ctx context.Context,
-	gs graph.Servicer,
 	userID, baseDirID string,
 	optionalFields ...string,
 ) (
 	*users.ItemContactFoldersItemChildFoldersRequestBuilder,
 	*users.ItemContactFoldersItemChildFoldersRequestBuilderGetRequestConfiguration,
+	*graph.Service,
 	error,
 ) {
+	service, err := c.service()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	fields := append([]string{"displayName", "parentFolderId"}, optionalFields...)
 
 	ofcf, err := optionsForContactChildFolders(fields)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "options for contact child folders: %v", fields)
+		return nil, nil, nil, errors.Wrapf(err, "options for contact child folders: %v", fields)
 	}
 
-	builder := gs.Client().
+	builder := service.Client().
 		UsersById(userID).
 		ContactFoldersById(baseDirID).
 		ChildFolders()
 
-	return builder, ofcf, nil
+	return builder, ofcf, service, nil
 }
 
 // FetchContactIDsFromDirectory function that returns a list of  all the m365IDs of the contacts
 // of the targeted directory
-func FetchContactIDsFromDirectory(
+func (c Client) FetchContactIDsFromDirectory(
 	ctx context.Context,
-	gs graph.Servicer,
 	user, directoryID, oldDelta string,
 ) ([]string, []string, DeltaUpdate, error) {
+	service, err := c.service()
+	if err != nil {
+		return nil, nil, DeltaUpdate{}, err
+	}
+
 	var (
 		errs       *multierror.Error
 		ids        []string
@@ -167,14 +200,14 @@ func FetchContactIDsFromDirectory(
 				break
 			}
 
-			builder = users.NewItemContactFoldersItemContactsDeltaRequestBuilder(*nextLink, gs.Adapter())
+			builder = users.NewItemContactFoldersItemContactsDeltaRequestBuilder(*nextLink, service.Adapter())
 		}
 
 		return nil
 	}
 
 	if len(oldDelta) > 0 {
-		err := getIDs(users.NewItemContactFoldersItemContactsDeltaRequestBuilder(oldDelta, gs.Adapter()))
+		err := getIDs(users.NewItemContactFoldersItemContactsDeltaRequestBuilder(oldDelta, service.Adapter()))
 		// note: happy path, not the error condition
 		if err == nil {
 			return ids, removedIDs, DeltaUpdate{deltaURL, false}, errs.ErrorOrNil()
@@ -189,7 +222,7 @@ func FetchContactIDsFromDirectory(
 		errs = nil
 	}
 
-	builder := gs.Client().
+	builder := service.Client().
 		UsersById(user).
 		ContactFoldersById(directoryID).
 		Contacts().

--- a/src/internal/connector/exchange/api/contacts.go
+++ b/src/internal/connector/exchange/api/contacts.go
@@ -19,16 +19,11 @@ func (c Client) CreateContactFolder(
 	ctx context.Context,
 	user, folderName string,
 ) (models.ContactFolderable, error) {
-	service, err := c.service()
-	if err != nil {
-		return nil, err
-	}
-
 	requestBody := models.NewContactFolder()
 	temp := folderName
 	requestBody.SetDisplayName(&temp)
 
-	return service.Client().UsersById(user).ContactFolders().Post(ctx, requestBody, nil)
+	return c.stable.Client().UsersById(user).ContactFolders().Post(ctx, requestBody, nil)
 }
 
 // DeleteContactFolder deletes the ContactFolder associated with the M365 ID if permissions are valid.
@@ -37,12 +32,7 @@ func (c Client) DeleteContactFolder(
 	ctx context.Context,
 	user, folderID string,
 ) error {
-	service, err := c.service()
-	if err != nil {
-		return err
-	}
-
-	return service.Client().UsersById(user).ContactFoldersById(folderID).Delete(ctx, nil)
+	return c.stable.Client().UsersById(user).ContactFoldersById(folderID).Delete(ctx, nil)
 }
 
 // RetrieveContactDataForUser is a GraphRetrievalFun that returns all associated fields.
@@ -50,12 +40,7 @@ func (c Client) RetrieveContactDataForUser(
 	ctx context.Context,
 	user, m365ID string,
 ) (serialization.Parsable, error) {
-	service, err := c.service()
-	if err != nil {
-		return nil, err
-	}
-
-	return service.Client().UsersById(user).ContactsById(m365ID).Get(ctx, nil)
+	return c.stable.Client().UsersById(user).ContactsById(m365ID).Get(ctx, nil)
 }
 
 // GetAllContactFolderNamesForUser is a GraphQuery function for getting
@@ -65,17 +50,12 @@ func (c Client) GetAllContactFolderNamesForUser(
 	ctx context.Context,
 	user string,
 ) (serialization.Parsable, error) {
-	service, err := c.service()
-	if err != nil {
-		return nil, err
-	}
-
 	options, err := optionsForContactFolders([]string{"displayName", "parentFolderId"})
 	if err != nil {
 		return nil, err
 	}
 
-	return service.Client().UsersById(user).ContactFolders().Get(ctx, options)
+	return c.stable.Client().UsersById(user).ContactFolders().Get(ctx, options)
 }
 
 func (c Client) GetContactFolderByID(
@@ -83,11 +63,6 @@ func (c Client) GetContactFolderByID(
 	userID, dirID string,
 	optionalFields ...string,
 ) (models.ContactFolderable, error) {
-	service, err := c.service()
-	if err != nil {
-		return nil, err
-	}
-
 	fields := append([]string{"displayName", "parentFolderId"}, optionalFields...)
 
 	ofcf, err := optionsForContactFolderByID(fields)
@@ -95,7 +70,7 @@ func (c Client) GetContactFolderByID(
 		return nil, errors.Wrapf(err, "options for contact folder: %v", fields)
 	}
 
-	return service.Client().
+	return c.stable.Client().
 		UsersById(userID).
 		ContactFoldersById(dirID).
 		Get(ctx, ofcf)

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -19,15 +19,10 @@ func (c Client) CreateCalendar(
 	ctx context.Context,
 	user, calendarName string,
 ) (models.Calendarable, error) {
-	service, err := c.service()
-	if err != nil {
-		return nil, err
-	}
-
 	requestbody := models.NewCalendar()
 	requestbody.SetName(&calendarName)
 
-	return service.Client().UsersById(user).Calendars().Post(ctx, requestbody, nil)
+	return c.stable.Client().UsersById(user).Calendars().Post(ctx, requestbody, nil)
 }
 
 // DeleteCalendar removes calendar from user's M365 account
@@ -36,12 +31,7 @@ func (c Client) DeleteCalendar(
 	ctx context.Context,
 	user, calendarID string,
 ) error {
-	service, err := c.service()
-	if err != nil {
-		return err
-	}
-
-	return service.Client().UsersById(user).CalendarsById(calendarID).Delete(ctx, nil)
+	return c.stable.Client().UsersById(user).CalendarsById(calendarID).Delete(ctx, nil)
 }
 
 // RetrieveEventDataForUser is a GraphRetrievalFunc that returns event data.
@@ -50,29 +40,19 @@ func (c Client) RetrieveEventDataForUser(
 	ctx context.Context,
 	user, m365ID string,
 ) (serialization.Parsable, error) {
-	service, err := c.service()
-	if err != nil {
-		return nil, err
-	}
-
-	return service.Client().UsersById(user).EventsById(m365ID).Get(ctx, nil)
+	return c.stable.Client().UsersById(user).EventsById(m365ID).Get(ctx, nil)
 }
 
 func (c Client) GetAllCalendarNamesForUser(
 	ctx context.Context,
 	user string,
 ) (serialization.Parsable, error) {
-	service, err := c.service()
-	if err != nil {
-		return nil, err
-	}
-
 	options, err := optionsForCalendars([]string{"name", "owner"})
 	if err != nil {
 		return nil, err
 	}
 
-	return service.Client().UsersById(user).Calendars().Get(ctx, options)
+	return c.stable.Client().UsersById(user).Calendars().Get(ctx, options)
 }
 
 // TODO: we want this to be the full handler, not only the builder.

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -15,68 +15,103 @@ import (
 
 // CreateCalendar makes an event Calendar with the name in the user's M365 exchange account
 // Reference: https://docs.microsoft.com/en-us/graph/api/user-post-calendars?view=graph-rest-1.0&tabs=go
-func CreateCalendar(ctx context.Context, gs graph.Servicer, user, calendarName string) (models.Calendarable, error) {
+func (c Client) CreateCalendar(
+	ctx context.Context,
+	user, calendarName string,
+) (models.Calendarable, error) {
+	service, err := c.service()
+	if err != nil {
+		return nil, err
+	}
+
 	requestbody := models.NewCalendar()
 	requestbody.SetName(&calendarName)
 
-	return gs.Client().UsersById(user).Calendars().Post(ctx, requestbody, nil)
+	return service.Client().UsersById(user).Calendars().Post(ctx, requestbody, nil)
 }
 
 // DeleteCalendar removes calendar from user's M365 account
 // Reference: https://docs.microsoft.com/en-us/graph/api/calendar-delete?view=graph-rest-1.0&tabs=go
-func DeleteCalendar(ctx context.Context, gs graph.Servicer, user, calendarID string) error {
-	return gs.Client().UsersById(user).CalendarsById(calendarID).Delete(ctx, nil)
+func (c Client) DeleteCalendar(
+	ctx context.Context,
+	user, calendarID string,
+) error {
+	service, err := c.service()
+	if err != nil {
+		return err
+	}
+
+	return service.Client().UsersById(user).CalendarsById(calendarID).Delete(ctx, nil)
 }
 
 // RetrieveEventDataForUser is a GraphRetrievalFunc that returns event data.
 // Calendarable and attachment fields are omitted due to size
-func RetrieveEventDataForUser(
+func (c Client) RetrieveEventDataForUser(
 	ctx context.Context,
-	gs graph.Servicer,
 	user, m365ID string,
 ) (serialization.Parsable, error) {
-	return gs.Client().UsersById(user).EventsById(m365ID).Get(ctx, nil)
+	service, err := c.service()
+	if err != nil {
+		return nil, err
+	}
+
+	return service.Client().UsersById(user).EventsById(m365ID).Get(ctx, nil)
 }
 
-func GetAllCalendarNamesForUser(ctx context.Context, gs graph.Servicer, user string) (serialization.Parsable, error) {
+func (c Client) GetAllCalendarNamesForUser(
+	ctx context.Context,
+	user string,
+) (serialization.Parsable, error) {
+	service, err := c.service()
+	if err != nil {
+		return nil, err
+	}
+
 	options, err := optionsForCalendars([]string{"name", "owner"})
 	if err != nil {
 		return nil, err
 	}
 
-	return gs.Client().UsersById(user).Calendars().Get(ctx, options)
+	return service.Client().UsersById(user).Calendars().Get(ctx, options)
 }
 
 // TODO: we want this to be the full handler, not only the builder.
 // but this halfway point minimizes changes for now.
-func GetCalendarsBuilder(
+func (c Client) GetCalendarsBuilder(
 	ctx context.Context,
-	gs graph.Servicer,
 	userID string,
 	optionalFields ...string,
 ) (
 	*users.ItemCalendarsRequestBuilder,
 	*users.ItemCalendarsRequestBuilderGetRequestConfiguration,
+	*graph.Service,
 	error,
 ) {
-	ofcf, err := optionsForCalendars(optionalFields)
+	service, err := c.service()
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "options for event calendars: %v", optionalFields)
+		return nil, nil, nil, err
 	}
 
-	builder := gs.Client().
-		UsersById(userID).
-		Calendars()
+	ofcf, err := optionsForCalendars(optionalFields)
+	if err != nil {
+		return nil, nil, nil, errors.Wrapf(err, "options for event calendars: %v", optionalFields)
+	}
 
-	return builder, ofcf, nil
+	builder := service.Client().UsersById(userID).Calendars()
+
+	return builder, ofcf, service, nil
 }
 
 // FetchEventIDsFromCalendar returns a list of all M365IDs of events of the targeted Calendar.
-func FetchEventIDsFromCalendar(
+func (c Client) FetchEventIDsFromCalendar(
 	ctx context.Context,
-	gs graph.Servicer,
 	user, calendarID, oldDelta string,
 ) ([]string, []string, DeltaUpdate, error) {
+	service, err := c.service()
+	if err != nil {
+		return nil, nil, DeltaUpdate{}, err
+	}
+
 	var (
 		errs *multierror.Error
 		ids  []string
@@ -87,10 +122,7 @@ func FetchEventIDsFromCalendar(
 		return nil, nil, DeltaUpdate{}, err
 	}
 
-	builder := gs.Client().
-		UsersById(user).
-		CalendarsById(calendarID).
-		Events()
+	builder := service.Client().UsersById(user).CalendarsById(calendarID).Events()
 
 	for {
 		resp, err := builder.Get(ctx, options)
@@ -121,7 +153,7 @@ func FetchEventIDsFromCalendar(
 			break
 		}
 
-		builder = users.NewItemCalendarsItemEventsRequestBuilder(*nextLink, gs.Adapter())
+		builder = users.NewItemCalendarsItemEventsRequestBuilder(*nextLink, service.Adapter())
 	}
 
 	// Events don't have a delta endpoint so just return an empty string.

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -35,7 +35,6 @@ func (c Client) DeleteCalendar(
 }
 
 // RetrieveEventDataForUser is a GraphRetrievalFunc that returns event data.
-// Calendarable and attachment fields are omitted due to size
 func (c Client) RetrieveEventDataForUser(
 	ctx context.Context,
 	user, m365ID string,

--- a/src/internal/connector/exchange/api/mail.go
+++ b/src/internal/connector/exchange/api/mail.go
@@ -19,17 +19,12 @@ func (c Client) CreateMailFolder(
 	ctx context.Context,
 	user, folder string,
 ) (models.MailFolderable, error) {
-	service, err := c.service()
-	if err != nil {
-		return nil, err
-	}
-
 	isHidden := false
 	requestBody := models.NewMailFolder()
 	requestBody.SetDisplayName(&folder)
 	requestBody.SetIsHidden(&isHidden)
 
-	return service.Client().UsersById(user).MailFolders().Post(ctx, requestBody, nil)
+	return c.stable.Client().UsersById(user).MailFolders().Post(ctx, requestBody, nil)
 }
 
 func (c Client) CreateMailFolderWithParent(
@@ -60,12 +55,7 @@ func (c Client) DeleteMailFolder(
 	ctx context.Context,
 	user, folderID string,
 ) error {
-	service, err := c.service()
-	if err != nil {
-		return err
-	}
-
-	return service.Client().UsersById(user).MailFoldersById(folderID).Delete(ctx, nil)
+	return c.stable.Client().UsersById(user).MailFoldersById(folderID).Delete(ctx, nil)
 }
 
 // RetrieveMessageDataForUser is a GraphRetrievalFunc that returns message data.
@@ -74,12 +64,7 @@ func (c Client) RetrieveMessageDataForUser(
 	ctx context.Context,
 	user, m365ID string,
 ) (serialization.Parsable, error) {
-	service, err := c.service()
-	if err != nil {
-		return nil, err
-	}
-
-	return service.Client().UsersById(user).MessagesById(m365ID).Get(ctx, nil)
+	return c.stable.Client().UsersById(user).MessagesById(m365ID).Get(ctx, nil)
 }
 
 // GetMailFoldersBuilder retrieves all of the users current mail folders.
@@ -113,17 +98,12 @@ func (c Client) GetMailFolderByID(
 	userID, dirID string,
 	optionalFields ...string,
 ) (models.MailFolderable, error) {
-	service, err := c.service()
-	if err != nil {
-		return nil, err
-	}
-
 	ofmf, err := optionsForMailFoldersItem(optionalFields)
 	if err != nil {
 		return nil, errors.Wrapf(err, "options for mail folder: %v", optionalFields)
 	}
 
-	return service.Client().UsersById(userID).MailFoldersById(dirID).Get(ctx, ofmf)
+	return c.stable.Client().UsersById(userID).MailFoldersById(dirID).Get(ctx, ofmf)
 }
 
 // FetchMessageIDsFromDirectory function that returns a list of  all the m365IDs of the exchange.Mail

--- a/src/internal/connector/exchange/api/mail.go
+++ b/src/internal/connector/exchange/api/mail.go
@@ -59,7 +59,6 @@ func (c Client) DeleteMailFolder(
 }
 
 // RetrieveMessageDataForUser is a GraphRetrievalFunc that returns message data.
-// Attachment field is omitted due to size.
 func (c Client) RetrieveMessageDataForUser(
 	ctx context.Context,
 	user, m365ID string,

--- a/src/internal/connector/exchange/api/mail.go
+++ b/src/internal/connector/exchange/api/mail.go
@@ -15,26 +15,39 @@ import (
 
 // CreateMailFolder makes a mail folder iff a folder of the same name does not exist
 // Reference: https://docs.microsoft.com/en-us/graph/api/user-post-mailfolders?view=graph-rest-1.0&tabs=http
-func CreateMailFolder(ctx context.Context, gs graph.Servicer, user, folder string) (models.MailFolderable, error) {
+func (c Client) CreateMailFolder(
+	ctx context.Context,
+	user, folder string,
+) (models.MailFolderable, error) {
+	service, err := c.service()
+	if err != nil {
+		return nil, err
+	}
+
 	isHidden := false
 	requestBody := models.NewMailFolder()
 	requestBody.SetDisplayName(&folder)
 	requestBody.SetIsHidden(&isHidden)
 
-	return gs.Client().UsersById(user).MailFolders().Post(ctx, requestBody, nil)
+	return service.Client().UsersById(user).MailFolders().Post(ctx, requestBody, nil)
 }
 
-func CreateMailFolderWithParent(
+func (c Client) CreateMailFolderWithParent(
 	ctx context.Context,
-	gs graph.Servicer,
 	user, folder, parentID string,
 ) (models.MailFolderable, error) {
+	service, err := c.service()
+	if err != nil {
+		return nil, err
+	}
+
 	isHidden := false
 	requestBody := models.NewMailFolder()
 	requestBody.SetDisplayName(&folder)
 	requestBody.SetIsHidden(&isHidden)
 
-	return gs.Client().
+	return service.
+		Client().
 		UsersById(user).
 		MailFoldersById(parentID).
 		ChildFolders().
@@ -43,18 +56,30 @@ func CreateMailFolderWithParent(
 
 // DeleteMailFolder removes a mail folder with the corresponding M365 ID  from the user's M365 Exchange account
 // Reference: https://docs.microsoft.com/en-us/graph/api/mailfolder-delete?view=graph-rest-1.0&tabs=http
-func DeleteMailFolder(ctx context.Context, gs graph.Servicer, user, folderID string) error {
-	return gs.Client().UsersById(user).MailFoldersById(folderID).Delete(ctx, nil)
+func (c Client) DeleteMailFolder(
+	ctx context.Context,
+	user, folderID string,
+) error {
+	service, err := c.service()
+	if err != nil {
+		return err
+	}
+
+	return service.Client().UsersById(user).MailFoldersById(folderID).Delete(ctx, nil)
 }
 
 // RetrieveMessageDataForUser is a GraphRetrievalFunc that returns message data.
 // Attachment field is omitted due to size.
-func RetrieveMessageDataForUser(
+func (c Client) RetrieveMessageDataForUser(
 	ctx context.Context,
-	gs graph.Servicer,
 	user, m365ID string,
 ) (serialization.Parsable, error) {
-	return gs.Client().UsersById(user).MessagesById(m365ID).Get(ctx, nil)
+	service, err := c.service()
+	if err != nil {
+		return nil, err
+	}
+
+	return service.Client().UsersById(user).MessagesById(m365ID).Get(ctx, nil)
 }
 
 // GetMailFoldersBuilder retrieves all of the users current mail folders.
@@ -62,41 +87,56 @@ func RetrieveMessageDataForUser(
 // not contain historical data.
 // TODO: we want this to be the full handler, not only the builder.
 // but this halfway point minimizes changes for now.
-func GetAllMailFoldersBuilder(
+func (c Client) GetAllMailFoldersBuilder(
 	ctx context.Context,
-	gs graph.Servicer,
 	userID string,
-) *users.ItemMailFoldersDeltaRequestBuilder {
-	return gs.Client().
+) (
+	*users.ItemMailFoldersDeltaRequestBuilder,
+	*graph.Service,
+	error,
+) {
+	service, err := c.service()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	builder := service.Client().
 		UsersById(userID).
 		MailFolders().
 		Delta()
+
+	return builder, service, nil
 }
 
-func GetMailFolderByID(
+func (c Client) GetMailFolderByID(
 	ctx context.Context,
-	gs graph.Servicer,
 	userID, dirID string,
 	optionalFields ...string,
 ) (models.MailFolderable, error) {
+	service, err := c.service()
+	if err != nil {
+		return nil, err
+	}
+
 	ofmf, err := optionsForMailFoldersItem(optionalFields)
 	if err != nil {
 		return nil, errors.Wrapf(err, "options for mail folder: %v", optionalFields)
 	}
 
-	return gs.Client().
-		UsersById(userID).
-		MailFoldersById(dirID).
-		Get(ctx, ofmf)
+	return service.Client().UsersById(userID).MailFoldersById(dirID).Get(ctx, ofmf)
 }
 
 // FetchMessageIDsFromDirectory function that returns a list of  all the m365IDs of the exchange.Mail
 // of the targeted directory
-func FetchMessageIDsFromDirectory(
+func (c Client) FetchMessageIDsFromDirectory(
 	ctx context.Context,
-	gs graph.Servicer,
 	user, directoryID, oldDelta string,
 ) ([]string, []string, DeltaUpdate, error) {
+	service, err := c.service()
+	if err != nil {
+		return nil, nil, DeltaUpdate{}, err
+	}
+
 	var (
 		errs       *multierror.Error
 		ids        []string
@@ -153,14 +193,14 @@ func FetchMessageIDsFromDirectory(
 				break
 			}
 
-			builder = users.NewItemMailFoldersItemMessagesDeltaRequestBuilder(*nextLink, gs.Adapter())
+			builder = users.NewItemMailFoldersItemMessagesDeltaRequestBuilder(*nextLink, service.Adapter())
 		}
 
 		return nil
 	}
 
 	if len(oldDelta) > 0 {
-		err := getIDs(users.NewItemMailFoldersItemMessagesDeltaRequestBuilder(oldDelta, gs.Adapter()))
+		err := getIDs(users.NewItemMailFoldersItemMessagesDeltaRequestBuilder(oldDelta, service.Adapter()))
 		// note: happy path, not the error condition
 		if err == nil {
 			return ids, removedIDs, DeltaUpdate{deltaURL, false}, errs.ErrorOrNil()
@@ -175,11 +215,7 @@ func FetchMessageIDsFromDirectory(
 		errs = nil
 	}
 
-	builder := gs.Client().
-		UsersById(user).
-		MailFoldersById(directoryID).
-		Messages().
-		Delta()
+	builder := service.Client().UsersById(user).MailFoldersById(directoryID).Messages().Delta()
 
 	if err := getIDs(builder); err != nil {
 		return nil, nil, DeltaUpdate{}, err

--- a/src/internal/connector/exchange/contact_folder_cache.go
+++ b/src/internal/connector/exchange/contact_folder_cache.go
@@ -16,7 +16,8 @@ var _ graph.ContainerResolver = &contactFolderCache{}
 
 type contactFolderCache struct {
 	*containerResolver
-	gs     graph.Servicer
+	ac api.Client
+	// gs     graph.Servicer
 	userID string
 }
 
@@ -25,7 +26,7 @@ func (cfc *contactFolderCache) populateContactRoot(
 	directoryID string,
 	baseContainerPath []string,
 ) error {
-	f, err := api.GetContactFolderByID(ctx, cfc.gs, cfc.userID, directoryID)
+	f, err := cfc.ac.GetContactFolderByID(ctx, cfc.userID, directoryID)
 	if err != nil {
 		return errors.Wrapf(
 			err,
@@ -56,9 +57,8 @@ func (cfc *contactFolderCache) Populate(
 
 	var errs error
 
-	builder, options, err := api.GetContactChildFoldersBuilder(
+	builder, options, servicer, err := cfc.ac.GetContactChildFoldersBuilder(
 		ctx,
-		cfc.gs,
 		cfc.userID,
 		baseID)
 	if err != nil {
@@ -97,7 +97,7 @@ func (cfc *contactFolderCache) Populate(
 			break
 		}
 
-		builder = msuser.NewItemContactFoldersItemChildFoldersRequestBuilder(*resp.GetOdataNextLink(), cfc.gs.Adapter())
+		builder = msuser.NewItemContactFoldersItemChildFoldersRequestBuilder(*resp.GetOdataNextLink(), servicer.Adapter())
 	}
 
 	if err := cfc.populatePaths(ctx); err != nil {

--- a/src/internal/connector/exchange/contact_folder_cache.go
+++ b/src/internal/connector/exchange/contact_folder_cache.go
@@ -16,8 +16,7 @@ var _ graph.ContainerResolver = &contactFolderCache{}
 
 type contactFolderCache struct {
 	*containerResolver
-	ac api.Client
-	// gs     graph.Servicer
+	ac     api.Client
 	userID string
 }
 

--- a/src/internal/connector/exchange/container_resolver_test.go
+++ b/src/internal/connector/exchange/container_resolver_test.go
@@ -494,9 +494,6 @@ func (suite *FolderCacheIntegrationSuite) TestCreateContainerDestination() {
 	m365, err := a.M365Config()
 	require.NoError(suite.T(), err)
 
-	connector, err := createService(m365)
-	require.NoError(suite.T(), err)
-
 	var (
 		user            = tester.M365UserID(suite.T())
 		directoryCaches = make(map[path.CategoryType]graph.ContainerResolver)
@@ -596,11 +593,10 @@ func (suite *FolderCacheIntegrationSuite) TestCreateContainerDestination() {
 		suite.T().Run(test.name, func(t *testing.T) {
 			folderID, err := CreateContainerDestinaion(
 				ctx,
-				connector,
+				m365,
 				test.pathFunc1(t),
 				folderName,
-				directoryCaches,
-			)
+				directoryCaches)
 
 			require.NoError(t, err)
 			resolver := directoryCaches[test.category]
@@ -609,11 +605,10 @@ func (suite *FolderCacheIntegrationSuite) TestCreateContainerDestination() {
 
 			secondID, err := CreateContainerDestinaion(
 				ctx,
-				connector,
+				m365,
 				test.pathFunc2(t),
 				folderName,
-				directoryCaches,
-			)
+				directoryCaches)
 
 			require.NoError(t, err)
 			_, err = resolver.IDToPath(ctx, secondID)

--- a/src/internal/connector/exchange/event_calendar_cache.go
+++ b/src/internal/connector/exchange/event_calendar_cache.go
@@ -16,7 +16,6 @@ var _ graph.ContainerResolver = &eventCalendarCache{}
 
 type eventCalendarCache struct {
 	*containerResolver
-	// gs     graph.Servicer
 	ac     api.Client
 	userID string
 }

--- a/src/internal/connector/exchange/event_calendar_cache.go
+++ b/src/internal/connector/exchange/event_calendar_cache.go
@@ -16,7 +16,8 @@ var _ graph.ContainerResolver = &eventCalendarCache{}
 
 type eventCalendarCache struct {
 	*containerResolver
-	gs     graph.Servicer
+	// gs     graph.Servicer
+	ac     api.Client
 	userID string
 }
 
@@ -32,7 +33,7 @@ func (ecc *eventCalendarCache) Populate(
 		ecc.containerResolver = newContainerResolver()
 	}
 
-	builder, options, err := api.GetCalendarsBuilder(ctx, ecc.gs, ecc.userID, "name")
+	builder, options, servicer, err := ecc.ac.GetCalendarsBuilder(ctx, ecc.userID, "name")
 	if err != nil {
 		return err
 	}
@@ -67,7 +68,7 @@ func (ecc *eventCalendarCache) Populate(
 			break
 		}
 
-		builder = msuser.NewItemCalendarsRequestBuilder(*resp.GetOdataNextLink(), ecc.gs.Adapter())
+		builder = msuser.NewItemCalendarsRequestBuilder(*resp.GetOdataNextLink(), servicer.Adapter())
 	}
 
 	for _, container := range directories {

--- a/src/internal/connector/exchange/exchange_data_collection_test.go
+++ b/src/internal/connector/exchange/exchange_data_collection_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/connector/exchange/api"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -136,7 +137,7 @@ func (suite *ExchangeDataCollectionSuite) TestNewCollection_state() {
 			c := NewCollection(
 				"u",
 				test.curr, test.prev,
-				0, nil, nil, control.Options{},
+				0, api.Client{}, nil, nil, control.Options{},
 				false)
 			assert.Equal(t, test.expect, c.State())
 		})

--- a/src/internal/connector/exchange/folder_resolver_test.go
+++ b/src/internal/connector/exchange/folder_resolver_test.go
@@ -44,17 +44,20 @@ func (suite *CacheResolverSuite) TestPopulate() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 
+	ac, err := api.NewClient(suite.credentials)
+	require.NoError(suite.T(), err)
+
 	eventFunc := func(t *testing.T) graph.ContainerResolver {
 		return &eventCalendarCache{
 			userID: tester.M365UserID(t),
-			ac:     api.Client{Credentials: suite.credentials},
+			ac:     ac,
 		}
 	}
 
 	contactFunc := func(t *testing.T) graph.ContainerResolver {
 		return &contactFolderCache{
 			userID: tester.M365UserID(t),
-			ac:     api.Client{Credentials: suite.credentials},
+			ac:     ac,
 		}
 	}
 

--- a/src/internal/connector/exchange/folder_resolver_test.go
+++ b/src/internal/connector/exchange/folder_resolver_test.go
@@ -7,13 +7,15 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/connector/exchange/api"
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/account"
 )
 
 type CacheResolverSuite struct {
 	suite.Suite
-	gs graph.Servicer
+	credentials account.M365Config
 }
 
 func TestCacheResolverIntegrationSuite(t *testing.T) {
@@ -35,10 +37,7 @@ func (suite *CacheResolverSuite) SetupSuite() {
 	m365, err := a.M365Config()
 	require.NoError(t, err)
 
-	service, err := createService(m365)
-	require.NoError(t, err)
-
-	suite.gs = service
+	suite.credentials = m365
 }
 
 func (suite *CacheResolverSuite) TestPopulate() {
@@ -48,14 +47,14 @@ func (suite *CacheResolverSuite) TestPopulate() {
 	eventFunc := func(t *testing.T) graph.ContainerResolver {
 		return &eventCalendarCache{
 			userID: tester.M365UserID(t),
-			gs:     suite.gs,
+			ac:     api.Client{Credentials: suite.credentials},
 		}
 	}
 
 	contactFunc := func(t *testing.T) graph.ContainerResolver {
 		return &contactFolderCache{
 			userID: tester.M365UserID(t),
-			gs:     suite.gs,
+			ac:     api.Client{Credentials: suite.credentials},
 		}
 	}
 

--- a/src/internal/connector/exchange/iterators_test.go
+++ b/src/internal/connector/exchange/iterators_test.go
@@ -85,7 +85,7 @@ func (suite *ExchangeIteratorSuite) TestCollectionFunctions() {
 
 	tests := []struct {
 		name              string
-		queryFunc         func(account.M365Config) api.GraphQuery
+		queryFunc         func(*testing.T, account.M365Config) api.GraphQuery
 		scope             selectors.ExchangeScope
 		iterativeFunction func(
 			container map[string]graph.Container,
@@ -95,16 +95,20 @@ func (suite *ExchangeIteratorSuite) TestCollectionFunctions() {
 	}{
 		{
 			name: "Contacts Iterative Check",
-			queryFunc: func(amc account.M365Config) api.GraphQuery {
-				return api.Client{Credentials: amc}.GetAllContactFolderNamesForUser
+			queryFunc: func(t *testing.T, amc account.M365Config) api.GraphQuery {
+				ac, err := api.NewClient(amc)
+				require.NoError(t, err)
+				return ac.GetAllContactFolderNamesForUser
 			},
 			transformer:       models.CreateContactFolderCollectionResponseFromDiscriminatorValue,
 			iterativeFunction: IterativeCollectContactContainers,
 		},
 		{
 			name: "Events Iterative Check",
-			queryFunc: func(amc account.M365Config) api.GraphQuery {
-				return api.Client{Credentials: amc}.GetAllCalendarNamesForUser
+			queryFunc: func(t *testing.T, amc account.M365Config) api.GraphQuery {
+				ac, err := api.NewClient(amc)
+				require.NoError(t, err)
+				return ac.GetAllCalendarNamesForUser
 			},
 			transformer:       models.CreateCalendarCollectionResponseFromDiscriminatorValue,
 			iterativeFunction: IterativeCollectCalendarContainers,
@@ -119,7 +123,7 @@ func (suite *ExchangeIteratorSuite) TestCollectionFunctions() {
 			service, err := createService(m365)
 			require.NoError(t, err)
 
-			response, err := test.queryFunc(m365)(ctx, userID)
+			response, err := test.queryFunc(t, m365)(ctx, userID)
 			require.NoError(t, err)
 
 			// Iterator Creation

--- a/src/internal/connector/exchange/mail_folder_cache.go
+++ b/src/internal/connector/exchange/mail_folder_cache.go
@@ -20,7 +20,6 @@ var _ graph.ContainerResolver = &mailFolderCache{}
 // nameLookup map: Key: DisplayName Value: ID
 type mailFolderCache struct {
 	*containerResolver
-	// gs     graph.Servicer
 	ac     api.Client
 	userID string
 }

--- a/src/internal/connector/exchange/mail_folder_cache_test.go
+++ b/src/internal/connector/exchange/mail_folder_cache_test.go
@@ -8,8 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/alcionai/corso/src/internal/connector/graph"
+	"github.com/alcionai/corso/src/internal/connector/exchange/api"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/account"
 )
 
 const (
@@ -26,7 +27,7 @@ const (
 
 type MailFolderCacheIntegrationSuite struct {
 	suite.Suite
-	gs graph.Servicer
+	credentials account.M365Config
 }
 
 func TestMailFolderCacheIntegrationSuite(t *testing.T) {
@@ -48,10 +49,7 @@ func (suite *MailFolderCacheIntegrationSuite) SetupSuite() {
 	m365, err := a.M365Config()
 	require.NoError(t, err)
 
-	service, err := createService(m365)
-	require.NoError(t, err)
-
-	suite.gs = service
+	suite.credentials = m365
 }
 
 func (suite *MailFolderCacheIntegrationSuite) TestDeltaFetch() {
@@ -85,7 +83,7 @@ func (suite *MailFolderCacheIntegrationSuite) TestDeltaFetch() {
 		suite.T().Run(test.name, func(t *testing.T) {
 			mfc := mailFolderCache{
 				userID: userID,
-				gs:     suite.gs,
+				ac:     api.Client{Credentials: suite.credentials},
 			}
 
 			require.NoError(t, mfc.Populate(ctx, test.root, test.path...))

--- a/src/internal/connector/exchange/mail_folder_cache_test.go
+++ b/src/internal/connector/exchange/mail_folder_cache_test.go
@@ -81,9 +81,12 @@ func (suite *MailFolderCacheIntegrationSuite) TestDeltaFetch() {
 
 	for _, test := range tests {
 		suite.T().Run(test.name, func(t *testing.T) {
+			ac, err := api.NewClient(suite.credentials)
+			require.NoError(t, err)
+
 			mfc := mailFolderCache{
 				userID: userID,
-				ac:     api.Client{Credentials: suite.credentials},
+				ac:     ac,
 			}
 
 			require.NoError(t, mfc.Populate(ctx, test.root, test.path...))

--- a/src/internal/connector/exchange/restore_test.go
+++ b/src/internal/connector/exchange/restore_test.go
@@ -45,15 +45,8 @@ func (suite *ExchangeRestoreSuite) SetupSuite() {
 	require.NoError(t, err)
 
 	suite.credentials = m365
-	suite.ac = api.Client{Credentials: m365}
-
-	// adpt, err := graph.CreateAdapter(
-	// 	m365.AzureTenantID,
-	// 	m365.AzureClientID,
-	// 	m365.AzureClientSecret)
-	// require.NoError(t, err)
-
-	// suite.gs = graph.NewService(adpt)
+	suite.ac, err = api.NewClient(m365)
+	require.NoError(t, err)
 
 	require.NoError(suite.T(), err)
 }

--- a/src/internal/connector/exchange/restore_test.go
+++ b/src/internal/connector/exchange/restore_test.go
@@ -48,6 +48,11 @@ func (suite *ExchangeRestoreSuite) SetupSuite() {
 	suite.ac, err = api.NewClient(m365)
 	require.NoError(t, err)
 
+	adpt, err := graph.CreateAdapter(m365.AzureTenantID, m365.AzureClientID, m365.AzureClientSecret)
+	require.NoError(t, err)
+
+	suite.gs = graph.NewService(adpt)
+
 	require.NoError(suite.T(), err)
 }
 
@@ -75,7 +80,8 @@ func (suite *ExchangeRestoreSuite) TestRestoreContact() {
 		assert.NoError(t, err)
 	}()
 
-	info, err := RestoreExchangeContact(ctx,
+	info, err := RestoreExchangeContact(
+		ctx,
 		mockconnector.GetMockContactBytes("Corso TestContact"),
 		suite.gs,
 		control.Copy,

--- a/src/internal/connector/exchange/service_functions.go
+++ b/src/internal/connector/exchange/service_functions.go
@@ -41,25 +41,30 @@ func PopulateExchangeContainerResolver(
 		cacheRoot string
 	)
 
+	ac, err := api.NewClient(qp.Credentials)
+	if err != nil {
+		return nil, err
+	}
+
 	switch qp.Category {
 	case path.EmailCategory:
 		res = &mailFolderCache{
 			userID: qp.ResourceOwner,
-			ac:     api.Client{Credentials: qp.Credentials},
+			ac:     ac,
 		}
 		cacheRoot = rootFolderAlias
 
 	case path.ContactsCategory:
 		res = &contactFolderCache{
 			userID: qp.ResourceOwner,
-			ac:     api.Client{Credentials: qp.Credentials},
+			ac:     ac,
 		}
 		cacheRoot = DefaultContactFolder
 
 	case path.EventsCategory:
 		res = &eventCalendarCache{
 			userID: qp.ResourceOwner,
-			ac:     api.Client{Credentials: qp.Credentials},
+			ac:     ac,
 		}
 		cacheRoot = DefaultCalendar
 

--- a/src/internal/connector/exchange/service_functions.go
+++ b/src/internal/connector/exchange/service_functions.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/alcionai/corso/src/internal/connector/exchange/api"
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -36,34 +37,29 @@ func PopulateExchangeContainerResolver(
 	qp graph.QueryParams,
 ) (graph.ContainerResolver, error) {
 	var (
-		res          graph.ContainerResolver
-		cacheRoot    string
-		service, err = createService(qp.Credentials)
+		res       graph.ContainerResolver
+		cacheRoot string
 	)
-
-	if err != nil {
-		return nil, err
-	}
 
 	switch qp.Category {
 	case path.EmailCategory:
 		res = &mailFolderCache{
 			userID: qp.ResourceOwner,
-			gs:     service,
+			ac:     api.Client{Credentials: qp.Credentials},
 		}
 		cacheRoot = rootFolderAlias
 
 	case path.ContactsCategory:
 		res = &contactFolderCache{
 			userID: qp.ResourceOwner,
-			gs:     service,
+			ac:     api.Client{Credentials: qp.Credentials},
 		}
 		cacheRoot = DefaultContactFolder
 
 	case path.EventsCategory:
 		res = &eventCalendarCache{
 			userID: qp.ResourceOwner,
-			gs:     service,
+			ac:     api.Client{Credentials: qp.Credentials},
 		}
 		cacheRoot = DefaultCalendar
 

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -35,7 +35,6 @@ func filterContainersAndFillCollections(
 ) error {
 	var (
 		errs error
-		ac   = api.Client{Credentials: qp.Credentials}
 		// folder ID -> delta url or folder path lookups
 		deltaURLs = map[string]string{}
 		currPaths = map[string]string{}
@@ -43,6 +42,12 @@ func filterContainersAndFillCollections(
 		// deleted from this map, leaving only the deleted folders behind
 		tombstones = makeTombstones(dps)
 	)
+
+	// TODO(rkeepers): pass in the api client instead of generating it here.
+	ac, err := api.NewClient(qp.Credentials)
+	if err != nil {
+		return err
+	}
 
 	getJobs, err := getFetchIDFunc(ac, qp.Category)
 	if err != nil {

--- a/src/internal/connector/exchange/service_restore.go
+++ b/src/internal/connector/exchange/service_restore.go
@@ -439,13 +439,18 @@ func CreateContainerDestinaion(
 	caches map[path.CategoryType]graph.ContainerResolver,
 ) (string, error) {
 	var (
-		ac             = api.Client{Credentials: creds}
 		newCache       = false
 		user           = directory.ResourceOwner()
 		category       = directory.Category()
 		directoryCache = caches[category]
 		newPathFolders = append([]string{destination}, directory.Folders()...)
 	)
+
+	// TODO(rkeepers): pass the api client into this func, rather than generating one.
+	ac, err := api.NewClient(creds)
+	if err != nil {
+		return "", err
+	}
 
 	switch category {
 	case path.EmailCategory:

--- a/src/internal/connector/graph_connector.go
+++ b/src/internal/connector/graph_connector.go
@@ -252,6 +252,7 @@ func (gc *GraphConnector) UnionSiteIDsAndWebURLs(ctx context.Context, ids, urls 
 // SideEffect: gc.status is updated at the completion of operation
 func (gc *GraphConnector) RestoreDataCollections(
 	ctx context.Context,
+	acct account.Account,
 	selector selectors.Selector,
 	dest control.RestoreDestination,
 	dcs []data.Collection,
@@ -265,9 +266,14 @@ func (gc *GraphConnector) RestoreDataCollections(
 		deets  = &details.Builder{}
 	)
 
+	creds, err := acct.M365Config()
+	if err != nil {
+		return nil, errors.Wrap(err, "malformed azure credentials")
+	}
+
 	switch selector.Service {
 	case selectors.ServiceExchange:
-		status, err = exchange.RestoreExchangeDataCollections(ctx, gc.Service, dest, dcs, deets)
+		status, err = exchange.RestoreExchangeDataCollections(ctx, creds, gc.Service, dest, dcs, deets)
 	case selectors.ServiceOneDrive:
 		status, err = onedrive.RestoreCollections(ctx, gc.Service, dest, dcs, deets)
 	case selectors.ServiceSharePoint:

--- a/src/internal/connector/graph_connector_disconnected_test.go
+++ b/src/internal/connector/graph_connector_disconnected_test.go
@@ -168,18 +168,20 @@ func (suite *DisconnectedGraphConnectorSuite) TestGraphConnector_ErrorChecking()
 }
 
 func (suite *DisconnectedGraphConnectorSuite) TestRestoreFailsBadService() {
-	t := suite.T()
-
 	ctx, flush := tester.NewContext()
 	defer flush()
 
-	gc := GraphConnector{wg: &sync.WaitGroup{}}
-	sel := selectors.Selector{
-		Service: selectors.ServiceUnknown,
-	}
-	dest := tester.DefaultTestRestoreDestination()
+	var (
+		t    = suite.T()
+		acct = tester.NewM365Account(t)
+		dest = tester.DefaultTestRestoreDestination()
+		gc   = GraphConnector{wg: &sync.WaitGroup{}}
+		sel  = selectors.Selector{
+			Service: selectors.ServiceUnknown,
+		}
+	)
 
-	deets, err := gc.RestoreDataCollections(ctx, sel, dest, nil)
+	deets, err := gc.RestoreDataCollections(ctx, acct, sel, dest, nil)
 	assert.Error(t, err)
 	assert.NotNil(t, deets)
 

--- a/src/internal/connector/graph_connector_test.go
+++ b/src/internal/connector/graph_connector_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
@@ -133,8 +134,10 @@ func (suite *GraphConnectorUnitSuite) TestUnionSiteIDsAndWebURLs() {
 
 type GraphConnectorIntegrationSuite struct {
 	suite.Suite
-	connector *GraphConnector
-	user      string
+	connector   *GraphConnector
+	user        string
+	acct        account.Account
+	credentials account.M365Config
 }
 
 func TestGraphConnectorIntegrationSuite(t *testing.T) {
@@ -155,6 +158,7 @@ func (suite *GraphConnectorIntegrationSuite) SetupSuite() {
 
 	suite.connector = loadConnector(ctx, suite.T(), Users)
 	suite.user = tester.M365UserID(suite.T())
+	suite.acct = tester.NewM365Account(suite.T())
 
 	tester.LogTimeOfTest(suite.T())
 }
@@ -265,7 +269,12 @@ func (suite *GraphConnectorIntegrationSuite) TestEmptyCollections() {
 			ctx, flush := tester.NewContext()
 			defer flush()
 
-			deets, err := suite.connector.RestoreDataCollections(ctx, test.sel, dest, test.col)
+			deets, err := suite.connector.RestoreDataCollections(
+				ctx,
+				suite.acct,
+				test.sel,
+				dest,
+				test.col)
 			require.NoError(t, err)
 			assert.NotNil(t, deets)
 
@@ -308,6 +317,7 @@ func mustGetDefaultDriveID(
 
 func runRestoreBackupTest(
 	t *testing.T,
+	acct account.Account,
 	test restoreBackupInfo,
 	tenant string,
 	users []string,
@@ -349,7 +359,12 @@ func runRestoreBackupTest(
 
 	restoreGC := loadConnector(ctx, t, test.resource)
 	restoreSel := getSelectorWith(test.service)
-	deets, err := restoreGC.RestoreDataCollections(ctx, restoreSel, dest, collections)
+	deets, err := restoreGC.RestoreDataCollections(
+		ctx,
+		acct,
+		restoreSel,
+		dest,
+		collections)
 	require.NoError(t, err)
 	assert.NotNil(t, deets)
 
@@ -724,7 +739,7 @@ func (suite *GraphConnectorIntegrationSuite) TestRestoreAndBackup() {
 
 	for _, test := range table {
 		suite.T().Run(test.name, func(t *testing.T) {
-			runRestoreBackupTest(t, test, suite.connector.tenant, []string{suite.user})
+			runRestoreBackupTest(t, suite.acct, test, suite.connector.tenant, []string{suite.user})
 		})
 	}
 }
@@ -833,7 +848,7 @@ func (suite *GraphConnectorIntegrationSuite) TestMultiFolderBackupDifferentNames
 				)
 
 				restoreGC := loadConnector(ctx, t, test.resource)
-				deets, err := restoreGC.RestoreDataCollections(ctx, restoreSel, dest, collections)
+				deets, err := restoreGC.RestoreDataCollections(ctx, suite.acct, restoreSel, dest, collections)
 				require.NoError(t, err)
 				require.NotNil(t, deets)
 
@@ -977,7 +992,7 @@ func (suite *GraphConnectorIntegrationSuite) TestMultiuserRestoreAndBackup() {
 
 	for _, test := range table {
 		suite.T().Run(test.name, func(t *testing.T) {
-			runRestoreBackupTest(t, test, suite.connector.tenant, users)
+			runRestoreBackupTest(t, suite.acct, test, suite.connector.tenant, users)
 		})
 	}
 }

--- a/src/internal/connector/graph_connector_test.go
+++ b/src/internal/connector/graph_connector_test.go
@@ -134,10 +134,9 @@ func (suite *GraphConnectorUnitSuite) TestUnionSiteIDsAndWebURLs() {
 
 type GraphConnectorIntegrationSuite struct {
 	suite.Suite
-	connector   *GraphConnector
-	user        string
-	acct        account.Account
-	credentials account.M365Config
+	connector *GraphConnector
+	user      string
+	acct      account.Account
 }
 
 func TestGraphConnectorIntegrationSuite(t *testing.T) {

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -652,8 +652,13 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchangeIncrementals() {
 	gc, err := connector.NewGraphConnector(ctx, acct, connector.Users)
 	require.NoError(t, err)
 
-	// generate 2 new containers with two items each.
-	// A third container will be introduced partway through the changes.
+	ac, err := api.NewClient(m365)
+	require.NoError(t, err)
+
+	// generate 3 new folders with two items each.
+	// Only the first two folders will be part of the initial backup and
+	// incrementals.  The third folder will be introduced partway through
+	// the changes.
 	// This should be enough to cover most delta actions, since moving one
 	// container into another generates a delta for both addition and deletion.
 	type contDeets struct {
@@ -927,7 +932,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchangeIncrementals() {
 
 					switch category {
 					case path.EmailCategory:
-						ids, _, _, err := api.FetchMessageIDsFromDirectory(ctx, gc.Service, suite.user, containerID, "")
+						ids, _, _, err := ac.FetchMessageIDsFromDirectory(ctx, suite.user, containerID, "")
 						require.NoError(t, err, "getting message ids")
 						require.NotEmpty(t, ids, "message ids in folder")
 
@@ -935,7 +940,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchangeIncrementals() {
 						require.NoError(t, err, "deleting email item: %s", support.ConnectorStackErrorTrace(err))
 
 					case path.ContactsCategory:
-						ids, _, _, err := api.FetchContactIDsFromDirectory(ctx, gc.Service, suite.user, containerID, "")
+						ids, _, _, err := ac.FetchContactIDsFromDirectory(ctx, suite.user, containerID, "")
 						require.NoError(t, err, "getting contact ids")
 						require.NotEmpty(t, ids, "contact ids in folder")
 

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -294,6 +294,7 @@ func generateContainerOfItems(
 	ctx context.Context,
 	gc *connector.GraphConnector,
 	service path.ServiceType,
+	acct account.Account,
 	cat path.CategoryType,
 	sel selectors.Selector,
 	tenantID, userID, destFldr string,
@@ -330,7 +331,7 @@ func generateContainerOfItems(
 		dest,
 		collections)
 
-	deets, err := gc.RestoreDataCollections(ctx, sel, dest, dataColls)
+	deets, err := gc.RestoreDataCollections(ctx, acct, sel, dest, dataColls)
 	require.NoError(t, err)
 
 	return deets
@@ -705,6 +706,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchangeIncrementals() {
 				ctx,
 				gc,
 				path.ExchangeService,
+				acct,
 				category,
 				selectors.NewExchangeRestore(users).Selector,
 				m365.AzureTenantID, suite.user, destName,

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -831,6 +831,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchangeIncrementals() {
 						ctx,
 						gc,
 						path.ExchangeService,
+						acct,
 						category,
 						selectors.NewExchangeRestore(users).Selector,
 						m365.AzureTenantID, suite.user, container3,

--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -188,7 +188,12 @@ func (op *RestoreOperation) Run(ctx context.Context) (restoreDetails *details.De
 	defer closer()
 	defer close(restoreComplete)
 
-	restoreDetails, err = gc.RestoreDataCollections(ctx, op.Selectors, op.Destination, dcs)
+	restoreDetails, err = gc.RestoreDataCollections(
+		ctx,
+		op.account,
+		op.Selectors,
+		op.Destination,
+		dcs)
 	if err != nil {
 		err = errors.Wrap(err, "restoring service data")
 		opStats.writeErr = err


### PR DESCRIPTION
## Description

In order to use the api layer as an interface, we
need the functions therein to be methods, so
that callers can leverage local interfaces.  This
change introduces the api.Client, and begins
to spread it throughout the exchange package,
largely in place of graph servicers.

No logic changes have occurred here.  The only
modifications are what is required to utilize the
api client.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :robot: Test

## Issue(s)

* #1967

## Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
