### PR TITLE
Correctly add CA certificates

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -16,8 +16,7 @@ LABEL org.opencontainers.image.vendor="Alcion, Inc."
 
 COPY --from=builder /go/src/app/corso /corso
 
-#  Pull tls certs directly from latest upstream image
-COPY --from=alpine:latest /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+RUN apk add --no-cache ca-certificates
 
 ENV CORSO_HOME=/app/corso
 ENV CORSO_CONFIG_DIR=$CORSO_HOME \


### PR DESCRIPTION
## Description

This ensures that the CA certificates are not from some random version of Alpine but from the version we are using as a base image.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :bug: Bugfix
- [x] :broom: Tech Debt/Cleanup

## Issue(s)

* #2529 

## Test Plan

- [x] :muscle: Manual
