### PR TITLE
OneDrive Permissions Backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Incremental backup support for exchange is now enabled by default.
+- Support for backing up OneDrive permissions ([#2059](https://github.com/alcionai/corso/pull/2059))
 
 ### Changed
 

--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -542,6 +542,10 @@ func (od *Stream) ToReader() io.ReadCloser {
 	return io.NopCloser(bytes.NewReader(od.message))
 }
 
+func (od *Stream) ToMetaReader() (io.ReadCloser, error) {
+	return nil, nil
+}
+
 func (od Stream) Deleted() bool {
 	return od.deleted
 }

--- a/src/internal/connector/graph/metadata_collection.go
+++ b/src/internal/connector/graph/metadata_collection.go
@@ -200,3 +200,7 @@ func (mi MetadataItem) Deleted() bool {
 func (mi MetadataItem) ToReader() io.ReadCloser {
 	return io.NopCloser(bytes.NewReader(mi.data))
 }
+
+func (mi MetadataItem) ToMetaReader() (io.ReadCloser, error) {
+	return nil, nil
+}

--- a/src/internal/connector/mockconnector/mock_data_collection.go
+++ b/src/internal/connector/mockconnector/mock_data_collection.go
@@ -157,6 +157,10 @@ func (med *MockExchangeData) ToReader() io.ReadCloser {
 	return med.Reader
 }
 
+func (med *MockExchangeData) ToMetaReader() (io.ReadCloser, error) {
+	return nil, nil
+}
+
 func (med *MockExchangeData) Info() details.ItemInfo {
 	return details.ItemInfo{
 		Exchange: &details.ExchangeInfo{

--- a/src/internal/connector/mockconnector/mock_data_list.go
+++ b/src/internal/connector/mockconnector/mock_data_list.go
@@ -78,6 +78,10 @@ func (mld *MockListData) ToReader() io.ReadCloser {
 	return mld.Reader
 }
 
+func (mld *MockListData) ToMetaReader() (io.ReadCloser, error) {
+	return nil, nil
+}
+
 // GetMockList returns a Listable object with two columns.
 // @param: Name of the displayable list
 // @param: Column Name: Defines the 2nd Column Name of the created list the values from the map.

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -230,6 +230,12 @@ func (oc *Collection) populateItems(ctx context.Context) {
 			break
 		}
 
+		// Don't process folders for non-onedrive(sharepoint).
+		isFile := item.GetFile() != nil
+		if !isFile && oc.source != OneDriveSource {
+			continue
+		}
+
 		semaphoreCh <- struct{}{}
 
 		wg.Add(1)

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -262,8 +262,10 @@ func (oc *Collection) populateItems(ctx context.Context) {
 					err = nil
 				}
 
-				if err == nil {
-					itemMeta, err = oneDriveItemMetaInfo(ctx, oc.driveID, item, oc.service)
+				if err == nil && oc.source == OneDriveSource {
+					// Metadata information is only available for
+					// OneDrive and not Sharepoint
+					itemMeta, err = oneDriveItemMetaInfo(ctx, oc.service, oc.driveID, item)
 				}
 
 				// retry on Timeout type errors, break otherwise.

--- a/src/internal/connector/onedrive/collection_test.go
+++ b/src/internal/connector/onedrive/collection_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"sync"
 	"testing"
+	"time"
 
 	msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -118,7 +119,22 @@ func (suite *CollectionUnitTestSuite) TestCollection() {
 
 			// Set a item reader, add an item and validate we get the item back
 			mockItem := models.NewDriveItem()
+
 			mockItem.SetId(&testItemID)
+			mockItem.SetName(&testItemName)
+
+			now := time.Now()
+			mockItem.SetCreatedDateTime(&now)
+			mockItem.SetLastModifiedDateTime(&now)
+
+			size := int64(10)
+			mockItem.SetSize(&size)
+
+			user := models.NewIdentitySet()
+			mockItem.SetCreatedBy(user)
+
+			mockItem.SetPermissions([]models.Permissionable{})
+
 			coll.Add(mockItem)
 			coll.itemReader = test.itemReader
 

--- a/src/internal/connector/onedrive/collection_test.go
+++ b/src/internal/connector/onedrive/collection_test.go
@@ -62,7 +62,7 @@ func (suite *CollectionUnitTestSuite) TestCollection() {
 
 	table := []struct {
 		name       string
-		source     driveSource
+		source     DriveSource
 		itemReader itemReaderFunc
 		infoFrom   func(*testing.T, details.ItemInfo) (string, string)
 	}{
@@ -156,7 +156,7 @@ func (suite *CollectionUnitTestSuite) TestCollection() {
 func (suite *CollectionUnitTestSuite) TestCollectionReadError() {
 	table := []struct {
 		name   string
-		source driveSource
+		source DriveSource
 	}{
 		{
 			name:   "oneDrive",

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -17,10 +17,10 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
-type driveSource int
+type DriveSource int
 
 const (
-	unknownDriveSource driveSource = iota
+	unknownDriveSource DriveSource = iota
 	OneDriveSource
 	SharePointSource
 )
@@ -35,7 +35,7 @@ type folderMatcher interface {
 type Collections struct {
 	tenant        string
 	resourceOwner string
-	source        driveSource
+	source        DriveSource
 	matcher       folderMatcher
 	service       graph.Servicer
 	statusUpdater support.StatusUpdater
@@ -55,7 +55,7 @@ type Collections struct {
 func NewCollections(
 	tenant string,
 	resourceOwner string,
-	source driveSource,
+	source DriveSource,
 	matcher folderMatcher,
 	service graph.Servicer,
 	statusUpdater support.StatusUpdater,
@@ -130,12 +130,7 @@ func (c *Collections) UpdateCollections(ctx context.Context, driveID string, ite
 		}
 
 		switch {
-		case item.GetFolder() != nil, item.GetPackage() != nil:
-			// Leave this here so we don't fall into the default case.
-			// TODO: This is where we might create a "special file" to represent these in the backup repository
-			// e.g. a ".folderMetadataFile"
-
-		case item.GetFile() != nil:
+		case item.GetFolder() != nil, item.GetPackage() != nil, item.GetFile() != nil:
 			col, found := c.CollectionMap[collectionPath.String()]
 			if !found {
 				col = NewCollection(
@@ -166,7 +161,7 @@ func (c *Collections) UpdateCollections(ctx context.Context, driveID string, ite
 }
 
 // GetCanonicalPath constructs the standard path for the given source.
-func GetCanonicalPath(p, tenant, resourceOwner string, source driveSource) (path.Path, error) {
+func GetCanonicalPath(p, tenant, resourceOwner string, source DriveSource) (path.Path, error) {
 	var (
 		pathBuilder = path.Builder{}.Append(strings.Split(p, "/")...)
 		result      path.Path

--- a/src/internal/connector/onedrive/collections_test.go
+++ b/src/internal/connector/onedrive/collections_test.go
@@ -44,7 +44,7 @@ func (suite *OneDriveCollectionsSuite) TestGetCanonicalPath() {
 
 	table := []struct {
 		name      string
-		source    driveSource
+		source    DriveSource
 		dir       []string
 		expect    string
 		expectErr assert.ErrorAssertionFunc

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -72,7 +72,7 @@ func drives(
 	ctx context.Context,
 	service graph.Servicer,
 	resourceOwner string,
-	source driveSource,
+	source DriveSource,
 ) ([]models.Driveable, error) {
 	switch source {
 	case OneDriveSource:

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -118,8 +118,9 @@ func oneDriveItemInfo(di models.DriveItemable, itemSize int64) *details.OneDrive
 // oneDriveItemMetaInfo will fetch the meta information for a drive
 // item. As of now, it only adds the permissions applicable for a
 // onedrive item.
-func oneDriveItemMetaInfo(ctx context.Context, driveID string,
-	di models.DriveItemable, service graph.Servicer,
+func oneDriveItemMetaInfo(
+	ctx context.Context, service graph.Servicer,
+	driveID string, di models.DriveItemable,
 ) (ItemMeta, error) {
 	itemID := di.GetId()
 

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -71,7 +71,7 @@ func RestoreCollection(
 	ctx context.Context,
 	service graph.Servicer,
 	dc data.Collection,
-	source driveSource,
+	source DriveSource,
 	restoreContainerName string,
 	deets *details.Builder,
 	errUpdater func(string, error),
@@ -209,7 +209,7 @@ func restoreItem(
 	itemData data.Stream,
 	driveID, parentFolderID string,
 	copyBuffer []byte,
-	source driveSource,
+	source DriveSource,
 ) (details.ItemInfo, error) {
 	ctx, end := D.Span(ctx, "gc:oneDrive:restoreItem", D.Label("item_uuid", itemData.UUID()))
 	defer end()

--- a/src/internal/connector/sharepoint/collection.go
+++ b/src/internal/connector/sharepoint/collection.go
@@ -112,6 +112,10 @@ func (sd *Item) ToReader() io.ReadCloser {
 	return sd.data
 }
 
+func (sd *Item) ToMetaReader() (io.ReadCloser, error) {
+	return nil, nil
+}
+
 func (sd Item) Deleted() bool {
 	return sd.deleted
 }

--- a/src/internal/data/data_collection.go
+++ b/src/internal/data/data_collection.go
@@ -63,6 +63,9 @@ type Collection interface {
 type Stream interface {
 	// ToReader returns an io.Reader for the DataStream
 	ToReader() io.ReadCloser
+	// ToMetaReader returns and io.ReadCloser of the metadata
+	// marshalled into json
+	ToMetaReader() (io.ReadCloser, error)
 	// UUID provides a unique identifier for this data
 	UUID() string
 	// Deleted returns true if the item represented by this Stream has been

--- a/src/internal/kopia/data_collection.go
+++ b/src/internal/kopia/data_collection.go
@@ -48,13 +48,18 @@ func (kdc kopiaDataCollection) DoNotMergeItems() bool {
 }
 
 type kopiaDataStream struct {
-	reader io.ReadCloser
-	uuid   string
-	size   int64
+	reader     io.ReadCloser
+	metaReader io.ReadCloser
+	uuid       string
+	size       int64
 }
 
 func (kds kopiaDataStream) ToReader() io.ReadCloser {
 	return kds.reader
+}
+
+func (kds kopiaDataStream) ToMetaReader() (io.ReadCloser, error) {
+	return kds.metaReader, nil
 }
 
 func (kds kopiaDataStream) UUID() string {

--- a/src/internal/streamstore/streamstore.go
+++ b/src/internal/streamstore/streamstore.go
@@ -212,6 +212,10 @@ func (di *streamItem) ToReader() io.ReadCloser {
 	return io.NopCloser(bytes.NewReader(di.data))
 }
 
+func (di *streamItem) ToMetaReader() (io.ReadCloser, error) {
+	return nil, nil
+}
+
 func (di *streamItem) Deleted() bool {
 	return false
 }


### PR DESCRIPTION
## Description

This PR is the backup part of https://github.com/alcionai/corso/pull/2015 . It backs up the metadata file with the `:meta` suffix. It will be empty if there is no additional metadata. As of now, the meta file is only used to backup permissions.

## Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* https://github.com/alcionai/corso/issues/1774

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
