### PR TITLE
Patch: Direct Import of Minimal Beta packages for Feature Development

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/microsoft/kiota-authentication-azure-go v0.5.0
 	github.com/microsoft/kiota-http-go v0.11.0
 	github.com/microsoft/kiota-serialization-json-go v0.7.2
-	github.com/microsoftgraph/msgraph-beta-sdk-go v0.51.0
 	github.com/microsoftgraph/msgraph-sdk-go v0.50.0
 	github.com/microsoftgraph/msgraph-sdk-go-core v0.31.1
 	github.com/pkg/errors v0.9.1

--- a/src/go.sum
+++ b/src/go.sum
@@ -269,8 +269,6 @@ github.com/microsoft/kiota-serialization-json-go v0.7.2 h1:DSb4fNDi5O+DqJwrHo+vR
 github.com/microsoft/kiota-serialization-json-go v0.7.2/go.mod h1:Ojum5prlijopyCOZ2XctRcVlE2pU8h+43r3tMdiWoDU=
 github.com/microsoft/kiota-serialization-text-go v0.6.0 h1:3N2vftYZlwKdog69AN7ha+FZT0QxPG7xp/hLv0/W2OQ=
 github.com/microsoft/kiota-serialization-text-go v0.6.0/go.mod h1:OUA4dNH+f6afiJUs+rQAatJos7QVF5PJkyrqoD89lx4=
-github.com/microsoftgraph/msgraph-beta-sdk-go v0.51.0 h1:iTlmUmBQKEacrXFmaFGOuPz1jTyfAM2LZ1AdxFCUwnk=
-github.com/microsoftgraph/msgraph-beta-sdk-go v0.51.0/go.mod h1:5a4lNmlchvt/kYXWRXxfMie4IFICZglWDuRp3VQ8CPg=
 github.com/microsoftgraph/msgraph-sdk-go v0.50.0 h1:yfPBDr7+tSdq8jKiNCvY5XzQji1kZzOHXvxQ9XxQ4E4=
 github.com/microsoftgraph/msgraph-sdk-go v0.50.0/go.mod h1:XoTT9lzRSersVV4/lsFup3sOLfOLEf2dMsLckiAAKq8=
 github.com/microsoftgraph/msgraph-sdk-go-core v0.31.1 h1:aVvnO5l8qLCEcvELc5n9grt7UXhAVtpog1QeQKLMlTE=

