### PR TITLE
Use mutex when appending to error

### DIFF
--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -197,7 +197,11 @@ func (col *Collection) streamItems(ctx context.Context) {
 	semaphoreCh := make(chan struct{}, urlPrefetchChannelBufferSize)
 	defer close(semaphoreCh)
 
+	updaterMu := sync.Mutex{}
 	errUpdater := func(user string, err error) {
+		updaterMu.Lock()
+		defer updaterMu.Unlock()
+
 		errs = support.WrapAndAppend(user, err, errs)
 	}
 


### PR DESCRIPTION
## Description

Make error appending thread-safe since multiple goroutines may attempt to add an error at the same time.

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

* closes #2197

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
