### PR TITLE
don't look up details if id is missing in backup

### DIFF
--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -556,6 +556,12 @@ func mergeDetails(
 			detailsStore,
 		)
 		if err != nil {
+			// if the backup has no prior details recorded, then there's nothing to merge.
+			if errors.Is(err, errNoDetailsID) {
+				logger.Ctx(ctx).Infof("backup %s contains no details ID, skipping merger", bID)
+				continue
+			}
+
 			return errors.Wrapf(err, "backup fetching base details for backup %s", bID)
 		}
 

--- a/src/internal/operations/common.go
+++ b/src/internal/operations/common.go
@@ -15,6 +15,8 @@ type detailsReader interface {
 	ReadBackupDetails(ctx context.Context, detailsID string) (*details.Details, error)
 }
 
+var errNoDetailsID = errors.New("no details id in backup")
+
 func getBackupAndDetailsFromID(
 	ctx context.Context,
 	backupID model.StableID,
@@ -24,6 +26,10 @@ func getBackupAndDetailsFromID(
 	dID, bup, err := ms.GetDetailsIDFromBackupID(ctx, backupID)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "getting backup details ID")
+	}
+
+	if len(dID) == 0 {
+		return nil, nil, errNoDetailsID
 	}
 
 	deets, err := detailsStore.ReadBackupDetails(ctx, dID)


### PR DESCRIPTION
## Description

In case of a failure that causes the detailsID to not be recorded in the backup, do not attempt to look up
the details from the model store.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :bug: Bugfix

## Issue(s)

* #1878

## Test Plan

- [x] :green_heart: E2E
