### PR TITLE
CLI: SharePoint --data flag and wildcards

### DIFF
--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -303,19 +303,13 @@ func sharePointBackupCreateSelectors(
 
 	for _, site := range sites {
 		if site == utils.Wildcard {
-			sel := selectors.NewSharePointBackup(selectors.Any())
-			sel.Include(sel.AllData())
-
-			return sel, nil
+			return handleWildCard(cats), nil
 		}
 	}
 
 	for _, wURL := range weburls {
 		if wURL == utils.Wildcard {
-			sel := selectors.NewSharePointBackup(selectors.Any())
-			sel.Include(sel.AllData())
-
-			return sel, nil
+			return handleWildCard(cats), nil
 		}
 	}
 
@@ -334,6 +328,21 @@ func sharePointBackupCreateSelectors(
 		return sel, nil
 	}
 
+	return addCategories(sel, cats), nil
+}
+
+func handleWildCard(categories []string) *selectors.SharePointBackup {
+	sel := selectors.NewSharePointBackup(selectors.Any())
+	if len(categories) == 0 {
+		sel.Include(sel.AllData())
+	} else {
+		sel = addCategories(sel, categories)
+	}
+
+	return sel
+}
+
+func addCategories(sel *selectors.SharePointBackup, cats []string) *selectors.SharePointBackup {
 	for _, d := range cats {
 		switch d {
 		case dataLibraries:
@@ -343,7 +352,7 @@ func sharePointBackupCreateSelectors(
 		}
 	}
 
-	return sel, nil
+	return sel
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -303,13 +303,13 @@ func sharePointBackupCreateSelectors(
 
 	for _, site := range sites {
 		if site == utils.Wildcard {
-			return handleWildCard(cats), nil
+			return includeAllSitesWithCategories(cats), nil
 		}
 	}
 
 	for _, wURL := range weburls {
 		if wURL == utils.Wildcard {
-			return handleWildCard(cats), nil
+			return includeAllSitesWithCategories(cats), nil
 		}
 	}
 
@@ -322,27 +322,23 @@ func sharePointBackupCreateSelectors(
 	}
 
 	sel := selectors.NewSharePointBackup(union)
-	if len(cats) == 0 {
-		sel.Include(sel.AllData())
-
-		return sel, nil
-	}
 
 	return addCategories(sel, cats), nil
 }
 
-func handleWildCard(categories []string) *selectors.SharePointBackup {
-	sel := selectors.NewSharePointBackup(selectors.Any())
-	if len(categories) == 0 {
-		sel.Include(sel.AllData())
-	} else {
-		sel = addCategories(sel, categories)
-	}
+func includeAllSitesWithCategories(categories []string) *selectors.SharePointBackup {
+	sel := addCategories(
+		selectors.NewSharePointBackup(selectors.Any()),
+		categories)
 
 	return sel
 }
 
 func addCategories(sel *selectors.SharePointBackup, cats []string) *selectors.SharePointBackup {
+	if len(cats) == 0 {
+		sel.Include(sel.AllData())
+	}
+
 	for _, d := range cats {
 		switch d {
 		case dataLibraries:


### PR DESCRIPTION
## Description
Enables feature SharePoint to use "wildcard" to select all available sites with the ability to only backup selected categories.

Example 
```bash
./corso backup create sharepoint --web-url "*" --data libraries
```



<!-- Insert PR description-->

## Does this PR need a docs update or release note?
- [x] :no_entry: No 

## Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :bug: Bugfix


## Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* closes #2579<issue>

## Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual

