### PR TITLE
Disable kopia incrementals for OneDrive

### DIFF
--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -35,10 +35,10 @@ const (
 )
 
 var (
-	_ data.Collection    = &Collection{}
-	_ data.Stream        = &Item{}
-	_ data.StreamInfo    = &Item{}
-	_ data.StreamModTime = &Item{}
+	_ data.Collection = &Collection{}
+	_ data.Stream     = &Item{}
+	_ data.StreamInfo = &Item{}
+	// _ data.StreamModTime = &Item{}
 )
 
 // Collection represents a set of OneDrive objects retrieved from M365
@@ -158,9 +158,9 @@ func (od *Item) Info() details.ItemInfo {
 	return od.info
 }
 
-func (od *Item) ModTime() time.Time {
-	return od.info.Modified()
-}
+// func (od *Item) ModTime() time.Time {
+// 	return od.info.Modified()
+// }
 
 // populateItems iterates through items added to the collection
 // and uses the collection `itemReader` to read the item

--- a/src/internal/connector/onedrive/collection_test.go
+++ b/src/internal/connector/onedrive/collection_test.go
@@ -179,9 +179,9 @@ func (suite *CollectionUnitTestSuite) TestCollection() {
 
 			assert.Equal(t, testItemName, readItem.UUID())
 
-			require.Implements(t, (*data.StreamModTime)(nil), readItem)
-			mt := readItem.(data.StreamModTime)
-			assert.Equal(t, now, mt.ModTime())
+			// require.Implements(t, (*data.StreamModTime)(nil), readItem)
+			// mt := readItem.(data.StreamModTime)
+			// assert.Equal(t, now, mt.ModTime())
 
 			readData, err := io.ReadAll(readItem.ToReader())
 			require.NoError(t, err)

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -237,7 +237,6 @@ func restoreItem(
 	}
 
 	iReader := itemData.ToReader()
-	fmt.Println("File size is ", ss.Size())
 	progReader, closer := observe.ItemProgress(iReader, observe.ItemRestoreMsg, itemName, ss.Size())
 
 	go closer()

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -2,6 +2,7 @@ package onedrive
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"runtime/trace"
 
@@ -236,6 +237,7 @@ func restoreItem(
 	}
 
 	iReader := itemData.ToReader()
+	fmt.Println("File size is ", ss.Size())
 	progReader, closer := observe.ItemProgress(iReader, observe.ItemRestoreMsg, itemName, ss.Size())
 
 	go closer()

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -2,7 +2,6 @@ package onedrive
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"runtime/trace"
 


### PR DESCRIPTION
## Description

Kopia-assisted incremental backups do not appear to have the correct file size set on restore

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
