### PR TITLE
re-fetch file download url after expiration

### DIFF
--- a/src/internal/connector/graph/errors.go
+++ b/src/internal/connector/graph/errors.go
@@ -26,9 +26,7 @@ const (
 	errCodeMailboxNotEnabledForRESTAPI = "MailboxNotEnabledForRESTAPI"
 )
 
-var (
-	err401Unauthorized = errors.New("401 unauthorized intercepted")
-)
+var err401Unauthorized = errors.New("401 unauthorized intercepted")
 
 // The folder or item was deleted between the time we identified
 // it and when we tried to fetch data for it.

--- a/src/internal/connector/graph/errors.go
+++ b/src/internal/connector/graph/errors.go
@@ -31,7 +31,8 @@ var (
 	// normally the graph client will catch this for us, but in case we
 	// run our own client Do(), we need to translate it to a timeout type
 	// failure locally.
-	Err429TooManyRequests = errors.New("429 too many requests")
+	Err429TooManyRequests    = errors.New("429 too many requests")
+	Err503ServiceUnavailable = errors.New("503 Service Unavailable")
 )
 
 // The folder or item was deleted between the time we identified
@@ -168,6 +169,27 @@ func IsErrUnauthorized(err error) error {
 }
 
 func asUnauthorized(err error) bool {
+	e := ErrUnauthorized{}
+	return errors.As(err, &e)
+}
+
+type ErrServiceUnavailable struct {
+	common.Err
+}
+
+func IsSericeUnavailable(err error) error {
+	if errors.Is(err, Err503ServiceUnavailable) {
+		return err
+	}
+
+	if asServiceUnavailable(err) {
+		return err
+	}
+
+	return nil
+}
+
+func asServiceUnavailable(err error) bool {
 	e := ErrUnauthorized{}
 	return errors.As(err, &e)
 }

--- a/src/internal/connector/graph/errors.go
+++ b/src/internal/connector/graph/errors.go
@@ -10,7 +10,6 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/alcionai/corso/src/internal/common"
-	"github.com/alcionai/corso/src/pkg/logger"
 )
 
 // ---------------------------------------------------------------------------
@@ -54,7 +53,7 @@ func asDeletedInFlight(err error) bool {
 	return errors.As(err, &e)
 }
 
