### PR TITLE
Remove duplicate string->path.CategoryType helper function

### DIFF
--- a/src/cmd/getM365/getItem.go
+++ b/src/cmd/getM365/getItem.go
@@ -19,7 +19,6 @@ import (
 	"github.com/alcionai/corso/src/internal/common"
 	"github.com/alcionai/corso/src/internal/connector"
 	"github.com/alcionai/corso/src/internal/connector/exchange/api"
-	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/credentials"
@@ -96,7 +95,7 @@ func runDisplayM365JSON(
 	var (
 		bs  []byte
 		err error
-		cat = graph.StringToPathCategory(category)
+		cat = path.ToCategoryType(category)
 		sw  = kw.NewJsonSerializationWriter()
 	)
 

--- a/src/internal/connector/graph/service_helper.go
+++ b/src/internal/connector/graph/service_helper.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"os"
-	"strings"
 	"time"
 
 	az "github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -15,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/alcionai/corso/src/pkg/logger"
-	"github.com/alcionai/corso/src/pkg/path"
 )
 
 const (
@@ -103,27 +101,4 @@ func (handler *LoggingMiddleware) Intercept(
 	}
 
 	return resp, err
-}
-
-// ---------------------------------------------------------------------------
-// Other Helpers
-// ---------------------------------------------------------------------------
-
-func StringToPathCategory(input string) path.CategoryType {
-	param := strings.ToLower(input)
-
-	switch param {
-	case "email":
-		return path.EmailCategory
-	case "contacts":
-		return path.ContactsCategory
-	case "events":
-		return path.EventsCategory
-	case "files":
-		return path.FilesCategory
-	case "libraries":
-		return path.LibrariesCategory
-	default:
-		return path.UnknownCategory
-	}
 }

--- a/src/pkg/path/resource_path.go
+++ b/src/pkg/path/resource_path.go
@@ -1,6 +1,8 @@
 package path
 
 import (
+	"strings"
+
 	"github.com/pkg/errors"
 )
 
@@ -30,7 +32,9 @@ const (
 )
 
 func toServiceType(service string) ServiceType {
-	switch service {
+	s := strings.ToLower(service)
+
+	switch s {
 	case ExchangeService.String():
 		return ExchangeService
 	case OneDriveService.String():
@@ -70,7 +74,9 @@ const (
 )
 
 func ToCategoryType(category string) CategoryType {
-	switch category {
+	cat := strings.ToLower(category)
+
+	switch cat {
 	case EmailCategory.String():
 		return EmailCategory
 	case ContactsCategory.String():

--- a/src/pkg/path/service_category_test.go
+++ b/src/pkg/path/service_category_test.go
@@ -1,6 +1,7 @@
 package path
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -72,6 +73,14 @@ func (suite *ServiceCategoryUnitSuite) TestValidateServiceAndCategory() {
 			service:  ExchangeService.String(),
 			category: "foo",
 			check:    assert.Error,
+		},
+		{
+			name:             "DifferentCases",
+			service:          strings.ToUpper(ExchangeService.String()),
+			category:         strings.ToUpper(EmailCategory.String()),
+			expectedService:  ExchangeService,
+			expectedCategory: EmailCategory,
+			check:            assert.NoError,
 		},
 		{
 			name:             "ExchangeEmail",


### PR DESCRIPTION
## Description

Tackles a few things:
* normalize case when going from string->path.Service or path.Category
* removes duplicate helper function for string->path.Category in favor of path package one

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

## Issue(s)

* closes #2259

## Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
