### PR TITLE
GC: Logging: Expand `ItemAttachment` object details for coverage

### DIFF
--- a/src/internal/connector/exchange/attachment.go
+++ b/src/internal/connector/exchange/attachment.go
@@ -58,6 +58,7 @@ func uploadAttachment(
 		logger.Ctx(ctx).Infow("item attachment uploads are not supported ",
 			"attachment_name", *attachment.GetName(), // TODO: Update to support PII protection
 			"attachment_type", attachmentType,
+			"internal_item_type", getItemAttachmentItemType(attachment),
 			"attachment_id", *attachment.GetId(),
 		)
 
@@ -100,4 +101,20 @@ func uploadLargeAttachment(ctx context.Context, uploader attachmentUploadable,
 	}
 
 	return nil
+}
+
+func getItemAttachmentItemType(query models.Attachmentable) string {
+	empty := ""
+	attachment, ok := query.(models.ItemAttachmentable)
+
+	if !ok {
+		return empty
+	}
+
+	item := attachment.GetItem()
+	if item.GetOdataType() == nil {
+		return empty
+	}
+
+	return *item.GetOdataType()
 }


### PR DESCRIPTION
## Description
Updates within /internal/connector/exchange package. Adds helper function for displaying the internal object item type that is included as an attachment. This will help overall with supporting additional `ItemAttachment` objects. 
<!-- Insert PR description-->

## Does this PR need a docs update or release note?
- [x] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->

- [x] :broom: Tech Debt/Cleanup

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* related to #2353<issue>

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
