### PR TITLE
Enable OneDrive incrementals, disable incrementals for permission backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sharepoint library (document files) support: backup, list, details, and restore.
 - OneDrive item downloads that return 404 during backup (normally due to external deletion while Corso processes) are now skipped instead of quietly dropped.  These items will appear in the skipped list alongside other skipped cases such as malware detection.
 - Listing a single backup by id will also list the skipped and failed items that occurred during the backup.  These can be filtered out with the flags `--failed-items hide`, `--skipped-items hide`, and `--recovered-errors hide`.
+- Enable incremental backups for OneDrive if permissions aren't being backed up.
 
 ### Fixed
 - Fix repo connect not working without a config file
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Known Issues
 - Owner (Full control) or empty (Restricted View) roles cannot be restored for OneDrive
+- OneDrive will not do an incremental backup if permissions are being backed up.
 
 ## [v0.5.0] (beta) - 2023-03-13
 

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -1096,9 +1096,6 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDrive() {
 
 // TestBackup_Run ensures that Integration Testing works for OneDrive
 func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveIncrementals() {
-	// TODO: Enable once we have https://github.com/alcionai/corso/pull/2642
-	suite.T().Skip("Enable once OneDrive incrementals is available")
-
 	ctx, flush := tester.NewContext()
 	defer flush()
 

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -1410,7 +1410,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveIncrementals() {
 
 				containerIDs[container3] = ptr.Val(resp.GetId())
 			},
-			itemsRead:    4, // 2*2 (.data and .meta for 2 files)
+			itemsRead:    2, // 2 .data for 2 files
 			itemsWritten: 6, // read items + 2 directory meta
 		},
 	}


### PR DESCRIPTION
Permissions backup requires more work, so we only support delta incrementals for OneDrive if that's not enabled.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #2333

Pending merge of
* #2650
* #2496

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
