### PR TITLE
Make sure OneDrive collections are returned in order 

### DIFF
--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -415,12 +415,6 @@ func (c *Collections) UpdateCollections(
 			return err
 		}
 
-		// Skip items that don't match the folder selectors we were given.
-		if shouldSkipDrive(ctx, collectionPath, c.matcher, driveName) {
-			logger.Ctx(ctx).Infof("Skipping path %s", collectionPath.String())
-			continue
-		}
-
 		switch {
 		case item.GetFolder() != nil, item.GetPackage() != nil:
 			if item.GetDeleted() != nil {
@@ -445,6 +439,12 @@ func (c *Collections) UpdateCollections(
 
 			visitedPaths[folderPath.String()] = *item.GetId()
 
+			// Skip items that don't match the folder selectors we were given.
+			if shouldSkipDrive(ctx, collectionPath, c.matcher, driveName) {
+				logger.Ctx(ctx).Infof("Skipping path %s", collectionPath.String())
+				continue
+			}
+
 			// Moved folders don't cause delta results for any subfolders nested in
 			// them. We need to go through and update paths to handle that. We only
 			// update newPaths so we don't accidentally clobber previous deletes.
@@ -461,6 +461,12 @@ func (c *Collections) UpdateCollections(
 			fallthrough
 
 		case item.GetFile() != nil:
+			// Skip items that don't match the folder selectors we were given.
+			if shouldSkipDrive(ctx, collectionPath, c.matcher, driveName) {
+				logger.Ctx(ctx).Infof("Skipping path %s", collectionPath.String())
+				continue
+			}
+
 			if item.GetDeleted() != nil {
 				excluded[*item.GetId()] = struct{}{}
 				// Exchange counts items streamed through it which includes deletions so

--- a/src/internal/connector/onedrive/collections_test.go
+++ b/src/internal/connector/onedrive/collections_test.go
@@ -679,6 +679,7 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			assert.Equal(t, tt.expectedFileCount, c.NumFiles, "file count")
 			assert.Equal(t, tt.expectedContainerCount, c.NumContainers, "container count")
 
+			assert.Equal(t, tt.expectedCollectionIDs, c.CollectionOrdering)
 			for _, collPath := range tt.expectedCollectionIDs {
 				assert.Contains(t, c.CollectionMap, collPath)
 			}

--- a/src/internal/connector/sharepoint/data_collections_test.go
+++ b/src/internal/connector/sharepoint/data_collections_test.go
@@ -21,7 +21,7 @@ import (
 // ---------------------------------------------------------------------------
 
 const (
-	testBaseDrivePath = "drive/driveID1/root:"
+	testBaseDrivePath = "drives/driveID1/root:"
 )
 
 type testFolderMatcher struct {
@@ -61,6 +61,7 @@ func (suite *SharePointLibrariesSuite) TestUpdateCollections() {
 		items                   []models.DriveItemable
 		scope                   selectors.SharePointScope
 		expect                  assert.ErrorAssertionFunc
+		expectedCollectionIDs   []string
 		expectedCollectionPaths []string
 		expectedItemCount       int
 		expectedContainerCount  int
@@ -69,10 +70,12 @@ func (suite *SharePointLibrariesSuite) TestUpdateCollections() {
 		{
 			testCase: "Single File",
 			items: []models.DriveItemable{
+				driveRootItem("root"),
 				driveItem("file", testBaseDrivePath, true),
 			},
-			scope:  anyFolder,
-			expect: assert.NoError,
+			scope:                 anyFolder,
+			expect:                assert.NoError,
+			expectedCollectionIDs: []string{"root"},
 			expectedCollectionPaths: expectedPathAsSlice(
 				suite.T(),
 				tenant,
@@ -102,14 +105,17 @@ func (suite *SharePointLibrariesSuite) TestUpdateCollections() {
 				&MockGraphService{},
 				nil,
 				control.Options{})
-			err := c.UpdateCollections(ctx, "driveID", "General", test.items, paths, newPaths, excluded, true)
+			err := c.UpdateCollections(ctx, "driveID1", "General", test.items, paths, newPaths, excluded, true)
 			test.expect(t, err)
-			assert.Equal(t, len(test.expectedCollectionPaths), len(c.CollectionMap), "collection paths")
+			assert.Equal(t, len(test.expectedCollectionIDs), len(c.CollectionMap), "collection paths")
 			assert.Equal(t, test.expectedItemCount, c.NumItems, "item count")
 			assert.Equal(t, test.expectedFileCount, c.NumFiles, "file count")
 			assert.Equal(t, test.expectedContainerCount, c.NumContainers, "container count")
-			for _, collPath := range test.expectedCollectionPaths {
+			for _, collPath := range test.expectedCollectionIDs {
 				assert.Contains(t, c.CollectionMap, collPath)
+			}
+			for _, col := range c.CollectionMap {
+				assert.Contains(t, test.expectedCollectionPaths, col.FullPath().String())
 			}
 		})
 	}
@@ -127,6 +133,16 @@ func driveItem(name string, path string, isFile bool) models.DriveItemable {
 	if isFile {
 		item.SetFile(models.NewFile())
 	}
+
+	return item
+}
+
+func driveRootItem(id string) models.DriveItemable {
+	name := "root"
+	item := models.NewDriveItem()
+	item.SetName(&name)
+	item.SetId(&id)
+	item.SetRoot(models.NewRoot())
 
 	return item
 }

--- a/src/internal/connector/sharepoint/data_collections_test.go
+++ b/src/internal/connector/sharepoint/data_collections_test.go
@@ -111,6 +111,8 @@ func (suite *SharePointLibrariesSuite) TestUpdateCollections() {
 			assert.Equal(t, test.expectedItemCount, c.NumItems, "item count")
 			assert.Equal(t, test.expectedFileCount, c.NumFiles, "file count")
 			assert.Equal(t, test.expectedContainerCount, c.NumContainers, "container count")
+
+			assert.Equal(t, test.expectedCollectionIDs, c.CollectionOrdering)
 			for _, collPath := range test.expectedCollectionIDs {
 				assert.Contains(t, c.CollectionMap, collPath)
 			}


### PR DESCRIPTION
## Description

We were using a map so as to not create duplicate collections but this
causes issues with ordering of the collections. This is not
necessarily important as of now, but will be needed when we work on
delta incrementals and have to handle deletes, updates etc.

ref: https://github.com/alcionai/corso/pull/2407#discussion_r1101377901

<!-- Insert PR description-->

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [x] :clock1: Yes, but in a later PR
- [ ] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
