### PR TITLE
Always make collections for prefix directories

### DIFF
--- a/src/internal/connector/data_collections.go
+++ b/src/internal/connector/data_collections.go
@@ -235,20 +235,18 @@ func (gc *GraphConnector) OneDriveDataCollections(
 		categories[scope.Category().PathType()] = struct{}{}
 	}
 
-	ferrs := fault.New(true)
 	baseCols, baseErrs := graph.BaseCollections(
 		gc.credentials.AzureTenantID,
 		user,
 		path.OneDriveService,
 		categories,
-		gc.UpdateStatus,
-		ferrs)
+		gc.UpdateStatus)
 
-	if baseErrs.Err() != nil {
-		errs = support.WrapAndAppend(user, ferrs.Err(), errs)
-	} else {
-		collections = append(collections, baseCols...)
+	if baseErrs != nil {
+		errs = support.WrapAndAppend(user, baseErrs, errs)
 	}
+
+	collections = append(collections, baseCols...)
 
 	for _, c := range collections {
 		if c.State() != data.DeletedState {

--- a/src/internal/connector/data_collections.go
+++ b/src/internal/connector/data_collections.go
@@ -206,7 +206,6 @@ func (gc *GraphConnector) OneDriveDataCollections(
 		collections = []data.BackupCollection{}
 		allExcludes = map[string]struct{}{}
 		categories  = map[path.CategoryType]struct{}{}
-		errs        error
 	)
 
 	// for each scope that includes oneDrive items, get all
@@ -243,7 +242,7 @@ func (gc *GraphConnector) OneDriveDataCollections(
 		gc.UpdateStatus)
 
 	if baseErrs != nil {
-		errs = support.WrapAndAppend(user, baseErrs, errs)
+		return collections, allExcludes, baseErrs
 	}
 
 	collections = append(collections, baseCols...)

--- a/src/internal/connector/exchange/data_collections.go
+++ b/src/internal/connector/exchange/data_collections.go
@@ -179,6 +179,7 @@ func DataCollections(
 		user        = selector.DiscreteOwner
 		collections = []data.BackupCollection{}
 		et          = errs.Tracker()
+		categories  = map[path.CategoryType]struct{}{}
 	)
 
 	cdps, err := parseMetadataCollections(ctx, metadata, errs)
@@ -205,7 +206,22 @@ func DataCollections(
 			continue
 		}
 
+		categories[scope.Category().PathType()] = struct{}{}
+
 		collections = append(collections, dcs...)
+	}
+
+	baseCols, baseErrs := graph.BaseCollections(
+		acct.AzureTenantID,
+		user,
+		path.ExchangeService,
+		categories,
+		su,
+		errs)
+	if baseErrs.Err() != nil {
+		errs.Add(baseErrs.Err())
+	} else {
+		collections = append(collections, baseCols...)
 	}
 
 	return collections, nil, et.Err()

--- a/src/internal/connector/exchange/data_collections.go
+++ b/src/internal/connector/exchange/data_collections.go
@@ -216,13 +216,12 @@ func DataCollections(
 		user,
 		path.ExchangeService,
 		categories,
-		su,
-		errs)
-	if baseErrs.Err() != nil {
-		errs.Add(baseErrs.Err())
-	} else {
-		collections = append(collections, baseCols...)
+		su)
+	if baseErrs != nil {
+		return collections, nil, baseErrs
 	}
+
+	collections = append(collections, baseCols...)
 
 	return collections, nil, et.Err()
 }

--- a/src/internal/connector/graph/collections.go
+++ b/src/internal/connector/graph/collections.go
@@ -1,0 +1,78 @@
+package graph
+
+import (
+	"context"
+
+	"github.com/alcionai/clues"
+
+	"github.com/alcionai/corso/src/internal/connector/support"
+	"github.com/alcionai/corso/src/internal/data"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/path"
+)
+
+var _ data.BackupCollection = emptyCollection{}
+
+type emptyCollection struct {
+	p  path.Path
+	su support.StatusUpdater
+}
+
+func (c emptyCollection) Items(ctx context.Context, errs *fault.Errors) <-chan data.Stream {
+	res := make(chan data.Stream)
+	close(res)
+
+	s := support.CreateStatus(ctx, support.Backup, 0, support.CollectionMetrics{}, nil, "")
+	c.su(s)
+
+	return res
+}
+
+func (c emptyCollection) FullPath() path.Path {
+	return c.p
+}
+
+func (c emptyCollection) PreviousPath() path.Path {
+	return c.p
+}
+
+func (c emptyCollection) State() data.CollectionState {
+	// This assumes we won't change the prefix path. Could probably use MovedState
+	// as well if we do need to change things around.
+	return data.NotMovedState
+}
+
+func (c emptyCollection) DoNotMergeItems() bool {
+	return false
+}
+
+func BaseCollections(
+	tenant, user string,
+	service path.ServiceType,
+	categories map[path.CategoryType]struct{},
+	su support.StatusUpdater,
+	errs *fault.Errors,
+) ([]data.BackupCollection, *fault.Errors) {
+	res := []data.BackupCollection{}
+
+	for cat := range categories {
+		p, err := path.Builder{}.Append("tmp").ToDataLayerPath(tenant, user, service, cat, false)
+		if err != nil {
+			// Shouldn't happen.
+			errs.Fail(clues.Wrap(err, "making path").WithAll("service", service, "category", cat))
+			continue
+		}
+
+		p, err = p.Dir()
+		if err != nil {
+			// Shouldn't happen.
+			errs.Fail(clues.Wrap(err, "getting base prefix").WithAll("serivce", service, "category", cat))
+			continue
+		}
+
+		// Pop off the last path element because we just want the prefix.
+		res = append(res, emptyCollection{p: p, su: su})
+	}
+
+	return res, errs
+}

--- a/src/internal/connector/graph/collections.go
+++ b/src/internal/connector/graph/collections.go
@@ -82,5 +82,9 @@ func BaseCollections(
 		res = append(res, emptyCollection{p: p, su: su})
 	}
 
+	if len(errs) > 0 {
+		return res, clues.Stack(errs...)
+	}
+
 	return res, nil
 }

