### PR TITLE
Remove OneDrive license GUID check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handle case where user's drive has not been initialized
 - Inline attachments (e.g. copy/paste ) are discovered and backed up correctly ([#2163](https://github.com/alcionai/corso/issues/2163))
 - Guest and External users (for cloud accounts) and non-on-premise users (for systems that use on-prem AD syncs) are now excluded from backup and restore operations.
+- Remove the M365 license guid check in OneDrive backup which wasn't reliable.
 
 
 ## [v0.1.0] (alpha) - 2023-01-13

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -79,7 +79,7 @@ func userDrives(ctx context.Context, service graph.Servicer, user string) ([]mod
 			detailedError := support.ConnectorStackErrorTrace(err)
 			if strings.Contains(detailedError, userMysiteURLNotFound) ||
 				strings.Contains(detailedError, userMysiteNotFound) {
-				logger.Ctx(ctx).Debugf("User %s does not have a drive", user)
+				logger.Ctx(ctx).Infof("User %s does not have a drive", user)
 				return make([]models.Driveable, 0), nil // no license
 			}
 


### PR DESCRIPTION
## Description

This check is brittle and shouldn't be needed. It should be sufficient to check whether a user has a 
drive or not (similar to what we now do for exchange mailboxes).

Validated with the existing integration test.

## Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #2271

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
