### PR TITLE
Wire kopia exclude list up to BackupOp

### DIFF
--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -119,6 +119,7 @@ func (w Wrapper) BackupCollections(
 	ctx context.Context,
 	previousSnapshots []IncrementalBase,
 	collections []data.Collection,
+	globalExcludeSet map[string]struct{},
 	tags map[string]string,
 	buildTreeWithBase bool,
 ) (*BackupStats, *details.Builder, map[string]path.Path, error) {
@@ -128,10 +129,6 @@ func (w Wrapper) BackupCollections(
 
 	ctx, end := D.Span(ctx, "kopia:backupCollections")
 	defer end()
-
-	// TODO(ashmrtn): Make this a parameter when actually enabling the global
-	// exclude set.
-	var globalExcludeSet map[string]struct{}
 
 	if len(collections) == 0 && len(globalExcludeSet) == 0 {
 		return &BackupStats{}, &details.Builder{}, nil, nil

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -266,6 +266,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 				suite.ctx,
 				prevSnaps,
 				collections,
+				nil,
 				tags,
 				true,
 			)
@@ -353,6 +354,7 @@ func (suite *KopiaIntegrationSuite) TestRestoreAfterCompressionChange() {
 		ctx,
 		nil,
 		[]data.Collection{dc1, dc2},
+		nil,
 		tags,
 		true,
 	)
@@ -435,6 +437,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_ReaderError() {
 		suite.ctx,
 		nil,
 		collections,
+		nil,
 		tags,
 		true,
 	)
@@ -495,6 +498,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollectionsHandlesNoCollections() 
 				ctx,
 				nil,
 				test.collections,
+				nil,
 				nil,
 				true,
 			)
@@ -653,6 +657,7 @@ func (suite *KopiaSimpleRepoIntegrationSuite) SetupTest() {
 		suite.ctx,
 		nil,
 		collections,
+		nil,
 		tags,
 		false,
 	)

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -275,6 +275,7 @@ type backuper interface {
 		ctx context.Context,
 		bases []kopia.IncrementalBase,
 		cs []data.Collection,
+		excluded map[string]struct{},
 		tags map[string]string,
 		buildTreeWithBase bool,
 	) (*kopia.BackupStats, *details.Builder, map[string]path.Path, error)
@@ -404,6 +405,7 @@ func consumeBackupDataCollections(
 		ctx,
 		bases,
 		cs,
+		nil,
 		tags,
 		isIncremental,
 	)

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -95,6 +95,7 @@ func (mbu mockBackuper) BackupCollections(
 	ctx context.Context,
 	bases []kopia.IncrementalBase,
 	cs []data.Collection,
+	excluded map[string]struct{},
 	tags map[string]string,
 	buildTreeWithBase bool,
 ) (*kopia.BackupStats, *details.Builder, map[string]path.Path, error) {

--- a/src/internal/streamstore/streamstore.go
+++ b/src/internal/streamstore/streamstore.go
@@ -78,6 +78,7 @@ func (ss *streamStore) WriteBackupDetails(
 		nil,
 		[]data.Collection{dc},
 		nil,
+		nil,
 		false,
 	)
 	if err != nil {


### PR DESCRIPTION
## Description

Expose the global exclude list mechanism in kopia BackupCollections to other components. Add tests for BackupCollections testing new exclude list functionality

Currently wired to always be passed nil

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

* #2243

merge after:
* #2143 

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
