### PR TITLE
Print Corso version on one line

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -39,7 +39,7 @@ var corsoCmd = &cobra.Command{
 func handleCorsoCmd(cmd *cobra.Command, args []string) error {
 	v, _ := cmd.Flags().GetBool("version")
 	if v {
-		print.Outf(cmd.Context(), "Corso\nversion: "+version.Version)
+		print.Outf(cmd.Context(), "Corso version: "+version.Version)
 		return nil
 	}
 


### PR DESCRIPTION
## Description

Don't split the Corso version information across lines. This is unexpected.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :broom: Tech Debt/Cleanup
