### PR TITLE
Docs: Hide progress when asking for logs

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yaml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yaml
@@ -35,6 +35,6 @@ body:
     id: logs
     attributes:
       label: Relevant log output
-      description: Please run Corso with `--log-level debug` and attach the log file.
+      description: Please run Corso with `--hide-progress --log-level debug` and attach the log file.
       placeholder: This will be automatically formatted, so no need for backticks.
       render: shell

--- a/website/docs/support/bugs-and-features.md
+++ b/website/docs/support/bugs-and-features.md
@@ -3,6 +3,6 @@
 You can learn more about the Corso roadmap and how to interpret it [here](https://github.com/alcionai/corso-roadmap).
 
 If you run into a bug or have feature requests, please file a [GitHub issue](https://github.com/alcionai/corso/issues/)
-and attach the `bug` or `enhancement` label to the issue. When filing bugs, please run Corso with `--log-level debug`
-and add the logs to the bug report. You can find more information about where logs are stored in the
-[log files](../../setup/configuration/#log-files) section in setup docs.
+and attach the `bug` or `enhancement` label to the issue. When filing bugs, please run Corso with
+`--hide-progress --log-level debug` and add the logs to the bug report. You can find more information about where logs
+are stored in the [log files](../../setup/configuration/#log-files) section in setup docs.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -47,7 +47,7 @@ const config = {
           sidebarPath: require.resolve('./sidebars.js'),
           remarkPlugins: [require('mdx-mermaid')],
           editUrl:
-            'https://github.com/alcionai/corso/tree/main/docs',
+            'https://github.com/alcionai/corso/tree/main/website',
         },
         blog: {
           showReadingTime: true,


### PR DESCRIPTION

## Description

Fixes instructions on gathering logs. Also fixes the direct docs edit link.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :world_map: Documentation

