### PR TITLE
write test logs to stdout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
           CORSO_M365_TEST_USER_ID: ${{ secrets.CORSO_M365_TEST_USER_ID }}
           CORSO_SECONDARY_M365_TEST_USER_ID: ${{ secrets.CORSO_SECONDARY_M365_TEST_USER_ID }}
           CORSO_PASSPHRASE: ${{ secrets.INTEGRATION_TEST_CORSO_PASSPHRASE }}
-          CORSO_LOG_FILE: stderr
+          CORSO_LOG_FILE: ./src/testlog/testlogging.log
           LOG_GRAPH_REQUESTS: true
         run: |
           set -euo pipefail
@@ -226,7 +226,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-log
-          path: src/testlog/gotest.log
+          path: src/testlog/*
           if-no-files-found: error
           retention-days: 14
 
@@ -297,6 +297,7 @@ jobs:
           CORSO_CI_TESTS: true
           CORSO_M365_TEST_USER_ID: ${{ secrets.CORSO_M365_TEST_USER_ID }}
           CORSO_PASSPHRASE: ${{ secrets.INTEGRATION_TEST_CORSO_PASSPHRASE }}
+          CORSO_LOG_FILE: ./src/testlog/testlogging.log
         run: |
           set -euo pipefail
           go test \
@@ -310,7 +311,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-log
-          path: src/testlog/gotest.log
+          path: src/testlog/*
           if-no-files-found: error
           retention-days: 14
 

--- a/.github/workflows/load_test.yml
+++ b/.github/workflows/load_test.yml
@@ -53,7 +53,7 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           CORSO_LOAD_TESTS: true 
-          CORSO_LOG_FILE: stderr
+          CORSO_LOG_FILE: stdout
           CORSO_M365_LOAD_TEST_USER_ID: ${{ secrets.CORSO_M365_LOAD_TEST_USER_ID }}
           CORSO_M365_LOAD_TEST_ORG_USERS: ${{ secrets.CORSO_M365_LOAD_TEST_ORG_USERS }}
           CORSO_PASSPHRASE: ${{ secrets.CORSO_PASSPHRASE }}

--- a/.github/workflows/load_test.yml
+++ b/.github/workflows/load_test.yml
@@ -53,7 +53,7 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           CORSO_LOAD_TESTS: true 
-          CORSO_LOG_FILE: ./src/testlog/testlogging.log
+          CORSO_LOG_FILE: ./src/test_results/testlogging.log
           CORSO_M365_LOAD_TEST_USER_ID: ${{ secrets.CORSO_M365_LOAD_TEST_USER_ID }}
           CORSO_M365_LOAD_TEST_ORG_USERS: ${{ secrets.CORSO_M365_LOAD_TEST_ORG_USERS }}
           CORSO_PASSPHRASE: ${{ secrets.CORSO_PASSPHRASE }}

--- a/.github/workflows/load_test.yml
+++ b/.github/workflows/load_test.yml
@@ -53,7 +53,7 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           CORSO_LOAD_TESTS: true 
-          CORSO_LOG_FILE: stdout
+          CORSO_LOG_FILE: ./src/testlog/testlogging.log
           CORSO_M365_LOAD_TEST_USER_ID: ${{ secrets.CORSO_M365_LOAD_TEST_USER_ID }}
           CORSO_M365_LOAD_TEST_ORG_USERS: ${{ secrets.CORSO_M365_LOAD_TEST_ORG_USERS }}
           CORSO_PASSPHRASE: ${{ secrets.CORSO_PASSPHRASE }}


### PR DESCRIPTION
stderr logging writes all our logs to the terminal (ie, what shows up in github workflows) instead of the logging file artifact.  On failures with thousands of lines of logs, this makes searching for the error source nearly impossible.  This change ensures we have clean outputs in github workflows, and logs stored in artifact files for extensive review.