### PR TITLE
full backup if prev snapshots have no details

### DIFF
--- a/src/internal/kopia/snapshot_manager.go
+++ b/src/internal/kopia/snapshot_manager.go
@@ -322,11 +322,9 @@ func fetchPrevSnapshotManifests(
 				// If the manifest already exists and it's incomplete then we should
 				// merge the reasons for consistency. This will become easier to handle
 				// once we update how checkpoint manifests are tagged.
-				if len(found.IncompleteReason) == 0 {
-					continue
+				if len(found.IncompleteReason) > 0 {
+					found.Reasons = append(found.Reasons, m.Reasons...)
 				}
-
-				found.Reasons = append(found.Reasons, m.Reasons...)
 			}
 		}
 	}

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -283,7 +283,9 @@ func produceManifestsAndMetadata(
 			continue
 		}
 
-		bID := man.Tags[kopia.TagBackupID]
+		tk, _ := kopia.MakeTagKV(kopia.TagBackupID)
+
+		bID := man.Tags[tk]
 		if len(bID) == 0 {
 			return nil, nil, errors.New("missing backup id in prior manifest")
 		}


### PR DESCRIPTION
## Description

In the event that a backup is completed but the details, somehow, isn't persisted, we want the next backup to do a full, instead of an incremental, backup.  If we don't have this protection the following backups could end up in a bad state.  Future changes will add better resilience so that the fallback isn't needed.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :sunflower: Feature

## Issue(s)

* #1878

## Test Plan

- [x] :green_heart: E2E
