### PR TITLE
fix url logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Errors from duplicate names in Exchange Calendars
 - Resolved an issue where progress bar displays could fail to exit, causing unbounded CPU consumption.
 - Fix Corso panic within Docker images
-- Debugging with the CORSO_URL_LOGGING env variable.
+- Debugging with the CORSO_URL_LOGGING env variable no longer causes accidental request failures.
 
 ### Changed
 - When using Restore and Details on Exchange Calendars, the `--event-calendar` flag can now identify calendars by either a Display Name or a Microsoft 365 ID.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Errors from duplicate names in Exchange Calendars
 - Resolved an issue where progress bar displays could fail to exit, causing unbounded CPU consumption.
 - Fix Corso panic within Docker images
+- Debugging with the CORSO_URL_LOGGING env variable.
 
 ### Changed
 - When using Restore and Details on Exchange Calendars, the `--event-calendar` flag can now identify calendars by either a Display Name or a Microsoft 365 ID.
@@ -28,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Known Issues
 - Nested attachments are currently not restored due to an [issue](https://github.com/microsoft/kiota-serialization-json-go/issues/61) discovered in the Graph APIs
 - Breaking changes to Exchange Calendar backups.
+- The debugging env variable CORSO_URL_LOGGING causes exchange get requests to fail.
 
 ## [v0.3.0] (alpha) - 2023-2-07
 

--- a/src/internal/connector/exchange/api/contacts.go
+++ b/src/internal/connector/exchange/api/contacts.go
@@ -248,16 +248,11 @@ func (c Contacts) GetAddedAndRemovedItemIDs(
 	pgr := &contactPager{service, builder, options}
 
 	if len(os.Getenv("CORSO_URL_LOGGING")) > 0 {
-		gri, err := builder.ToGetRequestInformation(ctx, options)
+		gri, err := builder.ToGetRequestInformation(ctx, nil)
 		if err != nil {
 			logger.Ctx(ctx).Errorw("getting builder info", "error", err)
 		} else {
-			uri, err := gri.GetUri()
-			if err != nil {
-				logger.Ctx(ctx).Errorw("getting builder uri", "error", err)
-			} else {
-				logger.Ctx(ctx).Infow("contact builder", "user", user, "directoryID", directoryID, "uri", uri)
-			}
+			logger.Ctx(ctx).Warnf("path-parameters %v", gri.PathParameters)
 		}
 	}
 

--- a/src/internal/connector/exchange/api/contacts.go
+++ b/src/internal/connector/exchange/api/contacts.go
@@ -248,11 +248,13 @@ func (c Contacts) GetAddedAndRemovedItemIDs(
 	pgr := &contactPager{service, builder, options}
 
 	if len(os.Getenv("CORSO_URL_LOGGING")) > 0 {
-		gri, err := builder.ToGetRequestInformation(ctx, nil)
+		gri, err := builder.ToGetRequestInformation(ctx, options)
 		if err != nil {
 			logger.Ctx(ctx).Errorw("getting builder info", "error", err)
 		} else {
-			logger.Ctx(ctx).Warnf("path-parameters %v", gri.PathParameters)
+			logger.Ctx(ctx).
+				With("user", user, "container", directoryID).
+				Warnw("builder path-parameters", "path_parameters", gri.PathParameters)
 		}
 	}
 

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -279,12 +279,7 @@ func (c Events) GetAddedAndRemovedItemIDs(
 		if err != nil {
 			logger.Ctx(ctx).Errorw("getting builder info", "error", err)
 		} else {
-			uri, err := gri.GetUri()
-			if err != nil {
-				logger.Ctx(ctx).Errorw("getting builder uri", "error", err)
-			} else {
-				logger.Ctx(ctx).Infow("calendar builder", "user", user, "directoryID", calendarID, "uri", uri)
-			}
+			logger.Ctx(ctx).Warnf("path-parameters %v", gri.PathParameters)
 		}
 	}
 

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -279,7 +279,9 @@ func (c Events) GetAddedAndRemovedItemIDs(
 		if err != nil {
 			logger.Ctx(ctx).Errorw("getting builder info", "error", err)
 		} else {
-			logger.Ctx(ctx).Warnf("path-parameters %v", gri.PathParameters)
+			logger.Ctx(ctx).
+				With("user", user, "container", calendarID).
+				Warnw("builder path-parameters", "path_parameters", gri.PathParameters)
 		}
 	}
 

--- a/src/internal/connector/exchange/api/mail.go
+++ b/src/internal/connector/exchange/api/mail.go
@@ -286,11 +286,13 @@ func (c Mail) GetAddedAndRemovedItemIDs(
 	pgr := &mailPager{service, builder, options}
 
 	if len(os.Getenv("CORSO_URL_LOGGING")) > 0 {
-		gri, err := builder.ToGetRequestInformation(ctx, nil)
+		gri, err := builder.ToGetRequestInformation(ctx, options)
 		if err != nil {
 			logger.Ctx(ctx).Errorw("getting builder info", "error", err)
 		} else {
-			logger.Ctx(ctx).Warnf("path-parameters %v", gri.PathParameters)
+			logger.Ctx(ctx).
+				With("user", user, "container", directoryID).
+				Warnw("builder path-parameters", "path_parameters", gri.PathParameters)
 		}
 	}
 

--- a/src/internal/connector/exchange/api/mail.go
+++ b/src/internal/connector/exchange/api/mail.go
@@ -286,16 +286,11 @@ func (c Mail) GetAddedAndRemovedItemIDs(
 	pgr := &mailPager{service, builder, options}
 
 	if len(os.Getenv("CORSO_URL_LOGGING")) > 0 {
-		gri, err := builder.ToGetRequestInformation(ctx, options)
+		gri, err := builder.ToGetRequestInformation(ctx, nil)
 		if err != nil {
 			logger.Ctx(ctx).Errorw("getting builder info", "error", err)
 		} else {
-			uri, err := gri.GetUri()
-			if err != nil {
-				logger.Ctx(ctx).Errorw("getting builder uri", "error", err)
-			} else {
-				logger.Ctx(ctx).Infow("mail builder", "user", user, "directoryID", directoryID, "uri", uri)
-			}
+			logger.Ctx(ctx).Warnf("path-parameters %v", gri.PathParameters)
 		}
 	}
 

--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -264,10 +264,8 @@ func (handler *LoggingMiddleware) Intercept(
 		resp, err = pipeline.Next(req, middlewareIndex)
 	)
 
-	if len(os.Getenv("CORSO_URL_LOGGING")) > 0 {
-		if strings.Contains(req.URL.String(), "users//") {
-			logger.Ctx(ctx).Errorw("malformed request url: missing user", "url", req.URL)
-		}
+	if strings.Contains(req.URL.String(), "users//") {
+		logger.Ctx(ctx).Errorw("malformed request url: missing resource", "url", req.URL)
 	}
 
 	if resp == nil {


### PR DESCRIPTION
## Description

The `GetUri()` call contains side-effects which drain the builder of its constructed url data.  As a result, running a backup with CORSO_URL_LOGGING actually forces the bug to manifest unintentionally.

## Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

## Type of change

- [x] :bug: Bugfix

## Test Plan

- [x] :muscle: Manual
