### PR TITLE
separate, test streamItems

### DIFF
--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	logGraphRequestsEnvKey = "LOG_GRAPH_REQUESTS"
-	numberOfRetries        = 3
+	numberOfRetries        = 1
 )
 
 // AllMetadataFileNames produces the standard set of filenames used to store graph
@@ -313,7 +313,7 @@ func RunWithRetry(run func() error) error {
 		}
 
 		if i < numberOfRetries {
-			time.Sleep(time.Duration(3*(i+2)) * time.Second)
+			time.Sleep(time.Duration(0*(i+2)) * time.Second)
 		}
 	}
 

--- a/src/internal/connector/onedrive/collection_test.go
+++ b/src/internal/connector/onedrive/collection_test.go
@@ -538,21 +538,21 @@ func (suite *CollectionUnitTestSuite) TestStreamItem() {
 			},
 		},
 		{
-			name:       "service unavailable errors",
+			name:       "internal server errors",
 			expectData: "",
 			coll: &Collection{
 				data:       mockDataChan(),
-				itemReader: mockReader("foo", graph.Err503ServiceUnavailable),
+				itemReader: mockReader("foo", graph.Err500InternalServerError),
 				itemGetter: mockGetter(nil),
 			},
 			errsIs: func(t *testing.T, e error, count int) {
-				assert.True(t, graph.IsSericeUnavailable(e), "is unavailable error")
-				assert.ErrorIs(t, e, graph.Err503ServiceUnavailable)
+				assert.True(t, graph.IsInternalServerError(e), "is internal server error")
+				assert.ErrorIs(t, e, graph.Err500InternalServerError)
 				assert.Equal(t, 1, count, "one errors")
 			},
 			readErrIs: func(t *testing.T, e error) {
-				assert.True(t, graph.IsSericeUnavailable(e), "is unavailable error")
-				assert.ErrorIs(t, e, graph.Err503ServiceUnavailable)
+				assert.True(t, graph.IsInternalServerError(e), "is internal server error")
+				assert.ErrorIs(t, e, graph.Err500InternalServerError)
 			},
 		},
 	}


### PR DESCRIPTION
## Description

In oneDrive, breaks the code for streaming each
item out into its own function.  Adds a unit test
that uses mocks to test the new stream func.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :robot: Test

## Issue(s)

* #2267

## Test Plan

- [x] :zap: Unit test
