### PR TITLE
use locationRef in reduce when available

### DIFF
--- a/src/pkg/path/path.go
+++ b/src/pkg/path/path.go
@@ -140,6 +140,14 @@ func (pb Builder) UnescapeAndAppend(elements ...string) (*Builder, error) {
 	return res, nil
 }
 
+// SplitUnescapeAppend takes in an escaped string representing a directory
+// path, splits the string, and appends it to the current builder.
+func (pb Builder) SplitUnescapeAppend(s string) (*Builder, error) {
+	elems := Split(TrimTrailingSlash(s))
+
+	return pb.UnescapeAndAppend(elems...)
+}
+
 // Append creates a copy of this Builder and adds the given elements them to the
 // end of the new Builder. Elements are added in the order they are passed.
 func (pb Builder) Append(elements ...string) *Builder {

--- a/src/pkg/selectors/exchange_test.go
+++ b/src/pkg/selectors/exchange_test.go
@@ -833,10 +833,6 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 		return deets
 	}
 
-	arr := func(s ...string) []string {
-		return s
-	}
-
 	table := []struct {
 		name         string
 		deets        *details.Details
@@ -861,7 +857,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Include(er.AllData())
 				return er
 			},
-			arr(contact),
+			[]string{contact},
 		},
 		{
 			"event only",
@@ -871,7 +867,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Include(er.AllData())
 				return er
 			},
-			arr(event),
+			[]string{event},
 		},
 		{
 			"mail only",
@@ -881,7 +877,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Include(er.AllData())
 				return er
 			},
-			arr(mail),
+			[]string{mail},
 		},
 		{
 			"all",
@@ -891,7 +887,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Include(er.AllData())
 				return er
 			},
-			arr(contact, event, mail),
+			[]string{contact, event, mail},
 		},
 		{
 			"only match contact",
@@ -901,7 +897,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Include(er.Contacts([]string{"cfld"}, []string{"cid"}))
 				return er
 			},
-			arr(contact),
+			[]string{contact},
 		},
 		{
 			"only match contactInSubFolder",
@@ -911,7 +907,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Include(er.ContactFolders([]string{"cfld1/cfld2"}))
 				return er
 			},
-			arr(contactInSubFolder),
+			[]string{contactInSubFolder},
 		},
 		{
 			"only match contactInSubFolder by prefix",
@@ -921,7 +917,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Include(er.ContactFolders([]string{"cfld1/cfld2"}, PrefixMatch()))
 				return er
 			},
-			arr(contactInSubFolder),
+			[]string{contactInSubFolder},
 		},
 		{
 			"only match contactInSubFolder by leaf folder",
@@ -931,7 +927,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Include(er.ContactFolders([]string{"cfld2"}))
 				return er
 			},
-			arr(contactInSubFolder),
+			[]string{contactInSubFolder},
 		},
 		{
 			"only match event",
@@ -941,7 +937,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Include(er.Events([]string{"ecld"}, []string{"eid"}))
 				return er
 			},
-			arr(event),
+			[]string{event},
 		},
 		{
 			"only match mail",
@@ -951,7 +947,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Include(er.Mails([]string{"mfld"}, []string{"mid"}))
 				return er
 			},
-			arr(mail),
+			[]string{mail},
 		},
 		{
 			"exclude contact",
@@ -962,7 +958,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Exclude(er.Contacts([]string{"cfld"}, []string{"cid"}))
 				return er
 			},
-			arr(event, mail),
+			[]string{event, mail},
 		},
 		{
 			"exclude event",
@@ -973,7 +969,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Exclude(er.Events([]string{"ecld"}, []string{"eid"}))
 				return er
 			},
-			arr(contact, mail),
+			[]string{contact, mail},
 		},
 		{
 			"exclude mail",
@@ -984,7 +980,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Exclude(er.Mails([]string{"mfld"}, []string{"mid"}))
 				return er
 			},
-			arr(contact, event),
+			[]string{contact, event},
 		},
 		{
 			"filter on mail subject",
@@ -1001,7 +997,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Filter(er.MailSubject("subj"))
 				return er
 			},
