### PR TITLE
OneDrive test framework

### DIFF
--- a/src/internal/connector/graph_connector_helper_test.go
+++ b/src/internal/connector/graph_connector_helper_test.go
@@ -191,7 +191,6 @@ type restoreBackupInfo struct {
 }
 
 type restoreBackupInfoMultiVersion struct {
-	name                string
 	service             path.ServiceType
 	collectionsLatest   []colInfo
 	collectionsPrevious []colInfo
@@ -762,6 +761,7 @@ func compareOneDriveItem(
 	}
 
 	var fileData testOneDriveData
+
 	err = json.Unmarshal(buf, &fileData)
 	if !assert.NoErrorf(t, err, "unmarshalling file data for file %s", name) {
 		return

--- a/src/internal/connector/graph_connector_onedrive_test.go
+++ b/src/internal/connector/graph_connector_onedrive_test.go
@@ -35,17 +35,6 @@ func getMetadata(fileName, user string, roles []string) onedrive.Metadata {
 	return testMeta
 }
 
-func getTestMetaJSON(t *testing.T, fileName, user string, roles []string) []byte {
-	testMeta := getMetadata(fileName, user, roles)
-
-	testMetaJSON, err := json.Marshal(testMeta)
-	if err != nil {
-		t.Fatal("unable to marshall test permissions", err)
-	}
-
-	return testMetaJSON
-}
-
 type testOneDriveData struct {
 	FileName string `json:"fileName,omitempty"`
 	Data     []byte `json:"data,omitempty"`

--- a/src/internal/connector/graph_connector_onedrive_test.go
+++ b/src/internal/connector/graph_connector_onedrive_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -193,20 +194,7 @@ func (c *onedriveCollection) withFile(
 		c.aux = append(c.aux, metadata)
 
 	default:
-		c.items = append(c.items, onedriveItemWithData(
-			c.t,
-			name+"-id"+onedrive.DataFileSuffix,
-			name+onedrive.DataFileSuffix,
-			fileData))
-
-		metadata := onedriveMetadata(
-			c.t,
-			name,
-			name+"-id"+onedrive.MetaFileSuffix,
-			user,
-			roles)
-		c.items = append(c.items, metadata)
-		c.aux = append(c.aux, metadata)
+		assert.FailNowf(c.t, "bad backup version", "version %d", c.backupVersion)
 	}
 
 	return c
@@ -217,11 +205,10 @@ func (c *onedriveCollection) withFolder(
 	user string,
 	roles []string,
 ) *onedriveCollection {
-	if c.backupVersion < 1 {
-		return c
-	}
-
 	switch c.backupVersion {
+	case 0:
+		return c
+
 	case 1:
 		fallthrough
 	case 2:
@@ -236,15 +223,7 @@ func (c *onedriveCollection) withFolder(
 		)
 
 	default:
-		c.items = append(
-			c.items,
-			onedriveMetadata(
-				c.t,
-				name,
-				name+onedrive.DirMetaFileSuffix,
-				user,
-				roles),
-		)
+		assert.FailNowf(c.t, "bad backup version", "version %d", c.backupVersion)
 	}
 
 	return c

--- a/src/internal/connector/graph_connector_onedrive_test.go
+++ b/src/internal/connector/graph_connector_onedrive_test.go
@@ -275,6 +275,10 @@ func (c *onedriveCollection) withPermissions(
 
 	name := c.pathElements[len(c.pathElements)-1]
 
+	if name == "root:" {
+		return c
+	}
+
 	c.items = append(
 		c.items,
 		onedriveMetadata(
@@ -284,6 +288,8 @@ func (c *onedriveCollection) withPermissions(
 			user,
 			roles),
 	)
+
+	return c
 }
 
 type permData struct {


### PR DESCRIPTION
## Description

Major changes:
* OneDrive files now store the lookup key in the first few bytes of the
  file and then the file data. This allows the test framework to
  continue working even when we switch to using item IDs as names
* Create a framework to create the data necessary for testing. This
  framework uses something akin to the builder pattern and automatically
  adds files to the collection if they should appear in that version.
  For example, trying to add a metadata file to a backup version that
  didn't have metadata files will result in a noop. Adding files will
  also add the metadata to the aux file set

Long term this will hopefully make ensuring compatibility between OneDrive
versions easier because only a few places in the code need to be updated
to support another version. It also allows easy ranges over different
versions via for-loop

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

* #1535

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
