### PR TITLE
use delta queries for calendar events

### DIFF
--- a/src/internal/connector/data_collections_test.go
+++ b/src/internal/connector/data_collections_test.go
@@ -67,7 +67,7 @@ func (suite *ConnectorDataCollectionIntegrationSuite) TestExchangeDataCollection
 		getSelector func(t *testing.T) selectors.Selector
 	}{
 		{
-			name: suite.user + " Email",
+			name: "Email",
 			getSelector: func(t *testing.T) selectors.Selector {
 				sel := selectors.NewExchangeBackup(selUsers)
 				sel.Include(sel.MailFolders([]string{exchange.DefaultMailFolder}, selectors.PrefixMatch()))
@@ -76,7 +76,7 @@ func (suite *ConnectorDataCollectionIntegrationSuite) TestExchangeDataCollection
 			},
 		},
 		{
-			name: suite.user + " Contacts",
+			name: "Contacts",
 			getSelector: func(t *testing.T) selectors.Selector {
 				sel := selectors.NewExchangeBackup(selUsers)
 				sel.Include(sel.ContactFolders([]string{exchange.DefaultContactFolder}, selectors.PrefixMatch()))
@@ -85,7 +85,7 @@ func (suite *ConnectorDataCollectionIntegrationSuite) TestExchangeDataCollection
 			},
 		},
 		// {
-		// 	name: suite.user + " Events",
+		// 	name: "Events",
 		// 	getSelector: func(t *testing.T) selectors.Selector {
 		// 		sel := selectors.NewExchangeBackup(selUsers)
 		// 		sel.Include(sel.EventCalendars([]string{exchange.DefaultCalendar}, selectors.PrefixMatch()))

--- a/src/internal/connector/exchange/api/options.go
+++ b/src/internal/connector/exchange/api/options.go
@@ -214,19 +214,19 @@ func optionsForContactFoldersItemDelta(
 }
 
 // optionsForEvents ensures a valid option inputs for `exchange.Events` when selected from within a Calendar
-func optionsForEventsByCalendar(
+func optionsForEventsByCalendarDelta(
 	moreOps []string,
-) (*users.ItemCalendarsItemEventsRequestBuilderGetRequestConfiguration, error) {
+) (*users.ItemCalendarsItemEventsDeltaRequestBuilderGetRequestConfiguration, error) {
 	selecting, err := buildOptions(moreOps, fieldsForEvents)
 	if err != nil {
 		return nil, err
 	}
 
-	requestParameters := &users.ItemCalendarsItemEventsRequestBuilderGetQueryParameters{
+	requestParameters := &users.ItemCalendarsItemEventsDeltaRequestBuilderGetQueryParameters{
 		Select: selecting,
 	}
 
-	options := &users.ItemCalendarsItemEventsRequestBuilderGetRequestConfiguration{
+	options := &users.ItemCalendarsItemEventsDeltaRequestBuilderGetRequestConfiguration{
 		QueryParameters: requestParameters,
 	}
 

--- a/src/internal/connector/exchange/data_collections_test.go
+++ b/src/internal/connector/exchange/data_collections_test.go
@@ -313,6 +313,13 @@ func (suite *DataCollectionsIntegrationSuite) TestDelta() {
 				selectors.PrefixMatch(),
 			)[0],
 		},
+		{
+			name: "Events",
+			scope: selectors.NewExchangeBackup(users).EventCalendars(
+				[]string{DefaultCalendar},
+				selectors.PrefixMatch(),
+			)[0],
+		},
 	}
 	for _, test := range tests {
 		suite.T().Run(test.name, func(t *testing.T) {

--- a/src/internal/operations/restore_test.go
+++ b/src/internal/operations/restore_test.go
@@ -198,9 +198,9 @@ func (suite *RestoreOpIntegrationSuite) SetupSuite() {
 	require.NotEmpty(t, bo.Results.BackupID)
 
 	suite.backupID = bo.Results.BackupID
-	// Discount metadata files (3 paths, 2 deltas) as
+	// Discount metadata files (3 paths, 3 deltas) as
 	// they are not part of the data restored.
-	suite.numItems = bo.Results.ItemsWritten - 5
+	suite.numItems = bo.Results.ItemsWritten - 6
 }
 
 func (suite *RestoreOpIntegrationSuite) TearDownSuite() {


### PR DESCRIPTION
## Description

Hacks the beta version call into the events api
when iterating through items, allowing us to run
delta-based queries for calendar events.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :sunflower: Feature

## Issue(s)

* #2022

## Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
