### PR TITLE
Bump up max page size preference for exchange delta requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Document Corso's fault-tolerance and restartability features
 - Add retries on timeouts and status code 500 for Exchange
+- Increase page size preference for delta requests for Exchange to reduce number of roundtrips
 
 ## [v0.2.0] (alpha) - 2023-1-29
 

--- a/src/internal/connector/exchange/api/options.go
+++ b/src/internal/connector/exchange/api/options.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 
+	abstractions "github.com/microsoft/kiota-abstractions-go"
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
 )
 
@@ -53,6 +54,16 @@ var (
 	}
 )
 
+const (
+	// headerKeyPrefer is used to set query preferences
+	headerKeyPrefer = "Prefer"
+	// maxPageSizeHeaderFmt is used to indicate max page size
+	// preferences
+	maxPageSizeHeaderFmt = "odata.maxpagesize=%d"
+	// deltaMaxPageSize is the max page size to use for delta queries
+	deltaMaxPageSize = 200
+)
+
 // -----------------------------------------------------------------------
 // exchange.Query Option Section
 // These functions can be used to filter a response on M365
@@ -71,8 +82,10 @@ func optionsForFolderMessagesDelta(
 	requestParameters := &users.ItemMailFoldersItemMessagesDeltaRequestBuilderGetQueryParameters{
 		Select: selecting,
 	}
+
 	options := &users.ItemMailFoldersItemMessagesDeltaRequestBuilderGetRequestConfiguration{
 		QueryParameters: requestParameters,
+		Headers:         buildDeltaRequestHeaders(),
 	}
 
 	return options, nil
@@ -218,6 +231,7 @@ func optionsForContactFoldersItemDelta(
 
 	options := &users.ItemContactFoldersItemContactsDeltaRequestBuilderGetRequestConfiguration{
 		QueryParameters: requestParameters,
+		Headers:         buildDeltaRequestHeaders(),
 	}
 
 	return options, nil
@@ -274,4 +288,12 @@ func buildOptions(fields []string, allowed map[string]struct{}) ([]string, error
 	}
 
 	return append(returnedOptions, fields...), nil
+}
+
+// buildDeltaRequestHeaders returns the headers we add to delta page requests
+func buildDeltaRequestHeaders() *abstractions.RequestHeaders {
+	headers := abstractions.NewRequestHeaders()
+	headers.Add(headerKeyPrefer, fmt.Sprintf(maxPageSizeHeaderFmt, deltaMaxPageSize))
+
+	return headers
 }

--- a/src/internal/connector/exchange/api/shared.go
+++ b/src/internal/connector/exchange/api/shared.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/graph/api"
 	"github.com/alcionai/corso/src/internal/connector/support"
+	"github.com/alcionai/corso/src/pkg/logger"
 )
 
 // ---------------------------------------------------------------------------
@@ -81,6 +82,8 @@ func getItemsAddedAndRemovedFromContainer(
 		if err != nil {
 			return nil, nil, "", err
 		}
+
+		logger.Ctx(ctx).Infow("Got page", "items", len(items))
 
 		// iterate through the items in the page
 		for _, item := range items {


### PR DESCRIPTION
## Description

Reduces the number of roundtrips when requesting delta records for exchange

TODO: Need to investigate OneDrive behavior - this header doesn't appear to work with OneDrive.

## Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #2332 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