-			arr(mail),
+			[]string{mail},
 		},
 		{
 			"filter on mail subject multiple input categories",
@@ -1022,7 +1018,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 				er.Filter(er.MailSubject("subj"))
 				return er
 			},
-			arr(mail),
+			[]string{mail},
 		},
 	}
 	for _, test := range table {
@@ -1090,10 +1086,6 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 		return deets
 	}
 
-	arr := func(s ...string) []string {
-		return s
-	}
-
 	table := []struct {
 		name         string
 		deets        *details.Details
@@ -1118,7 +1110,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Include(er.AllData())
 				return er
 			},
-			arr(contact),
+			[]string{contact},
 		},
 		{
 			"event only",
@@ -1128,7 +1120,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Include(er.AllData())
 				return er
 			},
-			arr(event),
+			[]string{event},
 		},
 		{
 			"mail only",
@@ -1138,7 +1130,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Include(er.AllData())
 				return er
 			},
-			arr(mail),
+			[]string{mail},
 		},
 		{
 			"all",
@@ -1148,7 +1140,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Include(er.AllData())
 				return er
 			},
-			arr(contact, event, mail),
+			[]string{contact, event, mail},
 		},
 		{
 			"only match contact",
@@ -1158,7 +1150,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Include(er.Contacts([]string{contactLocation}, []string{"cid"}))
 				return er
 			},
-			arr(contact),
+			[]string{contact},
 		},
 		{
 			"only match event",
@@ -1168,7 +1160,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Include(er.Events([]string{eventLocation}, []string{"eid"}))
 				return er
 			},
-			arr(event),
+			[]string{event},
 		},
 		{
 			"only match mail",
@@ -1178,7 +1170,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Include(er.Mails([]string{mailLocation}, []string{"mid"}))
 				return er
 			},
-			arr(mail),
+			[]string{mail},
 		},
 		{
 			"exclude contact",
@@ -1189,7 +1181,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Exclude(er.Contacts([]string{contactLocation}, []string{"cid"}))
 				return er
 			},
-			arr(event, mail),
+			[]string{event, mail},
 		},
 		{
 			"exclude event",
@@ -1200,7 +1192,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Exclude(er.Events([]string{eventLocation}, []string{"eid"}))
 				return er
 			},
-			arr(contact, mail),
+			[]string{contact, mail},
 		},
 		{
 			"exclude mail",
@@ -1211,7 +1203,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Exclude(er.Mails([]string{mailLocation}, []string{"mid"}))
 				return er
 			},
-			arr(contact, event),
+			[]string{contact, event},
 		},
 		{
 			"filter on mail subject",
@@ -1228,7 +1220,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Filter(er.MailSubject("subj"))
 				return er
 			},
-			arr(mail),
+			[]string{mail},
 		},
 		{
 			"filter on mail subject multiple input categories",
@@ -1249,7 +1241,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 				er.Filter(er.MailSubject("subj"))
 				return er
 			},
-			arr(mail),
+			[]string{mail},
 		},
 	}
 	for _, test := range table {
@@ -1262,7 +1254,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 			sel := test.makeSelector()
 			results := sel.Reduce(ctx, test.deets, errs)
 			paths := results.Paths()
-			assert.Equal(t, test.expect, paths)
+			assert.ElementsMatch(t, test.expect, paths)
 			assert.Empty(t, errs.Errs)
 		})
 	}

--- a/src/pkg/selectors/exchange_test.go
+++ b/src/pkg/selectors/exchange_test.go
@@ -1041,6 +1041,233 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 	}
 }
 
