### PR TITLE
Make calendars a 2-level hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `--restore-permissions` flag to toggle restoration of OneDrive permissions
 - Add versions to backups so that we can understand/handle older backup formats
 
+### Fixed
+- Fix bug when backing up a calendar that has the same name as the default calendar
+
 ### Known Issues
 
 - When the same user has permissions to a file and the containing

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -19,7 +19,6 @@ import (
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/logger"
-	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 )
 
@@ -203,13 +202,13 @@ func (c Events) EnumerateContainers(
 		}
 
 		for _, cal := range resp.GetValue() {
-			cd := CalendarDisplayable{Calendarable: cal}
+			cd := CalendarDisplayable{Calendarable: cal, parentID: &baseDirID}
 			if err := checkIDAndName(cd); err != nil {
 				errs = multierror.Append(err, errs)
 				continue
 			}
 
-			temp := graph.NewCacheFolder(cd, path.Builder{}.Append(*cd.GetDisplayName()))
+			temp := graph.NewCacheFolder(cd, nil)
 
 			err = fn(temp)
 			if err != nil {
@@ -369,6 +368,7 @@ func (c Events) Serialize(
 // Therefore, that value will always return nil.
 type CalendarDisplayable struct {
 	models.Calendarable
+	parentID *string
 }
 
 // GetDisplayName returns the *string of the models.Calendable
@@ -383,7 +383,7 @@ func (c CalendarDisplayable) GetDisplayName() *string {
 //
 //nolint:revive
 func (c CalendarDisplayable) GetParentFolderId() *string {
-	return nil
+	return c.parentID
 }
 
 func EventInfo(evt models.Eventable) *details.ExchangeInfo {

--- a/src/internal/connector/exchange/event_calendar_cache.go
+++ b/src/internal/connector/exchange/event_calendar_cache.go
@@ -17,6 +17,7 @@ type eventCalendarCache struct {
 	enumer containersEnumerator
 	getter containerGetter
 	userID string
+	rootID string
 }
 
 // init ensures that the structure's fields are initialized.
@@ -49,6 +50,10 @@ func (ecc *eventCalendarCache) populateEventRoot(ctx context.Context) error {
 		return errors.Wrap(err, "initializing calendar resolver")
 	}
 
+	// Save the ID of the root container so we can build a hierarchy when
+	// populating the resolver.
+	ecc.rootID = *f.GetId()
+
 	return nil
 }
 
@@ -64,7 +69,12 @@ func (ecc *eventCalendarCache) Populate(
 		return errors.Wrap(err, "initializing")
 	}
 
-	err := ecc.enumer.EnumerateContainers(ctx, ecc.userID, "", ecc.addFolder)
+	err := ecc.enumer.EnumerateContainers(
+		ctx,
+		ecc.userID,
+		ecc.rootID,
+		ecc.addFolder,
+	)
 	if err != nil {
 		return errors.Wrap(err, "enumerating containers")
 	}

--- a/src/internal/connector/exchange/event_calendar_cache.go
+++ b/src/internal/connector/exchange/event_calendar_cache.go
@@ -61,7 +61,6 @@ func (ecc *eventCalendarCache) populateEventRoot(ctx context.Context) error {
 
 func (ecc *eventCalendarCache) PathInCache(p string) (string, bool) {
 	pb := path.Builder{}.Append(ecc.rootName, p)
-
 	return ecc.containerResolver.PathInCache(pb.String())
 }
 


### PR DESCRIPTION
## Description

All calendars except the default are nested under the default calendar. Having a non-default calendar named the same as the default calendar does not cause problems when fetching the default calendar by name. Only the default calendar will be returned in that situation.

This fixes the bug where we had multiple collections for the same path but representing different folders.

Also updates the restore execution path to handle the new nested folder structure.

## Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

* closes #2388 

## Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
