### PR TITLE
add locationRef to details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Support for item.Attachment:Mail restore
+- Errors from duplicate names in Exchange Calendars
 
 ### Changed
+- When using Restore and Details on Exchange Calendars, the `--event-calendar` flag can now identify calendars by either a Display Name or a Microsoft 365 ID.
+- Exchange Calendars storage entries now construct their paths using container IDs instead of display names.  This fixes cases where duplicate display names caused system failures.
 
 ### Known Issues
 - Nested attachments are currently not restored due to an [issue](https://github.com/microsoft/kiota-serialization-json-go/issues/61) discovered in the Graph APIs
+- Breaking changes to Exchange Calendar backups.
 
 ## [v0.3.0] (alpha) - 2023-2-07
 

--- a/src/cli/utils/testdata/opts.go
+++ b/src/cli/utils/testdata/opts.go
@@ -137,14 +137,14 @@ var (
 			Name:     "EmailsFolderPrefixMatch",
 			Expected: testdata.ExchangeEmailItems,
 			Opts: utils.ExchangeOpts{
-				EmailFolder: []string{testdata.ExchangeEmailInboxPath.Folder()},
+				EmailFolder: []string{testdata.ExchangeEmailInboxPath.Folder(false)},
 			},
 		},
 		{
 			Name:     "EmailsFolderPrefixMatchTrailingSlash",
 			Expected: testdata.ExchangeEmailItems,
 			Opts: utils.ExchangeOpts{
-				EmailFolder: []string{testdata.ExchangeEmailInboxPath.Folder() + "/"},
+				EmailFolder: []string{testdata.ExchangeEmailInboxPath.Folder(false) + "/"},
 			},
 		},
 		{
@@ -154,7 +154,7 @@ var (
 				testdata.ExchangeEmailItems[2],
 			},
 			Opts: utils.ExchangeOpts{
-				EmailFolder: []string{testdata.ExchangeEmailBasePath2.Folder()},
+				EmailFolder: []string{testdata.ExchangeEmailBasePath2.Folder(false)},
 			},
 		},
 		{
@@ -164,7 +164,7 @@ var (
 				testdata.ExchangeEmailItems[2],
 			},
 			Opts: utils.ExchangeOpts{
-				EmailFolder: []string{testdata.ExchangeEmailBasePath2.Folder() + "/"},
+				EmailFolder: []string{testdata.ExchangeEmailBasePath2.Folder(false) + "/"},
 			},
 		},
 		{

--- a/src/cmd/factory/impl/common.go
+++ b/src/cmd/factory/impl/common.go
@@ -172,7 +172,7 @@ func buildCollections(
 			return nil, err
 		}
 
-		mc := mockconnector.NewMockExchangeCollection(pth, len(c.items))
+		mc := mockconnector.NewMockExchangeCollection(pth, pth, len(c.items))
 
 		for i := 0; i < len(c.items); i++ {
 			mc.Names[i] = c.items[i].name

--- a/src/internal/connector/exchange/api/api_test.go
+++ b/src/internal/connector/exchange/api/api_test.go
@@ -161,39 +161,6 @@ func (suite *ExchangeServiceSuite) TestOptionsForContacts() {
 	}
 }
 
-// TestGraphQueryFunctions verifies if Query functions APIs
-// through Microsoft Graph are functional
-func (suite *ExchangeServiceSuite) TestGraphQueryFunctions() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
-	c, err := NewClient(suite.credentials)
-	require.NoError(suite.T(), err)
-
-	userID := tester.M365UserID(suite.T())
-	tests := []struct {
-		name     string
-		function GraphQuery
-	}{
-		{
-			name:     "GraphQuery: Get All ContactFolders",
-			function: c.Contacts().GetAllContactFolderNamesForUser,
-		},
-		{
-			name:     "GraphQuery: Get All Calendars for User",
-			function: c.Events().GetAllCalendarNamesForUser,
-		},
-	}
-
-	for _, test := range tests {
-		suite.T().Run(test.name, func(t *testing.T) {
-			response, err := test.function(ctx, userID)
-			assert.NoError(t, err)
-			assert.NotNil(t, response)
-		})
-	}
-}
-
 //nolint:lll
 var stubHTMLContent = "<html><head>\r\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"><style type=\"text/css\" style=\"display:none\">\r\n<!--\r\np\r\n\t{margin-top:0;\r\n\tmargin-bottom:0}\r\n-->\r\n</style></head><body dir=\"ltr\"><div class=\"elementToProof\" style=\"font-family:Calibri,Arial,Helvetica,sans-serif; font-size:12pt; color:rgb(0,0,0); background-color:rgb(255,255,255)\">Happy New Year,</div><div class=\"elementToProof\" style=\"font-family:Calibri,Arial,Helvetica,sans-serif; font-size:12pt; color:rgb(0,0,0); background-color:rgb(255,255,255)\"><br></div><div class=\"elementToProof\" style=\"font-family:Calibri,Arial,Helvetica,sans-serif; font-size:12pt; color:rgb(0,0,0); background-color:rgb(255,255,255)\">In accordance with TPS report guidelines, there have been questions about how to address our activities SharePoint Cover page. Do you believe this is the best picture?&nbsp;</div><div class=\"elementToProof\" style=\"font-family:Calibri,Arial,Helvetica,sans-serif; font-size:12pt; color:rgb(0,0,0); background-color:rgb(255,255,255)\"><br></div><div class=\"elementToProof\" style=\"font-family:Calibri,Arial,Helvetica,sans-serif; font-size:12pt; color:rgb(0,0,0); background-color:rgb(255,255,255)\"><img class=\"FluidPluginCopy ContentPasted0 w-2070 h-1380\" size=\"5854817\" data-outlook-trace=\"F:1|T:1\" src=\"cid:85f4faa3-9851-40c7-ba0a-e63dce1185f9\" style=\"max-width:100%\"><br></div><div class=\"elementToProof\" style=\"font-family:Calibri,Arial,Helvetica,sans-serif; font-size:12pt; color:rgb(0,0,0); background-color:rgb(255,255,255)\"><br></div><div class=\"elementToProof\" style=\"font-family:Calibri,Arial,Helvetica,sans-serif; font-size:12pt; color:rgb(0,0,0); background-color:rgb(255,255,255)\">Let me know if this meets our culture requirements.</div><div class=\"elementToProof\" style=\"font-family:Calibri,Arial,Helvetica,sans-serif; font-size:12pt; color:rgb(0,0,0); background-color:rgb(255,255,255)\"><br></div><div class=\"elementToProof\" style=\"font-family:Calibri,Arial,Helvetica,sans-serif; font-size:12pt; color:rgb(0,0,0); background-color:rgb(255,255,255)\">Warm Regards,</div><div class=\"elementToProof\" style=\"font-family:Calibri,Arial,Helvetica,sans-serif; font-size:12pt; color:rgb(0,0,0); background-color:rgb(255,255,255)\"><br></div><div class=\"elementToProof\" style=\"font-family:Calibri,Arial,Helvetica,sans-serif; font-size:12pt; color:rgb(0,0,0); background-color:rgb(255,255,255)\">Dustin</div></body></html>"
 

--- a/src/internal/connector/exchange/api/contacts.go
+++ b/src/internal/connector/exchange/api/contacts.go
@@ -169,10 +169,8 @@ func (c Contacts) EnumerateContainers(
 				continue
 			}
 
-			temp := graph.NewCacheFolder(fold, nil)
-
-			err = fn(temp)
-			if err != nil {
+			temp := graph.NewCacheFolder(fold, nil, nil)
+			if err := fn(temp); err != nil {
 				errs = multierror.Append(err, errs)
 				continue
 			}

--- a/src/internal/connector/exchange/api/contacts.go
+++ b/src/internal/connector/exchange/api/contacts.go
@@ -80,28 +80,6 @@ func (c Contacts) GetItem(
 	return cont, ContactInfo(cont), nil
 }
 
-// GetAllContactFolderNamesForUser is a GraphQuery function for getting
-// ContactFolderId and display names for contacts. All other information is omitted.
-// Does not return the default Contact Folder
-func (c Contacts) GetAllContactFolderNamesForUser(
-	ctx context.Context,
-	user string,
-) (serialization.Parsable, error) {
-	options, err := optionsForContactFolders([]string{"displayName", "parentFolderId"})
-	if err != nil {
-		return nil, err
-	}
-
-	var resp models.ContactFolderCollectionResponseable
-
-	err = graph.RunWithRetry(func() error {
-		resp, err = c.stable.Client().UsersById(user).ContactFolders().Get(ctx, options)
-		return err
-	})
-
-	return resp, err
-}
-
 func (c Contacts) GetContainerByID(
 	ctx context.Context,
 	userID, dirID string,

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -210,10 +210,11 @@ func (c Events) EnumerateContainers(
 				continue
 			}
 
-			temp := graph.NewCacheFolder(cd, path.Builder{}.Append(*cd.GetDisplayName()))
-
-			err = fn(temp)
-			if err != nil {
+			temp := graph.NewCacheFolder(
+				cd,
+				path.Builder{}.Append(*cd.GetDisplayName()),
+				path.Builder{}.Append(*cd.GetDisplayName()))
+			if err := fn(temp); err != nil {
 				errs = multierror.Append(err, errs)
 				continue
 			}

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -144,25 +144,6 @@ func (c Events) GetItem(
 	return event, EventInfo(event), nil
 }
 
-func (c Client) GetAllCalendarNamesForUser(
-	ctx context.Context,
-	user string,
-) (serialization.Parsable, error) {
-	options, err := optionsForCalendars([]string{"name", "owner"})
-	if err != nil {
-		return nil, err
-	}
-
-	var resp models.CalendarCollectionResponseable
-
-	err = graph.RunWithRetry(func() error {
-		resp, err = c.stable.Client().UsersById(user).Calendars().Get(ctx, options)
-		return err
-	})
-
-	return resp, err
-}
-
 // EnumerateContainers iterates through all of the users current
 // calendars, converting each to a graph.CacheFolder, and
 // calling fn(cf) on each one.  If fn(cf) errors, the error is

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -212,8 +212,8 @@ func (c Events) EnumerateContainers(
 
 			temp := graph.NewCacheFolder(
 				cd,
-				path.Builder{}.Append(*cd.GetDisplayName()),
-				path.Builder{}.Append(*cd.GetDisplayName()))
+				path.Builder{}.Append(*cd.GetId()), // storage path
+				path.Builder{}.Append(*cd.GetDisplayName())) // display location
 			if err := fn(temp); err != nil {
 				errs = multierror.Append(err, errs)
 				continue

--- a/src/internal/connector/exchange/api/mail.go
+++ b/src/internal/connector/exchange/api/mail.go
@@ -198,8 +198,7 @@ func (c Mail) EnumerateContainers(
 		}
 
 		for _, v := range resp.GetValue() {
-			temp := graph.NewCacheFolder(v, nil)
-
+			temp := graph.NewCacheFolder(v, nil, nil)
 			if err := fn(temp); err != nil {
 				errs = multierror.Append(errs, errors.Wrap(err, "iterating mail folders delta"))
 				continue

--- a/src/internal/connector/exchange/api/options.go
+++ b/src/internal/connector/exchange/api/options.go
@@ -135,27 +135,6 @@ func optionsForCalendarsByID(moreOps []string) (
 	return options, nil
 }
 
-// optionsForContactFolders places allowed options for exchange.ContactFolder object
-// @return is first call in ContactFolders().GetWithRequestConfigurationAndResponseHandler
-func optionsForContactFolders(moreOps []string) (
-	*users.ItemContactFoldersRequestBuilderGetRequestConfiguration,
-	error,
-) {
-	selecting, err := buildOptions(moreOps, fieldsForFolders)
-	if err != nil {
-		return nil, err
-	}
-
-	requestParameters := &users.ItemContactFoldersRequestBuilderGetQueryParameters{
-		Select: selecting,
-	}
-	options := &users.ItemContactFoldersRequestBuilderGetRequestConfiguration{
-		QueryParameters: requestParameters,
-	}
-
-	return options, nil
-}
-
 func optionsForContactFolderByID(moreOps []string) (
 	*users.ItemContactFoldersContactFolderItemRequestBuilderGetRequestConfiguration,
 	error,

--- a/src/internal/connector/exchange/contact_folder_cache.go
+++ b/src/internal/connector/exchange/contact_folder_cache.go
@@ -58,7 +58,7 @@ func (cfc *contactFolderCache) Populate(
 		return errors.Wrap(err, "enumerating containers")
 	}
 
-	if err := cfc.populatePaths(ctx); err != nil {
+	if err := cfc.populatePaths(ctx, false); err != nil {
 		return errors.Wrap(err, "populating paths")
 	}
 

--- a/src/internal/connector/exchange/contact_folder_cache.go
+++ b/src/internal/connector/exchange/contact_folder_cache.go
@@ -29,8 +29,10 @@ func (cfc *contactFolderCache) populateContactRoot(
 		return support.ConnectorStackErrorTraceWrap(err, "fetching root folder")
 	}
 
-	temp := graph.NewCacheFolder(f, path.Builder{}.Append(baseContainerPath...))
-
+	temp := graph.NewCacheFolder(
+		f,
+		path.Builder{}.Append(baseContainerPath...), // storage path
+		path.Builder{}.Append(baseContainerPath...)) // display location
 	if err := cfc.addFolder(temp); err != nil {
 		return errors.Wrap(err, "adding resolver dir")
 	}

--- a/src/internal/connector/exchange/container_resolver.go
+++ b/src/internal/connector/exchange/container_resolver.go
@@ -51,38 +51,52 @@ type containerResolver struct {
 func (cr *containerResolver) IDToPath(
 	ctx context.Context,
 	folderID string,
-) (*path.Builder, error) {
-	return cr.idToPath(ctx, folderID, 0)
+	useIDInPath bool,
+) (*path.Builder, *path.Builder, error) {
+	return cr.idToPath(ctx, folderID, 0, useIDInPath)
 }
 
 func (cr *containerResolver) idToPath(
 	ctx context.Context,
 	folderID string,
 	depth int,
-) (*path.Builder, error) {
+	useIDInPath bool,
+) (*path.Builder, *path.Builder, error) {
 	if depth >= maxIterations {
-		return nil, errors.New("path contains cycle or is too tall")
+		return nil, nil, errors.New("path contains cycle or is too tall")
 	}
 
 	c, ok := cr.cache[folderID]
 	if !ok {
-		return nil, errors.Errorf("folder %s not cached", folderID)
+		return nil, nil, errors.Errorf("folder %s not cached", folderID)
 	}
 
 	p := c.Path()
 	if p != nil {
-		return p, nil
+		return p, c.Location(), nil
 	}
 
-	parentPath, err := cr.idToPath(ctx, *c.GetParentFolderId(), depth+1)
+	parentPath, parentLoc, err := cr.idToPath(ctx, *c.GetParentFolderId(), depth+1, useIDInPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "retrieving parent folder")
+		return nil, nil, errors.Wrap(err, "retrieving parent folder")
 	}
 
-	fullPath := parentPath.Append(*c.GetDisplayName())
+	toAppend := *c.GetDisplayName()
+	if useIDInPath {
+		toAppend = *c.GetId()
+	}
+
+	fullPath := parentPath.Append(toAppend)
 	c.SetPath(fullPath)
 
-	return fullPath, nil
+	var locPath *path.Builder
+
+	if parentLoc != nil {
+		locPath = parentLoc.Append(*c.GetDisplayName())
+		c.SetLocation(locPath)
+	}
+
+	return fullPath, locPath, nil
 }
 
 // PathInCache utility function to return m365ID of folder if the path.Folders
@@ -141,7 +155,11 @@ func (cr *containerResolver) Items() []graph.CachedContainer {
 
 // AddToCache adds container to map in field 'cache'
 // @returns error iff the required values are not accessible.
-func (cr *containerResolver) AddToCache(ctx context.Context, f graph.Container) error {
+func (cr *containerResolver) AddToCache(
+	ctx context.Context,
+	f graph.Container,
+	useIDInPath bool,
+) error {
 	temp := graph.CacheFolder{
 		Container: f,
 	}
@@ -152,7 +170,7 @@ func (cr *containerResolver) AddToCache(ctx context.Context, f graph.Container) 
 
 	// Populate the path for this entry so calls to PathInCache succeed no matter
 	// when they're made.
-	_, err := cr.IDToPath(ctx, *f.GetId())
+	_, _, err := cr.IDToPath(ctx, *f.GetId(), useIDInPath)
 	if err != nil {
 		return errors.Wrap(err, "adding cache entry")
 	}
@@ -160,12 +178,12 @@ func (cr *containerResolver) AddToCache(ctx context.Context, f graph.Container) 
 	return nil
 }
 
-func (cr *containerResolver) populatePaths(ctx context.Context) error {
+func (cr *containerResolver) populatePaths(ctx context.Context, useIDInPath bool) error {
 	var errs *multierror.Error
 
 	// Populate all folder paths.
 	for _, f := range cr.Items() {
-		_, err := cr.IDToPath(ctx, *f.GetId())
+		_, _, err := cr.IDToPath(ctx, *f.GetId(), useIDInPath)
 		if err != nil {
 			errs = multierror.Append(errs, errors.Wrap(err, "populating path"))
 		}

--- a/src/internal/connector/exchange/container_resolver.go
+++ b/src/internal/connector/exchange/container_resolver.go
@@ -107,13 +107,13 @@ func (cr *containerResolver) PathInCache(pathString string) (string, bool) {
 		return "", false
 	}
 
-	for _, contain := range cr.cache {
-		if contain.Path() == nil {
+	for _, cc := range cr.cache {
+		if cc.Path() == nil {
 			continue
 		}
 
-		if contain.Path().String() == pathString {
-			return *contain.GetId(), true
+		if cc.Path().String() == pathString {
+			return *cc.GetId(), true
 		}
 	}
 

--- a/src/internal/connector/exchange/container_resolver.go
+++ b/src/internal/connector/exchange/container_resolver.go
@@ -163,7 +163,6 @@ func (cr *containerResolver) AddToCache(
 	temp := graph.CacheFolder{
 		Container: f,
 	}
-
 	if err := cr.addFolder(temp); err != nil {
 		return errors.Wrap(err, "adding cache folder")
 	}
@@ -176,6 +175,12 @@ func (cr *containerResolver) AddToCache(
 	}
 
 	return nil
+}
+
+// DestinationNameToID returns an empty string.  This is only supported by exchange
+// calendars at this time.
+func (cr *containerResolver) DestinationNameToID(dest string) string {
+	return ""
 }
 
 func (cr *containerResolver) populatePaths(ctx context.Context, useIDInPath bool) error {

--- a/src/internal/connector/exchange/container_resolver_test.go
+++ b/src/internal/connector/exchange/container_resolver_test.go
@@ -595,7 +595,7 @@ func (suite *FolderCacheIntegrationSuite) TestCreateContainerDestination() {
 
 	for _, test := range tests {
 		suite.T().Run(test.name, func(t *testing.T) {
-			folderID, err := CreateContainerDestinaion(
+			folderID, err := CreateContainerDestination(
 				ctx,
 				m365,
 				test.pathFunc1(t),
@@ -608,7 +608,7 @@ func (suite *FolderCacheIntegrationSuite) TestCreateContainerDestination() {
 			_, err = resolver.IDToPath(ctx, folderID)
 			assert.NoError(t, err)
 
-			secondID, err := CreateContainerDestinaion(
+			secondID, err := CreateContainerDestination(
 				ctx,
 				m365,
 				test.pathFunc2(t),

--- a/src/internal/connector/exchange/container_resolver_test.go
+++ b/src/internal/connector/exchange/container_resolver_test.go
@@ -26,16 +26,19 @@ type mockContainer struct {
 	displayName *string
 	parentID    *string
 	p           *path.Builder
+	l           *path.Builder
 }
 
 //nolint:revive
 func (m mockContainer) GetId() *string { return m.id }
 
 //nolint:revive
-func (m mockContainer) GetParentFolderId() *string { return m.parentID }
-func (m mockContainer) GetDisplayName() *string    { return m.displayName }
-func (m mockContainer) Path() *path.Builder        { return m.p }
-func (m mockContainer) SetPath(p *path.Builder)    {}
+func (m mockContainer) GetParentFolderId() *string  { return m.parentID }
+func (m mockContainer) GetDisplayName() *string     { return m.displayName }
+func (m mockContainer) Location() *path.Builder     { return m.l }
+func (m mockContainer) SetLocation(p *path.Builder) {}
+func (m mockContainer) Path() *path.Builder         { return m.p }
+func (m mockContainer) SetPath(p *path.Builder)     {}
 
 func strPtr(s string) *string {
 	return &s
@@ -168,7 +171,7 @@ func (suite *FolderCacheUnitSuite) TestAddFolder() {
 					parentID:    nil,
 				},
 				nil,
-			),
+				nil),
 			check: assert.Error,
 		},
 		{
@@ -180,7 +183,7 @@ func (suite *FolderCacheUnitSuite) TestAddFolder() {
 					parentID:    nil,
 				},
 				path.Builder{}.Append("foo"),
-			),
+				path.Builder{}.Append("loc")),
 			check: assert.NoError,
 		},
 		{
@@ -192,7 +195,7 @@ func (suite *FolderCacheUnitSuite) TestAddFolder() {
 					parentID:    &testParentID,
 				},
 				path.Builder{}.Append("foo"),
-			),
+				path.Builder{}.Append("loc")),
 			check: assert.Error,
 		},
 		{
@@ -204,7 +207,7 @@ func (suite *FolderCacheUnitSuite) TestAddFolder() {
 					parentID:    &testParentID,
 				},
 				path.Builder{}.Append("foo"),
-			),
+				path.Builder{}.Append("loc")),
 			check: assert.Error,
 		},
 		{
@@ -216,7 +219,7 @@ func (suite *FolderCacheUnitSuite) TestAddFolder() {
 					parentID:    &testParentID,
 				},
 				nil,
-			),
+				nil),
 			check: assert.NoError,
 		},
 	}
@@ -241,31 +244,21 @@ type mockCachedContainer struct {
 	id           string
 	parentID     string
 	displayName  string
+	l            *path.Builder
 	p            *path.Builder
 	expectedPath string
 }
 
 //nolint:revive
-func (m mockCachedContainer) GetId() *string {
-	return &m.id
-}
+func (m mockCachedContainer) GetId() *string { return &m.id }
 
 //nolint:revive
-func (m mockCachedContainer) GetParentFolderId() *string {
-	return &m.parentID
-}
-
-func (m mockCachedContainer) GetDisplayName() *string {
-	return &m.displayName
-}
-
-func (m mockCachedContainer) Path() *path.Builder {
-	return m.p
-}
-
-func (m *mockCachedContainer) SetPath(newPath *path.Builder) {
-	m.p = newPath
-}
+func (m mockCachedContainer) GetParentFolderId() *string        { return &m.parentID }
+func (m mockCachedContainer) GetDisplayName() *string           { return &m.displayName }
+func (m mockCachedContainer) Location() *path.Builder           { return m.l }
+func (m *mockCachedContainer) SetLocation(newLoc *path.Builder) { m.l = newLoc }
+func (m mockCachedContainer) Path() *path.Builder               { return m.p }
+func (m *mockCachedContainer) SetPath(newPath *path.Builder)    { m.p = newPath }
 
 func resolverWithContainers(numContainers int) (*containerResolver, []*mockCachedContainer) {
 	containers := make([]*mockCachedContainer, 0, numContainers)

--- a/src/internal/connector/exchange/container_resolver_test.go
+++ b/src/internal/connector/exchange/container_resolver_test.go
@@ -560,27 +560,29 @@ func (suite *FolderCacheIntegrationSuite) TestCreateContainerDestination() {
 				name:     "Mail Cache Test",
 				category: path.EmailCategory,
 				pathFunc1: func(t *testing.T) path.Path {
-					pth, err := path.Builder{}.Append("Griffindor").
-						Append("Croix").ToDataLayerExchangePathForCategory(
-						suite.credentials.AzureTenantID,
-						user,
-						path.EmailCategory,
-						false,
-					)
-
+					pth, err := path.Builder{}.
+						Append("Griffindor").
+						Append("Croix").
+						ToDataLayerExchangePathForCategory(
+							suite.credentials.AzureTenantID,
+							user,
+							path.EmailCategory,
+							false)
 					require.NoError(t, err)
+
 					return pth
 				},
 				pathFunc2: func(t *testing.T) path.Path {
-					pth, err := path.Builder{}.Append("Griffindor").
-						Append("Felicius").ToDataLayerExchangePathForCategory(
-						suite.credentials.AzureTenantID,
-						user,
-						path.EmailCategory,
-						false,
-					)
-
+					pth, err := path.Builder{}.
+						Append("Griffindor").
+						Append("Felicius").
+						ToDataLayerExchangePathForCategory(
+							suite.credentials.AzureTenantID,
+							user,
+							path.EmailCategory,
+							false)
 					require.NoError(t, err)
+
 					return pth
 				},
 			},
@@ -588,27 +590,27 @@ func (suite *FolderCacheIntegrationSuite) TestCreateContainerDestination() {
 				name:     "Contact Cache Test",
 				category: path.ContactsCategory,
 				pathFunc1: func(t *testing.T) path.Path {
-					aPath, err := path.Builder{}.Append("HufflePuff").
+					aPath, err := path.Builder{}.
+						Append("HufflePuff").
 						ToDataLayerExchangePathForCategory(
 							suite.credentials.AzureTenantID,
 							user,
 							path.ContactsCategory,
-							false,
-						)
-
+							false)
 					require.NoError(t, err)
+
 					return aPath
 				},
 				pathFunc2: func(t *testing.T) path.Path {
-					aPath, err := path.Builder{}.Append("Ravenclaw").
+					aPath, err := path.Builder{}.
+						Append("Ravenclaw").
 						ToDataLayerExchangePathForCategory(
 							suite.credentials.AzureTenantID,
 							user,
 							path.ContactsCategory,
-							false,
-						)
-
+							false)
 					require.NoError(t, err)
+
 					return aPath
 				},
 			},
@@ -617,25 +619,27 @@ func (suite *FolderCacheIntegrationSuite) TestCreateContainerDestination() {
 				category:     path.EventsCategory,
 				useIDForPath: true,
 				pathFunc1: func(t *testing.T) path.Path {
-					aPath, err := path.Builder{}.Append("Durmstrang").
+					aPath, err := path.Builder{}.
+						Append("Durmstrang").
 						ToDataLayerExchangePathForCategory(
 							suite.credentials.AzureTenantID,
 							user,
 							path.EventsCategory,
-							false,
-						)
+							false)
 					require.NoError(t, err)
+
 					return aPath
 				},
 				pathFunc2: func(t *testing.T) path.Path {
-					aPath, err := path.Builder{}.Append("Beauxbatons").
+					aPath, err := path.Builder{}.
+						Append("Beauxbatons").
 						ToDataLayerExchangePathForCategory(
 							suite.credentials.AzureTenantID,
 							user,
 							path.EventsCategory,
-							false,
-						)
+							false)
 					require.NoError(t, err)
+
 					return aPath
 				},
 				folderPrefix: calendarOthersFolder,
@@ -658,18 +662,23 @@ func (suite *FolderCacheIntegrationSuite) TestCreateContainerDestination() {
 			_, _, err = resolver.IDToPath(ctx, folderID, test.useIDForPath)
 			assert.NoError(t, err)
 
+			parentContainer := folderName
+			if test.useIDForPath {
+				parentContainer = folderID
+			}
+
 			secondID, err := CreateContainerDestination(
 				ctx,
 				m365,
 				test.pathFunc2(t),
-				folderName,
+				parentContainer,
 				directoryCaches)
 			require.NoError(t, err)
 
 			_, _, err = resolver.IDToPath(ctx, secondID, test.useIDForPath)
 			require.NoError(t, err)
 
-			p := stdpath.Join(test.folderPrefix, folderName)
+			p := stdpath.Join(test.folderPrefix, parentContainer)
 			_, ok := resolver.PathInCache(p)
 			require.True(t, ok, "looking for path in cache: %s", p)
 		})

--- a/src/internal/connector/exchange/container_resolver_test.go
+++ b/src/internal/connector/exchange/container_resolver_test.go
@@ -642,7 +642,6 @@ func (suite *FolderCacheIntegrationSuite) TestCreateContainerDestination() {
 
 					return aPath
 				},
-				folderPrefix: calendarOthersFolder,
 			},
 		}
 	)

--- a/src/internal/connector/exchange/container_resolver_test.go
+++ b/src/internal/connector/exchange/container_resolver_test.go
@@ -478,16 +478,20 @@ func (suite *ConfiguredFolderCacheUnitSuite) TestAddToCache() {
 	defer flush()
 
 	var (
+		dest = "testAddFolder"
 		t    = suite.T()
 		last = suite.allContainers[len(suite.allContainers)-1]
-		m    = newMockCachedContainer("testAddFolder")
+		m    = newMockCachedContainer(dest)
 	)
 
 	m.parentID = last.id
 	m.expectedPath = stdpath.Join(last.expectedPath, m.displayName)
 	m.expectedLocation = stdpath.Join(last.expectedPath, m.displayName)
 
+	require.Empty(t, suite.fc.DestinationNameToID(dest), "destination not yet added to cache")
 	require.NoError(t, suite.fc.AddToCache(ctx, m, false))
+	require.Empty(t, suite.fc.DestinationNameToID(dest),
+		"destination id from cache, still empty, because this is not a calendar")
 
 	p, l, err := suite.fc.IDToPath(ctx, m.id, false)
 	require.NoError(t, err)

--- a/src/internal/connector/exchange/data_collections_test.go
+++ b/src/internal/connector/exchange/data_collections_test.go
@@ -274,8 +274,8 @@ func (suite *DataCollectionsIntegrationSuite) TestMailFetch() {
 					continue
 				}
 
-				require.NotEmpty(t, c.FullPath().Folder())
-				folder := c.FullPath().Folder()
+				require.NotEmpty(t, c.FullPath().Folder(false))
+				folder := c.FullPath().Folder(false)
 
 				delete(test.folderNames, folder)
 			}
@@ -507,7 +507,7 @@ func (suite *DataCollectionsIntegrationSuite) TestContactSerializationRegression
 					continue
 				}
 
-				assert.Equal(t, edc.FullPath().Folder(), DefaultContactFolder)
+				assert.Equal(t, edc.FullPath().Folder(false), DefaultContactFolder)
 				assert.NotZero(t, count)
 			}
 
@@ -571,9 +571,9 @@ func (suite *DataCollectionsIntegrationSuite) TestEventsSerializationRegression(
 
 				if edc.FullPath().Service() != path.ExchangeMetadataService {
 					isMetadata = true
-					assert.Equal(t, test.expected, edc.FullPath().Folder())
+					assert.Equal(t, test.expected, edc.FullPath().Folder(false))
 				} else {
-					assert.Equal(t, "", edc.FullPath().Folder())
+					assert.Equal(t, "", edc.FullPath().Folder(false))
 				}
 
 				for item := range edc.Items() {

--- a/src/internal/connector/exchange/data_collections_test.go
+++ b/src/internal/connector/exchange/data_collections_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/connector/exchange/api"
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/data"
@@ -527,13 +528,19 @@ func (suite *DataCollectionsIntegrationSuite) TestEventsSerializationRegression(
 
 	users := []string{suite.user}
 
+	ac, err := api.NewClient(acct)
+	require.NoError(suite.T(), err, "creating client")
+
+	cal, err := ac.Events().GetContainerByID(ctx, suite.user, DefaultCalendar)
+	require.NoError(suite.T(), err)
+
 	tests := []struct {
 		name, expected string
 		scope          selectors.ExchangeScope
 	}{
 		{
 			name:     "Default Event Calendar",
-			expected: DefaultCalendar,
+			expected: *cal.GetId(),
 			scope: selectors.NewExchangeBackup(users).EventCalendars(
 				[]string{DefaultCalendar},
 				selectors.PrefixMatch(),

--- a/src/internal/connector/exchange/event_calendar_cache.go
+++ b/src/internal/connector/exchange/event_calendar_cache.go
@@ -90,8 +90,9 @@ func (ecc *eventCalendarCache) AddToCache(ctx context.Context, f graph.Container
 		return errors.Wrap(err, "validating container")
 	}
 
-	temp := graph.NewCacheFolder(f,
-		path.Builder{}.Append(*f.GetId()),          // storage path
+	temp := graph.NewCacheFolder(
+		f,
+		path.Builder{}.Append(*f.GetId()), // storage path
 		path.Builder{}.Append(*f.GetDisplayName())) // display location
 
 	if err := ecc.addFolder(temp); err != nil {

--- a/src/internal/connector/exchange/event_calendar_cache.go
+++ b/src/internal/connector/exchange/event_calendar_cache.go
@@ -44,7 +44,10 @@ func (ecc *eventCalendarCache) populateEventRoot(ctx context.Context) error {
 		return errors.Wrap(err, "fetching calendar "+support.ConnectorStackErrorTrace(err))
 	}
 
-	temp := graph.NewCacheFolder(f, path.Builder{}.Append(container))
+	temp := graph.NewCacheFolder(
+		f,
+		path.Builder{}.Append(container), // storage path
+		path.Builder{}.Append(container)) // display location
 	if err := ecc.addFolder(temp); err != nil {
 		return errors.Wrap(err, "initializing calendar resolver")
 	}
@@ -91,7 +94,10 @@ func (ecc *eventCalendarCache) AddToCache(ctx context.Context, f graph.Container
 		return errors.Wrap(err, "validating container")
 	}
 
-	temp := graph.NewCacheFolder(f, path.Builder{}.Append(calendarOthersFolder, *f.GetDisplayName()))
+	temp := graph.NewCacheFolder(
+		f,
+		path.Builder{}.Append(calendarOthersFolder, *f.GetDisplayName()), // storage path
+		path.Builder{}.Append(calendarOthersFolder, *f.GetDisplayName())) // display location
 
 	if err := ecc.addFolder(temp); err != nil {
 		return errors.Wrap(err, "adding container")

--- a/src/internal/connector/exchange/event_calendar_cache.go
+++ b/src/internal/connector/exchange/event_calendar_cache.go
@@ -117,3 +117,9 @@ func (ecc *eventCalendarCache) AddToCache(ctx context.Context, f graph.Container
 
 	return nil
 }
+
+// DestinationNameToID returns an empty string.  This is only supported by exchange
+// calendars at this time.
+func (ecc *eventCalendarCache) DestinationNameToID(dest string) string {
+	return ecc.newAdditions[dest]
+}

--- a/src/internal/connector/exchange/event_calendar_cache.go
+++ b/src/internal/connector/exchange/event_calendar_cache.go
@@ -73,6 +73,7 @@ func (ecc *eventCalendarCache) Populate(
 		"",
 		func(cf graph.CacheFolder) error {
 			cf.SetPath(path.Builder{}.Append(calendarOthersFolder, *cf.GetDisplayName()))
+			cf.SetLocation(path.Builder{}.Append(calendarOthersFolder, *cf.GetDisplayName()))
 			return ecc.addFolder(cf)
 		},
 	)
@@ -80,7 +81,7 @@ func (ecc *eventCalendarCache) Populate(
 		return errors.Wrap(err, "enumerating containers")
 	}
 
-	if err := ecc.populatePaths(ctx); err != nil {
+	if err := ecc.populatePaths(ctx, true); err != nil {
 		return errors.Wrap(err, "establishing calendar paths")
 	}
 
@@ -89,7 +90,7 @@ func (ecc *eventCalendarCache) Populate(
 
 // AddToCache adds container to map in field 'cache'
 // @returns error iff the required values are not accessible.
-func (ecc *eventCalendarCache) AddToCache(ctx context.Context, f graph.Container) error {
+func (ecc *eventCalendarCache) AddToCache(ctx context.Context, f graph.Container, useIDInPath bool) error {
 	if err := checkIDAndName(f); err != nil {
 		return errors.Wrap(err, "validating container")
 	}
@@ -105,7 +106,7 @@ func (ecc *eventCalendarCache) AddToCache(ctx context.Context, f graph.Container
 
 	// Populate the path for this entry so calls to PathInCache succeed no matter
 	// when they're made.
-	_, err := ecc.IDToPath(ctx, *f.GetId())
+	_, _, err := ecc.IDToPath(ctx, *f.GetId(), true)
 	if err != nil {
 		return errors.Wrap(err, "setting path to container id")
 	}

--- a/src/internal/connector/exchange/event_calendar_cache.go
+++ b/src/internal/connector/exchange/event_calendar_cache.go
@@ -46,8 +46,8 @@ func (ecc *eventCalendarCache) populateEventRoot(ctx context.Context) error {
 
 	temp := graph.NewCacheFolder(
 		f,
-		path.Builder{}.Append(container), // storage path
-		path.Builder{}.Append(container)) // display location
+		path.Builder{}.Append(*f.GetId()), // storage path
+		path.Builder{}.Append(*f.GetDisplayName())) // display location
 	if err := ecc.addFolder(temp); err != nil {
 		return errors.Wrap(err, "initializing calendar resolver")
 	}
@@ -97,7 +97,7 @@ func (ecc *eventCalendarCache) AddToCache(ctx context.Context, f graph.Container
 
 	temp := graph.NewCacheFolder(
 		f,
-		path.Builder{}.Append(calendarOthersFolder, *f.GetDisplayName()), // storage path
+		path.Builder{}.Append(calendarOthersFolder, *f.GetId()),          // storage path
 		path.Builder{}.Append(calendarOthersFolder, *f.GetDisplayName())) // display location
 
 	if err := ecc.addFolder(temp); err != nil {

--- a/src/internal/connector/exchange/event_calendar_cache.go
+++ b/src/internal/connector/exchange/event_calendar_cache.go
@@ -71,12 +71,7 @@ func (ecc *eventCalendarCache) Populate(
 		ctx,
 		ecc.userID,
 		"",
-		func(cf graph.CacheFolder) error {
-			cf.SetPath(path.Builder{}.Append(calendarOthersFolder, *cf.GetDisplayName()))
-			cf.SetLocation(path.Builder{}.Append(calendarOthersFolder, *cf.GetDisplayName()))
-			return ecc.addFolder(cf)
-		},
-	)
+		ecc.addFolder)
 	if err != nil {
 		return errors.Wrap(err, "enumerating containers")
 	}
@@ -95,10 +90,9 @@ func (ecc *eventCalendarCache) AddToCache(ctx context.Context, f graph.Container
 		return errors.Wrap(err, "validating container")
 	}
 
-	temp := graph.NewCacheFolder(
-		f,
-		path.Builder{}.Append(calendarOthersFolder, *f.GetId()),          // storage path
-		path.Builder{}.Append(calendarOthersFolder, *f.GetDisplayName())) // display location
+	temp := graph.NewCacheFolder(f,
+		path.Builder{}.Append(*f.GetId()),          // storage path
+		path.Builder{}.Append(*f.GetDisplayName())) // display location
 
 	if err := ecc.addFolder(temp); err != nil {
 		return errors.Wrap(err, "adding container")

--- a/src/internal/connector/exchange/event_calendar_cache.go
+++ b/src/internal/connector/exchange/event_calendar_cache.go
@@ -14,9 +14,10 @@ var _ graph.ContainerResolver = &eventCalendarCache{}
 
 type eventCalendarCache struct {
 	*containerResolver
-	enumer containersEnumerator
-	getter containerGetter
-	userID string
+	enumer       containersEnumerator
+	getter       containerGetter
+	userID       string
+	newAdditions map[string]string
 }
 
 // init ensures that the structure's fields are initialized.
@@ -95,7 +96,14 @@ func (ecc *eventCalendarCache) AddToCache(ctx context.Context, f graph.Container
 		path.Builder{}.Append(*f.GetId()), // storage path
 		path.Builder{}.Append(*f.GetDisplayName())) // display location
 
+	if len(ecc.newAdditions) == 0 {
+		ecc.newAdditions = map[string]string{}
+	}
+
+	ecc.newAdditions[*f.GetDisplayName()] = *f.GetId()
+
 	if err := ecc.addFolder(temp); err != nil {
+		delete(ecc.newAdditions, *f.GetDisplayName())
 		return errors.Wrap(err, "adding container")
 	}
 
@@ -103,6 +111,7 @@ func (ecc *eventCalendarCache) AddToCache(ctx context.Context, f graph.Container
 	// when they're made.
 	_, _, err := ecc.IDToPath(ctx, *f.GetId(), true)
 	if err != nil {
+		delete(ecc.newAdditions, *f.GetDisplayName())
 		return errors.Wrap(err, "setting path to container id")
 	}
 

--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -77,6 +77,11 @@ type Collection struct {
 	// moved.  It will be empty on its first retrieval.
 	prevPath path.Path
 
+	// LocationPath contains the path with human-readable display names.
+	// IE: "/Inbox/Important" instead of "/abcdxyz123/algha=lgkhal=t"
+	// Currently only implemented for Exchange Calendars.
+	locationPath path.Path
+
 	state data.CollectionState
 
 	// doNotMergeItems should only be true if the old delta token expired.
@@ -91,7 +96,7 @@ type Collection struct {
 // or notMoved (if they match).
 func NewCollection(
 	user string,
-	curr, prev path.Path,
+	curr, prev, location path.Path,
 	category path.CategoryType,
 	items itemer,
 	statusUpdater support.StatusUpdater,
@@ -99,18 +104,19 @@ func NewCollection(
 	doNotMergeItems bool,
 ) Collection {
 	collection := Collection{
+		added:           make(map[string]struct{}, 0),
 		category:        category,
 		ctrl:            ctrlOpts,
 		data:            make(chan data.Stream, collectionChannelBufferSize),
 		doNotMergeItems: doNotMergeItems,
 		fullPath:        curr,
-		added:           make(map[string]struct{}, 0),
-		removed:         make(map[string]struct{}, 0),
+		items:           items,
+		locationPath:    location,
 		prevPath:        prev,
+		removed:         make(map[string]struct{}, 0),
 		state:           data.StateOf(prev, curr),
 		statusUpdater:   statusUpdater,
 		user:            user,
-		items:           items,
 	}
 
 	return collection
@@ -126,6 +132,12 @@ func (col *Collection) Items() <-chan data.Stream {
 // FullPath returns the Collection's fullPath []string
 func (col *Collection) FullPath() path.Path {
 	return col.fullPath
+}
+
+// LocationPath produces the Collection's full path, but with display names
+// instead of IDs in the folders.  Only populated for Calendars.
+func (col *Collection) LocationPath() path.Path {
+	return col.locationPath
 }
 
 // TODO(ashmrtn): Fill in with previous path once GraphConnector compares old

--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -184,7 +184,7 @@ func (col *Collection) streamItems(ctx context.Context) {
 			ctx,
 			col.fullPath.Category().String(),
 			observe.PII(user),
-			observe.PII(col.fullPath.Folder()))
+			observe.PII(col.fullPath.Folder(false)))
 
 		go closer()
 
@@ -343,7 +343,7 @@ func (col *Collection) finishPopulation(ctx context.Context, success int, totalB
 			TotalBytes: totalBytes,
 		},
 		errs,
-		col.fullPath.Folder())
+		col.fullPath.Folder(false))
 	logger.Ctx(ctx).Debugw("done streaming items", "status", status.String())
 	col.statusUpdater(status)
 }

--- a/src/internal/connector/exchange/exchange_data_collection_test.go
+++ b/src/internal/connector/exchange/exchange_data_collection_test.go
@@ -12,8 +12,10 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common"
 	"github.com/alcionai/corso/src/internal/connector/graph"
+	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
@@ -114,6 +116,70 @@ func (suite *ExchangeDataCollectionSuite) TestExchangeDataCollection_NewExchange
 	}
 	suite.Equal(name, edc.user)
 	suite.Equal(fullPath, edc.FullPath())
+}
+
+func (suite *ExchangeDataCollectionSuite) TestNewCollection_state() {
+	fooP, err := path.Builder{}.
+		Append("foo").
+		ToDataLayerExchangePathForCategory("t", "u", path.EmailCategory, false)
+	require.NoError(suite.T(), err)
+	barP, err := path.Builder{}.
+		Append("bar").
+		ToDataLayerExchangePathForCategory("t", "u", path.EmailCategory, false)
+	require.NoError(suite.T(), err)
+	locP, err := path.Builder{}.
+		Append("human-readable").
+		ToDataLayerExchangePathForCategory("t", "u", path.EmailCategory, false)
+	require.NoError(suite.T(), err)
+
+	table := []struct {
+		name   string
+		prev   path.Path
+		curr   path.Path
+		loc    path.Path
+		expect data.CollectionState
+	}{
+		{
+			name:   "new",
+			curr:   fooP,
+			loc:    locP,
+			expect: data.NewState,
+		},
+		{
+			name:   "not moved",
+			prev:   fooP,
+			curr:   fooP,
+			loc:    locP,
+			expect: data.NotMovedState,
+		},
+		{
+			name:   "moved",
+			prev:   fooP,
+			curr:   barP,
+			loc:    locP,
+			expect: data.MovedState,
+		},
+		{
+			name:   "deleted",
+			prev:   fooP,
+			expect: data.DeletedState,
+		},
+	}
+	for _, test := range table {
+		suite.T().Run(test.name, func(t *testing.T) {
+			c := NewCollection(
+				"u",
+				test.curr, test.prev, test.loc,
+				0,
+				&mockItemer{}, nil,
+				control.Options{},
+				false)
+			assert.Equal(t, test.expect, c.State(), "collection state")
+			assert.Equal(t, test.curr, c.fullPath, "full path")
+			assert.Equal(t, test.prev, c.prevPath, "prev path")
+			assert.Equal(t, test.loc, c.locationPath, "location path")
+		})
+	}
 }
 
 func (suite *ExchangeDataCollectionSuite) TestGetItemWithRetries() {

--- a/src/internal/connector/exchange/exchange_vars.go
+++ b/src/internal/connector/exchange/exchange_vars.go
@@ -38,5 +38,4 @@ const (
 	rootFolderAlias      = "msgfolderroot"
 	DefaultContactFolder = "Contacts"
 	DefaultCalendar      = "Calendar"
-	calendarOthersFolder = "Other Calendars"
 )

--- a/src/internal/connector/exchange/folder_resolver_test.go
+++ b/src/internal/connector/exchange/folder_resolver_test.go
@@ -47,6 +47,9 @@ func (suite *CacheResolverSuite) TestPopulate() {
 	ac, err := api.NewClient(suite.credentials)
 	require.NoError(suite.T(), err)
 
+	cal, err := ac.Events().GetContainerByID(ctx, tester.M365UserID(suite.T()), DefaultCalendar)
+	require.NoError(suite.T(), err)
+
 	eventFunc := func(t *testing.T) graph.ContainerResolver {
 		return &eventCalendarCache{
 			userID: tester.M365UserID(t),
@@ -64,61 +67,61 @@ func (suite *CacheResolverSuite) TestPopulate() {
 	}
 
 	tests := []struct {
-		name, folderName, root, basePath string
-		resolverFunc                     func(t *testing.T) graph.ContainerResolver
-		canFind                          assert.BoolAssertionFunc
+		name, folderInCache, root, basePath string
+		resolverFunc                        func(t *testing.T) graph.ContainerResolver
+		canFind                             assert.BoolAssertionFunc
 	}{
 		{
-			name:         "Default Event Cache",
-			folderName:   DefaultCalendar,
-			root:         DefaultCalendar,
-			basePath:     DefaultCalendar,
-			resolverFunc: eventFunc,
-			canFind:      assert.True,
+			name:          "Default Event Cache",
+			folderInCache: *cal.GetId(),
+			root:          DefaultCalendar,
+			basePath:      DefaultCalendar,
+			resolverFunc:  eventFunc,
+			canFind:       assert.True,
 		},
 		{
-			name:         "Default Event Folder Hidden",
-			root:         DefaultCalendar,
-			folderName:   DefaultContactFolder,
-			canFind:      assert.False,
-			resolverFunc: eventFunc,
+			name:          "Default Event Folder Hidden",
+			folderInCache: DefaultContactFolder,
+			root:          DefaultCalendar,
+			canFind:       assert.False,
+			resolverFunc:  eventFunc,
 		},
 		{
-			name:         "Name Not in Cache",
-			folderName:   "testFooBarWhoBar",
-			root:         DefaultCalendar,
-			canFind:      assert.False,
-			resolverFunc: eventFunc,
+			name:          "Name Not in Cache",
+			folderInCache: "testFooBarWhoBar",
+			root:          DefaultCalendar,
+			canFind:       assert.False,
+			resolverFunc:  eventFunc,
 		},
 		{
-			name:         "Default Contact Cache",
-			folderName:   DefaultContactFolder,
-			root:         DefaultContactFolder,
-			basePath:     DefaultContactFolder,
-			canFind:      assert.True,
-			resolverFunc: contactFunc,
+			name:          "Default Contact Cache",
+			folderInCache: DefaultContactFolder,
+			root:          DefaultContactFolder,
+			basePath:      DefaultContactFolder,
+			canFind:       assert.True,
+			resolverFunc:  contactFunc,
 		},
 		{
-			name:         "Default Contact Hidden",
-			folderName:   DefaultContactFolder,
-			root:         DefaultContactFolder,
-			canFind:      assert.False,
-			resolverFunc: contactFunc,
+			name:          "Default Contact Hidden",
+			folderInCache: DefaultContactFolder,
+			root:          DefaultContactFolder,
+			canFind:       assert.False,
+			resolverFunc:  contactFunc,
 		},
 		{
-			name:         "Name Not in Cache",
-			folderName:   "testFooBarWhoBar",
-			root:         DefaultContactFolder,
-			canFind:      assert.False,
-			resolverFunc: contactFunc,
+			name:          "Name Not in Cache",
+			folderInCache: "testFooBarWhoBar",
+			root:          DefaultContactFolder,
+			canFind:       assert.False,
+			resolverFunc:  contactFunc,
 		},
 	}
 	for _, test := range tests {
 		suite.T().Run(test.name, func(t *testing.T) {
 			resolver := test.resolverFunc(t)
-
 			require.NoError(t, resolver.Populate(ctx, test.root, test.basePath))
-			_, isFound := resolver.PathInCache(test.folderName)
+
+			_, isFound := resolver.PathInCache(test.folderInCache)
 			test.canFind(t, isFound)
 		})
 	}

--- a/src/internal/connector/exchange/mail_folder_cache.go
+++ b/src/internal/connector/exchange/mail_folder_cache.go
@@ -83,7 +83,7 @@ func (mc *mailFolderCache) Populate(
 		return errors.Wrap(err, "enumerating containers")
 	}
 
-	if err := mc.populatePaths(ctx); err != nil {
+	if err := mc.populatePaths(ctx, false); err != nil {
 		return errors.Wrap(err, "populating paths")
 	}
 

--- a/src/internal/connector/exchange/mail_folder_cache.go
+++ b/src/internal/connector/exchange/mail_folder_cache.go
@@ -53,7 +53,9 @@ func (mc *mailFolderCache) populateMailRoot(ctx context.Context) error {
 			directory = DefaultMailFolder
 		}
 
-		temp := graph.NewCacheFolder(f, path.Builder{}.Append(directory))
+		temp := graph.NewCacheFolder(f,
+			path.Builder{}.Append(directory), // storage path
+			path.Builder{}.Append(directory)) // display location
 		if err := mc.addFolder(temp); err != nil {
 			return errors.Wrap(err, "adding resolver dir")
 		}

--- a/src/internal/connector/exchange/mail_folder_cache_test.go
+++ b/src/internal/connector/exchange/mail_folder_cache_test.go
@@ -18,9 +18,9 @@ const (
 	// top-level folders right now.
 	//nolint:lll
 	testFolderID = "AAMkAGZmNjNlYjI3LWJlZWYtNGI4Mi04YjMyLTIxYThkNGQ4NmY1MwAuAAAAAADCNgjhM9QmQYWNcI7hCpPrAQDSEBNbUIB9RL6ePDeF3FIYAABl7AqpAAA="
-
 	//nolint:lll
 	topFolderID = "AAMkAGZmNjNlYjI3LWJlZWYtNGI4Mi04YjMyLTIxYThkNGQ4NmY1MwAuAAAAAADCNgjhM9QmQYWNcI7hCpPrAQDSEBNbUIB9RL6ePDeF3FIYAAAAAAEIAAA="
+	//nolint:lll
 	// Full folder path for the folder above.
 	expectedFolderPath = "toplevel/subFolder/subsubfolder"
 )
@@ -94,9 +94,10 @@ func (suite *MailFolderCacheIntegrationSuite) TestDeltaFetch() {
 
 			require.NoError(t, mfc.Populate(ctx, test.root, test.path...))
 
-			p, err := mfc.IDToPath(ctx, testFolderID)
+			p, l, err := mfc.IDToPath(ctx, testFolderID, true)
 			require.NoError(t, err)
 			t.Logf("Path: %s\n", p.String())
+			t.Logf("Location: %s\n", l.String())
 
 			expectedPath := stdpath.Join(append(test.path, expectedFolderPath)...)
 			assert.Equal(t, expectedPath, p.String())

--- a/src/internal/connector/exchange/service_functions.go
+++ b/src/internal/connector/exchange/service_functions.go
@@ -86,44 +86,70 @@ func PopulateExchangeContainerResolver(
 }
 
 // Returns true if the container passes the scope comparison and should be included.
-// Also returns the path representing the directory.
+// Returns:
+// - the path representing the directory as it should be stored in the repository.
+// - the human-readable path using display names.
+// - true if the path passes the scope comparison.
 func includeContainer(
 	qp graph.QueryParams,
 	c graph.CachedContainer,
 	scope selectors.ExchangeScope,
-) (path.Path, bool) {
+) (path.Path, path.Path, bool) {
 	var (
-		category  = scope.Category().PathType()
 		directory string
+		locPath   path.Path
+		category  = scope.Category().PathType()
 		pb        = c.Path()
+		loc       = c.Location()
 	)
 
 	// Clause ensures that DefaultContactFolder is inspected properly
 	if category == path.ContactsCategory && *c.GetDisplayName() == DefaultContactFolder {
-		pb = c.Path().Append(DefaultContactFolder)
+		pb = pb.Append(DefaultContactFolder)
+
+		if loc != nil {
+			loc = loc.Append(DefaultContactFolder)
+		}
 	}
 
 	dirPath, err := pb.ToDataLayerExchangePathForCategory(
 		qp.Credentials.AzureTenantID,
 		qp.ResourceOwner,
 		category,
-		false,
-	)
+		false)
 	// Containers without a path (e.g. Root mail folder) always err here.
 	if err != nil {
-		return nil, false
+		return nil, nil, false
 	}
 
-	directory = pb.String()
+	directory = dirPath.Folder()
+
+	if loc != nil {
+		locPath, err = loc.ToDataLayerExchangePathForCategory(
+			qp.Credentials.AzureTenantID,
+			qp.ResourceOwner,
+			category,
+			false)
+		// Containers without a path (e.g. Root mail folder) always err here.
+		if err != nil {
+			return nil, nil, false
+		}
+
+		directory = locPath.Folder()
+	}
+
+	var ok bool
 
 	switch category {
 	case path.EmailCategory:
-		return dirPath, scope.Matches(selectors.ExchangeMailFolder, directory)
+		ok = scope.Matches(selectors.ExchangeMailFolder, directory)
 	case path.ContactsCategory:
-		return dirPath, scope.Matches(selectors.ExchangeContactFolder, directory)
+		ok = scope.Matches(selectors.ExchangeContactFolder, directory)
 	case path.EventsCategory:
-		return dirPath, scope.Matches(selectors.ExchangeEventCalendar, directory)
+		ok = scope.Matches(selectors.ExchangeEventCalendar, directory)
 	default:
-		return dirPath, false
+		return nil, nil, false
 	}
+
+	return dirPath, locPath, ok
 }

--- a/src/internal/connector/exchange/service_functions.go
+++ b/src/internal/connector/exchange/service_functions.go
@@ -122,7 +122,7 @@ func includeContainer(
 		return nil, nil, false
 	}
 
-	directory = dirPath.Folder()
+	directory = dirPath.Folder(false)
 
 	if loc != nil {
 		locPath, err = loc.ToDataLayerExchangePathForCategory(
@@ -135,7 +135,7 @@ func includeContainer(
 			return nil, nil, false
 		}
 
-		directory = locPath.Folder()
+		directory = locPath.Folder(false)
 	}
 
 	var ok bool

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -70,7 +70,7 @@ func filterContainersAndFillCollections(
 		cID := *c.GetId()
 		delete(tombstones, cID)
 
-		currPath, ok := includeContainer(qp, c, scope)
+		currPath, locPath, ok := includeContainer(qp, c, scope)
 		// Only create a collection if the path matches the scope.
 		if !ok {
 			continue
@@ -110,10 +110,15 @@ func filterContainersAndFillCollections(
 			deltaURLs[cID] = newDelta.URL
 		}
 
+		if qp.Category != path.EventsCategory {
+			locPath = nil
+		}
+
 		edc := NewCollection(
 			qp.ResourceOwner,
 			currPath,
 			prevPath,
+			locPath,
 			scope.Category().PathType(),
 			ibt,
 			statusUpdater,
@@ -167,6 +172,7 @@ func filterContainersAndFillCollections(
 			qp.ResourceOwner,
 			nil, // marks the collection as deleted
 			prevPath,
+			nil, // tombstones don't need a location
 			scope.Category().PathType(),
 			ibt,
 			statusUpdater,

--- a/src/internal/connector/exchange/service_iterators_test.go
+++ b/src/internal/connector/exchange/service_iterators_test.go
@@ -59,6 +59,7 @@ var _ graph.ContainerResolver = &mockResolver{}
 type (
 	mockResolver struct {
 		items []graph.CachedContainer
+		added map[string]string
 	}
 )
 
@@ -76,7 +77,16 @@ func (m mockResolver) Items() []graph.CachedContainer {
 	return m.items
 }
 
-func (m mockResolver) AddToCache(context.Context, graph.Container, bool) error { return nil }
+func (m mockResolver) AddToCache(ctx context.Context, gc graph.Container, b bool) error {
+	if len(m.added) == 0 {
+		m.added = map[string]string{}
+	}
+
+	m.added[*gc.GetDisplayName()] = *gc.GetId()
+
+	return nil
+}
+func (m mockResolver) DestinationNameToID(dest string) string { return m.added[dest] }
 func (m mockResolver) IDToPath(context.Context, string, bool) (*path.Builder, *path.Builder, error) {
 	return nil, nil, nil
 }

--- a/src/internal/connector/exchange/service_iterators_test.go
+++ b/src/internal/connector/exchange/service_iterators_test.go
@@ -76,10 +76,12 @@ func (m mockResolver) Items() []graph.CachedContainer {
 	return m.items
 }
 
-func (m mockResolver) AddToCache(context.Context, graph.Container) error       { return nil }
-func (m mockResolver) IDToPath(context.Context, string) (*path.Builder, error) { return nil, nil }
-func (m mockResolver) PathInCache(string) (string, bool)                       { return "", false }
-func (m mockResolver) Populate(context.Context, string, ...string) error       { return nil }
+func (m mockResolver) AddToCache(context.Context, graph.Container, bool) error { return nil }
+func (m mockResolver) IDToPath(context.Context, string, bool) (*path.Builder, *path.Builder, error) {
+	return nil, nil, nil
+}
+func (m mockResolver) PathInCache(string) (string, bool)                 { return "", false }
+func (m mockResolver) Populate(context.Context, string, ...string) error { return nil }
 
 // ---------------------------------------------------------------------------
 // tests

--- a/src/internal/connector/exchange/service_restore.go
+++ b/src/internal/connector/exchange/service_restore.go
@@ -482,7 +482,6 @@ func CreateContainerDestination(
 		user           = directory.ResourceOwner()
 		category       = directory.Category()
 		directoryCache = caches[category]
-		newPathFolders = append([]string{destination}, directory.Folders()...)
 	)
 
 	// TODO(rkeepers): pass the api client into this func, rather than generating one.
@@ -493,6 +492,8 @@ func CreateContainerDestination(
 
 	switch category {
 	case path.EmailCategory:
+		folders := append([]string{destination}, directory.Folders()...)
+
 		if directoryCache == nil {
 			acm := ac.Mail()
 			mfc := &mailFolderCache{
@@ -509,12 +510,14 @@ func CreateContainerDestination(
 		return establishMailRestoreLocation(
 			ctx,
 			ac,
-			newPathFolders,
+			folders,
 			directoryCache,
 			user,
 			newCache)
 
 	case path.ContactsCategory:
+		folders := append([]string{destination}, directory.Folders()...)
+
 		if directoryCache == nil {
 			acc := ac.Contacts()
 			cfc := &contactFolderCache{
@@ -530,12 +533,14 @@ func CreateContainerDestination(
 		return establishContactsRestoreLocation(
 			ctx,
 			ac,
-			newPathFolders,
+			folders,
 			directoryCache,
 			user,
 			newCache)
 
 	case path.EventsCategory:
+		dest := destination
+
 		if directoryCache == nil {
 			ace := ac.Events()
 			ecc := &eventCalendarCache{
@@ -546,16 +551,23 @@ func CreateContainerDestination(
 			caches[category] = ecc
 			newCache = true
 			directoryCache = ecc
+		} else if did := directoryCache.DestinationNameToID(dest); len(did) > 0 {
+			// calendars are cached by ID in the resolver, not name, so once we have
+			// created the destination calendar, we need to look up its id and use
+			// that for resolver lookups instead of the display name.
+			dest = did
 		}
+
+		folders := append([]string{dest}, directory.Folders()...)
 
 		return establishEventsRestoreLocation(
 			ctx,
 			ac,
-			newPathFolders,
+			folders,
 			directoryCache,
 			user,
-			newCache,
-		)
+			newCache)
+
 	default:
 		return "", fmt.Errorf("category: %s not support for exchange cache", category)
 	}

--- a/src/internal/connector/exchange/service_restore.go
+++ b/src/internal/connector/exchange/service_restore.go
@@ -398,7 +398,7 @@ func restoreCollection(
 		ctx,
 		category.String(),
 		observe.PII(user),
-		observe.PII(directory.Folder()))
+		observe.PII(directory.Folder(false)))
 	defer closer()
 	defer close(colProgress)
 
@@ -447,7 +447,7 @@ func restoreCollection(
 
 			// var locationRef string
 			// if category == path.ContactsCategory {
-			// 	locationRef = itemPath.Folder()
+			// 	locationRef = itemPath.Folder(false)
 			// }
 
 			deets.Add(

--- a/src/internal/connector/exchange/service_restore.go
+++ b/src/internal/connector/exchange/service_restore.go
@@ -664,10 +664,7 @@ func establishEventsRestoreLocation(
 	isNewCache bool,
 ) (string, error) {
 	// Need to prefix with the "Other Calendars" folder so lookup happens properly.
-	cached, ok := ecc.PathInCache(path.Builder{}.Append(
-		calendarOthersFolder,
-		folders[0],
-	).String())
+	cached, ok := ecc.PathInCache(folders[0])
 	if ok {
 		return cached, nil
 	}

--- a/src/internal/connector/exchange/service_restore.go
+++ b/src/internal/connector/exchange/service_restore.go
@@ -608,7 +608,7 @@ func establishMailRestoreLocation(
 		}
 
 		// NOOP if the folder is already in the cache.
-		if err = mfc.AddToCache(ctx, temp); err != nil {
+		if err = mfc.AddToCache(ctx, temp, false); err != nil {
 			return "", errors.Wrap(err, "adding folder to cache")
 		}
 	}
@@ -647,7 +647,7 @@ func establishContactsRestoreLocation(
 			return "", errors.Wrap(err, "populating contact cache")
 		}
 
-		if err = cfc.AddToCache(ctx, temp); err != nil {
+		if err = cfc.AddToCache(ctx, temp, false); err != nil {
 			return "", errors.Wrap(err, "adding contact folder to cache")
 		}
 	}
@@ -685,7 +685,7 @@ func establishEventsRestoreLocation(
 		}
 
 		displayable := api.CalendarDisplayable{Calendarable: temp}
-		if err = ecc.AddToCache(ctx, displayable); err != nil {
+		if err = ecc.AddToCache(ctx, displayable, true); err != nil {
 			return "", errors.Wrap(err, "adding new calendar to cache")
 		}
 	}

--- a/src/internal/connector/exchange/service_restore.go
+++ b/src/internal/connector/exchange/service_restore.go
@@ -445,16 +445,16 @@ func restoreCollection(
 				continue
 			}
 
-			// var locationRef string
-			// if category == path.ContactsCategory {
-			// 	locationRef = itemPath.Folder(false)
-			// }
+			var locationRef string
+			if category == path.ContactsCategory {
+				locationRef = itemPath.Folder(false)
+			}
 
 			deets.Add(
 				itemPath.String(),
 				itemPath.ShortRef(),
 				"",
-				"", // TODO: locationRef
+				locationRef,
 				true,
 				details.ItemInfo{
 					Exchange: info,

--- a/src/internal/connector/exchange/service_restore.go
+++ b/src/internal/connector/exchange/service_restore.go
@@ -342,7 +342,7 @@ func RestoreExchangeDataCollections(
 			userCaches = directoryCaches[userID]
 		}
 
-		containerID, err := CreateContainerDestinaion(
+		containerID, err := CreateContainerDestination(
 			ctx,
 			creds,
 			dc.FullPath(),
@@ -445,10 +445,16 @@ func restoreCollection(
 				continue
 			}
 
+			// var locationRef string
+			// if category == path.ContactsCategory {
+			// 	locationRef = itemPath.Folder()
+			// }
+
 			deets.Add(
 				itemPath.String(),
 				itemPath.ShortRef(),
 				"",
+				"", // TODO: locationRef
 				true,
 				details.ItemInfo{
 					Exchange: info,
@@ -459,12 +465,12 @@ func restoreCollection(
 	}
 }
 
-// CreateContainerDestinaion builds the destination into the container
+// CreateContainerDestination builds the destination into the container
 // at the provided path.  As a precondition, the destination cannot
 // already exist.  If it does then an error is returned.  The provided
 // containerResolver is updated with the new destination.
 // @ returns the container ID of the new destination container.
-func CreateContainerDestinaion(
+func CreateContainerDestination(
 	ctx context.Context,
 	creds account.M365Config,
 	directory path.Path,

--- a/src/internal/connector/graph/cache_container.go
+++ b/src/internal/connector/graph/cache_container.go
@@ -72,6 +72,11 @@ type ContainerResolver interface {
 
 	AddToCache(ctx context.Context, m365Container Container, useIDInPath bool) error
 
+	// DestinationNameToID returns the ID of the destination container.  Dest is
+	// assumed to be a display name.  The ID is only populated if the destination
+	// was added using `AddToCache()`.  Returns an empty string if not found.
+	DestinationNameToID(dest string) string
+
 	// Items returns the containers in the cache.
 	Items() []CachedContainer
 }

--- a/src/internal/connector/graph/cache_container.go
+++ b/src/internal/connector/graph/cache_container.go
@@ -1,12 +1,38 @@
 package graph
 
 import (
-	"github.com/alcionai/clues"
+	"context"
+
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/pkg/errors"
 
 	"github.com/alcionai/corso/src/pkg/path"
 )
+
+// Idable represents objects that implement msgraph-sdk-go/models.entityable
+// and have the concept of an ID.
+type Idable interface {
+	GetId() *string
+}
+
+// Descendable represents objects that implement msgraph-sdk-go/models.entityable
+// and have the concept of a "parent folder".
+type Descendable interface {
+	Idable
+	GetParentFolderId() *string
+}
+
+// Displayable represents objects that implement msgraph-sdk-go/models.entityable
+// and have the concept of a display name.
+type Displayable interface {
+	Idable
+	GetDisplayName() *string
+}
+
+type Container interface {
+	Descendable
+	Displayable
+}
 
 // CachedContainer is used for local unit tests but also makes it so that this
 // code can be broken into generic- and service-specific chunks later on to
@@ -23,25 +49,31 @@ type CachedContainer interface {
 	SetPath(*path.Builder)
 }
 
-// checkRequiredValues is a helper function to ensure that
-// all the pointers are set prior to being called.
-func CheckRequiredValues(c Container) error {
-	idPtr := c.GetId()
-	if idPtr == nil || len(*idPtr) == 0 {
-		return errors.New("folder without ID")
-	}
+// ContainerResolver houses functions for getting information about containers
+// from remote APIs (i.e. resolve folder paths with Graph API). Resolvers may
+// cache information about containers.
+type ContainerResolver interface {
+	// IDToPath takes an m365 container ID and converts it to a hierarchical path
+	// to that container. The path has a similar format to paths on the local
+	// file system.
+	IDToPath(ctx context.Context, m365ID string, useIDInPath bool) (*path.Builder, *path.Builder, error)
 
-	ptr := c.GetDisplayName()
-	if ptr == nil || len(*ptr) == 0 {
-		return clues.New("folder missing display name").With("container_id", *idPtr)
-	}
+	// Populate performs initialization steps for the resolver
+	// @param ctx is necessary param for Graph API tracing
+	// @param baseFolderID represents the M365ID base that the resolver will
+	// conclude its search. Default input is "".
+	Populate(ctx context.Context, baseFolderID string, baseContainerPather ...string) error
 
-	ptr = c.GetParentFolderId()
-	if ptr == nil || len(*ptr) == 0 {
-		return clues.New("folder missing parent ID").With("container_parent_id", *idPtr)
-	}
+	// PathInCache performs a look up of a path reprensentation
+	// and returns the m365ID of directory iff the pathString
+	// matches the path of a container within the cache.
+	// @returns bool represents if m365ID was found.
+	PathInCache(pathString string) (string, bool)
 
-	return nil
+	AddToCache(ctx context.Context, m365Container Container, useIDInPath bool) error
+
+	// Items returns the containers in the cache.
+	Items() []CachedContainer
 }
 
 // ======================================
@@ -124,4 +156,29 @@ func CreateCalendarDisplayable(entry any, parentID string) *CalendarDisplayable 
 		Calendarable: calendar,
 		parentID:     parentID,
 	}
+}
+
+// =========================================
+// helper funcs
+// =========================================
+
+// checkRequiredValues is a helper function to ensure that
+// all the pointers are set prior to being called.
+func CheckRequiredValues(c Container) error {
+	idPtr := c.GetId()
+	if idPtr == nil || len(*idPtr) == 0 {
+		return errors.New("folder without ID")
+	}
+
+	ptr := c.GetDisplayName()
+	if ptr == nil || len(*ptr) == 0 {
+		return errors.Errorf("folder %s without display name", *idPtr)
+	}
+
+	ptr = c.GetParentFolderId()
+	if ptr == nil || len(*ptr) == 0 {
+		return errors.Errorf("folder %s without parent ID", *idPtr)
+	}
+
+	return nil
 }

--- a/src/internal/connector/graph/cache_container.go
+++ b/src/internal/connector/graph/cache_container.go
@@ -13,6 +13,12 @@ import (
 // reuse logic in IDToPath.
 type CachedContainer interface {
 	Container
+	// Location contains either the display names for the dirs (if this is a calendar)
+	// or nil
+	Location() *path.Builder
+	SetLocation(*path.Builder)
+	// Path contains either the ids for the dirs (if this is a calendar)
+	// or the display names for the dirs
 	Path() *path.Builder
 	SetPath(*path.Builder)
 }
@@ -46,13 +52,15 @@ var _ CachedContainer = &CacheFolder{}
 
 type CacheFolder struct {
 	Container
+	l *path.Builder
 	p *path.Builder
 }
 
 // NewCacheFolder public constructor for struct
-func NewCacheFolder(c Container, pb *path.Builder) CacheFolder {
+func NewCacheFolder(c Container, pb, lpb *path.Builder) CacheFolder {
 	cf := CacheFolder{
 		Container: c,
+		l:         lpb,
 		p:         pb,
 	}
 
@@ -62,6 +70,14 @@ func NewCacheFolder(c Container, pb *path.Builder) CacheFolder {
 // =========================================
 // Required Functions to satisfy interfaces
 // =========================================
+
+func (cf CacheFolder) Location() *path.Builder {
+	return cf.l
+}
+
+func (cf *CacheFolder) SetLocation(newLocation *path.Builder) {
+	cf.l = newLocation
+}
 
 func (cf CacheFolder) Path() *path.Builder {
 	return cf.p

--- a/src/internal/connector/graph/metadata_collection.go
+++ b/src/internal/connector/graph/metadata_collection.go
@@ -151,7 +151,7 @@ func (md MetadataCollection) Items() <-chan data.Stream {
 					TotalBytes: totalBytes,
 				},
 				nil,
-				md.fullPath.Folder(),
+				md.fullPath.Folder(false),
 			)
 
 			md.statusUpdater(status)

--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -205,7 +205,7 @@ type ContainerResolver interface {
 	// IDToPath takes an m365 container ID and converts it to a hierarchical path
 	// to that container. The path has a similar format to paths on the local
 	// file system.
-	IDToPath(ctx context.Context, m365ID string) (*path.Builder, error)
+	IDToPath(ctx context.Context, m365ID string, useIDInPath bool) (*path.Builder, *path.Builder, error)
 	// Populate performs initialization steps for the resolver
 	// @param ctx is necessary param for Graph API tracing
 	// @param baseFolderID represents the M365ID base that the resolver will
@@ -218,7 +218,7 @@ type ContainerResolver interface {
 	// @returns bool represents if m365ID was found.
 	PathInCache(pathString string) (string, bool)
 
-	AddToCache(ctx context.Context, m365Container Container) error
+	AddToCache(ctx context.Context, m365Container Container, useIDInPath bool) error
 
 	// Items returns the containers in the cache.
 	Items() []CachedContainer

--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -1,7 +1,6 @@
 package graph
 
 import (
-	"context"
 	"net/http"
 	"net/http/httputil"
 	"os"
@@ -171,57 +170,6 @@ type Servicer interface {
 	// Adapter() returns GraphRequest adapter used to process large requests, create batches
 	// and page iterators
 	Adapter() *msgraphsdk.GraphRequestAdapter
-}
-
-// Idable represents objects that implement msgraph-sdk-go/models.entityable
-// and have the concept of an ID.
-type Idable interface {
-	GetId() *string
-}
-
-// Descendable represents objects that implement msgraph-sdk-go/models.entityable
-// and have the concept of a "parent folder".
-type Descendable interface {
-	Idable
-	GetParentFolderId() *string
-}
-
-// Displayable represents objects that implement msgraph-sdk-go/models.entityable
-// and have the concept of a display name.
-type Displayable interface {
-	Idable
-	GetDisplayName() *string
-}
-
-type Container interface {
-	Descendable
-	Displayable
-}
-
-// ContainerResolver houses functions for getting information about containers
-// from remote APIs (i.e. resolve folder paths with Graph API). Resolvers may
-// cache information about containers.
-type ContainerResolver interface {
-	// IDToPath takes an m365 container ID and converts it to a hierarchical path
-	// to that container. The path has a similar format to paths on the local
-	// file system.
-	IDToPath(ctx context.Context, m365ID string, useIDInPath bool) (*path.Builder, *path.Builder, error)
-	// Populate performs initialization steps for the resolver
-	// @param ctx is necessary param for Graph API tracing
-	// @param baseFolderID represents the M365ID base that the resolver will
-	// conclude its search. Default input is "".
-	Populate(ctx context.Context, baseFolderID string, baseContainerPather ...string) error
-
-	// PathInCache performs a look up of a path reprensentation
-	// and returns the m365ID of directory iff the pathString
-	// matches the path of a container within the cache.
-	// @returns bool represents if m365ID was found.
-	PathInCache(pathString string) (string, bool)
-
-	AddToCache(ctx context.Context, m365Container Container, useIDInPath bool) error
-
-	// Items returns the containers in the cache.
-	Items() []CachedContainer
 }
 
 // ---------------------------------------------------------------------------

--- a/src/internal/connector/graph_connector_helper_test.go
+++ b/src/internal/connector/graph_connector_helper_test.go
@@ -1013,9 +1013,9 @@ func collectionsForInfo(
 			user,
 			info.category,
 			info.pathElements,
-			false,
-		)
-		mc := mockconnector.NewMockExchangeCollection(pth, len(info.items))
+			false)
+
+		mc := mockconnector.NewMockExchangeCollection(pth, pth, len(info.items))
 		baseDestPath := backupOutputPathFromRestore(t, dest, pth)
 
 		baseExpected := expectedData[baseDestPath.String()]
@@ -1076,7 +1076,7 @@ func collectionsForInfoVersion0(
 			info.pathElements,
 			false,
 		)
-		c := mockconnector.NewMockExchangeCollection(pth, len(info.items))
+		c := mockconnector.NewMockExchangeCollection(pth, pth, len(info.items))
 		baseDestPath := backupOutputPathFromRestore(t, dest, pth)
 
 		baseExpected := expectedData[baseDestPath.String()]

--- a/src/internal/connector/mockconnector/mock_data_collection.go
+++ b/src/internal/connector/mockconnector/mock_data_collection.go
@@ -16,6 +16,7 @@ import (
 // MockExchangeDataCollection represents a mock exchange mailbox
 type MockExchangeDataCollection struct {
 	fullPath     path.Path
+	LocPath      path.Path
 	messageCount int
 	Data         [][]byte
 	Names        []string
@@ -35,9 +36,14 @@ var (
 
 // NewMockExchangeDataCollection creates an data collection that will return the specified number of
 // mock messages when iterated. Exchange type mail
-func NewMockExchangeCollection(pathRepresentation path.Path, numMessagesToReturn int) *MockExchangeDataCollection {
+func NewMockExchangeCollection(
+	storagePath path.Path,
+	locationPath path.Path,
+	numMessagesToReturn int,
+) *MockExchangeDataCollection {
 	c := &MockExchangeDataCollection{
-		fullPath:     pathRepresentation,
+		fullPath:     storagePath,
+		LocPath:      locationPath,
 		messageCount: numMessagesToReturn,
 		Data:         [][]byte{},
 		Names:        []string{},
@@ -93,21 +99,11 @@ func NewMockContactCollection(pathRepresentation path.Path, numMessagesToReturn 
 	return c
 }
 
-func (medc *MockExchangeDataCollection) FullPath() path.Path {
-	return medc.fullPath
-}
-
-func (medc MockExchangeDataCollection) PreviousPath() path.Path {
-	return medc.PrevPath
-}
-
-func (medc MockExchangeDataCollection) State() data.CollectionState {
-	return medc.ColState
-}
-
-func (medc MockExchangeDataCollection) DoNotMergeItems() bool {
-	return medc.DoNotMerge
-}
+func (medc MockExchangeDataCollection) FullPath() path.Path         { return medc.fullPath }
+func (medc MockExchangeDataCollection) LocationPath() path.Path     { return medc.LocPath }
+func (medc MockExchangeDataCollection) PreviousPath() path.Path     { return medc.PrevPath }
+func (medc MockExchangeDataCollection) State() data.CollectionState { return medc.ColState }
+func (medc MockExchangeDataCollection) DoNotMergeItems() bool       { return medc.DoNotMerge }
 
 // Items returns a channel that has the next items in the collection. The
 // channel is closed when there are no more items available.

--- a/src/internal/connector/mockconnector/mock_data_collection_test.go
+++ b/src/internal/connector/mockconnector/mock_data_collection_test.go
@@ -25,7 +25,7 @@ func TestMockExchangeCollectionSuite(t *testing.T) {
 }
 
 func (suite *MockExchangeCollectionSuite) TestMockExchangeCollection() {
-	mdc := mockconnector.NewMockExchangeCollection(nil, 2)
+	mdc := mockconnector.NewMockExchangeCollection(nil, nil, 2)
 
 	messagesRead := 0
 
@@ -40,7 +40,7 @@ func (suite *MockExchangeCollectionSuite) TestMockExchangeCollection() {
 
 func (suite *MockExchangeCollectionSuite) TestMockExchangeCollectionItemSize() {
 	t := suite.T()
-	mdc := mockconnector.NewMockExchangeCollection(nil, 2)
+	mdc := mockconnector.NewMockExchangeCollection(nil, nil, 2)
 
 	mdc.Data[1] = []byte("This is some buffer of data so that the size is different than the default")
 
@@ -58,7 +58,7 @@ func (suite *MockExchangeCollectionSuite) TestMockExchangeCollectionItemSize() {
 // functions by verifying no failures on (de)serializing steps using kiota serialization library
 func (suite *MockExchangeCollectionSuite) TestMockExchangeCollection_NewExchangeCollectionMail_Hydration() {
 	t := suite.T()
-	mdc := mockconnector.NewMockExchangeCollection(nil, 3)
+	mdc := mockconnector.NewMockExchangeCollection(nil, nil, 3)
 	buf := &bytes.Buffer{}
 
 	for stream := range mdc.Items() {

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -439,7 +439,7 @@ func (oc *Collection) reportAsCompleted(ctx context.Context, itemsFound, itemsRe
 			TotalBytes: byteCount,  // Number of bytes read in the operation,
 		},
 		errs,
-		oc.folderPath.Folder(), // Additional details
+		oc.folderPath.Folder(false), // Additional details
 	)
 	logger.Ctx(ctx).Debugw("done streaming items", "status", status.String())
 	oc.statusUpdater(status)

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -284,7 +284,13 @@ func RestoreCollection(
 						continue
 					}
 
-					deets.Add(itemPath.String(), itemPath.ShortRef(), "", true, itemInfo)
+					deets.Add(
+						itemPath.String(),
+						itemPath.ShortRef(),
+						"",
+						"", // TODO: implement locationRef
+						true,
+						itemInfo)
 
 					// Mark it as success without processing .meta
 					// file if we are not restoring permissions
@@ -371,7 +377,13 @@ func RestoreCollection(
 					continue
 				}
 
-				deets.Add(itemPath.String(), itemPath.ShortRef(), "", true, itemInfo)
+				deets.Add(
+					itemPath.String(),
+					itemPath.ShortRef(),
+					"",
+					"", // TODO: implement locationRef
+					true,
+					itemInfo)
 				metrics.Successes++
 			}
 		}

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -213,7 +213,7 @@ func RestoreCollection(
 	trace.Log(ctx, "gc:oneDrive:restoreCollection", directory.String())
 	logger.Ctx(ctx).Infow(
 		"restoring to destination",
-		"origin", dc.FullPath().Folder(),
+		"origin", dc.FullPath().Folder(false),
 		"destination", restoreFolderElements)
 
 	parentPerms, colPerms, err := getParentAndCollectionPermissions(

--- a/src/internal/connector/sharepoint/collection.go
+++ b/src/internal/connector/sharepoint/collection.go
@@ -167,7 +167,7 @@ func (sc *Collection) finishPopulation(ctx context.Context, attempts, success in
 			TotalBytes: totalBytes,
 		},
 		errs,
-		sc.fullPath.Folder())
+		sc.fullPath.Folder(false))
 	logger.Ctx(ctx).Debug(status.String())
 
 	if sc.statusUpdater != nil {
@@ -191,7 +191,7 @@ func (sc *Collection) populate(ctx context.Context) {
 		ctx,
 		sc.fullPath.Category().String(),
 		observe.Safe("name"),
-		observe.PII(sc.fullPath.Folder()))
+		observe.PII(sc.fullPath.Folder(false)))
 	go closer()
 
 	defer func() {

--- a/src/internal/connector/sharepoint/restore.go
+++ b/src/internal/connector/sharepoint/restore.go
@@ -276,6 +276,7 @@ func RestoreListCollection(
 				itemPath.String(),
 				itemPath.ShortRef(),
 				"",
+				"", // TODO: implement locationRef
 				true,
 				itemInfo)
 
@@ -355,6 +356,7 @@ func RestorePageCollection(
 				itemPath.String(),
 				itemPath.ShortRef(),
 				"",
+				"", // TODO: implement locationRef
 				true,
 				itemInfo,
 			)

--- a/src/internal/data/data_collection.go
+++ b/src/internal/data/data_collection.go
@@ -96,6 +96,12 @@ type Stream interface {
 	Deleted() bool
 }
 
+// Locationer provides a LocationPath describing the path with Display Names
+// instead of canonical IDs
+type LocationPather interface {
+	LocationPath() path.Path
+}
+
 // StreamInfo is used to provide service specific
 // information about the Stream
 type StreamInfo interface {

--- a/src/internal/data/data_collection.go
+++ b/src/internal/data/data_collection.go
@@ -130,7 +130,7 @@ func StateOf(prev, curr path.Path) CollectionState {
 		return NewState
 	}
 
-	if curr.Folder() != prev.Folder() {
+	if curr.Folder(false) != prev.Folder(false) {
 		return MovedState
 	}
 

--- a/src/internal/data/data_collection.go
+++ b/src/internal/data/data_collection.go
@@ -96,7 +96,7 @@ type Stream interface {
 	Deleted() bool
 }
 
-// Locationer provides a LocationPath describing the path with Display Names
+// LocationPather provides a LocationPath describing the path with Display Names
 // instead of canonical IDs
 type LocationPather interface {
 	LocationPath() path.Path

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -136,7 +136,7 @@ type corsoProgress struct {
 	deets   *details.Builder
 	// toMerge represents items that we don't have in-memory item info for. The
 	// item info for these items should be sourced from a base snapshot later on.
-	toMerge    map[string]path.Path
+	toMerge    map[string]PrevRefs
 	mu         sync.RWMutex
 	totalBytes int64
 	errs       *fault.Errors
@@ -181,7 +181,10 @@ func (cp *corsoProgress) FinishedFile(relativePath string, err error) {
 		cp.mu.Lock()
 		defer cp.mu.Unlock()
 
-		cp.toMerge[d.prevPath.ShortRef()] = d.repoPath
+		cp.toMerge[d.prevPath.ShortRef()] = PrevRefs{
+			Repo:     d.repoPath,
+			Location: d.locationPath,
+		}
 
 		return
 	}

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -123,10 +123,11 @@ func (rw *restoreStreamReader) Read(p []byte) (n int, err error) {
 }
 
 type itemDetails struct {
-	info     *details.ItemInfo
-	repoPath path.Path
-	prevPath path.Path
-	cached   bool
+	info         *details.ItemInfo
+	repoPath     path.Path
+	prevPath     path.Path
+	locationPath path.Path
+	cached       bool
 }
 
 type corsoProgress struct {
@@ -187,20 +188,24 @@ func (cp *corsoProgress) FinishedFile(relativePath string, err error) {
 
 	parent := d.repoPath.ToBuilder().Dir()
 
+	var locationFolders string
+	if d.locationPath != nil {
+		locationFolders = d.locationPath.Folder()
+	}
+
 	cp.deets.Add(
 		d.repoPath.String(),
 		d.repoPath.ShortRef(),
 		parent.ShortRef(),
+		locationFolders,
 		!d.cached,
-		*d.info,
-	)
+		*d.info)
 
-	folders := details.FolderEntriesForPath(parent)
+	folders := details.FolderEntriesForPath(parent, d.locationPath.ToBuilder())
 	cp.deets.AddFoldersForItem(
 		folders,
 		*d.info,
-		!d.cached,
-	)
+		!d.cached)
 }
 
 // Kopia interface function used as a callback when kopia finishes hashing a file.
@@ -307,6 +312,12 @@ func collectionEntries(
 				continue
 			}
 
+			var locationPath path.Path
+
+			if lp, ok := e.(data.LocationPather); ok {
+				locationPath = lp.LocationPath()
+			}
+
 			trace.Log(ctx, "kopia:streamEntries:item", itemPath.String())
 
 			if e.Deleted() {
@@ -328,7 +339,11 @@ func collectionEntries(
 				// previous snapshot then we should populate prevPath here and leave
 				// info nil.
 				itemInfo := ei.Info()
-				d := &itemDetails{info: &itemInfo, repoPath: itemPath}
+				d := &itemDetails{
+					info:         &itemInfo,
+					repoPath:     itemPath,
+					locationPath: locationPath,
+				}
 				progress.put(encodeAsPath(itemPath.PopFront().Elements()...), d)
 			}
 

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -190,7 +190,7 @@ func (cp *corsoProgress) FinishedFile(relativePath string, err error) {
 
 	var locationFolders string
 	if d.locationPath != nil {
-		locationFolders = d.locationPath.Folder()
+		locationFolders = d.locationPath.Folder(true)
 	}
 
 	cp.deets.Add(

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -201,7 +201,12 @@ func (cp *corsoProgress) FinishedFile(relativePath string, err error) {
 		!d.cached,
 		*d.info)
 
-	folders := details.FolderEntriesForPath(parent, d.locationPath.ToBuilder())
+	var locPB *path.Builder
+	if d.locationPath != nil {
+		locPB = d.locationPath.ToBuilder()
+	}
+
+	folders := details.FolderEntriesForPath(parent, locPB)
 	cp.deets.AddFoldersForItem(
 		folders,
 		*d.info,

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -186,11 +186,15 @@ func (cp *corsoProgress) FinishedFile(relativePath string, err error) {
 		return
 	}
 
-	parent := d.repoPath.ToBuilder().Dir()
+	var (
+		locationFolders string
+		locPB           *path.Builder
+		parent          = d.repoPath.ToBuilder().Dir()
+	)
 
-	var locationFolders string
 	if d.locationPath != nil {
 		locationFolders = d.locationPath.Folder(true)
+		locPB = d.locationPath.ToBuilder()
 	}
 
 	cp.deets.Add(
@@ -200,11 +204,6 @@ func (cp *corsoProgress) FinishedFile(relativePath string, err error) {
 		locationFolders,
 		!d.cached,
 		*d.info)
-
-	var locPB *path.Builder
-	if d.locationPath != nil {
-		locPB = d.locationPath.ToBuilder()
-	}
 
 	folders := details.FolderEntriesForPath(parent, locPB)
 	cp.deets.AddFoldersForItem(

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -197,7 +197,14 @@ func (cp *corsoProgress) FinishedFile(relativePath string, err error) {
 
 	if d.locationPath != nil {
 		locationFolders = d.locationPath.Folder(true)
+
 		locPB = d.locationPath.ToBuilder()
+
+		// folderEntriesForPath assumes the location will
+		// not have an item element appended
+		if len(d.locationPath.Item()) > 0 {
+			locPB = locPB.Dir()
+		}
 	}
 
 	cp.deets.Add(

--- a/src/internal/kopia/upload_test.go
+++ b/src/internal/kopia/upload_test.go
@@ -535,7 +535,7 @@ func (suite *CorsoProgressUnitSuite) TestFinishedFileBuildsHierarchyNewItem() {
 		UploadProgress: &snapshotfs.NullUploadProgress{},
 		deets:          bd,
 		pending:        map[string]*itemDetails{},
-		toMerge:        map[string]path.Path{},
+		toMerge:        map[string]PrevRefs{},
 		errs:           fault.New(true),
 	}
 
@@ -598,30 +598,34 @@ func (suite *CorsoProgressUnitSuite) TestFinishedFileBaseItemDoesntBuildHierarch
 		true,
 	)
 
-	expectedToMerge := map[string]path.Path{
-		prevPath.ShortRef(): suite.targetFilePath,
+	expectedToMerge := map[string]PrevRefs{
+		prevPath.ShortRef(): {
+			Repo:     suite.targetFilePath,
+			Location: suite.targetFilePath,
+		},
 	}
 
 	// Setup stuff.
-	bd := &details.Builder{}
+	db := &details.Builder{}
 	cp := corsoProgress{
 		UploadProgress: &snapshotfs.NullUploadProgress{},
-		deets:          bd,
+		deets:          db,
 		pending:        map[string]*itemDetails{},
-		toMerge:        map[string]path.Path{},
+		toMerge:        map[string]PrevRefs{},
 		errs:           fault.New(true),
 	}
 
 	deets := &itemDetails{
-		info:     nil,
-		repoPath: suite.targetFilePath,
-		prevPath: prevPath,
+		info:         nil,
+		repoPath:     suite.targetFilePath,
+		prevPath:     prevPath,
+		locationPath: suite.targetFilePath,
 	}
+
 	cp.put(suite.targetFileName, deets)
 	require.Len(t, cp.pending, 1)
 
 	cp.FinishedFile(suite.targetFileName, nil)
-
 	assert.Equal(t, expectedToMerge, cp.toMerge)
 	assert.Empty(t, cp.deets)
 }

--- a/src/internal/kopia/upload_test.go
+++ b/src/internal/kopia/upload_test.go
@@ -655,15 +655,19 @@ func (suite *CorsoProgressUnitSuite) TestFinishedHashingFile() {
 
 type HierarchyBuilderUnitSuite struct {
 	suite.Suite
-	testPath path.Path
+	testStoragePath  path.Path
+	testLocationPath path.Path
 }
 
 func (suite *HierarchyBuilderUnitSuite) SetupSuite() {
-	suite.testPath = makePath(
+	suite.testStoragePath = makePath(
+		suite.T(),
+		[]string{testTenant, service, testUser, category, testInboxID},
+		false)
+	suite.testLocationPath = makePath(
 		suite.T(),
 		[]string{testTenant, service, testUser, category, testInboxDir},
-		false,
-	)
+		false)
 }
 
 func TestHierarchyBuilderUnitSuite(t *testing.T) {
@@ -676,14 +680,16 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree() {
 
 	defer flush()
 
-	t := suite.T()
-	tenant := "a-tenant"
-	user1 := testUser
-	user1Encoded := encodeAsPath(user1)
-	user2 := "user2"
-	user2Encoded := encodeAsPath(user2)
-
-	p2 := makePath(t, []string{tenant, service, user2, category, testInboxDir}, false)
+	var (
+		t            = suite.T()
+		tenant       = "a-tenant"
+		user1        = testUser
+		user1Encoded = encodeAsPath(user1)
+		user2        = "user2"
+		user2Encoded = encodeAsPath(user2)
+		storeP2      = makePath(t, []string{tenant, service, user2, category, testInboxID}, false)
+		locP2        = makePath(t, []string{tenant, service, user2, category, testInboxDir}, false)
+	)
 
 	// Encode user names here so we don't have to decode things later.
 	expectedFileCount := map[string]int{
@@ -698,13 +704,13 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree() {
 
 	collections := []data.BackupCollection{
 		mockconnector.NewMockExchangeCollection(
-			suite.testPath,
-			expectedFileCount[user1Encoded],
-		),
+			suite.testStoragePath,
+			suite.testLocationPath,
+			expectedFileCount[user1Encoded]),
 		mockconnector.NewMockExchangeCollection(
-			p2,
-			expectedFileCount[user2Encoded],
-		),
+			storeP2,
+			locP2,
+			expectedFileCount[user2Encoded]),
 	}
 
 	// Returned directory structure should look like:
@@ -738,7 +744,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree() {
 		expectDirs(t, entries, encodeElements(category), true)
 
 		entries = getDirEntriesForEntry(t, ctx, entries[0])
-		expectDirs(t, entries, encodeElements(testInboxDir), true)
+		expectDirs(t, entries, encodeElements(testInboxID), true)
 
 		entries = getDirEntriesForEntry(t, ctx, entries[0])
 		assert.Len(t, entries, expectedFileCount[userName])
@@ -756,9 +762,12 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_MixedDirectory() 
 	ctx, flush := tester.NewContext()
 	defer flush()
 
-	subdir := "subfolder"
-
-	p2 := makePath(suite.T(), append(suite.testPath.Elements(), subdir), false)
+	var (
+		subfldID  = "subfolder_ID"
+		subfldDir = "subfolder"
+		storeP2   = makePath(suite.T(), append(suite.testStoragePath.Elements(), subfldID), false)
+		locP2     = makePath(suite.T(), append(suite.testLocationPath.Elements(), subfldDir), false)
+	)
 
 	// Test multiple orders of items because right now order can matter. Both
 	// orders result in a directory structure like:
@@ -766,8 +775,8 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_MixedDirectory() 
 	//   - exchange
 	//     - user1
 	//       - emails
-	//         - Inbox
-	//           - subfolder
+	//         - Inbox_ID
+	//           - subfolder_ID
 	//             - 5 separate files
 	//           - 42 separate files
 	table := []struct {
@@ -778,26 +787,26 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_MixedDirectory() 
 			name: "SubdirFirst",
 			layout: []data.BackupCollection{
 				mockconnector.NewMockExchangeCollection(
-					p2,
-					5,
-				),
+					storeP2,
+					locP2,
+					5),
 				mockconnector.NewMockExchangeCollection(
-					suite.testPath,
-					42,
-				),
+					suite.testStoragePath,
+					suite.testLocationPath,
+					42),
 			},
 		},
 		{
 			name: "SubdirLast",
 			layout: []data.BackupCollection{
 				mockconnector.NewMockExchangeCollection(
-					suite.testPath,
-					42,
-				),
+					suite.testStoragePath,
+					suite.testLocationPath,
+					42),
 				mockconnector.NewMockExchangeCollection(
-					p2,
-					5,
-				),
+					storeP2,
+					locP2,
+					5),
 			},
 		},
 	}
@@ -826,7 +835,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_MixedDirectory() 
 			expectDirs(t, entries, encodeElements(category), true)
 
 			entries = getDirEntriesForEntry(t, ctx, entries[0])
-			expectDirs(t, entries, encodeElements(testInboxDir), true)
+			expectDirs(t, entries, encodeElements(testInboxID), true)
 
 			entries = getDirEntriesForEntry(t, ctx, entries[0])
 			// 42 files and 1 subdirectory.
@@ -841,7 +850,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_MixedDirectory() 
 				}
 
 				subDirs = append(subDirs, d)
-				assert.Equal(t, encodeAsPath(subdir), d.Name())
+				assert.Equal(t, encodeAsPath(subfldID), d.Name())
 			}
 
 			require.Len(t, subDirs, 1)
@@ -853,11 +862,14 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_MixedDirectory() 
 }
 
 func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_Fails() {
-	p2 := makePath(
+	storeP2 := makePath(
+		suite.T(),
+		[]string{"tenant2", service, "user2", category, testInboxID},
+		false)
+	locP2 := makePath(
 		suite.T(),
 		[]string{"tenant2", service, "user2", category, testInboxDir},
-		false,
-	)
+		false)
 
 	table := []struct {
 		name   string
@@ -880,13 +892,13 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_Fails() {
 			//           - 42 separate files
 			[]data.BackupCollection{
 				mockconnector.NewMockExchangeCollection(
-					suite.testPath,
-					5,
-				),
+					suite.testStoragePath,
+					suite.testLocationPath,
+					5),
 				mockconnector.NewMockExchangeCollection(
-					p2,
-					42,
-				),
+					storeP2,
+					locP2,
+					42),
 			},
 		},
 		{
@@ -894,8 +906,8 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_Fails() {
 			[]data.BackupCollection{
 				mockconnector.NewMockExchangeCollection(
 					nil,
-					5,
-				),
+					nil,
+					5),
 			},
 		},
 	}
@@ -935,15 +947,19 @@ func mockIncrementalBase(
 }
 
 func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeErrors() {
-	dirPath := makePath(
-		suite.T(),
-		[]string{testTenant, service, testUser, category, testInboxDir},
-		false,
-	)
-	dirPath2 := makePath(
-		suite.T(),
-		[]string{testTenant, service, testUser, category, testArchiveDir},
-		false,
+	var (
+		storePath = makePath(
+			suite.T(),
+			[]string{testTenant, service, testUser, category, testInboxID},
+			false)
+		storePath2 = makePath(
+			suite.T(),
+			[]string{testTenant, service, testUser, category, testArchiveID},
+			false)
+		locPath = makePath(
+			suite.T(),
+			[]string{testTenant, service, testUser, category, testArchiveDir},
+			false)
 	)
 
 	table := []struct {
@@ -994,17 +1010,17 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeErrors() {
 
 			cols := []data.BackupCollection{}
 			for _, s := range test.states {
-				prevPath := dirPath
-				nowPath := dirPath
+				prevPath := storePath
+				nowPath := storePath
 
 				switch s {
 				case data.DeletedState:
 					nowPath = nil
 				case data.MovedState:
-					nowPath = dirPath2
+					nowPath = storePath2
 				}
 
-				mc := mockconnector.NewMockExchangeCollection(nowPath, 0)
+				mc := mockconnector.NewMockExchangeCollection(nowPath, locPath, 0)
 				mc.ColState = s
 				mc.PrevPath = prevPath
 
@@ -1018,15 +1034,23 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeErrors() {
 }
 
 func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
-	dirPath := makePath(
-		suite.T(),
-		[]string{testTenant, service, testUser, category, testInboxDir},
-		false,
-	)
-	dirPath2 := makePath(
-		suite.T(),
-		[]string{testTenant, service, testUser, category, testArchiveDir},
-		false,
+	var (
+		storePath = makePath(
+			suite.T(),
+			[]string{testTenant, service, testUser, category, testInboxID},
+			false)
+		storePath2 = makePath(
+			suite.T(),
+			[]string{testTenant, service, testUser, category, testArchiveID},
+			false)
+		locPath = makePath(
+			suite.T(),
+			[]string{testTenant, service, testUser, category, testInboxDir},
+			false)
+		locPath2 = makePath(
+			suite.T(),
+			[]string{testTenant, service, testUser, category, testArchiveDir},
+			false)
 	)
 
 	// Must be a function that returns a new instance each time as StreamingFile
@@ -1041,7 +1065,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
 			},
 			[]fs.Entry{
 				virtualfs.NewStaticDirectory(
-					encodeElements(testInboxDir)[0],
+					encodeElements(testInboxID)[0],
 					[]fs.Entry{
 						virtualfs.StreamingFileWithModTimeFromReader(
 							encodeElements(testFileName)[0],
@@ -1062,7 +1086,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
 		{
 			name: "SkipsDeletedItems",
 			inputCollections: func() []data.BackupCollection {
-				mc := mockconnector.NewMockExchangeCollection(dirPath, 1)
+				mc := mockconnector.NewMockExchangeCollection(storePath, locPath, 1)
 				mc.Names[0] = testFileName
 				mc.DeletedItems[0] = true
 
@@ -1077,7 +1101,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
 				},
 				[]*expectedNode{
 					{
-						name:     testInboxDir,
+						name:     testInboxID,
 						children: []*expectedNode{},
 					},
 				},
@@ -1086,7 +1110,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
 		{
 			name: "AddsNewItems",
 			inputCollections: func() []data.BackupCollection {
-				mc := mockconnector.NewMockExchangeCollection(dirPath, 1)
+				mc := mockconnector.NewMockExchangeCollection(storePath, locPath, 1)
 				mc.Names[0] = testFileName2
 				mc.Data[0] = testFileData2
 				mc.ColState = data.NotMovedState
@@ -1102,7 +1126,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
 				},
 				[]*expectedNode{
 					{
-						name: testInboxDir,
+						name: testInboxID,
 						children: []*expectedNode{
 							{
 								name:     testFileName,
@@ -1121,7 +1145,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
 		{
 			name: "SkipsUpdatedItems",
 			inputCollections: func() []data.BackupCollection {
-				mc := mockconnector.NewMockExchangeCollection(dirPath, 1)
+				mc := mockconnector.NewMockExchangeCollection(storePath, locPath, 1)
 				mc.Names[0] = testFileName
 				mc.Data[0] = testFileData2
 				mc.ColState = data.NotMovedState
@@ -1137,7 +1161,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
 				},
 				[]*expectedNode{
 					{
-						name: testInboxDir,
+						name: testInboxID,
 						children: []*expectedNode{
 							{
 								name:     testFileName,
@@ -1152,11 +1176,11 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
 		{
 			name: "DeleteAndNew",
 			inputCollections: func() []data.BackupCollection {
-				mc1 := mockconnector.NewMockExchangeCollection(dirPath, 0)
+				mc1 := mockconnector.NewMockExchangeCollection(storePath, locPath, 0)
 				mc1.ColState = data.DeletedState
-				mc1.PrevPath = dirPath
+				mc1.PrevPath = storePath
 
-				mc2 := mockconnector.NewMockExchangeCollection(dirPath, 1)
+				mc2 := mockconnector.NewMockExchangeCollection(storePath, locPath, 1)
 				mc2.ColState = data.NewState
 				mc2.Names[0] = testFileName2
 				mc2.Data[0] = testFileData2
@@ -1172,7 +1196,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
 				},
 				[]*expectedNode{
 					{
-						name: testInboxDir,
+						name: testInboxID,
 						children: []*expectedNode{
 							{
 								name:     testFileName2,
@@ -1187,11 +1211,11 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
 		{
 			name: "MovedAndNew",
 			inputCollections: func() []data.BackupCollection {
-				mc1 := mockconnector.NewMockExchangeCollection(dirPath2, 0)
+				mc1 := mockconnector.NewMockExchangeCollection(storePath2, locPath2, 0)
 				mc1.ColState = data.MovedState
-				mc1.PrevPath = dirPath
+				mc1.PrevPath = storePath
 
-				mc2 := mockconnector.NewMockExchangeCollection(dirPath, 1)
+				mc2 := mockconnector.NewMockExchangeCollection(storePath, locPath, 1)
 				mc2.ColState = data.NewState
 				mc2.Names[0] = testFileName2
 				mc2.Data[0] = testFileData2
@@ -1207,7 +1231,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
 				},
 				[]*expectedNode{
 					{
-						name: testInboxDir,
+						name: testInboxID,
 						children: []*expectedNode{
 							{
 								name:     testFileName2,
@@ -1217,7 +1241,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
 						},
 					},
 					{
-						name: testArchiveDir,
+						name: testArchiveID,
 						children: []*expectedNode{
 							{
 								name:     testFileName,
@@ -1231,7 +1255,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
 		{
 			name: "NewDoesntMerge",
 			inputCollections: func() []data.BackupCollection {
-				mc1 := mockconnector.NewMockExchangeCollection(dirPath, 1)
+				mc1 := mockconnector.NewMockExchangeCollection(storePath, locPath, 1)
 				mc1.ColState = data.NewState
 				mc1.Names[0] = testFileName2
 				mc1.Data[0] = testFileData2
@@ -1247,7 +1271,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
 				},
 				[]*expectedNode{
 					{
-						name: testInboxDir,
+						name: testInboxID,
 						children: []*expectedNode{
 							{
 								name:     testFileName2,
@@ -1295,37 +1319,49 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
 
 func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirectories() {
 	const (
+		personalID  = "personal_ID"
+		workID      = "work_ID"
 		personalDir = "personal"
 		workDir     = "work"
 	)
 
-	inboxPath := makePath(
-		suite.T(),
-		[]string{testTenant, service, testUser, category, testInboxDir},
-		false,
-	)
-	inboxFileName1 := testFileName
-	inboxFileData1 := testFileData4
-	inboxFileName2 := testFileName5
-	inboxFileData2 := testFileData5
+	var (
+		inboxStorePath = makePath(
+			suite.T(),
+			[]string{testTenant, service, testUser, category, testInboxID},
+			false)
+		inboxLocPath = makePath(
+			suite.T(),
+			[]string{testTenant, service, testUser, category, testInboxDir},
+			false)
+		inboxFileName1 = testFileName
+		inboxFileData1 = testFileData4
+		inboxFileName2 = testFileName5
+		inboxFileData2 = testFileData5
 
-	personalPath := makePath(
-		suite.T(),
-		append(inboxPath.Elements(), personalDir),
-		false,
-	)
-	personalFileName1 := inboxFileName1
-	personalFileName2 := testFileName2
+		personalStorePath = makePath(
+			suite.T(),
+			append(inboxStorePath.Elements(), personalID),
+			false)
+		personalLocPath = makePath(
+			suite.T(),
+			append(inboxLocPath.Elements(), personalDir),
+			false)
+		personalFileName1 = inboxFileName1
+		personalFileName2 = testFileName2
 
-	workPath := makePath(
-		suite.T(),
-		append(inboxPath.Elements(), workDir),
-		false,
+		workStorePath = makePath(
+			suite.T(),
+			append(inboxStorePath.Elements(), workID),
+			false)
+		workLocPath = makePath(
+			suite.T(),
+			append(inboxLocPath.Elements(), workDir),
+			false)
+		workFileName1 = testFileName3
+		workFileName2 = testFileName4
+		workFileData2 = testFileData
 	)
-	workFileName1 := testFileName3
-	workFileName2 := testFileName4
-
-	workFileData2 := testFileData
 
 	// Must be a function that returns a new instance each time as StreamingFile
 	// can only return its Reader once.
@@ -1334,12 +1370,12 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 	//   - exchange
 	//     - user1
 	//       - email
-	//         - Inbox
+	//         - Inbox_ID
 	//           - file1
-	//           - personal
+	//           - personal_ID
 	//             - file1
 	//             - file2
-	//           - work
+	//           - work_ID
 	//             - file3
 	getBaseSnapshot := func() fs.Entry {
 		return baseWithChildren(
@@ -1351,7 +1387,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 			},
 			[]fs.Entry{
 				virtualfs.NewStaticDirectory(
-					encodeElements(testInboxDir)[0],
+					encodeElements(testInboxID)[0],
 					[]fs.Entry{
 						virtualfs.StreamingFileWithModTimeFromReader(
 							encodeElements(inboxFileName1)[0],
@@ -1359,7 +1395,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 							io.NopCloser(bytes.NewReader(inboxFileData1)),
 						),
 						virtualfs.NewStaticDirectory(
-							encodeElements(personalDir)[0],
+							encodeElements(personalID)[0],
 							[]fs.Entry{
 								virtualfs.StreamingFileWithModTimeFromReader(
 									encodeElements(personalFileName1)[0],
@@ -1374,7 +1410,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 							},
 						),
 						virtualfs.NewStaticDirectory(
-							encodeElements(workDir)[0],
+							encodeElements(workID)[0],
 							[]fs.Entry{
 								virtualfs.StreamingFileWithModTimeFromReader(
 									encodeElements(workFileName1)[0],
@@ -1412,10 +1448,10 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 				},
 				[]*expectedNode{
 					{
-						name: testInboxDir,
+						name: testInboxID,
 						children: []*expectedNode{
 							{
-								name: personalDir,
+								name: personalID,
 								children: []*expectedNode{
 									{
 										name:     personalFileName2,
@@ -1424,7 +1460,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 								},
 							},
 							{
-								name: workDir,
+								name: workID,
 								children: []*expectedNode{
 									{
 										name:     workFileName1,
@@ -1440,14 +1476,17 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 		{
 			name: "MovesSubtree",
 			inputCollections: func(t *testing.T) []data.BackupCollection {
-				newPath := makePath(
+				newStorePath := makePath(
+					t,
+					[]string{testTenant, service, testUser, category, testInboxID + "2"},
+					false)
+				newLocPath := makePath(
 					t,
 					[]string{testTenant, service, testUser, category, testInboxDir + "2"},
-					false,
-				)
+					false)
 
-				mc := mockconnector.NewMockExchangeCollection(newPath, 0)
-				mc.PrevPath = inboxPath
+				mc := mockconnector.NewMockExchangeCollection(newStorePath, newLocPath, 0)
+				mc.PrevPath = inboxStorePath
 				mc.ColState = data.MovedState
 
 				return []data.BackupCollection{mc}
@@ -1461,14 +1500,14 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 				},
 				[]*expectedNode{
 					{
-						name: testInboxDir + "2",
+						name: testInboxID + "2",
 						children: []*expectedNode{
 							{
 								name:     inboxFileName1,
 								children: []*expectedNode{},
 							},
 							{
-								name: personalDir,
+								name: personalID,
 								children: []*expectedNode{
 									{
 										name:     personalFileName1,
@@ -1481,7 +1520,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 								},
 							},
 							{
-								name: workDir,
+								name: workID,
 								children: []*expectedNode{
 									{
 										name:     workFileName1,
@@ -1497,23 +1536,29 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 		{
 			name: "MovesChildAfterAncestorMove",
 			inputCollections: func(t *testing.T) []data.BackupCollection {
-				newInboxPath := makePath(
+				newInboxStorePath := makePath(
+					t,
+					[]string{testTenant, service, testUser, category, testInboxID + "2"},
+					false)
+				newWorkStorePath := makePath(
+					t,
+					[]string{testTenant, service, testUser, category, workID},
+					false)
+				newInboxLocPath := makePath(
 					t,
 					[]string{testTenant, service, testUser, category, testInboxDir + "2"},
-					false,
-				)
-				newWorkPath := makePath(
+					false)
+				newWorkLocPath := makePath(
 					t,
-					[]string{testTenant, service, testUser, category, workDir},
-					false,
-				)
+					[]string{testTenant, service, testUser, category, workID},
+					false)
 
-				inbox := mockconnector.NewMockExchangeCollection(newInboxPath, 0)
-				inbox.PrevPath = inboxPath
+				inbox := mockconnector.NewMockExchangeCollection(newInboxStorePath, newInboxLocPath, 0)
+				inbox.PrevPath = inboxStorePath
 				inbox.ColState = data.MovedState
 
-				work := mockconnector.NewMockExchangeCollection(newWorkPath, 0)
-				work.PrevPath = workPath
+				work := mockconnector.NewMockExchangeCollection(newWorkStorePath, newWorkLocPath, 0)
+				work.PrevPath = workStorePath
 				work.ColState = data.MovedState
 
 				return []data.BackupCollection{inbox, work}
@@ -1527,14 +1572,14 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 				},
 				[]*expectedNode{
 					{
-						name: testInboxDir + "2",
+						name: testInboxID + "2",
 						children: []*expectedNode{
 							{
 								name:     inboxFileName1,
 								children: []*expectedNode{},
 							},
 							{
-								name: personalDir,
+								name: personalID,
 								children: []*expectedNode{
 									{
 										name:     personalFileName1,
@@ -1549,7 +1594,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 						},
 					},
 					{
-						name: workDir,
+						name: workID,
 						children: []*expectedNode{
 							{
 								name:     workFileName1,
@@ -1563,18 +1608,21 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 		{
 			name: "MovesChildAfterAncestorDelete",
 			inputCollections: func(t *testing.T) []data.BackupCollection {
-				newWorkPath := makePath(
+				newWorkStorePath := makePath(
+					t,
+					[]string{testTenant, service, testUser, category, workID},
+					false)
+				newWorkLocPath := makePath(
 					t,
 					[]string{testTenant, service, testUser, category, workDir},
-					false,
-				)
+					false)
 
-				inbox := mockconnector.NewMockExchangeCollection(inboxPath, 0)
-				inbox.PrevPath = inboxPath
+				inbox := mockconnector.NewMockExchangeCollection(inboxStorePath, inboxLocPath, 0)
+				inbox.PrevPath = inboxStorePath
 				inbox.ColState = data.DeletedState
 
-				work := mockconnector.NewMockExchangeCollection(newWorkPath, 0)
-				work.PrevPath = workPath
+				work := mockconnector.NewMockExchangeCollection(newWorkStorePath, newWorkLocPath, 0)
+				work.PrevPath = workStorePath
 				work.ColState = data.MovedState
 
 				return []data.BackupCollection{inbox, work}
@@ -1588,7 +1636,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 				},
 				[]*expectedNode{
 					{
-						name: workDir,
+						name: workID,
 						children: []*expectedNode{
 							{
 								name:     workFileName1,
@@ -1602,12 +1650,12 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 		{
 			name: "ReplaceDeletedDirectory",
 			inputCollections: func(t *testing.T) []data.BackupCollection {
-				personal := mockconnector.NewMockExchangeCollection(personalPath, 0)
-				personal.PrevPath = personalPath
+				personal := mockconnector.NewMockExchangeCollection(personalStorePath, personalLocPath, 0)
+				personal.PrevPath = personalStorePath
 				personal.ColState = data.DeletedState
 
-				work := mockconnector.NewMockExchangeCollection(personalPath, 0)
-				work.PrevPath = workPath
+				work := mockconnector.NewMockExchangeCollection(personalStorePath, personalLocPath, 0)
+				work.PrevPath = workStorePath
 				work.ColState = data.MovedState
 
 				return []data.BackupCollection{personal, work}
@@ -1621,14 +1669,14 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 				},
 				[]*expectedNode{
 					{
-						name: testInboxDir,
+						name: testInboxID,
 						children: []*expectedNode{
 							{
 								name:     inboxFileName1,
 								children: []*expectedNode{},
 							},
 							{
-								name: personalDir,
+								name: personalID,
 								children: []*expectedNode{
 									{
 										name: workFileName1,
@@ -1643,11 +1691,11 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 		{
 			name: "ReplaceDeletedDirectoryWithNew",
 			inputCollections: func(t *testing.T) []data.BackupCollection {
-				personal := mockconnector.NewMockExchangeCollection(personalPath, 0)
-				personal.PrevPath = personalPath
+				personal := mockconnector.NewMockExchangeCollection(personalStorePath, personalLocPath, 0)
+				personal.PrevPath = personalStorePath
 				personal.ColState = data.DeletedState
 
-				newCol := mockconnector.NewMockExchangeCollection(personalPath, 1)
+				newCol := mockconnector.NewMockExchangeCollection(personalStorePath, personalLocPath, 1)
 				newCol.ColState = data.NewState
 				newCol.Names[0] = workFileName2
 				newCol.Data[0] = workFileData2
@@ -1663,14 +1711,14 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 				},
 				[]*expectedNode{
 					{
-						name: testInboxDir,
+						name: testInboxID,
 						children: []*expectedNode{
 							{
 								name:     inboxFileName1,
 								children: []*expectedNode{},
 							},
 							{
-								name: personalDir,
+								name: personalID,
 								children: []*expectedNode{
 									{
 										name: workFileName2,
@@ -1679,7 +1727,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 								},
 							},
 							{
-								name: workDir,
+								name: workID,
 								children: []*expectedNode{
 									{
 										name: workFileName1,
@@ -1694,18 +1742,21 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 		{
 			name: "ReplaceMovedDirectory",
 			inputCollections: func(t *testing.T) []data.BackupCollection {
-				newPersonalPath := makePath(
+				newPersonalStorePath := makePath(
+					t,
+					[]string{testTenant, service, testUser, category, personalID},
+					false)
+				newPersonalLocPath := makePath(
 					t,
 					[]string{testTenant, service, testUser, category, personalDir},
-					false,
-				)
+					false)
 
-				personal := mockconnector.NewMockExchangeCollection(newPersonalPath, 0)
-				personal.PrevPath = personalPath
+				personal := mockconnector.NewMockExchangeCollection(newPersonalStorePath, newPersonalLocPath, 0)
+				personal.PrevPath = personalStorePath
 				personal.ColState = data.MovedState
 
-				work := mockconnector.NewMockExchangeCollection(personalPath, 0)
-				work.PrevPath = workPath
+				work := mockconnector.NewMockExchangeCollection(personalStorePath, personalLocPath, 0)
+				work.PrevPath = workStorePath
 				work.ColState = data.MovedState
 
 				return []data.BackupCollection{personal, work}
@@ -1719,14 +1770,14 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 				},
 				[]*expectedNode{
 					{
-						name: testInboxDir,
+						name: testInboxID,
 						children: []*expectedNode{
 							{
 								name:     inboxFileName1,
 								children: []*expectedNode{},
 							},
 							{
-								name: personalDir,
+								name: personalID,
 								children: []*expectedNode{
 									{
 										name: workFileName1,
@@ -1736,7 +1787,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 						},
 					},
 					{
-						name: personalDir,
+						name: personalID,
 						children: []*expectedNode{
 							{
 								name: personalFileName1,
@@ -1752,14 +1803,17 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 		{
 			name: "MoveDirectoryAndMergeItems",
 			inputCollections: func(t *testing.T) []data.BackupCollection {
-				newPersonalPath := makePath(
+				newPersonalStorePath := makePath(
+					t,
+					[]string{testTenant, service, testUser, category, workID},
+					false)
+				newPersonalLocPath := makePath(
 					t,
 					[]string{testTenant, service, testUser, category, workDir},
-					false,
-				)
+					false)
 
-				personal := mockconnector.NewMockExchangeCollection(newPersonalPath, 2)
-				personal.PrevPath = personalPath
+				personal := mockconnector.NewMockExchangeCollection(newPersonalStorePath, newPersonalLocPath, 2)
+				personal.PrevPath = personalStorePath
 				personal.ColState = data.MovedState
 				personal.Names[0] = personalFileName2
 				personal.Data[0] = testFileData5
@@ -1777,14 +1831,14 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 				},
 				[]*expectedNode{
 					{
-						name: testInboxDir,
+						name: testInboxID,
 						children: []*expectedNode{
 							{
 								name:     inboxFileName1,
 								children: []*expectedNode{},
 							},
 							{
-								name: workDir,
+								name: workID,
 								children: []*expectedNode{
 									{
 										name:     workFileName1,
@@ -1795,7 +1849,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 						},
 					},
 					{
-						name: workDir,
+						name: workID,
 						children: []*expectedNode{
 							{
 								name: personalFileName1,
@@ -1816,23 +1870,29 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 		{
 			name: "MoveParentDeleteFileNoMergeSubtreeMerge",
 			inputCollections: func(t *testing.T) []data.BackupCollection {
-				newInboxPath := makePath(
+				newInboxStorePath := makePath(
+					t,
+					[]string{testTenant, service, testUser, category, personalID},
+					false)
+				newInboxLocPath := makePath(
 					t,
 					[]string{testTenant, service, testUser, category, personalDir},
-					false,
-				)
+					false)
 
 				// This path is implicitly updated because we update the inbox path. If
 				// we didn't update it here then it would end up at the old location
 				// still.
-				newWorkPath := makePath(
+				newWorkStorePath := makePath(
+					t,
+					[]string{testTenant, service, testUser, category, personalID, workID},
+					false)
+				newWorkLocPath := makePath(
 					t,
 					[]string{testTenant, service, testUser, category, personalDir, workDir},
-					false,
-				)
+					false)
 
-				inbox := mockconnector.NewMockExchangeCollection(newInboxPath, 1)
-				inbox.PrevPath = inboxPath
+				inbox := mockconnector.NewMockExchangeCollection(newInboxStorePath, newInboxLocPath, 1)
+				inbox.PrevPath = inboxStorePath
 				inbox.ColState = data.MovedState
 				inbox.DoNotMerge = true
 				// First file in inbox is implicitly deleted as we're not merging items
@@ -1840,8 +1900,8 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 				inbox.Names[0] = inboxFileName2
 				inbox.Data[0] = inboxFileData2
 
-				work := mockconnector.NewMockExchangeCollection(newWorkPath, 1)
-				work.PrevPath = workPath
+				work := mockconnector.NewMockExchangeCollection(newWorkStorePath, newWorkLocPath, 1)
+				work.PrevPath = workStorePath
 				work.ColState = data.MovedState
 				work.Names[0] = testFileName6
 				work.Data[0] = testFileData6
@@ -1857,7 +1917,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 				},
 				[]*expectedNode{
 					{
-						name: personalDir,
+						name: personalID,
 						children: []*expectedNode{
 							{
 								name:     inboxFileName2,
@@ -1865,7 +1925,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 								data:     inboxFileData2,
 							},
 							{
-								name: personalDir,
+								name: personalID,
 								children: []*expectedNode{
 									{
 										name:     personalFileName1,
@@ -1878,7 +1938,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 								},
 							},
 							{
-								name: workDir,
+								name: workID,
 								children: []*expectedNode{
 									{
 										name:     workFileName1,
@@ -1899,8 +1959,8 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 		{
 			name: "NoMoveParentDeleteFileNoMergeSubtreeMerge",
 			inputCollections: func(t *testing.T) []data.BackupCollection {
-				inbox := mockconnector.NewMockExchangeCollection(inboxPath, 1)
-				inbox.PrevPath = inboxPath
+				inbox := mockconnector.NewMockExchangeCollection(inboxStorePath, inboxLocPath, 1)
+				inbox.PrevPath = inboxStorePath
 				inbox.ColState = data.NotMovedState
 				inbox.DoNotMerge = true
 				// First file in inbox is implicitly deleted as we're not merging items
@@ -1908,8 +1968,8 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 				inbox.Names[0] = inboxFileName2
 				inbox.Data[0] = inboxFileData2
 
-				work := mockconnector.NewMockExchangeCollection(workPath, 1)
-				work.PrevPath = workPath
+				work := mockconnector.NewMockExchangeCollection(workStorePath, workLocPath, 1)
+				work.PrevPath = workStorePath
 				work.ColState = data.NotMovedState
 				work.Names[0] = testFileName6
 				work.Data[0] = testFileData6
@@ -1925,7 +1985,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 				},
 				[]*expectedNode{
 					{
-						name: testInboxDir,
+						name: testInboxID,
 						children: []*expectedNode{
 							{
 								name:     inboxFileName2,
@@ -1933,7 +1993,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 								data:     inboxFileData2,
 							},
 							{
-								name: personalDir,
+								name: personalID,
 								children: []*expectedNode{
 									{
 										name:     personalFileName1,
@@ -1946,7 +2006,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 								},
 							},
 							{
-								name: workDir,
+								name: workID,
 								children: []*expectedNode{
 									{
 										name:     workFileName1,
@@ -1989,8 +2049,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 				},
 				test.inputCollections(t),
 				test.inputExcludes,
-				progress,
-			)
+				progress)
 			require.NoError(t, err)
 
 			expectTree(t, ctx, test.expected, dirTree)
@@ -2035,7 +2094,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSkipsDeletedSubtre
 			},
 			[]fs.Entry{
 				virtualfs.NewStaticDirectory(
-					encodeElements(testInboxDir)[0],
+					encodeElements(testInboxID)[0],
 					[]fs.Entry{
 						virtualfs.NewStaticDirectory(
 							encodeElements(personalDir)[0],
@@ -2060,7 +2119,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSkipsDeletedSubtre
 					},
 				),
 				virtualfs.NewStaticDirectory(
-					encodeElements(testArchiveDir)[0],
+					encodeElements(testArchiveID)[0],
 					[]fs.Entry{
 						virtualfs.NewStaticDirectory(
 							encodeElements(personalDir)[0],
@@ -2097,7 +2156,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSkipsDeletedSubtre
 		},
 		[]*expectedNode{
 			{
-				name: testArchiveDir,
+				name: testArchiveID,
 				children: []*expectedNode{
 					{
 						name: personalDir,
@@ -2126,7 +2185,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSkipsDeletedSubtre
 		pending: map[string]*itemDetails{},
 		errs:    fault.New(true),
 	}
-	mc := mockconnector.NewMockExchangeCollection(suite.testPath, 1)
+	mc := mockconnector.NewMockExchangeCollection(suite.testStoragePath, suite.testStoragePath, 1)
 	mc.PrevPath = mc.FullPath()
 	mc.ColState = data.DeletedState
 	msw := &mockSnapshotWalker{
@@ -2153,8 +2212,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSkipsDeletedSubtre
 		},
 		collections,
 		nil,
-		progress,
-	)
+		progress)
 	require.NoError(t, err)
 
 	expectTree(t, ctx, expected, dirTree)
@@ -2181,24 +2239,25 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSelectsCorrectSubt
 
 	const contactsDir = "contacts"
 
-	inboxPath := makePath(
-		suite.T(),
-		[]string{testTenant, service, testUser, category, testInboxDir},
-		false,
+	var (
+		inboxPath = makePath(
+			suite.T(),
+			[]string{testTenant, service, testUser, category, testInboxID},
+			false)
+
+		inboxFileName1 = testFileName
+		inboxFileName2 = testFileName2
+
+		inboxFileData1   = testFileData
+		inboxFileData1v2 = testFileData5
+		inboxFileData2   = testFileData2
+
+		contactsFileName1 = testFileName3
+		contactsFileData1 = testFileData3
+
+		eventsFileName1 = testFileName5
+		eventsFileData1 = testFileData
 	)
-
-	inboxFileName1 := testFileName
-	inboxFileName2 := testFileName2
-
-	inboxFileData1 := testFileData
-	inboxFileData1v2 := testFileData5
-	inboxFileData2 := testFileData2
-
-	contactsFileName1 := testFileName3
-	contactsFileData1 := testFileData3
-
-	eventsFileName1 := testFileName5
-	eventsFileData1 := testFileData
 
 	// Must be a function that returns a new instance each time as StreamingFile
 	// can only return its Reader once.
@@ -2224,7 +2283,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSelectsCorrectSubt
 					encodeElements(category)[0],
 					[]fs.Entry{
 						virtualfs.NewStaticDirectory(
-							encodeElements(testInboxDir)[0],
+							encodeElements(testInboxID)[0],
 							[]fs.Entry{
 								virtualfs.StreamingFileWithModTimeFromReader(
 									encodeElements(inboxFileName1)[0],
@@ -2278,7 +2337,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSelectsCorrectSubt
 					encodeElements(category)[0],
 					[]fs.Entry{
 						virtualfs.NewStaticDirectory(
-							encodeElements(testInboxDir)[0],
+							encodeElements(testInboxID)[0],
 							[]fs.Entry{
 								virtualfs.StreamingFileWithModTimeFromReader(
 									encodeElements(inboxFileName1)[0],
@@ -2341,7 +2400,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSelectsCorrectSubt
 				name: category,
 				children: []*expectedNode{
 					{
-						name: testInboxDir,
+						name: testInboxID,
 						children: []*expectedNode{
 							{
 								name:     inboxFileName1,
@@ -2379,7 +2438,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSelectsCorrectSubt
 		errs:    fault.New(true),
 	}
 
-	mc := mockconnector.NewMockExchangeCollection(inboxPath, 1)
+	mc := mockconnector.NewMockExchangeCollection(inboxPath, inboxPath, 1)
 	mc.PrevPath = mc.FullPath()
 	mc.ColState = data.NotMovedState
 	mc.Names[0] = inboxFileName2

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -114,6 +114,13 @@ type IncrementalBase struct {
 	SubtreePaths []*path.Builder
 }
 
+// PrevRefs hold the repoRef and locationRef from the items
+// that need to be merged in from prior snapshots.
+type PrevRefs struct {
+	Repo     path.Path
+	Location path.Path
+}
+
 // BackupCollections takes a set of collections and creates a kopia snapshot
 // with the data that they contain. previousSnapshots is used for incremental
 // backups and should represent the base snapshot from which metadata is sourced
@@ -128,7 +135,7 @@ func (w Wrapper) BackupCollections(
 	tags map[string]string,
 	buildTreeWithBase bool,
 	errs *fault.Errors,
-) (*BackupStats, *details.Builder, map[string]path.Path, error) {
+) (*BackupStats, *details.Builder, map[string]PrevRefs, error) {
 	if w.c == nil {
 		return nil, nil, nil, clues.Stack(errNotConnected).WithClues(ctx)
 	}
@@ -143,7 +150,7 @@ func (w Wrapper) BackupCollections(
 	progress := &corsoProgress{
 		pending: map[string]*itemDetails{},
 		deets:   &details.Builder{},
-		toMerge: map[string]path.Path{},
+		toMerge: map[string]PrevRefs{},
 		errs:    errs,
 	}
 

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -580,10 +580,11 @@ func mergeDetails(
 				newPath.String(),
 				newPath.ShortRef(),
 				newPath.ToBuilder().Dir().ShortRef(),
+				"", // TODO Location Ref,
 				itemUpdated,
 				item)
 
-			folders := details.FolderEntriesForPath(newPath.ToBuilder().Dir())
+			folders := details.FolderEntriesForPath(newPath.ToBuilder().Dir(), nil)
 			deets.AddFoldersForItem(folders, item, itemUpdated)
 
 			// Track how many entries we added so that we know if we got them all when

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -338,7 +338,7 @@ type backuper interface {
 		tags map[string]string,
 		buildTreeWithBase bool,
 		errs *fault.Errors,
-	) (*kopia.BackupStats, *details.Builder, map[string]path.Path, error)
+	) (*kopia.BackupStats, *details.Builder, map[string]kopia.PrevRefs, error)
 }
 
 func selectorToReasons(sel selectors.Selector) []kopia.Reason {
@@ -397,7 +397,7 @@ func consumeBackupDataCollections(
 	backupID model.StableID,
 	isIncremental bool,
 	errs *fault.Errors,
-) (*kopia.BackupStats, *details.Builder, map[string]path.Path, error) {
+) (*kopia.BackupStats, *details.Builder, map[string]kopia.PrevRefs, error) {
 	complete, closer := observe.MessageWithCompletion(ctx, observe.Safe("Backing up data"))
 	defer func() {
 		complete <- struct{}{}
@@ -503,7 +503,7 @@ func mergeDetails(
 	ms *store.Wrapper,
 	detailsStore detailsReader,
 	mans []*kopia.ManifestEntry,
-	shortRefsFromPrevBackup map[string]path.Path,
+	shortRefsFromPrevBackup map[string]kopia.PrevRefs,
 	deets *details.Builder,
 	errs *fault.Errors,
 ) error {
@@ -559,12 +559,15 @@ func mergeDetails(
 				continue
 			}
 
-			newPath := shortRefsFromPrevBackup[rr.ShortRef()]
-			if newPath == nil {
+			prev, ok := shortRefsFromPrevBackup[rr.ShortRef()]
+			if !ok {
 				// This entry was not sourced from a base snapshot or cached from a
 				// previous backup, skip it.
 				continue
 			}
+
+			newPath := prev.Repo
+			newLoc := prev.Location
 
 			// Fixup paths in the item.
 			item := entry.ItemInfo
@@ -574,17 +577,27 @@ func mergeDetails(
 
 			// TODO(ashmrtn): This may need updated if we start using this merge
 			// strategry for items that were cached in kopia.
-			itemUpdated := newPath.String() != rr.String()
+			var (
+				itemUpdated = newPath.String() != rr.String()
+				newLocStr   string
+				locBuilder  *path.Builder
+			)
+
+			if newLoc != nil {
+				locBuilder = newLoc.ToBuilder()
+				newLocStr = newLoc.Folder(true)
+				itemUpdated = itemUpdated || newLocStr != entry.LocationRef
+			}
 
 			deets.Add(
 				newPath.String(),
 				newPath.ShortRef(),
 				newPath.ToBuilder().Dir().ShortRef(),
-				"", // TODO Location Ref,
+				newLocStr,
 				itemUpdated,
 				item)
 
-			folders := details.FolderEntriesForPath(newPath.ToBuilder().Dir(), nil)
+			folders := details.FolderEntriesForPath(newPath.ToBuilder().Dir(), locBuilder)
 			deets.AddFoldersForItem(folders, item, itemUpdated)
 
 			// Track how many entries we added so that we know if we got them all when

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -402,7 +402,7 @@ func buildCollections(
 			c.pathFolders,
 			false)
 
-		mc := mockconnector.NewMockExchangeCollection(pth, len(c.items))
+		mc := mockconnector.NewMockExchangeCollection(pth, pth, len(c.items))
 
 		for i := 0; i < len(c.items); i++ {
 			mc.Names[i] = c.items[i].name

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -777,8 +777,8 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchangeIncrementals() {
 			p, err := path.FromDataLayerPath(dest.deets.Entries[0].RepoRef, true)
 			require.NoError(t, err)
 
-			id, ok := cr.PathInCache(p.Folder())
-			require.True(t, ok, "dir %s found in %s cache", p.Folder(), category)
+			id, ok := cr.PathInCache(p.Folder(false))
+			require.True(t, ok, "dir %s found in %s cache", p.Folder(false), category)
 
 			d := dataset[category].dests[destName]
 			d.containerID = id
@@ -895,8 +895,8 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchangeIncrementals() {
 					p, err := path.FromDataLayerPath(deets.Entries[0].RepoRef, true)
 					require.NoError(t, err)
 
-					id, ok := cr.PathInCache(p.Folder())
-					require.True(t, ok, "dir %s found in %s cache", p.Folder(), category)
+					id, ok := cr.PathInCache(p.Folder(false))
+					require.True(t, ok, "dir %s found in %s cache", p.Folder(false), category)
 
 					dataset[category].dests[container3] = contDeets{id, deets}
 				}

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -1256,8 +1256,12 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails_AddsFolders()
 		itemPath1 = makePath(
 			t,
 			pathElems,
-			true,
-		)
+			true)
+
+		locPath1 = makePath(
+			t,
+			pathElems[:len(pathElems)-1],
+			false)
 
 		backup1 = backup.Backup{
 			BaseModel: model.BaseModel{
@@ -1275,7 +1279,7 @@ func (suite *BackupOpSuite) TestBackupOperation_MergeBackupDetails_AddsFolders()
 		inputToMerge = map[string]kopia.PrevRefs{
 			itemPath1.ShortRef(): {
 				Repo:     itemPath1,
-				Location: itemPath1,
+				Location: locPath1,
 			},
 		}
 

--- a/src/internal/streamstore/streamstore_test.go
+++ b/src/internal/streamstore/streamstore_test.go
@@ -44,7 +44,7 @@ func (suite *StreamStoreIntegrationSuite) TestDetails() {
 
 	deetsBuilder := &details.Builder{}
 
-	deetsBuilder.Add("ref", "shortref", "parentref", true,
+	deetsBuilder.Add("ref", "shortref", "parentref", "locationRef", true,
 		details.ItemInfo{
 			Exchange: &details.ExchangeInfo{
 				Subject: "hello world",
@@ -66,6 +66,7 @@ func (suite *StreamStoreIntegrationSuite) TestDetails() {
 	assert.Equal(t, deets.Entries[0].ParentRef, readDeets.Entries[0].ParentRef)
 	assert.Equal(t, deets.Entries[0].ShortRef, readDeets.Entries[0].ShortRef)
 	assert.Equal(t, deets.Entries[0].RepoRef, readDeets.Entries[0].RepoRef)
+	assert.Equal(t, deets.Entries[0].LocationRef, readDeets.Entries[0].LocationRef)
 	assert.Equal(t, deets.Entries[0].Updated, readDeets.Entries[0].Updated)
 	assert.NotNil(t, readDeets.Entries[0].Exchange)
 	assert.Equal(t, *deets.Entries[0].Exchange, *readDeets.Entries[0].Exchange)

--- a/src/pkg/backup/backup.go
+++ b/src/pkg/backup/backup.go
@@ -14,7 +14,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/selectors"
 )
 
-const Version = 1
+const Version = 2
 
 // Backup represents the result of a backup operation
 type Backup struct {

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -141,13 +141,20 @@ func FolderEntriesForPath(parent, location *path.Builder) []folderEntry {
 	lfs := locationRefOf(location)
 
 	for len(parent.Elements()) > 0 {
-		nextParent := parent.Dir()
+		var (
+			nextParent = parent.Dir()
+			lr         string
+			dn         = parent.LastElem()
+		)
 
 		// TODO: We may have future cases where the storage hierarchy
 		// doesn't match the location hierarchy.
-		var lr string
 		if lfs != nil {
 			lr = lfs.String()
+
+			if len(lfs.Elements()) > 0 {
+				dn = lfs.LastElem()
+			}
 		}
 
 		folders = append(folders, folderEntry{
@@ -158,7 +165,7 @@ func FolderEntriesForPath(parent, location *path.Builder) []folderEntry {
 			Info: ItemInfo{
 				Folder: &FolderInfo{
 					ItemType:    FolderItem,
-					DisplayName: parent.Elements()[len(parent.Elements())-1],
+					DisplayName: dn,
 				},
 			},
 		})

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -143,6 +143,8 @@ func FolderEntriesForPath(parent, location *path.Builder) []folderEntry {
 	for len(parent.Elements()) > 0 {
 		nextParent := parent.Dir()
 
+		// TODO: We may have future cases where the storage hierarchy
+		// doesn't match the location hierarchy.
 		var lr string
 		if lfs != nil {
 			lr = lfs.String()
@@ -239,11 +241,12 @@ func (d *Details) add(
 	info ItemInfo,
 ) {
 	d.Entries = append(d.Entries, DetailsEntry{
-		RepoRef:   repoRef,
-		ShortRef:  shortRef,
-		ParentRef: parentRef,
-		Updated:   updated,
-		ItemInfo:  info,
+		RepoRef:     repoRef,
+		ShortRef:    shortRef,
+		ParentRef:   parentRef,
+		LocationRef: locationRef,
+		Updated:     updated,
+		ItemInfo:    info,
 	})
 }
 
@@ -363,18 +366,21 @@ const (
 	FolderItem ItemType = iota + 300
 )
 
-func UpdateItem(item *ItemInfo, newPath path.Path) error {
+func UpdateItem(item *ItemInfo, repoPath path.Path) error {
 	// Only OneDrive and SharePoint have information about parent folders
 	// contained in them.
+	var updatePath func(path.Path) error
+
 	switch item.infoType() {
 	case SharePointItem:
-		return item.SharePoint.UpdateParentPath(newPath)
-
+		updatePath = item.SharePoint.UpdateParentPath
 	case OneDriveItem:
-		return item.OneDrive.UpdateParentPath(newPath)
+		updatePath = item.OneDrive.UpdateParentPath
+	default:
+		return nil
 	}
 
-	return nil
+	return updatePath(repoPath)
 }
 
 // ItemInfo is a oneOf that contains service specific

--- a/src/pkg/backup/details/details_test.go
+++ b/src/pkg/backup/details/details_test.go
@@ -234,7 +234,7 @@ func (suite *DetailsUnitSuite) TestDetailsModel_Path() {
 					Entries: test.ents,
 				},
 			}
-			assert.Equal(t, test.expectRepoRefs, d.Paths())
+			assert.ElementsMatch(t, test.expectRepoRefs, d.Paths())
 		})
 	}
 }

--- a/src/pkg/backup/details/details_test.go
+++ b/src/pkg/backup/details/details_test.go
@@ -601,7 +601,8 @@ func (suite *DetailsUnitSuite) TestUpdateItem() {
 	table := []struct {
 		name         string
 		input        ItemInfo
-		newPath      path.Path
+		repoPath     path.Path
+		locPath      path.Path
 		errCheck     assert.ErrorAssertionFunc
 		expectedItem ItemInfo
 	}{
@@ -655,7 +656,8 @@ func (suite *DetailsUnitSuite) TestUpdateItem() {
 					ParentPath: folder1,
 				},
 			},
-			newPath:  newOneDrivePath,
+			repoPath: newOneDrivePath,
+			locPath:  newOneDrivePath,
 			errCheck: assert.NoError,
 			expectedItem: ItemInfo{
 				OneDrive: &OneDriveInfo{
@@ -672,7 +674,8 @@ func (suite *DetailsUnitSuite) TestUpdateItem() {
 					ParentPath: folder1,
 				},
 			},
-			newPath:  newOneDrivePath,
+			repoPath: newOneDrivePath,
+			locPath:  newOneDrivePath,
 			errCheck: assert.NoError,
 			expectedItem: ItemInfo{
 				SharePoint: &SharePointInfo{
@@ -689,7 +692,8 @@ func (suite *DetailsUnitSuite) TestUpdateItem() {
 					ParentPath: folder1,
 				},
 			},
-			newPath:  badOneDrivePath,
+			repoPath: badOneDrivePath,
+			locPath:  badOneDrivePath,
 			errCheck: assert.Error,
 		},
 		{
@@ -700,7 +704,8 @@ func (suite *DetailsUnitSuite) TestUpdateItem() {
 					ParentPath: folder1,
 				},
 			},
-			newPath:  badOneDrivePath,
+			repoPath: badOneDrivePath,
+			locPath:  badOneDrivePath,
 			errCheck: assert.Error,
 		},
 	}
@@ -708,7 +713,7 @@ func (suite *DetailsUnitSuite) TestUpdateItem() {
 	for _, test := range table {
 		suite.T().Run(test.name, func(t *testing.T) {
 			item := test.input
-			err := UpdateItem(&item, test.newPath)
+			err := UpdateItem(&item, test.repoPath)
 			test.errCheck(t, err)
 
 			if err != nil {

--- a/src/pkg/backup/details/details_test.go
+++ b/src/pkg/backup/details/details_test.go
@@ -39,8 +39,9 @@ func (suite *DetailsUnitSuite) TestDetailsEntry_HeadersValues() {
 		{
 			name: "no info",
 			entry: DetailsEntry{
-				RepoRef:  "reporef",
-				ShortRef: "deadbeef",
+				RepoRef:     "reporef",
+				ShortRef:    "deadbeef",
+				LocationRef: "locationref",
 			},
 			expectHs: []string{"ID"},
 			expectVs: []string{"deadbeef"},
@@ -48,8 +49,9 @@ func (suite *DetailsUnitSuite) TestDetailsEntry_HeadersValues() {
 		{
 			name: "exchange event info",
 			entry: DetailsEntry{
-				RepoRef:  "reporef",
-				ShortRef: "deadbeef",
+				RepoRef:     "reporef",
+				ShortRef:    "deadbeef",
+				LocationRef: "locationref",
 				ItemInfo: ItemInfo{
 					Exchange: &ExchangeInfo{
 						ItemType:    ExchangeEvent,
@@ -67,8 +69,9 @@ func (suite *DetailsUnitSuite) TestDetailsEntry_HeadersValues() {
 		{
 			name: "exchange contact info",
 			entry: DetailsEntry{
-				RepoRef:  "reporef",
-				ShortRef: "deadbeef",
+				RepoRef:     "reporef",
+				ShortRef:    "deadbeef",
+				LocationRef: "locationref",
 				ItemInfo: ItemInfo{
 					Exchange: &ExchangeInfo{
 						ItemType:    ExchangeContact,
@@ -82,8 +85,9 @@ func (suite *DetailsUnitSuite) TestDetailsEntry_HeadersValues() {
 		{
 			name: "exchange mail info",
 			entry: DetailsEntry{
-				RepoRef:  "reporef",
-				ShortRef: "deadbeef",
+				RepoRef:     "reporef",
+				ShortRef:    "deadbeef",
+				LocationRef: "locationref",
 				ItemInfo: ItemInfo{
 					Exchange: &ExchangeInfo{
 						ItemType: ExchangeMail,
@@ -99,8 +103,9 @@ func (suite *DetailsUnitSuite) TestDetailsEntry_HeadersValues() {
 		{
 			name: "sharepoint info",
 			entry: DetailsEntry{
-				RepoRef:  "reporef",
-				ShortRef: "deadbeef",
+				RepoRef:     "reporef",
+				ShortRef:    "deadbeef",
+				LocationRef: "locationref",
 				ItemInfo: ItemInfo{
 					SharePoint: &SharePointInfo{
 						ItemName:   "itemName",
@@ -128,8 +133,9 @@ func (suite *DetailsUnitSuite) TestDetailsEntry_HeadersValues() {
 		{
 			name: "oneDrive info",
 			entry: DetailsEntry{
-				RepoRef:  "reporef",
-				ShortRef: "deadbeef",
+				RepoRef:     "reporef",
+				ShortRef:    "deadbeef",
+				LocationRef: "locationref",
 				ItemInfo: ItemInfo{
 					OneDrive: &OneDriveInfo{
 						ItemName:   "itemName",
@@ -157,37 +163,57 @@ func (suite *DetailsUnitSuite) TestDetailsEntry_HeadersValues() {
 }
 
 var pathItemsTable = []struct {
-	name       string
-	ents       []DetailsEntry
-	expectRefs []string
+	name               string
+	ents               []DetailsEntry
+	expectRepoRefs     []string
+	expectLocationRefs []string
 }{
 	{
-		name:       "nil entries",
-		ents:       nil,
-		expectRefs: []string{},
+		name:               "nil entries",
+		ents:               nil,
+		expectRepoRefs:     []string{},
+		expectLocationRefs: []string{},
 	},
 	{
 		name: "single entry",
 		ents: []DetailsEntry{
-			{RepoRef: "abcde"},
+			{
+				RepoRef:     "abcde",
+				LocationRef: "locationref",
+			},
 		},
-		expectRefs: []string{"abcde"},
+		expectRepoRefs:     []string{"abcde"},
+		expectLocationRefs: []string{"locationref"},
 	},
 	{
 		name: "multiple entries",
 		ents: []DetailsEntry{
-			{RepoRef: "abcde"},
-			{RepoRef: "12345"},
+			{
+				RepoRef:     "abcde",
+				LocationRef: "locationref",
+			},
+			{
+				RepoRef:     "12345",
+				LocationRef: "locationref2",
+			},
 		},
-		expectRefs: []string{"abcde", "12345"},
+		expectRepoRefs:     []string{"abcde", "12345"},
+		expectLocationRefs: []string{"locationref", "locationref2"},
 	},
 	{
 		name: "multiple entries with folder",
 		ents: []DetailsEntry{
-			{RepoRef: "abcde"},
-			{RepoRef: "12345"},
 			{
-				RepoRef: "deadbeef",
+				RepoRef:     "abcde",
+				LocationRef: "locationref",
+			},
+			{
+				RepoRef:     "12345",
+				LocationRef: "locationref2",
+			},
+			{
+				RepoRef:     "deadbeef",
+				LocationRef: "locationref3",
 				ItemInfo: ItemInfo{
 					Folder: &FolderInfo{
 						DisplayName: "test folder",
@@ -195,7 +221,8 @@ var pathItemsTable = []struct {
 				},
 			},
 		},
-		expectRefs: []string{"abcde", "12345"},
+		expectRepoRefs:     []string{"abcde", "12345"},
+		expectLocationRefs: []string{"locationref", "locationref2"},
 	},
 }
 
@@ -207,7 +234,7 @@ func (suite *DetailsUnitSuite) TestDetailsModel_Path() {
 					Entries: test.ents,
 				},
 			}
-			assert.Equal(t, test.expectRefs, d.Paths())
+			assert.Equal(t, test.expectRepoRefs, d.Paths())
 		})
 	}
 }
@@ -222,10 +249,11 @@ func (suite *DetailsUnitSuite) TestDetailsModel_Items() {
 			}
 
 			ents := d.Items()
-			assert.Len(t, ents, len(test.expectRefs))
+			assert.Len(t, ents, len(test.expectRepoRefs))
 
 			for _, e := range ents {
-				assert.Contains(t, test.expectRefs, e.RepoRef)
+				assert.Contains(t, test.expectRepoRefs, e.RepoRef)
+				assert.Contains(t, test.expectLocationRefs, e.LocationRef)
 			}
 		})
 	}
@@ -253,9 +281,10 @@ func (suite *DetailsUnitSuite) TestDetails_AddFolders() {
 			name: "MultipleFolders",
 			folders: []folderEntry{
 				{
-					RepoRef:   "rr1",
-					ShortRef:  "sr1",
-					ParentRef: "pr1",
+					RepoRef:     "rr1",
+					ShortRef:    "sr1",
+					ParentRef:   "pr1",
+					LocationRef: "lr1",
 					Info: ItemInfo{
 						Folder: &FolderInfo{
 							Modified: folderTimeOlderThanItem,
@@ -263,9 +292,10 @@ func (suite *DetailsUnitSuite) TestDetails_AddFolders() {
 					},
 				},
 				{
-					RepoRef:   "rr2",
-					ShortRef:  "sr2",
-					ParentRef: "pr2",
+					RepoRef:     "rr2",
+					ShortRef:    "sr2",
+					ParentRef:   "pr2",
+					LocationRef: "lr2",
 					Info: ItemInfo{
 						Folder: &FolderInfo{
 							Modified: folderTimeNewerThanItem,
@@ -283,9 +313,10 @@ func (suite *DetailsUnitSuite) TestDetails_AddFolders() {
 			name: "MultipleFoldersWithRepeats",
 			folders: []folderEntry{
 				{
-					RepoRef:   "rr1",
-					ShortRef:  "sr1",
-					ParentRef: "pr1",
+					RepoRef:     "rr1",
+					ShortRef:    "sr1",
+					ParentRef:   "pr1",
+					LocationRef: "lr1",
 					Info: ItemInfo{
 						Folder: &FolderInfo{
 							Modified: folderTimeOlderThanItem,
@@ -293,9 +324,10 @@ func (suite *DetailsUnitSuite) TestDetails_AddFolders() {
 					},
 				},
 				{
-					RepoRef:   "rr2",
-					ShortRef:  "sr2",
-					ParentRef: "pr2",
+					RepoRef:     "rr2",
+					ShortRef:    "sr2",
+					ParentRef:   "pr2",
+					LocationRef: "lr2",
 					Info: ItemInfo{
 						Folder: &FolderInfo{
 							Modified: folderTimeOlderThanItem,
@@ -303,9 +335,10 @@ func (suite *DetailsUnitSuite) TestDetails_AddFolders() {
 					},
 				},
 				{
-					RepoRef:   "rr1",
-					ShortRef:  "sr1",
-					ParentRef: "pr1",
+					RepoRef:     "rr1",
+					ShortRef:    "sr1",
+					ParentRef:   "pr1",
+					LocationRef: "lr1",
 					Info: ItemInfo{
 						Folder: &FolderInfo{
 							Modified: folderTimeOlderThanItem,
@@ -313,9 +346,10 @@ func (suite *DetailsUnitSuite) TestDetails_AddFolders() {
 					},
 				},
 				{
-					RepoRef:   "rr3",
-					ShortRef:  "sr3",
-					ParentRef: "pr3",
+					RepoRef:     "rr3",
+					ShortRef:    "sr3",
+					ParentRef:   "pr3",
+					LocationRef: "lr3",
 					Info: ItemInfo{
 						Folder: &FolderInfo{
 							Modified: folderTimeNewerThanItem,
@@ -363,18 +397,20 @@ func (suite *DetailsUnitSuite) TestDetails_AddFoldersUpdate() {
 			name: "ItemNotUpdated_NoChange",
 			folders: []folderEntry{
 				{
-					RepoRef:   "rr1",
-					ShortRef:  "sr1",
-					ParentRef: "pr1",
+					RepoRef:     "rr1",
+					ShortRef:    "sr1",
+					ParentRef:   "pr1",
+					LocationRef: "lr1",
 					Info: ItemInfo{
 						Folder: &FolderInfo{},
 					},
 					Updated: true,
 				},
 				{
-					RepoRef:   "rr2",
-					ShortRef:  "sr2",
-					ParentRef: "pr2",
+					RepoRef:     "rr2",
+					ShortRef:    "sr2",
+					ParentRef:   "pr2",
+					LocationRef: "lr2",
 					Info: ItemInfo{
 						Folder: &FolderInfo{},
 					},
@@ -390,17 +426,19 @@ func (suite *DetailsUnitSuite) TestDetails_AddFoldersUpdate() {
 			name: "ItemUpdated",
 			folders: []folderEntry{
 				{
-					RepoRef:   "rr1",
-					ShortRef:  "sr1",
-					ParentRef: "pr1",
+					RepoRef:     "rr1",
+					ShortRef:    "sr1",
+					ParentRef:   "pr1",
+					LocationRef: "lr1",
 					Info: ItemInfo{
 						Folder: &FolderInfo{},
 					},
 				},
 				{
-					RepoRef:   "rr2",
-					ShortRef:  "sr2",
-					ParentRef: "pr2",
+					RepoRef:     "rr2",
+					ShortRef:    "sr2",
+					ParentRef:   "pr2",
+					LocationRef: "lr2",
 					Info: ItemInfo{
 						Folder: &FolderInfo{},
 					},
@@ -482,9 +520,10 @@ func (suite *DetailsUnitSuite) TestDetails_AddFoldersDifferentServices() {
 	for _, test := range table {
 		suite.T().Run(test.name, func(t *testing.T) {
 			folder := folderEntry{
-				RepoRef:   "rr1",
-				ShortRef:  "sr1",
-				ParentRef: "pr1",
+				RepoRef:     "rr1",
+				ShortRef:    "sr1",
+				ParentRef:   "pr1",
+				LocationRef: "lr1",
 				Info: ItemInfo{
 					Folder: &FolderInfo{},
 				},

--- a/src/pkg/path/onedrive.go
+++ b/src/pkg/path/onedrive.go
@@ -20,7 +20,7 @@ func ToOneDrivePath(p Path) (*DrivePath, error) {
 	if len(folders) < 3 {
 		return nil, clues.
 			New("folder path doesn't match expected format for OneDrive items").
-			With("path_folders", p.Folder())
+			With("path_folders", p.Folder(false))
 	}
 
 	return &DrivePath{DriveID: folders[1], Folders: folders[3:]}, nil

--- a/src/pkg/path/path.go
+++ b/src/pkg/path/path.go
@@ -140,6 +140,14 @@ func (pb Builder) UnescapeAndAppend(elements ...string) (*Builder, error) {
 	return res, nil
 }
 
+// SplitUnescapeAppend takes in an escaped string representing a directory
+// path, splits the string, and appends it to the current builder.
+func (pb Builder) SplitUnescapeAppend(s string) (*Builder, error) {
+	elems := Split(TrimTrailingSlash(s))
+
+	return pb.UnescapeAndAppend(elems...)
+}
+
 // Append creates a copy of this Builder and adds the given elements them to the
 // end of the new Builder. Elements are added in the order they are passed.
 func (pb Builder) Append(elements ...string) *Builder {

--- a/src/pkg/path/path.go
+++ b/src/pkg/path/path.go
@@ -86,7 +86,7 @@ type Path interface {
 	Category() CategoryType
 	Tenant() string
 	ResourceOwner() string
-	Folder() string
+	Folder(bool) string
 	Folders() []string
 	Item() string
 	// PopFront returns a Builder object with the first element (left-side)
@@ -253,11 +253,6 @@ func (pb Builder) ShortRef() string {
 // elements in the future.
 func (pb Builder) Elements() []string {
 	return append([]string{}, pb.elements...)
-}
-
-//nolint:unused
-func (pb Builder) join(start, end int) string {
-	return join(pb.elements[start:end])
 }
 
 func verifyInputValues(tenant, resourceOwner string) error {

--- a/src/pkg/path/path.go
+++ b/src/pkg/path/path.go
@@ -213,6 +213,14 @@ func (pb Builder) Dir() *Builder {
 	}
 }
 
+func (pb Builder) LastElem() string {
+	if len(pb.elements) == 0 {
+		return ""
+	}
+
+	return pb.elements[len(pb.elements)-1]
+}
+
 // String returns a string that contains all path elements joined together.
 // Elements of the path that need escaping are escaped.
 func (pb Builder) String() string {

--- a/src/pkg/path/resource_path.go
+++ b/src/pkg/path/resource_path.go
@@ -201,13 +201,20 @@ func (rp dataLayerResourcePath) lastFolderIdx() int {
 }
 
 // Folder returns the folder segment embedded in the dataLayerResourcePath.
-func (rp dataLayerResourcePath) Folder() string {
+func (rp dataLayerResourcePath) Folder(escape bool) string {
 	endIdx := rp.lastFolderIdx()
 	if endIdx == 4 {
 		return ""
 	}
 
-	return rp.Builder.join(4, endIdx)
+	fs := rp.Folders()
+
+	if !escape {
+		return join(fs)
+	}
+
+	// builder.String() will escape all individual elements.
+	return Builder{}.Append(fs...).String()
 }
 
 // Folders returns the individual folder elements embedded in the

--- a/src/pkg/path/resource_path_test.go
+++ b/src/pkg/path/resource_path_test.go
@@ -172,7 +172,7 @@ func (suite *DataLayerResourcePath) TestMailItemNoFolder() {
 			)
 			require.NoError(t, err)
 
-			assert.Empty(t, p.Folder())
+			assert.Empty(t, p.Folder(false))
 			assert.Empty(t, p.Folders())
 			assert.Equal(t, item, p.Item())
 		})
@@ -391,7 +391,7 @@ func (suite *DataLayerResourcePath) TestToExchangePathForCategory() {
 					assert.Equal(t, path.ExchangeService, p.Service())
 					assert.Equal(t, test.category, p.Category())
 					assert.Equal(t, testUser, p.ResourceOwner())
-					assert.Equal(t, strings.Join(m.expectedFolders, "/"), p.Folder())
+					assert.Equal(t, strings.Join(m.expectedFolders, "/"), p.Folder(false))
 					assert.Equal(t, m.expectedFolders, p.Folders())
 					assert.Equal(t, m.expectedItem, p.Item())
 				})
@@ -465,7 +465,7 @@ func (suite *PopulatedDataLayerResourcePath) TestFolder() {
 			assert.Equal(
 				t,
 				strings.Join(m.expectedFolders, "/"),
-				suite.paths[m.isItem].Folder(),
+				suite.paths[m.isItem].Folder(false),
 			)
 		})
 	}
@@ -525,7 +525,7 @@ func (suite *PopulatedDataLayerResourcePath) TestAppend() {
 						return
 					}
 
-					assert.Equal(t, test.expectedFolder, newPath.Folder())
+					assert.Equal(t, test.expectedFolder, newPath.Folder(false))
 					assert.Equal(t, test.expectedItem, newPath.Item())
 				})
 			}

--- a/src/pkg/selectors/exchange.go
+++ b/src/pkg/selectors/exchange.go
@@ -598,7 +598,7 @@ func (ec exchangeCategory) pathValues(p path.Path) map[categorizer]string {
 	}
 
 	return map[categorizer]string{
-		folderCat: p.Folder(),
+		folderCat: p.Folder(false),
 		itemCat:   p.Item(),
 	}
 }

--- a/src/pkg/selectors/exchange.go
+++ b/src/pkg/selectors/exchange.go
@@ -575,12 +575,12 @@ func (ec exchangeCategory) isLeaf() bool {
 	return ec == ec.leafCat()
 }
 
-// pathValues transforms a path to a map of identified properties.
+// pathValues transforms the two paths to maps of identified properties.
 //
 // Example:
 // [tenantID, service, userPN, category, mailFolder, mailID]
-// => {exchUser: userPN, exchMailFolder: mailFolder, exchMail: mailID}
-func (ec exchangeCategory) pathValues(p path.Path) map[categorizer]string {
+// => {exchMailFolder: mailFolder, exchMail: mailID}
+func (ec exchangeCategory) pathValues(repo, location path.Path) (map[categorizer]string, map[categorizer]string) {
 	var folderCat, itemCat categorizer
 
 	switch ec {
@@ -594,13 +594,24 @@ func (ec exchangeCategory) pathValues(p path.Path) map[categorizer]string {
 		folderCat, itemCat = ExchangeMailFolder, ExchangeMail
 
 	default:
-		return map[categorizer]string{}
+		return map[categorizer]string{}, map[categorizer]string{}
 	}
 
-	return map[categorizer]string{
-		folderCat: p.Folder(false),
-		itemCat:   p.Item(),
+	rv := map[categorizer]string{
+		folderCat: repo.Folder(false),
+		itemCat:   repo.Item(),
 	}
+
+	lv := map[categorizer]string{}
+
+	if location != nil {
+		lv = map[categorizer]string{
+			folderCat: location.Folder(false),
+			itemCat:   location.Item(),
+		}
+	}
+
+	return rv, lv
 }
 
 // pathKeys returns the path keys recognized by the receiver's leaf type.

--- a/src/pkg/selectors/exchange_test.go
+++ b/src/pkg/selectors/exchange_test.go
@@ -1262,13 +1262,10 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 			ctx, flush := tester.NewContext()
 			defer flush()
 
-			errs := mock.NewAdder()
-
 			sel := test.makeSelector()
-			results := sel.Reduce(ctx, test.deets, errs)
+			results := sel.Reduce(ctx, test.deets, fault.New(true))
 			paths := results.Paths()
 			assert.Equal(t, test.expect, paths)
-			assert.Empty(t, errs.Errs)
 		})
 	}
 }

--- a/src/pkg/selectors/exchange_test.go
+++ b/src/pkg/selectors/exchange_test.go
@@ -833,10 +833,6 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 		return deets
 	}
 
-	arr := func(s ...string) []string {
-		return s
-	}
-
 	table := []struct {
 		name         string
 		deets        *details.Details
@@ -861,7 +857,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Include(er.AllData())
 				return er
 			},
-			arr(contact),
+			[]string{contact},
 		},
 		{
 			"event only",
@@ -871,7 +867,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Include(er.AllData())
 				return er
 			},
-			arr(event),
+			[]string{event},
 		},
 		{
 			"mail only",
@@ -881,7 +877,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Include(er.AllData())
 				return er
 			},
-			arr(mail),
+			[]string{mail},
 		},
 		{
 			"all",
@@ -891,7 +887,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Include(er.AllData())
 				return er
 			},
-			arr(contact, event, mail),
+			[]string{contact, event, mail},
 		},
 		{
 			"only match contact",
@@ -901,7 +897,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Include(er.Contacts([]string{"cfld"}, []string{"cid"}))
 				return er
 			},
-			arr(contact),
+			[]string{contact},
 		},
 		{
 			"only match contactInSubFolder",
@@ -911,7 +907,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Include(er.ContactFolders([]string{"cfld1/cfld2"}))
 				return er
 			},
-			arr(contactInSubFolder),
+			[]string{contactInSubFolder},
 		},
 		{
 			"only match contactInSubFolder by prefix",
@@ -921,7 +917,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Include(er.ContactFolders([]string{"cfld1/cfld2"}, PrefixMatch()))
 				return er
 			},
-			arr(contactInSubFolder),
+			[]string{contactInSubFolder},
 		},
 		{
 			"only match contactInSubFolder by leaf folder",
@@ -931,7 +927,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Include(er.ContactFolders([]string{"cfld2"}))
 				return er
 			},
-			arr(contactInSubFolder),
+			[]string{contactInSubFolder},
 		},
 		{
 			"only match event",
@@ -941,7 +937,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Include(er.Events([]string{"ecld"}, []string{"eid"}))
 				return er
 			},
-			arr(event),
+			[]string{event},
 		},
 		{
 			"only match mail",
@@ -951,7 +947,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Include(er.Mails([]string{"mfld"}, []string{"mid"}))
 				return er
 			},
-			arr(mail),
+			[]string{mail},
 		},
 		{
 			"exclude contact",
@@ -962,7 +958,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Exclude(er.Contacts([]string{"cfld"}, []string{"cid"}))
 				return er
 			},
-			arr(event, mail),
+			[]string{event, mail},
 		},
 		{
 			"exclude event",
@@ -973,7 +969,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Exclude(er.Events([]string{"ecld"}, []string{"eid"}))
 				return er
 			},
-			arr(contact, mail),
+			[]string{contact, mail},
 		},
 		{
 			"exclude mail",
@@ -984,7 +980,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Exclude(er.Mails([]string{"mfld"}, []string{"mid"}))
 				return er
 			},
-			arr(contact, event),
+			[]string{contact, event},
 		},
 		{
 			"filter on mail subject",
@@ -1001,7 +997,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Filter(er.MailSubject("subj"))
 				return er
 			},
-			arr(mail),
+			[]string{mail},
 		},
 		{
 			"filter on mail subject multiple input categories",
@@ -1022,7 +1018,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Filter(er.MailSubject("subj"))
 				return er
 			},
-			arr(mail),
+			[]string{mail},
 		},
 	}
 	for _, test := range table {
@@ -1087,10 +1083,6 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 		return deets
 	}
 
-	arr := func(s ...string) []string {
-		return s
-	}
-
 	table := []struct {
 		name         string
 		deets        *details.Details
@@ -1115,7 +1107,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Include(er.AllData())
 				return er
 			},
-			arr(contact),
+			[]string{contact},
 		},
 		{
 			"event only",
@@ -1125,7 +1117,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Include(er.AllData())
 				return er
 			},
-			arr(event),
+			[]string{event},
 		},
 		{
 			"mail only",
@@ -1135,7 +1127,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Include(er.AllData())
 				return er
 			},
-			arr(mail),
+			[]string{mail},
 		},
 		{
 			"all",
@@ -1145,7 +1137,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Include(er.AllData())
 				return er
 			},
-			arr(contact, event, mail),
+			[]string{contact, event, mail},
 		},
 		{
 			"only match contact",
@@ -1155,7 +1147,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Include(er.Contacts([]string{contactLocation}, []string{"cid"}))
 				return er
 			},
-			arr(contact),
+			[]string{contact},
 		},
 		{
 			"only match event",
@@ -1165,7 +1157,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Include(er.Events([]string{eventLocation}, []string{"eid"}))
 				return er
 			},
-			arr(event),
+			[]string{event},
 		},
 		{
 			"only match mail",
@@ -1175,7 +1167,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Include(er.Mails([]string{mailLocation}, []string{"mid"}))
 				return er
 			},
-			arr(mail),
+			[]string{mail},
 		},
 		{
 			"exclude contact",
@@ -1186,7 +1178,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Exclude(er.Contacts([]string{contactLocation}, []string{"cid"}))
 				return er
 			},
-			arr(event, mail),
+			[]string{event, mail},
 		},
 		{
 			"exclude event",
@@ -1197,7 +1189,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Exclude(er.Events([]string{eventLocation}, []string{"eid"}))
 				return er
 			},
-			arr(contact, mail),
+			[]string{contact, mail},
 		},
 		{
 			"exclude mail",
@@ -1208,7 +1200,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Exclude(er.Mails([]string{mailLocation}, []string{"mid"}))
 				return er
 			},
-			arr(contact, event),
+			[]string{contact, event},
 		},
 		{
 			"filter on mail subject",
@@ -1225,7 +1217,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Filter(er.MailSubject("subj"))
 				return er
 			},
-			arr(mail),
+			[]string{mail},
 		},
 		{
 			"filter on mail subject multiple input categories",
@@ -1246,7 +1238,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Filter(er.MailSubject("subj"))
 				return er
 			},
-			arr(mail),
+			[]string{mail},
 		},
 	}
 	for _, test := range table {
@@ -1259,7 +1251,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 			sel := test.makeSelector()
 			results := sel.Reduce(ctx, test.deets, errs)
 			paths := results.Paths()
-			assert.Equal(t, test.expect, paths)
+			assert.ElementsMatch(t, test.expect, paths)
 			assert.Empty(t, errs.Errs)
 		})
 	}

--- a/src/pkg/selectors/exchange_test.go
+++ b/src/pkg/selectors/exchange_test.go
@@ -1038,6 +1038,233 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 	}
 }
 
+func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
+	var (
+		contact         = stubRepoRef(path.ExchangeService, path.ContactsCategory, "uid", "id5/id6", "cid")
+		contactLocation = "conts/my_cont"
+		event           = stubRepoRef(path.ExchangeService, path.EventsCategory, "uid", "id1/id2", "eid")
+		eventLocation   = "cal/my_cal"
+		mail            = stubRepoRef(path.ExchangeService, path.EmailCategory, "uid", "id3/id4", "mid")
+		mailLocation    = "inbx/my_mail"
+	)
+
+	makeDeets := func(refs ...string) *details.Details {
+		deets := &details.Details{
+			DetailsModel: details.DetailsModel{
+				Entries: []details.DetailsEntry{},
+			},
+		}
+
+		for _, r := range refs {
+			var (
+				location string
+				itype    = details.UnknownType
+			)
+
+			switch r {
+			case contact:
+				itype = details.ExchangeContact
+				location = contactLocation
+			case event:
+				itype = details.ExchangeEvent
+				location = eventLocation
+			case mail:
+				itype = details.ExchangeMail
+				location = mailLocation
+			}
+
+			deets.Entries = append(deets.Entries, details.DetailsEntry{
+				RepoRef:     r,
+				LocationRef: location,
+				ItemInfo: details.ItemInfo{
+					Exchange: &details.ExchangeInfo{
+						ItemType: itype,
+					},
+				},
+			})
+		}
+
+		return deets
+	}
+
+	arr := func(s ...string) []string {
+		return s
+	}
+
+	table := []struct {
+		name         string
+		deets        *details.Details
+		makeSelector func() *ExchangeRestore
+		expect       []string
+	}{
+		{
+			"no refs",
+			makeDeets(),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore(Any())
+				er.Include(er.AllData())
+				return er
+			},
+			[]string{},
+		},
+		{
+			"contact only",
+			makeDeets(contact),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore(Any())
+				er.Include(er.AllData())
+				return er
+			},
+			arr(contact),
+		},
+		{
+			"event only",
+			makeDeets(event),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore(Any())
+				er.Include(er.AllData())
+				return er
+			},
+			arr(event),
+		},
+		{
+			"mail only",
+			makeDeets(mail),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore(Any())
+				er.Include(er.AllData())
+				return er
+			},
+			arr(mail),
+		},
+		{
+			"all",
+			makeDeets(contact, event, mail),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore(Any())
+				er.Include(er.AllData())
+				return er
+			},
+			arr(contact, event, mail),
+		},
+		{
+			"only match contact",
+			makeDeets(contact, event, mail),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore([]string{"uid"})
+				er.Include(er.Contacts([]string{contactLocation}, []string{"cid"}))
+				return er
+			},
+			arr(contact),
+		},
+		{
+			"only match event",
+			makeDeets(contact, event, mail),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore([]string{"uid"})
+				er.Include(er.Events([]string{eventLocation}, []string{"eid"}))
+				return er
+			},
+			arr(event),
+		},
+		{
+			"only match mail",
+			makeDeets(contact, event, mail),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore([]string{"uid"})
+				er.Include(er.Mails([]string{mailLocation}, []string{"mid"}))
+				return er
+			},
+			arr(mail),
+		},
+		{
+			"exclude contact",
+			makeDeets(contact, event, mail),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore(Any())
+				er.Include(er.AllData())
+				er.Exclude(er.Contacts([]string{contactLocation}, []string{"cid"}))
+				return er
+			},
+			arr(event, mail),
+		},
+		{
+			"exclude event",
+			makeDeets(contact, event, mail),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore(Any())
+				er.Include(er.AllData())
+				er.Exclude(er.Events([]string{eventLocation}, []string{"eid"}))
+				return er
+			},
+			arr(contact, mail),
+		},
+		{
+			"exclude mail",
+			makeDeets(contact, event, mail),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore(Any())
+				er.Include(er.AllData())
+				er.Exclude(er.Mails([]string{mailLocation}, []string{"mid"}))
+				return er
+			},
+			arr(contact, event),
+		},
+		{
+			"filter on mail subject",
+			func() *details.Details {
+				ds := makeDeets(mail)
+				for i := range ds.Entries {
+					ds.Entries[i].Exchange.Subject = "has a subject"
+				}
+				return ds
+			}(),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore(Any())
+				er.Include(er.AllData())
+				er.Filter(er.MailSubject("subj"))
+				return er
+			},
+			arr(mail),
+		},
+		{
+			"filter on mail subject multiple input categories",
+			func() *details.Details {
+				mds := makeDeets(mail)
+				for i := range mds.Entries {
+					mds.Entries[i].Exchange.Subject = "has a subject"
+				}
+
+				ds := makeDeets(contact, event)
+				ds.Entries = append(ds.Entries, mds.Entries...)
+
+				return ds
+			}(),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore(Any())
+				er.Include(er.AllData())
+				er.Filter(er.MailSubject("subj"))
+				return er
+			},
+			arr(mail),
+		},
+	}
+	for _, test := range table {
+		suite.T().Run(test.name, func(t *testing.T) {
+			ctx, flush := tester.NewContext()
+			defer flush()
+
+			errs := mock.NewAdder()
+
+			sel := test.makeSelector()
+			results := sel.Reduce(ctx, test.deets, errs)
+			paths := results.Paths()
+			assert.Equal(t, test.expect, paths)
+			assert.Empty(t, errs.Errs)
+		})
+	}
+}
+
 func (suite *ExchangeSelectorSuite) TestScopesByCategory() {
 	var (
 		es       = NewExchangeRestore(Any())

--- a/src/pkg/selectors/exchange_test.go
+++ b/src/pkg/selectors/exchange_test.go
@@ -1452,17 +1452,17 @@ func (suite *ExchangeSelectorSuite) TestExchangeCategory_PathValues() {
 
 	contactPath := stubPath(t, "user", []string{"cfolder", "contactitem"}, path.ContactsCategory)
 	contactMap := map[categorizer]string{
-		ExchangeContactFolder: contactPath.Folder(),
+		ExchangeContactFolder: contactPath.Folder(false),
 		ExchangeContact:       contactPath.Item(),
 	}
 	eventPath := stubPath(t, "user", []string{"ecalendar", "eventitem"}, path.EventsCategory)
 	eventMap := map[categorizer]string{
-		ExchangeEventCalendar: eventPath.Folder(),
+		ExchangeEventCalendar: eventPath.Folder(false),
 		ExchangeEvent:         eventPath.Item(),
 	}
 	mailPath := stubPath(t, "user", []string{"mfolder", "mailitem"}, path.EmailCategory)
 	mailMap := map[categorizer]string{
-		ExchangeMailFolder: mailPath.Folder(),
+		ExchangeMailFolder: mailPath.Folder(false),
 		ExchangeMail:       mailPath.Item(),
 	}
 

--- a/src/pkg/selectors/exchange_test.go
+++ b/src/pkg/selectors/exchange_test.go
@@ -1083,6 +1083,10 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 		return deets
 	}
 
+	arr := func(s ...string) []string {
+		return s
+	}
+
 	table := []struct {
 		name         string
 		deets        *details.Details
@@ -1107,7 +1111,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Include(er.AllData())
 				return er
 			},
-			[]string{contact},
+			arr(contact),
 		},
 		{
 			"event only",
@@ -1117,7 +1121,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Include(er.AllData())
 				return er
 			},
-			[]string{event},
+			arr(event),
 		},
 		{
 			"mail only",
@@ -1127,7 +1131,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Include(er.AllData())
 				return er
 			},
-			[]string{mail},
+			arr(mail),
 		},
 		{
 			"all",
@@ -1137,7 +1141,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Include(er.AllData())
 				return er
 			},
-			[]string{contact, event, mail},
+			arr(contact, event, mail),
 		},
 		{
 			"only match contact",
@@ -1147,7 +1151,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Include(er.Contacts([]string{contactLocation}, []string{"cid"}))
 				return er
 			},
-			[]string{contact},
+			arr(contact),
 		},
 		{
 			"only match event",
@@ -1157,7 +1161,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Include(er.Events([]string{eventLocation}, []string{"eid"}))
 				return er
 			},
-			[]string{event},
+			arr(event),
 		},
 		{
 			"only match mail",
@@ -1167,7 +1171,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Include(er.Mails([]string{mailLocation}, []string{"mid"}))
 				return er
 			},
-			[]string{mail},
+			arr(mail),
 		},
 		{
 			"exclude contact",
@@ -1178,7 +1182,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Exclude(er.Contacts([]string{contactLocation}, []string{"cid"}))
 				return er
 			},
-			[]string{event, mail},
+			arr(event, mail),
 		},
 		{
 			"exclude event",
@@ -1189,7 +1193,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Exclude(er.Events([]string{eventLocation}, []string{"eid"}))
 				return er
 			},
-			[]string{contact, mail},
+			arr(contact, mail),
 		},
 		{
 			"exclude mail",
@@ -1200,7 +1204,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Exclude(er.Mails([]string{mailLocation}, []string{"mid"}))
 				return er
 			},
-			[]string{contact, event},
+			arr(contact, event),
 		},
 		{
 			"filter on mail subject",
@@ -1217,7 +1221,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Filter(er.MailSubject("subj"))
 				return er
 			},
-			[]string{mail},
+			arr(mail),
 		},
 		{
 			"filter on mail subject multiple input categories",
@@ -1238,7 +1242,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Filter(er.MailSubject("subj"))
 				return er
 			},
-			[]string{mail},
+			arr(mail),
 		},
 	}
 	for _, test := range table {
@@ -1251,7 +1255,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 			sel := test.makeSelector()
 			results := sel.Reduce(ctx, test.deets, errs)
 			paths := results.Paths()
-			assert.ElementsMatch(t, test.expect, paths)
+			assert.Equal(t, test.expect, paths)
 			assert.Empty(t, errs.Errs)
 		})
 	}

--- a/src/pkg/selectors/helpers_test.go
+++ b/src/pkg/selectors/helpers_test.go
@@ -55,11 +55,13 @@ func (mc mockCategorizer) isLeaf() bool {
 	return mc == leafCatStub
 }
 
-func (mc mockCategorizer) pathValues(pth path.Path) map[categorizer]string {
-	return map[categorizer]string{
+func (mc mockCategorizer) pathValues(repo, location path.Path) (map[categorizer]string, map[categorizer]string) {
+	pv := map[categorizer]string{
 		rootCatStub: "root",
 		leafCatStub: "leaf",
 	}
+
+	return pv, pv
 }
 
 func (mc mockCategorizer) pathKeys() []categorizer {

--- a/src/pkg/selectors/onedrive.go
+++ b/src/pkg/selectors/onedrive.go
@@ -371,19 +371,30 @@ func (c oneDriveCategory) isLeaf() bool {
 	return c == OneDriveItem
 }
 
-// pathValues transforms a path to a map of identified properties.
+// pathValues transforms the two paths to maps of identified properties.
 //
 // Example:
 // [tenantID, service, userPN, category, folder, fileID]
-// => {odUser: userPN, odFolder: folder, odFileID: fileID}
-func (c oneDriveCategory) pathValues(p path.Path) map[categorizer]string {
+// => {odFolder: folder, odFileID: fileID}
+func (c oneDriveCategory) pathValues(repo, location path.Path) (map[categorizer]string, map[categorizer]string) {
 	// Ignore `drives/<driveID>/root:` for folder comparison
-	folder := path.Builder{}.Append(p.Folders()...).PopFront().PopFront().PopFront().String()
-
-	return map[categorizer]string{
-		OneDriveFolder: folder,
-		OneDriveItem:   p.Item(),
+	rFld := path.Builder{}.Append(repo.Folders()...).PopFront().PopFront().PopFront().String()
+	rv := map[categorizer]string{
+		OneDriveFolder: rFld,
+		OneDriveItem:   repo.Item(),
 	}
+
+	lv := map[categorizer]string{}
+
+	if location != nil {
+		lFld := path.Builder{}.Append(location.Folders()...).PopFront().PopFront().PopFront().String()
+		lv = map[categorizer]string{
+			OneDriveFolder: lFld,
+			OneDriveItem:   location.Item(),
+		}
+	}
+
+	return rv, lv
 }
 
 // pathKeys returns the path keys recognized by the receiver's leaf type.

--- a/src/pkg/selectors/onedrive_test.go
+++ b/src/pkg/selectors/onedrive_test.go
@@ -262,7 +262,9 @@ func (suite *OneDriveSelectorSuite) TestOneDriveCategory_PathValues() {
 		OneDriveItem:   "file",
 	}
 
-	assert.Equal(t, expected, OneDriveItem.pathValues(filePath))
+	r, l := OneDriveItem.pathValues(filePath, filePath)
+	assert.Equal(t, expected, r)
+	assert.Equal(t, expected, l)
 }
 
 func (suite *OneDriveSelectorSuite) TestOneDriveScope_MatchesInfo() {

--- a/src/pkg/selectors/scopes.go
+++ b/src/pkg/selectors/scopes.go
@@ -77,17 +77,18 @@ type (
 		// eg: in a resourceOwner/folder/item structure, the item is the leaf.
 		isLeaf() bool
 
-		// pathValues should produce a map of category:string pairs populated by extracting
-		// values out of the path.Path struct.
+		// pathValues takes in two paths, both variants of the repoRef, one containing the standard
+		// repoRef, and the other amended to include the locationRef directories (if available).  It
+		// should produce two maps of category:string pairs populated by extracting the values out of
+		// each path.Path.
 		//
 		// Ex: given a path builder like ["tenant", "service", "resource", "dataType", "folder", "itemID"],
 		// the func should use the path to construct a map similar to this:
 		// {
-		//   rootCat:   resource,
 		//   folderCat: folder,
 		//   itemCat:   itemID,
 		// }
-		pathValues(path.Path) map[categorizer]string
+		pathValues(path.Path, path.Path) (map[categorizer]string, map[categorizer]string)
 
 		// pathKeys produces a list of categorizers that can be used as keys in the pathValues
 		// map.  The combination of the two funcs generically interprets the context of the
@@ -317,6 +318,8 @@ func reduce[T scopeT, C categoryT](
 			continue
 		}
 
+		var locationPath path.Path
+
 		// if the details entry has a locationRef specified, use those folders in place
 		// of the repoRef folders, so that scopes can match against the display names
 		// instead of container IDs.
@@ -327,7 +330,7 @@ func reduce[T scopeT, C categoryT](
 				continue
 			}
 
-			lp, err := pb.Append(repoPath.Item()).
+			locationPath, err = pb.Append(repoPath.Item()).
 				ToDataLayerPath(
 					repoPath.Tenant(),
 					repoPath.ResourceOwner(),
@@ -338,8 +341,6 @@ func reduce[T scopeT, C categoryT](
 				errs.Add(clues.Wrap(err, "transforming locationRef to path").WithClues(ctx))
 				continue
 			}
-
-			repoPath = lp
 		}
 
 		// first check, every entry needs to match the selector's resource owners.
@@ -359,7 +360,9 @@ func reduce[T scopeT, C categoryT](
 			continue
 		}
 
-		passed := passes(dc, dc.pathValues(repoPath), *ent, e, f, i)
+		rv, lv := dc.pathValues(repoPath, locationPath)
+
+		passed := passes(dc, rv, lv, *ent, e, f, i)
 		if passed {
 			ents = append(ents, *ent)
 		}
@@ -404,7 +407,7 @@ func scopesByCategory[T scopeT, C categoryT](
 // if the path is included, passes filters, and not excluded.
 func passes[T scopeT, C categoryT](
 	cat C,
-	pathValues map[categorizer]string,
+	repoValues, locationValues map[categorizer]string,
 	entry details.DetailsEntry,
 	excs, filts, incs []T,
 ) bool {
@@ -420,7 +423,7 @@ func passes[T scopeT, C categoryT](
 		var included bool
 
 		for _, inc := range incs {
-			if matchesEntry(inc, cat, pathValues, entry) {
+			if matchesEntry(inc, cat, repoValues, locationValues, entry) {
 				included = true
 				break
 			}
@@ -433,14 +436,14 @@ func passes[T scopeT, C categoryT](
 
 	// all filters must pass
 	for _, filt := range filts {
-		if !matchesEntry(filt, cat, pathValues, entry) {
+		if !matchesEntry(filt, cat, repoValues, locationValues, entry) {
 			return false
 		}
 	}
 
 	// any matching exclusion means failure
 	for _, exc := range excs {
-		if matchesEntry(exc, cat, pathValues, entry) {
+		if matchesEntry(exc, cat, repoValues, locationValues, entry) {
 			return false
 		}
 	}
@@ -453,7 +456,7 @@ func passes[T scopeT, C categoryT](
 func matchesEntry[T scopeT, C categoryT](
 	sc T,
 	cat C,
-	pathValues map[categorizer]string,
+	repoValues, locationValues map[categorizer]string,
 	entry details.DetailsEntry,
 ) bool {
 	// filterCategory requires matching against service-specific info values
@@ -461,7 +464,11 @@ func matchesEntry[T scopeT, C categoryT](
 		return sc.matchesInfo(entry.ItemInfo)
 	}
 
-	return matchesPathValues(sc, cat, pathValues, entry.ShortRef)
+	if len(locationValues) > 0 && matchesPathValues(sc, cat, locationValues, entry.ShortRef) {
+		return true
+	}
+
+	return matchesPathValues(sc, cat, repoValues, entry.ShortRef)
 }
 
 // matchesPathValues will check whether the pathValues have matching entries

--- a/src/pkg/selectors/scopes.go
+++ b/src/pkg/selectors/scopes.go
@@ -321,9 +321,13 @@ func reduce[T scopeT, C categoryT](
 		// of the repoRef folders, so that scopes can match against the display names
 		// instead of container IDs.
 		if len(ent.LocationRef) > 0 {
-			pb, err := path.Builder{}.
-				Append(path.Split(ent.LocationRef)...).
-				Append(repoPath.Item()).
+			pb, err := path.Builder{}.SplitUnescapeAppend(ent.LocationRef)
+			if err != nil {
+				errs.Add(clues.Wrap(err, "transforming locationRef to path").WithClues(ctx))
+				continue
+			}
+
+			lp, err := pb.Append(repoPath.Item()).
 				ToDataLayerPath(
 					repoPath.Tenant(),
 					repoPath.ResourceOwner(),
@@ -335,7 +339,7 @@ func reduce[T scopeT, C categoryT](
 				continue
 			}
 
-			repoPath = pb
+			repoPath = lp
 		}
 
 		// first check, every entry needs to match the selector's resource owners.

--- a/src/pkg/selectors/scopes_test.go
+++ b/src/pkg/selectors/scopes_test.go
@@ -318,17 +318,14 @@ func (suite *SelectorScopesSuite) TestReduce_locationRef() {
 			ctx, flush := tester.NewContext()
 			defer flush()
 
-			errs := mock.NewAdder()
-
 			ds := deets()
 			result := reduce[mockScope](
 				ctx,
 				&ds,
 				test.sel().Selector,
 				dataCats,
-				errs)
+				fault.New(true))
 			require.NotNil(t, result)
-			require.Empty(t, errs.Errs, "iteration errors")
 			assert.Len(t, result.Entries, test.expectLen)
 		})
 	}

--- a/src/pkg/selectors/scopes_test.go
+++ b/src/pkg/selectors/scopes_test.go
@@ -353,7 +353,7 @@ func (suite *SelectorScopesSuite) TestScopesByCategory() {
 func (suite *SelectorScopesSuite) TestPasses() {
 	cat := rootCatStub
 	pth := stubPath(suite.T(), "uid", []string{"fld"}, path.EventsCategory)
-	pathVals := cat.pathValues(pth)
+	repoVals, locVals := cat.pathValues(pth, pth)
 	entry := details.DetailsEntry{}
 
 	for _, test := range reduceTestTable {
@@ -364,7 +364,8 @@ func (suite *SelectorScopesSuite) TestPasses() {
 			incl := toMockScope(sel.Includes)
 			result := passes(
 				cat,
-				pathVals,
+				repoVals,
+				locVals,
 				entry,
 				excl, filt, incl)
 			test.expectPasses(t, result)

--- a/src/pkg/selectors/scopes_test.go
+++ b/src/pkg/selectors/scopes_test.go
@@ -290,6 +290,50 @@ func (suite *SelectorScopesSuite) TestReduce() {
 	}
 }
 
+func (suite *SelectorScopesSuite) TestReduce_locationRef() {
+	deets := func() details.Details {
+		return details.Details{
+			DetailsModel: details.DetailsModel{
+				Entries: []details.DetailsEntry{
+					{
+						RepoRef: stubRepoRef(
+							pathServiceStub,
+							pathCatStub,
+							rootCatStub.String(),
+							"stub",
+							leafCatStub.String(),
+						),
+						LocationRef: "a/b/c//defg",
+					},
+				},
+			},
+		}
+	}
+	dataCats := map[path.CategoryType]mockCategorizer{
+		pathCatStub: rootCatStub,
+	}
+
+	for _, test := range reduceTestTable {
+		suite.T().Run(test.name, func(t *testing.T) {
+			ctx, flush := tester.NewContext()
+			defer flush()
+
+			errs := mock.NewAdder()
+
+			ds := deets()
+			result := reduce[mockScope](
+				ctx,
+				&ds,
+				test.sel().Selector,
+				dataCats,
+				errs)
+			require.NotNil(t, result)
+			require.Empty(t, errs.Errs, "iteration errors")
+			assert.Len(t, result.Entries, test.expectLen)
+		})
+	}
+}
+
 func (suite *SelectorScopesSuite) TestScopesByCategory() {
 	t := suite.T()
 	s1 := stubScope("")

--- a/src/pkg/selectors/selectors_reduce_test.go
+++ b/src/pkg/selectors/selectors_reduce_test.go
@@ -48,7 +48,7 @@ func (suite *SelectorReduceSuite) TestReduce() {
 			selFunc: func() selectors.Reducer {
 				sel := selectors.NewExchangeRestore(selectors.Any())
 				sel.Include(sel.MailFolders(
-					[]string{testdata.ExchangeEmailInboxPath.Folder()},
+					[]string{testdata.ExchangeEmailInboxPath.Folder(false)},
 				))
 
 				return sel
@@ -177,7 +177,7 @@ func (suite *SelectorReduceSuite) TestReduce() {
 			selFunc: func() selectors.Reducer {
 				sel := selectors.NewExchangeRestore(selectors.Any())
 				sel.Include(sel.MailFolders(
-					[]string{testdata.ExchangeEmailBasePath.Folder()},
+					[]string{testdata.ExchangeEmailBasePath.Folder(false)},
 				))
 
 				return sel
@@ -192,7 +192,7 @@ func (suite *SelectorReduceSuite) TestReduce() {
 			selFunc: func() selectors.Reducer {
 				sel := selectors.NewExchangeRestore(selectors.Any())
 				sel.Include(sel.MailFolders(
-					[]string{testdata.ExchangeEmailBasePath.Folder()},
+					[]string{testdata.ExchangeEmailBasePath.Folder(false)},
 					selectors.PrefixMatch(), // force prefix matching
 				))
 
@@ -205,7 +205,7 @@ func (suite *SelectorReduceSuite) TestReduce() {
 			selFunc: func() selectors.Reducer {
 				sel := selectors.NewExchangeRestore(selectors.Any())
 				sel.Include(sel.MailFolders(
-					[]string{testdata.ExchangeEmailInboxPath.Folder()},
+					[]string{testdata.ExchangeEmailInboxPath.Folder(false)},
 				))
 
 				return sel
@@ -217,7 +217,7 @@ func (suite *SelectorReduceSuite) TestReduce() {
 			selFunc: func() selectors.Reducer {
 				sel := selectors.NewExchangeRestore(selectors.Any())
 				sel.Include(sel.ContactFolders(
-					[]string{testdata.ExchangeContactsBasePath.Folder()},
+					[]string{testdata.ExchangeContactsBasePath.Folder(false)},
 				))
 
 				return sel
@@ -229,7 +229,7 @@ func (suite *SelectorReduceSuite) TestReduce() {
 			selFunc: func() selectors.Reducer {
 				sel := selectors.NewExchangeRestore(selectors.Any())
 				sel.Include(sel.ContactFolders(
-					[]string{testdata.ExchangeContactsRootPath.Folder()},
+					[]string{testdata.ExchangeContactsRootPath.Folder(false)},
 				))
 
 				return sel
@@ -242,7 +242,7 @@ func (suite *SelectorReduceSuite) TestReduce() {
 			selFunc: func() selectors.Reducer {
 				sel := selectors.NewExchangeRestore(selectors.Any())
 				sel.Include(sel.EventCalendars(
-					[]string{testdata.ExchangeEventsBasePath.Folder()},
+					[]string{testdata.ExchangeEventsBasePath.Folder(false)},
 				))
 
 				return sel
@@ -254,7 +254,7 @@ func (suite *SelectorReduceSuite) TestReduce() {
 			selFunc: func() selectors.Reducer {
 				sel := selectors.NewExchangeRestore(selectors.Any())
 				sel.Include(sel.EventCalendars(
-					[]string{testdata.ExchangeEventsRootPath.Folder()},
+					[]string{testdata.ExchangeEventsRootPath.Folder(false)},
 				))
 
 				return sel

--- a/src/pkg/selectors/sharepoint.go
+++ b/src/pkg/selectors/sharepoint.go
@@ -443,7 +443,7 @@ func (c sharePointCategory) pathValues(p path.Path) map[categorizer]string {
 	}
 
 	return map[categorizer]string{
-		folderCat: p.Folder(),
+		folderCat: p.Folder(false),
 		itemCat:   p.Item(),
 	}
 }

--- a/src/pkg/selectors/sharepoint.go
+++ b/src/pkg/selectors/sharepoint.go
@@ -423,12 +423,12 @@ func (c sharePointCategory) isLeaf() bool {
 	return c == c.leafCat()
 }
 
-// pathValues transforms a path to a map of identified properties.
+// pathValues transforms the two paths to maps of identified properties.
 //
 // Example:
 // [tenantID, service, siteID, category, folder, itemID]
-// => {spSite: siteID, spFolder: folder, spItemID: itemID}
-func (c sharePointCategory) pathValues(p path.Path) map[categorizer]string {
+// => {spFolder: folder, spItemID: itemID}
+func (c sharePointCategory) pathValues(repo, location path.Path) (map[categorizer]string, map[categorizer]string) {
 	var folderCat, itemCat categorizer
 
 	switch c {
@@ -439,13 +439,24 @@ func (c sharePointCategory) pathValues(p path.Path) map[categorizer]string {
 	case SharePointPage, SharePointPageFolder:
 		folderCat, itemCat = SharePointPageFolder, SharePointPage
 	default:
-		return map[categorizer]string{}
+		return map[categorizer]string{}, map[categorizer]string{}
 	}
 
-	return map[categorizer]string{
-		folderCat: p.Folder(false),
-		itemCat:   p.Item(),
+	rv := map[categorizer]string{
+		folderCat: repo.Folder(false),
+		itemCat:   repo.Item(),
 	}
+
+	lv := map[categorizer]string{}
+
+	if location != nil {
+		lv = map[categorizer]string{
+			folderCat: location.Folder(false),
+			itemCat:   location.Item(),
+		}
+	}
+
+	return rv, lv
 }
 
 // pathKeys returns the path keys recognized by the receiver's leaf type.

--- a/src/pkg/selectors/sharepoint_test.go
+++ b/src/pkg/selectors/sharepoint_test.go
@@ -346,10 +346,11 @@ func (suite *SharePointSelectorSuite) TestSharePointCategory_PathValues() {
 				"tenant",
 				"site",
 				test.sc.PathType(),
-				true,
-			)
+				true)
 			require.NoError(t, err)
-			assert.Equal(t, test.expected, test.sc.pathValues(itemPath))
+			r, l := test.sc.pathValues(itemPath, itemPath)
+			assert.Equal(t, test.expected, r)
+			assert.Equal(t, test.expected, l)
 		})
 	}
 }


### PR DESCRIPTION
## Description

Adds a new reference to the details ent: location-
ref.  The location holds the human-readable
version of the item's location in whatever m365
service sourced the item.  Hookup is incomplete,
following PRs will fill out functionality.

Also adds a LocationPather interface to data_
collections to pass this data back and forth
between producers and consumers.

Should be safe to merge into main.

## Does this PR need a docs update or release note?

- [x] :clock1: Yes, but in a later PR

## Type of change

- [x] :sunflower: Feature
- [x] :bug: Bugfix

## Issue(s)

* #2423

## Test Plan

- [x] :zap: Unit test
