### PR TITLE
clean up operation run-do funcs

### DIFF
--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -158,7 +158,6 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 	err = op.do(
 		ctx,
 		&opStats,
-		deets,
 		detailsStore)
 	if err != nil {
 		// No return here!  We continue down to persistResults, even in case of failure.
@@ -203,13 +202,13 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 func (op *BackupOperation) do(
 	ctx context.Context,
 	opStats *backupStats,
-	deets *details.Builder,
 	detailsStore detailsReader,
 ) error {
 	var (
 		toMerge  map[string]path.Path
 		tenantID = op.account.ID()
 		reasons  = selectorToReasons(op.Selectors)
+		deets    *details.Builder
 	)
 
 	// should always be 1, since backups are 1:1 with resourceOwners.
@@ -253,14 +252,14 @@ func (op *BackupOperation) do(
 		return errors.Wrap(err, "persisting collection backups")
 	}
 
-	if err = mergeDetails(
+	err = mergeDetails(
 		ctx,
 		op.store,
 		detailsStore,
 		mans,
 		toMerge,
-		deets,
-	); err != nil {
+		deets)
+	if err != nil {
 		return errors.Wrap(err, "merging details")
 	}
 

--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -112,7 +112,10 @@ func (op *RestoreOperation) Run(ctx context.Context) (restoreDetails *details.De
 		if r := recover(); r != nil {
 			err = clues.Wrap(r.(error), "panic recovery").
 				WithClues(ctx).
-				With("stacktrace", debug.Stack())
+				With("stacktrace", string(debug.Stack()))
+			logger.Ctx(ctx).
+				With("err", err).
+				Errorw("backup panic", clues.InErr(err).Slice()...)
 		}
 	}()
 

--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -110,9 +110,24 @@ type restorer interface {
 func (op *RestoreOperation) Run(ctx context.Context) (restoreDetails *details.Details, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = clues.Wrap(r.(error), "panic recovery").WithClues(ctx).With("stacktrace", debug.Stack())
+			err = clues.Wrap(r.(error), "panic recovery").
+				WithClues(ctx).
+				With("stacktrace", debug.Stack())
 		}
 	}()
+
+	var (
+		opStats = restoreStats{
+			bytesRead: &stats.ByteCounter{},
+			restoreID: uuid.NewString(),
+		}
+		start        = time.Now()
+		detailsStore = streamstore.New(op.kopia, op.account.ID(), op.Selectors.PathService())
+	)
+
+	// -----
+	// Setup
+	// -----
 
 	ctx, end := D.Span(ctx, "operations:restore:run")
 	defer func() {
@@ -127,13 +142,30 @@ func (op *RestoreOperation) Run(ctx context.Context) (restoreDetails *details.De
 		"backup_id", op.BackupID,
 		"service", op.Selectors.Service)
 
-	deets, err := op.do(ctx)
+	// -----
+	// Execution
+	// -----
+
+	deets, err := op.do(ctx, &opStats, detailsStore, start)
 	if err != nil {
+		// No return here!  We continue down to persistResults, even in case of failure.
 		logger.Ctx(ctx).
 			With("err", err).
-			Errorw("restore operation", clues.InErr(err).Slice()...)
+			Errorw("doing restore", clues.InErr(err).Slice()...)
+		op.Errors.Fail(errors.Wrap(err, "doing restore"))
+		opStats.readErr = op.Errors.Err()
+	}
 
-		return nil, err
+	// -----
+	// Persistence
+	// -----
+
+	err = op.persistResults(ctx, start, &opStats)
+	if err != nil {
+		op.Errors.Fail(errors.Wrap(err, "persisting restore results"))
+		opStats.writeErr = op.Errors.Err()
+
+		return nil, op.Errors.Err()
 	}
 
 	logger.Ctx(ctx).Infow("completed restore", "results", op.Results)
@@ -141,30 +173,12 @@ func (op *RestoreOperation) Run(ctx context.Context) (restoreDetails *details.De
 	return deets, nil
 }
 
-func (op *RestoreOperation) do(ctx context.Context) (restoreDetails *details.Details, err error) {
-	var (
-		opStats = restoreStats{
-			bytesRead: &stats.ByteCounter{},
-			restoreID: uuid.NewString(),
-		}
-		startTime = time.Now()
-	)
-
-	defer func() {
-		// panic recovery here prevents additional errors in op.persistResults()
-		if r := recover(); r != nil {
-			err = clues.Wrap(r.(error), "panic recovery").WithClues(ctx).With("stacktrace", debug.Stack())
-			return
-		}
-
-		err = op.persistResults(ctx, startTime, &opStats)
-		if err != nil {
-			return
-		}
-	}()
-
-	detailsStore := streamstore.New(op.kopia, op.account.ID(), op.Selectors.PathService())
-
+func (op *RestoreOperation) do(
+	ctx context.Context,
+	opStats *restoreStats,
+	detailsStore detailsReader,
+	start time.Time,
+) (*details.Details, error) {
 	bup, deets, err := getBackupAndDetailsFromID(
 		ctx,
 		op.BackupID,
@@ -172,30 +186,29 @@ func (op *RestoreOperation) do(ctx context.Context) (restoreDetails *details.Det
 		detailsStore,
 	)
 	if err != nil {
-		opStats.readErr = errors.Wrap(err, "restore")
-		return nil, opStats.readErr
+		return nil, errors.Wrap(err, "getting backup and details")
 	}
 
-	ctx = clues.Add(ctx, "resource_owner", bup.Selector.DiscreteOwner)
+	paths, err := formatDetailsForRestoration(ctx, op.Selectors, deets)
+	if err != nil {
+		return nil, errors.Wrap(err, "formatting paths from details")
+	}
+
+	ctx = clues.AddAll(
+		ctx,
+		"resource_owner", bup.Selector.DiscreteOwner,
+		"details_paths", len(paths))
 
 	op.bus.Event(
 		ctx,
 		events.RestoreStart,
 		map[string]any{
-			events.StartTime:        startTime,
+			events.StartTime:        start,
 			events.BackupID:         op.BackupID,
 			events.BackupCreateTime: bup.CreationTime,
 			events.RestoreID:        opStats.restoreID,
-		},
-	)
+		})
 
-	paths, err := formatDetailsForRestoration(ctx, op.Selectors, deets)
-	if err != nil {
-		opStats.readErr = err
-		return nil, err
-	}
-
-	ctx = clues.Add(ctx, "details_paths", len(paths))
 	observe.Message(ctx, observe.Safe(fmt.Sprintf("Discovered %d items in backup %s to restore", len(paths), op.BackupID)))
 
 	kopiaComplete, closer := observe.MessageWithCompletion(ctx, observe.Safe("Enumerating items in repository"))
@@ -204,41 +217,45 @@ func (op *RestoreOperation) do(ctx context.Context) (restoreDetails *details.Det
 
 	dcs, err := op.kopia.RestoreMultipleItems(ctx, bup.SnapshotID, paths, opStats.bytesRead)
 	if err != nil {
-		opStats.readErr = errors.Wrap(err, "retrieving service data")
-		return nil, opStats.readErr
+		return nil, errors.Wrap(err, "retrieving collections from repository")
 	}
+
 	kopiaComplete <- struct{}{}
 
 	ctx = clues.Add(ctx, "coll_count", len(dcs))
+
+	// should always be 1, since backups are 1:1 with resourceOwners.
+	opStats.resourceCount = 1
 	opStats.cs = dcs
-	opStats.resourceCount = len(data.ResourceOwnerSet(dcs))
 
 	gc, err := connectToM365(ctx, op.Selectors, op.account)
 	if err != nil {
-		opStats.readErr = errors.Wrap(err, "connecting to M365")
-		return nil, opStats.readErr
+		return nil, errors.Wrap(err, "connecting to M365")
 	}
 
 	restoreComplete, closer := observe.MessageWithCompletion(ctx, observe.Safe("Restoring data"))
 	defer closer()
 	defer close(restoreComplete)
 
-	restoreDetails, err = gc.RestoreDataCollections(
+	restoreDetails, err := gc.RestoreDataCollections(
 		ctx,
 		bup.Version,
 		op.account,
 		op.Selectors,
 		op.Destination,
 		op.Options,
-		dcs,
-	)
+		dcs)
 	if err != nil {
-		opStats.writeErr = errors.Wrap(err, "restoring service data")
-		return nil, opStats.writeErr
+		return nil, errors.Wrap(err, "restoring collections")
 	}
+
 	restoreComplete <- struct{}{}
 
 	opStats.gc = gc.AwaitStatus()
+	// TODO(keepers): remove when fault.Errors handles all iterable error aggregation.
+	if opStats.gc.ErrorCount > 0 {
+		return nil, opStats.gc.Err
+	}
 
 	logger.Ctx(ctx).Debug(gc.PrintableStatus())
 
@@ -273,10 +290,10 @@ func (op *RestoreOperation) persistResults(
 
 	if opStats.gc == nil {
 		op.Status = Failed
-		return errors.New("data restoration never completed")
+		return errors.New("restoration never completed")
 	}
 
-	if opStats.readErr == nil && opStats.writeErr == nil && opStats.gc.Successful == 0 {
+	if opStats.gc.Successful == 0 {
 		op.Status = NoData
 	}
 


### PR DESCRIPTION
## Description

The operation run-do pattern is currently spaghetti,
The do() call includes a deferred persistence that
occurs before the Run call concludes, causing
us to need panic handlers in multiple levels.

This change normalizes the interacton: do() now
only contains the behavior necessary to process
the backup or restore.  Run() contains all setup
and teardown processes surrounding that.

General pattern looks like this:

Run()
    0. defer panic recovery
    1. create state builders/recorder vars/clients
    2. call do()
    3. persist results of do(), even in case of error.
    
do()
    process step-by-step backup or restore operation
    update builders/recorders along the way
    exit immediately on any error

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :broom: Tech Debt/Cleanup

## Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
