### PR TITLE
Add owner in json output for backup list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] (beta)
 
+### Added
+- Show owner information when doing backup list in json format
+
 ## [v0.4.0] (alpha) - 2023-2-20
 
 ### Fixed

--- a/src/pkg/backup/backup.go
+++ b/src/pkg/backup/backup.go
@@ -108,6 +108,7 @@ type Printable struct {
 	Version       string         `json:"version"`
 	BytesRead     int64          `json:"bytesRead"`
 	BytesUploaded int64          `json:"bytesUploaded"`
+	Owner         string         `json:"owner"`
 }
 
 // MinimumPrintable reduces the Backup to its minimally printable details.
@@ -120,6 +121,7 @@ func (b Backup) MinimumPrintable() any {
 		Version:       "0",
 		BytesRead:     b.BytesRead,
 		BytesUploaded: b.BytesUploaded,
+		Owner:         b.Selector.DiscreteOwner,
 	}
 }
 

--- a/src/pkg/backup/backup_test.go
+++ b/src/pkg/backup/backup_test.go
@@ -102,4 +102,5 @@ func (suite *BackupSuite) TestBackup_MinimumPrintable() {
 	assert.Equal(t, b.Status, result.Status, "status")
 	assert.Equal(t, b.BytesRead, result.BytesRead, "size")
 	assert.Equal(t, b.BytesUploaded, result.BytesUploaded, "stored size")
+	assert.Equal(t, b.Selector.DiscreteOwner, result.Owner, "owner")
 }


### PR DESCRIPTION
## Description

This adds information about owner of the backup to `--json` output of backup list. Previously we were showing owner in the normal backup list command, but not when asked to as json.

## Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

## Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
