### PR TITLE
Wire up most of exclude list for OneDrive

### DIFF
--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -359,7 +359,7 @@ func (c *Collections) Get(
 	}
 
 	// TODO(ashmrtn): Track and return the set of items to exclude.
-	return collections, nil, nil
+	return collections, excludedItems, nil
 }
 
 // UpdateCollections initializes and adds the provided drive items to Collections

--- a/src/internal/connector/onedrive/collections_test.go
+++ b/src/internal/connector/onedrive/collections_test.go
@@ -1387,7 +1387,7 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 			c.itemPagerFunc = itemPagerFunc
 
 			// TODO(ashmrtn): Allow passing previous metadata.
-			cols, _, err := c.Get(ctx, nil)
+			cols, delList, err := c.Get(ctx, nil)
 			test.errCheck(t, err)
 
 			if err != nil {
@@ -1424,9 +1424,7 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 				assert.ElementsMatch(t, test.expectedCollections[folderPath], itemIDs)
 			}
 
-			// TODO(ashmrtn): Uncomment this when we begin return the set of items to
-			// remove from the upcoming backup.
-			// assert.Equal(t, test.expectedDelList, delList)
+			assert.Equal(t, test.expectedDelList, delList)
 		})
 	}
 }

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -575,6 +575,7 @@ func (suite *BackupOpSuite) TestBackupOperation_ConsumeBackupDataCollections_Pat
 				nil,
 				test.inputMan,
 				nil,
+				nil,
 				model.StableID(""),
 				true,
 			)


### PR DESCRIPTION
## Description

Push exclude list through the whole stack. It's not wired to kopia yet, but only one location (marked with a TODO) needs to be changed to have that happen.

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

## Issue(s)

* #2243

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
