### PR TITLE
Backup Details: Onedrive details expanded

### DIFF
--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -94,7 +94,7 @@ func driveItemReader(
 // doesn't have its size value updated as a side effect of creation,
 // and kiota drops any SetSize update.
 func oneDriveItemInfo(di models.DriveItemable, itemSize int64) *details.OneDriveInfo {
-	email := ""
+	var email, parent string
 
 	if di.GetCreatedBy().GetUser() != nil {
 		// User is sometimes not available when created via some
@@ -105,13 +105,19 @@ func oneDriveItemInfo(di models.DriveItemable, itemSize int64) *details.OneDrive
 		}
 	}
 
+	if di.GetParentReference().GetName() != nil {
+		// EndPoint is not always populated from external apps
+		parent = *di.GetParentReference().GetName()
+	}
+
 	return &details.OneDriveInfo{
-		ItemType: details.OneDriveItem,
-		ItemName: *di.GetName(),
-		Created:  *di.GetCreatedDateTime(),
-		Modified: *di.GetLastModifiedDateTime(),
-		Size:     itemSize,
-		Owner:    email,
+		ItemType:  details.OneDriveItem,
+		ItemName:  *di.GetName(),
+		Created:   *di.GetCreatedDateTime(),
+		Modified:  *di.GetLastModifiedDateTime(),
+		DriveName: parent,
+		Size:      itemSize,
+		Owner:     email,
 	}
 }
 

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -105,9 +105,11 @@ func oneDriveItemInfo(di models.DriveItemable, itemSize int64) *details.OneDrive
 		}
 	}
 
-	if di.GetParentReference().GetName() != nil {
-		// EndPoint is not always populated from external apps
-		parent = *di.GetParentReference().GetName()
+	if di.GetParentReference() != nil {
+		if di.GetParentReference().GetName() != nil {
+			// EndPoint is not always populated from external apps
+			parent = *di.GetParentReference().GetName()
+		}
 	}
 
 	return &details.OneDriveInfo{

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -520,6 +520,7 @@ func (i *SharePointInfo) UpdateParentPath(newPath path.Path) error {
 type OneDriveInfo struct {
 	Created    time.Time `json:"created,omitempty"`
 	ItemName   string    `json:"itemName"`
+	DriveName  string    `json:"driveName"`
 	ItemType   ItemType  `json:"itemType,omitempty"`
 	Modified   time.Time `json:"modified,omitempty"`
 	Owner      string    `json:"owner,omitempty"`


### PR DESCRIPTION
## Description
Updates the amount of metadata available for OneDrive backups.  This does not affect the way `OneDrive` information is displayed to the user. 
## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature


## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
*closes  #2074<issue>

## Test Plan

- [x] :zap: Unit test
