### PR TITLE
Set proper PreviousPath and State for OneDrive collections

### DIFF
--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -107,29 +107,13 @@ func NewCollection(
 		added:           make(map[string]struct{}, 0),
 		removed:         make(map[string]struct{}, 0),
 		prevPath:        prev,
-		state:           stateOf(prev, curr),
+		state:           data.StateOf(prev, curr),
 		statusUpdater:   statusUpdater,
 		user:            user,
 		items:           items,
 	}
 
 	return collection
-}
-
-func stateOf(prev, curr path.Path) data.CollectionState {
-	if curr == nil || len(curr.String()) == 0 {
-		return data.DeletedState
-	}
-
-	if prev == nil || len(prev.String()) == 0 {
-		return data.NewState
-	}
-
-	if curr.Folder() != prev.Folder() {
-		return data.MovedState
-	}
-
-	return data.NotMovedState
 }
 
 // Items utility function to asynchronously execute process to fill data channel with

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -136,7 +136,9 @@ func NewCollection(
 }
 
 // Figures out the state of a collection using prev and current path
-// FIXME(meain): Same as exchange_data_collection.go:stateOf
+// This is similar to the one in exchange, but instead of checking the
+// equivalence of folders, it checks it for the actual item.
+// TODO(meain): Why is exchange checking folders?
 func stateOf(prev, curr path.Path) data.CollectionState {
 	if curr == nil || len(curr.String()) == 0 {
 		return data.DeletedState
@@ -146,7 +148,7 @@ func stateOf(prev, curr path.Path) data.CollectionState {
 		return data.NewState
 	}
 
-	if curr.Folder() != prev.Folder() {
+	if curr.String() != prev.String() {
 		return data.MovedState
 	}
 
@@ -169,10 +171,13 @@ func (oc *Collection) FullPath() path.Path {
 	return oc.folderPath
 }
 
-// TODO(ashmrtn): Fill in with previous path once GraphConnector compares old
-// and new folder hierarchies.
 func (oc Collection) PreviousPath() path.Path {
-	return nil
+	return oc.prevPath
+}
+
+func (oc *Collection) SetPreviousPath(prevPath path.Path) {
+	oc.prevPath = prevPath
+	oc.state = stateOf(prevPath, oc.folderPath)
 }
 
 // TODO(ashmrtn): Fill in once GraphConnector compares old and new folder

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -69,6 +69,14 @@ type Collection struct {
 	itemMetaReader itemMetaReaderFunc
 	ctrl           control.Options
 
+	// PrevPath is the previous hierarchical path used by this collection.
+	// It may be the same as fullPath, if the folder was not renamed or
+	// moved.  It will be empty on its first retrieval.
+	prevPath path.Path
+
+	// Specifies if it new, moved/rename or deleted
+	state data.CollectionState
+
 	// should only be true if the old delta token expired
 	doNotMergeItems bool
 }
@@ -92,6 +100,7 @@ type itemMetaReaderFunc func(
 func NewCollection(
 	itemClient *http.Client,
 	folderPath path.Path,
+	prevPath path.Path,
 	driveID string,
 	service graph.Servicer,
 	statusUpdater support.StatusUpdater,
@@ -102,6 +111,7 @@ func NewCollection(
 	c := &Collection{
 		itemClient:      itemClient,
 		folderPath:      folderPath,
+		prevPath:        prevPath,
 		driveItems:      map[string]models.DriveItemable{},
 		driveID:         driveID,
 		source:          source,
@@ -109,6 +119,7 @@ func NewCollection(
 		data:            make(chan data.Stream, collectionChannelBufferSize),
 		statusUpdater:   statusUpdater,
 		ctrl:            ctrlOpts,
+		state:           stateOf(prevPath, folderPath),
 		doNotMergeItems: doNotMergeItems,
 	}
 
@@ -122,6 +133,24 @@ func NewCollection(
 	}
 
 	return c
+}
+
+// Figures out the state of a collection using prev and current path
+// FIXME(meain): Same as exchange_data_collection.go:stateOf
+func stateOf(prev, curr path.Path) data.CollectionState {
+	if curr == nil || len(curr.String()) == 0 {
+		return data.DeletedState
+	}
+
+	if prev == nil || len(prev.String()) == 0 {
+		return data.NewState
+	}
+
+	if curr.Folder() != prev.Folder() {
+		return data.MovedState
+	}
+
+	return data.NotMovedState
 }
 
 // Adds an itemID to the collection
@@ -149,7 +178,7 @@ func (oc Collection) PreviousPath() path.Path {
 // TODO(ashmrtn): Fill in once GraphConnector compares old and new folder
 // hierarchies.
 func (oc Collection) State() data.CollectionState {
-	return data.NewState
+	return oc.state
 }
 
 func (oc Collection) DoNotMergeItems() bool {

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -119,7 +119,7 @@ func NewCollection(
 		data:            make(chan data.Stream, collectionChannelBufferSize),
 		statusUpdater:   statusUpdater,
 		ctrl:            ctrlOpts,
-		state:           stateOf(prevPath, folderPath),
+		state:           data.StateOf(prevPath, folderPath),
 		doNotMergeItems: doNotMergeItems,
 	}
 
@@ -133,26 +133,6 @@ func NewCollection(
 	}
 
 	return c
-}
-
-// Figures out the state of a collection using prev and current path
-// This is similar to the one in exchange, but instead of checking the
-// equivalence of folders, it checks it for the actual item.
-// TODO(meain): Why is exchange checking folders?
-func stateOf(prev, curr path.Path) data.CollectionState {
-	if curr == nil || len(curr.String()) == 0 {
-		return data.DeletedState
-	}
-
-	if prev == nil || len(prev.String()) == 0 {
-		return data.NewState
-	}
-
-	if curr.String() != prev.String() {
-		return data.MovedState
-	}
-
-	return data.NotMovedState
 }
 
 // Adds an itemID to the collection
@@ -177,11 +157,9 @@ func (oc Collection) PreviousPath() path.Path {
 
 func (oc *Collection) SetPreviousPath(prevPath path.Path) {
 	oc.prevPath = prevPath
-	oc.state = stateOf(prevPath, oc.folderPath)
+	oc.state = data.StateOf(prevPath, oc.folderPath)
 }
 
-// TODO(ashmrtn): Fill in once GraphConnector compares old and new folder
-// hierarchies.
 func (oc Collection) State() data.CollectionState {
 	return oc.state
 }

--- a/src/internal/connector/onedrive/collection_test.go
+++ b/src/internal/connector/onedrive/collection_test.go
@@ -164,6 +164,7 @@ func (suite *CollectionUnitTestSuite) TestCollection() {
 			coll := NewCollection(
 				graph.HTTPClient(graph.NoTimeout()),
 				folderPath,
+				nil,
 				"drive-id",
 				suite,
 				suite.testStatusUpdater(&wg, &collStatus),
@@ -298,6 +299,7 @@ func (suite *CollectionUnitTestSuite) TestCollectionReadError() {
 			coll := NewCollection(
 				graph.HTTPClient(graph.NoTimeout()),
 				folderPath,
+				nil,
 				"fakeDriveID",
 				suite,
 				suite.testStatusUpdater(&wg, &collStatus),
@@ -370,6 +372,7 @@ func (suite *CollectionUnitTestSuite) TestCollectionDisablePermissionsBackup() {
 			coll := NewCollection(
 				graph.HTTPClient(graph.NoTimeout()),
 				folderPath,
+				nil,
 				"fakeDriveID",
 				suite,
 				suite.testStatusUpdater(&wg, &collStatus),

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -406,6 +406,7 @@ func (c *Collections) UpdateCollections(
 		switch {
 		case item.GetFolder() != nil, item.GetPackage() != nil:
 			var prevPath path.Path
+
 			prevColPath, ok := oldPaths[*item.GetId()]
 			if ok {
 				prevPath, err = path.FromDataLayerPath(prevColPath, false)
@@ -526,10 +527,16 @@ func (c *Collections) UpdateCollections(
 
 			col, found := c.CollectionMap[collectionPath.String()]
 			if !found {
+				oneDrivePath, err := path.ToOneDrivePath(collectionPath)
+				if err != nil {
+					return errors.Wrap(err, "invalid path for backup")
+				}
+
 				var prevPath path.Path
-				// TODO(meain): better check for root
-				if strings.HasSuffix(collectionPath.Folder(), "root:") && !invalidPrevDelta {
-					// Root collection is always added with not moved flag
+				if len(oneDrivePath.Folders) == 0 && !invalidPrevDelta {
+					// TODO(meain): Switch to storing root metadata in
+					// the backup so that we don't have to specially
+					// check for root in all the items
 					prevPath = collectionPath
 				}
 

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -488,7 +488,7 @@ func (c *Collections) UpdateCollections(
 				}
 			} else {
 				// If we have previously created a collection when
-				// we encountered a file, this gives us a change
+				// we encountered a file, this gives us a chance
 				// to mark the container as moved or not moved
 				// instead of new.
 				ccol, ok := col.(*Collection)

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -417,7 +417,7 @@ func (c *Collections) UpdateCollections(
 			}
 
 			if item.GetDeleted() != nil {
-				if !ok {
+				if prevPath == nil {
 					// It is possible that an item was created and
 					// deleted between two delta invocations. In
 					// that case, it will only produce a single

--- a/src/internal/connector/onedrive/collections_test.go
+++ b/src/internal/connector/onedrive/collections_test.go
@@ -1289,7 +1289,9 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 				// token for this drive is valid.
 				driveID1: {},
 			},
-			expectedDelList: map[string]struct{}{},
+			expectedDelList: map[string]struct{}{
+				"file": {},
+			},
 		},
 		{
 			name:   "OneDrive_OneItemPage_NoErrors",
@@ -1318,7 +1320,9 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 					"folder": folderPath,
 				},
 			},
-			expectedDelList: map[string]struct{}{},
+			expectedDelList: map[string]struct{}{
+				"file": {},
+			},
 		},
 		{
 			name:   "OneDrive_OneItemPage_EmptyDelta_NoErrors",
@@ -1341,7 +1345,9 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 			},
 			expectedDeltaURLs:   map[string]string{},
 			expectedFolderPaths: map[string]map[string]string{},
-			expectedDelList:     map[string]struct{}{},
+			expectedDelList: map[string]struct{}{
+				"file": {},
+			},
 		},
 		{
 			name:   "OneDrive_TwoItemPages_NoErrors",
@@ -1377,7 +1383,10 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 					"folder": folderPath,
 				},
 			},
-			expectedDelList: map[string]struct{}{},
+			expectedDelList: map[string]struct{}{
+				"file":  {},
+				"file2": {},
+			},
 		},
 		{
 			name: "TwoDrives_OneItemPageEach_NoErrors",
@@ -1398,8 +1407,8 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 				driveID2: {
 					{
 						items: []models.DriveItemable{
-							driveItem("folder", "folder", driveBasePath2, false, true, false),
-							driveItem("file", "file", driveBasePath2+"/folder", true, false, false),
+							driveItem("folder2", "folder", driveBasePath2, false, true, false),
+							driveItem("file2", "file", driveBasePath2+"/folder", true, false, false),
 						},
 						deltaLink: &delta2,
 					},
@@ -1408,9 +1417,9 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 			errCheck: assert.NoError,
 			expectedCollections: map[string][]string{
 				folderPath:      {"file"},
-				folderPath2:     {"file"},
+				folderPath2:     {"file2"},
 				rootFolderPath:  {"folder"},
-				rootFolderPath2: {"folder"},
+				rootFolderPath2: {"folder2"},
 			},
 			expectedDeltaURLs: map[string]string{
 				driveID1: delta,
@@ -1421,10 +1430,13 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 					"folder": folderPath,
 				},
 				driveID2: {
-					"folder": folderPath2,
+					"folder2": folderPath2,
 				},
 			},
-			expectedDelList: map[string]struct{}{},
+			expectedDelList: map[string]struct{}{
+				"file":  {},
+				"file2": {},
+			},
 		},
 		{
 			name:   "OneDrive_OneItemPage_Errors",
@@ -1539,7 +1551,7 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 					},
 					{
 						items: []models.DriveItemable{
-							driveItem("file", "file", testBaseDrivePath+"/folder", true, false, false),
+							driveItem("file2", "file2", testBaseDrivePath+"/folder", true, false, false),
 						},
 						deltaLink: &delta,
 					},
@@ -1558,7 +1570,7 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 					tenant,
 					user,
 					testBaseDrivePath+"/folder",
-				)[0]: {"file"},
+				)[0]: {"file2"},
 			},
 			expectedDeltaURLs: map[string]string{
 				driveID1: delta,
@@ -1568,7 +1580,10 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 				// token for this drive is valid.
 				driveID1: {},
 			},
-			expectedDelList: map[string]struct{}{},
+			expectedDelList: map[string]struct{}{
+				"file":  {},
+				"file2": {},
+			},
 			doNotMergeItems: false,
 		},
 	}

--- a/src/internal/connector/onedrive/collections_test.go
+++ b/src/internal/connector/onedrive/collections_test.go
@@ -700,6 +700,7 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			defer flush()
 
 			excludes := map[string]struct{}{}
+			visitedPaths := map[string]string{}
 			outputFolderMap := map[string]string{}
 			maps.Copy(outputFolderMap, tt.inputFolderMap)
 			c := NewCollections(
@@ -723,6 +724,7 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 				tt.items,
 				tt.inputFolderMap,
 				outputFolderMap,
+				visitedPaths,
 				excludes,
 				!tt.validPrevDelta,
 			)
@@ -1839,6 +1841,7 @@ func (suite *OneDriveCollectionsSuite) TestCollectItems() {
 				driveItems []models.DriveItemable,
 				oldPaths map[string]string,
 				newPaths map[string]string,
+				visitedPaths map[string]string,
 				excluded map[string]struct{},
 				doNotMergeItems bool,
 			) error {

--- a/src/internal/connector/onedrive/collections_test.go
+++ b/src/internal/connector/onedrive/collections_test.go
@@ -103,18 +103,21 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 	)
 
 	tests := []struct {
-		testCase                       string
-		items                          []models.DriveItemable
-		inputFolderMap                 map[string]string
-		scope                          selectors.OneDriveScope
-		expect                         assert.ErrorAssertionFunc
-		expectedCollectionPaths        []string
-		expectedDeletedCollectionPaths []string
-		expectedItemCount              int
-		expectedContainerCount         int
-		expectedFileCount              int
-		expectedMetadataPaths          map[string]string
-		expectedExcludes               map[string]struct{}
+		testCase                        string
+		items                           []models.DriveItemable
+		inputFolderMap                  map[string]string
+		scope                           selectors.OneDriveScope
+		expect                          assert.ErrorAssertionFunc
+		expectedCollectionPaths         []string
+		expectedMovedCollectionPaths    []string
+		expectedNotMovedCollectionPaths []string
+		expectedDeletedCollectionPaths  []string
+		expectedItemCount               int
+		expectedContainerCount          int
+		expectedFileCount               int
+		expectedMetadataPaths           map[string]string
+		expectedExcludes                map[string]struct{}
+		validPrevDelta                  bool
 	}{
 		{
 			testCase: "Invalid item",
@@ -367,15 +370,16 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			},
 			scope:  anyFolder,
 			expect: assert.NoError,
-			expectedCollectionPaths: expectedPathAsSlice(
+			expectedNotMovedCollectionPaths: expectedPathAsSlice(
 				suite.T(),
 				tenant,
 				user,
 				testBaseDrivePath,
+				testBaseDrivePath+"/folder",
 			),
 			expectedItemCount:      1,
 			expectedFileCount:      0,
-			expectedContainerCount: 1,
+			expectedContainerCount: 2,
 			expectedMetadataPaths: map[string]string{
 				"folder": expectedPathAsSlice(
 					suite.T(),
@@ -391,6 +395,7 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 				)[0],
 			},
 			expectedExcludes: map[string]struct{}{},
+			validPrevDelta:   true,
 		},
 		{
 			testCase: "moved folder tree",
@@ -413,7 +418,13 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			},
 			scope:  anyFolder,
 			expect: assert.NoError,
-			expectedCollectionPaths: expectedPathAsSlice(
+			expectedMovedCollectionPaths: expectedPathAsSlice(
+				suite.T(),
+				tenant,
+				user,
+				testBaseDrivePath+"/folder",
+			),
+			expectedNotMovedCollectionPaths: expectedPathAsSlice(
 				suite.T(),
 				tenant,
 				user,
@@ -421,7 +432,7 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			),
 			expectedItemCount:      1,
 			expectedFileCount:      0,
-			expectedContainerCount: 1,
+			expectedContainerCount: 2,
 			expectedMetadataPaths: map[string]string{
 				"folder": expectedPathAsSlice(
 					suite.T(),
@@ -437,6 +448,7 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 				)[0],
 			},
 			expectedExcludes: map[string]struct{}{},
+			validPrevDelta:   true,
 		},
 		{
 			testCase: "moved folder tree and subfolder 1",
@@ -460,15 +472,22 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			},
 			scope:  anyFolder,
 			expect: assert.NoError,
-			expectedCollectionPaths: expectedPathAsSlice(
+			expectedNotMovedCollectionPaths: expectedPathAsSlice(
 				suite.T(),
 				tenant,
 				user,
 				testBaseDrivePath,
 			),
+			expectedMovedCollectionPaths: expectedPathAsSlice(
+				suite.T(),
+				tenant,
+				user,
+				testBaseDrivePath+"/folder",
+				testBaseDrivePath+"/subfolder",
+			),
 			expectedItemCount:      2,
 			expectedFileCount:      0,
-			expectedContainerCount: 1,
+			expectedContainerCount: 3,
 			expectedMetadataPaths: map[string]string{
 				"folder": expectedPathAsSlice(
 					suite.T(),
@@ -484,6 +503,7 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 				)[0],
 			},
 			expectedExcludes: map[string]struct{}{},
+			validPrevDelta:   true,
 		},
 		{
 			testCase: "moved folder tree and subfolder 2",
@@ -507,15 +527,22 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			},
 			scope:  anyFolder,
 			expect: assert.NoError,
-			expectedCollectionPaths: expectedPathAsSlice(
+			expectedNotMovedCollectionPaths: expectedPathAsSlice(
 				suite.T(),
 				tenant,
 				user,
 				testBaseDrivePath,
 			),
+			expectedMovedCollectionPaths: expectedPathAsSlice(
+				suite.T(),
+				tenant,
+				user,
+				testBaseDrivePath+"/folder",
+				testBaseDrivePath+"/subfolder",
+			),
 			expectedItemCount:      2,
 			expectedFileCount:      0,
-			expectedContainerCount: 1,
+			expectedContainerCount: 3,
 			expectedMetadataPaths: map[string]string{
 				"folder": expectedPathAsSlice(
 					suite.T(),
@@ -531,6 +558,7 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 				)[0],
 			},
 			expectedExcludes: map[string]struct{}{},
+			validPrevDelta:   true,
 		},
 		{
 			testCase: "deleted folder and package",
@@ -564,9 +592,10 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			),
 			expectedItemCount:      0,
 			expectedFileCount:      0,
-			expectedContainerCount: 0,
+			expectedContainerCount: 2,
 			expectedMetadataPaths:  map[string]string{},
 			expectedExcludes:       map[string]struct{}{},
+			validPrevDelta:         true,
 		},
 		{
 			testCase: "delete folder tree move subfolder",
@@ -590,11 +619,17 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			},
 			scope:  anyFolder,
 			expect: assert.NoError,
-			expectedCollectionPaths: expectedPathAsSlice(
+			expectedNotMovedCollectionPaths: expectedPathAsSlice(
 				suite.T(),
 				tenant,
 				user,
 				testBaseDrivePath,
+			),
+			expectedMovedCollectionPaths: expectedPathAsSlice(
+				suite.T(),
+				tenant,
+				user,
+				testBaseDrivePath+"/subfolder",
 			),
 			expectedDeletedCollectionPaths: expectedPathAsSlice(
 				suite.T(),
@@ -604,7 +639,7 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			),
 			expectedItemCount:      1,
 			expectedFileCount:      0,
-			expectedContainerCount: 1,
+			expectedContainerCount: 3,
 			expectedMetadataPaths: map[string]string{
 				"subfolder": expectedPathAsSlice(
 					suite.T(),
@@ -614,6 +649,7 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 				)[0],
 			},
 			expectedExcludes: map[string]struct{}{},
+			validPrevDelta:   true,
 		},
 		{
 			testCase: "delete file",
@@ -631,6 +667,30 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			expectedExcludes: map[string]struct{}{
 				"item": {},
 			},
+			validPrevDelta: true,
+		},
+		{
+			testCase: "moved/renamed file",
+			items: []models.DriveItemable{
+				driveItem("file", "file", testBaseDrivePath, true, false, false),
+			},
+			inputFolderMap: map[string]string{},
+			scope:          anyFolder,
+			expect:         assert.NoError,
+			expectedNotMovedCollectionPaths: expectedPathAsSlice(
+				suite.T(),
+				tenant,
+				user,
+				testBaseDrivePath,
+			),
+			expectedItemCount:      1,
+			expectedFileCount:      1,
+			expectedContainerCount: 1,
+			expectedMetadataPaths:  map[string]string{},
+			expectedExcludes: map[string]struct{}{
+				"file": {},
+			},
+			validPrevDelta: true,
 		},
 	}
 
@@ -664,24 +724,37 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 				tt.inputFolderMap,
 				outputFolderMap,
 				excludes,
-				false,
+				!tt.validPrevDelta,
 			)
 			tt.expect(t, err)
-			assert.Equal(t, len(tt.expectedCollectionPaths)+len(tt.expectedDeletedCollectionPaths), len(c.CollectionMap), "collection paths")
+			assert.Equal(t,
+				len(tt.expectedCollectionPaths)+
+					len(tt.expectedMovedCollectionPaths)+
+					len(tt.expectedNotMovedCollectionPaths)+
+					len(tt.expectedDeletedCollectionPaths),
+				len(c.CollectionMap), "collection paths")
 			assert.Equal(t, tt.expectedItemCount, c.NumItems, "item count")
 			assert.Equal(t, tt.expectedFileCount, c.NumFiles, "file count")
 			assert.Equal(t, tt.expectedContainerCount, c.NumContainers, "container count")
 			for _, collPath := range tt.expectedCollectionPaths {
-				assert.Contains(t, c.CollectionMap, collPath, "collection items")
-				assert.NotEqual(t, c.CollectionMap[collPath].State(), data.DeletedState, "not deleted collection")
+				assert.Contains(t, c.CollectionMap, collPath, "collection items new")
+				assert.Equal(t, data.NewState, c.CollectionMap[collPath].State(), "collection state new "+collPath)
+			}
+			for _, collPath := range tt.expectedMovedCollectionPaths {
+				assert.Contains(t, c.CollectionMap, collPath, "collection items moved")
+				assert.Equal(t, data.MovedState, c.CollectionMap[collPath].State(), "collection state moved "+collPath)
+			}
+			for _, collPath := range tt.expectedNotMovedCollectionPaths {
+				assert.Contains(t, c.CollectionMap, collPath, "collection items not moved")
+				assert.Equal(t, data.NotMovedState, c.CollectionMap[collPath].State(), "collection state not moved "+collPath)
 			}
 			for _, collPath := range tt.expectedDeletedCollectionPaths {
-				assert.Contains(t, c.CollectionMap, collPath, "deleted collection items")
-				assert.Equal(t, c.CollectionMap[collPath].State(), data.DeletedState, "deleted collection")
+				assert.Contains(t, c.CollectionMap, collPath, "collection items deleted")
+				assert.Equal(t, data.DeletedState, c.CollectionMap[collPath].State(), "collection state deleted "+collPath)
 			}
 
-			assert.Equal(t, tt.expectedMetadataPaths, outputFolderMap)
-			assert.Equal(t, tt.expectedExcludes, excludes)
+			assert.Equal(t, tt.expectedMetadataPaths, outputFolderMap, "expected metadata paths")
+			assert.Equal(t, tt.expectedExcludes, excludes, "excludes list")
 		})
 	}
 }

--- a/src/internal/connector/onedrive/collections_test.go
+++ b/src/internal/connector/onedrive/collections_test.go
@@ -1190,6 +1190,12 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 		user,
 		testBaseDrivePath+"/folder",
 	)[0]
+	folder2Path := expectedPathAsSlice(
+		suite.T(),
+		tenant,
+		user,
+		testBaseDrivePath+"/folder2",
+	)[0]
 
 	empty := ""
 	next := "next"
@@ -1320,6 +1326,38 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 			expectedFolderPaths: map[string]map[string]string{
 				driveID1: {
 					"folder": folderPath,
+				},
+			},
+			expectedDelList: map[string]struct{}{
+				"file": {},
+			},
+		},
+		{
+			name:   "OneDrive_FolderRenameWithinDelta_NoErrors",
+			drives: []models.Driveable{drive1},
+			items: map[string][]deltaPagerResult{
+				driveID1: {
+					{
+						items: []models.DriveItemable{
+							driveItem("folder", "folder", testBaseDrivePath, false, true, false),
+							driveItem("file", "file", testBaseDrivePath+"/folder", true, false, false),
+							driveItem("folder", "folder2", testBaseDrivePath, false, true, false),
+						},
+						deltaLink: &delta,
+					},
+				},
+			},
+			errCheck: assert.NoError,
+			expectedCollections: map[string][]string{
+				folderPath:     {"file"},
+				rootFolderPath: {"folder"},
+			},
+			expectedDeltaURLs: map[string]string{
+				driveID1: delta,
+			},
+			expectedFolderPaths: map[string]map[string]string{
+				driveID1: {
+					"folder": folder2Path,
 				},
 			},
 			expectedDelList: map[string]struct{}{

--- a/src/internal/connector/onedrive/collections_test.go
+++ b/src/internal/connector/onedrive/collections_test.go
@@ -1629,8 +1629,33 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 			c.drivePagerFunc = drivePagerFunc
 			c.itemPagerFunc = itemPagerFunc
 
-			// TODO(ashmrtn): Allow passing previous metadata.
-			cols, delList, err := c.Get(ctx, nil)
+			mc, err := graph.MakeMetadataCollection(
+				tenant,
+				user,
+				path.OneDriveService,
+				path.FilesCategory,
+				[]graph.MetadataCollectionEntry{
+					graph.NewMetadataEntry(
+						graph.DeltaURLsFileName,
+						map[string]string{
+							driveID1: "prev-delta",
+							driveID2: "prev-delta",
+						},
+					),
+					graph.NewMetadataEntry(
+						graph.PreviousPathFileName,
+						map[string]map[string]string{
+							driveID1: {},
+							driveID2: {},
+						},
+					),
+				},
+				func(*support.ConnectorOperationStatus) {},
+			)
+			assert.NoError(t, err, "creating metadata collection")
+
+			prevMetadata := []data.RestoreCollection{mc}
+			cols, delList, err := c.Get(ctx, prevMetadata)
 			test.errCheck(t, err)
 
 			if err != nil {

--- a/src/internal/connector/onedrive/collections_test.go
+++ b/src/internal/connector/onedrive/collections_test.go
@@ -1765,12 +1765,14 @@ func getDeltaError() error {
 func (suite *OneDriveCollectionsSuite) TestCollectItems() {
 	next := "next"
 	delta := "delta"
+	prevDelta := "prev-delta"
 
 	table := []struct {
 		name             string
 		items            []deltaPagerResult
 		deltaURL         string
 		prevDeltaSuccess bool
+		prevDelta        string
 		err              error
 	}{
 		{
@@ -1780,6 +1782,16 @@ func (suite *OneDriveCollectionsSuite) TestCollectItems() {
 				{deltaLink: &delta},
 			},
 			prevDeltaSuccess: true,
+			prevDelta:        prevDelta,
+		},
+		{
+			name:     "empty prev delta",
+			deltaURL: delta,
+			items: []deltaPagerResult{
+				{deltaLink: &delta},
+			},
+			prevDeltaSuccess: false,
+			prevDelta:        "",
 		},
 		{
 			name:     "next then delta",
@@ -1789,6 +1801,7 @@ func (suite *OneDriveCollectionsSuite) TestCollectItems() {
 				{deltaLink: &delta},
 			},
 			prevDeltaSuccess: true,
+			prevDelta:        prevDelta,
 		},
 		{
 			name:     "invalid prev delta",
@@ -1797,6 +1810,7 @@ func (suite *OneDriveCollectionsSuite) TestCollectItems() {
 				{err: getDeltaError()},
 				{deltaLink: &delta}, // works on retry
 			},
+			prevDelta:        prevDelta,
 			prevDeltaSuccess: false,
 		},
 		{
@@ -1805,6 +1819,7 @@ func (suite *OneDriveCollectionsSuite) TestCollectItems() {
 				{nextLink: &next},
 				{err: assert.AnError},
 			},
+			prevDelta:        prevDelta,
 			prevDeltaSuccess: true,
 			err:              assert.AnError,
 		},
@@ -1836,7 +1851,7 @@ func (suite *OneDriveCollectionsSuite) TestCollectItems() {
 				"",
 				"General",
 				collectorFunc,
-				"",
+				test.prevDelta,
 			)
 
 			require.ErrorIs(suite.T(), err, test.err, "delta fetch err")

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -194,15 +194,13 @@ func collectItems(
 		oldPaths         = map[string]string{}
 		newPaths         = map[string]string{}
 		excluded         = map[string]struct{}{}
-		invalidPrevDelta = false
+		invalidPrevDelta = len(prevDelta) == 0
 	)
 
 	maps.Copy(newPaths, oldPaths)
 
-	if len(prevDelta) != 0 {
+	if !invalidPrevDelta {
 		pager.SetNext(prevDelta)
-	} else {
-		invalidPrevDelta = true
 	}
 
 	for {

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -201,6 +201,8 @@ func collectItems(
 
 	if len(prevDelta) != 0 {
 		pager.SetNext(prevDelta)
+	} else {
+		invalidPrevDelta = true
 	}
 
 	for {

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -142,6 +142,7 @@ type itemCollector func(
 	driveItems []models.DriveItemable,
 	oldPaths map[string]string,
 	newPaths map[string]string,
+	visitedPaths map[string]string,
 	excluded map[string]struct{},
 	validPrevDelta bool,
 ) error
@@ -193,6 +194,7 @@ func collectItems(
 		// take in previous paths.
 		oldPaths         = map[string]string{}
 		newPaths         = map[string]string{}
+		visitedPaths     = map[string]string{}
 		excluded         = map[string]struct{}{}
 		invalidPrevDelta = len(prevDelta) == 0
 	)
@@ -229,7 +231,7 @@ func collectItems(
 			return DeltaUpdate{}, nil, nil, errors.Wrap(err, "extracting items from response")
 		}
 
-		err = collector(ctx, driveID, driveName, vals, oldPaths, newPaths, excluded, invalidPrevDelta)
+		err = collector(ctx, driveID, driveName, vals, oldPaths, newPaths, visitedPaths, excluded, invalidPrevDelta)
 		if err != nil {
 			return DeltaUpdate{}, nil, nil, err
 		}
@@ -380,6 +382,7 @@ func GetAllFolders(
 				items []models.DriveItemable,
 				oldPaths map[string]string,
 				newPaths map[string]string,
+				visitedPaths map[string]string,
 				excluded map[string]struct{},
 				doNotMergeItems bool,
 			) error {

--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -105,6 +105,7 @@ func (suite *ItemIntegrationSuite) TestItemReader_oneDrive() {
 		items []models.DriveItemable,
 		oldPaths map[string]string,
 		newPaths map[string]string,
+		visitedPaths map[string]string,
 		excluded map[string]struct{},
 		doNotMergeItems bool,
 	) error {

--- a/src/internal/connector/sharepoint/data_collections_test.go
+++ b/src/internal/connector/sharepoint/data_collections_test.go
@@ -90,6 +90,7 @@ func (suite *SharePointLibrariesSuite) TestUpdateCollections() {
 
 			paths := map[string]string{}
 			newPaths := map[string]string{}
+			visitedPaths := map[string]string{}
 			excluded := map[string]struct{}{}
 			c := onedrive.NewCollections(
 				graph.HTTPClient(graph.NoTimeout()),
@@ -100,7 +101,7 @@ func (suite *SharePointLibrariesSuite) TestUpdateCollections() {
 				&MockGraphService{},
 				nil,
 				control.Options{})
-			err := c.UpdateCollections(ctx, "driveID", "General", test.items, paths, newPaths, excluded, true)
+			err := c.UpdateCollections(ctx, "driveID", "General", test.items, paths, newPaths, visitedPaths, excluded, true)
 			test.expect(t, err)
 			assert.Equal(t, len(test.expectedCollectionPaths), len(c.CollectionMap), "collection paths")
 			assert.Equal(t, test.expectedItemCount, c.NumItems, "item count")

--- a/src/internal/data/data_collection.go
+++ b/src/internal/data/data_collection.go
@@ -94,3 +94,21 @@ type StreamSize interface {
 type StreamModTime interface {
 	ModTime() time.Time
 }
+
+// StateOf lets us figure out the state of the collection from the
+// previous and current path
+func StateOf(prev, curr path.Path) CollectionState {
+	if curr == nil || len(curr.String()) == 0 {
+		return DeletedState
+	}
+
+	if prev == nil || len(prev.String()) == 0 {
+		return NewState
+	}
+
+	if curr.Folder() != prev.Folder() {
+		return MovedState
+	}
+
+	return NotMovedState
+}

--- a/src/internal/data/data_collection_test.go
+++ b/src/internal/data/data_collection_test.go
@@ -1,0 +1,57 @@
+package data
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/alcionai/corso/src/pkg/path"
+)
+
+func TestStateOf(t *testing.T) {
+	fooP, err := path.Builder{}.
+		Append("foo").
+		ToDataLayerExchangePathForCategory("t", "u", path.EmailCategory, false)
+	require.NoError(t, err)
+	barP, err := path.Builder{}.
+		Append("bar").
+		ToDataLayerExchangePathForCategory("t", "u", path.EmailCategory, false)
+	require.NoError(t, err)
+
+	table := []struct {
+		name   string
+		prev   path.Path
+		curr   path.Path
+		expect CollectionState
+	}{
+		{
+			name:   "new",
+			curr:   fooP,
+			expect: NewState,
+		},
+		{
+			name:   "not moved",
+			prev:   fooP,
+			curr:   fooP,
+			expect: NotMovedState,
+		},
+		{
+			name:   "moved",
+			prev:   fooP,
+			curr:   barP,
+			expect: MovedState,
+		},
+		{
+			name:   "deleted",
+			prev:   fooP,
+			expect: DeletedState,
+		},
+	}
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			state := StateOf(test.prev, test.curr)
+			assert.Equal(t, test.expect, state)
+		})
+	}
+}


### PR DESCRIPTION
## Description

This wires up OneDrive incrementals to properly set PreviousPath and State values in the Collections.

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [x] :clock1: Yes, but in a later PR
- [ ] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* https://github.com/alcionai/corso/issues/2123
* https://github.com/alcionai/corso/issues/2242

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
