### PR TITLE
Only make incremental backup if Reason:base is 1:1

### DIFF
--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -319,6 +319,22 @@ func produceManifestsAndMetadata(
 		return ms, nil, nil
 	}
 
+	// We only need to check that we have 1:1 reason:base if we're doing an
+	// incremental with associated metadata. This ensures that we're only sourcing
+	// data from a single Point-In-Time (base) for each incremental backup.
+	//
+	// TODO(ashmrtn): This may need updating if we start sourcing item backup
+	// details from previous snapshots when using kopia-assisted incrementals.
+	if err := verifyDistinctBases(ms); err != nil {
+		logger.Ctx(ctx).Warnw(
+			"base snapshot collision, falling back to full backup",
+			"error",
+			err,
+		)
+
+		return ms, nil, nil
+	}
+
 	for _, man := range ms {
 		if len(man.IncompleteReason) > 0 {
 			continue

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -276,7 +276,7 @@ func verifyDistinctBases(mans []*kopia.ManifestEntry) error {
 
 			if b, ok := reasons[reasonKey]; ok {
 				errs = multierror.Append(errs, errors.Errorf(
-					"%s %s is sourced from snapshots with IDs %s, %s",
+					"multiple base snapshots source data for %s %s. IDs: %s, %s",
 					reason.Service.String(),
 					reason.Category.String(),
 					b,


### PR DESCRIPTION
## Description

Ensure that each (resource owner, service, category) set of data is only sourced from a single base snapshot when doing an incremental backup. If not, fallback to doing a full backup.

Failure to error out or fallback to a full backup may result in repeated or zombie items in the resulting backup as multiple Point-In-Time backups will be used to source the same data

Incomplete manifests are ignored as they are currently only used for kopia-assisted incrementals, not sourcing items/backup details info when making a delta token-based incremental backup

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [x] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

* closes #1945 

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
