### PR TITLE
Prevent config-file default repeating in help

### DIFF
--- a/src/cli/config/config.go
+++ b/src/cli/config/config.go
@@ -68,7 +68,7 @@ func AddConfigFlags(cmd *cobra.Command) {
 		&configFilePathFlag,
 		"config-file",
 		displayDefaultFP,
-		"config file location (default is $HOME/.corso.toml)")
+		"config file location")
 }
 
 // ---------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Previously the help output looked like:

```
--config-file string   config file location (default is $HOME/.corso.toml) (default "$HOME/.corso.toml")
```

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
