### PR TITLE
Allow incremental backups for multiple data categories if some metadata is missing

### DIFF
--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -320,7 +320,10 @@ func collectMetadata(
 
 	dcs, err := r.RestoreMultipleItems(ctx, string(man.ID), paths, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "collecting prior metadata")
+		// Restore is best-effort and we want to keep it that way since we want to
+		// return as much metadata as we can to reduce the work we'll need to do.
+		// Just wrap the error here for better reporting/debugging.
+		return dcs, errors.Wrap(err, "collecting prior metadata")
 	}
 
 	return dcs, nil


### PR DESCRIPTION
## Description

Don't return nil if we had an error getting metadata. This gives us the best chance possible of having enough metadata retrieved from the best-effort restore execution flow to actually enable incrementals for some data category.

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

* #1777 

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
