### PR TITLE
Check whether the user has an exchange mailbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] (alpha)
 
+### Fixed
+
+- Check if the user specified for an exchange backup operation has a mailbox.
+
 
 ## [v0.1.0] (alpha) - 2023-01-13
 

--- a/src/internal/connector/data_collections.go
+++ b/src/internal/connector/data_collections.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/alcionai/corso/src/internal/connector/discovery"
 	"github.com/alcionai/corso/src/internal/connector/exchange"
+	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/onedrive"
 	"github.com/alcionai/corso/src/internal/connector/sharepoint"
 	"github.com/alcionai/corso/src/internal/connector/support"
@@ -15,12 +17,31 @@ import (
 	D "github.com/alcionai/corso/src/internal/diagnostics"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/logger"
+	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 )
 
 // ---------------------------------------------------------------------------
 // Data Collections
 // ---------------------------------------------------------------------------
+
+func checkServiceEnabled(ctx context.Context, gs graph.Servicer, service path.ServiceType, resource string) (bool, error) {
+	if service == path.SharePointService {
+		// No "enabled" check required for sharepoint
+		return true, nil
+	}
+
+	_, info, err := discovery.User(ctx, gs, resource)
+	if err != nil {
+		return false, err
+	}
+
+	if _, ok := info.DiscoveredServices[service]; !ok {
+		return false, nil
+	}
+
+	return true, nil
+}
 
 // DataCollections utility function to launch backup operations for exchange and
 // onedrive. metadataCols contains any collections with metadata files that may
@@ -41,8 +62,18 @@ func (gc *GraphConnector) DataCollections(
 		return nil, err
 	}
 
