### PR TITLE
Add progress logging to delta queries

### DIFF
--- a/src/internal/connector/exchange/api/contacts.go
+++ b/src/internal/connector/exchange/api/contacts.go
@@ -12,10 +12,12 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
 	"github.com/pkg/errors"
 
+	"github.com/alcionai/clues"
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/graph/api"
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/selectors"
 )
 
 // ---------------------------------------------------------------------------
@@ -233,6 +235,11 @@ func (c Contacts) GetAddedAndRemovedItemIDs(
 		errs       *multierror.Error
 		resetDelta bool
 	)
+
+	ctx = clues.AddAll(
+		ctx,
+		"category", selectors.ExchangeContact,
+		"folder_id", directoryID)
 
 	options, err := optionsForContactFoldersItemDelta([]string{"parentFolderId"})
 	if err != nil {

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -12,6 +12,7 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
 	"github.com/pkg/errors"
 
+	"github.com/alcionai/clues"
 	"github.com/alcionai/corso/src/internal/common"
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/graph/api"
@@ -19,6 +20,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/selectors"
 )
 
 // ---------------------------------------------------------------------------
@@ -270,6 +272,11 @@ func (c Events) GetAddedAndRemovedItemIDs(
 		resetDelta bool
 		errs       *multierror.Error
 	)
+
+	ctx = clues.AddAll(
+		ctx,
+		"category", selectors.ExchangeEvent,
+		"calendar_id", calendarID)
 
 	if len(oldDelta) > 0 {
 		builder := users.NewItemCalendarsItemEventsDeltaRequestBuilder(oldDelta, service.Adapter())

--- a/src/internal/connector/exchange/api/mail.go
+++ b/src/internal/connector/exchange/api/mail.go
@@ -12,11 +12,13 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
 	"github.com/pkg/errors"
 
+	"github.com/alcionai/clues"
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/graph/api"
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/logger"
+	"github.com/alcionai/corso/src/pkg/selectors"
 )
 
 // ---------------------------------------------------------------------------
@@ -258,6 +260,11 @@ func (c Mail) GetAddedAndRemovedItemIDs(
 		deltaURL   string
 		resetDelta bool
 	)
+
+	ctx = clues.AddAll(
+		ctx,
+		"category", selectors.ExchangeMail,
+		"folder_id", directoryID)
 
 	options, err := optionsForFolderMessagesDelta([]string{"isRead"})
 	if err != nil {

--- a/src/internal/connector/exchange/api/shared.go
+++ b/src/internal/connector/exchange/api/shared.go
@@ -87,7 +87,7 @@ func getItemsAddedAndRemovedFromContainer(
 		}
 
 		itemCount += len(items)
-		page += 1
+		page++
 
 		// Log every ~1000 items (the page size we use is 200)
 		if page%5 == 0 {

--- a/src/internal/connector/exchange/api/shared.go
+++ b/src/internal/connector/exchange/api/shared.go
@@ -65,6 +65,9 @@ func getItemsAddedAndRemovedFromContainer(
 		deltaURL   string
 	)
 
+	itemCount := 0
+	page := 0
+
 	for {
 		// get the next page of data, check for standard errors
 		resp, err := pager.getPage(ctx)
@@ -83,7 +86,13 @@ func getItemsAddedAndRemovedFromContainer(
 			return nil, nil, "", err
 		}
 
-		logger.Ctx(ctx).Infow("Got page", "items", len(items))
+		itemCount += len(items)
+		page += 1
+
+		// Log every ~1000 items (the page size we use is 200)
+		if page%5 == 0 {
+			logger.Ctx(ctx).Infow("queried items", "count", itemCount)
+		}
 
 		// iterate through the items in the page
 		for _, item := range items {
@@ -116,6 +125,8 @@ func getItemsAddedAndRemovedFromContainer(
 
 		pager.setNext(nextLink)
 	}
+
+	logger.Ctx(ctx).Infow("completed enumeration", "count", itemCount)
 
 	return addedIDs, removedIDs, deltaURL, nil
 }


### PR DESCRIPTION
## Description

Adds logging to delta enumeration to log every 1000 items or so (each page is set to 200 items)

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #2329 

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