--- a/src/internal/connector/graph/collections.go
+++ b/src/internal/connector/graph/collections.go
@@ -63,7 +63,7 @@ func BaseCollections(
 			// Shouldn't happen.
 			errs = append(
 				errs,
-				clues.Wrap(err, "making path").WithAll("service", service, "category", cat))
+				clues.Wrap(err, "making path").With("service", service, "category", cat))
 
 			continue
 		}
@@ -73,7 +73,7 @@ func BaseCollections(
 			// Shouldn't happen.
 			errs = append(
 				errs,
-				clues.Wrap(err, "getting base prefix").WithAll("serivce", service, "category", cat))
+				clues.Wrap(err, "getting base prefix").With("serivce", service, "category", cat))
 
 			continue
 		}
@@ -82,5 +82,5 @@ func BaseCollections(
 		res = append(res, emptyCollection{p: p, su: su})
 	}
 
-	return res, clues.Stack(errs...)
+	return res, nil
 }

--- a/src/internal/connector/graph/collections.go
+++ b/src/internal/connector/graph/collections.go
@@ -51,22 +51,30 @@ func BaseCollections(
 	service path.ServiceType,
 	categories map[path.CategoryType]struct{},
 	su support.StatusUpdater,
-	errs *fault.Errors,
-) ([]data.BackupCollection, *fault.Errors) {
-	res := []data.BackupCollection{}
+) ([]data.BackupCollection, error) {
+	var (
+		errs = []error{}
+		res  = []data.BackupCollection{}
+	)
 
 	for cat := range categories {
 		p, err := path.Builder{}.Append("tmp").ToDataLayerPath(tenant, user, service, cat, false)
 		if err != nil {
 			// Shouldn't happen.
-			errs.Fail(clues.Wrap(err, "making path").WithAll("service", service, "category", cat))
+			errs = append(
+				errs,
+				clues.Wrap(err, "making path").WithAll("service", service, "category", cat))
+
 			continue
 		}
 
 		p, err = p.Dir()
 		if err != nil {
 			// Shouldn't happen.
-			errs.Fail(clues.Wrap(err, "getting base prefix").WithAll("serivce", service, "category", cat))
+			errs = append(
+				errs,
+				clues.Wrap(err, "getting base prefix").WithAll("serivce", service, "category", cat))
+
 			continue
 		}
 
@@ -74,5 +82,5 @@ func BaseCollections(
 		res = append(res, emptyCollection{p: p, su: su})
 	}
 
-	return res, errs
+	return res, clues.Stack(errs...)
 }

--- a/src/internal/connector/sharepoint/data_collections.go
+++ b/src/internal/connector/sharepoint/data_collections.go
@@ -16,7 +16,6 @@ import (
 	"github.com/alcionai/corso/src/internal/observe"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
-	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
@@ -116,20 +115,18 @@ func DataCollections(
 		categories[scope.Category().PathType()] = struct{}{}
 	}
 
-	ferrs := fault.New(true)
 	baseCols, baseErrs := graph.BaseCollections(
 		creds.AzureTenantID,
 		site,
 		path.SharePointService,
 		categories,
-		su.UpdateStatus,
-		ferrs)
+		su.UpdateStatus)
 
-	if baseErrs.Err() != nil {
-		errs = support.WrapAndAppend(site, ferrs.Err(), errs)
-	} else {
-		collections = append(collections, baseCols...)
+	if baseErrs != nil {
+		return collections, nil, support.WrapAndAppend(site, baseErrs, errs)
 	}
+
+	collections = append(collections, baseCols...)
 
 	return collections, nil, et.Err()
 }

--- a/src/internal/connector/sharepoint/data_collections.go
+++ b/src/internal/connector/sharepoint/data_collections.go
@@ -16,6 +16,7 @@ import (
 	"github.com/alcionai/corso/src/internal/observe"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
@@ -47,7 +48,6 @@ func DataCollections(
 		site        = b.DiscreteOwner
 		collections = []data.BackupCollection{}
 		categories  = map[path.CategoryType]struct{}{}
-		errs        error
 	)
 
 	for _, scope := range b.Scopes() {
@@ -123,7 +123,7 @@ func DataCollections(
 		su.UpdateStatus)
 
 	if baseErrs != nil {
-		return collections, nil, support.WrapAndAppend(site, baseErrs, errs)
+		return collections, nil, baseErrs
 	}
 
 	collections = append(collections, baseCols...)


### PR DESCRIPTION
## Description

Use empty collections to ensure the prefix directories are available in
kopia no matter what user data we find.

This helps ensure we have some set of things we can assume about
non-failed backups including:
  1. They have a valid snapshot ID for data
  2. They have a valid snapshot ID for backup details

Eventually, this will allow us to say that backups using a base that
doesn't have a prefix directory is invalid in some way

SharePoint tests are disabled because lists and pages ignore the none
target in selectors

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [x] :clock1: Yes, but in a later PR
- [ ] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

* #2550

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