--- a/src/internal/connector/sharepoint/site_page.go
+++ b/src/internal/connector/sharepoint/site_page.go
@@ -1,0 +1,187 @@
+package sharepoint
+
+import (
+	kioser "github.com/microsoft/kiota-abstractions-go/serialization"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+)
+
+// SitePage provides operations to manage the minimal creation of a Site Page.
+// Altered from original: github.com/microsoftgraph/msgraph-beta-sdk-go/models
+// TODO:  remove when Issue #2086 resolved
+type SitePage struct {
+	models.BaseItem
+	// Indicates the layout of the content in a given SharePoint page, including horizontal sections and vertical section
+	// canvasLayout models.CanvasLayoutable
+	// Inherited from baseItem.
+	contentType models.ContentTypeInfoable
+	// The name of the page layout of the page.
+	// The possible values are: microsoftReserved, article, home, unknownFutureValue.
+	// pageLayout *models.PageLayoutType
+	// Indicates the promotion kind of the sitePage. The possible values are:
+	// microsoftReserved, page, newsPost, unknownFutureValue.
+	// promotionKind *models.PagePromotionType
+	// The publishing status and the MM.mm version of the page.
+	publishingState models.PublicationFacetable
+	// Reactions information for the page.
+	// reactions models.ReactionsFacetable
+	// Determines whether or not to show comments at the bottom of the page.
+	showComments *bool
+	// Determines whether or not to show recommended pages at the bottom of the page.
+	showRecommendedPages *bool
+	// Url of the sitePage's thumbnail image
+	//revive:disable:var-naming
+	thumbnailWebUrl *string
+	//revive:enable:var-naming
+	// Title of the sitePage.
+	title *string
+}
+
+// Title area on the SharePoint page.
+// titleArea models.TitleAreaable
+// Collection of webparts on the SharePoint page
+// webParts []models.WebPartable
+
+var _ SitePageable = &SitePage{}
+
+// NewSitePage instantiates a new sitePage and sets the default values.
+func NewSitePage() *SitePage {
+	m := &SitePage{
+		BaseItem: *models.NewBaseItem(),
+	}
+	odataTypeValue := "#microsoft.graph.sitePage"
+	m.SetOdataType(&odataTypeValue)
+
+	return m
+}
+
+// CreateSitePageFromDiscriminatorValue creates a new instance of the appropriate class based on discriminator value
+func CreateSitePageFromDiscriminatorValue(parseNode kioser.ParseNode) (kioser.Parsable, error) {
+	return NewSitePage(), nil
+}
+
+// GetContentType gets the contentType property value. Inherited from baseItem.
+func (m *SitePage) GetContentType() models.ContentTypeInfoable {
+	return m.contentType
+}
+
+// GetFieldDeserializers the deserialization information for the current model
+// Altered from original.
+func (m *SitePage) GetFieldDeserializers() map[string]func(kioser.ParseNode) error {
+	res := m.BaseItem.GetFieldDeserializers()
+
+	return res
+}
+
+// GetPublishingState gets the publishingState property value. The publishing status and the MM.mm version of the page.
+func (m *SitePage) GetPublishingState() models.PublicationFacetable {
+	return m.publishingState
+}
+
+// GetShowComments gets the showComments property value.
+// Determines whether or not to show comments at the bottom of the page.
+func (m *SitePage) GetShowComments() *bool {
+	return m.showComments
+}
+
+// GetShowRecommendedPages gets the showRecommendedPages property value.
+// Determines whether or not to show recommended pages at the bottom of the page.
+func (m *SitePage) GetShowRecommendedPages() *bool {
+	return m.showRecommendedPages
+}
+
+// GetThumbnailWebUrl gets the thumbnailWebUrl property value. Url of the sitePage's thumbnail image
+//
+//revive:disable:var-naming
+func (m *SitePage) GetThumbnailWebUrl() *string {
+	return m.thumbnailWebUrl
+}
+
+// GetTitle gets the title property value. Title of the sitePage.
+func (m *SitePage) GetTitle() *string {
+	return m.title
+}
+
+// Serialize serializes information the current object
+func (m *SitePage) Serialize(writer kioser.SerializationWriter) error {
+	err := m.BaseItem.Serialize(writer)
+	if err != nil {
+		return err
+	}
+
+	if m.GetContentType() != nil {
+		err = writer.WriteObjectValue("contentType", m.GetContentType())
+		if err != nil {
+			return err
+		}
+	}
+
+	if m.GetPublishingState() != nil {
+		err = writer.WriteObjectValue("publishingState", m.GetPublishingState())
+		if err != nil {
+			return err
+		}
+	}
+	{
+		err = writer.WriteBoolValue("showComments", m.GetShowComments())
+		if err != nil {
+			return err
+		}
+	}
+	{
+		err = writer.WriteBoolValue("showRecommendedPages", m.GetShowRecommendedPages())
+		if err != nil {
+			return err
+		}
+	}
+	{
+		err = writer.WriteStringValue("thumbnailWebUrl", m.GetThumbnailWebUrl())
+		if err != nil {
+			return err
+		}
+	}
+	{
+		err = writer.WriteStringValue("title", m.GetTitle())
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// SetContentType sets the contentType property value. Inherited from baseItem.
+func (m *SitePage) SetContentType(value models.ContentTypeInfoable) {
+	m.contentType = value
+}
+
+// SetPublishingState sets the publishingState property value. The publishing status and the MM.mm version of the page.
+func (m *SitePage) SetPublishingState(value models.PublicationFacetable) {
+	m.publishingState = value
+}
+
+// SetShowComments sets the showComments property value.
+// Determines whether or not to show comments at the bottom of the page.
+func (m *SitePage) SetShowComments(value *bool) {
+	m.showComments = value
+}
+
+// SetShowRecommendedPages sets the showRecommendedPages property value.
+// Determines whether or not to show recommended pages at the bottom of the page.
+func (m *SitePage) SetShowRecommendedPages(value *bool) {
+	m.showRecommendedPages = value
+}
+
+// SetThumbnailWebUrl sets the thumbnailWebUrl property value.
+// Url of the sitePage's thumbnail image
+//
+//revive:disable:var-naming
+func (m *SitePage) SetThumbnailWebUrl(value *string) {
+	m.thumbnailWebUrl = value
+}
+
+//revive:enable:var-naming
+
+// SetTitle sets the title property value. Title of the sitePage.
+func (m *SitePage) SetTitle(value *string) {
+	m.title = value
+}

--- a/src/internal/connector/sharepoint/site_pageable.go
+++ b/src/internal/connector/sharepoint/site_pageable.go
@@ -1,0 +1,24 @@
+package sharepoint
+
+import (
+	kioser "github.com/microsoft/kiota-abstractions-go/serialization"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+)
+
+// SitePageable adjusted from msgraph-beta-sdk-go for temporary testing
+type SitePageable interface {
+	models.BaseItemable
+	kioser.Parsable
+	GetContentType() models.ContentTypeInfoable
+	GetPublishingState() models.PublicationFacetable
+	GetShowComments() *bool
+	GetShowRecommendedPages() *bool
+	GetThumbnailWebUrl() *string
+	GetTitle() *string
+	SetContentType(value models.ContentTypeInfoable)
+	SetPublishingState(value models.PublicationFacetable)
+	SetShowComments(value *bool)
+	SetShowRecommendedPages(value *bool)
+	SetThumbnailWebUrl(value *string)
+	SetTitle(value *string)
+}


### PR DESCRIPTION
## Description
Imports minimal version of `site_page.go` and `site_pageable.go` to avoid compile time failures for `msgraph-beta-sdk-go`.  
<!-- Insert PR description-->
Fields that required additional `Data Types` from the `Beta` packages are commented out in `site_page.go`
## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
*related to  #2086<issue>

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
Should fix compile time errors for the package. 
