### PR TITLE
Lint rule for using wrapper classes for testify `suite.Suite`

### DIFF
--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -34,6 +34,10 @@ linters-settings:
       - '\bpath\.(Ext|Base|Dir|Join)'
       # Don't allow the typo m356 to be used in place of m365.
       - '[Mm]356'
+      # Don't allow use of testify suite directly. Use one of the wrappers from
+      # tester/suite.go instead. Use an ignore lower down to exclude packages
+      # that result in import cycles if they try to use the wrapper.
+      - 'suite\.Suite(# tests should use one of the Suite wrappers in tester package )?'
   lll:
     line-length: 120
   revive:
@@ -115,4 +119,22 @@ issues:
         - gofumpt
         - misspell
         - errcheck
-
+    - path: internal/tester/suite.go
+      linters:
+        - forbidigo
+      text: "suite.Suite"
+    # account package creates an import cycle with tester package.
+    - path: pkg/account
+      linters:
+        - forbidigo
+      text: "suite.Suite"
+    # storage package creates an import cycle with tester package.
+    - path: pkg/storage
+      linters:
+        - forbidigo
+      text: "suite.Suite"
+    # Not yet updated. Unclear if it should be updated.
+    - path: pkg/repository/loadtest
+      linters:
+        - forbidigo
+      text: "suite.Suite"

--- a/src/internal/connector/discovery/api/beta_service_test.go
+++ b/src/internal/connector/discovery/api/beta_service_test.go
@@ -13,11 +13,11 @@ import (
 )
 
 type BetaUnitSuite struct {
-	suite.Suite
+	tester.Suite
 }
 
 func TestBetaUnitSuite(t *testing.T) {
-	suite.Run(t, new(BetaUnitSuite))
+	suite.Run(t, &BetaUnitSuite{Suite: tester.NewUnitSuite(t)})
 }
 
 func (suite *BetaUnitSuite) TestBetaService_Adapter() {


### PR DESCRIPTION
Also fixup some missed instances of `suite.Suite`

----

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #2373

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
