### PR TITLE
GC:  Framework to use adapter's serialization writer.

### DIFF
--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -3,7 +3,9 @@ package graph
 import (
 	"context"
 
+	absser "github.com/microsoft/kiota-abstractions-go/serialization"
 	msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
+	"github.com/pkg/errors"
 
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -41,6 +43,23 @@ func (s Service) Adapter() *msgraphsdk.GraphRequestAdapter {
 
 func (s Service) Client() *msgraphsdk.GraphServiceClient {
 	return s.client
+}
+
+// Seraialize writes an M365 parsable object into a byte array using the built-in
+// application/json writer within the adapter.
+func (s Service) Serialize(object absser.Parsable) ([]byte, error) {
+	writer, err := s.adapter.GetSerializationWriterFactory().GetSerializationWriter("application/json")
+	if err != nil || writer == nil {
+		errorMessage := "service unable to create json serialization writer"
+		return nil, errors.Wrap(err, errorMessage)
+	}
+
+	err = writer.WriteObjectValue("", object)
+	if err != nil {
+		return nil, errors.Wrap(err, "writeObjectValue call failed during Service.Serialize call")
+	}
+
+	return writer.GetSerializedContent()
 }
 
 type Servicer interface {

--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -50,8 +50,7 @@ func (s Service) Client() *msgraphsdk.GraphServiceClient {
 func (s Service) Serialize(object absser.Parsable) ([]byte, error) {
 	writer, err := s.adapter.GetSerializationWriterFactory().GetSerializationWriter("application/json")
 	if err != nil || writer == nil {
-		errorMessage := "service unable to create json serialization writer"
-		return nil, errors.Wrap(err, errorMessage)
+		return nil, errors.Wrap(err, "creating json serialization writer")
 	}
 
 	err = writer.WriteObjectValue("", object)

--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -55,7 +55,7 @@ func (s Service) Serialize(object absser.Parsable) ([]byte, error) {
 
 	err = writer.WriteObjectValue("", object)
 	if err != nil {
-		return nil, errors.Wrap(err, "writeObjectValue call failed during Service.Serialize call")
+		return nil, errors.Wrap(err, "writeObjecValue serialization")
 	}
 
 	return writer.GetSerializedContent()

--- a/src/internal/connector/graph/service_test.go
+++ b/src/internal/connector/graph/service_test.go
@@ -1,0 +1,64 @@
+package graph_test
+
+import (
+	"testing"
+
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/connector/graph"
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/account"
+)
+
+type GraphUnitSuite struct {
+	suite.Suite
+	credentials account.M365Config
+}
+
+func TestGraphUnitSuite(t *testing.T) {
+	suite.Run(t, new(GraphUnitSuite))
+}
+
+func (suite *GraphUnitSuite) SetupSuite() {
+	t := suite.T()
+	a := tester.NewM365Account(t)
+	m365, err := a.M365Config()
+	require.NoError(t, err)
+
+	suite.credentials = m365
+}
+
+func (suite *GraphUnitSuite) TestCreateAdapter() {
+	t := suite.T()
+	adpt, err := graph.CreateAdapter(
+		suite.credentials.AzureTenantID,
+		suite.credentials.AzureClientID,
+		suite.credentials.AzureClientSecret,
+	)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, adpt)
+}
+
+func (suite *GraphUnitSuite) TestSerializationEndPoint() {
+	t := suite.T()
+	adpt, err := graph.CreateAdapter(
+		suite.credentials.AzureTenantID,
+		suite.credentials.AzureClientID,
+		suite.credentials.AzureClientSecret,
+	)
+	require.NoError(t, err)
+
+	serv := graph.NewService(adpt)
+	email := models.NewMessage()
+	subject := "TestSerializationEndPoint"
+	email.SetSubject(&subject)
+
+	byteArray, err := serv.Serialize(email)
+	assert.NoError(t, err)
+	assert.NotNil(t, byteArray)
+	t.Log(string(byteArray))
+}


### PR DESCRIPTION
## Description
The MS Graph's adapter contains a serialization writer within it. Create a framework to use this writer rather than creating the object within serialization workflows. The writer library was used separately when the package still had many bugs and the most current version was required. This does not change any of the writer instances within the package. Will change out the writer instances in follow-up PRs.

<!-- Insert PR description-->

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature


## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
*related to  #2031 <issue>

## Test Plan
- [x] :zap: Unit test
