### PR TITLE
migrate resolver iterators

### DIFF
--- a/src/internal/connector/exchange/api/api.go
+++ b/src/internal/connector/exchange/api/api.go
@@ -86,3 +86,23 @@ func newService(creds account.M365Config) (*graph.Service, error) {
 
 	return graph.NewService(adapter), nil
 }
+
+// ---------------------------------------------------------------------------
+// helper funcs
+// ---------------------------------------------------------------------------
+
+// checkIDAndName is a helper function to ensure that
+// the ID and name pointers are set prior to being called.
+func checkIDAndName(c graph.Container) error {
+	idPtr := c.GetId()
+	if idPtr == nil || len(*idPtr) == 0 {
+		return errors.New("folder without ID")
+	}
+
+	ptr := c.GetDisplayName()
+	if ptr == nil || len(*ptr) == 0 {
+		return errors.Errorf("folder %s without display name", *idPtr)
+	}
+
+	return nil
+}

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -73,7 +73,7 @@ func (c Client) EnumerateCalendars(
 
 	var errs *multierror.Error
 
-	ofc, err := optionsForCalendars([]string{})
+	ofc, err := optionsForCalendars([]string{"name"})
 	if err != nil {
 		return errors.Wrapf(err, "options for event calendars")
 	}
@@ -87,8 +87,7 @@ func (c Client) EnumerateCalendars(
 		}
 
 		for _, cal := range resp.GetValue() {
-			cd := CreateCalendarDisplayable(cal)
-
+			cd := CalendarDisplayable{Calendarable: cal}
 			if err := checkIDAndName(cd); err != nil {
 				errs = multierror.Append(err, errs)
 				continue
@@ -196,17 +195,4 @@ func (c CalendarDisplayable) GetDisplayName() *string {
 //nolint:revive
 func (c CalendarDisplayable) GetParentFolderId() *string {
 	return nil
-}
-
-// CreateCalendarDisplayable creates a calendarDisplayable from
-// the interface returned by graph when iterating over event calendars.
-func CreateCalendarDisplayable(entry any) CalendarDisplayable {
-	calendar, ok := entry.(models.Calendarable)
-	if !ok {
-		return CalendarDisplayable{}
-	}
-
-	return CalendarDisplayable{
-		Calendarable: calendar,
-	}
 }

--- a/src/internal/connector/exchange/cache_container.go
+++ b/src/internal/connector/exchange/cache_container.go
@@ -1,7 +1,6 @@
 package exchange
 
 import (
-	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/pkg/errors"
 
 	"github.com/alcionai/corso/src/internal/connector/graph"
@@ -36,43 +35,4 @@ func checkRequiredValues(c graph.Container) error {
 	}
 
 	return nil
-}
-
-// CalendarDisplayable is a transformative struct that aligns
-// models.Calendarable interface with the container interface.
-// Calendars do not have a parentFolderID. Therefore,
-// the call will always return nil
-type CalendarDisplayable struct {
-	models.Calendarable
-}
-
-// GetDisplayName returns the *string of the models.Calendable
-// variant:  calendar.GetName()
-func (c CalendarDisplayable) GetDisplayName() *string {
-	return c.GetName()
-}
-
-// GetParentFolderId returns the default calendar name address
-// EventCalendars have a flat hierarchy and Calendars are rooted
-// at the default
-//
-//nolint:revive
-func (c CalendarDisplayable) GetParentFolderId() *string {
-	return nil
-}
-
-// CreateCalendarDisplayable helper function to create the
-// calendarDisplayable during msgraph-sdk-go iterative process
-// @param entry is the input supplied by pageIterator.Iterate()
-// @param parentID of Calendar sets. Only populate when used with
-// EventCalendarCache
-func CreateCalendarDisplayable(entry any) *CalendarDisplayable {
-	calendar, ok := entry.(models.Calendarable)
-	if !ok {
-		return nil
-	}
-
-	return &CalendarDisplayable{
-		Calendarable: calendar,
-	}
 }

--- a/src/internal/connector/exchange/container_resolver_test.go
+++ b/src/internal/connector/exchange/container_resolver_test.go
@@ -597,9 +597,10 @@ func (suite *FolderCacheIntegrationSuite) TestCreateContainerDestination() {
 				test.pathFunc1(t),
 				folderName,
 				directoryCaches)
-
 			require.NoError(t, err)
+
 			resolver := directoryCaches[test.category]
+
 			_, err = resolver.IDToPath(ctx, folderID)
 			assert.NoError(t, err)
 
@@ -609,10 +610,11 @@ func (suite *FolderCacheIntegrationSuite) TestCreateContainerDestination() {
 				test.pathFunc2(t),
 				folderName,
 				directoryCaches)
-
 			require.NoError(t, err)
+
 			_, err = resolver.IDToPath(ctx, secondID)
 			require.NoError(t, err)
+
 			_, ok := resolver.PathInCache(folderName)
 			require.True(t, ok)
 		})

--- a/src/internal/connector/exchange/iterators_test.go
+++ b/src/internal/connector/exchange/iterators_test.go
@@ -3,20 +3,14 @@ package exchange
 import (
 	"testing"
 
-	absser "github.com/microsoft/kiota-abstractions-go/serialization"
-	msgraphgocore "github.com/microsoftgraph/msgraph-sdk-go-core"
-	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/alcionai/corso/src/internal/connector/exchange/api"
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/mockconnector"
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/pkg/account"
-	"github.com/alcionai/corso/src/pkg/selectors"
 )
 
 type ExchangeIteratorSuite struct {
@@ -55,100 +49,4 @@ func (suite *ExchangeIteratorSuite) TestDescendable() {
 	assert.True(t, ok)
 	assert.NotNil(t, aDescendable.GetId())
 	assert.NotNil(t, aDescendable.GetParentFolderId())
-}
-
-// TestCollectionFunctions verifies ability to gather
-// containers functions are valid for current versioning of msgraph-go-sdk.
-// Tests for mail have been moved to graph_connector_test.go.
-// exchange.Mail uses a sequential delta function.
-// TODO: Add exchange.Mail when delta iterator functionality implemented
-func (suite *ExchangeIteratorSuite) TestCollectionFunctions() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
-	var (
-		t                                   = suite.T()
-		mailScope, contactScope, eventScope []selectors.ExchangeScope
-		userID                              = tester.M365UserID(t)
-		users                               = []string{userID}
-		sel                                 = selectors.NewExchangeBackup(users)
-	)
-
-	eb, err := sel.ToExchangeBackup()
-	require.NoError(suite.T(), err)
-
-	contactScope = sel.ContactFolders(users, []string{DefaultContactFolder}, selectors.PrefixMatch())
-	eventScope = sel.EventCalendars(users, []string{DefaultCalendar}, selectors.PrefixMatch())
-	mailScope = sel.MailFolders(users, []string{DefaultMailFolder}, selectors.PrefixMatch())
-
-	eb.Include(contactScope, eventScope, mailScope)
-
-	tests := []struct {
-		name              string
-		queryFunc         func(*testing.T, account.M365Config) api.GraphQuery
-		scope             selectors.ExchangeScope
-		iterativeFunction func(
-			container map[string]graph.Container,
-			aFilter string,
-			errUpdater func(string, error)) func(any) bool
-		transformer absser.ParsableFactory
-	}{
-		{
-			name: "Contacts Iterative Check",
-			queryFunc: func(t *testing.T, amc account.M365Config) api.GraphQuery {
-				ac, err := api.NewClient(amc)
-				require.NoError(t, err)
-				return ac.GetAllContactFolderNamesForUser
-			},
-			transformer:       models.CreateContactFolderCollectionResponseFromDiscriminatorValue,
-			iterativeFunction: IterativeCollectContactContainers,
-		},
-		{
-			name: "Events Iterative Check",
-			queryFunc: func(t *testing.T, amc account.M365Config) api.GraphQuery {
-				ac, err := api.NewClient(amc)
-				require.NoError(t, err)
-				return ac.GetAllCalendarNamesForUser
-			},
-			transformer:       models.CreateCalendarCollectionResponseFromDiscriminatorValue,
-			iterativeFunction: IterativeCollectCalendarContainers,
-		},
-	}
-	for _, test := range tests {
-		suite.T().Run(test.name, func(t *testing.T) {
-			a := tester.NewM365Account(t)
-			m365, err := a.M365Config()
-			require.NoError(t, err)
-
-			service, err := createService(m365)
-			require.NoError(t, err)
-
-			response, err := test.queryFunc(t, m365)(ctx, userID)
-			require.NoError(t, err)
-
-			// Iterator Creation
-			pageIterator, err := msgraphgocore.NewPageIterator(
-				response,
-				service.Adapter(),
-				test.transformer)
-			require.NoError(t, err)
-
-			// Create collection for iterate test
-			collections := make(map[string]graph.Container)
-
-			var errs error
-
-			errUpdater := func(id string, err error) {
-				errs = support.WrapAndAppend(id, err, errs)
-			}
-
-			// callbackFunc iterates through all models.Messageable and fills exchange.Collection.added[]
-			// with corresponding item IDs. New collections are created for each directory
-			callbackFunc := test.iterativeFunction(collections, "", errUpdater)
-
-			iterateError := pageIterator.Iterate(ctx, callbackFunc)
-			assert.NoError(t, iterateError)
-			assert.NoError(t, errs)
-		})
-	}
 }

--- a/src/internal/connector/exchange/mail_folder_cache.go
+++ b/src/internal/connector/exchange/mail_folder_cache.go
@@ -3,8 +3,6 @@ package exchange
 import (
 	"context"
 
-	multierror "github.com/hashicorp/go-multierror"
-	msfolderdelta "github.com/microsoftgraph/msgraph-sdk-go/users"
 	"github.com/pkg/errors"
 
 	"github.com/alcionai/corso/src/internal/connector/exchange/api"
@@ -67,44 +65,19 @@ func (mc *mailFolderCache) Populate(
 		return err
 	}
 
-	query, servicer, err := mc.ac.GetAllMailFoldersBuilder(ctx, mc.userID)
+	// Use addFolder instead of AddToCache to be conservative about path
+	// population. The fetch order of the folders could cause failures while
+	// trying to resolve paths, so put it off until we've gotten all folders.
+	err := mc.ac.EnumerateMailFolders(ctx, mc.userID, mc.addFolder)
 	if err != nil {
 		return err
 	}
 
-	var errs *multierror.Error
-
-	for {
-		resp, err := query.Get(ctx, nil)
-		if err != nil {
-			return errors.Wrap(err, support.ConnectorStackErrorTrace(err))
-		}
-
-		for _, f := range resp.GetValue() {
-			temp := graph.NewCacheFolder(f, nil)
-
-			// Use addFolder instead of AddToCache to be conservative about path
-			// population. The fetch order of the folders could cause failures while
-			// trying to resolve paths, so put it off until we've gotten all folders.
-			if err := mc.addFolder(temp); err != nil {
-				errs = multierror.Append(errs, errors.Wrap(err, "delta fetch"))
-				continue
-			}
-		}
-
-		link := resp.GetOdataNextLink()
-		if link == nil {
-			break
-		}
-
-		query = msfolderdelta.NewItemMailFoldersDeltaRequestBuilder(*link, servicer.Adapter())
-	}
-
 	if err := mc.populatePaths(ctx); err != nil {
-		errs = multierror.Append(errs, errors.Wrap(err, "mail resolver"))
+		return errors.Wrap(err, "mail resolver")
 	}
 
-	return errs.ErrorOrNil()
+	return nil
 }
 
 // init ensures that the structure's fields are initialized.

--- a/src/internal/connector/exchange/mail_folder_cache.go
+++ b/src/internal/connector/exchange/mail_folder_cache.go
@@ -65,9 +65,6 @@ func (mc *mailFolderCache) Populate(
 		return err
 	}
 
-	// Use addFolder instead of AddToCache to be conservative about path
-	// population. The fetch order of the folders could cause failures while
-	// trying to resolve paths, so put it off until we've gotten all folders.
 	err := mc.ac.EnumerateMailFolders(ctx, mc.userID, mc.addFolder)
 	if err != nil {
 		return err

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -3,9 +3,7 @@ package exchange
 import (
 	"context"
 	"fmt"
-	"strings"
 
-	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/pkg/errors"
 
 	"github.com/alcionai/corso/src/internal/connector/exchange/api"
@@ -218,54 +216,6 @@ func pathFromPrevString(ps string) (path.Path, error) {
 	}
 
 	return p, nil
-}
-
-func IterativeCollectContactContainers(
-	containers map[string]graph.Container,
-	nameContains string,
-	errUpdater func(string, error),
-) func(any) bool {
-	return func(entry any) bool {
-		folder, ok := entry.(models.ContactFolderable)
-		if !ok {
-			errUpdater("iterateCollectContactContainers",
-				errors.New("casting item to models.ContactFolderable"))
-			return false
-		}
-
-		include := len(nameContains) == 0 ||
-			strings.Contains(*folder.GetDisplayName(), nameContains)
-
-		if include {
-			containers[*folder.GetDisplayName()] = folder
-		}
-
-		return true
-	}
-}
-
-func IterativeCollectCalendarContainers(
-	containers map[string]graph.Container,
-	nameContains string,
-	errUpdater func(string, error),
-) func(any) bool {
-	return func(entry any) bool {
-		cal, ok := entry.(models.Calendarable)
-		if !ok {
-			errUpdater("iterativeCollectCalendarContainers",
-				errors.New("casting item to models.Calendarable"))
-			return false
-		}
-
-		include := len(nameContains) == 0 ||
-			strings.Contains(*cal.GetName(), nameContains)
-		if include {
-			temp := CreateCalendarDisplayable(cal)
-			containers[*temp.GetDisplayName()] = temp
-		}
-
-		return true
-	}
 }
 
 // FetchIDFunc collection of helper functions which return a list of all item

--- a/src/internal/connector/exchange/service_restore.go
+++ b/src/internal/connector/exchange/service_restore.go
@@ -635,8 +635,8 @@ func establishEventsRestoreLocation(
 			return "", errors.Wrap(err, "populating event cache")
 		}
 
-		transform := api.CreateCalendarDisplayable(temp)
-		if err = ecc.AddToCache(ctx, transform); err != nil {
+		displayable := api.CalendarDisplayable{Calendarable: temp}
+		if err = ecc.AddToCache(ctx, displayable); err != nil {
 			return "", errors.Wrap(err, "adding new calendar to cache")
 		}
 	}

--- a/src/internal/connector/exchange/service_restore.go
+++ b/src/internal/connector/exchange/service_restore.go
@@ -635,7 +635,7 @@ func establishEventsRestoreLocation(
 			return "", errors.Wrap(err, "populating event cache")
 		}
 
-		transform := CreateCalendarDisplayable(temp)
+		transform := api.CreateCalendarDisplayable(temp)
 		if err = ecc.AddToCache(ctx, transform); err != nil {
 			return "", errors.Wrap(err, "adding new calendar to cache")
 		}


### PR DESCRIPTION
## Description

Previous changes held out on migrating the
resolver iterators into the api package because
they embedded function calls from the resolvers
themselves.  This change migrates that code
into the api package, and accepts a callback
function to hook in the resolver updates.  This
change sets up resolvers to better utilize an
interface in the next PR.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :robot: Test

## Issue(s)

* #1967

## Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
