### PR TITLE
details and restore exit on missing backup

### DIFF
--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -508,11 +508,6 @@ func runDetailsExchangeCmd(
 	sel := utils.IncludeExchangeRestoreDataSelectors(opts)
 	utils.FilterExchangeRestoreInfoSelectors(sel, opts)
 
-	// if no selector flags were specified, get all data in the service.
-	if len(sel.Scopes()) == 0 {
-		sel.Include(sel.AllData())
-	}
-
 	return sel.Reduce(ctx, d), nil
 }
 

--- a/src/cli/backup/onedrive.go
+++ b/src/cli/backup/onedrive.go
@@ -399,11 +399,6 @@ func runDetailsOneDriveCmd(
 	sel := utils.IncludeOneDriveRestoreDataSelectors(opts)
 	utils.FilterOneDriveRestoreInfoSelectors(sel, opts)
 
-	// if no selector flags were specified, get all data in the service.
-	if len(sel.Scopes()) == 0 {
-		sel.Include(sel.AllData())
-	}
-
 	return sel.Reduce(ctx, d), nil
 }
 

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -483,10 +483,5 @@ func runDetailsSharePointCmd(
 	sel := utils.IncludeSharePointRestoreDataSelectors(opts)
 	utils.FilterSharePointRestoreInfoSelectors(sel, opts)
 
-	// if no selector flags were specified, get all data in the service.
-	if len(sel.Scopes()) == 0 {
-		sel.Include(sel.AllData())
-	}
-
 	return sel.Reduce(ctx, d), nil
 }

--- a/src/cli/restore/onedrive.go
+++ b/src/cli/restore/onedrive.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/cli/utils"
 	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/kopia"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/repository"
 )
@@ -152,23 +153,22 @@ func restoreOneDriveCmd(cmd *cobra.Command, args []string) error {
 
 	defer utils.CloseRepo(ctx, r)
 
+	dest := control.DefaultRestoreDestination(common.SimpleDateTimeOneDrive)
+
 	sel := utils.IncludeOneDriveRestoreDataSelectors(opts)
 	utils.FilterOneDriveRestoreInfoSelectors(sel, opts)
 
-	// if no selector flags were specified, get all data in the service.
-	if len(sel.Scopes()) == 0 {
-		sel.Include(sel.AllData())
-	}
-
-	restoreDest := control.DefaultRestoreDestination(common.SimpleDateTimeOneDrive)
-
-	ro, err := r.NewRestore(ctx, backupID, sel.Selector, restoreDest)
+	ro, err := r.NewRestore(ctx, backupID, sel.Selector, dest)
 	if err != nil {
 		return Only(ctx, errors.Wrap(err, "Failed to initialize OneDrive restore"))
 	}
 
 	ds, err := ro.Run(ctx)
 	if err != nil {
+		if errors.Is(err, kopia.ErrNotFound) {
+			return Only(ctx, errors.Errorf("Backup or backup details missing for id %s", backupID))
+		}
+
 		return Only(ctx, errors.Wrap(err, "Failed to run OneDrive restore"))
 	}
 

--- a/src/cli/restore/sharepoint.go
+++ b/src/cli/restore/sharepoint.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/cli/utils"
 	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/kopia"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/repository"
 )
@@ -153,23 +154,22 @@ func restoreSharePointCmd(cmd *cobra.Command, args []string) error {
 
 	defer utils.CloseRepo(ctx, r)
 
+	dest := control.DefaultRestoreDestination(common.SimpleDateTime)
+
 	sel := utils.IncludeSharePointRestoreDataSelectors(opts)
 	utils.FilterSharePointRestoreInfoSelectors(sel, opts)
 
-	// if no selector flags were specified, get all data in the service.
-	if len(sel.Scopes()) == 0 {
-		sel.Include(sel.AllData())
-	}
-
-	restoreDest := control.DefaultRestoreDestination(common.SimpleDateTimeOneDrive)
-
-	ro, err := r.NewRestore(ctx, backupID, sel.Selector, restoreDest)
+	ro, err := r.NewRestore(ctx, backupID, sel.Selector, dest)
 	if err != nil {
 		return Only(ctx, errors.Wrap(err, "Failed to initialize SharePoint restore"))
 	}
 
 	ds, err := ro.Run(ctx)
 	if err != nil {
+		if errors.Is(err, kopia.ErrNotFound) {
+			return Only(ctx, errors.Errorf("Backup or backup details missing for id %s", backupID))
+		}
+
 		return Only(ctx, errors.Wrap(err, "Failed to run SharePoint restore"))
 	}
 

--- a/src/cli/utils/exchange.go
+++ b/src/cli/utils/exchange.go
@@ -138,7 +138,6 @@ func IncludeExchangeRestoreDataSelectors(opts ExchangeOpts) *selectors.ExchangeR
 	// either scope the request to a set of users
 	if lc+lcf+le+lef+lev+lec == 0 {
 		sel.Include(sel.AllData())
-
 		return sel
 	}
 

--- a/src/cli/utils/onedrive.go
+++ b/src/cli/utils/onedrive.go
@@ -84,7 +84,6 @@ func IncludeOneDriveRestoreDataSelectors(opts OneDriveOpts) *selectors.OneDriveR
 	// is specified
 	if lp+ln == 0 {
 		sel.Include(sel.AllData())
-
 		return sel
 	}
 


### PR DESCRIPTION
## Description

Ensures that the details and restore commands
exit without attempting further processing if a
backupID doesn't point to either a valid backup
or backup details, and that the user is appropriately notified.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :broom: Tech Debt/Cleanup

## Issue(s)

* #1877

## Test Plan

- [x] :green_heart: E2E
