### PR TITLE
Add a flag to toggle OneDrive delta incrementals

### DIFF
--- a/src/cli/backup/onedrive.go
+++ b/src/cli/backup/onedrive.go
@@ -81,6 +81,7 @@ func addOneDriveCommands(cmd *cobra.Command) *cobra.Command {
 	case createCommand:
 		c, fs = utils.AddCommand(cmd, oneDriveCreateCmd())
 		options.AddFeatureToggle(cmd, options.EnablePermissionsBackup())
+		options.AddFeatureToggle(cmd, options.EnableOneDriveDeltaIncrementals())
 
 		c.Use = c.Use + " " + oneDriveServiceCommandCreateUseSuffix
 		c.Example = oneDriveServiceCommandCreateExamples

--- a/src/cli/options/options.go
+++ b/src/cli/options/options.go
@@ -16,6 +16,7 @@ func Control() control.Options {
 	opt.RestorePermissions = restorePermissions
 	opt.ToggleFeatures.DisableIncrementals = disableIncrementals
 	opt.ToggleFeatures.EnablePermissionsBackup = enablePermissionsBackup
+	opt.ToggleFeatures.EnableOneDriveDeltaIncrementals = enableOneDriveDeltaIncrentals
 
 	return opt
 }
@@ -57,8 +58,9 @@ func AddRestorePermissionsFlag(cmd *cobra.Command) {
 // ---------------------------------------------------------------------------
 
 var (
-	disableIncrementals     bool
-	enablePermissionsBackup bool
+	disableIncrementals           bool
+	enablePermissionsBackup       bool
+	enableOneDriveDeltaIncrentals bool
 )
 
 type exposeFeatureFlag func(*pflag.FlagSet)
@@ -95,5 +97,18 @@ func EnablePermissionsBackup() func(*pflag.FlagSet) {
 			false,
 			"Enable backing up item permissions for OneDrive")
 		cobra.CheckErr(fs.MarkHidden("enable-permissions-backup"))
+	}
+}
+
+// Adds the hidden '--enable-onedrive-delta-incrementals' cli flag which, when
+// set, enables delta incrementals for OneDrive.
+func EnableOneDriveDeltaIncrementals() func(*pflag.FlagSet) {
+	return func(fs *pflag.FlagSet) {
+		fs.BoolVar(
+			&enableOneDriveDeltaIncrentals,
+			"enable-onedrive-delta-incrementals",
+			false,
+			"Enables delta based incrementals for OneDrive")
+		cobra.CheckErr(fs.MarkHidden("enable-onedrive-delta-incrementals"))
 	}
 }

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -294,6 +294,11 @@ func (op *BackupOperation) do(
 // checker to see if conditions are correct for incremental backup behavior such as
 // retrieving metadata like delta tokens and previous paths.
 func useIncrementalBackup(sel selectors.Selector, opts control.Options) bool {
+	// TODO(meain): remove this once we stabilize delta incrementals for OneDrive
+	if sel.Service == selectors.ServiceOneDrive {
+		return opts.ToggleFeatures.EnableOneDriveDeltaIncrementals
+	}
+
 	// Delta-based incrementals currently only supported for Exchange
 	if sel.Service != selectors.ServiceExchange {
 		return false

--- a/src/pkg/control/options.go
+++ b/src/pkg/control/options.go
@@ -80,4 +80,10 @@ type Toggles struct {
 	// permissions. Permission metadata increases graph api call count,
 	// so disabling their retrieval when not needed is advised.
 	EnablePermissionsBackup bool `json:"enablePermissionsBackup,omitempty"`
+
+	// EnableOneDriveDeltaIncrementals is used to enable OneDrive
+	// delta incrementals. It is set to false by default as OneDrive
+	// delta incrementals is still in development. This flag works
+	// independent of DisableIncrementals.
+	EnableOneDriveDeltaIncrementals bool `json:"enableOneDriveDeltaIncrementals,omitempty"`
 }


### PR DESCRIPTION
## Description

Flag to toggle delta incrementals for OneDrive till we stabilize  things. Once stabilized, it will be removed and the `--disable-incrementals` flag will be used instead to control the behaviour.

<!-- Insert PR description-->

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* https://github.com/alcionai/corso/issues/2117

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