+func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
+	var (
+		contact         = stubRepoRef(path.ExchangeService, path.ContactsCategory, "uid", "id5/id6", "cid")
+		contactLocation = "conts/my_cont"
+		event           = stubRepoRef(path.ExchangeService, path.EventsCategory, "uid", "id1/id2", "eid")
+		eventLocation   = "cal/my_cal"
+		mail            = stubRepoRef(path.ExchangeService, path.EmailCategory, "uid", "id3/id4", "mid")
+		mailLocation    = "inbx/my_mail"
+	)
+
+	makeDeets := func(refs ...string) *details.Details {
+		deets := &details.Details{
+			DetailsModel: details.DetailsModel{
+				Entries: []details.DetailsEntry{},
+			},
+		}
+
+		for _, r := range refs {
+			var (
+				location string
+				itype    = details.UnknownType
+			)
+
+			switch r {
+			case contact:
+				itype = details.ExchangeContact
+				location = contactLocation
+			case event:
+				itype = details.ExchangeEvent
+				location = eventLocation
+			case mail:
+				itype = details.ExchangeMail
+				location = mailLocation
+			}
+
+			deets.Entries = append(deets.Entries, details.DetailsEntry{
+				RepoRef:     r,
+				LocationRef: location,
+				ItemInfo: details.ItemInfo{
+					Exchange: &details.ExchangeInfo{
+						ItemType: itype,
+					},
+				},
+			})
+		}
+
+		return deets
+	}
+
+	arr := func(s ...string) []string {
+		return s
+	}
+
+	table := []struct {
+		name         string
+		deets        *details.Details
+		makeSelector func() *ExchangeRestore
+		expect       []string
+	}{
+		{
+			"no refs",
+			makeDeets(),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore(Any())
+				er.Include(er.AllData())
+				return er
+			},
+			[]string{},
+		},
+		{
+			"contact only",
+			makeDeets(contact),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore(Any())
+				er.Include(er.AllData())
+				return er
+			},
+			arr(contact),
+		},
+		{
+			"event only",
+			makeDeets(event),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore(Any())
+				er.Include(er.AllData())
+				return er
+			},
+			arr(event),
+		},
+		{
+			"mail only",
+			makeDeets(mail),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore(Any())
+				er.Include(er.AllData())
+				return er
+			},
+			arr(mail),
+		},
+		{
+			"all",
+			makeDeets(contact, event, mail),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore(Any())
+				er.Include(er.AllData())
+				return er
+			},
+			arr(contact, event, mail),
+		},
+		{
+			"only match contact",
+			makeDeets(contact, event, mail),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore([]string{"uid"})
+				er.Include(er.Contacts([]string{contactLocation}, []string{"cid"}))
+				return er
+			},
+			arr(contact),
+		},
+		{
+			"only match event",
+			makeDeets(contact, event, mail),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore([]string{"uid"})
+				er.Include(er.Events([]string{eventLocation}, []string{"eid"}))
+				return er
+			},
+			arr(event),
+		},
+		{
+			"only match mail",
+			makeDeets(contact, event, mail),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore([]string{"uid"})
+				er.Include(er.Mails([]string{mailLocation}, []string{"mid"}))
+				return er
+			},
+			arr(mail),
+		},
+		{
+			"exclude contact",
+			makeDeets(contact, event, mail),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore(Any())
+				er.Include(er.AllData())
+				er.Exclude(er.Contacts([]string{contactLocation}, []string{"cid"}))
+				return er
+			},
+			arr(event, mail),
+		},
+		{
+			"exclude event",
+			makeDeets(contact, event, mail),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore(Any())
+				er.Include(er.AllData())
+				er.Exclude(er.Events([]string{eventLocation}, []string{"eid"}))
+				return er
+			},
+			arr(contact, mail),
+		},
+		{
+			"exclude mail",
+			makeDeets(contact, event, mail),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore(Any())
+				er.Include(er.AllData())
+				er.Exclude(er.Mails([]string{mailLocation}, []string{"mid"}))
+				return er
+			},
+			arr(contact, event),
+		},
+		{
+			"filter on mail subject",
+			func() *details.Details {
+				ds := makeDeets(mail)
+				for i := range ds.Entries {
+					ds.Entries[i].Exchange.Subject = "has a subject"
+				}
+				return ds
+			}(),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore(Any())
+				er.Include(er.AllData())
+				er.Filter(er.MailSubject("subj"))
+				return er
+			},
+			arr(mail),
+		},
+		{
+			"filter on mail subject multiple input categories",
+			func() *details.Details {
+				mds := makeDeets(mail)
+				for i := range mds.Entries {
+					mds.Entries[i].Exchange.Subject = "has a subject"
+				}
+
+				ds := makeDeets(contact, event)
+				ds.Entries = append(ds.Entries, mds.Entries...)
+
+				return ds
+			}(),
+			func() *ExchangeRestore {
+				er := NewExchangeRestore(Any())
+				er.Include(er.AllData())
+				er.Filter(er.MailSubject("subj"))
+				return er
+			},
+			arr(mail),
+		},
+	}
+	for _, test := range table {
+		suite.T().Run(test.name, func(t *testing.T) {
+			ctx, flush := tester.NewContext()
+			defer flush()
+
+			errs := mock.NewAdder()
+
+			sel := test.makeSelector()
+			results := sel.Reduce(ctx, test.deets, errs)
+			paths := results.Paths()
+			assert.Equal(t, test.expect, paths)
+			assert.Empty(t, errs.Errs)
+		})
+	}
+}
+
 func (suite *ExchangeSelectorSuite) TestScopesByCategory() {
 	var (
 		es       = NewExchangeRestore(Any())

--- a/src/pkg/selectors/scopes.go
+++ b/src/pkg/selectors/scopes.go
@@ -321,9 +321,13 @@ func reduce[T scopeT, C categoryT](
 		// of the repoRef folders, so that scopes can match against the display names
 		// instead of container IDs.
 		if len(ent.LocationRef) > 0 {
-			pb, err := path.Builder{}.
-				Append(path.Split(ent.LocationRef)...).
-				Append(repoPath.Item()).
+			pb, err := path.Builder{}.SplitUnescapeAppend(ent.LocationRef)
+			if err != nil {
+				errs.Add(clues.Wrap(err, "transforming locationRef to path").WithClues(ctx))
+				continue
+			}
+
+			lp, err := pb.Append(repoPath.Item()).
 				ToDataLayerPath(
 					repoPath.Tenant(),
 					repoPath.ResourceOwner(),
@@ -335,7 +339,7 @@ func reduce[T scopeT, C categoryT](
 				continue
 			}
 
-			repoPath = pb
+			repoPath = lp
 		}
 
 		// first check, every entry needs to match the selector's resource owners.

--- a/src/pkg/selectors/scopes_test.go
+++ b/src/pkg/selectors/scopes_test.go
@@ -290,6 +290,50 @@ func (suite *SelectorScopesSuite) TestReduce() {
 	}
 }
 
+func (suite *SelectorScopesSuite) TestReduce_locationRef() {
+	deets := func() details.Details {
+		return details.Details{
+			DetailsModel: details.DetailsModel{
+				Entries: []details.DetailsEntry{
+					{
+						RepoRef: stubRepoRef(
+							pathServiceStub,
+							pathCatStub,
+							rootCatStub.String(),
+							"stub",
+							leafCatStub.String(),
+						),
+						LocationRef: "a/b/c//defg",
+					},
+				},
+			},
+		}
+	}
+	dataCats := map[path.CategoryType]mockCategorizer{
+		pathCatStub: rootCatStub,
+	}
+
+	for _, test := range reduceTestTable {
+		suite.T().Run(test.name, func(t *testing.T) {
+			ctx, flush := tester.NewContext()
+			defer flush()
+
+			errs := mock.NewAdder()
+
+			ds := deets()
+			result := reduce[mockScope](
+				ctx,
+				&ds,
+				test.sel().Selector,
+				dataCats,
+				errs)
+			require.NotNil(t, result)
+			require.Empty(t, errs.Errs, "iteration errors")
+			assert.Len(t, result.Entries, test.expectLen)
+		})
+	}
+}
+
 func (suite *SelectorScopesSuite) TestScopesByCategory() {
 	t := suite.T()
 	s1 := stubScope("")


### PR DESCRIPTION
## Description

When reducing selectors, if the details entry has
a LocationRef available, replace the repoRef
folders section with the locationRef values.
This allows users to continue using folder display
names as scope parameters while using folder
IDs in the repoRef path.

## Does this PR need a docs update or release note?

- [x] :clock1: Yes, but in a later PR

## Type of change

- [x] :sunflower: Feature

## Issue(s)

* #2423

## Test Plan

- [x] :zap: Unit test
