### PR TITLE
Fix unit tests that fail when not running with env vars

### DIFF
--- a/src/internal/connector/exchange/service_iterators_test.go
+++ b/src/internal/connector/exchange/service_iterators_test.go
@@ -95,7 +95,7 @@ func TestServiceIteratorsSuite(t *testing.T) {
 }
 
 func (suite *ServiceIteratorsSuite) SetupSuite() {
-	a := tester.NewM365Account(suite.T())
+	a := tester.NewMockM365Account(suite.T())
 	m365, err := a.M365Config()
 	require.NoError(suite.T(), err)
 	suite.creds = m365
@@ -343,7 +343,7 @@ func (suite *ServiceIteratorsSuite) TestFilterContainersAndFillCollections() {
 func (suite *ServiceIteratorsSuite) TestFilterContainersAndFillCollections_incrementals() {
 	var (
 		userID   = "user_id"
-		tenantID = tester.M365TenantID(suite.T())
+		tenantID = suite.creds.AzureTenantID
 		cat      = path.EmailCategory // doesn't matter which one we use,
 		qp       = graph.QueryParams{
 			Category:      cat,

--- a/src/internal/connector/graph/service_test.go
+++ b/src/internal/connector/graph/service_test.go
@@ -24,7 +24,7 @@ func TestGraphUnitSuite(t *testing.T) {
 
 func (suite *GraphUnitSuite) SetupSuite() {
 	t := suite.T()
-	a := tester.NewM365Account(t)
+	a := tester.NewMockM365Account(t)
 	m365, err := a.M365Config()
 	require.NoError(t, err)
 

--- a/src/internal/connector/graph_connector_disconnected_test.go
+++ b/src/internal/connector/graph_connector_disconnected_test.go
@@ -167,30 +167,6 @@ func (suite *DisconnectedGraphConnectorSuite) TestGraphConnector_ErrorChecking()
 	}
 }
 
-func (suite *DisconnectedGraphConnectorSuite) TestRestoreFailsBadService() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
-	var (
-		t    = suite.T()
-		acct = tester.NewM365Account(t)
-		dest = tester.DefaultTestRestoreDestination()
-		gc   = GraphConnector{wg: &sync.WaitGroup{}}
-		sel  = selectors.Selector{
-			Service: selectors.ServiceUnknown,
-		}
-	)
-
-	deets, err := gc.RestoreDataCollections(ctx, acct, sel, dest, nil)
-	assert.Error(t, err)
-	assert.NotNil(t, deets)
-
-	status := gc.AwaitStatus()
-	assert.Equal(t, 0, status.ObjectCount)
-	assert.Equal(t, 0, status.FolderCount)
-	assert.Equal(t, 0, status.Successful)
-}
-
 func (suite *DisconnectedGraphConnectorSuite) TestVerifyBackupInputs() {
 	users := []string{
 		"elliotReid@someHospital.org",

--- a/src/internal/connector/graph_connector_test.go
+++ b/src/internal/connector/graph_connector_test.go
@@ -212,6 +212,29 @@ func (suite *GraphConnectorIntegrationSuite) TestSetTenantSites() {
 	}
 }
 
+func (suite *GraphConnectorIntegrationSuite) TestRestoreFailsBadService() {
+	ctx, flush := tester.NewContext()
+	defer flush()
+
+	var (
+		t    = suite.T()
+		acct = tester.NewM365Account(t)
+		dest = tester.DefaultTestRestoreDestination()
+		sel  = selectors.Selector{
+			Service: selectors.ServiceUnknown,
+		}
+	)
+
+	deets, err := suite.connector.RestoreDataCollections(ctx, acct, sel, dest, nil)
+	assert.Error(t, err)
+	assert.NotNil(t, deets)
+
+	status := suite.connector.AwaitStatus()
+	assert.Equal(t, 0, status.ObjectCount)
+	assert.Equal(t, 0, status.FolderCount)
+	assert.Equal(t, 0, status.Successful)
+}
+
 func (suite *GraphConnectorIntegrationSuite) TestEmptyCollections() {
 	dest := tester.DefaultTestRestoreDestination()
 	table := []struct {

--- a/src/internal/connector/sharepoint/collection_test.go
+++ b/src/internal/connector/sharepoint/collection_test.go
@@ -25,6 +25,12 @@ type SharePointCollectionSuite struct {
 }
 
 func TestSharePointCollectionSuite(t *testing.T) {
+	tester.RunOnAny(
+		t,
+		tester.CorsoCITests,
+		tester.CorsoGraphConnectorTests,
+		tester.CorsoGraphConnectorSharePointTests)
+
 	suite.Run(t, new(SharePointCollectionSuite))
 }
 

--- a/src/internal/tester/account.go
+++ b/src/internal/tester/account.go
@@ -31,3 +31,19 @@ func NewM365Account(t *testing.T) account.Account {
 
 	return acc
 }
+
+func NewMockM365Account(t *testing.T) account.Account {
+	acc, err := account.NewAccount(
+		account.ProviderM365,
+		account.M365Config{
+			M365: credentials.M365{
+				AzureClientID:     "12345",
+				AzureClientSecret: "abcde",
+			},
+			AzureTenantID: "09876",
+		},
+	)
+	require.NoError(t, err, "initializing mock account")
+
+	return acc
+}


### PR DESCRIPTION
## Description

Refactoring and new code additions have led to some unit tests that fail unless testing is run with the proper env vars. Fixup code to either skip those tests or provide them with the proper information so they pass

* some tests moved from unit tests to integration tests
* function to get credentials with bogus info for unit tests
* skip some tests if env vars not passed

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

## Issue(s)

* closes #2052 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
