### PR TITLE
Issue 2022 eventincr

### DIFF
--- a/src/internal/connector/exchange/event_calendar_cache.go
+++ b/src/internal/connector/exchange/event_calendar_cache.go
@@ -73,10 +73,6 @@ func (ecc *eventCalendarCache) Populate(
 		return errors.Wrap(err, "establishing calendar paths")
 	}
 
-	if err := ecc.populatePaths(ctx); err != nil {
-		return errors.Wrap(err, "establishing calendar paths")
-	}
-
 	return nil
 }
 

--- a/src/internal/connector/exchange/event_calendar_cache.go
+++ b/src/internal/connector/exchange/event_calendar_cache.go
@@ -73,6 +73,10 @@ func (ecc *eventCalendarCache) Populate(
 		return errors.Wrap(err, "establishing calendar paths")
 	}
 
+	if err := ecc.populatePaths(ctx); err != nil {
+		return errors.Wrap(err, "establishing calendar paths")
+	}
+
 	return nil
 }
 

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -715,13 +715,14 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchangeIncrementals() {
 				container2: {},
 			},
 		},
-		path.EventsCategory: {
-			dbf: eventDBF,
-			dests: map[string]contDeets{
-				container1: {},
-				container2: {},
-			},
-		},
+		// TODO: not currently functioning; cannot retrieve generated calendars
+		// path.EventsCategory: {
+		// 	dbf: eventDBF,
+		// 	dests: map[string]contDeets{
+		// 		container1: {},
+		// 		container2: {},
+		// 	},
+		// },
 	}
 
 	// populate initial test data

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -715,14 +715,13 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchangeIncrementals() {
 				container2: {},
 			},
 		},
-		// TODO: not currently functioning; cannot retrieve generated calendars
-		// path.EventsCategory: {
-		// 	dbf: eventDBF,
-		// 	dests: map[string]contDeets{
-		// 		container1: {},
-		// 		container2: {},
-		// 	},
-		// },
+		path.EventsCategory: {
+			dbf: eventDBF,
+			dests: map[string]contDeets{
+				container1: {},
+				container2: {},
+			},
+		},
 	}
 
 	// populate initial test data


### PR DESCRIPTION
## Description

Fixes and unskips the tests incremental integration tests
for exchange calendar events.

Currently blocked on LynneR displaying the calendar
fetch issues where it's only possible to retrieve her default
Calendar, Birthdays, and US Holidays calendars.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :robot: Test

## Issue(s)

* #2022

## Test Plan

- [x] :muscle: Manual
- [x] :green_heart: E2E
