### PR TITLE
GC: Restore: SharePoint: List base object transformation for restore.

### DIFF
--- a/src/internal/connector/support/m365Transform.go
+++ b/src/internal/connector/support/m365Transform.go
@@ -119,3 +119,95 @@ func insertStringToBody(body getContenter, newContent string) string {
 
 	return newContent + content
 }
+
+// ToListable utility function to encapsulate stored data for restoration.
+// New Listable omits trackable fields such as `id` or `ETag` and other read-only
+// objects that are prevented upon upload. Additionally, read-Only columns are
+// not attached in this method.
+// ListItems not included in creation of new list. ListItems  have to be restored
+// in separate call.
+func ToListable(orig models.Listable, displayName string) models.Listable {
+	newList := models.NewList()
+
+	newList.SetContentTypes(orig.GetContentTypes())
+	newList.SetCreatedBy(orig.GetCreatedBy())
+	newList.SetCreatedByUser(orig.GetCreatedByUser())
+	newList.SetCreatedDateTime(orig.GetCreatedDateTime())
+	newList.SetDescription(orig.GetDescription())
+	newList.SetDisplayName(&displayName)
+	newList.SetLastModifiedBy(orig.GetLastModifiedBy())
+	newList.SetLastModifiedByUser(orig.GetLastModifiedByUser())
+	newList.SetLastModifiedDateTime(orig.GetLastModifiedDateTime())
+	newList.SetList(orig.GetList())
+	newList.SetOdataType(orig.GetOdataType())
+	newList.SetParentReference(orig.GetParentReference())
+
+	columns := make([]models.ColumnDefinitionable, 0)
+	leg := make(map[string]struct{})
+	empty := struct{}{}
+	legacyNames := []string{"Attachments", "Edit", "Content Type"}
+
+	for _, entry := range legacyNames {
+		leg[entry] = empty
+	}
+
+	for _, cd := range orig.GetColumns() {
+		tag := *cd.GetDisplayName()
+		_, isLegacy := leg[tag]
+
+		// Skips columns that cannot be uploaded for models.ColumnDefinitionable:
+		// - ReadOnly, Title, or Legacy columns: Attachments, Edit, or Content Type
+		if *cd.GetReadOnly() || tag == "Title" || isLegacy {
+			continue
+		}
+
+		columns = append(columns, cloneColumnDefinitionable(cd))
+	}
+
+	newList.SetColumns(columns)
+
+	return newList
+}
+
+// cloneColumnDefinitionable utility function for encapsulating models.ColumnDefinitionable data
+// into new object for upload.
+func cloneColumnDefinitionable(orig models.ColumnDefinitionable) models.ColumnDefinitionable {
+	newColumn := models.NewColumnDefinition()
+
+	newColumn.SetAdditionalData(orig.GetAdditionalData())
+	newColumn.SetBoolean(orig.GetBoolean())
+	newColumn.SetCalculated(orig.GetCalculated())
+	newColumn.SetChoice(orig.GetChoice())
+	newColumn.SetColumnGroup(orig.GetColumnGroup())
+	newColumn.SetContentApprovalStatus(orig.GetContentApprovalStatus())
+	newColumn.SetCurrency(orig.GetCurrency())
+	newColumn.SetDateTime(orig.GetDateTime())
+	newColumn.SetDefaultValue(orig.GetDefaultValue())
+	newColumn.SetDescription(orig.GetDescription())
+	newColumn.SetDisplayName(orig.GetDisplayName())
+	newColumn.SetEnforceUniqueValues(orig.GetEnforceUniqueValues())
+	newColumn.SetGeolocation(orig.GetGeolocation())
+	newColumn.SetHidden(orig.GetHidden())
+	newColumn.SetHyperlinkOrPicture(orig.GetHyperlinkOrPicture())
+	newColumn.SetIndexed(orig.GetIndexed())
+	newColumn.SetIsDeletable(orig.GetIsDeletable())
+	newColumn.SetIsReorderable(orig.GetIsReorderable())
+	newColumn.SetIsSealed(orig.GetIsSealed())
+	newColumn.SetLookup(orig.GetLookup())
+	newColumn.SetName(orig.GetName())
+	newColumn.SetNumber(orig.GetNumber())
+	newColumn.SetOdataType(orig.GetOdataType())
+	newColumn.SetPersonOrGroup(orig.GetPersonOrGroup())
+	newColumn.SetPropagateChanges(orig.GetPropagateChanges())
+	newColumn.SetReadOnly(orig.GetReadOnly())
+	newColumn.SetRequired(orig.GetRequired())
+	newColumn.SetSourceColumn(orig.GetSourceColumn())
+	newColumn.SetSourceContentType(orig.GetSourceContentType())
+	newColumn.SetTerm(orig.GetTerm())
+	newColumn.SetText(orig.GetText())
+	newColumn.SetThumbnail(orig.GetThumbnail())
+	newColumn.SetType(orig.GetType())
+	newColumn.SetValidation(orig.GetValidation())
+
+	return newColumn
+}


### PR DESCRIPTION
## Description
Functions for encapsulation of the base List object for restore workflow. List objects cannot be uploaded with previous M365 IDs from the original. Upload functions remove ETags, M365IDs, and other fields that are not permitted upon ListItem creation.
<!-- Insert PR description-->

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature


## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* related to Issue #<issue>

## Test Plan


- [x] :zap: Unit test

