### PR TITLE
add fault/clues to kopia, pt 1

### DIFF
--- a/src/internal/kopia/upload_test.go
+++ b/src/internal/kopia/upload_test.go
@@ -518,7 +518,7 @@ func (suite *CorsoProgressUnitSuite) TestFinishedFileCachedNoPrevPathErrors() {
 
 	assert.Empty(t, cp.pending)
 	assert.Empty(t, bd.Details().Entries)
-	assert.Error(t, cp.errs.ErrorOrNil())
+	assert.Error(t, cp.errs.Err())
 }
 
 func (suite *CorsoProgressUnitSuite) TestFinishedFileBuildsHierarchyNewItem() {

--- a/src/internal/kopia/upload_test.go
+++ b/src/internal/kopia/upload_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
@@ -456,6 +457,7 @@ func (suite *CorsoProgressUnitSuite) TestFinishedFile() {
 						UploadProgress: &snapshotfs.NullUploadProgress{},
 						deets:          bd,
 						pending:        map[string]*itemDetails{},
+						errs:           fault.New(true),
 					}
 
 					ci := test.cachedItems(suite.targetFileName, suite.targetFilePath)
@@ -503,6 +505,7 @@ func (suite *CorsoProgressUnitSuite) TestFinishedFileCachedNoPrevPathErrors() {
 		UploadProgress: &snapshotfs.NullUploadProgress{},
 		deets:          bd,
 		pending:        map[string]*itemDetails{},
+		errs:           fault.New(true),
 	}
 
 	for k, v := range cachedItems {
@@ -533,6 +536,7 @@ func (suite *CorsoProgressUnitSuite) TestFinishedFileBuildsHierarchyNewItem() {
 		deets:          bd,
 		pending:        map[string]*itemDetails{},
 		toMerge:        map[string]path.Path{},
+		errs:           fault.New(true),
 	}
 
 	deets := &itemDetails{info: &details.ItemInfo{}, repoPath: suite.targetFilePath}
@@ -605,6 +609,7 @@ func (suite *CorsoProgressUnitSuite) TestFinishedFileBaseItemDoesntBuildHierarch
 		deets:          bd,
 		pending:        map[string]*itemDetails{},
 		toMerge:        map[string]path.Path{},
+		errs:           fault.New(true),
 	}
 
 	deets := &itemDetails{
@@ -629,6 +634,7 @@ func (suite *CorsoProgressUnitSuite) TestFinishedHashingFile() {
 				UploadProgress: &snapshotfs.NullUploadProgress{},
 				deets:          bd,
 				pending:        map[string]*itemDetails{},
+				errs:           fault.New(true),
 			}
 
 			ci := test.cachedItems(suite.targetFileName, suite.targetFilePath)
@@ -681,7 +687,10 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree() {
 		user2Encoded: 42,
 	}
 
-	progress := &corsoProgress{pending: map[string]*itemDetails{}}
+	progress := &corsoProgress{
+		pending: map[string]*itemDetails{},
+		errs:    fault.New(true),
+	}
 
 	collections := []data.BackupCollection{
 		mockconnector.NewMockExchangeCollection(
@@ -791,7 +800,10 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_MixedDirectory() 
 
 	for _, test := range table {
 		suite.T().Run(test.name, func(t *testing.T) {
-			progress := &corsoProgress{pending: map[string]*itemDetails{}}
+			progress := &corsoProgress{
+				pending: map[string]*itemDetails{},
+				errs:    fault.New(true),
+			}
 
 			dirTree, err := inflateDirTree(ctx, nil, nil, test.layout, nil, progress)
 			require.NoError(t, err)
@@ -971,7 +983,10 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeErrors() {
 			ctx, flush := tester.NewContext()
 			defer flush()
 
-			progress := &corsoProgress{pending: map[string]*itemDetails{}}
+			progress := &corsoProgress{
+				pending: map[string]*itemDetails{},
+				errs:    fault.New(true),
+			}
 
 			cols := []data.BackupCollection{}
 			for _, s := range test.states {
@@ -1249,7 +1264,10 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
 			ctx, flush := tester.NewContext()
 			defer flush()
 
-			progress := &corsoProgress{pending: map[string]*itemDetails{}}
+			progress := &corsoProgress{
+				pending: map[string]*itemDetails{},
+				errs:    fault.New(true),
+			}
 			msw := &mockSnapshotWalker{
 				snapshotRoot: getBaseSnapshot(),
 			}
@@ -1951,7 +1969,10 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 			ctx, flush := tester.NewContext()
 			defer flush()
 
-			progress := &corsoProgress{pending: map[string]*itemDetails{}}
+			progress := &corsoProgress{
+				pending: map[string]*itemDetails{},
+				errs:    fault.New(true),
+			}
 			msw := &mockSnapshotWalker{
 				snapshotRoot: getBaseSnapshot(),
 			}
@@ -2097,7 +2118,10 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSkipsDeletedSubtre
 		},
 	)
 
-	progress := &corsoProgress{pending: map[string]*itemDetails{}}
+	progress := &corsoProgress{
+		pending: map[string]*itemDetails{},
+		errs:    fault.New(true),
+	}
 	mc := mockconnector.NewMockExchangeCollection(suite.testPath, 1)
 	mc.PrevPath = mc.FullPath()
 	mc.ColState = data.DeletedState
@@ -2346,7 +2370,10 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSelectsCorrectSubt
 		},
 	)
 
-	progress := &corsoProgress{pending: map[string]*itemDetails{}}
+	progress := &corsoProgress{
+		pending: map[string]*itemDetails{},
+		errs:    fault.New(true),
+	}
 
 	mc := mockconnector.NewMockExchangeCollection(inboxPath, 1)
 	mc.PrevPath = mc.FullPath()

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -291,8 +291,11 @@ func (w Wrapper) getSnapshotRoot(
 	}
 
 	rootDirEntry, err := snapshotfs.SnapshotRoot(w.c, man)
+	if err != nil {
+		return nil, clues.Wrap(err, "getting root directory").WithClues(ctx)
+	}
 
-	return rootDirEntry, clues.Wrap(err, "getting root directory").WithClues(ctx)
+	return rootDirEntry, nil
 }
 
 // getItemStream looks up the item at the given path starting from snapshotRoot.

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/hashicorp/go-multierror"
+	"github.com/alcionai/clues"
 	"github.com/kopia/kopia/fs"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/manifest"
@@ -17,6 +17,7 @@ import (
 	D "github.com/alcionai/corso/src/internal/diagnostics"
 	"github.com/alcionai/corso/src/internal/stats"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
 )
@@ -101,7 +102,7 @@ func (w *Wrapper) Close(ctx context.Context) error {
 	err := w.c.Close(ctx)
 	w.c = nil
 
-	return errors.Wrap(err, "closing Wrapper")
+	return clues.Wrap(err, "closing Wrapper").WithClues(ctx)
 }
 
 type IncrementalBase struct {
@@ -122,9 +123,10 @@ func (w Wrapper) BackupCollections(
 	globalExcludeSet map[string]struct{},
 	tags map[string]string,
 	buildTreeWithBase bool,
+	errs *fault.Errors,
 ) (*BackupStats, *details.Builder, map[string]path.Path, error) {
 	if w.c == nil {
-		return nil, nil, nil, errNotConnected
+		return nil, nil, nil, clues.Stack(errNotConnected).WithClues(ctx)
 	}
 
 	ctx, end := D.Span(ctx, "kopia:backupCollections")
@@ -138,6 +140,7 @@ func (w Wrapper) BackupCollections(
 		pending: map[string]*itemDetails{},
 		deets:   &details.Builder{},
 		toMerge: map[string]path.Path{},
+		errs:    errs,
 	}
 
 	// When running an incremental backup, we need to pass the prior
@@ -165,14 +168,12 @@ func (w Wrapper) BackupCollections(
 		previousSnapshots,
 		dirTree,
 		tags,
-		progress,
-	)
+		progress)
 	if err != nil {
-		combinedErrs := multierror.Append(nil, err, progress.errs)
-		return nil, nil, nil, combinedErrs.ErrorOrNil()
+		return nil, nil, nil, err
 	}
 
-	return s, progress.deets, progress.toMerge, progress.errs.ErrorOrNil()
+	return s, progress.deets, progress.toMerge, progress.errs.Err()
 }
 
 func (w Wrapper) makeSnapshotWithRoot(
@@ -197,9 +198,7 @@ func (w Wrapper) makeSnapshotWithRoot(
 
 	logger.Ctx(ctx).Infow(
 		"using snapshots for kopia-assisted incrementals",
-		"snapshot_ids",
-		snapIDs,
-	)
+		"snapshot_ids", snapIDs)
 
 	tags := map[string]string{}
 
@@ -224,6 +223,8 @@ func (w Wrapper) makeSnapshotWithRoot(
 			OnUpload:       bc.Count,
 		},
 		func(innerCtx context.Context, rw repo.RepositoryWriter) error {
+			log := logger.Ctx(innerCtx)
+
 			si := snapshot.SourceInfo{
 				Host:     corsoHost,
 				UserName: corsoUser,
@@ -240,8 +241,8 @@ func (w Wrapper) makeSnapshotWithRoot(
 			}
 			policyTree, err := policy.TreeForSourceWithOverride(innerCtx, w.c, si, errPolicy)
 			if err != nil {
-				err = errors.Wrap(err, "get policy tree")
-				logger.Ctx(innerCtx).Errorw("kopia backup", err)
+				err = clues.Wrap(err, "get policy tree").WithClues(ctx)
+				log.With("err", err).Errorw("building kopia backup", clues.InErr(err).Slice()...)
 				return err
 			}
 
@@ -253,16 +254,16 @@ func (w Wrapper) makeSnapshotWithRoot(
 
 			man, err = u.Upload(innerCtx, root, policyTree, si, prevSnaps...)
 			if err != nil {
-				err = errors.Wrap(err, "uploading data")
-				logger.Ctx(innerCtx).Errorw("kopia backup", err)
+				err = clues.Wrap(err, "uploading data").WithClues(ctx)
+				log.With("err", err).Errorw("uploading kopia backup", clues.InErr(err).Slice()...)
 				return err
 			}
 
 			man.Tags = tags
 
 			if _, err := snapshot.SaveSnapshot(innerCtx, rw, man); err != nil {
-				err = errors.Wrap(err, "saving snapshot")
-				logger.Ctx(innerCtx).Errorw("kopia backup", err)
+				err = clues.Wrap(err, "saving snapshot").WithClues(ctx)
+				log.With("err", err).Errorw("persisting kopia backup snapshot", clues.InErr(err).Slice()...)
 				return err
 			}
 
@@ -272,7 +273,7 @@ func (w Wrapper) makeSnapshotWithRoot(
 	// Telling kopia to always flush may hide other errors if it fails while
 	// flushing the write session (hence logging above).
 	if err != nil {
-		return nil, errors.Wrap(err, "kopia backup")
+		return nil, clues.Wrap(err, "kopia backup")
 	}
 
 	res := manifestToStats(man, progress, bc)
@@ -286,12 +287,12 @@ func (w Wrapper) getSnapshotRoot(
 ) (fs.Entry, error) {
 	man, err := snapshot.LoadSnapshot(ctx, w.c, manifest.ID(snapshotID))
 	if err != nil {
-		return nil, errors.Wrap(err, "getting snapshot handle")
+		return nil, clues.Wrap(err, "getting snapshot handle").WithClues(ctx)
 	}
 
 	rootDirEntry, err := snapshotfs.SnapshotRoot(w.c, man)
 
-	return rootDirEntry, errors.Wrap(err, "getting root directory")
+	return rootDirEntry, clues.Wrap(err, "getting root directory").WithClues(ctx)
 }
 
 // getItemStream looks up the item at the given path starting from snapshotRoot.
@@ -306,7 +307,7 @@ func getItemStream(
 	bcounter ByteCounter,
 ) (data.Stream, error) {
 	if itemPath == nil {
-		return nil, errors.WithStack(errNoRestorePath)
+		return nil, clues.Stack(errNoRestorePath).WithClues(ctx)
 	}
 
 	// GetNestedEntry handles nil properly.
@@ -317,15 +318,15 @@ func getItemStream(
 	)
 	if err != nil {
 		if strings.Contains(err.Error(), "entry not found") {
-			err = errors.Wrap(data.ErrNotFound, err.Error())
+			err = clues.Stack(data.ErrNotFound, err).WithClues(ctx)
 		}
 
-		return nil, errors.Wrap(err, "getting nested object handle")
+		return nil, clues.Wrap(err, "getting nested object handle").WithClues(ctx)
 	}
 
 	f, ok := e.(fs.File)
 	if !ok {
-		return nil, errors.New("requested object is not a file")
+		return nil, clues.New("requested object is not a file").WithClues(ctx)
 	}
 
 	if bcounter != nil {
@@ -334,12 +335,12 @@ func getItemStream(
 
 	r, err := f.Open(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "opening file")
+		return nil, clues.Wrap(err, "opening file").WithClues(ctx)
 	}
 
 	decodedName, err := decodeElement(f.Name())
 	if err != nil {
-		return nil, errors.Wrap(err, "decoding file name")
+		return nil, clues.Wrap(err, "decoding file name").WithClues(ctx)
 	}
 
 	return &kopiaDataStream{
@@ -368,12 +369,13 @@ func (w Wrapper) RestoreMultipleItems(
 	snapshotID string,
 	paths []path.Path,
 	bcounter ByteCounter,
+	errs *fault.Errors,
 ) ([]data.RestoreCollection, error) {
 	ctx, end := D.Span(ctx, "kopia:restoreMultipleItems")
 	defer end()
 
 	if len(paths) == 0 {
-		return nil, errors.WithStack(errNoRestorePath)
+		return nil, clues.Stack(errNoRestorePath).WithClues(ctx)
 	}
 
 	snapshotRoot, err := w.getSnapshotRoot(ctx, snapshotID)
@@ -381,22 +383,23 @@ func (w Wrapper) RestoreMultipleItems(
 		return nil, err
 	}
 
-	var (
-		errs *multierror.Error
-		// Maps short ID of parent path to data collection for that folder.
-		cols = map[string]*kopiaDataCollection{}
-	)
+	// Maps short ID of parent path to data collection for that folder.
+	cols := map[string]*kopiaDataCollection{}
 
 	for _, itemPath := range paths {
+		if errs.Err() != nil {
+			return nil, errs.Err()
+		}
+
 		ds, err := getItemStream(ctx, itemPath, snapshotRoot, bcounter)
 		if err != nil {
-			errs = multierror.Append(errs, err)
+			errs.Add(err)
 			continue
 		}
 
 		parentPath, err := itemPath.Dir()
 		if err != nil {
-			errs = multierror.Append(errs, errors.Wrap(err, "making directory collection"))
+			errs.Add(clues.Wrap(err, "making directory collection").WithClues(ctx))
 			continue
 		}
 
@@ -414,7 +417,7 @@ func (w Wrapper) RestoreMultipleItems(
 		res = append(res, c)
 	}
 
-	return res, errs.ErrorOrNil()
+	return res, errs.Err()
 }
 
 // DeleteSnapshot removes the provided manifest from kopia.
@@ -425,7 +428,7 @@ func (w Wrapper) DeleteSnapshot(
 	mid := manifest.ID(snapshotID)
 
 	if len(mid) == 0 {
-		return errors.New("attempt to delete unidentified snapshot")
+		return clues.New("attempt to delete unidentified snapshot").WithClues(ctx)
 	}
 
 	err := repo.WriteSession(
@@ -434,7 +437,7 @@ func (w Wrapper) DeleteSnapshot(
 		repo.WriteSessionOptions{Purpose: "KopiaWrapperBackupDeletion"},
 		func(innerCtx context.Context, rw repo.RepositoryWriter) error {
 			if err := rw.DeleteManifest(ctx, mid); err != nil {
-				return errors.Wrap(err, "deleting snapshot")
+				return clues.Wrap(err, "deleting snapshot").WithClues(ctx)
 			}
 
 			return nil
@@ -443,7 +446,7 @@ func (w Wrapper) DeleteSnapshot(
 	// Telling kopia to always flush may hide other errors if it fails while
 	// flushing the write session (hence logging above).
 	if err != nil {
-		return errors.Wrap(err, "kopia deleting backup manifest")
+		return clues.Wrap(err, "deleting backup manifest").WithClues(ctx)
 	}
 
 	return nil
@@ -464,7 +467,7 @@ func (w Wrapper) FetchPrevSnapshotManifests(
 	tags map[string]string,
 ) ([]*ManifestEntry, error) {
 	if w.c == nil {
-		return nil, errors.WithStack(errNotConnected)
+		return nil, clues.Stack(errNotConnected).WithClues(ctx)
 	}
 
 	return fetchPrevSnapshotManifests(ctx, w.c, reasons, tags), nil

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -102,7 +102,11 @@ func (w *Wrapper) Close(ctx context.Context) error {
 	err := w.c.Close(ctx)
 	w.c = nil
 
-	return clues.Wrap(err, "closing Wrapper").WithClues(ctx)
+	if err != nil {
+		return clues.Wrap(err, "closing Wrapper").WithClues(ctx)
+	}
+
+	return nil
 }
 
 type IncrementalBase struct {

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -509,7 +509,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_ReaderError() {
 		string(stats.SnapshotID),
 		[]path.Path{failedPath},
 		&ic,
-	)
+		fault.New(true))
 	// Files that had an error shouldn't make a dir entry in kopia. If they do we
 	// may run into kopia-assisted incrementals issues because only mod time and
 	// not file size is checked for StreamingFiles.
@@ -844,7 +844,7 @@ func (suite *KopiaSimpleRepoIntegrationSuite) TestBackupExcludeItem() {
 				excluded,
 				tags,
 				true,
-			)
+				fault.New(true))
 			require.NoError(t, err)
 			assert.Equal(t, test.expectedCachedItems, stats.CachedFileCount)
 			assert.Equal(t, test.expectedUncachedItems, stats.UncachedFileCount)
@@ -864,7 +864,7 @@ func (suite *KopiaSimpleRepoIntegrationSuite) TestBackupExcludeItem() {
 					suite.files[suite.testPath1.String()][0].itemPath,
 				},
 				&ic,
-			)
+				fault.New(true))
 			test.restoreCheck(t, err)
 		})
 	}

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -944,6 +944,10 @@ func (suite *KopiaSimpleRepoIntegrationSuite) TestRestoreMultipleItems() {
 				fault.New(true))
 			test.expectedErr(t, err)
 
+			if err != nil {
+				return
+			}
+
 			assert.Len(t, result, test.expectedCollections)
 			assert.Less(t, int64(0), ic.i)
 			testForFiles(t, expected, result)

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -903,7 +903,7 @@ func (suite *KopiaSimpleRepoIntegrationSuite) TestRestoreMultipleItems() {
 				suite.testPath1,
 				suite.files[suite.testPath2.String()][0].itemPath,
 			},
-			expectedCollections: 2,
+			expectedCollections: 0,
 			expectedErr:         assert.Error,
 		},
 		{
@@ -913,7 +913,7 @@ func (suite *KopiaSimpleRepoIntegrationSuite) TestRestoreMultipleItems() {
 				doesntExist,
 				suite.files[suite.testPath2.String()][0].itemPath,
 			},
-			expectedCollections: 2,
+			expectedCollections: 0,
 			expectedErr:         assert.Error,
 		},
 	}

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -263,8 +263,6 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 
 	for _, test := range table {
 		suite.T().Run(test.name, func(t *testing.T) {
-			errs := fault.New(false)
-
 			stats, deets, _, err := suite.w.BackupCollections(
 				suite.ctx,
 				prevSnaps,
@@ -272,9 +270,8 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 				nil,
 				tags,
 				true,
-				errs)
+				fault.New(true))
 			assert.NoError(t, err)
-			assert.Empty(t, errs.Errs())
 
 			assert.Equal(t, test.expectedUploadedFiles, stats.TotalFileCount, "total files")
 			assert.Equal(t, test.expectedUploadedFiles, stats.UncachedFileCount, "uncached files")
@@ -354,8 +351,6 @@ func (suite *KopiaIntegrationSuite) TestRestoreAfterCompressionChange() {
 	fp2, err := suite.testPath2.Append(dc2.Names[0], true)
 	require.NoError(t, err)
 
-	errs := fault.New(false)
-
 	stats, _, _, err := w.BackupCollections(
 		ctx,
 		nil,
@@ -363,9 +358,8 @@ func (suite *KopiaIntegrationSuite) TestRestoreAfterCompressionChange() {
 		nil,
 		tags,
 		true,
-		errs)
+		fault.New(true))
 	require.NoError(t, err)
-	require.Empty(t, errs.Errs())
 
 	require.NoError(t, k.Compression(ctx, "gzip"))
 
@@ -373,8 +367,6 @@ func (suite *KopiaIntegrationSuite) TestRestoreAfterCompressionChange() {
 		fp1.String(): dc1.Data[0],
 		fp2.String(): dc2.Data[0],
 	}
-
-	errs = fault.New(false)
 
 	result, err := w.RestoreMultipleItems(
 		ctx,
@@ -384,9 +376,8 @@ func (suite *KopiaIntegrationSuite) TestRestoreAfterCompressionChange() {
 			fp2,
 		},
 		nil,
-		errs)
+		fault.New(true))
 	require.NoError(t, err)
-	require.Empty(t, errs.Errs())
 	assert.Equal(t, 2, len(result))
 
 	testForFiles(t, expected, result)
@@ -478,8 +469,6 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_ReaderError() {
 		},
 	}
 
-	errs := fault.New(false)
-
 	stats, deets, _, err := suite.w.BackupCollections(
 		suite.ctx,
 		nil,
@@ -487,9 +476,8 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_ReaderError() {
 		nil,
 		tags,
 		true,
-		errs)
+		fault.New(true))
 	require.NoError(t, err)
-	require.Empty(t, errs.Errs())
 
 	assert.Equal(t, 0, stats.ErrorCount)
 	assert.Equal(t, 5, stats.TotalFileCount)
@@ -542,8 +530,6 @@ func (suite *KopiaIntegrationSuite) TestBackupCollectionsHandlesNoCollections() 
 			ctx, flush := tester.NewContext()
 			defer flush()
 
-			errs := fault.New(false)
-
 			s, d, _, err := suite.w.BackupCollections(
 				ctx,
 				nil,
@@ -551,9 +537,8 @@ func (suite *KopiaIntegrationSuite) TestBackupCollectionsHandlesNoCollections() 
 				nil,
 				nil,
 				true,
-				errs)
+				fault.New(true))
 			require.NoError(t, err)
-			require.Empty(t, errs.Errs())
 
 			assert.Equal(t, BackupStats{}, *s)
 			assert.Empty(t, d.Details().Entries)
@@ -704,8 +689,6 @@ func (suite *KopiaSimpleRepoIntegrationSuite) SetupTest() {
 		tags[k] = ""
 	}
 
-	errs := fault.New(false)
-
 	stats, deets, _, err := suite.w.BackupCollections(
 		suite.ctx,
 		nil,
@@ -713,9 +696,8 @@ func (suite *KopiaSimpleRepoIntegrationSuite) SetupTest() {
 		nil,
 		tags,
 		false,
-		errs)
+		fault.New(true))
 	require.NoError(t, err)
-	require.Empty(t, errs.Errs())
 	require.Equal(t, stats.ErrorCount, 0)
 	require.Equal(t, stats.TotalFileCount, expectedFiles)
 	require.Equal(t, stats.TotalDirectoryCount, expectedDirs)
@@ -953,16 +935,14 @@ func (suite *KopiaSimpleRepoIntegrationSuite) TestRestoreMultipleItems() {
 			}
 
 			ic := i64counter{}
-			errs := fault.New(false)
 
 			result, err := suite.w.RestoreMultipleItems(
 				suite.ctx,
 				string(suite.snapshotID),
 				test.inputPaths,
 				&ic,
-				errs)
+				fault.New(true))
 			test.expectedErr(t, err)
-			require.Empty(t, errs.Errs())
 
 			assert.Len(t, result, test.expectedCollections)
 			assert.Less(t, int64(0), ic.i)
@@ -1004,7 +984,7 @@ func (suite *KopiaSimpleRepoIntegrationSuite) TestRestoreMultipleItems_Errors() 
 				test.snapshotID,
 				test.paths,
 				nil,
-				fault.New(false))
+				fault.New(true))
 			assert.Error(t, err)
 			assert.Empty(t, c)
 		})
@@ -1025,7 +1005,7 @@ func (suite *KopiaSimpleRepoIntegrationSuite) TestDeleteSnapshot() {
 		string(suite.snapshotID),
 		[]path.Path{itemPath},
 		&ic,
-		fault.New(false))
+		fault.New(true))
 	assert.Error(t, err, "snapshot should be deleted")
 	assert.Empty(t, c)
 	assert.Zero(t, ic.i)

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -251,11 +251,8 @@ func checkMetadataFilesExist(
 				pathsByRef[dir.ShortRef()] = append(pathsByRef[dir.ShortRef()], fName)
 			}
 
-			errs := fault.New(false)
-
-			cols, err := kw.RestoreMultipleItems(ctx, bup.SnapshotID, paths, nil, errs)
+			cols, err := kw.RestoreMultipleItems(ctx, bup.SnapshotID, paths, nil, fault.New(true))
 			assert.NoError(t, err)
-			assert.Empty(t, errs.Errs())
 
 			for _, col := range cols {
 				itemNames := []string{}

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/store"
@@ -250,8 +251,11 @@ func checkMetadataFilesExist(
 				pathsByRef[dir.ShortRef()] = append(pathsByRef[dir.ShortRef()], fName)
 			}
 
-			cols, err := kw.RestoreMultipleItems(ctx, bup.SnapshotID, paths, nil)
+			errs := fault.New(false)
+
+			cols, err := kw.RestoreMultipleItems(ctx, bup.SnapshotID, paths, nil, errs)
 			assert.NoError(t, err)
+			assert.Empty(t, errs.Errs())
 
 			for _, col := range cols {
 				itemNames := []string{}

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -582,7 +582,7 @@ func (suite *BackupOpSuite) TestBackupOperation_ConsumeBackupDataCollections_Pat
 				nil,
 				model.StableID(""),
 				true,
-				fault.New(false))
+				fault.New(true))
 		})
 	}
 }
@@ -1171,7 +1171,6 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails_AddsFolders()
 	mdr := mockDetailsReader{entries: populatedDetails}
 	w := &store.Wrapper{Storer: mockBackupStorer{entries: populatedModels}}
 	deets := details.Builder{}
-	errs := fault.New(false)
 
 	err := mergeDetails(
 		ctx,
@@ -1180,8 +1179,7 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails_AddsFolders()
 		inputMans,
 		inputToMerge,
 		&deets,
-		errs)
+		fault.New(true))
 	assert.NoError(t, err)
