### PR TITLE
Fix ci test cleanup script

### DIFF
--- a/.github/workflows/ci_test_cleanup.yml
+++ b/.github/workflows/ci_test_cleanup.yml
@@ -16,8 +16,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.19'
 
-      # sets the maximimum time to now-30m.
+      # sets the maximum time to now-30m.
       # CI test have a 10 minute timeout.
       # At 20 minutes ago, we should be safe from conflicts.
       # The additional 10 minutes is just to be good citizens.


### PR DESCRIPTION
## Description

Purge script needs go 1.19 and ubuntu latest contains 1.18 as of now.
Here is a sample run failing because of this: https://github.com/alcionai/corso/actions/runs/3909006130/jobs/6679661266

<!-- Insert PR description-->

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
