### PR TITLE
update from Google Analytics to Google Tag Manager

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -59,7 +59,7 @@ const config = {
           filename: 'sitemap.xml',
         },
         gtag: {
-          trackingID: 'G-YXBFPQZ05N',
+          trackingID: 'GTM-KM3XWPV',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.scss'),


### PR DESCRIPTION
## Description

reconfigures to use google tag manager rather than direct to Google Analytics. 

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
