### PR TITLE
OneDrive Items API for mocking

### DIFF
--- a/src/internal/connector/onedrive/api/drive.go
+++ b/src/internal/connector/onedrive/api/drive.go
@@ -50,9 +50,6 @@ func NewItemPager(
 	res := &driveItemPager{
 		gs:      gs,
 		options: requestConfig,
-		// TODO: Specify a timestamp in the delta query
-		// https://docs.microsoft.com/en-us/graph/api/driveitem-delta?
-		// view=graph-rest-1.0&tabs=http#example-4-retrieving-delta-results-using-a-timestamp
 		builder: gs.Client().DrivesById(driveID).Root().Delta(),
 	}
 

--- a/src/internal/connector/onedrive/api/drive.go
+++ b/src/internal/connector/onedrive/api/drive.go
@@ -12,6 +12,18 @@ import (
 	"github.com/alcionai/corso/src/internal/connector/graph/api"
 )
 
+func getValues[T any](l api.PageLinker) ([]T, error) {
+	page, ok := l.(interface{ GetValue() []T })
+	if !ok {
+		return nil, errors.Errorf(
+			"response of type [%T] does not comply with GetValue() interface",
+			l,
+		)
+	}
+
+	return page.GetValue(), nil
+}
+
 type userDrivePager struct {
 	gs      graph.Servicer
 	builder *msusers.ItemDrivesRequestBuilder
@@ -47,15 +59,7 @@ func (p *userDrivePager) SetNext(link string) {
 }
 
 func (p *userDrivePager) ValuesIn(l api.PageLinker) ([]models.Driveable, error) {
-	page, ok := l.(interface{ GetValue() []models.Driveable })
-	if !ok {
-		return nil, errors.Errorf(
-			"response of type [%T] does not comply with GetValue() interface",
-			l,
-		)
-	}
-
-	return page.GetValue(), nil
+	return getValues[models.Driveable](l)
 }
 
 type siteDrivePager struct {
@@ -93,13 +97,5 @@ func (p *siteDrivePager) SetNext(link string) {
 }
 
 func (p *siteDrivePager) ValuesIn(l api.PageLinker) ([]models.Driveable, error) {
-	page, ok := l.(interface{ GetValue() []models.Driveable })
-	if !ok {
-		return nil, errors.Errorf(
-			"response of type [%T] does not comply with GetValue() interface",
-			l,
-		)
-	}
-
-	return page.GetValue(), nil
+	return getValues[models.Driveable](l)
 }

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -65,6 +65,13 @@ type Collections struct {
 	// for a OneDrive folder
 	CollectionMap map[string]data.Collection
 
+	// Not the most ideal, but allows us to change the pager function for testing
+	// as needed. This will allow us to mock out some scenarios during testing.
+	itemPagerFunc func(
+		servicer graph.Servicer,
+		driveID, link string,
+	) itemPager
+
 	// Track stats from drive enumeration. Represents the items backed up.
 	NumItems      int
 	NumFiles      int
@@ -88,6 +95,7 @@ func NewCollections(
 		source:        source,
 		matcher:       matcher,
 		CollectionMap: map[string]data.Collection{},
+		itemPagerFunc: defaultItemPager,
 		service:       service,
 		statusUpdater: statusUpdater,
 		ctrl:          ctrlOpts,
@@ -266,7 +274,11 @@ func (c *Collections) Get(
 
 		delta, paths, excluded, err := collectItems(
 			ctx,
-			c.service,
+			c.itemPagerFunc(
+				c.service,
+				driveID,
+				"",
+			),
 			driveID,
 			driveName,
 			c.UpdateCollections,

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -195,18 +195,19 @@ func collectItems(
 			return "", nil, nil, err
 		}
 
-		if r.GetOdataDeltaLink() != nil && len(*r.GetOdataDeltaLink()) > 0 {
-			newDeltaURL = *r.GetOdataDeltaLink()
+		nextLink, deltaLink := gapi.NextAndDeltaLink(page)
+
+		if len(deltaLink) > 0 {
+			newDeltaURL = deltaLink
 		}
 
 		// Check if there are more items
-		nextLink := r.GetOdataNextLink()
-		if nextLink == nil {
+		if len(nextLink) == 0 {
 			break
 		}
 
-		logger.Ctx(ctx).Debugf("Found %s nextLink", *nextLink)
-		builder = msdrives.NewItemRootDeltaRequestBuilder(*nextLink, service.Adapter())
+		logger.Ctx(ctx).Debugw("Found nextLink", "link", nextLink)
+		pager.SetNext(nextLink)
 	}
 
 	return newDeltaURL, newPaths, excluded, nil

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -328,7 +328,11 @@ func GetAllFolders(
 	for _, d := range drives {
 		_, _, _, err = collectItems(
 			ctx,
-			gs,
+			defaultItemPager(
+				gs,
+				*d.GetId(),
+				"",
+			),
 			*d.GetId(),
 			*d.GetName(),
 			func(

--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -115,7 +115,17 @@ func (suite *ItemIntegrationSuite) TestItemReader_oneDrive() {
 
 		return nil
 	}
-	_, _, _, err := collectItems(ctx, suite, suite.userDriveID, "General", itemCollector)
+	_, _, _, err := collectItems(
+		ctx,
+		defaultItemPager(
+			suite,
+			suite.userDriveID,
+			"",
+		),
+		suite.userDriveID,
+		"General",
+		itemCollector,
+	)
 	require.NoError(suite.T(), err)
 
 	// Test Requirement 2: Need a file


### PR DESCRIPTION
## Description

Create a pager for drive items that allows for better testing via mocking. Increased testing will come in later PRs

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

* #2264

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
