### PR TITLE
Patch and test some edge cases for deserializing OneDrive metadata

### DIFF
--- a/src/internal/connector/onedrive/collections_test.go
+++ b/src/internal/connector/onedrive/collections_test.go
@@ -712,6 +712,60 @@ func (suite *OneDriveCollectionsSuite) TestDeserializeMetadata() {
 			errCheck:       assert.NoError,
 		},
 		{
+			// An empty path map but valid delta results in metadata being returned
+			// since it's possible to have a drive with no folders other than the
+			// root.
+			name: "EmptyPaths",
+			cols: []func() []graph.MetadataCollectionEntry{
+				func() []graph.MetadataCollectionEntry {
+					return []graph.MetadataCollectionEntry{
+						graph.NewMetadataEntry(
+							graph.DeltaURLsFileName,
+							map[string]string{driveID1: deltaURL1},
+						),
+						graph.NewMetadataEntry(
+							graph.PreviousPathFileName,
+							map[string]map[string]string{
+								driveID1: {},
+							},
+						),
+					}
+				},
+			},
+			expectedDeltas: map[string]string{driveID1: deltaURL1},
+			expectedPaths:  map[string]map[string]string{driveID1: {}},
+			errCheck:       assert.NoError,
+		},
+		{
+			// An empty delta map but valid path results in no metadata for that drive
+			// being returned since the path map is only useful if we have a valid
+			// delta.
+			name: "EmptyDeltas",
+			cols: []func() []graph.MetadataCollectionEntry{
+				func() []graph.MetadataCollectionEntry {
+					return []graph.MetadataCollectionEntry{
+						graph.NewMetadataEntry(
+							graph.DeltaURLsFileName,
+							map[string]string{
+								driveID1: "",
+							},
+						),
+						graph.NewMetadataEntry(
+							graph.PreviousPathFileName,
+							map[string]map[string]string{
+								driveID1: {
+									folderID1: path1,
+								},
+							},
+						),
+					}
+				},
+			},
+			expectedDeltas: map[string]string{},
+			expectedPaths:  map[string]map[string]string{},
+			errCheck:       assert.NoError,
+		},
+		{
 			name: "SuccessTwoDrivesTwoCollections",
 			cols: []func() []graph.MetadataCollectionEntry{
 				func() []graph.MetadataCollectionEntry {


### PR DESCRIPTION
## Description

Currently no folder path entry is stored for the root folder. This leads to not having a folders map but having a valid delta token if all items are in the root of the drive.

Update the code to add at least an empty folders map entry so we don't think we have missing metadata. Add tests to check for these edge cases.

Long-term we may want to add a folder entry for the root folder. Whether we do or not may depend on how we decide to set the state field for that collection.

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

* #2122 

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
