### PR TITLE
Don't set updated in backup details for cached items

### DIFF
--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -241,16 +241,20 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 		name                  string
 		expectedUploadedFiles int
 		expectedCachedFiles   int
+		// Whether entries in the resulting details should be marked as updated.
+		deetsUpdated bool
 	}{
 		{
 			name:                  "Uncached",
 			expectedUploadedFiles: 47,
 			expectedCachedFiles:   0,
+			deetsUpdated:          true,
 		},
 		{
 			name:                  "Cached",
 			expectedUploadedFiles: 0,
 			expectedCachedFiles:   47,
+			deetsUpdated:          false,
 		},
 	}
 
@@ -274,12 +278,18 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 			assert.Equal(t, 0, stats.IgnoredErrorCount)
 			assert.Equal(t, 0, stats.ErrorCount)
 			assert.False(t, stats.Incomplete)
+
 			// 47 file and 6 folder entries.
+			details := deets.Details().Entries
 			assert.Len(
 				t,
-				deets.Details().Entries,
+				details,
 				test.expectedUploadedFiles+test.expectedCachedFiles+6,
 			)
+
+			for _, entry := range details {
+				assert.Equal(t, test.deetsUpdated, entry.Updated)
+			}
 
 			checkSnapshotTags(
 				t,


### PR DESCRIPTION
## Description

If an item is discovered to be cached in kopia (i.e. kopia-assisted incremental), set the backup details for the item to note that it was not updated.

Cached items are discovered by checking the item path and mod time against the snapshots passed into kopia's Upload function

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

* closes #2115 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
