### PR TITLE
Add test for check IsMeta flag in OneDrive

### DIFF
--- a/src/internal/connector/graph_connector_helper_test.go
+++ b/src/internal/connector/graph_connector_helper_test.go
@@ -741,9 +741,13 @@ func compareOneDriveItem(
 	}
 
 	name := item.UUID()
+	isMeta := strings.HasSuffix(name, onedrive.MetaFileSuffix) ||
+		strings.HasSuffix(name, onedrive.DirMetaFileSuffix)
 
-	if strings.HasSuffix(name, onedrive.MetaFileSuffix) ||
-		strings.HasSuffix(name, onedrive.DirMetaFileSuffix) {
+	oitem := item.(*onedrive.Item)
+	assert.Equal(t, oitem.Info().OneDrive.IsMeta, isMeta, "meta marker in details for file %s", name)
+
+	if isMeta {
 		var (
 			itemMeta     onedrive.Metadata
 			expectedMeta onedrive.Metadata

--- a/src/internal/connector/graph_connector_helper_test.go
+++ b/src/internal/connector/graph_connector_helper_test.go
@@ -744,8 +744,13 @@ func compareOneDriveItem(
 	isMeta := strings.HasSuffix(name, onedrive.MetaFileSuffix) ||
 		strings.HasSuffix(name, onedrive.DirMetaFileSuffix)
 
-	oitem := item.(*onedrive.Item)
-	assert.Equal(t, oitem.Info().OneDrive.IsMeta, isMeta, "meta marker in details for file %s", name)
+	if isMeta {
+		_, ok := item.(*onedrive.MetadataItem)
+		assert.True(t, ok, "metadata item")
+	} else {
+		oitem := item.(*onedrive.Item)
+		assert.False(t, oitem.Info().OneDrive.IsMeta, "meta marker for non meta item %s", name)
+	}
 
 	if isMeta {
 		var (

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -53,8 +53,8 @@ var (
 	_ data.Stream           = &Item{}
 	_ data.StreamInfo       = &Item{}
 	_ data.StreamModTime    = &Item{}
-	_ data.Stream           = &metadataItem{}
-	_ data.StreamModTime    = &metadataItem{}
+	_ data.Stream           = &MetadataItem{}
+	_ data.StreamModTime    = &MetadataItem{}
 )
 
 type SharingMode int
@@ -276,28 +276,28 @@ func (od *Item) ModTime() time.Time {
 	return od.info.Modified()
 }
 
-type metadataItem struct {
+type MetadataItem struct {
 	id      string
 	data    io.ReadCloser
 	modTime time.Time
 }
 
-func (od *metadataItem) UUID() string {
+func (od *MetadataItem) UUID() string {
 	return od.id
 }
 
-func (od *metadataItem) ToReader() io.ReadCloser {
+func (od *MetadataItem) ToReader() io.ReadCloser {
 	return od.data
 }
 
 // Deleted implements an interface function. However, OneDrive items are marked
 // as deleted by adding them to the exclude list so this can always return
 // false.
-func (od metadataItem) Deleted() bool {
+func (od MetadataItem) Deleted() bool {
 	return false
 }
 
-func (od *metadataItem) ModTime() time.Time {
+func (od *MetadataItem) ModTime() time.Time {
 	return od.modTime
 }
 
@@ -512,7 +512,7 @@ func (oc *Collection) populateItems(ctx context.Context, errs *fault.Bus) {
 				return progReader, nil
 			})
 
-			oc.data <- &metadataItem{
+			oc.data <- &MetadataItem{
 				id:      metaFileName + metaSuffix,
 				data:    metaReader,
 				modTime: time.Now(),


### PR DESCRIPTION
This adds a check to make sure all meta files are added with IsMeta flag properly set in details. Filtering of this flags is checked in https://github.com/alcionai/corso/pull/2606

<!-- Insert PR description-->

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* fixes https://github.com/alcionai/corso/issues/2669

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
