### PR TITLE
CLI: Sharepoint: Set Libraries to default 

### DIFF
--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -335,8 +335,9 @@ func includeAllSitesWithCategories(categories []string) *selectors.SharePointBac
 }
 
 func addCategories(sel *selectors.SharePointBackup, cats []string) *selectors.SharePointBackup {
+	// Issue #2631: Libraries are the only supported feature for SharePoint at this time.
 	if len(cats) == 0 {
-		sel.Include(sel.AllData())
+		sel.Include(sel.Libraries(selectors.Any()))
 	}
 
 	for _, d := range cats {


### PR DESCRIPTION
Issue #2631: library backup set to the default rather than all data.
- verified libraries is the default call in cli
- verified other categories can still be called if they asked for explicitly.
<!-- Insert PR description-->

---

#### Does this PR need a docs update or release note?


#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
*closes  #2631 <issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual

