### PR TITLE
remove unused test scoping envs

### DIFF
--- a/src/cli/backup/exchange_e2e_test.go
+++ b/src/cli/backup/exchange_e2e_test.go
@@ -54,8 +54,7 @@ func TestNoBackupExchangeE2ESuite(t *testing.T) {
 		t,
 		[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
 		tester.CorsoCITests,
-		tester.CorsoCLITests,
-		tester.CorsoCLIBackupTests)})
+	)})
 }
 
 func (suite *NoBackupExchangeE2ESuite) SetupSuite() {
@@ -134,8 +133,7 @@ func TestBackupExchangeE2ESuite(t *testing.T) {
 		t,
 		[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
 		tester.CorsoCITests,
-		tester.CorsoCLITests,
-		tester.CorsoCLIBackupTests)})
+	)})
 }
 
 func (suite *BackupExchangeE2ESuite) SetupSuite() {
@@ -265,8 +263,7 @@ func TestPreparedBackupExchangeE2ESuite(t *testing.T) {
 		t,
 		[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
 		tester.CorsoCITests,
-		tester.CorsoCLITests,
-		tester.CorsoCLIBackupTests)})
+	)})
 }
 
 func (suite *PreparedBackupExchangeE2ESuite) SetupSuite() {
@@ -503,8 +500,7 @@ func TestBackupDeleteExchangeE2ESuite(t *testing.T) {
 			t,
 			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
 			tester.CorsoCITests,
-			tester.CorsoCLITests,
-			tester.CorsoCLIBackupTests),
+		),
 	})
 }
 

--- a/src/cli/backup/onedrive_e2e_test.go
+++ b/src/cli/backup/onedrive_e2e_test.go
@@ -45,8 +45,7 @@ func TestNoBackupOneDriveE2ESuite(t *testing.T) {
 			t,
 			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
 			tester.CorsoCITests,
-			tester.CorsoCLITests,
-			tester.CorsoCLIBackupTests),
+		),
 	})
 }
 
@@ -169,8 +168,7 @@ func TestBackupDeleteOneDriveE2ESuite(t *testing.T) {
 			t,
 			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
 			tester.CorsoCITests,
-			tester.CorsoCLITests,
-			tester.CorsoCLIBackupTests),
+		),
 	})
 }
 

--- a/src/cli/backup/sharepoint_e2e_test.go
+++ b/src/cli/backup/sharepoint_e2e_test.go
@@ -44,8 +44,7 @@ func TestNoBackupSharePointE2ESuite(t *testing.T) {
 		t,
 		[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
 		tester.CorsoCITests,
-		tester.CorsoCLITests,
-		tester.CorsoCLIBackupTests)})
+	)})
 }
 
 func (suite *NoBackupSharePointE2ESuite) SetupSuite() {
@@ -125,8 +124,7 @@ func TestBackupDeleteSharePointE2ESuite(t *testing.T) {
 			t,
 			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
 			tester.CorsoCITests,
-			tester.CorsoCLITests,
-			tester.CorsoCLIBackupTests),
+		),
 	})
 }
 

--- a/src/cli/config/config_test.go
+++ b/src/cli/config/config_test.go
@@ -189,7 +189,7 @@ func TestConfigIntegrationSuite(t *testing.T) {
 	suite.Run(t, &ConfigIntegrationSuite{Suite: tester.NewIntegrationSuite(
 		t,
 		[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
-		tester.CorsoCLIConfigTests)})
+	)})
 }
 
 func (suite *ConfigIntegrationSuite) TestGetStorageAndAccount() {

--- a/src/cli/repo/s3_e2e_test.go
+++ b/src/cli/repo/s3_e2e_test.go
@@ -25,8 +25,7 @@ func TestS3E2ESuite(t *testing.T) {
 		t,
 		[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
 		tester.CorsoCITests,
-		tester.CorsoCLITests,
-		tester.CorsoCLIRepoTests)})
+	)})
 }
 
 func (suite *S3E2ESuite) TestInitS3Cmd() {

--- a/src/cli/restore/exchange_e2e_test.go
+++ b/src/cli/restore/exchange_e2e_test.go
@@ -47,8 +47,7 @@ func TestRestoreExchangeE2ESuite(t *testing.T) {
 			t,
 			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
 			tester.CorsoCITests,
-			tester.CorsoCLITests,
-			tester.CorsoCLIRestoreTests),
+		),
 	})
 }
 

