### PR TITLE
Store OneDrive directory metadata in directory

### DIFF
--- a/src/internal/connector/graph_connector_onedrive_test.go
+++ b/src/internal/connector/graph_connector_onedrive_test.go
@@ -173,7 +173,7 @@ func (c *onedriveCollection) withFile(
 			name+onedrive.DataFileSuffix,
 			fileData))
 
-	case 1, 2, 3, 4:
+	case version.OneDrive1DataAndMetaFiles, 2, version.OneDrive3IsMetaMarker, version.OneDrive4DirIncludesPermissions:
 		c.items = append(c.items, onedriveItemWithData(
 			c.t,
 			name+onedrive.DataFileSuffix,
@@ -202,10 +202,10 @@ func (c *onedriveCollection) withFolder(
 	roles []string,
 ) *onedriveCollection {
 	switch c.backupVersion {
-	case 0, 4:
+	case 0, version.OneDrive4DirIncludesPermissions:
 		return c
 
-	case 1, 2, 3:
+	case version.OneDrive1DataAndMetaFiles, 2, version.OneDrive3IsMetaMarker:
 		c.items = append(
 			c.items,
 			onedriveMetadata(
@@ -349,7 +349,7 @@ func (suite *GraphConnectorOneDriveIntegrationSuite) TestRestoreAndBackup_Multip
 	table := []onedriveTest{
 		{
 			name:         "WithMetadata",
-			startVersion: 1,
+			startVersion: version.OneDrive1DataAndMetaFiles,
 			cols: []onedriveColInfo{
 				{
 					pathElements: rootPath,
@@ -520,7 +520,7 @@ func (suite *GraphConnectorOneDriveIntegrationSuite) TestPermissionsRestoreAndBa
 		folderBName,
 	}
 
-	startVersion := 1
+	startVersion := version.OneDrive1DataAndMetaFiles
 
 	table := []onedriveTest{
 		{
@@ -735,7 +735,7 @@ func (suite *GraphConnectorOneDriveIntegrationSuite) TestPermissionsBackupAndNoR
 		suite.user,
 	)
 
-	startVersion := 1
+	startVersion := version.OneDrive1DataAndMetaFiles
 
 	table := []onedriveTest{
 		{

--- a/src/internal/connector/graph_connector_onedrive_test.go
+++ b/src/internal/connector/graph_connector_onedrive_test.go
@@ -230,7 +230,7 @@ func (c *onedriveCollection) withPermissions(
 ) *onedriveCollection {
 	// These versions didn't store permissions for the folder or didn't store them
 	// in the folder's collection.
-	if c.backupVersion < version.OneDriveDirIncludesPermissions {
+	if c.backupVersion < version.OneDrive4DirIncludesPermissions {
 		return c
 	}
 

--- a/src/internal/connector/graph_connector_onedrive_test.go
+++ b/src/internal/connector/graph_connector_onedrive_test.go
@@ -173,7 +173,7 @@ func (c *onedriveCollection) withFile(
 			name+onedrive.DataFileSuffix,
 			fileData))
 
-	case 1, 2, 3:
+	case 1, 2, 3, 4:
 		c.items = append(c.items, onedriveItemWithData(
 			c.t,
 			name+onedrive.DataFileSuffix,
@@ -202,7 +202,7 @@ func (c *onedriveCollection) withFolder(
 	roles []string,
 ) *onedriveCollection {
 	switch c.backupVersion {
-	case 0:
+	case 0, 4:
 		return c
 
 	case 1, 2, 3:
@@ -240,15 +240,15 @@ func (c *onedriveCollection) withPermissions(
 		return c
 	}
 
-	c.items = append(
-		c.items,
-		onedriveMetadata(
-			c.t,
-			name,
-			name+onedrive.DirMetaFileSuffix,
-			user,
-			roles),
-	)
+	metadata := onedriveMetadata(
+		c.t,
+		name,
+		name+onedrive.DirMetaFileSuffix,
+		user,
+		roles)
+
+	c.items = append(c.items, metadata)
+	c.aux = append(c.aux, metadata)
 
 	return c
 }
@@ -375,6 +375,10 @@ func (suite *GraphConnectorOneDriveIntegrationSuite) TestRestoreAndBackup_Multip
 				},
 				{
 					pathElements: folderBPath,
+					perms: permData{
+						user:  suite.secondaryUser,
+						roles: readPerm,
+					},
 					files: []itemData{
 						{
 							name: fileName,
@@ -888,6 +892,12 @@ func (suite *GraphConnectorOneDriveIntegrationSuite) TestPermissionsRestoreAndNo
 				withFile(
 					fileName,
 					fileEData,
+					"",
+					nil,
+				).
+				// Call this to generate a meta file with the folder name that we can
+				// check.
+				withPermissions(
 					"",
 					nil,
 				).

--- a/src/internal/connector/graph_connector_onedrive_test.go
+++ b/src/internal/connector/graph_connector_onedrive_test.go
@@ -230,7 +230,7 @@ func (c *onedriveCollection) withPermissions(
 ) *onedriveCollection {
 	// These versions didn't store permissions for the folder or didn't store them
 	// in the folder's collection.
-	if c.backupVersion < version.OneDriveXIncludesPermissions {
+	if c.backupVersion < version.OneDriveDirIncludesPermissions {
 		return c
 	}
 

--- a/src/internal/connector/graph_connector_test.go
+++ b/src/internal/connector/graph_connector_test.go
@@ -493,7 +493,14 @@ func runBackupAndCompare(
 
 	// Pull the data prior to waiting for the status as otherwise it will
 	// deadlock.
-	skipped := checkCollections(t, ctx, totalKopiaItems, expectedData, dcs, config.opts.RestorePermissions)
+	skipped := checkCollections(
+		t,
+		ctx,
+		totalKopiaItems,
+		expectedData,
+		dcs,
+		config.dest,
+		config.opts.RestorePermissions)
 
 	status := backupGC.AwaitStatus()
 
@@ -1000,7 +1007,15 @@ func (suite *GraphConnectorIntegrationSuite) TestMultiFolderBackupDifferentNames
 
 			// Pull the data prior to waiting for the status as otherwise it will
 			// deadlock.
-			skipped := checkCollections(t, ctx, allItems, allExpectedData, dcs, true)
+			skipped := checkCollections(
+				t,
+				ctx,
+				allItems,
+				allExpectedData,
+				dcs,
+				// Alright to be empty, needed for OneDrive.
+				control.RestoreDestination{},
+				true)
 
 			status := backupGC.AwaitStatus()
 			assert.Equal(t, allItems+skipped, status.ObjectCount, "status.ObjectCount")

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -640,24 +640,19 @@ func (c *Collections) UpdateCollections(
 			}
 
 			if !found {
-				// We only create collections for folder that are not
-				// new. This is so as to not create collections for
-				// new folders without any files within them.
-				if prevPath != nil {
-					col := NewCollection(
-						c.itemClient,
-						folderPath,
-						prevPath,
-						driveID,
-						c.service,
-						c.statusUpdater,
-						c.source,
-						c.ctrl,
-						invalidPrevDelta,
-					)
-					c.CollectionMap[*item.GetId()] = col
-					c.NumContainers++
-				}
+				col := NewCollection(
+					c.itemClient,
+					folderPath,
+					prevPath,
+					driveID,
+					c.service,
+					c.statusUpdater,
+					c.source,
+					c.ctrl,
+					invalidPrevDelta,
+				)
+				c.CollectionMap[*item.GetId()] = col
+				c.NumContainers++
 			}
 
 			if c.source != OneDriveSource {
@@ -742,14 +737,6 @@ func (c *Collections) UpdateCollections(
 				removed := pcollection.Remove(item)
 				if !removed {
 					return clues.New("removing from prev collection").With("item_id", *item.GetId())
-				}
-
-				// If that was the only item in that collection and is
-				// not getting added back, delete the collection
-				if itemColID != collectionID &&
-					pcollection.IsEmpty() &&
-					pcollection.State() == data.NewState {
-					delete(c.CollectionMap, itemColID)
 				}
 			}
 

--- a/src/internal/connector/onedrive/collections_test.go
+++ b/src/internal/connector/onedrive/collections_test.go
@@ -222,7 +222,7 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			scope:          anyFolder,
 			expect:         assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				"root": expectedStatePath(data.NotMovedState, ""),
+				"folder": expectedStatePath(data.NewState, folder),
 			},
 			expectedMetadataPaths: map[string]string{
 				"root":   expectedPath(""),
@@ -242,7 +242,7 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			scope:          anyFolder,
 			expect:         assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				"root": expectedStatePath(data.NotMovedState, ""),
+				"package": expectedStatePath(data.NewState, pkg),
 			},
 			expectedMetadataPaths: map[string]string{
 				"root":    expectedPath(""),
@@ -301,15 +301,16 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 				"subfolder": expectedStatePath(data.NewState, folderSub),
 				"folder2":   expectedStatePath(data.NewState, folderSub+folder),
 			},
-			expectedItemCount:      4,
+			expectedItemCount:      5,
 			expectedFileCount:      2,
 			expectedContainerCount: 3,
 			// just "folder" isn't added here because the include check is done on the
 			// parent path since we only check later if something is a folder or not.
 			expectedMetadataPaths: map[string]string{
 				"root":      expectedPath(""),
-				"subfolder": expectedPath("/folder/subfolder"),
-				"folder2":   expectedPath("/folder/subfolder/folder"),
+				"folder":    expectedPath(folder),
+				"subfolder": expectedPath(folderSub),
+				"folder2":   expectedPath(folderSub + folder),
 			},
 			expectedExcludes: getDelList("fileInFolder", "fileInFolder2"),
 		},
@@ -334,12 +335,13 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 				"subfolder": expectedStatePath(data.NewState, folderSub),
 				"folder2":   expectedStatePath(data.NewState, folderSub+folder),
 			},
-			expectedItemCount:      2,
+			expectedItemCount:      3,
 			expectedFileCount:      1,
 			expectedContainerCount: 2,
 			expectedMetadataPaths: map[string]string{
-				"root":    expectedPath(""),
-				"folder2": expectedPath("/folder/subfolder/folder"),
+				"root":      expectedPath(""),
+				"subfolder": expectedPath(folderSub),
+				"folder2":   expectedPath(folderSub + folder),
 			},
 			expectedExcludes: getDelList("fileInFolder2"),
 		},
@@ -361,12 +363,13 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			expectedCollectionIDs: map[string]statePath{
 				"subfolder": expectedStatePath(data.NewState, folderSub),
 			},
-			expectedItemCount:      1,
+			expectedItemCount:      2,
 			expectedFileCount:      1,
 			expectedContainerCount: 1,
 			// No child folders for subfolder so nothing here.
 			expectedMetadataPaths: map[string]string{
-				"root": expectedPath(""),
+				"root":      expectedPath(""),
+				"subfolder": expectedPath(folderSub),
 			},
 			expectedExcludes: getDelList("fileInSubfolder"),
 		},
@@ -377,22 +380,21 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 				driveItem("folder", "folder", testBaseDrivePath, "root", false, true, false),
 			},
 			inputFolderMap: map[string]string{
-				"folder":    expectedPath("/folder"),
-				"subfolder": expectedPath("/folder/subfolder"),
+				"folder":    expectedPath(folder),
+				"subfolder": expectedPath(folderSub),
 			},
 			scope:  anyFolder,
 			expect: assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				"root":   expectedStatePath(data.NotMovedState, ""),
-				"folder": expectedStatePath(data.NotMovedState, "/folder"),
+				"folder": expectedStatePath(data.NotMovedState, folder),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      0,
-			expectedContainerCount: 2,
+			expectedContainerCount: 1,
 			expectedMetadataPaths: map[string]string{
 				"root":      expectedPath(""),
-				"folder":    expectedPath("/folder"),
-				"subfolder": expectedPath("/folder/subfolder"),
+				"folder":    expectedPath(folder),
+				"subfolder": expectedPath(folderSub),
 			},
 			expectedExcludes: map[string]struct{}{},
 		},
@@ -409,16 +411,15 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			scope:  anyFolder,
 			expect: assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				"root":   expectedStatePath(data.NotMovedState, ""),
-				"folder": expectedStatePath(data.MovedState, "/folder", "/a-folder"),
+				"folder": expectedStatePath(data.MovedState, folder, "/a-folder"),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      0,
-			expectedContainerCount: 2,
+			expectedContainerCount: 1,
 			expectedMetadataPaths: map[string]string{
 				"root":      expectedPath(""),
-				"folder":    expectedPath("/folder"),
-				"subfolder": expectedPath("/folder/subfolder"),
+				"folder":    expectedPath(folder),
+				"subfolder": expectedPath(folderSub),
 			},
 			expectedExcludes: map[string]struct{}{},
 		},
@@ -430,20 +431,19 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 				driveItem("folder", "folder", testBaseDrivePath, "root", false, true, false),
 			},
 			inputFolderMap: map[string]string{
-				"folder": expectedPath("/folder"),
+				"folder": expectedPath(folder),
 			},
 			scope:  anyFolder,
 			expect: assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				"root":   expectedStatePath(data.NotMovedState, ""),
-				"folder": expectedStatePath(data.NotMovedState, "/folder"),
+				"folder": expectedStatePath(data.NotMovedState, folder),
 			},
 			expectedItemCount:      2,
 			expectedFileCount:      1,
-			expectedContainerCount: 2,
+			expectedContainerCount: 1,
 			expectedMetadataPaths: map[string]string{
 				"root":   expectedPath(""),
-				"folder": expectedPath("/folder"),
+				"folder": expectedPath(folder),
 			},
 			expectedExcludes: getDelList("file"),
 		},
@@ -459,12 +459,11 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			scope:          anyFolder,
 			expect:         assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				"root":   expectedStatePath(data.NotMovedState, ""),
 				"folder": expectedStatePath(data.NewState, "/folder2"),
 			},
-			expectedItemCount:      3, // permissions gets saved twice for folder
+			expectedItemCount:      2,
 			expectedFileCount:      1,
-			expectedContainerCount: 2,
+			expectedContainerCount: 1,
 			expectedMetadataPaths: map[string]string{
 				"root":   expectedPath(""),
 				"folder": expectedPath("/folder2"),
@@ -482,15 +481,14 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			scope:          anyFolder,
 			expect:         assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				"root":   expectedStatePath(data.NotMovedState, ""),
-				"folder": expectedStatePath(data.NewState, "/folder"),
+				"folder": expectedStatePath(data.NewState, folder),
 			},
 			expectedItemCount:      2,
 			expectedFileCount:      1,
-			expectedContainerCount: 2,
+			expectedContainerCount: 1,
 			expectedMetadataPaths: map[string]string{
 				"root":   expectedPath(""),
-				"folder": expectedPath("/folder"),
+				"folder": expectedPath(folder),
 			},
 			expectedExcludes: getDelList("file"),
 		},
@@ -508,16 +506,15 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			scope:  anyFolder,
 			expect: assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				"root":      expectedStatePath(data.NotMovedState, ""),
-				"folder":    expectedStatePath(data.MovedState, "/folder", "/a-folder"),
+				"folder":    expectedStatePath(data.MovedState, folder, "/a-folder"),
 				"subfolder": expectedStatePath(data.MovedState, "/subfolder", "/a-folder/subfolder"),
 			},
 			expectedItemCount:      2,
 			expectedFileCount:      0,
-			expectedContainerCount: 3,
+			expectedContainerCount: 2,
 			expectedMetadataPaths: map[string]string{
 				"root":      expectedPath(""),
-				"folder":    expectedPath("/folder"),
+				"folder":    expectedPath(folder),
 				"subfolder": expectedPath("/subfolder"),
 			},
 			expectedExcludes: map[string]struct{}{},
@@ -536,16 +533,15 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			scope:  anyFolder,
 			expect: assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				"root":      expectedStatePath(data.NotMovedState, ""),
-				"folder":    expectedStatePath(data.MovedState, "/folder", "/a-folder"),
+				"folder":    expectedStatePath(data.MovedState, folder, "/a-folder"),
 				"subfolder": expectedStatePath(data.MovedState, "/subfolder", "/a-folder/subfolder"),
 			},
 			expectedItemCount:      2,
 			expectedFileCount:      0,
-			expectedContainerCount: 3,
+			expectedContainerCount: 2,
 			expectedMetadataPaths: map[string]string{
 				"root":      expectedPath(""),
-				"folder":    expectedPath("/folder"),
+				"folder":    expectedPath(folder),
 				"subfolder": expectedPath("/subfolder"),
 			},
 			expectedExcludes: map[string]struct{}{},
@@ -556,6 +552,9 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 				driveRootItem("root"),
 				driveItem("folder2", "folder2", testBaseDrivePath, "root", false, true, false),
 				driveItem("itemInFolder2", "itemInFolder2", testBaseDrivePath+"/folder2", "folder2", true, false, false),
+				// Need to see the parent folder first (expected since that's what Graph
+				// consistently returns).
+				driveItem("folder", "a-folder", testBaseDrivePath, "root", false, true, false),
 				driveItem("subfolder", "subfolder", testBaseDrivePath+"/a-folder", "folder", false, true, false),
 				driveItem(
 					"itemInSubfolder",
@@ -575,14 +574,13 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			scope:  anyFolder,
 			expect: assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				"root":      expectedStatePath(data.NotMovedState, ""),
-				"folder":    expectedStatePath(data.MovedState, "/folder", "/a-folder"),
+				"folder":    expectedStatePath(data.MovedState, folder, "/a-folder"),
 				"folder2":   expectedStatePath(data.NewState, "/folder2"),
-				"subfolder": expectedStatePath(data.MovedState, "/folder/subfolder", "/a-folder/subfolder"),
+				"subfolder": expectedStatePath(data.MovedState, folderSub, "/a-folder/subfolder"),
 			},
 			expectedItemCount:      5,
 			expectedFileCount:      2,
-			expectedContainerCount: 4,
+			expectedContainerCount: 3,
 			expectedMetadataPaths: map[string]string{
 				"root":      expectedPath(""),
 				"folder":    expectedPath("/folder"),
@@ -606,12 +604,11 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			scope:  anyFolder,
 			expect: assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				"root":   expectedStatePath(data.NotMovedState, ""),
 				"folder": expectedStatePath(data.MovedState, "/folder2", "/a-folder"),
 			},
-			expectedItemCount:      3,
+			expectedItemCount:      2,
 			expectedFileCount:      1,
-			expectedContainerCount: 2,
+			expectedContainerCount: 1,
 			expectedMetadataPaths: map[string]string{
 				"root":      expectedPath(""),
 				"folder":    expectedPath("/folder2"),
@@ -680,13 +677,12 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			scope:  anyFolder,
 			expect: assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				"root":      expectedStatePath(data.NotMovedState, ""),
 				"folder":    expectedStatePath(data.DeletedState, folder),
-				"subfolder": expectedStatePath(data.MovedState, "/subfolder", "/folder/subfolder"),
+				"subfolder": expectedStatePath(data.MovedState, "/subfolder", folderSub),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      0,
-			expectedContainerCount: 2,
+			expectedContainerCount: 1,
 			expectedMetadataPaths: map[string]string{
 				"root":      expectedPath(""),
 				"subfolder": expectedPath("/subfolder"),
@@ -752,7 +748,11 @@ func (suite *OneDriveCollectionsSuite) TestUpdateCollections() {
 			assert.Equal(t, tt.expectedContainerCount, c.NumContainers, "container count")
 
 			for id, sp := range tt.expectedCollectionIDs {
-				assert.Containsf(t, c.CollectionMap, id, "contains collection with id %s", id)
+				if !assert.Containsf(t, c.CollectionMap, id, "missing collection with id %s", id) {
+					// Skip collections we don't find so we don't get an NPE.
+					continue
+				}
+
 				assert.Equalf(t, sp.state, c.CollectionMap[id].State(), "state for collection %s", id)
 				assert.Equalf(t, sp.curPath, c.CollectionMap[id].FullPath(), "current path for collection %s", id)
 				assert.Equalf(t, sp.prevPath, c.CollectionMap[id].PreviousPath(), "prev path for collection %s", id)
@@ -1299,8 +1299,7 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 				driveID1: {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				folderPath1:     {data.NewState: {"file"}},
-				rootFolderPath1: {data.NotMovedState: {"folder"}},
+				folderPath1: {data.NewState: {"folder", "file"}},
 			},
 			expectedDeltaURLs: map[string]string{
 				driveID1: delta,
@@ -1334,8 +1333,7 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 				driveID1: {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				folderPath1:     {data.NewState: {"file"}},
-				rootFolderPath1: {data.NotMovedState: {"folder"}},
+				folderPath1: {data.NewState: {"folder", "file"}},
 			},
 			expectedDeltaURLs: map[string]string{
 				driveID1: delta,
@@ -1369,7 +1367,8 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 				driveID1: {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				rootFolderPath1: {data.NotMovedState: {"folder", "file"}},
+				rootFolderPath1: {data.NotMovedState: {"file"}},
+				folderPath1:     {data.NewState: {"folder"}},
 			},
 			expectedDeltaURLs: map[string]string{
 				driveID1: delta,
@@ -1402,8 +1401,7 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 				driveID1: {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				folderPath1:     {data.NewState: {"file"}},
-				rootFolderPath1: {data.NotMovedState: {"folder"}},
+				folderPath1: {data.NewState: {"folder", "file"}},
 			},
 			expectedDeltaURLs:   map[string]string{},
 			expectedFolderPaths: map[string]map[string]string{},
@@ -1437,8 +1435,7 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 				driveID1: {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				folderPath1:     {data.NewState: {"file", "file2"}},
-				rootFolderPath1: {data.NotMovedState: {"folder"}},
+				folderPath1: {data.NewState: {"folder", "file", "file2"}},
 			},
 			expectedDeltaURLs: map[string]string{
 				driveID1: delta,
@@ -1485,10 +1482,8 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 				driveID2: {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				folderPath1:     {data.NewState: {"file"}},
-				folderPath2:     {data.NewState: {"file2"}},
-				rootFolderPath1: {data.NotMovedState: {"folder"}},
-				rootFolderPath2: {data.NotMovedState: {"folder2"}},
+				folderPath1: {data.NewState: {"folder", "file"}},
+				folderPath2: {data.NewState: {"folder2", "file2"}},
 			},
 			expectedDeltaURLs: map[string]string{
 				driveID1: delta,
@@ -1584,8 +1579,8 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 			},
 			errCheck: assert.NoError,
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				expectedPath1(""):        {data.NotMovedState: {"file", "folder"}},
-				expectedPath1("/folder"): {data.NewState: {"file2"}},
+				expectedPath1(""):        {data.NotMovedState: {"file"}},
+				expectedPath1("/folder"): {data.NewState: {"folder", "file2"}},
 			},
 			expectedDeltaURLs: map[string]string{
 				driveID1: delta,
@@ -1626,8 +1621,8 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 				driveID1: {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				expectedPath1(""):        {data.NotMovedState: {"file", "folder"}},
-				expectedPath1("/folder"): {data.NewState: {"file2"}},
+				expectedPath1(""):        {data.NotMovedState: {"file"}},
+				expectedPath1("/folder"): {data.NewState: {"folder", "file2"}},
 			},
 			expectedDeltaURLs: map[string]string{
 				driveID1: delta,
@@ -1667,9 +1662,8 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				expectedPath1(""):         {data.NotMovedState: {"folder2"}},
 				expectedPath1("/folder"):  {data.DeletedState: {}},
-				expectedPath1("/folder2"): {data.NewState: {"file"}},
+				expectedPath1("/folder2"): {data.NewState: {"folder2", "file"}},
 			},
 			expectedDeltaURLs: map[string]string{
 				driveID1: delta,
@@ -1709,8 +1703,7 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				expectedPath1(""):        {data.NotMovedState: {"folder2"}},
-				expectedPath1("/folder"): {data.NewState: {"file"}},
+				expectedPath1("/folder"): {data.NewState: {"folder2", "file"}},
 			},
 			expectedDeltaURLs: map[string]string{
 				driveID1: delta,
@@ -1842,9 +1835,9 @@ func (suite *OneDriveCollectionsSuite) TestGet() {
 					t,
 					test.expectedCollections[folderPath][baseCol.State()],
 					itemIDs,
-					"items in collection %s",
-					folderPath,
-				)
+					"state: %d, path: %s",
+					baseCol.State(),
+					folderPath)
 				assert.Equal(t, test.doNotMergeItems, baseCol.DoNotMergeItems(), "DoNotMergeItems")
 			}
 

--- a/src/internal/connector/onedrive/permission.go
+++ b/src/internal/connector/onedrive/permission.go
@@ -67,7 +67,7 @@ func getParentAndCollectionPermissions(
 		}
 	}
 
-	if backupVersion < version.OneDriveDirIncludesPermissions {
+	if backupVersion < version.OneDrive4DirIncludesPermissions {
 		colPerms, err = getParentPermissions(collectionPath, permissions)
 		if err != nil {
 			return nil, nil, clues.Wrap(err, "getting collection permissions")

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -283,7 +283,7 @@ func RestoreCollection(
 					// Only the version.OneDrive1DataAndMetaFiles needed to deserialize the
 					// permission for child folders here. Later versions can request
 					// permissions inline when processing the collection.
-					if !restorePerms || backupVersion >= version.OneDriveDirIncludesPermissions {
+					if !restorePerms || backupVersion >= version.OneDrive4DirIncludesPermissions {
 						continue
 					}
 

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -170,9 +170,11 @@ func RestoreCollection(
 	logger.Ctx(ctx).Info("restoring onedrive collection")
 
 	parentPerms, colPerms, err := getParentAndCollectionPermissions(
+		ctx,
 		drivePath,
-		dc.FullPath(),
+		dc,
 		parentPermissions,
+		backupVersion,
 		restorePerms)
 	if err != nil {
 		return metrics, folderPerms, permissionIDMappings, clues.Wrap(err, "getting permissions").WithClues(ctx)
@@ -278,7 +280,10 @@ func RestoreCollection(
 					// RestoreOp, so we still need to handle them in some way.
 					continue
 				} else if strings.HasSuffix(name, DirMetaFileSuffix) {
-					if !restorePerms {
+					// Only the version.OneDrive1DataAndMetaFiles needed to deserialize the
+					// permission for child folders here. Later versions can request
+					// permissions inline when processing the collection.
+					if !restorePerms || backupVersion >= version.OneDriveDirIncludesPermissions {
 						continue
 					}
 

--- a/src/internal/version/backup.go
+++ b/src/internal/version/backup.go
@@ -23,7 +23,7 @@ const (
 
 	// OneDrive4IncludesPermissions includes permissions for folders in the same
 	// collection as the folder itself.
-	OneDriveDirIncludesPermissions = 4
+	OneDrive4DirIncludesPermissions = 4
 
 	// OneDriveXNameInMeta points to the backup format version where we begin
 	// storing files in kopia with their item ID instead of their OneDrive file

--- a/src/internal/version/backup.go
+++ b/src/internal/version/backup.go
@@ -2,7 +2,7 @@ package version
 
 import "math"
 
-const Backup = 3
+const Backup = 4
 
 // Various labels to refer to important version changes.
 // Labels don't need 1:1 service:version representation.  Add a new
@@ -21,12 +21,9 @@ const (
 	// specifies if the file is a meta file or a data file.
 	OneDrive3IsMetaMarker = 3
 
-	// OneDrive4IncludesPermissions includes permissions in the backup.
-	// Note that this is larger than the current backup version.  That's
-	// because it isn't implemented yet.  But we have tests based on this,
-	// so maybe we just keep bumping the verson ahead of the backup until
-	// it gets implemented.
-	OneDriveXIncludesPermissions = Backup + 1
+	// OneDrive4IncludesPermissions includes permissions for folders in the same
+	// collection as the folder itself.
+	OneDriveDirIncludesPermissions = 4
 
 	// OneDriveXNameInMeta points to the backup format version where we begin
 	// storing files in kopia with their item ID instead of their OneDrive file


### PR DESCRIPTION
## Description

This PR does a couple of things, some of which are to make storing the directory metadata in the directory easier:
* backup empty folders
* expand what selectors match on slightly so it includes the folder specified in the selector (e.x. match on prefix `/foo` will now include the folder `/foo` and subfolders under it)
* add restore code path for having directory metadata in the directory
* update backup code path to store directory metadata in the directory
* bump the backup version so we can tell this apart from the previous version

The above should mostly be split out by commit if that makes reviewing easier

Storing the directory metadata in the directory allows removing the data dependency between
restoring parent directories and child directories (though there may still be a dependency there for permissions inheritance). This makes it so that the order kopia returns restore data does not matter

It also unblocks some of the OneDrive delta token-based incremental backup work as we no longer have to worry about directory metadata when moving/deleting a directory

## Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No 

## Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

## Issue(s)

* closes #2447
* closes #2532

## Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
