### PR TITLE
Custom onedrive resource path

### DIFF
--- a/src/pkg/path/onedrive.go
+++ b/src/pkg/path/onedrive.go
@@ -1,6 +1,7 @@
 package path
 
 import (
+	"github.com/alcionai/clues"
 	"github.com/pkg/errors"
 )
 
@@ -37,4 +38,28 @@ func GetDriveFolderPath(p Path) (string, error) {
 	}
 
 	return Builder{}.Append(drivePath.Folders...).String(), nil
+}
+
+func OneDriveResourcePath(itemName, itemPath string, isItem bool) (Path, error) {
+	p, err := FromDataLayerPath(itemPath, isItem)
+	if err != nil {
+		return nil, clues.Wrap(err, "building OneDrive path")
+	}
+
+	return &oneDriveResourcePath{
+		Path:     p,
+		itemName: itemName,
+	}, nil
+}
+
+type oneDriveResourcePath struct {
+	Path
+	itemName string
+}
+
+// ShortRef returns a hash of the contents of the path plus the itemName. This
+// ensures the returned string is updated even if the path doesn't change but
+// the item has been renamed in an external service.
+func (p oneDriveResourcePath) ShortRef() string {
+	return p.ToBuilder().Append(p.itemName).ShortRef()
 }

--- a/src/pkg/path/onedrive_test.go
+++ b/src/pkg/path/onedrive_test.go
@@ -57,3 +57,63 @@ func (suite *OneDrivePathSuite) Test_ToOneDrivePath() {
 		})
 	}
 }
+
+func (suite *OneDrivePathSuite) TestOneDriveResourcePath_ShortRef() {
+	path1 := "/tenant/" + path.OneDriveService.String() + "/user/" + path.FilesCategory.String() + "/drive-id/root:/item1"
+	path2 := "/tenant/" + path.OneDriveService.String() + "/user/" + path.FilesCategory.String() + "/drive-id/root:/item2"
+	itemName1 := "foo.txt"
+	itemName2 := "bar.txt"
+
+	table := []struct {
+		name        string
+		path1       string
+		itemName1   string
+		path2       string
+		itemName2   string
+		compareFunc assert.ComparisonAssertionFunc
+	}{
+		{
+			name:        "SamePath_SameName",
+			path1:       path1,
+			itemName1:   itemName1,
+			path2:       path1,
+			itemName2:   itemName1,
+			compareFunc: assert.Equal,
+		},
+		{
+			name:        "DifferentPath_SameName",
+			path1:       path1,
+			itemName1:   itemName1,
+			path2:       path2,
+			itemName2:   itemName1,
+			compareFunc: assert.NotEqual,
+		},
+		{
+			name:        "SamePath_DifferentName",
+			path1:       path1,
+			itemName1:   itemName1,
+			path2:       path1,
+			itemName2:   itemName2,
+			compareFunc: assert.NotEqual,
+		},
+		{
+			name:        "DifferentPath_DifferentName",
+			path1:       path1,
+			itemName1:   itemName1,
+			path2:       path2,
+			itemName2:   itemName2,
+			compareFunc: assert.NotEqual,
+		},
+	}
+	for _, test := range table {
+		suite.T().Run(test.name, func(t *testing.T) {
+			p1, err := path.OneDriveResourcePath(test.itemName1, test.path1, true)
+			require.NoError(t, err)
+
+			p2, err := path.OneDriveResourcePath(test.itemName2, test.path2, true)
+			require.NoError(t, err)
+
+			test.compareFunc(t, p1.ShortRef(), p2.ShortRef())
+		})
+	}
+}


### PR DESCRIPTION
## Description

Create custom resource path that can be used by SDK consumers to get a ShortRef for OneDrive that changes when either the filename or the path changes.

Currently do not expect Corso internal code to really need this unless we start using it to process backup details

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

* #1535

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
