### PR TITLE
Use case-insensitive comparison for emails in permission check

### DIFF
--- a/src/internal/connector/graph_connector_helper_test.go
+++ b/src/internal/connector/graph_connector_helper_test.go
@@ -698,7 +698,7 @@ func compareOneDriveItem(
 
 	// FIXME(meain): The permissions before and after might not be in the same order.
 	for i, p := range expectedMeta.Permissions {
-		assert.Equal(t, p.Email, itemMeta.Permissions[i].Email)
+		assert.Equal(t, strings.ToLower(p.Email), strings.ToLower(itemMeta.Permissions[i].Email))
 		assert.Equal(t, p.Roles, itemMeta.Permissions[i].Roles)
 		assert.Equal(t, p.Expiration, itemMeta.Permissions[i].Expiration)
 	}


### PR DESCRIPTION
## Description

Tests were flaking due to inconsistent case in strings. Normalize case prior to comparing.

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

* closes #2416

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
