### PR TITLE
Use same tags for checkpoints and snapshots

### DIFF
--- a/src/internal/kopia/snapshot_manager.go
+++ b/src/internal/kopia/snapshot_manager.go
@@ -24,9 +24,6 @@ const (
 	// (permalinks)
 	// [1] https://github.com/kopia/kopia/blob/05e729a7858a6e86cb48ba29fb53cb6045efce2b/cli/command_snapshot_create.go#L169
 	userTagPrefix = "tag:"
-
-	// Tag key applied to checkpoints (but not completed snapshots) in kopia.
-	checkpointTagKey = "checkpoint"
 )
 
 type Reason struct {

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -192,12 +192,7 @@ func (w Wrapper) makeSnapshotWithRoot(
 		snapIDs,
 	)
 
-	checkpointTagK, checkpointTagV := makeTagKV(checkpointTagKey)
-
 	tags := map[string]string{}
-	checkpointTags := map[string]string{
-		checkpointTagK: checkpointTagV,
-	}
 
 	for k, v := range addlTags {
 		mk, mv := makeTagKV(k)
@@ -207,7 +202,6 @@ func (w Wrapper) makeSnapshotWithRoot(
 		}
 
 		tags[mk] = v
-		checkpointTags[mk] = v
 	}
 
 	err := repo.WriteSession(
@@ -246,7 +240,7 @@ func (w Wrapper) makeSnapshotWithRoot(
 			u := snapshotfs.NewUploader(rw)
 			progress.UploadProgress = u.Progress
 			u.Progress = progress
-			u.CheckpointLabels = checkpointTags
+			u.CheckpointLabels = tags
 
 			man, err = u.Upload(innerCtx, root, policyTree, si, prevSnaps...)
 			if err != nil {


### PR DESCRIPTION
## Description

Use same tags for checkpoints and snapshots as having different tags won't get us too much benefit. We can revisit this if we find we're really doing too many manifest fetches, but until then the current code to fetch manifests is pretty good.

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

## Issue(s)

* #1674 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
