### PR TITLE
force omission of meta files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Known Issues
 - Folders and Calendars containing zero items or subfolders are not included in the backup.
+- OneDrive files ending in `.meta` or `.dirmeta` are omitted from details and restores.
 
 ## [v0.4.0] (beta) - 2023-2-20
 

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -3,6 +3,7 @@ package details
 import (
 	"context"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -127,7 +128,13 @@ func (dm DetailsModel) FilterMetaFiles() DetailsModel {
 // additional data like permissions in case of OneDrive and are not to
 // be treated as regular files.
 func (de DetailsEntry) isMetaFile() bool {
-	return de.ItemInfo.OneDrive != nil && de.ItemInfo.OneDrive.IsMeta
+	if de.ItemInfo.OneDrive == nil {
+		return false
+	}
+
+	return de.ItemInfo.OneDrive.IsMeta ||
+		strings.HasSuffix(de.RepoRef, ".meta") ||
+		strings.HasSuffix(de.RepoRef, ".dirmeta")
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/connector/onedrive"
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
@@ -133,8 +134,8 @@ func (de DetailsEntry) isMetaFile() bool {
 	}
 
 	return de.ItemInfo.OneDrive.IsMeta ||
-		strings.HasSuffix(de.RepoRef, ".meta") ||
-		strings.HasSuffix(de.RepoRef, ".dirmeta")
+		strings.HasSuffix(de.RepoRef, onedrive.MetaFileSuffix) ||
+		strings.HasSuffix(de.RepoRef, onedrive.DirMetaFileSuffix)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/internal/common"
-	"github.com/alcionai/corso/src/internal/connector/onedrive"
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
@@ -134,8 +133,8 @@ func (de DetailsEntry) isMetaFile() bool {
 	}
 
 	return de.ItemInfo.OneDrive.IsMeta ||
-		strings.HasSuffix(de.RepoRef, onedrive.MetaFileSuffix) ||
-		strings.HasSuffix(de.RepoRef, onedrive.DirMetaFileSuffix)
+		strings.HasSuffix(de.RepoRef, ".meta") ||
+		strings.HasSuffix(de.RepoRef, ".dirmeta")
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/backup/details/details_test.go
+++ b/src/pkg/backup/details/details_test.go
@@ -249,8 +249,8 @@ var pathItemsTable = []struct {
 				},
 			},
 		},
-		expectRepoRefs:     []string{"abcde", "foo.meta"},
-		expectLocationRefs: []string{"locationref", "locationref.dirmeta"},
+		expectRepoRefs:     []string{"abcde"},
+		expectLocationRefs: []string{"locationref"},
 	},
 	{
 		name: "multiple entries with folder and meta file",
@@ -287,8 +287,8 @@ var pathItemsTable = []struct {
 				},
 			},
 		},
-		expectRepoRefs:     []string{"abcde", "12345", "foo.meta"},
-		expectLocationRefs: []string{"locationref", "locationref2", "locationref.dirmeta"},
+		expectRepoRefs:     []string{"abcde", "12345"},
+		expectLocationRefs: []string{"locationref", "locationref2"},
 	},
 }
 
@@ -357,7 +357,7 @@ func (suite *DetailsUnitSuite) TestDetailsModel_FilterMetaFiles() {
 
 	d2 := d.FilterMetaFiles()
 
-	assert.Len(t, d2.Entries, 2)
+	assert.Len(t, d2.Entries, 1)
 	assert.Len(t, d.Entries, 3)
 }
 

--- a/website/docs/support/known-issues.md
+++ b/website/docs/support/known-issues.md
@@ -20,4 +20,4 @@ Below is a list of known Corso issues and limitations:
   while a backup is being created will be included in the running backup.
   Future backups run when the data isn't modified will include the data.
   
-* OneDrive files ending in `.meta` or `.dirmeta` are omitted from Details and Restore commands.
+* OneDrive files ending in `.meta` or `.dirmeta` get omitted from Details and Restore commands.

--- a/website/docs/support/known-issues.md
+++ b/website/docs/support/known-issues.md
@@ -20,3 +20,4 @@ Below is a list of known Corso issues and limitations:
   while a backup is being created will be included in the running backup.
   Future backups run when the data isn't modified will include the data.
   
+* OneDrive files ending in `.meta` or `.dirmeta` are omitted from Details and Restore commands.


### PR DESCRIPTION
While the `isMeta` flag will solve this in the
future, the current state requires us to filter
out all meta and dirmeta files, even historically.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

#### Type of change

- [x] :bug: Bugfix

#### Issue(s)

* #1970

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
