### PR TITLE
switch cli to e2e test suits

### DIFF
--- a/src/cli/backup/exchange_e2e_test.go
+++ b/src/cli/backup/exchange_e2e_test.go
@@ -38,7 +38,7 @@ var backupDataSets = []path.CategoryType{email, contacts, events}
 // tests with no backups
 // ---------------------------------------------------------------------------
 
-type NoBackupExchangeIntegrationSuite struct {
+type NoBackupExchangeE2ESuite struct {
 	tester.Suite
 	acct       account.Account
 	st         storage.Storage
@@ -49,15 +49,16 @@ type NoBackupExchangeIntegrationSuite struct {
 	recorder   strings.Builder
 }
 
-func TestNoBackupExchangeIntegrationSuite(t *testing.T) {
-	suite.Run(t, &NoBackupExchangeIntegrationSuite{Suite: tester.NewIntegrationSuite(
+func TestNoBackupExchangeE2ESuite(t *testing.T) {
+	suite.Run(t, &NoBackupExchangeE2ESuite{Suite: tester.NewE2ESuite(
 		t,
 		[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
+		tester.CorsoCITests,
 		tester.CorsoCLITests,
 		tester.CorsoCLIBackupTests)})
 }
 
-func (suite *NoBackupExchangeIntegrationSuite) SetupSuite() {
+func (suite *NoBackupExchangeE2ESuite) SetupSuite() {
 	t := suite.T()
 	ctx, flush := tester.NewContext()
 
@@ -87,7 +88,7 @@ func (suite *NoBackupExchangeIntegrationSuite) SetupSuite() {
 	require.NoError(t, err)
 }
 
-func (suite *NoBackupExchangeIntegrationSuite) TestExchangeBackupListCmd_empty() {
+func (suite *NoBackupExchangeE2ESuite) TestExchangeBackupListCmd_empty() {
 	t := suite.T()
 	ctx, flush := tester.NewContext()
 	ctx = config.SetViper(ctx, suite.vpr)
@@ -118,7 +119,7 @@ func (suite *NoBackupExchangeIntegrationSuite) TestExchangeBackupListCmd_empty()
 // tests with no prior backup
 // ---------------------------------------------------------------------------
 
-type BackupExchangeIntegrationSuite struct {
+type BackupExchangeE2ESuite struct {
 	tester.Suite
 	acct       account.Account
 	st         storage.Storage
@@ -128,15 +129,16 @@ type BackupExchangeIntegrationSuite struct {
 	m365UserID string
 }
 
-func TestBackupExchangeIntegrationSuite(t *testing.T) {
-	suite.Run(t, &BackupExchangeIntegrationSuite{Suite: tester.NewIntegrationSuite(
+func TestBackupExchangeE2ESuite(t *testing.T) {
+	suite.Run(t, &BackupExchangeE2ESuite{Suite: tester.NewE2ESuite(
 		t,
 		[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
+		tester.CorsoCITests,
 		tester.CorsoCLITests,
 		tester.CorsoCLIBackupTests)})
 }
 
-func (suite *BackupExchangeIntegrationSuite) SetupSuite() {
+func (suite *BackupExchangeE2ESuite) SetupSuite() {
 	t := suite.T()
 	ctx, flush := tester.NewContext()
 
@@ -165,7 +167,7 @@ func (suite *BackupExchangeIntegrationSuite) SetupSuite() {
 	require.NoError(t, err)
 }
 
-func (suite *BackupExchangeIntegrationSuite) TestExchangeBackupCmd() {
+func (suite *BackupExchangeE2ESuite) TestExchangeBackupCmd() {
 	recorder := strings.Builder{}
 
 	for _, set := range backupDataSets {
@@ -205,7 +207,7 @@ func (suite *BackupExchangeIntegrationSuite) TestExchangeBackupCmd() {
 // tests prepared with a previous backup
 // ---------------------------------------------------------------------------
 
-type PreparedBackupExchangeIntegrationSuite struct {
+type PreparedBackupExchangeE2ESuite struct {
 	tester.Suite
 	acct       account.Account
 	st         storage.Storage
@@ -217,15 +219,16 @@ type PreparedBackupExchangeIntegrationSuite struct {
 	recorder   strings.Builder
 }
 
-func TestPreparedBackupExchangeIntegrationSuite(t *testing.T) {
-	suite.Run(t, &PreparedBackupExchangeIntegrationSuite{Suite: tester.NewIntegrationSuite(
+func TestPreparedBackupExchangeE2ESuite(t *testing.T) {
+	suite.Run(t, &PreparedBackupExchangeE2ESuite{Suite: tester.NewE2ESuite(
 		t,
 		[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
+		tester.CorsoCITests,
 		tester.CorsoCLITests,
 		tester.CorsoCLIBackupTests)})
 }
 
-func (suite *PreparedBackupExchangeIntegrationSuite) SetupSuite() {
+func (suite *PreparedBackupExchangeE2ESuite) SetupSuite() {
 	t := suite.T()
 
 	// prepare common details
@@ -296,7 +299,7 @@ func (suite *PreparedBackupExchangeIntegrationSuite) SetupSuite() {
 	}
 }
 
-func (suite *PreparedBackupExchangeIntegrationSuite) TestExchangeListCmd() {
+func (suite *PreparedBackupExchangeE2ESuite) TestExchangeListCmd() {
 	for _, set := range backupDataSets {
 		suite.recorder.Reset()
 
@@ -326,7 +329,7 @@ func (suite *PreparedBackupExchangeIntegrationSuite) TestExchangeListCmd() {
 	}
 }
 
-func (suite *PreparedBackupExchangeIntegrationSuite) TestExchangeListCmd_singleID() {
+func (suite *PreparedBackupExchangeE2ESuite) TestExchangeListCmd_singleID() {
 	for _, set := range backupDataSets {
 		suite.recorder.Reset()
 
@@ -359,7 +362,7 @@ func (suite *PreparedBackupExchangeIntegrationSuite) TestExchangeListCmd_singleI
 	}
 }
 
-func (suite *PreparedBackupExchangeIntegrationSuite) TestExchangeListCmd_badID() {
+func (suite *PreparedBackupExchangeE2ESuite) TestExchangeListCmd_badID() {
 	for _, set := range backupDataSets {
 		suite.Run(set.String(), func() {
 			t := suite.T()
@@ -382,7 +385,7 @@ func (suite *PreparedBackupExchangeIntegrationSuite) TestExchangeListCmd_badID()
 	}
 }
 
-func (suite *PreparedBackupExchangeIntegrationSuite) TestExchangeDetailsCmd() {
+func (suite *PreparedBackupExchangeE2ESuite) TestExchangeDetailsCmd() {
 	for _, set := range backupDataSets {
 		suite.recorder.Reset()
 
@@ -443,7 +446,7 @@ func (suite *PreparedBackupExchangeIntegrationSuite) TestExchangeDetailsCmd() {
 // tests for deleting backups
 // ---------------------------------------------------------------------------
 
-type BackupDeleteExchangeIntegrationSuite struct {
+type BackupDeleteExchangeE2ESuite struct {
 	tester.Suite
 	acct     account.Account
 	st       storage.Storage
@@ -453,17 +456,18 @@ type BackupDeleteExchangeIntegrationSuite struct {
 	backupOp operations.BackupOperation
 }
 
-func TestBackupDeleteExchangeIntegrationSuite(t *testing.T) {
-	suite.Run(t, &BackupDeleteExchangeIntegrationSuite{
-		Suite: tester.NewIntegrationSuite(
+func TestBackupDeleteExchangeE2ESuite(t *testing.T) {
+	suite.Run(t, &BackupDeleteExchangeE2ESuite{
+		Suite: tester.NewE2ESuite(
 			t,
 			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
+			tester.CorsoCITests,
 			tester.CorsoCLITests,
 			tester.CorsoCLIBackupTests),
 	})
 }
 
-func (suite *BackupDeleteExchangeIntegrationSuite) SetupSuite() {
+func (suite *BackupDeleteExchangeE2ESuite) SetupSuite() {
 	t := suite.T()
 
 	// prepare common details
@@ -501,7 +505,7 @@ func (suite *BackupDeleteExchangeIntegrationSuite) SetupSuite() {
 	require.NoError(t, err)
 }
 
-func (suite *BackupDeleteExchangeIntegrationSuite) TestExchangeBackupDeleteCmd() {
+func (suite *BackupDeleteExchangeE2ESuite) TestExchangeBackupDeleteCmd() {
 	t := suite.T()
 	ctx, flush := tester.NewContext()
 	ctx = config.SetViper(ctx, suite.vpr)
@@ -527,7 +531,7 @@ func (suite *BackupDeleteExchangeIntegrationSuite) TestExchangeBackupDeleteCmd()
 	require.Error(t, cmd.ExecuteContext(ctx))
 }
 
-func (suite *BackupDeleteExchangeIntegrationSuite) TestExchangeBackupDeleteCmd_UnknownID() {
+func (suite *BackupDeleteExchangeE2ESuite) TestExchangeBackupDeleteCmd_UnknownID() {
 	t := suite.T()
 	ctx, flush := tester.NewContext()
 	ctx = config.SetViper(ctx, suite.vpr)

--- a/src/cli/backup/onedrive_e2e_test.go
+++ b/src/cli/backup/onedrive_e2e_test.go
@@ -28,7 +28,7 @@ import (
 // tests with no prior backup
 // ---------------------------------------------------------------------------
 
-type NoBackupOneDriveIntegrationSuite struct {
+type NoBackupOneDriveE2ESuite struct {
 	tester.Suite
 	acct       account.Account
 	st         storage.Storage
@@ -39,17 +39,18 @@ type NoBackupOneDriveIntegrationSuite struct {
 	recorder   strings.Builder
 }
 
-func TestNoBackupOneDriveIntegrationSuite(t *testing.T) {
-	suite.Run(t, &NoBackupOneDriveIntegrationSuite{
-		Suite: tester.NewIntegrationSuite(
+func TestNoBackupOneDriveE2ESuite(t *testing.T) {
+	suite.Run(t, &NoBackupOneDriveE2ESuite{
+		Suite: tester.NewE2ESuite(
 			t,
 			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
+			tester.CorsoCITests,
 			tester.CorsoCLITests,
 			tester.CorsoCLIBackupTests),
 	})
 }
 
-func (suite *NoBackupOneDriveIntegrationSuite) SetupSuite() {
+func (suite *NoBackupOneDriveE2ESuite) SetupSuite() {
 	t := suite.T()
 	ctx, flush := tester.NewContext()
 
@@ -85,7 +86,7 @@ func (suite *NoBackupOneDriveIntegrationSuite) SetupSuite() {
 	require.NoError(t, err)
 }
 
-func (suite *NoBackupOneDriveIntegrationSuite) TestOneDriveBackupListCmd_empty() {
+func (suite *NoBackupOneDriveE2ESuite) TestOneDriveBackupListCmd_empty() {
 	t := suite.T()
 	ctx, flush := tester.NewContext()
 	ctx = config.SetViper(ctx, suite.vpr)
@@ -116,7 +117,7 @@ func (suite *NoBackupOneDriveIntegrationSuite) TestOneDriveBackupListCmd_empty()
 // tests for deleting backups
 // ---------------------------------------------------------------------------
 
-type BackupDeleteOneDriveIntegrationSuite struct {
+type BackupDeleteOneDriveE2ESuite struct {
 	tester.Suite
 	acct     account.Account
 	st       storage.Storage
@@ -127,17 +128,18 @@ type BackupDeleteOneDriveIntegrationSuite struct {
 	recorder strings.Builder
 }
 
-func TestBackupDeleteOneDriveIntegrationSuite(t *testing.T) {
-	suite.Run(t, &BackupDeleteOneDriveIntegrationSuite{
-		Suite: tester.NewIntegrationSuite(
+func TestBackupDeleteOneDriveE2ESuite(t *testing.T) {
+	suite.Run(t, &BackupDeleteOneDriveE2ESuite{
+		Suite: tester.NewE2ESuite(
 			t,
 			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
+			tester.CorsoCITests,
 			tester.CorsoCLITests,
 			tester.CorsoCLIBackupTests),
 	})
 }
 
-func (suite *BackupDeleteOneDriveIntegrationSuite) SetupSuite() {
+func (suite *BackupDeleteOneDriveE2ESuite) SetupSuite() {
 	t := suite.T()
 
 	// prepare common details
@@ -182,7 +184,7 @@ func (suite *BackupDeleteOneDriveIntegrationSuite) SetupSuite() {
 	require.NoError(t, err)
 }
 
-func (suite *BackupDeleteOneDriveIntegrationSuite) TestOneDriveBackupDeleteCmd() {
+func (suite *BackupDeleteOneDriveE2ESuite) TestOneDriveBackupDeleteCmd() {
 	t := suite.T()
 	ctx, flush := tester.NewContext()
 	ctx = config.SetViper(ctx, suite.vpr)
@@ -217,7 +219,7 @@ func (suite *BackupDeleteOneDriveIntegrationSuite) TestOneDriveBackupDeleteCmd()
 	require.Error(t, cmd.ExecuteContext(ctx))
 }
 
-func (suite *BackupDeleteOneDriveIntegrationSuite) TestOneDriveBackupDeleteCmd_unknownID() {
+func (suite *BackupDeleteOneDriveE2ESuite) TestOneDriveBackupDeleteCmd_unknownID() {
 	t := suite.T()
 	ctx, flush := tester.NewContext()
 	ctx = config.SetViper(ctx, suite.vpr)

--- a/src/cli/backup/sharepoint_e2e_test.go
+++ b/src/cli/backup/sharepoint_e2e_test.go
@@ -28,7 +28,7 @@ import (
 // tests with no prior backup
 // ---------------------------------------------------------------------------
 
-type NoBackupSharePointIntegrationSuite struct {
+type NoBackupSharePointE2ESuite struct {
 	tester.Suite
 	acct       account.Account
 	st         storage.Storage
@@ -39,14 +39,16 @@ type NoBackupSharePointIntegrationSuite struct {
 	recorder   strings.Builder
 }
 
-func TestNoBackupSharePointIntegrationSuite(t *testing.T) {
-	suite.Run(t, &NoBackupSharePointIntegrationSuite{Suite: tester.NewIntegrationSuite(
+func TestNoBackupSharePointE2ESuite(t *testing.T) {
+	suite.Run(t, &NoBackupSharePointE2ESuite{Suite: tester.NewE2ESuite(
 		t,
 		[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
-		tester.CorsoCLITests, tester.CorsoCLIBackupTests)})
+		tester.CorsoCITests,
+		tester.CorsoCLITests,
+		tester.CorsoCLIBackupTests)})
 }
 
-func (suite *NoBackupSharePointIntegrationSuite) SetupSuite() {
+func (suite *NoBackupSharePointE2ESuite) SetupSuite() {
 	t := suite.T()
 	ctx, flush := tester.NewContext()
 
@@ -75,7 +77,7 @@ func (suite *NoBackupSharePointIntegrationSuite) SetupSuite() {
 	require.NoError(t, err)
 }
 
-func (suite *NoBackupSharePointIntegrationSuite) TestSharePointBackupListCmd_empty() {
+func (suite *NoBackupSharePointE2ESuite) TestSharePointBackupListCmd_empty() {
 	t := suite.T()
 	ctx, flush := tester.NewContext()
 	ctx = config.SetViper(ctx, suite.vpr)
@@ -106,7 +108,7 @@ func (suite *NoBackupSharePointIntegrationSuite) TestSharePointBackupListCmd_emp
 // tests for deleting backups
 // ---------------------------------------------------------------------------
 
-type BackupDeleteSharePointIntegrationSuite struct {
+type BackupDeleteSharePointE2ESuite struct {
 	tester.Suite
 	acct     account.Account
 	st       storage.Storage
@@ -117,16 +119,18 @@ type BackupDeleteSharePointIntegrationSuite struct {
 	recorder strings.Builder
 }
 
-func TestBackupDeleteSharePointIntegrationSuite(t *testing.T) {
-	suite.Run(t, &BackupDeleteSharePointIntegrationSuite{
-		Suite: tester.NewIntegrationSuite(
+func TestBackupDeleteSharePointE2ESuite(t *testing.T) {
+	suite.Run(t, &BackupDeleteSharePointE2ESuite{
+		Suite: tester.NewE2ESuite(
 			t,
 			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
-			tester.CorsoCLITests, tester.CorsoCLIBackupTests),
+			tester.CorsoCITests,
+			tester.CorsoCLITests,
+			tester.CorsoCLIBackupTests),
 	})
 }
 
-func (suite *BackupDeleteSharePointIntegrationSuite) SetupSuite() {
+func (suite *BackupDeleteSharePointE2ESuite) SetupSuite() {
 	t := suite.T()
 
 	// prepare common details
@@ -164,7 +168,7 @@ func (suite *BackupDeleteSharePointIntegrationSuite) SetupSuite() {
 	require.NoError(t, err)
 }
 
-func (suite *BackupDeleteSharePointIntegrationSuite) TestSharePointBackupDeleteCmd() {
+func (suite *BackupDeleteSharePointE2ESuite) TestSharePointBackupDeleteCmd() {
 	t := suite.T()
 	ctx, flush := tester.NewContext()
 	ctx = config.SetViper(ctx, suite.vpr)
@@ -200,7 +204,7 @@ func (suite *BackupDeleteSharePointIntegrationSuite) TestSharePointBackupDeleteC
 
 // require.Error(t, cmd.ExecuteContext(ctx))
 
-func (suite *BackupDeleteSharePointIntegrationSuite) TestSharePointBackupDeleteCmd_unknownID() {
+func (suite *BackupDeleteSharePointE2ESuite) TestSharePointBackupDeleteCmd_unknownID() {
 	t := suite.T()
 	ctx, flush := tester.NewContext()
 	ctx = config.SetViper(ctx, suite.vpr)

--- a/src/cli/repo/s3_e2e_test.go
+++ b/src/cli/repo/s3_e2e_test.go
@@ -15,19 +15,20 @@ import (
 	"github.com/alcionai/corso/src/pkg/repository"
 )
 
-type S3IntegrationSuite struct {
+type S3E2ESuite struct {
 	tester.Suite
 }
 
-func TestS3IntegrationSuite(t *testing.T) {
-	suite.Run(t, &S3IntegrationSuite{Suite: tester.NewIntegrationSuite(
+func TestS3E2ESuite(t *testing.T) {
+	suite.Run(t, &S3E2ESuite{Suite: tester.NewE2ESuite(
 		t,
 		[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
+		tester.CorsoCITests,
 		tester.CorsoCLITests,
 		tester.CorsoCLIRepoTests)})
 }
 
-func (suite *S3IntegrationSuite) TestInitS3Cmd() {
+func (suite *S3E2ESuite) TestInitS3Cmd() {
 	table := []struct {
 		name         string
 		bucketPrefix string
@@ -75,7 +76,7 @@ func (suite *S3IntegrationSuite) TestInitS3Cmd() {
 	}
 }
 
-func (suite *S3IntegrationSuite) TestInitMultipleTimes() {
+func (suite *S3E2ESuite) TestInitMultipleTimes() {
 	t := suite.T()
 	ctx, flush := tester.NewContext()
 
@@ -104,7 +105,7 @@ func (suite *S3IntegrationSuite) TestInitMultipleTimes() {
 	}
 }
 
-func (suite *S3IntegrationSuite) TestInitS3Cmd_missingBucket() {
+func (suite *S3E2ESuite) TestInitS3Cmd_missingBucket() {
 	t := suite.T()
 	ctx, flush := tester.NewContext()
 
@@ -128,7 +129,7 @@ func (suite *S3IntegrationSuite) TestInitS3Cmd_missingBucket() {
 	require.Error(t, cmd.ExecuteContext(ctx))
 }
 
-func (suite *S3IntegrationSuite) TestConnectS3Cmd() {
+func (suite *S3E2ESuite) TestConnectS3Cmd() {
 	table := []struct {
 		name         string
 		bucketPrefix string
@@ -182,7 +183,7 @@ func (suite *S3IntegrationSuite) TestConnectS3Cmd() {
 	}
 }
 
-func (suite *S3IntegrationSuite) TestConnectS3Cmd_BadBucket() {
+func (suite *S3E2ESuite) TestConnectS3Cmd_BadBucket() {
 	t := suite.T()
 	ctx, flush := tester.NewContext()
 
@@ -207,7 +208,7 @@ func (suite *S3IntegrationSuite) TestConnectS3Cmd_BadBucket() {
 	require.Error(t, cmd.ExecuteContext(ctx))
 }
 
-func (suite *S3IntegrationSuite) TestConnectS3Cmd_BadPrefix() {
+func (suite *S3E2ESuite) TestConnectS3Cmd_BadPrefix() {
 	t := suite.T()
 	ctx, flush := tester.NewContext()
 

--- a/src/cli/restore/exchange_e2e_test.go
+++ b/src/cli/restore/exchange_e2e_test.go
@@ -30,7 +30,7 @@ var (
 
 var backupDataSets = []path.CategoryType{email, contacts, events}
 
-type RestoreExchangeIntegrationSuite struct {
+type RestoreExchangeE2ESuite struct {
 	tester.Suite
 	acct       account.Account
 	st         storage.Storage
@@ -41,17 +41,18 @@ type RestoreExchangeIntegrationSuite struct {
 	backupOps  map[path.CategoryType]operations.BackupOperation
 }
 
-func TestRestoreExchangeIntegrationSuite(t *testing.T) {
-	suite.Run(t, &RestoreExchangeIntegrationSuite{
-		Suite: tester.NewIntegrationSuite(
+func TestRestoreExchangeE2ESuite(t *testing.T) {
+	suite.Run(t, &RestoreExchangeE2ESuite{
+		Suite: tester.NewE2ESuite(
 			t,
 			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
+			tester.CorsoCITests,
 			tester.CorsoCLITests,
 			tester.CorsoCLIRestoreTests),
 	})
 }
 
-func (suite *RestoreExchangeIntegrationSuite) SetupSuite() {
+func (suite *RestoreExchangeE2ESuite) SetupSuite() {
 	t := suite.T()
 
 	ctx, flush := tester.NewContext()
@@ -115,7 +116,7 @@ func (suite *RestoreExchangeIntegrationSuite) SetupSuite() {
 	}
 }
 
-func (suite *RestoreExchangeIntegrationSuite) TestExchangeRestoreCmd() {
+func (suite *RestoreExchangeE2ESuite) TestExchangeRestoreCmd() {
 	for _, set := range backupDataSets {
 		suite.Run(set.String(), func() {
 			t := suite.T()
@@ -137,7 +138,7 @@ func (suite *RestoreExchangeIntegrationSuite) TestExchangeRestoreCmd() {
 	}
 }
 
-func (suite *RestoreExchangeIntegrationSuite) TestExchangeRestoreCmd_badTimeFlags() {
+func (suite *RestoreExchangeE2ESuite) TestExchangeRestoreCmd_badTimeFlags() {
 	for _, set := range backupDataSets {
 		if set == contacts {
 			suite.T().Skip()
@@ -172,7 +173,7 @@ func (suite *RestoreExchangeIntegrationSuite) TestExchangeRestoreCmd_badTimeFlag
 	}
 }
 
-func (suite *RestoreExchangeIntegrationSuite) TestExchangeRestoreCmd_badBoolFlags() {
+func (suite *RestoreExchangeE2ESuite) TestExchangeRestoreCmd_badBoolFlags() {
 	for _, set := range backupDataSets {
 		if set != events {
 			suite.T().Skip()


### PR DESCRIPTION
Switches cli integration tests to e2e tests.  Keeps the CI testing flag in place so that the tests continue to run in the normal pipeline.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Test

#### Issue(s)

* #2373

#### Test Plan

- [x] :green_heart: E2E
