### PR TITLE
add --on-error flag to replace --fail-fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] (beta)
 ### Added
 
+- New Flag `--on-error` which controls recoverable error handling behavior.  Accepts `--on-error fail` (default) to fail out immediately, and `--on-error recover` to proceed with the operation.
+
 ### Fixed
 - Support for item.Attachment:Mail restore
 - Errors from duplicate names in Exchange Calendars

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] (beta)
 ### Added
 
-- New Flag `--on-error` which controls recoverable error handling behavior.  Accepts `--on-error fail` (default) to fail out immediately, and `--on-error recover` to proceed with the operation.
+- New Flag `--on-error` which controls recoverable error handling behavior.  Accepts `--on-error fail` to fail out immediately, and `--on-error continue` (default) to proceed with the operation.
 
 ### Fixed
 - Support for item.Attachment:Mail restore

--- a/src/cli/options/options.go
+++ b/src/cli/options/options.go
@@ -1,6 +1,8 @@
 package options
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -11,7 +13,7 @@ import (
 func Control() control.Options {
 	opt := control.Defaults()
 
-	opt.FailFast = fastFail
+	opt.FailFast = strings.ToLower(onError) != "recover"
 	opt.DisableMetrics = noStats
 	opt.RestorePermissions = restorePermissions
 	opt.ToggleFeatures.DisableIncrementals = disableIncrementals
@@ -25,7 +27,7 @@ func Control() control.Options {
 // ---------------------------------------------------------------------------
 
 var (
-	fastFail           bool
+	onError            string
 	noStats            bool
 	restorePermissions bool
 )
@@ -33,9 +35,10 @@ var (
 // AddOperationFlags adds command-local operation flags
 func AddOperationFlags(cmd *cobra.Command) {
 	fs := cmd.Flags()
-	fs.BoolVar(&fastFail, "fast-fail", false, "stop processing immediately if any error occurs")
-	// TODO: reveal this flag when fail-fast support is implemented
-	cobra.CheckErr(fs.MarkHidden("fast-fail"))
+	fs.StringVar(
+		&onError, "on-error",
+		"fail",
+		"Configure how Corso handles recoverable errors.  Accepts 'fail' (default) or 'recover'.")
 }
 
 // AddGlobalOperationFlags adds the global operations flag set.

--- a/src/cli/options/options.go
+++ b/src/cli/options/options.go
@@ -38,7 +38,7 @@ func AddOperationFlags(cmd *cobra.Command) {
 	fs.StringVar(
 		&onError, "on-error",
 		"continue",
-		"Configure how Corso handles recoverable errors.  Accepts 'fail' or 'continue' (default).")
+		"Configure how Corso handles recoverable errors. Accepts 'fail' or 'continue' (default).")
 }
 
 // AddGlobalOperationFlags adds the global operations flag set.

--- a/src/cli/options/options.go
+++ b/src/cli/options/options.go
@@ -13,7 +13,7 @@ import (
 func Control() control.Options {
 	opt := control.Defaults()
 
-	opt.FailFast = strings.ToLower(onError) != "recover"
+	opt.FailFast = strings.ToLower(onError) != "continue"
 	opt.DisableMetrics = noStats
 	opt.RestorePermissions = restorePermissions
 	opt.ToggleFeatures.DisableIncrementals = disableIncrementals
@@ -37,8 +37,8 @@ func AddOperationFlags(cmd *cobra.Command) {
 	fs := cmd.Flags()
 	fs.StringVar(
 		&onError, "on-error",
-		"fail",
-		"Configure how Corso handles recoverable errors.  Accepts 'fail' (default) or 'recover'.")
+		"continue",
+		"Configure how Corso handles recoverable errors.  Accepts 'fail' or 'continue' (default).")
 }
 
 // AddGlobalOperationFlags adds the global operations flag set.

--- a/src/cmd/getM365/getItem.go
+++ b/src/cmd/getM365/getItem.go
@@ -182,8 +182,7 @@ func getGC(ctx context.Context) (*connector.GraphConnector, account.M365Config, 
 		return nil, m365Cfg, Only(ctx, errors.Wrap(err, "finding m365 account details"))
 	}
 
-	// TODO: log/print recoverable errors
-	errs := fault.New(false)
+	errs := fault.New(true)
 
 	gc, err := connector.NewGraphConnector(ctx, graph.HTTPClient(graph.NoTimeout()), acct, connector.Users, errs)
 	if err != nil {

--- a/src/cmd/purge/purge.go
+++ b/src/cmd/purge/purge.go
@@ -261,8 +261,7 @@ func getGC(ctx context.Context) (*connector.GraphConnector, error) {
 	}
 
 	// build a graph connector
-	// TODO: log/print recoverable errors
-	errs := fault.New(false)
+	errs := fault.New(true)
 
 	gc, err := connector.NewGraphConnector(ctx, graph.HTTPClient(graph.NoTimeout()), acct, connector.Users, errs)
 	if err != nil {

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -301,7 +301,7 @@ func (r repository) Backup(ctx context.Context, id model.StableID) (*backup.Back
 func (r repository) Backups(ctx context.Context, ids []model.StableID) ([]*backup.Backup, *fault.Errors) {
 	var (
 		bups []*backup.Backup
-		errs = fault.New(false)
+		errs = fault.New(true)
 		sw   = store.NewKopiaStore(r.modelStore)
 	)
 
@@ -329,7 +329,7 @@ func (r repository) BackupDetails(
 	backupID string,
 ) (*details.Details, *backup.Backup, *fault.Errors) {
 	sw := store.NewKopiaStore(r.modelStore)
-	errs := fault.New(false)
+	errs := fault.New(true)
 
 	dID, b, err := sw.GetDetailsIDFromBackupID(ctx, model.StableID(backupID))
 	if err != nil {

--- a/website/docs/setup/fault-tolerance.md
+++ b/website/docs/setup/fault-tolerance.md
@@ -23,7 +23,7 @@ succeed in the face of transient or temporary failures.
 The Graph API can, for internal reasons, exhibit extended periods of
 failures for particular Graph objects. In this scenario, bounded retries
 will be ineffective. Unless invoked with the
-fail fast option, Corso will skip over these failing objects. For
+on-error recover option, Corso will skip over these failing objects. For
 backups, it will move forward with backing up other objects belonging
 to the user and, for restores, it will continue with trying to restore
 any remaining objects. If a multi-user backed is in progress (via `*`

--- a/website/docs/setup/fault-tolerance.md
+++ b/website/docs/setup/fault-tolerance.md
@@ -22,8 +22,8 @@ succeed in the face of transient or temporary failures.
 
 The Graph API can, for internal reasons, exhibit extended periods of
 failures for particular Graph objects. In this scenario, bounded retries
-will be ineffective. Unless invoked with the
-on-error recover option, Corso will skip over these failing objects. For
+will be ineffective. Unless invoked with the on-error continue option,
+Corso will skip over these failing objects. For
 backups, it will move forward with backing up other objects belonging
 to the user and, for restores, it will continue with trying to restore
 any remaining objects. If a multi-user backed is in progress (via `*`

--- a/website/docs/setup/fault-tolerance.md
+++ b/website/docs/setup/fault-tolerance.md
@@ -22,8 +22,8 @@ succeed in the face of transient or temporary failures.
 
 The Graph API can, for internal reasons, exhibit extended periods of
 failures for particular Graph objects. In this scenario, bounded retries
-will be ineffective. Unless invoked with the on-error continue option,
-Corso will skip over these failing objects. For
+will be ineffective. Corso will skip over these failing objects, unless
+invoked with the `--on-error fail` option. For
 backups, it will move forward with backing up other objects belonging
 to the user and, for restores, it will continue with trying to restore
 any remaining objects. If a multi-user backed is in progress (via `*`


### PR DESCRIPTION
## Description

Adds and exposes the flag on-error that allows
users to choose between 'fail' and 'recover' (ie:
fail-fast and best-effort) error handling modes.

Also sets some fault constructors to fail-fast
so that we don't let errors slip through.

## Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

## Type of change

- [x] :sunflower: Feature

## Issue(s)

* #1970

## Test Plan

- [x] :zap: Unit test
