### PR TITLE
Handle files moved multiple times within a delta query

### DIFF
--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -139,6 +139,7 @@ func NewCollection(
 func (oc *Collection) Add(item models.DriveItemable) bool {
 	_, found := oc.driveItems[*item.GetId()]
 	oc.driveItems[*item.GetId()] = item
+
 	return !found // !found = new
 }
 
@@ -150,7 +151,14 @@ func (oc *Collection) Remove(item models.DriveItemable) bool {
 	}
 
 	delete(oc.driveItems, *item.GetId())
+
 	return true
+}
+
+// IsEmpty check if a collection does not contain any items
+// TODO(meain): Should we just have function that returns driveItems?
+func (oc *Collection) IsEmpty() bool {
+	return len(oc.driveItems) == 0
 }
 
 // Items() returns the channel containing M365 Exchange objects

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -133,10 +133,24 @@ func NewCollection(
 	return c
 }
 
-// Adds an itemID to the collection
-// This will make it eligible to be populated
-func (oc *Collection) Add(item models.DriveItemable) {
+// Adds an itemID to the collection.  This will make it eligible to be
+// populated. The return values denotes if the item was previously
+// present or is new one.
+func (oc *Collection) Add(item models.DriveItemable) bool {
+	_, found := oc.driveItems[*item.GetId()]
 	oc.driveItems[*item.GetId()] = item
+	return !found // !found = new
+}
+
+// Remove removes a item from the collection
+func (oc *Collection) Remove(item models.DriveItemable) bool {
+	_, found := oc.driveItems[*item.GetId()]
+	if !found {
+		return false
+	}
+
+	delete(oc.driveItems, *item.GetId())
+	return true
 }
 
 // Items() returns the channel containing M365 Exchange objects

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -344,6 +344,13 @@ func (c *Collections) Get(
 		folderPaths[driveID] = map[string]string{}
 		maps.Copy(folderPaths[driveID], paths)
 
+		logger.Ctx(ctx).Infow(
+			"persisted metadata for drive",
+			"num_paths_entries",
+			len(paths),
+			"num_deltas_entries",
+			numDeltas)
+
 		if !delta.Reset {
 			maps.Copy(excludedItems, excluded)
 			continue

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -371,8 +371,8 @@ func (c *Collections) Get(
 
 			_, found = modifiedPaths[p]
 			if found {
-				// Path has been updated with something else already
-				// instead of being modified
+				// Original folder was deleted and new folder with the
+				// same name/path was created in its place
 				continue
 			}
 

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -497,6 +497,7 @@ func (c *Collections) UpdateCollections(
 	oldPaths map[string]string,
 	newPaths map[string]string,
 	excluded map[string]struct{},
+	itemCollection map[string]string,
 	invalidPrevDelta bool,
 ) error {
 	for _, item := range items {
@@ -713,14 +714,35 @@ func (c *Collections) UpdateCollections(
 			// times within a single delta response, we might end up
 			// storing the permissions multiple times. Switching the
 			// files to IDs should fix this.
-			collection := col.(*Collection)
-			collection.Add(item)
 
-			c.NumItems++
-			if item.GetFile() != nil {
-				// This is necessary as we have a fallthrough for
-				// folders and packages
-				c.NumFiles++
+			// Delete the file from previous collection. This will
+			// only kick in if the file was moved multiple times
+			// within a single delta query
+			cid, found := itemCollection[*item.GetId()]
+			if found {
+				pcol, found := c.CollectionMap[cid]
+				if !found {
+					return clues.New("previous collection not found").With("item_id", *item.GetId())
+				}
+
+				pcollection := pcol.(*Collection)
+
+				removed := pcollection.Remove(item)
+				if !removed {
+					return clues.New("removing from prev collection").With("item_id", *item.GetId())
+				}
+			}
+
+			itemCollection[*item.GetId()] = collectionID
+			collection := col.(*Collection)
+			new := collection.Add(item)
+			if new {
+				c.NumItems++
+				if item.GetFile() != nil {
+					// This is necessary as we have a fallthrough for
+					// folders and packages
+					c.NumFiles++
+				}
 			}
 
 		default:

--- a/src/internal/connector/onedrive/collections_test.go
+++ b/src/internal/connector/onedrive/collections_test.go
@@ -1360,7 +1360,6 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 				driveID1: {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				folderPath1:     {data.NewState: {}}, // TODO(meain): This should not be present
 				rootFolderPath1: {data.NotMovedState: {"folder", "file"}},
 			},
 			expectedDeltaURLs: map[string]string{
@@ -1790,6 +1789,7 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 				return
 			}
 
+			collectionCount := 0
 			for _, baseCol := range cols {
 				var folderPath string
 				if baseCol.State() != data.DeletedState {
@@ -1811,6 +1811,8 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 
 					continue
 				}
+
+				collectionCount++
 
 				// TODO(ashmrtn): We should really be getting items in the collection
 				// via the Items() channel, but we don't have a way to mock out the
@@ -1834,6 +1836,17 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 				)
 				assert.Equal(t, test.doNotMergeItems, baseCol.DoNotMergeItems(), "DoNotMergeItems")
 			}
+
+			expectedCollectionCount := 0
+			for c := range test.expectedCollections {
+				for range test.expectedCollections[c] {
+					expectedCollectionCount++
+				}
+			}
+
+			// This check is necessary to make sure we are all the
+			// collections we expect it to
+			assert.Equal(t, expectedCollectionCount, collectionCount, "number of collections")
 
 			assert.Equal(t, test.expectedDelList, delList, "del list")
 		})

--- a/src/internal/connector/onedrive/collections_test.go
+++ b/src/internal/connector/onedrive/collections_test.go
@@ -580,6 +580,36 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			expectedExcludes: map[string]struct{}{"itemInSubfolder": {}, "itemInFolder2": {}},
 		},
 		{
+			testCase: "moved folder tree multiple times",
+			items: []models.DriveItemable{
+				driveRootItem("root"),
+				driveItem("folder", "folder", testBaseDrivePath, "root", false, true, false),
+				driveItem("file", "file", testBaseDrivePath+"/folder", "folder", true, false, false),
+				driveItem("folder", "folder2", testBaseDrivePath, "root", false, true, false),
+			},
+			inputFolderMap: map[string]string{
+				"folder":    expectedPath("/a-folder"),
+				"subfolder": expectedPath("/a-folder/subfolder"),
+			},
+			scope:  anyFolder,
+			expect: assert.NoError,
+			expectedCollectionIDs: map[string]statePath{
+				"root":   expectedStatePath(data.NotMovedState, ""),
+				"folder": expectedStatePath(data.MovedState, "/folder2", "/a-folder"),
+			},
+			expectedItemCount:      3,
+			expectedFileCount:      1,
+			expectedContainerCount: 2,
+			expectedMetadataPaths: map[string]string{
+				"root":      expectedPath(""),
+				"folder":    expectedPath("/folder2"),
+				"subfolder": expectedPath("/folder2/subfolder"),
+			},
+			expectedExcludes: map[string]struct{}{
+				"file": {},
+			},
+		},
+		{
 			testCase: "deleted folder and package",
 			items: []models.DriveItemable{
 				driveRootItem("root"), // root is always present, but not necessary here
@@ -693,6 +723,7 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 				nil,
 				control.Options{ToggleFeatures: control.Toggles{EnablePermissionsBackup: true}})
 
+			itemCollection := map[string]string{}
 			err := c.UpdateCollections(
 				ctx,
 				"driveID1",
@@ -701,6 +732,7 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 				tt.inputFolderMap,
 				outputFolderMap,
 				excludes,
+				itemCollection,
 				false,
 			)
 			tt.expect(t, err)
@@ -1273,6 +1305,76 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 			expectedDelList: map[string]struct{}{"file": {}},
 		},
 		{
+			name:   "OneDrive_OneItemPage_NoErrors_FileRenamedMultiple",
+			drives: []models.Driveable{drive1},
+			items: map[string][]deltaPagerResult{
+				driveID1: {
+					{
+						items: []models.DriveItemable{
+							driveRootItem("root"),
+							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+							driveItem("file", "file2", driveBasePath1+"/folder", "folder", true, false, false),
+						},
+						deltaLink: &delta,
+					},
+				},
+			},
+			errCheck: assert.NoError,
+			prevFolderPaths: map[string]map[string]string{
+				driveID1: {},
+			},
+			expectedCollections: map[string]map[data.CollectionState][]string{
+				folderPath1:     {data.NewState: {"file"}},
+				rootFolderPath1: {data.NotMovedState: {"folder"}},
+			},
+			expectedDeltaURLs: map[string]string{
+				driveID1: delta,
+			},
+			expectedFolderPaths: map[string]map[string]string{
+				driveID1: {
+					"root":   rootFolderPath1,
+					"folder": folderPath1,
+				},
+			},
+			expectedDelList: map[string]struct{}{"file": {}},
+		},
+		{
+			name:   "OneDrive_OneItemPage_NoErrors_FileMovedMultiple",
+			drives: []models.Driveable{drive1},
+			items: map[string][]deltaPagerResult{
+				driveID1: {
+					{
+						items: []models.DriveItemable{
+							driveRootItem("root"),
+							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+							driveItem("file", "file2", driveBasePath1, "root", true, false, false),
+						},
+						deltaLink: &delta,
+					},
+				},
+			},
+			errCheck: assert.NoError,
+			prevFolderPaths: map[string]map[string]string{
+				driveID1: {},
+			},
+			expectedCollections: map[string]map[data.CollectionState][]string{
+				folderPath1:     {data.NewState: {}}, // TODO(meain): This should not be present
+				rootFolderPath1: {data.NotMovedState: {"folder", "file"}},
+			},
+			expectedDeltaURLs: map[string]string{
+				driveID1: delta,
+			},
+			expectedFolderPaths: map[string]map[string]string{
+				driveID1: {
+					"root":   rootFolderPath1,
+					"folder": folderPath1,
+				},
+			},
+			expectedDelList: map[string]struct{}{"file": {}},
+		},
+		{
 			name:   "OneDrive_OneItemPage_EmptyDelta_NoErrors",
 			drives: []models.Driveable{drive1},
 			items: map[string][]deltaPagerResult{
@@ -1466,7 +1568,7 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 						items: []models.DriveItemable{
 							driveRootItem("root"),
 							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
-							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+							driveItem("file2", "file", driveBasePath1+"/folder", "folder", true, false, false),
 						},
 						deltaLink: &delta,
 					},
@@ -1475,7 +1577,7 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 			errCheck: assert.NoError,
 			expectedCollections: map[string]map[data.CollectionState][]string{
 				expectedPath1(""):        {data.NotMovedState: {"file", "folder"}},
-				expectedPath1("/folder"): {data.NewState: {"file"}},
+				expectedPath1("/folder"): {data.NewState: {"file2"}},
 			},
 			expectedDeltaURLs: map[string]string{
 				driveID1: delta,
@@ -1505,7 +1607,7 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 						items: []models.DriveItemable{
 							driveRootItem("root"),
 							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
-							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+							driveItem("file2", "file", driveBasePath1+"/folder", "folder", true, false, false),
 						},
 						deltaLink: &delta,
 					},
@@ -1517,7 +1619,7 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
 				expectedPath1(""):        {data.NotMovedState: {"file", "folder"}},
-				expectedPath1("/folder"): {data.NewState: {"file"}},
+				expectedPath1("/folder"): {data.NewState: {"file2"}},
 			},
 			expectedDeltaURLs: map[string]string{
 				driveID1: delta,
@@ -1528,7 +1630,7 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 					"folder": folderPath1,
 				},
 			},
-			expectedDelList: map[string]struct{}{"file": {}},
+			expectedDelList: map[string]struct{}{"file": {}, "file2": {}},
 			doNotMergeItems: false,
 		},
 		{
@@ -1893,6 +1995,7 @@ func (suite *OneDriveCollectionsSuite) TestCollectItems() {
 				oldPaths map[string]string,
 				newPaths map[string]string,
 				excluded map[string]struct{},
+				itemCollection map[string]string,
 				doNotMergeItems bool,
 			) error {
 				return nil

--- a/src/internal/connector/onedrive/collections_test.go
+++ b/src/internal/connector/onedrive/collections_test.go
@@ -1179,6 +1179,7 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 		expectedFolderPaths map[string]map[string]string
 		expectedDelList     map[string]struct{}
 		doNotMergeItems     bool
+		emptyPrevDelta      bool
 	}{
 		{
 			name:   "OneDrive_OneItemPage_DelFileOnly_NoFolders_NoErrors",
@@ -1614,6 +1615,85 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 			expectedDelList: map[string]struct{}{},
 			doNotMergeItems: true,
 		},
+		{
+			name:   "OneDrive_OneItemPage_EmptyPrevDelta_DeleteNonExistantFolder",
+			drives: []models.Driveable{drive1},
+			items: map[string][]deltaPagerResult{
+				driveID1: {
+					{
+						items: []models.DriveItemable{
+							driveRootItem("root"),
+							driveItem("folder2", "folder2", driveBasePath1, "root", false, true, false),
+							driveItem("file", "file", driveBasePath1+"/folder2", "folder2", true, false, false),
+						},
+						deltaLink: &delta,
+					},
+				},
+			},
+			errCheck: assert.NoError,
+			prevFolderPaths: map[string]map[string]string{
+				driveID1: {
+					"root":   rootFolderPath1,
+					"folder": folderPath1,
+				},
+			},
+			expectedCollections: map[string]map[data.CollectionState][]string{
+				expectedPath1(""):         {data.NotMovedState: {"folder2"}},
+				expectedPath1("/folder"):  {data.DeletedState: {}},
+				expectedPath1("/folder2"): {data.NewState: {"file"}},
+			},
+			expectedDeltaURLs: map[string]string{
+				driveID1: delta,
+			},
+			expectedFolderPaths: map[string]map[string]string{
+				driveID1: {
+					"root":    rootFolderPath1,
+					"folder2": expectedPath1("/folder2"),
+				},
+			},
+			expectedDelList: map[string]struct{}{},
+			doNotMergeItems: true,
+			emptyPrevDelta:  true,
+		},
+		{
+			name:   "OneDrive_OneItemPage_EmptyPrevDelta_AnotherFolderAtDeletedLocation",
+			drives: []models.Driveable{drive1},
+			items: map[string][]deltaPagerResult{
+				driveID1: {
+					{
+						items: []models.DriveItemable{
+							driveRootItem("root"),
+							driveItem("folder2", "folder", driveBasePath1, "root", false, true, false),
+							driveItem("file", "file", driveBasePath1+"/folder", "folder2", true, false, false),
+						},
+						deltaLink: &delta,
+					},
+				},
+			},
+			errCheck: assert.NoError,
+			prevFolderPaths: map[string]map[string]string{
+				driveID1: {
+					"root":   rootFolderPath1,
+					"folder": folderPath1,
+				},
+			},
+			expectedCollections: map[string]map[data.CollectionState][]string{
+				expectedPath1(""):        {data.NotMovedState: {"folder2"}},
+				expectedPath1("/folder"): {data.NewState: {"file"}},
+			},
+			expectedDeltaURLs: map[string]string{
+				driveID1: delta,
+			},
+			expectedFolderPaths: map[string]map[string]string{
+				driveID1: {
+					"root":    rootFolderPath1,
+					"folder2": expectedPath1("/folder"),
+				},
+			},
+			expectedDelList: map[string]struct{}{},
+			doNotMergeItems: true,
+			emptyPrevDelta:  true,
+		},
 	}
 	for _, test := range table {
 		suite.T().Run(test.name, func(t *testing.T) {
@@ -1657,6 +1737,10 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 			c.drivePagerFunc = drivePagerFunc
 			c.itemPagerFunc = itemPagerFunc
 
+			prevDelta := ""
+			if !test.emptyPrevDelta {
+				prevDelta = "prev-delta"
+			}
 			mc, err := graph.MakeMetadataCollection(
 				tenant,
 				user,
@@ -1666,8 +1750,8 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 					graph.NewMetadataEntry(
 						graph.DeltaURLsFileName,
 						map[string]string{
-							driveID1: "prev-delta",
-							driveID2: "prev-delta",
+							driveID1: prevDelta,
+							driveID2: prevDelta,
 						},
 					),
 					graph.NewMetadataEntry(

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -213,6 +213,7 @@ func collectItems(
 			logger.Ctx(ctx).Infow("Invalid previous delta link", "link", prevDelta)
 
 			invalidPrevDelta = true
+			newPaths = map[string]string{}
 
 			pager.Reset()
 

--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -106,6 +106,7 @@ func (suite *ItemIntegrationSuite) TestItemReader_oneDrive() {
 		oldPaths map[string]string,
 		newPaths map[string]string,
 		excluded map[string]struct{},
+		itemCollection map[string]string,
 		doNotMergeItems bool,
 	) error {
 		for _, item := range items {

--- a/src/internal/connector/sharepoint/data_collections_test.go
+++ b/src/internal/connector/sharepoint/data_collections_test.go
@@ -105,7 +105,17 @@ func (suite *SharePointLibrariesSuite) TestUpdateCollections() {
 				&MockGraphService{},
 				nil,
 				control.Options{})
-			err := c.UpdateCollections(ctx, "driveID1", "General", test.items, paths, newPaths, excluded, true)
+			err := c.UpdateCollections(
+				ctx,
+				"driveID1",
+				"General",
+				test.items,
+				paths,
+				newPaths,
+				excluded,
+				map[string]string{},
+				true,
+			)
 			test.expect(t, err)
 			assert.Equal(t, len(test.expectedCollectionIDs), len(c.CollectionMap), "collection paths")
 			assert.Equal(t, test.expectedItemCount, c.NumItems, "item count")


### PR DESCRIPTION
## Description

It is possible that within a single delta query that files could be moved multiple times, this fixes that.

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [x] :clock1: Yes, but in a later PR
- [ ] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* fixes https://github.com/alcionai/corso/issues/2559

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
