### PR TITLE
Delete details snapshot on backup delete

### DIFF
--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -325,6 +325,10 @@ func (r repository) DeleteBackup(ctx context.Context, id model.StableID) error {
 		return err
 	}
 
+	if err := r.dataLayer.DeleteSnapshot(ctx, bu.DetailsID); err != nil {
+		return err
+	}
+
 	sw := store.NewKopiaStore(r.modelStore)
 
 	return sw.DeleteBackup(ctx, id)


### PR DESCRIPTION
## Description

Don't leave orphaned details snapshots when a backup is being deleted.

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

* closes #2152

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