-// Delta tokens can be desycned or Unauthorized.  In either case, the token
+// Delta tokens can be desycned or expired.  In either case, the token
 // becomes invalid, and cannot be used again.
 // https://learn.microsoft.com/en-us/graph/errors#code-property
 type ErrInvalidDelta struct {
@@ -169,8 +168,6 @@ func hasErrorCode(err error, codes ...string) bool {
 	if oDataError.GetError().GetCode() == nil {
 		return false
 	}
-
-	logger.Ctx(context.Background()).Errorw("ERR CODE", "code", *oDataError.GetError().GetCode())
 
 	return slices.Contains(codes, *oDataError.GetError().GetCode())
 }

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -224,6 +224,7 @@ func (oc *Collection) populateItems(ctx context.Context) {
 			defer func() { <-semaphoreCh }()
 
 			var (
+				itemID   = *item.GetId()
 				itemName = *item.GetName()
 				itemSize = *item.GetSize()
 				itemInfo details.ItemInfo
@@ -251,7 +252,27 @@ func (oc *Collection) populateItems(ctx context.Context) {
 
 				for i := 1; i <= maxRetries; i++ {
 					_, itemData, err = oc.itemReader(oc.itemClient, item)
-					if err == nil || graph.IsErrTimeout(err) == nil {
+					if err == nil {
+						break
+					}
+
+					if graph.IsErrUnauthorized(err) != nil {
+						// assume unauthorized requests are a sign of an expired
+						// jwt token, and that we've overrun the available window
+						// to download the actual file.  Re-downloading the item
+						// will refresh that download url.
+						di, diErr := getDriveItem(ctx, oc.service, oc.driveID, itemID)
+						if diErr != nil {
+							err = errors.Wrap(diErr, "retrieving expired item")
+							break
+						}
+
+						item = di
+
+						continue
+
+					} else if graph.IsErrTimeout(err) == nil {
+						// for all non-timeout, non-unauth errors, do not retry
 						break
 					}
 
@@ -262,7 +283,7 @@ func (oc *Collection) populateItems(ctx context.Context) {
 
 				// check for errors following retries
 				if err != nil {
-					errUpdater(*item.GetId(), err)
+					errUpdater(itemID, err)
 					return nil, err
 				}
 

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -271,7 +271,9 @@ func (oc *Collection) populateItems(ctx context.Context) {
 
 						continue
 
-					} else if graph.IsErrTimeout(err) == nil && graph.IsErrThrottled(err) == nil && graph.IsSericeUnavailable(err) == nil {
+					} else if graph.IsErrTimeout(err) == nil &&
+						graph.IsErrThrottled(err) == nil &&
+						graph.IsSericeUnavailable(err) == nil {
 						// TODO: graphAPI will provides headers that state the duration to wait
 						// in order to succeed again.  The one second sleep won't cut it here.
 						//

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -271,8 +271,11 @@ func (oc *Collection) populateItems(ctx context.Context) {
 
 						continue
 
-					} else if graph.IsErrTimeout(err) == nil {
-						// for all non-timeout, non-unauth errors, do not retry
+					} else if graph.IsErrTimeout(err) == nil && graph.IsErrThrottled(err) == nil {
+						// TODO: graphAPI will provides headers that state the duration to wait
+						// in order to succeed again.  The one second sleep won't cut it here.
+						//
+						// for all non-timeout, non-unauth, non-throttling errors, do not retry
 						break
 					}
 

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -271,7 +271,7 @@ func (oc *Collection) populateItems(ctx context.Context) {
 
 						continue
 
-					} else if graph.IsErrTimeout(err) == nil && graph.IsErrThrottled(err) == nil {
+					} else if graph.IsErrTimeout(err) == nil && graph.IsErrThrottled(err) == nil && graph.IsSericeUnavailable(err) == nil {
 						// TODO: graphAPI will provides headers that state the duration to wait
 						// in order to succeed again.  The one second sleep won't cut it here.
 						//

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -53,8 +53,6 @@ func sharePointItemReader(
 	return dii, resp.Body, nil
 }
 
-var iii = 0
-
 // oneDriveItemReader will return a io.ReadCloser for the specified item
 // It crafts this by querying M365 for a download URL for the item
 // and using a http client to initialize a reader
@@ -85,8 +83,8 @@ func downloadItem(hc *http.Client, item models.DriveItemable) (*http.Response, e
 		return nil, errors.Wrap(err, "new request")
 	}
 
-	// Decorate the traffic
 	//nolint:lll
+	// Decorate the traffic
 	// See https://learn.microsoft.com/en-us/sharepoint/dev/general-development/how-to-avoid-getting-throttled-or-blocked-in-sharepoint-online#how-to-decorate-your-http-traffic
 	req.Header.Set("User-Agent", "ISV|Alcion|Corso/"+version.Version)
 

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -25,6 +25,15 @@ const (
 	downloadURLKey = "@microsoft.graph.downloadUrl"
 )
 
+// generic drive item getter
+func getDriveItem(
+	ctx context.Context,
+	srv graph.Servicer,
+	driveID, itemID string,
+) (models.DriveItemable, error) {
+	return srv.Client().DrivesById(driveID).ItemsById(itemID).Get(ctx, nil)
+}
+
 // sharePointItemReader will return a io.ReadCloser for the specified item
 // It crafts this by querying M365 for a download URL for the item
 // and using a http client to initialize a reader
@@ -32,14 +41,9 @@ func sharePointItemReader(
 	hc *http.Client,
 	item models.DriveItemable,
 ) (details.ItemInfo, io.ReadCloser, error) {
-	url, ok := item.GetAdditionalData()[downloadURLKey].(*string)
-	if !ok {
-		return details.ItemInfo{}, nil, fmt.Errorf("failed to get url for %s", *item.GetName())
-	}
-
-	resp, err := hc.Get(*url)
+	resp, err := downloadItem(hc, item)
 	if err != nil {
-		return details.ItemInfo{}, nil, err
+		return details.ItemInfo{}, nil, errors.Wrap(err, "downloading item")
 	}
 
 	dii := details.ItemInfo{
@@ -49,6 +53,8 @@ func sharePointItemReader(
 	return dii, resp.Body, nil
 }
 
+var iii = 0
+
 // oneDriveItemReader will return a io.ReadCloser for the specified item
 // It crafts this by querying M365 for a download URL for the item
 // and using a http client to initialize a reader
@@ -56,24 +62,9 @@ func oneDriveItemReader(
 	hc *http.Client,
 	item models.DriveItemable,
 ) (details.ItemInfo, io.ReadCloser, error) {
-	url, ok := item.GetAdditionalData()[downloadURLKey].(*string)
-	if !ok {
-		return details.ItemInfo{}, nil, fmt.Errorf("failed to get url for %s", *item.GetName())
-	}
-
-	req, err := http.NewRequest(http.MethodGet, *url, nil)
+	resp, err := downloadItem(hc, item)
 	if err != nil {
-		return details.ItemInfo{}, nil, err
-	}
-
-	// Decorate the traffic
-	//nolint:lll
-	// See https://learn.microsoft.com/en-us/sharepoint/dev/general-development/how-to-avoid-getting-throttled-or-blocked-in-sharepoint-online#how-to-decorate-your-http-traffic
-	req.Header.Set("User-Agent", "ISV|Alcion|Corso/"+version.Version)
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return details.ItemInfo{}, nil, err
+		return details.ItemInfo{}, nil, errors.Wrap(err, "downloading item")
 	}
 
 	dii := details.ItemInfo{
@@ -81,6 +72,25 @@ func oneDriveItemReader(
 	}
 
 	return dii, resp.Body, nil
+}
+
+func downloadItem(hc *http.Client, item models.DriveItemable) (*http.Response, error) {
+	url, ok := item.GetAdditionalData()[downloadURLKey].(*string)
+	if !ok {
+		return nil, fmt.Errorf("extracting file url: file %s", *item.GetId())
+	}
+
+	req, err := http.NewRequest(http.MethodGet, *url, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "new request")
+	}
+
+	// Decorate the traffic
+	//nolint:lll
+	// See https://learn.microsoft.com/en-us/sharepoint/dev/general-development/how-to-avoid-getting-throttled-or-blocked-in-sharepoint-online#how-to-decorate-your-http-traffic
+	req.Header.Set("User-Agent", "ISV|Alcion|Corso/"+version.Version)
+
+	return hc.Do(req)
 }
 
 // oneDriveItemInfo will populate a details.OneDriveInfo struct

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -105,6 +105,10 @@ func downloadItem(hc *http.Client, item models.DriveItemable) (*http.Response, e
 		return resp, graph.Err401Unauthorized
 	}
 
+	if resp.StatusCode == http.StatusServiceUnavailable {
+		return resp, graph.Err503ServiceUnavailable
+	}
+
 	return resp, errors.New("non-2xx http response: " + resp.Status)
 }
 


### PR DESCRIPTION
## Description

If a drive item goes over its 1 hour jwt expiration to download the backing file, re-fetch the item
and use the new download url to get the file.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :sunflower: Feature

## Issue(s)

* #2267

## Test Plan

- [x] :muscle: Manual
