### PR TITLE
Hook into error callback in kopia

### DIFF
--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -257,6 +257,16 @@ func (cp *corsoProgress) CachedFile(fname string, size int64) {
 	d.cached = true
 }
 
+// Kopia interface function used as a callback when kopia encounters an error
+// during the upload process. This could be from reading a file or something
+// else.
+func (cp *corsoProgress) Error(relpath string, err error, isIgnored bool) {
+	defer cp.UploadProgress.Error(relpath, err, isIgnored)
+
+	cp.errs.Add(clues.Wrap(err, "kopia reported error").
+		WithAll("is_ignored", isIgnored, "relative_path", relpath))
+}
+
 func (cp *corsoProgress) put(k string, v *itemDetails) {
 	cp.mu.Lock()
 	defer cp.mu.Unlock()

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -483,7 +483,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_ReaderError() {
 		tags,
 		true,
 		fault.New(true))
-	require.NoError(t, err)
+	require.Error(t, err)
 
 	assert.Equal(t, 0, stats.ErrorCount)
 	assert.Equal(t, 5, stats.TotalFileCount)


### PR DESCRIPTION
## Description

Using this over extracting errors from the snapshot allows us to see all errors. The errors that each directory tracks are truncated when the directory is serialized for persistence if there're too many.

With the current `fault.Errors` behavior this cases the backup to fail if there's any errors
kopia ignored. This is consistent with behavior in the backup op that checks for any errors.

Unclear what the CLI output and log messages will be for these errors as they are grouped
into all other errors reported through the fault package

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

* #2548

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
