### PR TITLE
GC: Backup: ItemAttachment Complete 

### DIFF
--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -108,7 +108,14 @@ func (c Events) GetItem(
 		return nil, nil, err
 	}
 
-	var errs *multierror.Error
+	var (
+		errs    *multierror.Error
+		options = &users.ItemEventsItemAttachmentsRequestBuilderGetRequestConfiguration{
+			QueryParameters: &users.ItemEventsItemAttachmentsRequestBuilderGetQueryParameters{
+				Expand: []string{"microsoft.graph.itemattachment/item"},
+			},
+		}
+	)
 
 	if *event.GetHasAttachments() || HasAttachments(event.GetBody()) {
 		for count := 0; count < numberOfRetries; count++ {
@@ -117,7 +124,7 @@ func (c Events) GetItem(
 				UsersById(user).
 				EventsById(itemID).
 				Attachments().
-				Get(ctx, nil)
+				Get(ctx, options)
 			if err == nil {
 				event.SetAttachments(attached.GetValue())
 				break

--- a/src/internal/connector/exchange/api/mail.go
+++ b/src/internal/connector/exchange/api/mail.go
@@ -130,13 +130,18 @@ func (c Mail) GetItem(
 	var errs *multierror.Error
 
 	if *mail.GetHasAttachments() || HasAttachments(mail.GetBody()) {
+		options := &users.ItemMessagesItemAttachmentsRequestBuilderGetRequestConfiguration{
+			QueryParameters: &users.ItemMessagesItemAttachmentsRequestBuilderGetQueryParameters{
+				Expand: []string{"microsoft.graph.itemattachment/item"},
+			},
+		}
 		for count := 0; count < numberOfRetries; count++ {
 			attached, err := c.largeItem.
 				Client().
 				UsersById(user).
 				MessagesById(itemID).
 				Attachments().
-				Get(ctx, nil)
+				Get(ctx, options)
 			if err == nil {
 				mail.SetAttachments(attached.GetValue())
 				break


### PR DESCRIPTION
## Description
Bug fix: Ensures that `item.Attachment` content is completely backed up.

- Exchange 
Changes affect the behavior of Mail and Events. Downloads can be potentially bigger if the user have these types of attachments.

- `item.Attachments` are specific to Outlook objects such as `Events` or `Messages` are included as an attachment rather than inline.  

<!-- Insert PR description-->

## Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

## Type of change
- [x] :bug: Bugfix


## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* related to  #2353<issue>

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual

