### PR TITLE
Don't use OwnersCats struct

### DIFF
--- a/src/internal/kopia/snapshot_manager.go
+++ b/src/internal/kopia/snapshot_manager.go
@@ -305,8 +305,8 @@ func fetchPrevSnapshotManifests(
 
 		// If we found more recent snapshots then add them.
 		for _, m := range found {
-			found := mans[m.ID]
-			if found == nil {
+			man := mans[m.ID]
+			if man == nil {
 				mans[m.ID] = m
 				continue
 			}
@@ -314,11 +314,11 @@ func fetchPrevSnapshotManifests(
 			// If the manifest already exists and it's incomplete then we should
 			// merge the reasons for consistency. This will become easier to handle
 			// once we update how checkpoint manifests are tagged.
-			if len(found.IncompleteReason) == 0 {
+			if len(man.IncompleteReason) == 0 {
 				continue
 			}
 
-			found.Reasons = append(found.Reasons, m.Reasons...)
+			man.Reasons = append(man.Reasons, m.Reasons...)
 		}
 	}
 

--- a/src/internal/kopia/snapshot_manager.go
+++ b/src/internal/kopia/snapshot_manager.go
@@ -89,6 +89,9 @@ func MakeTagKV(k string) (string, string) {
 // tagsFromStrings returns a map[string]string with tags for all ownersCats
 // passed in. Currently uses placeholder values for each tag because there can
 // be multiple instances of resource owners and categories in a single snapshot.
+// TODO(ashmrtn): Remove in future PR.
+//
+//nolint:unused
 func tagsFromStrings(oc *OwnersCats) map[string]string {
 	if oc == nil {
 		return map[string]string{}
@@ -188,24 +191,17 @@ func fetchPrevManifests(
 	ctx context.Context,
 	sm snapshotManager,
 	foundMans map[manifest.ID]*ManifestEntry,
-	serviceCat ServiceCat,
-	resourceOwner string,
+	reason Reason,
 	tags map[string]string,
 ) ([]*ManifestEntry, error) {
 	tags = normalizeTagKVs(tags)
-	serviceCatKey, _ := MakeServiceCat(serviceCat.Service, serviceCat.Category)
+	serviceCatKey, _ := MakeServiceCat(reason.Service, reason.Category)
 	allTags := normalizeTagKVs(map[string]string{
-		serviceCatKey: "",
-		resourceOwner: "",
+		serviceCatKey:        "",
+		reason.ResourceOwner: "",
 	})
 
 	maps.Copy(allTags, tags)
-
-	reason := Reason{
-		ResourceOwner: resourceOwner,
-		Service:       serviceCat.Service,
-		Category:      serviceCat.Category,
-	}
 
 	metas, err := sm.FindManifests(ctx, allTags)
 	if err != nil {
@@ -275,57 +271,54 @@ func fetchPrevManifests(
 func fetchPrevSnapshotManifests(
 	ctx context.Context,
 	sm snapshotManager,
-	oc *OwnersCats,
+	reasons []Reason,
 	tags map[string]string,
 ) []*ManifestEntry {
-	if oc == nil {
-		return nil
-	}
-
 	mans := map[manifest.ID]*ManifestEntry{}
 
 	// For each serviceCat/resource owner pair that we will be backing up, see if
 	// there's a previous incomplete snapshot and/or a previous complete snapshot
 	// we can pass in. Can be expanded to return more than the most recent
 	// snapshots, but may require more memory at runtime.
-	for _, serviceCat := range oc.ServiceCats {
-		for resourceOwner := range oc.ResourceOwners {
-			found, err := fetchPrevManifests(
-				ctx,
-				sm,
-				mans,
-				serviceCat,
-				resourceOwner,
-				tags,
+	for _, reason := range reasons {
+		found, err := fetchPrevManifests(
+			ctx,
+			sm,
+			mans,
+			reason,
+			tags,
+		)
+		if err != nil {
+			logger.Ctx(ctx).Warnw(
+				"fetching previous snapshot manifests for service/category/resource owner",
+				"error",
+				err,
+				"service",
+				reason.Service.String(),
+				"category",
+				reason.Category.String(),
 			)
-			if err != nil {
-				logger.Ctx(ctx).Warnw(
-					"fetching previous snapshot manifests for service/category/resource owner",
-					"error",
-					err,
-					"service/category",
-					serviceCat,
-				)
 
-				// Snapshot can still complete fine, just not as efficient.
+			// Snapshot can still complete fine, just not as efficient.
+			continue
+		}
+
+		// If we found more recent snapshots then add them.
+		for _, m := range found {
+			found := mans[m.ID]
+			if found == nil {
+				mans[m.ID] = m
 				continue
 			}
 
-			// If we found more recent snapshots then add them.
-			for _, m := range found {
-				found := mans[m.ID]
-				if found == nil {
-					mans[m.ID] = m
-					continue
-				}
-
-				// If the manifest already exists and it's incomplete then we should
-				// merge the reasons for consistency. This will become easier to handle
-				// once we update how checkpoint manifests are tagged.
-				if len(found.IncompleteReason) > 0 {
-					found.Reasons = append(found.Reasons, m.Reasons...)
-				}
+			// If the manifest already exists and it's incomplete then we should
+			// merge the reasons for consistency. This will become easier to handle
+			// once we update how checkpoint manifests are tagged.
+			if len(found.IncompleteReason) == 0 {
+				continue
 			}
+
+			found.Reasons = append(found.Reasons, m.Reasons...)
 		}
 	}
 

--- a/src/internal/kopia/snapshot_manager.go
+++ b/src/internal/kopia/snapshot_manager.go
@@ -92,6 +92,7 @@ func MakeTagKV(k string) (string, string) {
 // TODO(ashmrtn): Remove in future PR.
 //
 //nolint:unused
+//lint:ignore U1000 will be removed in future PR.
 func tagsFromStrings(oc *OwnersCats) map[string]string {
 	if oc == nil {
 		return map[string]string{}

--- a/src/internal/kopia/snapshot_manager_test.go
+++ b/src/internal/kopia/snapshot_manager_test.go
@@ -43,25 +43,53 @@ var (
 	testUser2 = "user2"
 	testUser3 = "user3"
 
-	testAllUsersAllCats = &OwnersCats{
-		ResourceOwners: map[string]struct{}{
-			testUser1: {},
-			testUser2: {},
-			testUser3: {},
+	testAllUsersAllCats = []Reason{
+		{
+			ResourceOwner: testUser1,
+			Service:       path.ExchangeService,
+			Category:      path.EmailCategory,
 		},
-		ServiceCats: map[string]ServiceCat{
-			testMail:   testMailServiceCat,
-			testEvents: testEventsServiceCat,
+		{
+			ResourceOwner: testUser1,
+			Service:       path.ExchangeService,
+			Category:      path.EventsCategory,
+		},
+		{
+			ResourceOwner: testUser2,
+			Service:       path.ExchangeService,
+			Category:      path.EmailCategory,
+		},
+		{
+			ResourceOwner: testUser2,
+			Service:       path.ExchangeService,
+			Category:      path.EventsCategory,
+		},
+		{
+			ResourceOwner: testUser3,
+			Service:       path.ExchangeService,
+			Category:      path.EmailCategory,
+		},
+		{
+			ResourceOwner: testUser3,
+			Service:       path.ExchangeService,
+			Category:      path.EventsCategory,
 		},
 	}
-	testAllUsersMail = &OwnersCats{
-		ResourceOwners: map[string]struct{}{
-			testUser1: {},
-			testUser2: {},
-			testUser3: {},
+	testAllUsersMail = []Reason{
+		{
+			ResourceOwner: testUser1,
+			Service:       path.ExchangeService,
+			Category:      path.EmailCategory,
 		},
-		ServiceCats: map[string]ServiceCat{
-			testMail: testMailServiceCat,
+		{
+			ResourceOwner: testUser2,
+			Service:       path.ExchangeService,
+			Category:      path.EmailCategory,
+		},
+		{
+			ResourceOwner: testUser3,
+			Service:       path.ExchangeService,
+			Category:      path.EmailCategory,
 		},
 	}
 )
@@ -176,7 +204,7 @@ func TestSnapshotFetchUnitSuite(t *testing.T) {
 func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshots() {
 	table := []struct {
 		name  string
-		input *OwnersCats
+		input []Reason
 		data  []manifestInfo
 		// Use this to denote which manifests in data should be expected. Allows
 		// defining data in a table while not repeating things between data and
@@ -813,7 +841,7 @@ func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshots_customTags() {
 
 	table := []struct {
 		name  string
-		input *OwnersCats
+		input []Reason
 		tags  map[string]string
 		// Use this to denote which manifests in data should be expected. Allows
 		// defining data in a table while not repeating things between data and

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -442,12 +442,12 @@ func (w Wrapper) DeleteSnapshot(
 // normalized inside the func using MakeTagKV.
 func (w Wrapper) FetchPrevSnapshotManifests(
 	ctx context.Context,
-	oc *OwnersCats,
+	reasons []Reason,
 	tags map[string]string,
 ) ([]*ManifestEntry, error) {
 	if w.c == nil {
 		return nil, errors.WithStack(errNotConnected)
 	}
 
-	return fetchPrevSnapshotManifests(ctx, w.c, oc, tags), nil
+	return fetchPrevSnapshotManifests(ctx, w.c, reasons, tags), nil
 }

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -119,8 +119,6 @@ func (w Wrapper) BackupCollections(
 	ctx context.Context,
 	previousSnapshots []IncrementalBase,
 	collections []data.Collection,
-	service path.ServiceType,
-	oc *OwnersCats,
 	tags map[string]string,
 	buildTreeWithBase bool,
 ) (*BackupStats, *details.Builder, map[string]path.Path, error) {
@@ -158,7 +156,6 @@ func (w Wrapper) BackupCollections(
 		ctx,
 		previousSnapshots,
 		dirTree,
-		oc,
 		tags,
 		progress,
 	)
@@ -173,7 +170,6 @@ func (w Wrapper) makeSnapshotWithRoot(
 	ctx context.Context,
 	prevSnapEntries []IncrementalBase,
 	root fs.Directory,
-	oc *OwnersCats,
 	addlTags map[string]string,
 	progress *corsoProgress,
 ) (*BackupStats, error) {
@@ -231,7 +227,8 @@ func (w Wrapper) makeSnapshotWithRoot(
 				return err
 			}
 
-			man.Tags = tagsFromStrings(oc)
+			man.Tags = map[string]string{}
+
 			for k, v := range addlTags {
 				mk, mv := MakeTagKV(k)
 

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -176,16 +176,18 @@ func checkBackupIsInManifests(
 	for _, category := range categories {
 		t.Run(category.String(), func(t *testing.T) {
 			var (
-				sck, scv = kopia.MakeServiceCat(sel.PathService(), category)
-				oc       = &kopia.OwnersCats{
-					ResourceOwners: map[string]struct{}{resourceOwner: {}},
-					ServiceCats:    map[string]kopia.ServiceCat{sck: scv},
+				reasons = []kopia.Reason{
+					{
+						ResourceOwner: resourceOwner,
+						Service:       sel.PathService(),
+						Category:      category,
+					},
 				}
 				tags  = map[string]string{kopia.TagBackupCategory: ""}
 				found bool
 			)
 
-			mans, err := kw.FetchPrevSnapshotManifests(ctx, oc, tags)
+			mans, err := kw.FetchPrevSnapshotManifests(ctx, reasons, tags)
 			require.NoError(t, err)
 
 			for _, man := range mans {

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -61,8 +61,6 @@ type mockBackuper struct {
 	checkFunc func(
 		bases []kopia.IncrementalBase,
 		cs []data.Collection,
-		service path.ServiceType,
-		oc *kopia.OwnersCats,
 		tags map[string]string,
 		buildTreeWithBase bool,
 	)
@@ -72,13 +70,11 @@ func (mbu mockBackuper) BackupCollections(
 	ctx context.Context,
 	bases []kopia.IncrementalBase,
 	cs []data.Collection,
-	service path.ServiceType,
-	oc *kopia.OwnersCats,
 	tags map[string]string,
 	buildTreeWithBase bool,
 ) (*kopia.BackupStats, *details.Builder, map[string]path.Path, error) {
 	if mbu.checkFunc != nil {
-		mbu.checkFunc(bases, cs, service, oc, tags, buildTreeWithBase)
+		mbu.checkFunc(bases, cs, tags, buildTreeWithBase)
 	}
 
 	return &kopia.BackupStats{}, &details.Builder{}, nil, nil
@@ -673,8 +669,6 @@ func (suite *BackupOpSuite) TestBackupOperation_ConsumeBackupDataCollections_Pat
 		manifest2 = &snapshot.Manifest{
 			ID: "id2",
 		}
-
-		sel = selectors.NewExchangeBackup([]string{resourceOwner}).Selector
 	)
 
 	table := []struct {
@@ -768,8 +762,6 @@ func (suite *BackupOpSuite) TestBackupOperation_ConsumeBackupDataCollections_Pat
 				checkFunc: func(
 					bases []kopia.IncrementalBase,
 					cs []data.Collection,
-					service path.ServiceType,
-					oc *kopia.OwnersCats,
 					tags map[string]string,
 					buildTreeWithBase bool,
 				) {
@@ -782,7 +774,6 @@ func (suite *BackupOpSuite) TestBackupOperation_ConsumeBackupDataCollections_Pat
 				ctx,
 				mbu,
 				tenant,
-				sel,
 				nil,
 				test.inputMan,
 				nil,

--- a/src/internal/streamstore/streamstore.go
+++ b/src/internal/streamstore/streamstore.go
@@ -77,8 +77,6 @@ func (ss *streamStore) WriteBackupDetails(
 		ctx,
 		nil,
 		[]data.Collection{dc},
-		ss.service,
-		nil,
 		nil,
 		false,
 	)


### PR DESCRIPTION
## Description

Remove OwnersCats so only the Reason struct or tags pass information
between BackupOp and kopia

Instead of having a separate struct (OwnersCats) to fetch previous
snapshots, generate and use reasons. While this results in some repeated
data, it cuts down on the number of distinct structs and simplifies some
of the code for getting previous manifests.

A future PR should create a shared function to create a service/cat tag
given a reason.

Only pass in a set of tags to BackupCollections. This pushes the onus
of generating the tags for later snapshot lookups to BackupOp and
creates a somewhat asymmetric interface as Reason is used for the lookup
but tags is used for the backup. This will be updated later so that both
paths use a common function to convert from Reason->tags.

Despite that, it may result in a cleaner interface with kopia (depending
on how far we want to push it) where tags become the main mean of
communication.

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

## Issue(s)

* #1916 

## Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
