### PR TITLE
Don't retry if an item was not found

### DIFF
--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -257,6 +257,14 @@ func (col *Collection) streamItems(ctx context.Context) {
 					break
 				}
 
+				// If the data is no longer available just return here and chalk it up
+				// as a success. There's no reason to retry and no way we can backup up
+				// enough information to restore the item anyway.
+				if e := graph.IsErrDeletedInFlight(err); e != nil {
+					atomic.AddInt64(&success, 1)
+					return
+				}
+
 				if i < numberOfRetries {
 					time.Sleep(time.Duration(3*(i+1)) * time.Second)
 				}

--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -262,6 +262,16 @@ func (col *Collection) streamItems(ctx context.Context) {
 				// enough information to restore the item anyway.
 				if e := graph.IsErrDeletedInFlight(err); e != nil {
 					atomic.AddInt64(&success, 1)
+					logger.Ctx(ctx).Infow(
+						"Graph reported item not found",
+						"error",
+						e,
+						"service",
+						path.ExchangeService.String(),
+						"category",
+						col.category.String,
+					)
+
 					return
 				}
 
@@ -278,6 +288,16 @@ func (col *Collection) streamItems(ctx context.Context) {
 				// attempted items.
 				if e := graph.IsErrDeletedInFlight(err); e != nil {
 					atomic.AddInt64(&success, 1)
+					logger.Ctx(ctx).Infow(
+						"Graph reported item not found",
+						"error",
+						e,
+						"service",
+						path.ExchangeService.String(),
+						"category",
+						col.category.String,
+					)
+
 					return
 				}
 


### PR DESCRIPTION
## Description

When fetching item data, don't backoff and retry if Graph reported the item was not found. In this case, we mark it as succeeded as we can never get the data anyway.

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

## Issue(s)

* closes #2217

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
