### PR TITLE
remove DiscreteScopes() from selectors

### DIFF
--- a/src/internal/connector/exchange/data_collections.go
+++ b/src/internal/connector/exchange/data_collections.go
@@ -175,7 +175,6 @@ func DataCollections(
 
 	var (
 		user        = selector.DiscreteOwner
-		scopes      = eb.DiscreteScopes([]string{user})
 		collections = []data.Collection{}
 		errs        error
 	)
@@ -185,7 +184,7 @@ func DataCollections(
 		return nil, err
 	}
 
-	for _, scope := range scopes {
+	for _, scope := range eb.Scopes() {
 		dps := cdps[scope.Category().PathType()]
 
 		dcs, err := createCollections(

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -208,7 +208,7 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 	}
 
 	// should always be 1, since backups are 1:1 with resourceOwners.
-	opStats.resourceCount++
+	opStats.resourceCount = 1
 	opStats.started = true
 	opStats.gc = gc.AwaitStatus()
 
@@ -678,7 +678,7 @@ func (op *BackupOperation) persistResults(
 	op.Results.BytesUploaded = opStats.k.TotalUploadedBytes
 	op.Results.ItemsRead = opStats.gc.Successful
 	op.Results.ItemsWritten = opStats.k.TotalFileCount
-	op.Results.ResourceOwners = opStats.resourceCount
+	op.Results.ResourceOwners = 1
 
 	return nil
 }

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -678,7 +678,7 @@ func (op *BackupOperation) persistResults(
 	op.Results.BytesUploaded = opStats.k.TotalUploadedBytes
 	op.Results.ItemsRead = opStats.gc.Successful
 	op.Results.ItemsWritten = opStats.k.TotalFileCount
-	op.Results.ResourceOwners = 1
+	op.Results.ResourceOwners = opStats.resourceCount
 
 	return nil
 }

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -207,8 +207,8 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 		return opStats.writeErr
 	}
 
-	// TODO: should always be 1, since backups are 1:1 with resourceOwners now.
-	opStats.resourceCount = len(data.ResourceOwnerSet(cs))
+	// should always be 1, since backups are 1:1 with resourceOwners.
+	opStats.resourceCount++
 	opStats.started = true
 	opStats.gc = gc.AwaitStatus()
 

--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -150,7 +150,6 @@ func (op *RestoreOperation) Run(ctx context.Context) (restoreDetails *details.De
 			events.BackupID:         op.BackupID,
 			events.BackupCreateTime: bup.CreationTime,
 			events.RestoreID:        opStats.restoreID,
-			// TODO: restore options,
 		},
 	)
 

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -229,8 +229,7 @@ func (d *Details) addFolder(folder folderEntry) {
 
 // DetailsEntry describes a single item stored in a Backup
 type DetailsEntry struct {
-	// TODO: `RepoRef` is currently the full path to the item in Kopia
-	// This can be optimized.
+	// RepoRef is the full storage path of the item in Kopia
 	RepoRef   string `json:"repoRef"`
 	ShortRef  string `json:"shortRef"`
 	ParentRef string `json:"parentRef,omitempty"`

--- a/src/pkg/selectors/exchange.go
+++ b/src/pkg/selectors/exchange.go
@@ -188,21 +188,6 @@ func (s *exchange) Scopes() []ExchangeScope {
 	return scopes[ExchangeScope](s.Selector)
 }
 
-// DiscreteScopes retrieves the list of exchangeScopes in the selector.
-// If any Include scope's User category is set to Any, replaces that
-// scope's value with the list of userPNs instead.
-func (s *exchange) DiscreteScopes(userPNs []string) []ExchangeScope {
-	scopes := discreteScopes[ExchangeScope](s.Includes, ExchangeUser, userPNs)
-
-	ss := make([]ExchangeScope, 0, len(scopes))
-
-	for _, scope := range scopes {
-		ss = append(ss, ExchangeScope(scope))
-	}
-
-	return ss
-}
-
 type ExchangeItemScopeConstructor func([]string, []string, ...option) []ExchangeScope
 
 // -------------------

--- a/src/pkg/selectors/exchange_test.go
+++ b/src/pkg/selectors/exchange_test.go
@@ -479,49 +479,6 @@ func (suite *ExchangeSelectorSuite) TestExchangeBackup_Scopes() {
 	}
 }
 
-func (suite *ExchangeSelectorSuite) TestExchangeBackup_DiscreteScopes() {
-	usrs := []string{"u1", "u2"}
-	table := []struct {
-		name     string
-		include  []string
-		discrete []string
-		expect   []string
-	}{
-		{
-			name:     "any user",
-			include:  Any(),
-			discrete: usrs,
-			expect:   usrs,
-		},
-		{
-			name:     "discrete user",
-			include:  []string{"u3"},
-			discrete: usrs,
-			expect:   []string{"u3"},
-		},
-		{
-			name:     "nil discrete slice",
-			include:  Any(),
-			discrete: nil,
-			expect:   Any(),
-		},
-	}
-
-	for _, test := range table {
-		suite.T().Run(test.name, func(t *testing.T) {
-			// todo: remove discreteScopes
-			// eb := NewExchangeBackup(test.include)
-			// eb.Include(eb.AllData())
-
-			// scopes := eb.DiscreteScopes(test.discrete)
-			// for _, sc := range scopes {
-			// 	users := sc.Get(ExchangeUser)
-			// 	assert.Equal(t, test.expect, users)
-			// }
-		})
-	}
-}
-
 func (suite *ExchangeSelectorSuite) TestExchangeScope_Category() {
 	table := []struct {
 		is     exchangeCategory
@@ -1144,7 +1101,7 @@ func (suite *ExchangeSelectorSuite) TestPasses() {
 	)
 
 	var (
-		es        = NewExchangeRestore(Any()) // TODO: move into test and compose with each test value
+		es        = NewExchangeRestore(Any())
 		otherMail = setScopesToDefault(es.Mails(Any(), []string{"smarf"}))
 		mail      = setScopesToDefault(es.Mails(Any(), []string{mid}))
 		noMail    = setScopesToDefault(es.Mails(Any(), None()))
@@ -1186,7 +1143,7 @@ func (suite *ExchangeSelectorSuite) TestContains() {
 	target := "fnords"
 
 	var (
-		es                  = NewExchangeRestore(Any()) // TODO: move into test and compose with each test value
+		es                  = NewExchangeRestore(Any())
 		noMail              = setScopesToDefault(es.Mails(None(), None()))
 		does                = setScopesToDefault(es.Mails(Any(), []string{target}))
 		doesNot             = setScopesToDefault(es.Mails(Any(), []string{"smarf"}))
@@ -1221,7 +1178,7 @@ func (suite *ExchangeSelectorSuite) TestContains() {
 
 func (suite *ExchangeSelectorSuite) TestIsAny() {
 	var (
-		es           = NewExchangeRestore(Any()) // TODO: move into test and compose with each test value
+		es           = NewExchangeRestore(Any())
 		specificMail = setScopesToDefault(es.Mails(Any(), []string{"email"}))
 		anyMail      = setScopesToDefault(es.Mails(Any(), Any()))
 	)

--- a/src/pkg/selectors/onedrive.go
+++ b/src/pkg/selectors/onedrive.go
@@ -181,21 +181,6 @@ func (s *oneDrive) Scopes() []OneDriveScope {
 	return scopes[OneDriveScope](s.Selector)
 }
 
-// DiscreteScopes retrieves the list of oneDriveScopes in the selector.
-// If any Include scope's User category is set to Any, replaces that
-// scope's value with the list of userPNs instead.
-func (s *oneDrive) DiscreteScopes(userPNs []string) []OneDriveScope {
-	scopes := discreteScopes[OneDriveScope](s.Includes, OneDriveUser, userPNs)
-
-	ss := make([]OneDriveScope, 0, len(scopes))
-
-	for _, scope := range scopes {
-		ss = append(ss, OneDriveScope(scope))
-	}
-
-	return ss
-}
-
 // -------------------
 // Scope Factories
 

--- a/src/pkg/selectors/onedrive_test.go
+++ b/src/pkg/selectors/onedrive_test.go
@@ -39,49 +39,6 @@ func (suite *OneDriveSelectorSuite) TestToOneDriveBackup() {
 	assert.NotZero(t, ob.Scopes())
 }
 
-func (suite *OneDriveSelectorSuite) TestOneDriveBackup_DiscreteScopes() {
-	usrs := []string{"u1", "u2"}
-	table := []struct {
-		name     string
-		include  []string
-		discrete []string
-		expect   []string
-	}{
-		{
-			name:     "any user",
-			include:  Any(),
-			discrete: usrs,
-			expect:   usrs,
-		},
-		{
-			name:     "discrete user",
-			include:  []string{"u3"},
-			discrete: usrs,
-			expect:   []string{"u3"},
-		},
-		{
-			name:     "nil discrete slice",
-			include:  Any(),
-			discrete: nil,
-			expect:   Any(),
-		},
-	}
-
-	for _, test := range table {
-		suite.T().Run(test.name, func(t *testing.T) {
-			// todo: remove discreteScopes
-			// eb := NewOneDriveBackup(test.include)
-			// eb.Include(eb.AllData())
-
-			// scopes := eb.DiscreteScopes(test.discrete)
-			// for _, sc := range scopes {
-			// 	users := sc.Get(OneDriveUser)
-			// 	assert.Equal(t, test.expect, users)
-			// }
-		})
-	}
-}
-
 func (suite *OneDriveSelectorSuite) TestOneDriveSelector_AllData() {
 	t := suite.T()
 

--- a/src/pkg/selectors/selectors.go
+++ b/src/pkg/selectors/selectors.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"golang.org/x/exp/maps"
 
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/filters"
@@ -182,11 +181,6 @@ func splitByResourceOwner[T scopeT, C categoryT](s Selector, allOwners []string,
 	for _, ro := range targets {
 		c := s
 		c.DiscreteOwner = ro
-
-		// TODO: when the rootCat gets removed from the scopes, we can remove this
-		c.Includes = discreteScopes[T](s.Includes, rootCat, []string{ro})
-		c.Filters = discreteScopes[T](s.Filters, rootCat, []string{ro})
-
 		ss = append(ss, c)
 	}
 
@@ -221,7 +215,6 @@ func appendScopes[T scopeT](to []scope, scopes ...[]T) []scope {
 }
 
 // scopes retrieves the list of scopes in the selector.
-// future TODO: if Inclues is nil, return filters.
 func scopes[T scopeT](s Selector) []T {
 	scopes := []T{}
 
@@ -230,38 +223,6 @@ func scopes[T scopeT](s Selector) []T {
 	}
 
 	return scopes
-}
-
-// discreteScopes retrieves the list of scopes in the selector.
-// for any scope in the `Includes` set, if scope.IsAny(rootCat),
-// then that category's value is replaced with the provided set of
-// discrete identifiers.
-// If discreteIDs is an empty slice, returns the normal scopes(s).
-// future TODO: if Includes is nil, return filters.
-func discreteScopes[T scopeT, C categoryT](
-	scopes []scope,
-	rootCat C,
-	discreteIDs []string,
-) []scope {
-	sl := []scope{}
-
-	if len(discreteIDs) == 0 {
-		return scopes
-	}
-
-	for _, v := range scopes {
-		t := T(v)
-
-		if isAnyTarget(t, rootCat) {
-			w := maps.Clone(t)
-			set(w, rootCat, discreteIDs)
-			t = w
-		}
-
-		sl = append(sl, scope(t))
-	}
-
-	return sl
 }
 
 // Returns the path.ServiceType matching the selector service.

--- a/src/pkg/selectors/sharepoint.go
+++ b/src/pkg/selectors/sharepoint.go
@@ -179,21 +179,6 @@ func (s *sharePoint) Scopes() []SharePointScope {
 	return scopes[SharePointScope](s.Selector)
 }
 
-// DiscreteScopes retrieves the list of sharePointScopes in the selector.
-// If any Include scope's Site category is set to Any, replaces that
-// scope's value with the list of siteIDs instead.
-func (s *sharePoint) DiscreteScopes(siteIDs []string) []SharePointScope {
-	scopes := discreteScopes[SharePointScope](s.Includes, SharePointSite, siteIDs)
-
-	ss := make([]SharePointScope, 0, len(scopes))
-
-	for _, scope := range scopes {
-		ss = append(ss, SharePointScope(scope))
-	}
-
-	return ss
-}
-
 // -------------------
 // Scope Factories
 

--- a/src/pkg/selectors/sharepoint_test.go
+++ b/src/pkg/selectors/sharepoint_test.go
@@ -37,49 +37,6 @@ func (suite *SharePointSelectorSuite) TestToSharePointBackup() {
 	assert.NotZero(t, ob.Scopes())
 }
 
-func (suite *SharePointSelectorSuite) TestSharePointBackup_DiscreteScopes() {
-	sites := []string{"s1", "s2"}
-	table := []struct {
-		name     string
-		include  []string
-		discrete []string
-		expect   []string
-	}{
-		{
-			name:     "any site",
-			include:  Any(),
-			discrete: sites,
-			expect:   sites,
-		},
-		{
-			name:     "discrete sitet",
-			include:  []string{"s3"},
-			discrete: sites,
-			expect:   []string{"s3"},
-		},
-		{
-			name:     "nil discrete slice",
-			include:  Any(),
-			discrete: nil,
-			expect:   Any(),
-		},
-	}
-
-	for _, test := range table {
-		suite.T().Run(test.name, func(t *testing.T) {
-			// todo: remove discreteScopes
-			// eb := NewSharePointBackup(test.include)
-			// eb.Include(eb.AllData())
-
-			// scopes := eb.DiscreteScopes(test.discrete)
-			// for _, sc := range scopes {
-			// 	sites := sc.Get(SharePointSite)
-			// 	assert.Equal(t, test.expect, sites)
-			// }
-		})
-	}
-}
-
 func (suite *SharePointSelectorSuite) TestSharePointSelector_AllData() {
 	t := suite.T()
 
@@ -368,7 +325,7 @@ func (suite *SharePointSelectorSuite) TestSharePointCategory_PathValues() {
 
 func (suite *SharePointSelectorSuite) TestSharePointScope_MatchesInfo() {
 	var (
-		ods  = NewSharePointRestore(nil) // TODO: move into test
+		ods  = NewSharePointRestore(nil)
 		host = "www.website.com"
 		pth  = "/foo"
 		url  = host + pth


### PR DESCRIPTION
## Description

DiscreteScopes is a vestigial func from when scopes contained the list of resource owners to track.  That behavior is no longer in use.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :broom: Tech Debt/Cleanup

## Issue(s)

* #1617

## Test Plan

- [x] :zap: Unit test