--- a/src/internal/connector/data_collections_test.go
+++ b/src/internal/connector/data_collections_test.go
@@ -35,8 +35,7 @@ func TestConnectorDataCollectionIntegrationSuite(t *testing.T) {
 		Suite: tester.NewIntegrationSuite(
 			t,
 			[][]string{tester.M365AcctCredEnvs},
-			tester.CorsoGraphConnectorTests,
-			tester.CorsoConnectorDataCollectionTests),
+		),
 	})
 }
 
@@ -307,8 +306,7 @@ func TestConnectorCreateSharePointCollectionIntegrationSuite(t *testing.T) {
 		Suite: tester.NewIntegrationSuite(
 			t,
 			[][]string{tester.M365AcctCredEnvs},
-			tester.CorsoGraphConnectorTests,
-			tester.CorsoConnectorCreateSharePointCollectionTests),
+		),
 	})
 }
 

--- a/src/internal/connector/discovery/discovery_test.go
+++ b/src/internal/connector/discovery/discovery_test.go
@@ -19,11 +19,11 @@ type DiscoveryIntegrationSuite struct {
 }
 
 func TestDiscoveryIntegrationSuite(t *testing.T) {
-	suite.Run(t, &DiscoveryIntegrationSuite{Suite: tester.NewIntegrationSuite(
-		t,
-		[][]string{tester.M365AcctCredEnvs},
-		tester.CorsoGraphConnectorTests,
-	)})
+	suite.Run(t, &DiscoveryIntegrationSuite{
+		Suite: tester.NewIntegrationSuite(
+			t,
+			[][]string{tester.M365AcctCredEnvs}),
+	})
 }
 
 func (suite *DiscoveryIntegrationSuite) TestUsers() {

--- a/src/internal/connector/exchange/api/api_test.go
+++ b/src/internal/connector/exchange/api/api_test.go
@@ -26,8 +26,7 @@ func TestExchangeServiceSuite(t *testing.T) {
 		Suite: tester.NewIntegrationSuite(
 			t,
 			[][]string{tester.M365AcctCredEnvs},
-			tester.CorsoGraphConnectorTests,
-			tester.CorsoGraphConnectorExchangeTests),
+		),
 	})
 }
 

--- a/src/internal/connector/exchange/container_resolver_test.go
+++ b/src/internal/connector/exchange/container_resolver_test.go
@@ -520,9 +520,7 @@ func TestFolderCacheIntegrationSuite(t *testing.T) {
 		Suite: tester.NewIntegrationSuite(
 			t,
 			[][]string{tester.M365AcctCredEnvs},
-			tester.CorsoGraphConnectorTests,
-			tester.CorsoGraphConnectorExchangeTests,
-			tester.CorsoConnectorExchangeFolderCacheTests),
+		),
 	})
 }
 

--- a/src/internal/connector/exchange/data_collections_test.go
+++ b/src/internal/connector/exchange/data_collections_test.go
@@ -219,9 +219,7 @@ func TestDataCollectionsIntegrationSuite(t *testing.T) {
 		Suite: tester.NewIntegrationSuite(
 			t,
 			[][]string{tester.M365AcctCredEnvs},
-			tester.CorsoGraphConnectorTests,
-			tester.CorsoGraphConnectorExchangeTests,
-			tester.CorsoConnectorCreateExchangeCollectionTests),
+		),
 	})
 }
 

--- a/src/internal/connector/exchange/folder_resolver_test.go
+++ b/src/internal/connector/exchange/folder_resolver_test.go
@@ -25,8 +25,7 @@ func TestCacheResolverIntegrationSuite(t *testing.T) {
 		Suite: tester.NewIntegrationSuite(
 			t,
 			[][]string{tester.M365AcctCredEnvs},
-			tester.CorsoGraphConnectorTests,
-			tester.CorsoGraphConnectorExchangeTests),
+		),
 	})
 }
 

