### PR TITLE
log all recoverable errors in backup/restore

### DIFF
--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -169,6 +169,15 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 		opStats.readErr = op.Errors.Err()
 	}
 
+	// TODO: the consumer (sdk or cli) should run this, not operations.
+	recoverableCount := len(op.Errors.Errs())
+	for i, err := range op.Errors.Errs() {
+		logger.Ctx(ctx).
+			With("error", err).
+			With(clues.InErr(err).Slice()...).
+			Errorf("doing backup: recoverable error %d of %d", i+1, recoverableCount)
+	}
+
 	// -----
 	// Persistence
 	// -----

--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -156,6 +156,15 @@ func (op *RestoreOperation) Run(ctx context.Context) (restoreDetails *details.De
 		opStats.readErr = op.Errors.Err()
 	}
 
+	// TODO: the consumer (sdk or cli) should run this, not operations.
+	recoverableCount := len(op.Errors.Errs())
+	for i, err := range op.Errors.Errs() {
+		logger.Ctx(ctx).
+			With("error", err).
+			With(clues.InErr(err).Slice()...).
+			Errorf("doing restore: recoverable error %d of %d", i+1, recoverableCount)
+	}
+
 	// -----
 	// Persistence
 	// -----


### PR DESCRIPTION
## Description

fault is aggregating recoverable errors, but no code currently reports them.  This is a quick hack to add logging around those errors.  In the future, we'll want to refine who and where performs this report.

## Does this PR need a docs update or release note?

- [x] :no_entry: No 

## Type of change

- [x] :broom: Tech Debt/Cleanup

## Issue(s)

* #1970

## Test Plan

- [x] :muscle: Manual
