### PR TITLE
Issue 2329 logfile 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@
 .corso_test.toml
 .corso.toml
 
+# Logging
+.corso.log
+
 # Build directories
 /bin
 /docker/bin

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/exp/slices"
 
 	"github.com/alcionai/corso/src/cli/backup"
 	"github.com/alcionai/corso/src/cli/config"
@@ -48,6 +49,11 @@ func preRun(cc *cobra.Command, args []string) error {
 	// currently only tracking flag names to avoid pii leakage.
 	for f := range flags {
 		flagSl = append(flagSl, f)
+	}
+
+	avoidTheseCommands := []string{"corso", "env", "help", "sharepoint", "onedrive", "exchange", "repo"}
+	if len(logger.LogFile) > 0 && !slices.Contains(avoidTheseCommands, cc.Use) {
+		print.Info(cc.Context(), "Logging to file: "+logger.LogFile)
 	}
 
 	log.Infow("cli command", "command", cc.CommandPath(), "flags", flagSl, "version", version.CurrentVersion())

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -51,7 +51,9 @@ func preRun(cc *cobra.Command, args []string) error {
 		flagSl = append(flagSl, f)
 	}
 
-	avoidTheseCommands := []string{"corso", "env", "help", "sharepoint", "onedrive", "exchange", "repo"}
+	avoidTheseCommands := []string{
+		"corso", "env", "help", "backup", "details", "list", "restore", "delete", "repo", "init", "connect",
+	}
 	if len(logger.LogFile) > 0 && !slices.Contains(avoidTheseCommands, cc.Use) {
 		print.Info(cc.Context(), "Logging to file: "+logger.LogFile)
 	}

--- a/src/pkg/logger/logger.go
+++ b/src/pkg/logger/logger.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/alcionai/clues"
+	"github.com/alcionai/corso/src/cli/print"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
@@ -118,6 +119,7 @@ func PreloadLoggingFlags() (string, string) {
 
 	if logfile != "stdout" && logfile != "stderr" {
 		logdir := filepath.Dir(logfile)
+		print.Info(context.Background(), "Logging to file: "+logfile)
 
 		err := os.MkdirAll(logdir, 0o755)
 		if err != nil {

--- a/src/pkg/logger/logger.go
+++ b/src/pkg/logger/logger.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/alcionai/clues"
-	"github.com/alcionai/corso/src/cli/print"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
@@ -29,6 +28,8 @@ var (
 
 	DebugAPI       bool
 	readableOutput bool
+
+	LogFile string
 )
 
 type logLevel int
@@ -118,8 +119,8 @@ func PreloadLoggingFlags() (string, string) {
 	}
 
 	if logfile != "stdout" && logfile != "stderr" {
+		LogFile = logfile
 		logdir := filepath.Dir(logfile)
-		print.Info(context.Background(), "Logging to file: "+logfile)
 
 		err := os.MkdirAll(logdir, 0o755)
 		if err != nil {


### PR DESCRIPTION
## Description

Prevents showing the log file location when calling commands that defer to help output or env details.
Certain cases aren't caught, such as when calling a command with no flags (ex: `corso backup create exchange`).
In those cases we catch the lack of flags and manually display the usage within the command handler.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :broom: Tech Debt/Cleanup

## Issue(s)

* #2329

## Test Plan

- [x] :muscle: Manual