--- a/src/internal/connector/exchange/mail_folder_cache_test.go
+++ b/src/internal/connector/exchange/mail_folder_cache_test.go
@@ -36,8 +36,7 @@ func TestMailFolderCacheIntegrationSuite(t *testing.T) {
 		Suite: tester.NewIntegrationSuite(
 			t,
 			[][]string{tester.M365AcctCredEnvs},
-			tester.CorsoGraphConnectorTests,
-			tester.CorsoGraphConnectorExchangeTests),
+		),
 	})
 }
 

--- a/src/internal/connector/exchange/restore_test.go
+++ b/src/internal/connector/exchange/restore_test.go
@@ -33,9 +33,7 @@ func TestExchangeRestoreSuite(t *testing.T) {
 		Suite: tester.NewIntegrationSuite(
 			t,
 			[][]string{tester.M365AcctCredEnvs},
-			tester.CorsoGraphConnectorTests,
-			tester.CorsoGraphConnectorExchangeTests,
-			tester.CorsoConnectorRestoreExchangeCollectionTests),
+		),
 	})
 }
 

--- a/src/internal/connector/graph/betasdk/beta_client_test.go
+++ b/src/internal/connector/graph/betasdk/beta_client_test.go
@@ -19,10 +19,7 @@ type BetaClientSuite struct {
 
 func TestBetaClientSuite(t *testing.T) {
 	suite.Run(t, &BetaClientSuite{
-		Suite: tester.NewIntegrationSuite(
-			t,
-			[][]string{tester.M365AcctCredEnvs},
-			tester.CorsoGraphConnectorTests),
+		Suite: tester.NewIntegrationSuite(t, [][]string{tester.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/internal/connector/graph_connector_onedrive_test.go
+++ b/src/internal/connector/graph_connector_onedrive_test.go
@@ -113,8 +113,7 @@ func TestGraphConnectorOneDriveIntegrationSuite(t *testing.T) {
 		Suite: tester.NewIntegrationSuite(
 			t,
 			[][]string{tester.M365AcctCredEnvs},
-			tester.CorsoGraphConnectorTests,
-			tester.CorsoGraphConnectorOneDriveTests),
+		),
 	})
 }
 

--- a/src/internal/connector/graph_connector_test.go
+++ b/src/internal/connector/graph_connector_test.go
@@ -149,8 +149,7 @@ func TestGraphConnectorIntegrationSuite(t *testing.T) {
 		Suite: tester.NewIntegrationSuite(
 			t,
 			[][]string{tester.M365AcctCredEnvs},
-			tester.CorsoGraphConnectorTests,
-			tester.CorsoGraphConnectorExchangeTests),
+		),
 	})
 }
 

--- a/src/internal/connector/onedrive/api/drive_test.go
+++ b/src/internal/connector/onedrive/api/drive_test.go
@@ -36,8 +36,7 @@ func TestOneDriveAPIs(t *testing.T) {
 	suite.Run(t, &OneDriveAPISuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs},
-			tester.CorsoGraphConnectorOneDriveTests),
+			[][]string{tester.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/internal/connector/onedrive/drive_test.go
+++ b/src/internal/connector/onedrive/drive_test.go
@@ -332,8 +332,7 @@ func TestOneDriveDriveSuite(t *testing.T) {
 		Suite: tester.NewIntegrationSuite(
 			t,
 			[][]string{tester.M365AcctCredEnvs},
-			tester.CorsoGraphConnectorTests,
-			tester.CorsoGraphConnectorOneDriveTests),
+		),
 	})
 }
 

--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -30,8 +30,7 @@ func TestItemIntegrationSuite(t *testing.T) {
 		Suite: tester.NewIntegrationSuite(
 			t,
 			[][]string{tester.M365AcctCredEnvs},
-			tester.CorsoGraphConnectorTests,
-			tester.CorsoGraphConnectorOneDriveTests),
+		),
 	})
 }
 

