### PR TITLE
Switch to "delete wins" merge strategy for Exchange IDs

### DIFF
--- a/src/internal/connector/exchange/api/api.go
+++ b/src/internal/connector/exchange/api/api.go
@@ -24,15 +24,6 @@ type DeltaUpdate struct {
 	Reset bool
 }
 
-// DeltaResult contains the ID and whether the item referenced by the ID was
-// deleted. This allows functions that fetch items for a folder to return a
-// single consolidated stream which is easier to dedupe as the order between
-// add/update and delete operations is known.
-type DeltaResult struct {
-	ID      string
-	Deleted bool
-}
-
 // GraphQuery represents functions which perform exchange-specific queries
 // into M365 backstore. Responses -> returned items will only contain the information
 // that is included in the options

--- a/src/internal/connector/exchange/api/contacts.go
+++ b/src/internal/connector/exchange/api/contacts.go
@@ -179,10 +179,10 @@ func (p *contactPager) valuesIn(pl pageLinker) ([]getIDAndAddtler, error) {
 func (c Contacts) GetAddedAndRemovedItemIDs(
 	ctx context.Context,
 	user, directoryID, oldDelta string,
-) ([]DeltaResult, DeltaUpdate, error) {
+) ([]string, []string, DeltaUpdate, error) {
 	service, err := c.service()
 	if err != nil {
-		return nil, DeltaUpdate{}, err
+		return nil, nil, DeltaUpdate{}, err
 	}
 
 	var (
@@ -192,22 +192,22 @@ func (c Contacts) GetAddedAndRemovedItemIDs(
 
 	options, err := optionsForContactFoldersItemDelta([]string{"parentFolderId"})
 	if err != nil {
-		return nil, DeltaUpdate{}, errors.Wrap(err, "getting query options")
+		return nil, nil, DeltaUpdate{}, errors.Wrap(err, "getting query options")
 	}
 
 	if len(oldDelta) > 0 {
 		builder := users.NewItemContactFoldersItemContactsDeltaRequestBuilder(oldDelta, service.Adapter())
 		pgr := &contactPager{service, builder, options}
 
-		items, deltaURL, err := getItemsAddedAndRemovedFromContainer(ctx, pgr)
+		added, removed, deltaURL, err := getItemsAddedAndRemovedFromContainer(ctx, pgr)
 		// note: happy path, not the error condition
 		if err == nil {
-			return items, DeltaUpdate{deltaURL, false}, errs.ErrorOrNil()
+			return added, removed, DeltaUpdate{deltaURL, false}, errs.ErrorOrNil()
 		}
 		// only return on error if it is NOT a delta issue.
 		// on bad deltas we retry the call with the regular builder
 		if graph.IsErrInvalidDelta(err) == nil {
-			return nil, DeltaUpdate{}, err
+			return nil, nil, DeltaUpdate{}, err
 		}
 
 		resetDelta = true
@@ -217,10 +217,10 @@ func (c Contacts) GetAddedAndRemovedItemIDs(
 	builder := service.Client().UsersById(user).ContactFoldersById(directoryID).Contacts().Delta()
 	pgr := &contactPager{service, builder, options}
 
-	items, deltaURL, err := getItemsAddedAndRemovedFromContainer(ctx, pgr)
+	added, removed, deltaURL, err := getItemsAddedAndRemovedFromContainer(ctx, pgr)
 	if err != nil {
-		return nil, DeltaUpdate{}, err
+		return nil, nil, DeltaUpdate{}, err
 	}
 
-	return items, DeltaUpdate{deltaURL, resetDelta}, errs.ErrorOrNil()
+	return added, removed, DeltaUpdate{deltaURL, resetDelta}, errs.ErrorOrNil()
 }

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -165,29 +165,29 @@ func (p *eventPager) valuesIn(pl pageLinker) ([]getIDAndAddtler, error) {
 func (c Events) GetAddedAndRemovedItemIDs(
 	ctx context.Context,
 	user, calendarID, oldDelta string,
-) ([]DeltaResult, DeltaUpdate, error) {
+) ([]string, []string, DeltaUpdate, error) {
 	service, err := c.service()
 	if err != nil {
-		return nil, DeltaUpdate{}, err
+		return nil, nil, DeltaUpdate{}, err
 	}
 
 	var errs *multierror.Error
 
 	options, err := optionsForEventsByCalendar([]string{"id"})
 	if err != nil {
-		return nil, DeltaUpdate{}, err
+		return nil, nil, DeltaUpdate{}, err
 	}
 
 	builder := service.Client().UsersById(user).CalendarsById(calendarID).Events()
 	pgr := &eventPager{service, builder, options}
 
-	items, _, err := getItemsAddedAndRemovedFromContainer(ctx, pgr)
+	added, _, _, err := getItemsAddedAndRemovedFromContainer(ctx, pgr)
 	if err != nil {
-		return nil, DeltaUpdate{}, err
+		return nil, nil, DeltaUpdate{}, err
 	}
 
 	// Events don't have a delta endpoint so just return an empty string.
-	return items, DeltaUpdate{}, errs.ErrorOrNil()
+	return added, nil, DeltaUpdate{}, errs.ErrorOrNil()
 }
 
 // ---------------------------------------------------------------------------

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -19,7 +19,7 @@ type addedAndRemovedItemIDsGetter interface {
 	GetAddedAndRemovedItemIDs(
 		ctx context.Context,
 		user, containerID, oldDeltaToken string,
-	) ([]api.DeltaResult, api.DeltaUpdate, error)
+	) ([]string, []string, api.DeltaUpdate, error)
 }
 
 // filterContainersAndFillCollections is a utility function
@@ -93,7 +93,7 @@ func filterContainersAndFillCollections(
 			}
 		}
 
-		items, newDelta, err := getter.GetAddedAndRemovedItemIDs(ctx, qp.ResourceOwner, cID, prevDelta)
+		added, removed, newDelta, err := getter.GetAddedAndRemovedItemIDs(ctx, qp.ResourceOwner, cID, prevDelta)
 		if err != nil {
 			// note == nil check; only catches non-inFlight error cases.
 			if graph.IsErrDeletedInFlight(err) == nil {
@@ -125,22 +125,8 @@ func filterContainersAndFillCollections(
 			newDelta.Reset)
 
 		collections[cID] = &edc
-
-		// This results in "last one wins" if there's duplicate entries for an ID
-		// and some are deleted while some are added.
-		for _, i := range items {
-			m := edc.added
-			del := edc.removed
-
-			if i.Deleted {
-				m = edc.removed
-				del = edc.added
-			}
-
-			m[i.ID] = struct{}{}
-
-			delete(del, i.ID)
-		}
+		edc.added = append(edc.added, added...)
+		edc.removed = append(edc.removed, removed...)
 
 		// add the current path for the container ID to be used in the next backup
 		// as the "previous path", for reference in case of a rename or relocation.

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -125,8 +125,18 @@ func filterContainersAndFillCollections(
 			newDelta.Reset)
 
 		collections[cID] = &edc
-		edc.added = append(edc.added, added...)
-		edc.removed = append(edc.removed, removed...)
+
+		for _, add := range added {
+			edc.added[add] = struct{}{}
+		}
+
+		// Remove any deleted IDs from the set of added IDs because items that are
+		// deleted and then restored will have a different ID than they did
+		// originally.
+		for _, remove := range removed {
+			delete(edc.added, remove)
+			edc.removed[remove] = struct{}{}
+		}
 
 		// add the current path for the container ID to be used in the next backup
 		// as the "previous path", for reference in case of a rename or relocation.

--- a/src/internal/connector/exchange/service_iterators_test.go
+++ b/src/internal/connector/exchange/service_iterators_test.go
@@ -391,7 +391,7 @@ func (suite *ServiceIteratorsSuite) TestFilterContainersAndFillCollections_repea
 			},
 		},
 		{
-			name: "remove wins",
+			name: "remove for same item wins",
 			getter: map[string]mockGetterResults{
 				"1": {
 					added:    []string{"i1", "a2", "a3"},

--- a/src/internal/connector/exchange/service_iterators_test.go
+++ b/src/internal/connector/exchange/service_iterators_test.go
@@ -333,131 +333,105 @@ func (suite *ServiceIteratorsSuite) TestFilterContainersAndFillCollections() {
 				exColl, ok := coll.(*Collection)
 				require.True(t, ok, "collection is an *exchange.Collection")
 
-				assert.ElementsMatch(t, expect.added, exColl.added, "added items")
-				assert.ElementsMatch(t, expect.removed, exColl.removed, "removed items")
+				ids := [][]string{
+					make([]string, 0, len(exColl.added)),
+					make([]string, 0, len(exColl.removed)),
+				}
+
+				for i, cIDs := range []map[string]struct{}{exColl.added, exColl.removed} {
+					for id := range cIDs {
+						ids[i] = append(ids[i], id)
+					}
+				}
+
+				assert.ElementsMatch(t, expect.added, ids[0], "added items")
+				assert.ElementsMatch(t, expect.removed, ids[1], "removed items")
 			}
 		})
 	}
 }
 
 func (suite *ServiceIteratorsSuite) TestFilterContainersAndFillCollections_repeatedItems() {
-	var (
-		userID = "user_id"
-		qp     = graph.QueryParams{
-			Category:      path.EmailCategory, // doesn't matter which one we use.
-			ResourceOwner: userID,
-			Credentials:   suite.creds,
-		}
-		statusUpdater = func(*support.ConnectorOperationStatus) {}
-		allScope      = selectors.NewExchangeBackup(nil).MailFolders(selectors.Any())[0]
-		dps           = DeltaPaths{} // incrementals are tested separately
-		delta         = api.DeltaUpdate{URL: "delta_url"}
-		container1    = mockContainer{
-			id:          strPtr("1"),
-			displayName: strPtr("display_name_1"),
-			p:           path.Builder{}.Append("display_name_1"),
-		}
-	)
+	newDelta := api.DeltaUpdate{URL: "delta_url"}
 
 	table := []struct {
-		name                string
-		getter              mockGetter
-		resolver            graph.ContainerResolver
-		scope               selectors.ExchangeScope
-		failFast            bool
-		expectErr           assert.ErrorAssertionFunc
-		expectNewColls      int
-		expectMetadataColls int
-		expectAdded         map[string]struct{}
-		expectRemoved       map[string]struct{}
+		name          string
+		getter        mockGetter
+		expectAdded   map[string]struct{}
+		expectRemoved map[string]struct{}
 	}{
 		{
-			name: "repeated add",
+			name: "repeated adds",
 			getter: map[string]mockGetterResults{
 				"1": {
-					items: []api.DeltaResult{
-						{ID: "a1"},
-						{ID: "a1"},
-					},
-					newDelta: delta,
+					added:    []string{"a1", "a2", "a3", "a1"},
+					newDelta: newDelta,
 				},
 			},
-			resolver:            newMockResolver(container1),
-			scope:               allScope,
-			expectErr:           assert.NoError,
-			expectNewColls:      1,
-			expectMetadataColls: 1,
-			expectAdded:         map[string]struct{}{"a1": {}},
-			// Avoid failures for nil map.
+			expectAdded: map[string]struct{}{
+				"a1": {},
+				"a2": {},
+				"a3": {},
+			},
 			expectRemoved: map[string]struct{}{},
 		},
 		{
-			name: "repeated remove",
+			name: "repeated removes",
 			getter: map[string]mockGetterResults{
 				"1": {
-					items: []api.DeltaResult{
-						{ID: "a1", Deleted: true},
-						{ID: "a1", Deleted: true},
-					},
-					newDelta: delta,
+					removed:  []string{"r1", "r2", "r3", "r1"},
+					newDelta: newDelta,
 				},
 			},
-			resolver:            newMockResolver(container1),
-			scope:               allScope,
-			expectErr:           assert.NoError,
-			expectNewColls:      1,
-			expectMetadataColls: 1,
-			expectAdded:         map[string]struct{}{},
-			expectRemoved:       map[string]struct{}{"a1": {}},
+			expectAdded: map[string]struct{}{},
+			expectRemoved: map[string]struct{}{
+				"r1": {},
+				"r2": {},
+				"r3": {},
+			},
 		},
 		{
-			name: "interleaved, final remove",
+			name: "remove wins",
 			getter: map[string]mockGetterResults{
 				"1": {
-					items: []api.DeltaResult{
-						{ID: "a1"},
-						{ID: "a1", Deleted: true},
-						{ID: "a1"},
-						{ID: "a1", Deleted: true},
-					},
-					newDelta: delta,
+					added:    []string{"i1", "a2", "a3"},
+					removed:  []string{"i1", "r2", "r3"},
+					newDelta: newDelta,
 				},
 			},
-			resolver:            newMockResolver(container1),
-			scope:               allScope,
-			expectErr:           assert.NoError,
-			expectNewColls:      1,
-			expectMetadataColls: 1,
-			expectAdded:         map[string]struct{}{},
-			expectRemoved:       map[string]struct{}{"a1": {}},
-		},
-		{
-			name: "interleaved, final add",
-			getter: map[string]mockGetterResults{
-				"1": {
-					items: []api.DeltaResult{
-						{ID: "a1"},
-						{ID: "a1", Deleted: true},
-						{ID: "a1"},
-						{ID: "a1", Deleted: true},
-						{ID: "a1"},
-					},
-					newDelta: delta,
-				},
+			expectAdded: map[string]struct{}{
+				"a2": {},
+				"a3": {},
 			},
-			resolver:            newMockResolver(container1),
-			scope:               allScope,
-			expectErr:           assert.NoError,
-			expectNewColls:      1,
-			expectMetadataColls: 1,
-			expectAdded:         map[string]struct{}{"a1": {}},
-			expectRemoved:       map[string]struct{}{},
+			expectRemoved: map[string]struct{}{
+				"i1": {},
+				"r2": {},
+				"r3": {},
+			},
 		},
 	}
 	for _, test := range table {
 		suite.T().Run(test.name, func(t *testing.T) {
 			ctx, flush := tester.NewContext()
 			defer flush()
+
+			var (
+				userID = "user_id"
+				qp     = graph.QueryParams{
+					Category:      path.EmailCategory, // doesn't matter which one we use.
+					ResourceOwner: userID,
+					Credentials:   suite.creds,
+				}
+				statusUpdater = func(*support.ConnectorOperationStatus) {}
+				allScope      = selectors.NewExchangeBackup(nil).MailFolders(selectors.Any())[0]
+				dps           = DeltaPaths{} // incrementals are tested separately
+				container1    = mockContainer{
+					id:          strPtr("1"),
+					displayName: strPtr("display_name_1"),
+					p:           path.Builder{}.Append("display_name_1"),
+				}
+				resolver = newMockResolver(container1)
+			)
 
 			collections := map[string]data.Collection{}
 
@@ -467,12 +441,12 @@ func (suite *ServiceIteratorsSuite) TestFilterContainersAndFillCollections_repea
 				test.getter,
 				collections,
 				statusUpdater,
-				test.resolver,
-				test.scope,
+				resolver,
+				allScope,
 				dps,
-				control.Options{FailFast: test.failFast},
+				control.Options{FailFast: true},
 			)
-			test.expectErr(t, err)
+			require.NoError(t, err)
 
 			// collection assertions
 
@@ -494,17 +468,26 @@ func (suite *ServiceIteratorsSuite) TestFilterContainersAndFillCollections_repea
 				if c.DoNotMergeItems() {
 					doNotMerges++
 				}
-
-				exColl, ok := c.(*Collection)
-				require.True(t, ok, "collection is an *exchange.Collection")
-
-				assert.Equal(t, test.expectAdded, exColl.added)
-				assert.Equal(t, test.expectRemoved, exColl.removed)
 			}
 
 			assert.Zero(t, deleteds, "deleted collections")
-			assert.Equal(t, test.expectMetadataColls, metadatas, "metadata collections")
-			assert.Equal(t, test.expectNewColls, news, "new collections")
+			assert.Equal(t, 1, news, "new collections")
+			assert.Equal(t, 1, metadatas, "metadata collections")
+			assert.Zero(t, doNotMerges, "doNotMerge collections")
+
+			// items in collections assertions
+			for k := range test.getter {
+				coll := collections[k]
+				if !assert.NotNilf(t, coll, "missing collection for path %s", k) {
+					continue
+				}
+
+				exColl, ok := coll.(*Collection)
+				require.True(t, ok, "collection is an *exchange.Collection")
+
+				assert.Equal(t, test.expectAdded, exColl.added, "added items")
+				assert.Equal(t, test.expectRemoved, exColl.removed, "removed items")
+			}
 		})
 	}
 }

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -941,35 +941,19 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchangeIncrementals() {
 
 					switch category {
 					case path.EmailCategory:
-						ids, _, err := ac.Mail().GetAddedAndRemovedItemIDs(ctx, suite.user, containerID, "")
+						ids, _, _, err := ac.Mail().GetAddedAndRemovedItemIDs(ctx, suite.user, containerID, "")
 						require.NoError(t, err, "getting message ids")
 						require.NotEmpty(t, ids, "message ids in folder")
 
-						var idx int
-
-						for _, item := range ids {
-							if item.Deleted {
-								idx++
-							}
-						}
-
-						err = cli.MessagesById(ids[idx].ID).Delete(ctx, nil)
+						err = cli.MessagesById(ids[0]).Delete(ctx, nil)
 						require.NoError(t, err, "deleting email item: %s", support.ConnectorStackErrorTrace(err))
 
 					case path.ContactsCategory:
-						ids, _, err := ac.Contacts().GetAddedAndRemovedItemIDs(ctx, suite.user, containerID, "")
+						ids, _, _, err := ac.Contacts().GetAddedAndRemovedItemIDs(ctx, suite.user, containerID, "")
 						require.NoError(t, err, "getting contact ids")
 						require.NotEmpty(t, ids, "contact ids in folder")
 
-						var idx int
-
-						for _, item := range ids {
-							if item.Deleted {
-								idx++
-							}
-						}
-
-						err = cli.ContactsById(ids[idx].ID).Delete(ctx, nil)
+						err = cli.ContactsById(ids[0]).Delete(ctx, nil)
 						require.NoError(t, err, "deleting contact item: %s", support.ConnectorStackErrorTrace(err))
 					}
 				}


### PR DESCRIPTION
## Description

#2116 implemented a "last change wins" strategy for deduping IDs. However, it appears Graph API doesn't really enforce an ordering for returned items so that strategy may not work. Instead, implement a "delete wins" strategy.

Items that are added, deleted, and then restored in M365 will be restored with a different ID

This PR does the following:
* reverts changes to return a unified list of IDs and added/removed status
* switches to a "delete wins" merge strategy for duplicate IDs
* updates tests

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

* closes #1954 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
