### PR TITLE
find calendars by id when restoring

### DIFF
--- a/src/internal/connector/exchange/container_resolver.go
+++ b/src/internal/connector/exchange/container_resolver.go
@@ -46,6 +46,15 @@ func newContainerResolver() *containerResolver {
 
 type containerResolver struct {
 	cache map[string]graph.CachedContainer
+	// newAdditions is a map of displayName: ID tuples.
+	// Since we don't know the ID of newly added containers until
+	// they've been generated via graph api, we don't have an easy
+	// way of mapping destination names onto CachedContainers.
+	// This map should get updated on every call to AddToCache, and
+	// can be accessed via the AddedIDs func, so that we avoid
+	// FolderAlreadyExists errors for types that store IDs instead
+	// of display names in their path.
+	newAdditions map[string]string
 }
 
 func (cr *containerResolver) IDToPath(
@@ -164,7 +173,14 @@ func (cr *containerResolver) AddToCache(
 		Container: f,
 	}
 
+	if len(cr.newAdditions) == 0 {
+		cr.newAdditions = map[string]string{}
+	}
+
+	cr.newAdditions[*f.GetDisplayName()] = *f.GetId()
+
 	if err := cr.addFolder(temp); err != nil {
+		delete(cr.newAdditions, *f.GetDisplayName())
 		return errors.Wrap(err, "adding cache folder")
 	}
 
@@ -172,10 +188,18 @@ func (cr *containerResolver) AddToCache(
 	// when they're made.
 	_, _, err := cr.IDToPath(ctx, *f.GetId(), useIDInPath)
 	if err != nil {
+		delete(cr.newAdditions, *f.GetDisplayName())
 		return errors.Wrap(err, "adding cache entry")
 	}
 
 	return nil
+}
+
+// DestinationNameToID returns the ID of the destination container.  Dest is
+// assumed to be a display name.  The ID is only populated if the destination
+// was added using `AddToCache()`.  Returns an empty string if not found.
+func (cr *containerResolver) DestinationNameToID(dest string) string {
+	return cr.newAdditions[dest]
 }
 
 func (cr *containerResolver) populatePaths(ctx context.Context, useIDInPath bool) error {

--- a/src/internal/connector/exchange/container_resolver_test.go
+++ b/src/internal/connector/exchange/container_resolver_test.go
@@ -478,16 +478,19 @@ func (suite *ConfiguredFolderCacheUnitSuite) TestAddToCache() {
 	defer flush()
 
 	var (
+		dest = "testAddFolder"
 		t    = suite.T()
 		last = suite.allContainers[len(suite.allContainers)-1]
-		m    = newMockCachedContainer("testAddFolder")
+		m    = newMockCachedContainer(dest)
 	)
 
 	m.parentID = last.id
 	m.expectedPath = stdpath.Join(last.expectedPath, m.displayName)
 	m.expectedLocation = stdpath.Join(last.expectedPath, m.displayName)
 
+	require.Empty(t, suite.fc.DestinationNameToID(dest), "destination not yet added to cache")
 	require.NoError(t, suite.fc.AddToCache(ctx, m, false))
+	require.NotEmpty(t, suite.fc.DestinationNameToID(dest), "destination id from cache")
 
 	p, l, err := suite.fc.IDToPath(ctx, m.id, false)
 	require.NoError(t, err)

--- a/src/internal/connector/exchange/container_resolver_test.go
+++ b/src/internal/connector/exchange/container_resolver_test.go
@@ -490,7 +490,8 @@ func (suite *ConfiguredFolderCacheUnitSuite) TestAddToCache() {
 
 	require.Empty(t, suite.fc.DestinationNameToID(dest), "destination not yet added to cache")
 	require.NoError(t, suite.fc.AddToCache(ctx, m, false))
-	require.NotEmpty(t, suite.fc.DestinationNameToID(dest), "destination id from cache")
+	require.Empty(t, suite.fc.DestinationNameToID(dest),
+		"destination id from cache, still empty, because this is not a calendar")
 
 	p, l, err := suite.fc.IDToPath(ctx, m.id, false)
 	require.NoError(t, err)

--- a/src/internal/connector/exchange/event_calendar_cache.go
+++ b/src/internal/connector/exchange/event_calendar_cache.go
@@ -95,7 +95,14 @@ func (ecc *eventCalendarCache) AddToCache(ctx context.Context, f graph.Container
 		path.Builder{}.Append(*f.GetId()), // storage path
 		path.Builder{}.Append(*f.GetDisplayName())) // display location
 
+	if len(ecc.newAdditions) == 0 {
+		ecc.newAdditions = map[string]string{}
+	}
+
+	ecc.newAdditions[*f.GetDisplayName()] = *f.GetId()
+
 	if err := ecc.addFolder(temp); err != nil {
+		delete(ecc.newAdditions, *f.GetDisplayName())
 		return errors.Wrap(err, "adding container")
 	}
 
@@ -103,6 +110,7 @@ func (ecc *eventCalendarCache) AddToCache(ctx context.Context, f graph.Container
 	// when they're made.
 	_, _, err := ecc.IDToPath(ctx, *f.GetId(), true)
 	if err != nil {
+		delete(ecc.newAdditions, *f.GetDisplayName())
 		return errors.Wrap(err, "setting path to container id")
 	}
 

--- a/src/internal/connector/exchange/event_calendar_cache.go
+++ b/src/internal/connector/exchange/event_calendar_cache.go
@@ -14,9 +14,10 @@ var _ graph.ContainerResolver = &eventCalendarCache{}
 
 type eventCalendarCache struct {
 	*containerResolver
-	enumer containersEnumerator
-	getter containerGetter
-	userID string
+	enumer       containersEnumerator
+	getter       containerGetter
+	userID       string
+	newAdditions map[string]string
 }
 
 // init ensures that the structure's fields are initialized.

--- a/src/internal/connector/exchange/service_iterators_test.go
+++ b/src/internal/connector/exchange/service_iterators_test.go
@@ -59,6 +59,7 @@ var _ graph.ContainerResolver = &mockResolver{}
 type (
 	mockResolver struct {
 		items []graph.CachedContainer
+		added map[string]string
 	}
 )
 
@@ -76,7 +77,16 @@ func (m mockResolver) Items() []graph.CachedContainer {
 	return m.items
 }
 
-func (m mockResolver) AddToCache(context.Context, graph.Container, bool) error { return nil }
+func (m mockResolver) AddToCache(ctx context.Context, gc graph.Container, b bool) error {
+	if len(m.added) == 0 {
+		m.added = map[string]string{}
+	}
+
+	m.added[*gc.GetDisplayName()] = *gc.GetId()
+
+	return nil
+}
+func (m mockResolver) DestinationNameToID(dest string) string { return m.added[dest] }
 func (m mockResolver) IDToPath(context.Context, string, bool) (*path.Builder, *path.Builder, error) {
 	return nil, nil, nil
 }

--- a/src/internal/connector/exchange/service_restore.go
+++ b/src/internal/connector/exchange/service_restore.go
@@ -554,8 +554,9 @@ func CreateContainerDestination(
 			newCache = true
 			directoryCache = ecc
 		} else if did := directoryCache.DestinationNameToID(dest); len(did) > 0 {
-			// calendars are cached by ID, not name, so we need to look up
-			// the destination id before falling back to destination name
+			// calendars are cached by ID in the resolver, not name, so once we have
+			// created the destination calendar, we need to look up its id and use
+			// that for resolver lookups instead of the display name.
 			dest = did
 		}
 

--- a/src/internal/connector/exchange/service_restore.go
+++ b/src/internal/connector/exchange/service_restore.go
@@ -484,7 +484,6 @@ func CreateContainerDestination(
 		user           = directory.ResourceOwner()
 		category       = directory.Category()
 		directoryCache = caches[category]
-		newPathFolders = append([]string{destination}, directory.Folders()...)
 	)
 
 	// TODO(rkeepers): pass the api client into this func, rather than generating one.
@@ -495,6 +494,8 @@ func CreateContainerDestination(
 
 	switch category {
 	case path.EmailCategory:
+		folders := append([]string{destination}, directory.Folders()...)
+
 		if directoryCache == nil {
 			acm := ac.Mail()
 			mfc := &mailFolderCache{
@@ -511,12 +512,14 @@ func CreateContainerDestination(
 		return establishMailRestoreLocation(
 			ctx,
 			ac,
-			newPathFolders,
+			folders,
 			directoryCache,
 			user,
 			newCache)
 
 	case path.ContactsCategory:
+		folders := append([]string{destination}, directory.Folders()...)
+
 		if directoryCache == nil {
 			acc := ac.Contacts()
 			cfc := &contactFolderCache{
@@ -532,12 +535,14 @@ func CreateContainerDestination(
 		return establishContactsRestoreLocation(
 			ctx,
 			ac,
-			newPathFolders,
+			folders,
 			directoryCache,
 			user,
 			newCache)
 
 	case path.EventsCategory:
+		dest := destination
+
 		if directoryCache == nil {
 			ace := ac.Events()
 			ecc := &eventCalendarCache{
@@ -548,16 +553,22 @@ func CreateContainerDestination(
 			caches[category] = ecc
 			newCache = true
 			directoryCache = ecc
+		} else if did := directoryCache.DestinationNameToID(dest); len(did) > 0 {
+			// calendars are cached by ID, not name, so we need to look up
+			// the destination id before falling back to destination name
+			dest = did
 		}
+
+		folders := append([]string{dest}, directory.Folders()...)
 
 		return establishEventsRestoreLocation(
 			ctx,
 			ac,
-			newPathFolders,
+			folders,
 			directoryCache,
 			user,
-			newCache,
-		)
+			newCache)
+
 	default:
 		return "", fmt.Errorf("category: %s not support for exchange cache", category)
 	}

--- a/src/internal/connector/graph/cache_container.go
+++ b/src/internal/connector/graph/cache_container.go
@@ -72,6 +72,11 @@ type ContainerResolver interface {
 
 	AddToCache(ctx context.Context, m365Container Container, useIDInPath bool) error
 
+	// DestinationNameToID returns the ID of the destination container.  Dest is
+	// assumed to be a display name.  The ID is only populated if the destination
+	// was added using `AddToCache()`.  Returns an empty string if not found.
+	DestinationNameToID(dest string) string
+
 	// Items returns the containers in the cache.
 	Items() []CachedContainer
 }


### PR DESCRIPTION
## Description

Now that calenders are stored by ID, we have a
problem with restore destinations: the dest is
a name, not an ID.  Even though we create the
dest during restoration, we don't have a way to
reference the ID of the created dest, which
causes additional restores to fail on a "folder
already exists" post error.  This change adds in
the missing dest -> id lookup.

## Does this PR need a docs update or release note?

- [x] :clock1: Yes, but in a later PR

## Type of change

- [x] :bug: Bugfix

## Issue(s)

* #2423

## Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
