### PR TITLE
Add a common prefix to test storage prefixes

### DIFF
--- a/src/internal/tester/storage.go
+++ b/src/internal/tester/storage.go
@@ -9,6 +9,8 @@ import (
 	"github.com/alcionai/corso/src/pkg/storage"
 )
 
+const testRepoRootPrefix = "integration_test/"
+
 var AWSStorageCredEnvs = []string{
 	credentials.AWSAccessKeyID,
 	credentials.AWSSecretAccessKey,
@@ -31,7 +33,7 @@ func NewPrefixedS3Storage(t *testing.T) storage.Storage {
 		storage.ProviderS3,
 		storage.S3Config{
 			Bucket: cfg[TestCfgBucket],
-			Prefix: t.Name() + "-" + now,
+			Prefix: testRepoRootPrefix + t.Name() + "-" + now,
 		},
 		storage.CommonConfig{
 			Corso:       credentials.GetCorso(),

--- a/src/internal/tester/storage.go
+++ b/src/internal/tester/storage.go
@@ -9,7 +9,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/storage"
 )
 
-const testRepoRootPrefix = "integration_test/"
+const testRepoRootPrefix = "corso_integration_test/"
 
 var AWSStorageCredEnvs = []string{
 	credentials.AWSAccessKeyID,


### PR DESCRIPTION
## Description

This results in all test kopia repositories being created under the same "folder" in S3, thus making manual cleanup much easier.

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

## Issue(s)

* closes #2053 

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
