### PR TITLE
log and continue if kopia can't find expected base snapshot directory

### DIFF
--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -908,6 +908,11 @@ func inflateBaseTree(
 
 		ent, err := snapshotfs.GetNestedEntry(ctx, dir, pathElems)
 		if err != nil {
+			if isErrEntryNotFound(err) {
+				logger.Ctx(ctx).Infow("base snapshot missing subtree", "error", err)
+				continue
+			}
+
 			return errors.Wrapf(err, "snapshot %s getting subtree root", snap.ID)
 		}
 

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -331,7 +331,7 @@ func getItemStream(
 		encodeElements(itemPath.PopFront().Elements()...),
 	)
 	if err != nil {
-		if strings.Contains(err.Error(), "entry not found") {
+		if isErrEntryNotFound(err) {
 			err = clues.Stack(data.ErrNotFound, err).WithClues(ctx)
 		}
 
@@ -491,4 +491,9 @@ func (w Wrapper) FetchPrevSnapshotManifests(
 	}
 
 	return fetchPrevSnapshotManifests(ctx, w.c, reasons, tags), nil
+}
+
+func isErrEntryNotFound(err error) bool {
+	return strings.Contains(err.Error(), "entry not found") &&
+		!strings.Contains(err.Error(), "parent is not a directory")
 }

--- a/src/internal/tester/config.go
+++ b/src/internal/tester/config.go
@@ -111,7 +111,7 @@ func readTestConfig() (map[string]string, error) {
 		TestCfgUserID,
 		os.Getenv(EnvCorsoM365TestUserID),
 		vpr.GetString(TestCfgUserID),
-		"conneri@8qzvrj.onmicrosoft.com",
+		"pradeepg@8qzvrj.onmicrosoft.com",
 	)
 	fallbackTo(
 		testEnv,
@@ -132,7 +132,7 @@ func readTestConfig() (map[string]string, error) {
 		TestCfgLoadTestOrgUsers,
 		os.Getenv(EnvCorsoM365LoadTestOrgUsers),
 		vpr.GetString(TestCfgLoadTestOrgUsers),
-		"lidiah@8qzvrj.onmicrosoft.com,conneri@8qzvrj.onmicrosoft.com",
+		"lidiah@8qzvrj.onmicrosoft.com,pradeepg@8qzvrj.onmicrosoft.com",
 	)
 	fallbackTo(
 		testEnv,


### PR DESCRIPTION
## Description

This allows corso to continue making a snapshot even if the expected directory in the base is not found. The fact that the entry wasn't found will be logged

This should be safe so long as backups that had any sort of error, including "non-catastrophic" errors are marked as failed. Marking those as failed ensures that corso is using a matched set of metadata and data in the base snapshot rather than a partial snapshot

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [x] :clock1: Yes, but in a later PR
- [ ] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

* #2550

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
