### PR TITLE
centralize folder creation and permission setting for OneDrive restore

### DIFF
--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -332,8 +332,6 @@ func RestoreCollection(
 					// RestoreOp, so we still need to handle them in some way.
 					continue
 				} else if strings.HasSuffix(name, DirMetaFileSuffix) {
-					// Only the first version needed to deserialize the permission for
-					// child folders here. Later versions can request permissions inline.
 					if !restorePerms {
 						continue
 					}
@@ -406,11 +404,8 @@ func createRestoreFoldersWithPermissions(
 		parentPermissions,
 		folderPermissions,
 		permissionIDMappings)
-	if err != nil {
-		return id, permissionIDMappings, err
-	}
 
-	return id, permissionIDMappings, nil
+	return id, permissionIDMappings, err
 }
 
 // CreateRestoreFolders creates the restore folder hierarchy in the specified

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -380,26 +380,6 @@ func RestoreCollection(
 	}
 }
 
-// Creates a folder with its permissions
-func createRestoreFolder(
-	ctx context.Context,
-	service graph.Servicer,
-	driveID, folder, parentFolderID string,
-) (string, error) {
-	folderItem, err := createItem(ctx, service, driveID, parentFolderID, newItem(folder, true))
-	if err != nil {
-		return "", errors.Wrapf(
-			err,
-			"failed to create folder %s/%s. details: %s", parentFolderID, folder,
-			support.ConnectorStackErrorTrace(err),
-		)
-	}
-
-	logger.Ctx(ctx).Debugf("Resolved %s in %s to %s", folder, parentFolderID, *folderItem.GetId())
-
-	return *folderItem.GetId(), nil
-}
-
 // createRestoreFoldersWithPermissions creates the restore folder hierarchy in
 // the specified drive and returns the folder ID of the last folder entry in the
 // hierarchy. Permissions are only applied to the last folder in the hierarchy.

--- a/src/internal/connector/sharepoint/restore.go
+++ b/src/internal/connector/sharepoint/restore.go
@@ -69,7 +69,7 @@ func RestoreCollections(
 				backupVersion,
 				service,
 				dc,
-				[]onedrive.UserPermission{}, // Currently permission data is not stored for sharepoint
+				map[string][]onedrive.UserPermission{}, // Currently permission data is not stored for sharepoint
 				onedrive.OneDriveSource,
 				dest.ContainerName,
 				deets,


### PR DESCRIPTION
## Description

Rearrange how folder permissions are restored. Instead of restoring them when reading the meta file in the parent folder restore them when iterating through the collection itself.

This solution leans more heavily on the idea of having a map[folder path]->folder permissions and uses that to lookup what to restore

Folder permissions are still read and added to the map as they are encountered

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

* #2447 

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