--- a/src/internal/connector/sharepoint/api/pages_test.go
+++ b/src/internal/connector/sharepoint/api/pages_test.go
@@ -40,11 +40,7 @@ func (suite *SharePointPageSuite) SetupSuite() {
 
 func TestSharePointPageSuite(t *testing.T) {
 	suite.Run(t, &SharePointPageSuite{
-		Suite: tester.NewIntegrationSuite(
-			t,
-			[][]string{tester.M365AcctCredEnvs},
-			tester.CorsoGraphConnectorTests,
-			tester.CorsoGraphConnectorSharePointTests),
+		Suite: tester.NewIntegrationSuite(t, [][]string{tester.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/internal/connector/sharepoint/collection_test.go
+++ b/src/internal/connector/sharepoint/collection_test.go
@@ -47,8 +47,7 @@ func TestSharePointCollectionSuite(t *testing.T) {
 		Suite: tester.NewIntegrationSuite(
 			t,
 			[][]string{tester.M365AcctCredEnvs},
-			tester.CorsoGraphConnectorTests,
-			tester.CorsoGraphConnectorSharePointTests),
+		),
 	})
 }
 

--- a/src/internal/connector/sharepoint/data_collections_test.go
+++ b/src/internal/connector/sharepoint/data_collections_test.go
@@ -185,8 +185,7 @@ func TestSharePointPagesSuite(t *testing.T) {
 		Suite: tester.NewIntegrationSuite(
 			t,
 			[][]string{tester.M365AcctCredEnvs},
-			tester.CorsoGraphConnectorTests,
-			tester.CorsoGraphConnectorSharePointTests),
+		),
 	})
 }
 

--- a/src/internal/connector/sharepoint/list_test.go
+++ b/src/internal/connector/sharepoint/list_test.go
@@ -31,8 +31,7 @@ func TestSharePointSuite(t *testing.T) {
 		Suite: tester.NewIntegrationSuite(
 			t,
 			[][]string{tester.M365AcctCredEnvs},
-			tester.CorsoGraphConnectorTests,
-			tester.CorsoGraphConnectorSharePointTests),
+		),
 	})
 }
 

--- a/src/internal/kopia/conn_test.go
+++ b/src/internal/kopia/conn_test.go
@@ -63,7 +63,6 @@ func TestWrapperIntegrationSuite(t *testing.T) {
 		Suite: tester.NewIntegrationSuite(
 			t,
 			[][]string{tester.AWSStorageCredEnvs},
-			tester.CorsoKopiaWrapperTests,
 		),
 	})
 }

--- a/src/internal/kopia/model_store_test.go
+++ b/src/internal/kopia/model_store_test.go
@@ -67,7 +67,6 @@ func TestModelStoreIntegrationSuite(t *testing.T) {
 		Suite: tester.NewIntegrationSuite(
 			t,
 			[][]string{tester.AWSStorageCredEnvs},
-			tester.CorsoModelStoreTests,
 		),
 	})
 }
@@ -724,7 +723,6 @@ func TestModelStoreRegressionSuite(t *testing.T) {
 		Suite: tester.NewIntegrationSuite(
 			t,
 			[][]string{tester.AWSStorageCredEnvs},
-			tester.CorsoModelStoreTests,
 		),
 	})
 }

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -159,7 +159,6 @@ func TestKopiaIntegrationSuite(t *testing.T) {
 		Suite: tester.NewIntegrationSuite(
 			t,
 			[][]string{tester.AWSStorageCredEnvs},
-			tester.CorsoKopiaWrapperTests,
 		),
 	})
 }
