### PR TITLE
Check for and ignore item not found errors

### DIFF
--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/microsoft/kiota-abstractions-go/serialization"
 
+	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/observe"
@@ -258,7 +259,18 @@ func (col *Collection) streamItems(ctx context.Context) {
 			}
 
 			if err != nil {
+				// Don't report errors for deleted items as there's no way for us to
+				// back up data that is gone. Chalk them up as a "success" though since
+				// there's really nothing we can do and not reporting it will make the
+				// status code upset cause we won't have the same number of results as
+				// attempted items.
+				if e := graph.IsErrDeletedInFlight(err); e != nil {
+					atomic.AddInt64(&success, 1)
+					return
+				}
+
 				errUpdater(user, err)
+
 				return
 			}
 


### PR DESCRIPTION
## Description

Item not found errors may appear because an item was moved or deleted between enumerating the items in a folder and fetching the data for the items in the folder. This keeps them from being reported as there is nothing we can do if the item data is no longer available.

This applies to all Exchange data categories

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

* closes #2198

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
