### PR TITLE
Proof of concept wrapper for suite.Suite

### DIFF
--- a/src/internal/connector/graph_connector_disconnected_test.go
+++ b/src/internal/connector/graph_connector_disconnected_test.go
@@ -22,12 +22,16 @@ import (
 // Disconnected Test Section
 // ---------------------------------------------------------------
 type DisconnectedGraphConnectorSuite struct {
-	suite.Suite
+	*tester.UnitSuite
 }
 
 func TestDisconnectedGraphSuite(t *testing.T) {
+	s := &DisconnectedGraphConnectorSuite{
+		UnitSuite: tester.NewUnitSuite(t),
+	}
+
 	tester.LogTimeOfTest(t)
-	suite.Run(t, new(DisconnectedGraphConnectorSuite))
+	suite.Run(t, s)
 }
 
 func (suite *DisconnectedGraphConnectorSuite) TestBadConnection() {

--- a/src/internal/connector/graph_connector_disconnected_test.go
+++ b/src/internal/connector/graph_connector_disconnected_test.go
@@ -70,8 +70,15 @@ func (suite *DisconnectedGraphConnectorSuite) TestBadConnection() {
 	}
 
 	for _, test := range table {
-		suite.T().Run(test.name, func(t *testing.T) {
-			gc, err := NewGraphConnector(ctx, graph.HTTPClient(graph.NoTimeout()), test.acct(t), Users, fault.New(true))
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			gc, err := NewGraphConnector(
+				ctx,
+				graph.HTTPClient(graph.NoTimeout()),
+				test.acct(t),
+				Users,
+				fault.New(true))
 			assert.Nil(t, gc, test.name+" failed")
 			assert.NotNil(t, err, test.name+" failed")
 		})

--- a/src/internal/connector/graph_connector_disconnected_test.go
+++ b/src/internal/connector/graph_connector_disconnected_test.go
@@ -22,12 +22,12 @@ import (
 // Disconnected Test Section
 // ---------------------------------------------------------------
 type DisconnectedGraphConnectorSuite struct {
-	*tester.UnitSuite
+	tester.Suite
 }
 
 func TestDisconnectedGraphSuite(t *testing.T) {
 	s := &DisconnectedGraphConnectorSuite{
-		UnitSuite: tester.NewUnitSuite(t, nil),
+		Suite: tester.NewUnitSuite(t, nil),
 	}
 
 	tester.LogTimeOfTest(t)
@@ -112,13 +112,16 @@ func (suite *DisconnectedGraphConnectorSuite) TestGraphConnector_Status() {
 	go statusTestTask(&gc, 4, 1, 1)
 
 	gc.AwaitStatus()
-	suite.NotEmpty(gc.PrintableStatus())
+
+	t := suite.T()
+
+	assert.NotEmpty(t, gc.PrintableStatus())
 	// Expect 8 objects
-	suite.Equal(8, gc.Status().ObjectCount)
+	assert.Equal(t, 8, gc.Status().ObjectCount)
 	// Expect 2 success
-	suite.Equal(2, gc.Status().Successful)
+	assert.Equal(t, 2, gc.Status().Successful)
 	// Expect 2 folders
-	suite.Equal(2, gc.Status().FolderCount)
+	assert.Equal(t, 2, gc.Status().FolderCount)
 }
 
 func (suite *DisconnectedGraphConnectorSuite) TestVerifyBackupInputs() {

--- a/src/internal/connector/graph_connector_disconnected_test.go
+++ b/src/internal/connector/graph_connector_disconnected_test.go
@@ -27,7 +27,7 @@ type DisconnectedGraphConnectorSuite struct {
 
 func TestDisconnectedGraphSuite(t *testing.T) {
 	s := &DisconnectedGraphConnectorSuite{
-		UnitSuite: tester.NewUnitSuite(t),
+		UnitSuite: tester.NewUnitSuite(t, nil),
 	}
 
 	tester.LogTimeOfTest(t)

--- a/src/internal/connector/graph_connector_disconnected_test.go
+++ b/src/internal/connector/graph_connector_disconnected_test.go
@@ -27,10 +27,9 @@ type DisconnectedGraphConnectorSuite struct {
 
 func TestDisconnectedGraphSuite(t *testing.T) {
 	s := &DisconnectedGraphConnectorSuite{
-		Suite: tester.NewUnitSuite(t, nil),
+		Suite: tester.NewUnitSuite(t),
 	}
 
-	tester.LogTimeOfTest(t)
 	suite.Run(t, s)
 }
 

--- a/src/internal/tester/integration_runners.go
+++ b/src/internal/tester/integration_runners.go
@@ -11,7 +11,10 @@ import (
 )
 
 const (
-	CorsoLoadTests                                = "CORSO_LOAD_TESTS"
+	CorsoLoadTests = "CORSO_LOAD_TESTS"
+	// Run only integration tests.
+	CorsoIntegrationTests = "CORSO_INTEGRATION_TESTS"
+	// Run all tests, unit and integration.
 	CorsoCITests                                  = "CORSO_CI_TESTS"
 	CorsoCLIBackupTests                           = "CORSO_COMMAND_LINE_BACKUP_TESTS"
 	CorsoCLIConfigTests                           = "CORSO_COMMAND_LINE_CONFIG_TESTS"
@@ -52,7 +55,22 @@ func RunOnAny(t *testing.T, tests ...string) {
 
 	if l == 0 {
 		t.Skipf(
-			"one or more env vars mus be flagged to run this test: %v",
+			"one or more env vars must be flagged to run this test: %v",
+			strings.Join(tests, ", "))
+	}
+}
+
+// dontRunOn takes in a list of env variable names and skips running tests if
+// any of them are set.
+func dontRunOn(t *testing.T, tests ...string) {
+	var l int
+	for _, test := range tests {
+		l += len(os.Getenv(test))
+	}
+
+	if l > 0 {
+		t.Skipf(
+			"one or more env vars excluding these tests are flagged: %v",
 			strings.Join(tests, ", "))
 	}
 }

--- a/src/internal/tester/integration_runners.go
+++ b/src/internal/tester/integration_runners.go
@@ -60,21 +60,6 @@ func RunOnAny(t *testing.T, tests ...string) {
 	}
 }
 
-// dontRunOn takes in a list of env variable names and skips running tests if
-// any of them are set.
-func dontRunOn(t *testing.T, tests ...string) {
-	var l int
-	for _, test := range tests {
-		l += len(os.Getenv(test))
-	}
-
-	if l > 0 {
-		t.Skipf(
-			"one or more env vars excluding these tests are flagged: %v",
-			strings.Join(tests, ", "))
-	}
-}
-
 // LogTimeOfTest logs the test name and the time that it was run.
 func LogTimeOfTest(t *testing.T) string {
 	now := time.Now().UTC().Format(time.RFC3339Nano)

--- a/src/internal/tester/integration_runners.go
+++ b/src/internal/tester/integration_runners.go
@@ -11,10 +11,7 @@ import (
 )
 
 const (
-	CorsoLoadTests = "CORSO_LOAD_TESTS"
-	// Run only integration tests.
-	CorsoIntegrationTests = "CORSO_INTEGRATION_TESTS"
-	// Run all tests, unit and integration.
+	CorsoLoadTests                                = "CORSO_LOAD_TESTS"
 	CorsoCITests                                  = "CORSO_CI_TESTS"
 	CorsoCLIBackupTests                           = "CORSO_COMMAND_LINE_BACKUP_TESTS"
 	CorsoCLIConfigTests                           = "CORSO_COMMAND_LINE_CONFIG_TESTS"

--- a/src/internal/tester/suite.go
+++ b/src/internal/tester/suite.go
@@ -1,0 +1,39 @@
+package tester
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+func NewUnitSuite(t *testing.T, excludeGroups ...string) *UnitSuite {
+	dontRunOn(
+		t,
+		append(
+			[]string{CorsoIntegrationTests},
+			excludeGroups...,
+		)...,
+	)
+
+	return new(UnitSuite)
+}
+
+type UnitSuite struct {
+	suite.Suite
+}
+
+func NewIntegrationSuite(t *testing.T, includeGroups ...string) *IntegrationSuite {
+	RunOnAny(
+		t,
+		append(
+			[]string{CorsoCITests, CorsoIntegrationTests},
+			includeGroups...,
+		)...,
+	)
+
+	return new(IntegrationSuite)
+}
+
+type IntegrationSuite struct {
+	suite.Suite
+}

--- a/src/internal/tester/suite.go
+++ b/src/internal/tester/suite.go
@@ -11,8 +11,7 @@ type Suite interface {
 	Run(name string, subtest func()) bool
 }
 
-func NewUnitSuite(t *testing.T, envSets [][]string) *unitSuite {
-	MustGetEnvSets(t, envSets...)
+func NewUnitSuite(t *testing.T) *unitSuite {
 	return new(unitSuite)
 }
 

--- a/src/internal/tester/suite.go
+++ b/src/internal/tester/suite.go
@@ -6,7 +6,8 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func NewUnitSuite(t *testing.T) *UnitSuite {
+func NewUnitSuite(t *testing.T, envSets [][]string) *UnitSuite {
+	MustGetEnvSets(t, envSets...)
 	return new(UnitSuite)
 }
 
@@ -14,7 +15,11 @@ type UnitSuite struct {
 	suite.Suite
 }
 
-func NewIntegrationSuite(t *testing.T, includeGroups ...string) *IntegrationSuite {
+func NewIntegrationSuite(
+	t *testing.T,
+	envSets [][]string,
+	includeGroups ...string,
+) *IntegrationSuite {
 	RunOnAny(
 		t,
 		append(
@@ -22,6 +27,8 @@ func NewIntegrationSuite(t *testing.T, includeGroups ...string) *IntegrationSuit
 			includeGroups...,
 		)...,
 	)
+
+	MustGetEnvSets(t, envSets...)
 
 	return new(IntegrationSuite)
 }

--- a/src/internal/tester/suite.go
+++ b/src/internal/tester/suite.go
@@ -6,12 +6,17 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func NewUnitSuite(t *testing.T, envSets [][]string) *UnitSuite {
-	MustGetEnvSets(t, envSets...)
-	return new(UnitSuite)
+type Suite interface {
+	suite.TestingSuite
+	Run(name string, subtest func()) bool
 }
 
-type UnitSuite struct {
+func NewUnitSuite(t *testing.T, envSets [][]string) *unitSuite {
+	MustGetEnvSets(t, envSets...)
+	return new(unitSuite)
+}
+
+type unitSuite struct {
 	suite.Suite
 }
 
@@ -19,20 +24,20 @@ func NewIntegrationSuite(
 	t *testing.T,
 	envSets [][]string,
 	includeGroups ...string,
-) *IntegrationSuite {
+) *integrationSuite {
 	RunOnAny(
 		t,
 		append(
-			[]string{CorsoCITests, CorsoIntegrationTests},
+			[]string{CorsoCITests},
 			includeGroups...,
 		)...,
 	)
 
 	MustGetEnvSets(t, envSets...)
 
-	return new(IntegrationSuite)
+	return new(integrationSuite)
 }
 
-type IntegrationSuite struct {
+type integrationSuite struct {
 	suite.Suite
 }

--- a/src/internal/tester/suite.go
+++ b/src/internal/tester/suite.go
@@ -6,15 +6,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func NewUnitSuite(t *testing.T, excludeGroups ...string) *UnitSuite {
-	dontRunOn(
-		t,
-		append(
-			[]string{CorsoIntegrationTests},
-			excludeGroups...,
-		)...,
-	)
-
+func NewUnitSuite(t *testing.T) *UnitSuite {
 	return new(UnitSuite)
 }
 


### PR DESCRIPTION
## Description

Proof of concept for how to wrap suite.Suite and insert our own logic for determining if a test should be skipped or not.

Adds a new env var for running only integration tests

May require future work to add unit tests with the same (non-default) labels as their integration tests

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Test
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

## Issue(s)

* #2373

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
