### PR TITLE
Handle ResourceNotFound error when fetching drive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Check if the user specified for an exchange backup operation has a mailbox.
+- Handle case where user's drive has not been initialized
 
 
 ## [v0.1.0] (alpha) - 2023-01-13

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -76,7 +76,8 @@ const (
 	itemChildrenRawURLFmt = "https://graph.microsoft.com/v1.0/drives/%s/items/%s/children"
 	itemByPathRawURLFmt   = "https://graph.microsoft.com/v1.0/drives/%s/items/%s:/%s"
 	itemNotFoundErrorCode = "itemNotFound"
-	userDoesNotHaveDrive  = "BadRequest Unable to retrieve user's mysite URL"
+	userMysiteURLNotFound = "BadRequest Unable to retrieve user's mysite URL"
+	userMysiteNotFound    = "ResourceNotFound User's mysite not found"
 )
 
 // Enumerates the drives for the specified user
@@ -134,7 +135,8 @@ func userDrives(ctx context.Context, service graph.Servicer, user string) ([]mod
 		r, err = service.Client().UsersById(user).Drives().Get(ctx, nil)
 		if err != nil {
 			detailedError := support.ConnectorStackErrorTrace(err)
-			if strings.Contains(detailedError, userDoesNotHaveDrive) {
+			if strings.Contains(detailedError, userMysiteURLNotFound) ||
+				strings.Contains(detailedError, userMysiteNotFound) {
 				logger.Ctx(ctx).Debugf("User %s does not have a drive", user)
 				return make([]models.Driveable, 0), nil // no license
 			}


### PR DESCRIPTION
## Description

Follow up for https://github.com/alcionai/corso/pull/2156. We might deice to change where we add the logic to handle this, as in if we should move it to discovery module.

## Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* https://github.com/alcionai/corso/issues/2145
* https://github.com/alcionai/corso/pull/2156

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
