### PR TITLE
Dedupe collection items for OneDrive

### DIFF
--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -49,7 +49,7 @@ type Collection struct {
 	// represents
 	folderPath path.Path
 	// M365 IDs of file items within this collection
-	driveItems []models.DriveItemable
+	driveItems map[string]models.DriveItemable
 	// M365 ID of the drive this collection was created from
 	driveID       string
 	source        driveSource
@@ -79,6 +79,7 @@ func NewCollection(
 ) *Collection {
 	c := &Collection{
 		folderPath:    folderPath,
+		driveItems:    map[string]models.DriveItemable{},
 		driveID:       driveID,
 		source:        source,
 		service:       service,
@@ -101,7 +102,7 @@ func NewCollection(
 // Adds an itemID to the collection
 // This will make it eligible to be populated
 func (oc *Collection) Add(item models.DriveItemable) {
-	oc.driveItems = append(oc.driveItems, item)
+	oc.driveItems[*item.GetId()] = item
 }
 
 // Items() returns the channel containing M365 Exchange objects


### PR DESCRIPTION
## Description

Under some circumstances items can be returned multiple times when iterating through the endpoint. This dedupes items within a single collection.

It does not address the following:
* item being removed from the collection during iteration
* item appearing multiple times in different collections

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

## Issue(s)

* #1954 

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
