### PR TITLE
fix user query filtering on null userType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Backing up a calendar that has the same name as the default calendar
 - Added additional backoff-retry to all OneDrive queries.
+- Users with `null` userType values are no excluded from user queries.
 
 ### Known Issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Backing up a calendar that has the same name as the default calendar
 - Added additional backoff-retry to all OneDrive queries.
-- Users with `null` userType values are no excluded from user queries.
+- Users with `null` userType values are no longer excluded from user queries.
 
 ### Known Issues
 

--- a/src/internal/connector/discovery/api/users.go
+++ b/src/internal/connector/discovery/api/users.go
@@ -59,6 +59,11 @@ const (
 // require more fine-tuned controls in the future.
 // https://stackoverflow.com/questions/64044266/error-message-unsupported-or-invalid-query-filter-clause-specified-for-property
 //
+// ne 'Guest' ensures we don't filter out users where userType = null, which can happen
+// for user accounts created prior to 2014.  In order to use the `ne` comparator, we
+// MUST include $count=true and the ConsistencyLevel: eventual header.
+// https://stackoverflow.com/questions/49340485/how-to-filter-users-by-usertype-null
+//
 //nolint:lll
 var userFilterNoGuests = "onPremisesSyncEnabled eq true OR userType ne 'Guest'"
 

--- a/src/internal/connector/discovery/api/users.go
+++ b/src/internal/connector/discovery/api/users.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 
+	absser "github.com/microsoft/kiota-abstractions-go"
 	msgraphgocore "github.com/microsoftgraph/msgraph-sdk-go-core"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
@@ -59,13 +60,21 @@ const (
 // https://stackoverflow.com/questions/64044266/error-message-unsupported-or-invalid-query-filter-clause-specified-for-property
 //
 //nolint:lll
-var userFilterNoGuests = "onPremisesSyncEnabled eq true OR userType eq 'Member'"
+var userFilterNoGuests = "onPremisesSyncEnabled eq true OR userType ne 'Guest'"
+
+// I can't believe I have to do this.
+var t = true
 
 func userOptions(fs *string) *users.UsersRequestBuilderGetRequestConfiguration {
+	headers := absser.NewRequestHeaders()
+	headers.Add("ConsistencyLevel", "eventual")
+
 	return &users.UsersRequestBuilderGetRequestConfiguration{
+		Headers: headers,
 		QueryParameters: &users.UsersRequestBuilderGetQueryParameters{
 			Select: []string{userSelectID, userSelectPrincipalName, userSelectDisplayName},
 			Filter: fs,
+			Count:  &t,
 		},
 	}
 }


### PR DESCRIPTION
## Description

UserType can be null for users created before
2014.  In order to not filter them out with the
other guest users, we have to amend our user
query to only exclude guests, and retain all
other persons.

## Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

## Type of change

- [x] :bug: Bugfix

## Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