-	assert.Empty(t, errs.Errs())
 	assert.ElementsMatch(t, expectedEntries, deets.Details().Entries)
 }

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -1065,7 +1065,6 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails_AddsItems() {
 			mdr := mockDetailsReader{entries: test.populatedDetails}
 			w := &store.Wrapper{Storer: mockBackupStorer{entries: test.populatedModels}}
 			deets := details.Builder{}
-			errs := fault.New(false)
 
 			err := mergeDetails(
 				ctx,
@@ -1074,10 +1073,8 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails_AddsItems() {
 				test.inputMans,
 				test.inputShortRefsFromPrevBackup,
 				&deets,
-				errs)
-
+				fault.New(true))
 			test.errCheck(t, err)
-			assert.Empty(t, errs.Errs)
 			if err != nil {
 				return
 			}

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -64,7 +64,7 @@ func (mr *mockRestorer) RestoreMultipleItems(
 	paths []path.Path,
 	bc kopia.ByteCounter,
 	errs *fault.Errors,
-) ([]data.Collection, error) {
+) ([]data.RestoreCollection, error) {
 	mr.gotPaths = append(mr.gotPaths, paths...)
 
 	if mr.onRestore != nil {

--- a/src/internal/operations/common.go
+++ b/src/internal/operations/common.go
@@ -8,11 +8,12 @@ import (
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/store"
 )
 
 type detailsReader interface {
-	ReadBackupDetails(ctx context.Context, detailsID string) (*details.Details, error)
+	ReadBackupDetails(ctx context.Context, detailsID string, errs *fault.Errors) (*details.Details, error)
 }
 
 func getBackupAndDetailsFromID(
@@ -20,13 +21,14 @@ func getBackupAndDetailsFromID(
 	backupID model.StableID,
 	ms *store.Wrapper,
 	detailsStore detailsReader,
+	errs *fault.Errors,
 ) (*backup.Backup, *details.Details, error) {
 	dID, bup, err := ms.GetDetailsIDFromBackupID(ctx, backupID)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "getting backup details ID")
 	}
 
-	deets, err := detailsStore.ReadBackupDetails(ctx, dID)
+	deets, err := detailsStore.ReadBackupDetails(ctx, dID, errs)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "getting backup details data")
 	}

--- a/src/internal/operations/manifests_test.go
+++ b/src/internal/operations/manifests_test.go
@@ -227,11 +227,8 @@ func (suite *OperationsManifestsUnitSuite) TestCollectMetadata() {
 				Reasons:  test.reasons,
 			}
 
-			errs := fault.New(false)
-
-			_, err := collectMetadata(ctx, &mr, man, test.fileNames, tid, errs)
+			_, err := collectMetadata(ctx, &mr, man, test.fileNames, tid, fault.New(true))
 			assert.ErrorIs(t, err, test.expectErr)
-			assert.Empty(t, errs.Errs())
 		})
 	}
 }
