### PR TITLE
Exclude metadata files from the set that we merge during incrementals

### DIFF
--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -37,6 +38,10 @@ const (
 	DirMetaFileSuffix = ".dirmeta"
 	DataFileSuffix    = ".data"
 )
+
+func IsMetaFile(name string) bool {
+	return strings.HasSuffix(name, MetaFileSuffix) || strings.HasSuffix(name, DirMetaFileSuffix)
+}
 
 var (
 	_ data.BackupCollection = &Collection{}

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/alcionai/corso/src/internal/connector/mockconnector"
+	"github.com/alcionai/corso/src/internal/connector/onedrive"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -297,6 +298,155 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 
 			for _, entry := range details {
 				assert.Equal(t, test.deetsUpdated, entry.Updated)
+			}
+
+			checkSnapshotTags(
+				t,
+				suite.ctx,
+				suite.w.c,
+				expectedTags,
+				stats.SnapshotID,
+			)
+
+			snap, err := snapshot.LoadSnapshot(
+				suite.ctx,
+				suite.w.c,
+				manifest.ID(stats.SnapshotID),
+			)
+			require.NoError(t, err)
+
+			prevSnaps = append(prevSnaps, IncrementalBase{
+				Manifest: snap,
+				SubtreePaths: []*path.Builder{
+					suite.storePath1.ToBuilder().Dir(),
+				},
+			})
+		})
+	}
+}
+
+func (suite *KopiaIntegrationSuite) TestBackupCollections_NoDetailsForMeta() {
+	// tags that are supplied by the caller. This includes basic tags to support
+	// lookups and extra tags the caller may want to apply.
+	tags := map[string]string{
+		"fnords":    "smarf",
+		"brunhilda": "",
+	}
+
+	reasons := []Reason{
+		{
+			ResourceOwner: suite.storePath1.ResourceOwner(),
+			Service:       suite.storePath1.Service(),
+			Category:      suite.storePath1.Category(),
+		},
+	}
+
+	for _, r := range reasons {
+		for _, k := range r.TagKeys() {
+			tags[k] = ""
+		}
+	}
+
+	expectedTags := map[string]string{}
+
+	maps.Copy(expectedTags, normalizeTagKVs(tags))
+
+	table := []struct {
+		name                  string
+		expectedUploadedFiles int
+		expectedCachedFiles   int
+		numDeetsEntries       int
+		hasMetaDeets          bool
+		cols                  func() []data.BackupCollection
+	}{
+		{
+			name:                  "Uncached",
+			expectedUploadedFiles: 3,
+			expectedCachedFiles:   0,
+			// MockStream implements item info even though OneDrive doesn't.
+			numDeetsEntries: 3,
+			hasMetaDeets:    true,
+			cols: func() []data.BackupCollection {
+				mc := mockconnector.NewMockExchangeCollection(
+					suite.storePath1,
+					suite.locPath1,
+					3)
+				mc.Names[0] = testFileName
+				mc.Names[1] = testFileName + onedrive.MetaFileSuffix
+				mc.Names[2] = suite.storePath1.Folders()[0] + onedrive.DirMetaFileSuffix
+
+				return []data.BackupCollection{mc}
+			},
+		},
+		{
+			name:                  "Cached",
+			expectedUploadedFiles: 1,
+			expectedCachedFiles:   2,
+			// Meta entries are filtered out.
+			numDeetsEntries: 1,
+			hasMetaDeets:    false,
+			cols: func() []data.BackupCollection {
+				mc := mockconnector.NewMockExchangeCollection(
+					suite.storePath1,
+					suite.locPath1,
+					1)
+				mc.Names[0] = testFileName
+				mc.ColState = data.NotMovedState
+
+				return []data.BackupCollection{mc}
+			},
+		},
+	}
+
+	prevSnaps := []IncrementalBase{}
+
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+			collections := test.cols()
+
+			stats, deets, prevShortRefs, err := suite.w.BackupCollections(
+				suite.ctx,
+				prevSnaps,
+				collections,
+				nil,
+				tags,
+				true,
+				fault.New(true))
+			assert.NoError(t, err)
+
+			assert.Equal(t, test.expectedUploadedFiles, stats.TotalFileCount, "total files")
+			assert.Equal(t, test.expectedUploadedFiles, stats.UncachedFileCount, "uncached files")
+			assert.Equal(t, test.expectedCachedFiles, stats.CachedFileCount, "cached files")
+			assert.Equal(t, 5, stats.TotalDirectoryCount)
+			assert.Equal(t, 0, stats.IgnoredErrorCount)
+			assert.Equal(t, 0, stats.ErrorCount)
+			assert.False(t, stats.Incomplete)
+
+			// 47 file and 5 folder entries.
+			details := deets.Details().Entries
+			assert.Len(
+				t,
+				details,
+				test.numDeetsEntries+5,
+			)
+
+			for _, entry := range details {
+				assert.True(t, entry.Updated)
+
+				if test.hasMetaDeets {
+					continue
+				}
+
+				assert.False(t, onedrive.IsMetaFile(entry.RepoRef), "metadata entry in details")
+			}
+
+			assert.Len(t, prevShortRefs, 0)
+			for _, prevRef := range prevShortRefs {
+				assert.False(
+					t,
+					onedrive.IsMetaFile(prevRef.Repo.String()),
+					"metadata entry in base details")
 			}
 
 			checkSnapshotTags(

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/alcionai/clues"
@@ -367,10 +366,7 @@ func (r repository) BackupDetails(
 	if b.Version >= version.OneDrive1DataAndMetaFiles && b.Version < version.OneDrive3IsMetaMarker {
 		for _, d := range deets.Entries {
 			if d.OneDrive != nil {
-				if strings.HasSuffix(d.RepoRef, onedrive.MetaFileSuffix) ||
-					strings.HasSuffix(d.RepoRef, onedrive.DirMetaFileSuffix) {
-					d.OneDrive.IsMeta = true
-				}
+				d.OneDrive.IsMeta = onedrive.IsMetaFile(d.RepoRef)
 			}
 		}
 	}


### PR DESCRIPTION
Metadata files don't need to appear in backup
details, which means they also shouldn't be
merged during incremental backups. If we
expect them to be merged then we'll fail the
item count check for the merge process

This excludes items with metadata extensions
from merging by not adding the to the list
of items to merge

Also make it so that metadata items don't
create backup details entries in the first
place

Manually tested to ensure
restore(backup(onedrive)) still works as
expected
---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* closes #2498

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