@@ -740,7 +739,6 @@ func TestKopiaSimpleRepoIntegrationSuite(t *testing.T) {
 		Suite: tester.NewIntegrationSuite(
 			t,
 			[][]string{tester.AWSStorageCredEnvs},
-			tester.CorsoKopiaWrapperTests,
 		),
 	})
 }

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -467,9 +467,7 @@ func TestBackupOpIntegrationSuite(t *testing.T) {
 	suite.Run(t, &BackupOpIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
-			tester.CorsoOperationTests,
-			tester.CorsoOperationBackupTests),
+			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/internal/operations/restore_test.go
+++ b/src/internal/operations/restore_test.go
@@ -151,8 +151,7 @@ func TestRestoreOpIntegrationSuite(t *testing.T) {
 	suite.Run(t, &RestoreOpIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
-			tester.CorsoOperationTests),
+			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/internal/tester/suite.go
+++ b/src/internal/tester/suite.go
@@ -15,28 +15,6 @@ const (
 	CorsoCITests   = "CORSO_CI_TESTS"
 	CorsoE2ETests  = "CORSO_E2E_TESTS"
 	CorsoLoadTests = "CORSO_LOAD_TESTS"
-
-	CorsoCLIBackupTests                           = "CORSO_COMMAND_LINE_BACKUP_TESTS"
-	CorsoCLIConfigTests                           = "CORSO_COMMAND_LINE_CONFIG_TESTS"
-	CorsoCLIRepoTests                             = "CORSO_COMMAND_LINE_REPO_TESTS"
-	CorsoCLIRestoreTests                          = "CORSO_COMMAND_LINE_RESTORE_TESTS"
-	CorsoCLITests                                 = "CORSO_COMMAND_LINE_TESTS"
-	CorsoConnectorCreateCollectionTests           = "CORSO_CONNECTOR_CREATE_COLLECTION_TESTS"
-	CorsoConnectorCreateExchangeCollectionTests   = "CORSO_CONNECTOR_CREATE_EXCHANGE_COLLECTION_TESTS"
-	CorsoConnectorCreateSharePointCollectionTests = "CORSO_CONNECTOR_CREATE_SHAREPOINT_COLLECTION_TESTS"
-	CorsoConnectorDataCollectionTests             = "CORSO_CONNECTOR_DATA_COLLECTION_TESTS"
-	CorsoConnectorExchangeFolderCacheTests        = "CORSO_CONNECTOR_EXCHANGE_FOLDER_CACHE_TESTS"
-	CorsoConnectorRestoreExchangeCollectionTests  = "CORSO_CONNECTOR_RESTORE_EXCHANGE_COLLECTION_TESTS"
-	CorsoGraphConnectorTests                      = "CORSO_GRAPH_CONNECTOR_TESTS"
-	CorsoGraphConnectorExchangeTests              = "CORSO_GRAPH_CONNECTOR_EXCHANGE_TESTS"
-	CorsoGraphConnectorOneDriveTests              = "CORSO_GRAPH_CONNECTOR_ONE_DRIVE_TESTS"
-	CorsoGraphConnectorSharePointTests            = "CORSO_GRAPH_CONNECTOR_SHAREPOINT_TESTS"
-	CorsoKopiaWrapperTests                        = "CORSO_KOPIA_WRAPPER_TESTS"
-	CorsoModelStoreTests                          = "CORSO_MODEL_STORE_TESTS"
-	CorsoOneDriveTests                            = "CORSO_ONE_DRIVE_TESTS"
-	CorsoOperationTests                           = "CORSO_OPERATION_TESTS"
-	CorsoOperationBackupTests                     = "CORSO_OPERATION_BACKUP_TESTS"
-	CorsoRepositoryTests                          = "CORSO_REPOSITORY_TESTS"
 )
 
 type Suite interface {

--- a/src/pkg/repository/repository_test.go
+++ b/src/pkg/repository/repository_test.go
@@ -103,9 +103,7 @@ func TestRepositoryIntegrationSuite(t *testing.T) {
 	suite.Run(t, &RepositoryIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
-			tester.CorsoRepositoryTests,
-		),
+			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/pkg/repository/repository_unexported_test.go
+++ b/src/pkg/repository/repository_unexported_test.go
@@ -19,9 +19,7 @@ func TestRepositoryModelSuite(t *testing.T) {
 	suite.Run(t, &RepositoryModelSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
-			tester.CorsoRepositoryTests,
-		),
+			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs}),
 	})
 }
 


### PR DESCRIPTION
Doesn't seem like we're using these

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Test
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #2373

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
