### PR TITLE
Fixed twice display of "Logging to file" line 

### DIFF
--- a/src/pkg/logger/logger.go
+++ b/src/pkg/logger/logger.go
@@ -11,8 +11,6 @@ import (
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-
-	"github.com/alcionai/corso/src/cli/print"
 )
 
 // Default location for writing logs, initialized in platform specific files
@@ -123,7 +121,6 @@ func PreloadLoggingFlags() (string, string) {
 	if logfile != "stdout" && logfile != "stderr" {
 		LogFile = logfile
 		logdir := filepath.Dir(logfile)
-		print.Info(context.Background(), "Logging to file: "+logfile)
 
 		err := os.MkdirAll(logdir, 0o755)
 		if err != nil {


### PR DESCRIPTION
## Description

Issue - https://github.com/alcionai/corso/issues/2404
Fixed display of redundant messages. 
## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :bug: Bugfix

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* https://github.com/alcionai/corso/issues/2404

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual

