### PR TITLE
Add `--restore-permissions` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - OneDrive file/folder permissions can now be backed up and restored
-- Add `--restore-permissions` flag to choose weather to restore OneDrive permissions
+- Add `--restore-permissions` flag to toggle restoration of OneDrive permissions
 
 ### Known Issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - OneDrive file/folder permissions can now be backed up and restored
+- Add `--restore-permissions` flag to choose weather to restore OneDrive permissions
 
 ### Known Issues
 

--- a/src/cli/options/options.go
+++ b/src/cli/options/options.go
@@ -11,17 +11,10 @@ import (
 func Control() control.Options {
 	opt := control.Defaults()
 
-	if fastFail {
-		opt.FailFast = true
-	}
-
-	if noStats {
-		opt.DisableMetrics = true
-	}
-
-	if disableIncrementals {
-		opt.ToggleFeatures.DisableIncrementals = true
-	}
+	opt.FailFast = fastFail
+	opt.DisableMetrics = noStats
+	opt.RestorePermissions = restorePermissions
+	opt.ToggleFeatures.DisableIncrementals = disableIncrementals
 
 	return opt
 }
@@ -31,8 +24,9 @@ func Control() control.Options {
 // ---------------------------------------------------------------------------
 
 var (
-	fastFail bool
-	noStats  bool
+	fastFail           bool
+	noStats            bool
+	restorePermissions bool
 )
 
 // AddOperationFlags adds command-local operation flags
@@ -47,6 +41,12 @@ func AddOperationFlags(cmd *cobra.Command) {
 func AddGlobalOperationFlags(cmd *cobra.Command) {
 	fs := cmd.PersistentFlags()
 	fs.BoolVar(&noStats, "no-stats", false, "disable anonymous usage statistics gathering")
+}
+
+// AddRestorePermissionsFlag adds OneDrive flag for restoring permissions
+func AddRestorePermissionsFlag(cmd *cobra.Command) {
+	fs := cmd.Flags()
+	fs.BoolVar(&restorePermissions, "restore-permissions", false, "Restore permissions for files and folders")
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli/restore/onedrive.go
+++ b/src/cli/restore/onedrive.go
@@ -100,6 +100,9 @@ const (
 	oneDriveServiceCommandRestoreExamples = `# Restore file with ID 98765abcdef
 corso restore onedrive --backup 1234abcd-12ab-cd34-56de-1234abcd --file 98765abcdef
 
+# Restore file with ID 98765abcdef along with any permissions associated to it
+corso restore onedrive --backup 1234abcd-12ab-cd34-56de-1234abcd --file 98765abcdef --restore-permissions
+
 # Restore Alice's file named "FY2021 Planning.xlsx in "Documents/Finance Reports" from a specific backup
 corso restore onedrive --backup 1234abcd-12ab-cd34-56de-1234abcd \
       --user alice@example.com --file "FY2021 Planning.xlsx" --folder "Documents/Finance Reports"

--- a/src/cli/restore/onedrive.go
+++ b/src/cli/restore/onedrive.go
@@ -63,6 +63,9 @@ func addOneDriveCommands(cmd *cobra.Command) *cobra.Command {
 			utils.FileFN, nil,
 			"Restore items by file name or ID")
 
+		// permissions restore flag
+		options.AddRestorePermissionsFlag(c)
+
 		// onedrive info flags
 
 		fs.StringVar(

--- a/src/cli/restore/onedrive.go
+++ b/src/cli/restore/onedrive.go
@@ -100,7 +100,7 @@ const (
 	oneDriveServiceCommandRestoreExamples = `# Restore file with ID 98765abcdef
 corso restore onedrive --backup 1234abcd-12ab-cd34-56de-1234abcd --file 98765abcdef
 
-# Restore file with ID 98765abcdef along with any permissions associated to it
+# Restore file with ID 98765abcdef along with its associated permissions
 corso restore onedrive --backup 1234abcd-12ab-cd34-56de-1234abcd --file 98765abcdef --restore-permissions
 
 # Restore Alice's file named "FY2021 Planning.xlsx in "Documents/Finance Reports" from a specific backup

--- a/src/cmd/factory/impl/common.go
+++ b/src/cmd/factory/impl/common.go
@@ -74,7 +74,7 @@ func generateAndRestoreItems(
 		items:        items,
 	}}
 
-	// TODO: fit the designation to the containers
+	// TODO: fit the destination to the containers
 	dest := control.DefaultRestoreDestination(common.SimpleTimeTesting)
 	dest.ContainerName = destFldr
 

--- a/src/cmd/factory/impl/common.go
+++ b/src/cmd/factory/impl/common.go
@@ -49,6 +49,7 @@ func generateAndRestoreItems(
 	tenantID, userID, destFldr string,
 	howMany int,
 	dbf dataBuilderFunc,
+	opts control.Options,
 ) (*details.Details, error) {
 	items := make([]item, 0, howMany)
 
@@ -73,7 +74,7 @@ func generateAndRestoreItems(
 		items:        items,
 	}}
 
-	// TODO: fit the desination to the containers
+	// TODO: fit the designation to the containers
 	dest := control.DefaultRestoreDestination(common.SimpleTimeTesting)
 	dest.ContainerName = destFldr
 
@@ -89,7 +90,7 @@ func generateAndRestoreItems(
 
 	Infof(ctx, "Generating %d %s items in %s\n", howMany, cat, Destination)
 
-	return gc.RestoreDataCollections(ctx, acct, sel, dest, dataColls)
+	return gc.RestoreDataCollections(ctx, acct, sel, dest, opts, dataColls)
 }
 
 // ------------------------------------------------------------------------------------------

--- a/src/cmd/factory/impl/exchange.go
+++ b/src/cmd/factory/impl/exchange.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/cli/utils"
 	"github.com/alcionai/corso/src/internal/connector/mockconnector"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 )
@@ -67,6 +68,7 @@ func handleExchangeEmailFactory(cmd *cobra.Command, args []string) error {
 				subject, body, body,
 				now, now, now, now)
 		},
+		control.Options{},
 	)
 	if err != nil {
 		return Only(ctx, err)
@@ -107,6 +109,7 @@ func handleExchangeCalendarEventFactory(cmd *cobra.Command, args []string) error
 				User, subject, body, body,
 				now, now, false)
 		},
