### PR TITLE
Fix some edge cases around OneDrive permissions backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When the same user has permissions to a file and the containing
   folder, we only restore folder level permissions for the user and no
   separate file only permission is restored.
+- Link shares are not restored
 
 ## [v0.2.0] (alpha) - 2023-1-29
 

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -292,7 +292,9 @@ func (oc *Collection) populateItems(ctx context.Context) {
 					itemMeta, itemMetaSize, err = oc.itemMetaReader(ctx, oc.service, oc.driveID, item)
 
 					// retry on Timeout type errors, break otherwise.
-					if err == nil || !graph.IsErrTimeout(err) {
+					if err == nil ||
+						!graph.IsErrTimeout(err) ||
+						!graph.IsInternalServerError(err) {
 						break
 					}
 

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -304,7 +304,7 @@ func (oc *Collection) populateItems(ctx context.Context) {
 				}
 
 				if err != nil {
-					errUpdater(*item.GetId(), err)
+					errUpdater(*item.GetId(), errors.Wrap(err, "failed to get item permissions"))
 					return
 				}
 			}

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -191,7 +191,7 @@ func oneDriveItemMetaInfo(
 
 	perm, err := service.Client().DrivesById(driveID).ItemsById(*itemID).Permissions().Get(ctx, nil)
 	if err != nil {
-		return Metadata{}, errors.Wrapf(err, "failed to get item permissions %s", *itemID)
+		return Metadata{}, err
 	}
 
 	uperms := filterUserPermissions(perm.GetValue())

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -194,9 +194,21 @@ func oneDriveItemMetaInfo(
 		return Metadata{}, errors.Wrapf(err, "failed to get item permissions %s", *itemID)
 	}
 
+	uperms := filterUserPermissions(perm.GetValue())
+
+	return Metadata{Permissions: uperms}, nil
+}
+
+func filterUserPermissions(perms []models.Permissionable) []UserPermission {
 	up := []UserPermission{}
 
-	for _, p := range perm.GetValue() {
+	for _, p := range perms {
+		if p.GetGrantedToV2() == nil {
+			// For link shares, we get permissions without a user
+			// specified
+			continue
+		}
+
 		roles := []string{}
 
 		for _, r := range p.GetRoles() {
@@ -218,7 +230,7 @@ func oneDriveItemMetaInfo(
 		})
 	}
 
-	return Metadata{Permissions: up}, nil
+	return up
 }
 
 // sharePointItemInfo will populate a details.SharePointInfo struct

--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -292,38 +292,38 @@ func TestOneDrivePermissionsFilter(t *testing.T) {
 	noPerm.SetGrantedToV2(nil) // eg: link shares
 
 	cases := []struct {
-		name   string
-		perms  []models.Permissionable
-		uperms []UserPermission
+		name              string
+		graphPermissions  []models.Permissionable
+		parsedPermissions []UserPermission
 	}{
 		{
-			name:   "no perms",
-			perms:  []models.Permissionable{},
-			uperms: []UserPermission{},
+			name:              "no perms",
+			graphPermissions:  []models.Permissionable{},
+			parsedPermissions: []UserPermission{},
 		},
 		{
-			name:   "no user bound to perms",
-			perms:  []models.Permissionable{noPerm},
-			uperms: []UserPermission{},
+			name:              "no user bound to perms",
+			graphPermissions:  []models.Permissionable{noPerm},
+			parsedPermissions: []UserPermission{},
 		},
 		{
-			name:   "user with read permissions",
-			perms:  []models.Permissionable{readPerm},
-			uperms: []UserPermission{readUperm},
+			name:              "user with read permissions",
+			graphPermissions:  []models.Permissionable{readPerm},
+			parsedPermissions: []UserPermission{readUperm},
 		},
 		{
-			name:   "user with read and write permissions",
-			perms:  []models.Permissionable{readWritePerm},
-			uperms: []UserPermission{readWriteUperm},
+			name:              "user with read and write permissions",
+			graphPermissions:  []models.Permissionable{readWritePerm},
+			parsedPermissions: []UserPermission{readWriteUperm},
 		},
 		{
-			name:   "multiple users with separate permissions",
-			perms:  []models.Permissionable{readPerm, readWritePerm},
-			uperms: []UserPermission{readUperm, readWriteUperm},
+			name:              "multiple users with separate permissions",
+			graphPermissions:  []models.Permissionable{readPerm, readWritePerm},
+			parsedPermissions: []UserPermission{readUperm, readWriteUperm},
 		},
 	}
 	for _, tc := range cases {
-		actual := filterUserPermissions(tc.perms)
-		assert.ElementsMatch(t, tc.uperms, actual)
+		actual := filterUserPermissions(tc.graphPermissions)
+		assert.ElementsMatch(t, tc.parsedPermissions, actual)
 	}
 }


### PR DESCRIPTION
## Description

This fixes tying to parse link shares as permissions and some error/retry handling.

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