@@ -648,7 +645,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				test.reasons,
 				tid,
 				test.getMeta,
-				fault.New(false))
+				fault.New(true))
 			test.assertErr(t, err)
 			test.assertB(t, b)
 
@@ -937,11 +934,9 @@ func (suite *BackupManifestSuite) TestBackupOperation_CollectMetadata() {
 			defer flush()
 
 			mr := &mockRestorer{}
-			errs := fault.New(false)
 
-			_, err := collectMetadata(ctx, mr, test.inputMan, test.inputFiles, tenant, errs)
+			_, err := collectMetadata(ctx, mr, test.inputMan, test.inputFiles, tenant, fault.New(true))
 			assert.NoError(t, err)
-			assert.Empty(t, errs.Errs())
 
 			checkPaths(t, test.expected, mr.gotPaths)
 		})

--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -104,6 +104,7 @@ type restorer interface {
 		snapshotID string,
 		paths []path.Path,
 		bc kopia.ByteCounter,
+		errs *fault.Errors,
 	) ([]data.RestoreCollection, error)
 }
 
@@ -197,7 +198,7 @@ func (op *RestoreOperation) do(
 		op.BackupID,
 		op.store,
 		detailsStore,
-	)
+		op.Errors)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting backup and details")
 	}
@@ -228,7 +229,7 @@ func (op *RestoreOperation) do(
 	defer closer()
 	defer close(kopiaComplete)
 
-	dcs, err := op.kopia.RestoreMultipleItems(ctx, bup.SnapshotID, paths, opStats.bytesRead)
+	dcs, err := op.kopia.RestoreMultipleItems(ctx, bup.SnapshotID, paths, opStats.bytesRead, op.Errors)
 	if err != nil {
 		return nil, errors.Wrap(err, "retrieving collections from repository")
 	}

--- a/src/internal/streamstore/streamstore.go
+++ b/src/internal/streamstore/streamstore.go
@@ -15,6 +15,7 @@ import (
 	"github.com/alcionai/corso/src/internal/kopia"
 	"github.com/alcionai/corso/src/internal/stats"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
@@ -46,6 +47,7 @@ const (
 func (ss *streamStore) WriteBackupDetails(
 	ctx context.Context,
 	backupDetails *details.Details,
+	errs *fault.Errors,
 ) (string, error) {
 	// construct the path of the container for the `details` item
 	p, err := path.Builder{}.
@@ -79,7 +81,8 @@ func (ss *streamStore) WriteBackupDetails(
 		[]data.BackupCollection{dc},
 		nil,
 		nil,
-		false)
+		false,
+		errs)
 	if err != nil {
 		return "", errors.Wrap(err, "storing details in repository")
 	}
@@ -92,6 +95,7 @@ func (ss *streamStore) WriteBackupDetails(
 func (ss *streamStore) ReadBackupDetails(
 	ctx context.Context,
 	detailsID string,
+	errs *fault.Errors,
 ) (*details.Details, error) {
 	// construct the path for the `details` item
 	detailsPath, err := path.Builder{}.
@@ -108,7 +112,7 @@ func (ss *streamStore) ReadBackupDetails(
 
 	var bc stats.ByteCounter
 
-	dcs, err := ss.kw.RestoreMultipleItems(ctx, detailsID, []path.Path{detailsPath}, &bc)
+	dcs, err := ss.kw.RestoreMultipleItems(ctx, detailsID, []path.Path{detailsPath}, &bc, errs)
 	if err != nil {
 		return nil, errors.Wrap(err, "retrieving backup details data")
 	}

--- a/src/internal/streamstore/streamstore_test.go
+++ b/src/internal/streamstore/streamstore_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alcionai/corso/src/internal/kopia"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
@@ -51,15 +52,19 @@ func (suite *StreamStoreIntegrationSuite) TestDetails() {
 		})
 
 	deets := deetsBuilder.Details()
-
 	ss := New(kw, "tenant", path.ExchangeService)
+	errs := fault.New(false)
 
-	id, err := ss.WriteBackupDetails(ctx, deets)
+	id, err := ss.WriteBackupDetails(ctx, deets, errs)
 	require.NoError(t, err)
+	require.Empty(t, errs.Errs())
 	require.NotNil(t, id)
 
-	readDeets, err := ss.ReadBackupDetails(ctx, id)
+	errs = fault.New(false)
+
+	readDeets, err := ss.ReadBackupDetails(ctx, id, errs)
 	require.NoError(t, err)
+	require.Empty(t, errs.Errs())
 	require.NotNil(t, readDeets)
 
 	assert.Equal(t, len(deets.Entries), len(readDeets.Entries))

--- a/src/internal/streamstore/streamstore_test.go
+++ b/src/internal/streamstore/streamstore_test.go
@@ -53,18 +53,13 @@ func (suite *StreamStoreIntegrationSuite) TestDetails() {
 
 	deets := deetsBuilder.Details()
 	ss := New(kw, "tenant", path.ExchangeService)
-	errs := fault.New(false)
 
-	id, err := ss.WriteBackupDetails(ctx, deets, errs)
+	id, err := ss.WriteBackupDetails(ctx, deets, fault.New(true))
 	require.NoError(t, err)
-	require.Empty(t, errs.Errs())
 	require.NotNil(t, id)
 
-	errs = fault.New(false)
-
-	readDeets, err := ss.ReadBackupDetails(ctx, id, errs)
+	readDeets, err := ss.ReadBackupDetails(ctx, id, fault.New(true))
 	require.NoError(t, err)
-	require.Empty(t, errs.Errs())
 	require.NotNil(t, readDeets)
 
 	assert.Equal(t, len(deets.Entries), len(readDeets.Entries))

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -323,7 +323,8 @@ func (r repository) BackupDetails(
 	deets, err := streamstore.New(
 		r.dataLayer,
 		r.Account.ID(),
-		b.Selector.PathService()).ReadBackupDetails(ctx, dID)
+		b.Selector.PathService(),
+	).ReadBackupDetails(ctx, dID, errs)
 	if err != nil {
 		return nil, nil, errs.Fail(err)
 	}


### PR DESCRIPTION
## Description

Begins adding fault and clues to kopia.  Part 1
just covers the surface kopia/Wrapper, and all the
upstream packages that call it.  This also
replaces the progress multierr with a fault errs.

RestoreMultipleItems changes from always
handling errors in failFast mode to checking for
failFast configuraton, and handling bestEffort
otherwise.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :broom: Tech Debt/Cleanup

## Issue(s)

* #1970

## Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
