### PR TITLE
GC: Item attachment contact support

### DIFF
--- a/src/internal/common/ptr/pointer.go
+++ b/src/internal/common/ptr/pointer.go
@@ -1,0 +1,14 @@
+package ptr
+
+// Val helper method for unwrapping strings
+// Microsoft Graph saves many variables as string pointers.
+// Function will safely check if the point is nil prior to
+// dereferencing the pointer. If the pointer is nil,
+// an empty string is returned.
+func Val(ptr *string) string {
+	if ptr == nil {
+		return ""
+	}
+
+	return *ptr
+}

--- a/src/internal/connector/exchange/attachment.go
+++ b/src/internal/connector/exchange/attachment.go
@@ -8,7 +8,7 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/pkg/errors"
 
-	"github.com/alcionai/corso/src/internal/connector/graph"
+	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/connector/uploadsession"
 	"github.com/alcionai/corso/src/pkg/logger"
@@ -64,7 +64,7 @@ func uploadAttachment(
 
 		attachment, err = support.ToItemAttachment(attachment)
 		if err != nil {
-			name := graph.UnWrapStringPointer(prev.GetName())
+			name := ptr.Val(prev.GetName())
 			msg := "item attachment restore not supported for this type. skipping upload."
 
 			// TODO: (rkeepers) Update to support PII protection
@@ -73,7 +73,7 @@ func uploadAttachment(
 				"attachment_name", name,
 				"attachment_type", attachmentType,
 				"internal_item_type", getItemAttachmentItemType(prev),
-				"attachment_id", graph.UnWrapStringPointer(prev.GetId()),
+				"attachment_id", ptr.Val(prev.GetId()),
 			)
 
 			return nil
@@ -128,5 +128,5 @@ func getItemAttachmentItemType(query models.Attachmentable) string {
 
 	item := attachment.GetItem()
 
-	return graph.UnWrapStringPointer(item.GetOdataType())
+	return ptr.Val(item.GetOdataType())
 }

--- a/src/internal/connector/exchange/attachment.go
+++ b/src/internal/connector/exchange/attachment.go
@@ -8,6 +8,7 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/pkg/errors"
 
+	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/connector/uploadsession"
 	"github.com/alcionai/corso/src/pkg/logger"
@@ -63,19 +64,16 @@ func uploadAttachment(
 
 		attachment, err = support.ToItemAttachment(attachment)
 		if err != nil {
-			name := ""
-			if prev.GetName() != nil {
-				name = *prev.GetName()
-			}
+			name := graph.UnWrapStringPointer(prev.GetName())
+			msg := "item attachment restore not supported for this type. skipping upload."
 
 			// TODO: (rkeepers) Update to support PII protection
-			msg := "item attachment restore not supported for this type. skipping upload."
 			logger.Ctx(ctx).Infow(msg,
 				"err", err,
 				"attachment_name", name,
 				"attachment_type", attachmentType,
 				"internal_item_type", getItemAttachmentItemType(prev),
-				"attachment_id", *prev.GetId(),
+				"attachment_id", graph.UnWrapStringPointer(prev.GetId()),
 			)
 
 			return nil
@@ -129,9 +127,6 @@ func getItemAttachmentItemType(query models.Attachmentable) string {
 	}
 
 	item := attachment.GetItem()
-	if item.GetOdataType() == nil {
-		return empty
-	}
 
-	return *item.GetOdataType()
+	return graph.UnWrapStringPointer(item.GetOdataType())
 }

--- a/src/internal/connector/exchange/restore_test.go
+++ b/src/internal/connector/exchange/restore_test.go
@@ -230,6 +230,21 @@ func (suite *ExchangeRestoreSuite) TestRestoreExchangeObject() {
 				return *folder.GetId()
 			},
 		},
+		{
+			name: "Test Mail: Item Attachment_Contact",
+			bytes: mockconnector.GetMockMessageWithNestedItemAttachmentContact(t,
+				mockconnector.GetMockContactBytes("Victor"),
+				"Contact Item Attachment",
+			),
+			category: path.EmailCategory,
+			destination: func(t *testing.T, ctx context.Context) string {
+				folderName := "ItemMailAttachment_Contact " + common.FormatSimpleDateTime(now)
+				folder, err := suite.ac.Mail().CreateMailFolder(ctx, userID, folderName)
+				require.NoError(t, err)
+
+				return *folder.GetId()
+			},
+		},
 		{ // Restore will upload the Message without uploading the attachment
 			name:     "Test Mail: Item Attachment_NestedEvent",
 			bytes:    mockconnector.GetMockMessageWithNestedItemAttachmentEvent("Nested Item Attachment"),

--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -319,3 +319,16 @@ func RunWithRetry(run func() error) error {
 
 	return support.ConnectorStackErrorTraceWrap(err, "maximum retries or unretryable")
 }
+
+// UnwrapStringPointer helper method for unwrapping strings
+// Microsoft Graph saves many variables as string pointers.
+// Function will safely check if the point is nil prior to
+// dereferencing the pointer. If the pointer is nil,
+// an empty string is returned.
+func UnWrapStringPointer(ptr *string) string {
+	if ptr == nil {
+		return ""
+	}
+
+	return *ptr
+}

--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -320,7 +320,7 @@ func RunWithRetry(run func() error) error {
 	return support.ConnectorStackErrorTraceWrap(err, "maximum retries or unretryable")
 }
 
-// UnwrapStringPointer helper method for unwrapping strings
+// UnWrapStringPointer helper method for unwrapping strings
 // Microsoft Graph saves many variables as string pointers.
 // Function will safely check if the point is nil prior to
 // dereferencing the pointer. If the pointer is nil,

--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -319,16 +319,3 @@ func RunWithRetry(run func() error) error {
 
 	return support.ConnectorStackErrorTraceWrap(err, "maximum retries or unretryable")
 }
-
-// UnWrapStringPointer helper method for unwrapping strings
-// Microsoft Graph saves many variables as string pointers.
-// Function will safely check if the point is nil prior to
-// dereferencing the pointer. If the pointer is nil,
-// an empty string is returned.
-func UnWrapStringPointer(ptr *string) string {
-	if ptr == nil {
-		return ""
-	}
-
-	return *ptr
-}

--- a/src/internal/connector/support/m365Transform.go
+++ b/src/internal/connector/support/m365Transform.go
@@ -306,9 +306,10 @@ func cloneColumnDefinitionable(orig models.ColumnDefinitionable) models.ColumnDe
 //
 //nolint:lll
 const (
-	itemAttachment = "#microsoft.graph.itemAttachment"
-	eventItemType  = "#microsoft.graph.event"
-	mailItemType   = "#microsoft.graph.message"
+	itemAttachment  = "#microsoft.graph.itemAttachment"
+	eventItemType   = "#microsoft.graph.event"
+	mailItemType    = "#microsoft.graph.message"
+	contactItemType = "#microsoft.graph.contact"
 )
 
 // ToItemAttachment transforms internal item, OutlookItemables, into
@@ -323,6 +324,13 @@ func ToItemAttachment(orig models.Attachmentable) (models.Attachmentable, error)
 	itemType := item.GetOdataType()
 
 	switch *itemType {
+	case contactItemType:
+		contact := item.(models.Contactable)
+		revised := sanitizeContact(contact)
+
+		transform.SetItem(revised)
+
+		return transform, nil
 	case eventItemType:
 		event := item.(models.Eventable)
 
@@ -371,6 +379,15 @@ func ToItemAttachment(orig models.Attachmentable) (models.Attachmentable, error)
 
 // 	return attachments, nil
 // }
+
+// sanitizeContact removes fields which prevent a Contact from
+// being uploaded as an attachment.
+func sanitizeContact(orig models.Contactable) models.Contactable {
+	orig.SetParentFolderId(nil)
+	orig.SetAdditionalData(nil)
+
+	return orig
+}
 
 // sanitizeEvent transfers data into event object and
 // removes unique IDs from the M365 object


### PR DESCRIPTION
## Description
The logic for sanitizing Contactable data for restoration of `ItemAttachable.Contact` types. 

Contact `Item.Attachment`s required the removal of:
- `odata.Context` 
- `ETag` 
- `ParentFolder`

Otherwise, the following error occurs on POST. 
```bash
UnableToDeserializePostBody were unable to deserialize
```
<!-- Insert PR description-->

## Does this PR need a docs update or release note?
- [x] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [x] :bug: Bugfix

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* closes #2426<issue>

## Test Plan
- [x] :zap: Unit test