+		control.Options{},
 	)
 	if err != nil {
 		return Only(ctx, err)
@@ -152,6 +155,7 @@ func handleExchangeContactFactory(cmd *cobra.Command, args []string) error {
 				"123-456-7890",
 			)
 		},
+		control.Options{},
 	)
 	if err != nil {
 		return Only(ctx, err)

--- a/src/internal/connector/graph_connector.go
+++ b/src/internal/connector/graph_connector.go
@@ -261,6 +261,7 @@ func (gc *GraphConnector) RestoreDataCollections(
 	acct account.Account,
 	selector selectors.Selector,
 	dest control.RestoreDestination,
+	opts control.Options,
 	dcs []data.Collection,
 ) (*details.Details, error) {
 	ctx, end := D.Span(ctx, "connector:restore")
@@ -281,7 +282,7 @@ func (gc *GraphConnector) RestoreDataCollections(
 	case selectors.ServiceExchange:
 		status, err = exchange.RestoreExchangeDataCollections(ctx, creds, gc.Service, dest, dcs, deets)
 	case selectors.ServiceOneDrive:
-		status, err = onedrive.RestoreCollections(ctx, gc.Service, dest, dcs, deets)
+		status, err = onedrive.RestoreCollections(ctx, gc.Service, dest, opts, dcs, deets)
 	case selectors.ServiceSharePoint:
 		status, err = sharepoint.RestoreCollections(ctx, gc.Service, dest, dcs, deets)
 	default:

--- a/src/internal/connector/graph_connector_helper_test.go
+++ b/src/internal/connector/graph_connector_helper_test.go
@@ -645,6 +645,7 @@ func compareOneDriveItem(
 	t *testing.T,
 	expected map[string][]byte,
 	item data.Stream,
+	restorePermissions bool,
 ) {
 	name := item.UUID()
 
@@ -676,6 +677,12 @@ func compareOneDriveItem(
 
 	err = json.Unmarshal(expectedData, &expectedMeta)
 	assert.Nil(t, err)
+
+	if !restorePermissions {
+		assert.Equal(t, 0, len(itemMeta.Permissions))
+		return
+	}
+
 	assert.Equal(t, len(expectedMeta.Permissions), len(itemMeta.Permissions), "number of permissions after restore")
 
 	// FIXME(meain): The permissions before and after might not be in the same order.
@@ -692,6 +699,7 @@ func compareItem(
 	service path.ServiceType,
 	category path.CategoryType,
 	item data.Stream,
+	restorePermissions bool,
 ) {
 	if mt, ok := item.(data.StreamModTime); ok {
 		assert.NotZero(t, mt.ModTime())
@@ -711,7 +719,7 @@ func compareItem(
 		}
 
 	case path.OneDriveService:
-		compareOneDriveItem(t, expected, item)
+		compareOneDriveItem(t, expected, item, restorePermissions)
 
 	default:
 		assert.FailNowf(t, "unexpected service: %s", service.String())
@@ -744,6 +752,7 @@ func checkCollections(
 	expectedItems int,
 	expected map[string]map[string][]byte,
 	got []data.Collection,
+	restorePermissions bool,
 ) int {
 	collectionsWithItems := []data.Collection{}
 
@@ -778,7 +787,7 @@ func checkCollections(
 				continue
 			}
 
-			compareItem(t, expectedColData, service, category, item)
+			compareItem(t, expectedColData, service, category, item, restorePermissions)
 		}
 
 		if gotItems != startingItems {

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -31,7 +31,10 @@ const (
 	copyBufferSize = 5 * 1024 * 1024
 )
 
-func getParentPermissions(parentPath path.Path, parentPermissions map[string][]UserPermission) ([]UserPermission, error) {
+func getParentPermissions(
+	parentPath path.Path,
+	parentPermissions map[string][]UserPermission,
+) ([]UserPermission, error) {
 	parentPerms, ok := parentPermissions[parentPath.String()]
 	if !ok {
 		onedrivePath, err := path.ToOneDrivePath(parentPath)
@@ -39,13 +42,13 @@ func getParentPermissions(parentPath path.Path, parentPermissions map[string][]U
 			return nil, errors.Wrap(err, "invalid restore path")
 		}
 
-		if len(onedrivePath.Folders) == 0 {
-			// root directory will not have permissions
-			parentPerms = []UserPermission{}
-		} else {
+		if len(onedrivePath.Folders) != 0 {
 			return nil, errors.Wrap(err, "unable to find parent permissions")
 		}
+
+		parentPerms = []UserPermission{}
 	}
+
 	return parentPerms, nil
 }
 
@@ -88,6 +91,7 @@ func RestoreCollections(
 			parentPerms []UserPermission
 			err         error
 		)
+
 		if opts.RestorePermissions {
 			parentPerms, err = getParentPermissions(dc.FullPath(), parentPermissions)
 			if err != nil {

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -214,6 +214,12 @@ func RestoreCollection(
 					restoredIDs[trimmedName] = itemID
 
 					deets.Add(itemPath.String(), itemPath.ShortRef(), "", true, itemInfo)
+
+					// Mark it as success without processing .meta
+					// file if we are not restoring permissions
+					if !enablePermissionsRestore {
+						metrics.Successes++
+					}
 				} else if strings.HasSuffix(name, MetaFileSuffix) {
 					if !enablePermissionsRestore {
 						continue

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -43,7 +43,7 @@ func getParentPermissions(
 		}
 
 		if len(onedrivePath.Folders) != 0 {
-			return nil, errors.Wrap(err, "unable to find parent permissions")
+			return nil, errors.Wrap(err, "unable to compute item permissions")
 		}
 
 		parentPerms = []UserPermission{}

--- a/src/internal/connector/sharepoint/restore.go
+++ b/src/internal/connector/sharepoint/restore.go
@@ -69,6 +69,7 @@ func RestoreCollections(
 				deets,
 				errUpdater,
 				map[string]string{},
+				false,
 			)
 		case path.ListsCategory:
 			metrics, canceled = RestoreCollection(

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -337,7 +337,7 @@ func generateContainerOfItems(
 		dest,
 		collections)
 
-	deets, err := gc.RestoreDataCollections(ctx, acct, sel, dest, dataColls)
+	deets, err := gc.RestoreDataCollections(ctx, acct, sel, dest, control.Options{RestorePermissions: true}, dataColls)
 	require.NoError(t, err)
 
 	return deets

--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -193,7 +193,9 @@ func (op *RestoreOperation) Run(ctx context.Context) (restoreDetails *details.De
 		op.account,
 		op.Selectors,
 		op.Destination,
-		dcs)
+		op.Options,
+		dcs,
+	)
 	if err != nil {
 		err = errors.Wrap(err, "restoring service data")
 		opStats.writeErr = err

--- a/src/pkg/control/options.go
+++ b/src/pkg/control/options.go
@@ -6,10 +6,11 @@ import (
 
 // Options holds the optional configurations for a process
 type Options struct {
-	Collision      CollisionPolicy `json:"-"`
-	DisableMetrics bool            `json:"disableMetrics"`
-	FailFast       bool            `json:"failFast"`
-	ToggleFeatures Toggles         `json:"ToggleFeatures"`
+	Collision          CollisionPolicy `json:"-"`
+	DisableMetrics     bool            `json:"disableMetrics"`
+	FailFast           bool            `json:"failFast"`
+	RestorePermissions bool            `json:"restorePermissions"`
+	ToggleFeatures     Toggles         `json:"ToggleFeatures"`
 }
 
 // Defaults provides an Options with the default values set.


### PR DESCRIPTION
## Description

By default we do not restore permissions for OneDrive. When this flag is provided, we enable restoring permissions to OneDrive.
Will switch from draft once https://github.com/alcionai/corso/pull/2148 is merged.

## Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* fixes https://github.com/alcionai/corso/issues/2028

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
