### PR TITLE
return gc stats errors in backup

### DIFF
--- a/src/internal/connector/support/status.go
+++ b/src/internal/connector/support/status.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	multierror "github.com/hashicorp/go-multierror"
 	bytesize "github.com/inhies/go-bytesize"
 
 	"github.com/alcionai/corso/src/pkg/logger"
@@ -21,6 +22,7 @@ type ConnectorOperationStatus struct {
 	FolderCount       int
 	Successful        int
 	ErrorCount        int
+	Err               error
 	incomplete        bool
 	incompleteReason  string
 	additionalDetails string
@@ -70,6 +72,7 @@ func CreateStatus(
 		FolderCount:       folders,
 		Successful:        cm.Successes,
 		ErrorCount:        numErr,
+		Err:               err,
 		incomplete:        hasErrors,
 		incompleteReason:  reason,
 		bytes:             cm.TotalBytes,
@@ -115,6 +118,7 @@ func MergeStatus(one, two ConnectorOperationStatus) ConnectorOperationStatus {
 		FolderCount:       one.FolderCount + two.FolderCount,
 		Successful:        one.Successful + two.Successful,
 		ErrorCount:        one.ErrorCount + two.ErrorCount,
+		Err:               multierror.Append(one.Err, two.Err).ErrorOrNil(),
 		bytes:             one.bytes + two.bytes,
 		incomplete:        hasErrors,
 		incompleteReason:  one.incompleteReason + ", " + two.incompleteReason,

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -208,13 +208,11 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 	opStats.gc = gc.AwaitStatus()
 
 	if opStats.gc.ErrorCount > 0 {
-		opStats.writeErr = multierror.Append(nil, opStats.writeErr, errors.Errorf(
-			"%v errors reported while fetching item data",
-			opStats.gc.ErrorCount,
-		)).ErrorOrNil()
+		merr := multierror.Append(opStats.readErr, errors.Wrap(opStats.gc.Err, "retrieving data"))
+		opStats.readErr = merr.ErrorOrNil()
 
 		// Need to exit before we set started to true else we'll report no errors.
-		return opStats.writeErr
+		return opStats.readErr
 	}
 
 	// should always be 1, since backups are 1:1 with resourceOwners.


### PR DESCRIPTION
## Description

If gc.stats reports a non-zero error count at the
end of a backup, retrieve the error from the
status and return it as the backup operation err.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :bug: Bugfix

## Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