+	serviceEnabled, err := checkServiceEnabled(ctx, gc.Service, path.ServiceType(sels.Service), sels.DiscreteOwner)
+	if err != nil {
+		return nil, err
+	}
+
+	if !serviceEnabled {
+		return []data.Collection{}, nil
+	}
+
 	switch sels.Service {
 	case selectors.ServiceExchange:
+
 		colls, err := exchange.DataCollections(
 			ctx,
 			sels,

--- a/src/internal/connector/data_collections.go
+++ b/src/internal/connector/data_collections.go
@@ -25,24 +25,6 @@ import (
 // Data Collections
 // ---------------------------------------------------------------------------
 
-func checkServiceEnabled(ctx context.Context, gs graph.Servicer, service path.ServiceType, resource string) (bool, error) {
-	if service == path.SharePointService {
-		// No "enabled" check required for sharepoint
-		return true, nil
-	}
-
-	_, info, err := discovery.User(ctx, gs, resource)
-	if err != nil {
-		return false, err
-	}
-
-	if _, ok := info.DiscoveredServices[service]; !ok {
-		return false, nil
-	}
-
-	return true, nil
-}
-
 // DataCollections utility function to launch backup operations for exchange and
 // onedrive. metadataCols contains any collections with metadata files that may
 // be useful for the current backup. Metadata can include things like delta
@@ -73,7 +55,6 @@ func (gc *GraphConnector) DataCollections(
 
 	switch sels.Service {
 	case selectors.ServiceExchange:
-
 		colls, err := exchange.DataCollections(
 			ctx,
 			sels,
@@ -153,6 +134,29 @@ func verifyBackupInputs(sels selectors.Selector, userPNs, siteIDs []string) erro
 	}
 
 	return nil
+}
+
+func checkServiceEnabled(
+	ctx context.Context,
+	gs graph.Servicer,
+	service path.ServiceType,
+	resource string,
+) (bool, error) {
+	if service == path.SharePointService {
+		// No "enabled" check required for sharepoint
+		return true, nil
+	}
+
+	_, info, err := discovery.User(ctx, gs, resource)
+	if err != nil {
+		return false, err
+	}
+
+	if _, ok := info.DiscoveredServices[service]; !ok {
+		return false, nil
+	}
+
+	return true, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/src/internal/connector/discovery/discovery.go
+++ b/src/internal/connector/discovery/discovery.go
@@ -70,7 +70,6 @@ type UserInfo struct {
 }
 
 func User(ctx context.Context, gs graph.Servicer, userID string) (models.Userable, *UserInfo, error) {
-
 	user, err := gs.Client().UsersById(userID).Get(ctx, nil)
 	if err != nil {
 		return nil, nil, errors.Wrapf(
@@ -100,6 +99,7 @@ func User(ctx context.Context, gs graph.Servicer, userID string) (models.Userabl
 				support.ConnectorStackErrorTrace(err),
 			)
 		}
+
 		delete(userInfo.DiscoveredServices, path.ExchangeService)
 	}
 

--- a/src/internal/connector/discovery/discovery.go
+++ b/src/internal/connector/discovery/discovery.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/support"
+	"github.com/alcionai/corso/src/pkg/path"
 )
 
 const (
@@ -62,6 +63,49 @@ func Users(ctx context.Context, gs graph.Servicer, tenantID string) ([]models.Us
 	}
 
 	return users, iterErrs
+}
+
+type UserInfo struct {
+	DiscoveredServices map[path.ServiceType]struct{}
+}
+
+func User(ctx context.Context, gs graph.Servicer, userID string) (models.Userable, *UserInfo, error) {
+
+	user, err := gs.Client().UsersById(userID).Get(ctx, nil)
+	if err != nil {
+		return nil, nil, errors.Wrapf(
+			err,
+			"retrieving resource for tenant: %s",
+			support.ConnectorStackErrorTrace(err),
+		)
+	}
+
+	// Assume all services are enabled
+	userInfo := &UserInfo{
+		DiscoveredServices: map[path.ServiceType]struct{}{
+			path.ExchangeService: {},
+			path.OneDriveService: {},
+		},
+	}
+
+	// Discover which services the user has enabled
+
+	// Exchange: Query `MailFolders`
+	_, err = gs.Client().UsersById(userID).MailFolders().Get(ctx, nil)
+	if err != nil {
+		if !graph.IsErrExchangeMailFolderNotFound(err) {
+			return nil, nil, errors.Wrapf(
+				err,
+				"retrieving mail folders for tenant: %s",
+				support.ConnectorStackErrorTrace(err),
+			)
+		}
+		delete(userInfo.DiscoveredServices, path.ExchangeService)
+	}
+
+	// TODO: OneDrive
+
+	return user, userInfo, nil
 }
 
 // parseUser extracts information from `models.Userable` we care about

--- a/src/internal/connector/graph/errors.go
+++ b/src/internal/connector/graph/errors.go
@@ -72,10 +72,7 @@ func asInvalidDelta(err error) bool {
 }
 
 func IsErrExchangeMailFolderNotFound(err error) bool {
-	if hasErrorCode(err, errCodeResourceNotFound, errCodeMailboxNotEnabledForRESTAPI) {
-		return true
-	}
-	return false
+	return hasErrorCode(err, errCodeResourceNotFound, errCodeMailboxNotEnabledForRESTAPI)
 }
 
 // Timeout errors are identified for tracking the need to retry calls.

--- a/src/internal/connector/graph/errors.go
+++ b/src/internal/connector/graph/errors.go
@@ -15,11 +15,13 @@ import (
 // ---------------------------------------------------------------------------
 
 const (
-	errCodeItemNotFound        = "ErrorItemNotFound"
-	errCodeEmailFolderNotFound = "ErrorSyncFolderNotFound"
-	errCodeResyncRequired      = "ResyncRequired"
-	errCodeSyncFolderNotFound  = "ErrorSyncFolderNotFound"
-	errCodeSyncStateNotFound   = "SyncStateNotFound"
+	errCodeItemNotFound                = "ErrorItemNotFound"
+	errCodeEmailFolderNotFound         = "ErrorSyncFolderNotFound"
+	errCodeResyncRequired              = "ResyncRequired"
+	errCodeSyncFolderNotFound          = "ErrorSyncFolderNotFound"
+	errCodeSyncStateNotFound           = "SyncStateNotFound"
+	errCodeResourceNotFound            = "ResourceNotFound"
+	errCodeMailboxNotEnabledForRESTAPI = "MailboxNotEnabledForRESTAPI"
 )
 
 // The folder or item was deleted between the time we identified
@@ -67,6 +69,13 @@ func IsErrInvalidDelta(err error) error {
 func asInvalidDelta(err error) bool {
 	e := ErrInvalidDelta{}
 	return errors.As(err, &e)
+}
+
+func IsErrExchangeMailFolderNotFound(err error) bool {
+	if hasErrorCode(err, errCodeResourceNotFound, errCodeMailboxNotEnabledForRESTAPI) {
+		return true
+	}
+	return false
 }
 
 // Timeout errors are identified for tracking the need to retry calls.


### PR DESCRIPTION
## Description

This commit adds logic in discovery and backup to check whether the specified user has
an exchange mailbox that is available/enabled.

If so - the backup is short-circuited to succeed but with "no data"

Going forward - we should be able to move the logic in the OneDrive connector that checks
for a valid drive and license in here.

## Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #2145 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
