### PR TITLE
[BUG FIX]: CLI: Details: Sharepoint 

### DIFF
--- a/src/pkg/selectors/sharepoint.go
+++ b/src/pkg/selectors/sharepoint.go
@@ -224,7 +224,7 @@ func (s *sharePoint) AllData() []SharePointScope {
 		scopes,
 		makeScope[SharePointScope](SharePointLibrary, Any()),
 		makeScope[SharePointScope](SharePointList, Any()),
-		makeScope[SharePointScope](SharePointPage, Any()),
+		makeScope[SharePointScope](SharePointPageFolder, Any()),
 	)
 
 	return scopes
@@ -323,7 +323,7 @@ func (s *sharePoint) PageItems(pages, items []string, opts ...option) []SharePoi
 	scopes = append(
 		scopes,
 		makeScope[SharePointScope](SharePointPage, items).
-			set(SharePointPage, pages, opts...),
+			set(SharePointPageFolder, pages, opts...),
 	)
 
 	return scopes

--- a/src/pkg/selectors/sharepoint_test.go
+++ b/src/pkg/selectors/sharepoint_test.go
@@ -193,12 +193,12 @@ func (suite *SharePointSelectorSuite) TestToSharePointRestore() {
 
 func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 	var (
-		pairA = "folderA/folderC"
-		item  = stubRepoRef(path.SharePointService, path.LibrariesCategory, "sid", "folderA/folderB", "item")
-		item2 = stubRepoRef(path.SharePointService, path.LibrariesCategory, "sid", pairA, "item2")
-		item3 = stubRepoRef(path.SharePointService, path.LibrariesCategory, "sid", "folderD/folderE", "item3")
-		item4 = stubRepoRef(path.SharePointService, path.PagesCategory, "sid", "folderG/folderH", "item4")
-		item5 = stubRepoRef(path.SharePointService, path.PagesCategory, "sid", "folderG/folderH", "item5")
+		pairAC = "folderA/folderC"
+		item   = stubRepoRef(path.SharePointService, path.LibrariesCategory, "sid", "folderA/folderB", "item")
+		item2  = stubRepoRef(path.SharePointService, path.LibrariesCategory, "sid", pairAC, "item2")
+		item3  = stubRepoRef(path.SharePointService, path.LibrariesCategory, "sid", "folderD/folderE", "item3")
+		item4  = stubRepoRef(path.SharePointService, path.PagesCategory, "sid", "folderG/folderH", "item4")
+		item5  = stubRepoRef(path.SharePointService, path.PagesCategory, "sid", "folderG/folderH", "item5")
 	)
 
 	deets := &details.Details{
@@ -283,7 +283,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 			deets: deets,
 			makeSelector: func() *SharePointRestore {
 				odr := NewSharePointRestore([]string{"sid"})
-				odr.Include(odr.Libraries([]string{"folderA/folderB", pairA}))
+				odr.Include(odr.Libraries([]string{"folderA/folderB", pairAC}))
 				return odr
 			},
 			expect: arr(item, item2),
@@ -293,7 +293,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 			deets: deets,
 			makeSelector: func() *SharePointRestore {
 				odr := NewSharePointRestore([]string{"sid"})
-				odr.Include(odr.Pages([]string{"folderG/folderH", pairA}))
+				odr.Include(odr.Pages([]string{"folderG/folderH", pairAC}))
 				return odr
 			},
 			expect: arr(item4, item5),

--- a/src/pkg/selectors/sharepoint_test.go
+++ b/src/pkg/selectors/sharepoint_test.go
@@ -194,11 +194,12 @@ func (suite *SharePointSelectorSuite) TestToSharePointRestore() {
 func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 	var (
 		pairAC = "folderA/folderC"
+		pairGH = "folderG/folderH"
 		item   = stubRepoRef(path.SharePointService, path.LibrariesCategory, "sid", "folderA/folderB", "item")
 		item2  = stubRepoRef(path.SharePointService, path.LibrariesCategory, "sid", pairAC, "item2")
 		item3  = stubRepoRef(path.SharePointService, path.LibrariesCategory, "sid", "folderD/folderE", "item3")
-		item4  = stubRepoRef(path.SharePointService, path.PagesCategory, "sid", "folderG/folderH", "item4")
-		item5  = stubRepoRef(path.SharePointService, path.PagesCategory, "sid", "folderG/folderH", "item5")
+		item4  = stubRepoRef(path.SharePointService, path.PagesCategory, "sid", pairGH, "item4")
+		item5  = stubRepoRef(path.SharePointService, path.PagesCategory, "sid", pairGH, "item5")
 	)
 
 	deets := &details.Details{
@@ -293,7 +294,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 			deets: deets,
 			makeSelector: func() *SharePointRestore {
 				odr := NewSharePointRestore([]string{"sid"})
-				odr.Include(odr.Pages([]string{"folderG/folderH", pairAC}))
+				odr.Include(odr.Pages([]string{pairGH, pairAC}))
 				return odr
 			},
 			expect: arr(item4, item5),

--- a/src/pkg/selectors/sharepoint_test.go
+++ b/src/pkg/selectors/sharepoint_test.go
@@ -196,6 +196,8 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 		item  = stubRepoRef(path.SharePointService, path.LibrariesCategory, "sid", "folderA/folderB", "item")
 		item2 = stubRepoRef(path.SharePointService, path.LibrariesCategory, "sid", "folderA/folderC", "item2")
 		item3 = stubRepoRef(path.SharePointService, path.LibrariesCategory, "sid", "folderD/folderE", "item3")
+		item4 = stubRepoRef(path.SharePointService, path.PagesCategory, "sid", "folderG/folderH", "item4")
+		item5 = stubRepoRef(path.SharePointService, path.PagesCategory, "sid", "folderG/folderH", "item5")
 	)
 
 	deets := &details.Details{
@@ -225,6 +227,22 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 						},
 					},
 				},
+				{
+					RepoRef: item4,
+					ItemInfo: details.ItemInfo{
+						SharePoint: &details.SharePointInfo{
+							ItemType: details.SharePointItem,
+						},
+					},
+				},
+				{
+					RepoRef: item5,
+					ItemInfo: details.ItemInfo{
+						SharePoint: &details.SharePointInfo{
+							ItemType: details.SharePointItem,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -247,7 +265,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 				odr.Include(odr.AllData())
 				return odr
 			},
-			expect: arr(item, item2, item3),
+			expect: arr(item, item2, item3, item4, item5),
 		},
 		{
 			name:  "only match item",
@@ -268,6 +286,16 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 				return odr
 			},
 			expect: arr(item, item2),
+		},
+		{
+			name:  "pages match folder",
+			deets: deets,
+			makeSelector: func() *SharePointRestore {
+				odr := NewSharePointRestore([]string{"sid"})
+				odr.Include(odr.Pages([]string{"folderG/folderH", "folderA/folderC"}))
+				return odr
+			},
+			expect: arr(item4, item5),
 		},
 	}
 	for _, test := range table {

--- a/src/pkg/selectors/sharepoint_test.go
+++ b/src/pkg/selectors/sharepoint_test.go
@@ -193,8 +193,9 @@ func (suite *SharePointSelectorSuite) TestToSharePointRestore() {
 
 func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 	var (
+		pairA = "folderA/folderC"
 		item  = stubRepoRef(path.SharePointService, path.LibrariesCategory, "sid", "folderA/folderB", "item")
-		item2 = stubRepoRef(path.SharePointService, path.LibrariesCategory, "sid", "folderA/folderC", "item2")
+		item2 = stubRepoRef(path.SharePointService, path.LibrariesCategory, "sid", pairA, "item2")
 		item3 = stubRepoRef(path.SharePointService, path.LibrariesCategory, "sid", "folderD/folderE", "item3")
 		item4 = stubRepoRef(path.SharePointService, path.PagesCategory, "sid", "folderG/folderH", "item4")
 		item5 = stubRepoRef(path.SharePointService, path.PagesCategory, "sid", "folderG/folderH", "item5")
@@ -282,7 +283,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 			deets: deets,
 			makeSelector: func() *SharePointRestore {
 				odr := NewSharePointRestore([]string{"sid"})
-				odr.Include(odr.Libraries([]string{"folderA/folderB", "folderA/folderC"}))
+				odr.Include(odr.Libraries([]string{"folderA/folderB", pairA}))
 				return odr
 			},
 			expect: arr(item, item2),
@@ -292,7 +293,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 			deets: deets,
 			makeSelector: func() *SharePointRestore {
 				odr := NewSharePointRestore([]string{"sid"})
-				odr.Include(odr.Pages([]string{"folderG/folderH", "folderA/folderC"}))
+				odr.Include(odr.Pages([]string{"folderG/folderH", pairA}))
 				return odr
 			},
 			expect: arr(item4, item5),


### PR DESCRIPTION
## Description
Enabling backup commands for `SharePoint.Pages` in #2216 introduced failures when `backup details()` called in Corso. 
Test suite updated

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :bug: Bugfix


## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* related to  #2216<issue>
* related to #2173

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :zap: Unit test
