### PR TITLE
Switch to using ids for storing permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Show owner information when doing backup list in json format
 - Onedrive files that are flagged as malware get skipped during backup.
+- Permissions for groups can now be backed up and restored
 
 ### Fixed
 - Corso-generated .meta files and permissions no longer appear in the backup details.

--- a/src/internal/connector/graph_connector_onedrive_test.go
+++ b/src/internal/connector/graph_connector_onedrive_test.go
@@ -22,7 +22,7 @@ import (
 
 // For any version post this(inclusive), we expect to be using IDs for
 // permission instead of email
-const versionPermissionSwitchedToId = version.OneDrive4DirIncludesPermissions
+const versionPermissionSwitchedToID = version.OneDrive4DirIncludesPermissions
 
 func getMetadata(fileName string, perm permData, permUseID bool) onedrive.Metadata {
 	if len(perm.user) == 0 || len(perm.roles) == 0 {
@@ -200,7 +200,7 @@ func (c *onedriveCollection) withFile(name string, fileData []byte, perm permDat
 			"",
 			name+onedrive.MetaFileSuffix,
 			perm,
-			c.backupVersion >= versionPermissionSwitchedToId)
+			c.backupVersion >= versionPermissionSwitchedToID)
 		c.items = append(c.items, metadata)
 		c.aux = append(c.aux, metadata)
 
@@ -224,7 +224,7 @@ func (c *onedriveCollection) withFolder(name string, perm permData) *onedriveCol
 				"",
 				name+onedrive.DirMetaFileSuffix,
 				perm,
-				c.backupVersion >= versionPermissionSwitchedToId))
+				c.backupVersion >= versionPermissionSwitchedToID))
 
 	default:
 		assert.FailNowf(c.t, "bad backup version", "version %d", c.backupVersion)
@@ -253,7 +253,7 @@ func (c *onedriveCollection) withPermissions(perm permData) *onedriveCollection 
 		name,
 		name+onedrive.DirMetaFileSuffix,
 		perm,
-		c.backupVersion >= versionPermissionSwitchedToId)
+		c.backupVersion >= versionPermissionSwitchedToID)
 
 	c.items = append(c.items, metadata)
 	c.aux = append(c.aux, metadata)

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -206,9 +206,6 @@ type UserPermission struct {
 	Roles      []string   `json:"role,omitempty"`
 	Email      string     `json:"email,omitempty"` // DEPRECATED: Replaced with UserID in newer backups
 	EntityID   string     `json:"entityId,omitempty"`
-	// TODO(meain): Should we be storing the type of entity? It is not
-	// needed for restoring, but just as extra info useful for
-	// debugging.
 	Expiration *time.Time `json:"expiration,omitempty"`
 }
 

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -204,7 +204,11 @@ func (oc Collection) DoNotMergeItems() bool {
 type UserPermission struct {
 	ID         string     `json:"id,omitempty"`
 	Roles      []string   `json:"role,omitempty"`
-	Email      string     `json:"email,omitempty"`
+	Email      string     `json:"email,omitempty"` // DEPRECATED: Replaced with UserID in newer backups
+	EntityID   string     `json:"entityId,omitempty"`
+	// TODO(meain): Should we be storing the type of entity? It is not
+	// needed for restoring, but just as extra info useful for
+	// debugging.
 	Expiration *time.Time `json:"expiration,omitempty"`
 }
 

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -272,6 +272,8 @@ func filterUserPermissions(perms []models.Permissionable) []UserPermission {
 		} else if gv2.GetGroup() != nil {
 			entityID = *gv2.GetGroup().GetId()
 		} else if gv2.GetApplication() != nil {
+			// TODO(meain): Applications permissions restore not
+			// tested manually
 			entityID = *gv2.GetApplication().GetId()
 		}
 

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -237,12 +237,12 @@ func oneDriveItemPermissionInfo(
 		return nil, err
 	}
 
-	uperms := filterUserPermissions(perm.GetValue())
+	uperms := filterUserPermissions(ctx, perm.GetValue())
 
 	return uperms, nil
 }
 
-func filterUserPermissions(perms []models.Permissionable) []UserPermission {
+func filterUserPermissions(ctx context.Context, perms []models.Permissionable) []UserPermission {
 	up := []UserPermission{}
 
 	for _, p := range perms {
@@ -271,10 +271,17 @@ func filterUserPermissions(perms []models.Permissionable) []UserPermission {
 			entityID = *gv2.GetUser().GetId()
 		} else if gv2.GetGroup() != nil {
 			entityID = *gv2.GetGroup().GetId()
-		} else if gv2.GetApplication() != nil {
-			// TODO(meain): Applications permissions restore not
-			// tested manually
-			entityID = *gv2.GetApplication().GetId()
+		} else {
+			// TODO Add appliction permissions when adding permissions for SharePoint
+			// https://devblogs.microsoft.com/microsoft365dev/controlling-app-access-on-specific-sharepoint-site-collections/
+			logm := logger.Ctx(ctx)
+			if gv2.GetApplication() != nil {
+				logm.With("application_id", *gv2.GetApplication().GetId())
+			}
+			if gv2.GetDevice() != nil {
+				logm.With("application_id", *gv2.GetDevice().GetId())
+			}
+			logm.Warn("untracked permission")
 		}
 
 		// Technically GrantedToV2 can also contain devices, but the

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -252,6 +252,7 @@ func filterUserPermissions(perms []models.Permissionable) []UserPermission {
 			continue
 		}
 
+		gv2 := p.GetGrantedToV2()
 		roles := []string{}
 
 		for _, r := range p.GetRoles() {
@@ -265,10 +266,26 @@ func filterUserPermissions(perms []models.Permissionable) []UserPermission {
 			continue
 		}
 
+		entityID := ""
+		if gv2.GetUser() != nil {
+			entityID = *gv2.GetUser().GetId()
+		} else if gv2.GetGroup() != nil {
+			entityID = *gv2.GetGroup().GetId()
+		} else if gv2.GetApplication() != nil {
+			entityID = *gv2.GetApplication().GetId()
+		}
+
+		// Technically GrantedToV2 can also contain devices, but the
+		// documentation does not mention about devices in permissions
+		if entityID == "" {
+			// This should ideally not be hit
+			continue
+		}
+
 		up = append(up, UserPermission{
 			ID:         ptr.Val(p.GetId()),
 			Roles:      roles,
-			Email:      *p.GetGrantedToV2().GetUser().GetAdditionalData()["email"].(*string),
+			EntityID:   entityID,
 			Expiration: p.GetExpirationDateTime(),
 		})
 	}

--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -241,6 +241,7 @@ func getPermsUperms(permID, userID, entity string, scopes []string) (models.Perm
 	identity.SetAdditionalData(map[string]any{"email": &userID})
 
 	sharepointIdentity := models.NewSharePointIdentitySet()
+
 	switch entity {
 	case "user":
 		sharepointIdentity.SetUser(identity)

--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -267,7 +267,15 @@ func getPermsUperms(permID, userID, entity string, scopes []string) (models.Perm
 	return perm, uperm
 }
 
-func TestOneDrivePermissionsFilter(t *testing.T) {
+type ItemUnitTestSuite struct {
+	tester.Suite
+}
+
+func TestItemUnitTestSuite(t *testing.T) {
+	suite.Run(t, &ItemUnitTestSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *ItemUnitTestSuite) TestOneDrivePermissionsFilter() {
 	permID := "fakePermId"
 	userID := "fakeuser@provider.com"
 	userID2 := "fakeuser2@provider.com"
@@ -332,7 +340,12 @@ func TestOneDrivePermissionsFilter(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		actual := filterUserPermissions(tc.graphPermissions)
-		assert.ElementsMatch(t, tc.parsedPermissions, actual)
+		suite.Run(tc.name, func() {
+			ctx, flush := tester.NewContext()
+			defer flush()
+
+			actual := filterUserPermissions(ctx, tc.graphPermissions)
+			assert.ElementsMatch(suite.T(), tc.parsedPermissions, actual)
+		})
 	}
 }

--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -235,12 +235,22 @@ func (suite *ItemIntegrationSuite) TestDriveGetFolder() {
 	}
 }
 
-func getPermsUperms(permID, userID string, scopes []string) (models.Permissionable, UserPermission) {
+func getPermsUperms(permID, userID, entity string, scopes []string) (models.Permissionable, UserPermission) {
 	identity := models.NewIdentity()
+	identity.SetId(&userID)
 	identity.SetAdditionalData(map[string]any{"email": &userID})
 
 	sharepointIdentity := models.NewSharePointIdentitySet()
-	sharepointIdentity.SetUser(identity)
+	switch entity {
+	case "user":
+		sharepointIdentity.SetUser(identity)
+	case "group":
+		sharepointIdentity.SetGroup(identity)
+	case "application":
+		sharepointIdentity.SetApplication(identity)
+	case "device":
+		sharepointIdentity.SetDevice(identity)
+	}
 
 	perm := models.NewPermission()
 	perm.SetId(&permID)
@@ -248,9 +258,9 @@ func getPermsUperms(permID, userID string, scopes []string) (models.Permissionab
 	perm.SetGrantedToV2(sharepointIdentity)
 
 	uperm := UserPermission{
-		ID:    permID,
-		Roles: []string{"read"},
-		Email: userID,
+		ID:       permID,
+		Roles:    []string{"read"},
+		EntityID: userID,
 	}
 
 	return perm, uperm
@@ -261,10 +271,13 @@ func TestOneDrivePermissionsFilter(t *testing.T) {
 	userID := "fakeuser@provider.com"
 	userID2 := "fakeuser2@provider.com"
 
-	readPerm, readUperm := getPermsUperms(permID, userID, []string{"read"})
-	readWritePerm, readWriteUperm := getPermsUperms(permID, userID2, []string{"read", "write"})
+	userReadPerm, userReadUperm := getPermsUperms(permID, userID, "user", []string{"read"})
+	userReadWritePerm, userReadWriteUperm := getPermsUperms(permID, userID2, "user", []string{"read", "write"})
 
-	noPerm, _ := getPermsUperms(permID, userID, []string{"read"})
+	groupReadPerm, groupReadUperm := getPermsUperms(permID, userID, "group", []string{"read"})
+	groupReadWritePerm, groupReadWriteUperm := getPermsUperms(permID, userID2, "group", []string{"read", "write"})
+
+	noPerm, _ := getPermsUperms(permID, userID, "user", []string{"read"})
 	noPerm.SetGrantedToV2(nil) // eg: link shares
 
 	cases := []struct {
@@ -282,20 +295,39 @@ func TestOneDrivePermissionsFilter(t *testing.T) {
 			graphPermissions:  []models.Permissionable{noPerm},
 			parsedPermissions: []UserPermission{},
 		},
+
+		// user
 		{
 			name:              "user with read permissions",
-			graphPermissions:  []models.Permissionable{readPerm},
-			parsedPermissions: []UserPermission{readUperm},
+			graphPermissions:  []models.Permissionable{userReadPerm},
+			parsedPermissions: []UserPermission{userReadUperm},
 		},
 		{
 			name:              "user with read and write permissions",
-			graphPermissions:  []models.Permissionable{readWritePerm},
-			parsedPermissions: []UserPermission{readWriteUperm},
+			graphPermissions:  []models.Permissionable{userReadWritePerm},
+			parsedPermissions: []UserPermission{userReadWriteUperm},
 		},
 		{
 			name:              "multiple users with separate permissions",
-			graphPermissions:  []models.Permissionable{readPerm, readWritePerm},
-			parsedPermissions: []UserPermission{readUperm, readWriteUperm},
+			graphPermissions:  []models.Permissionable{userReadPerm, userReadWritePerm},
+			parsedPermissions: []UserPermission{userReadUperm, userReadWriteUperm},
+		},
+
+		// group
+		{
+			name:              "group with read permissions",
+			graphPermissions:  []models.Permissionable{groupReadPerm},
+			parsedPermissions: []UserPermission{groupReadUperm},
+		},
+		{
+			name:              "group with read and write permissions",
+			graphPermissions:  []models.Permissionable{groupReadWritePerm},
+			parsedPermissions: []UserPermission{groupReadWriteUperm},
+		},
+		{
+			name:              "multiple groups with separate permissions",
+			graphPermissions:  []models.Permissionable{groupReadPerm, groupReadWritePerm},
+			parsedPermissions: []UserPermission{groupReadUperm, groupReadWriteUperm},
 		},
 	}
 	for _, tc := range cases {

--- a/src/internal/connector/onedrive/permission.go
+++ b/src/internal/connector/onedrive/permission.go
@@ -210,7 +210,14 @@ func restorePermissions(
 		pbody.SetRequireSignIn(&rs)
 
 		rec := models.NewDriveRecipient()
-		rec.SetEmail(&p.Email)
+		if p.EntityID != "" {
+			rec.SetObjectId(&p.EntityID)
+		} else {
+			// Previous versions used to only store email for a
+			// permissions. Use that if id is not found.
+			rec.SetEmail(&p.Email)
+		}
+
 		pbody.SetRecipients([]models.DriveRecipientable{rec})
 
 		np, err := service.Client().DrivesById(driveID).ItemsById(itemID).Invite().Post(ctx, pbody, nil)


### PR DESCRIPTION
This also enable backing up and restoring permissions for groups and applications.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* fixes https://github.com/alcionai/corso/issues/2621
* fixes https://github.com/alcionai/corso/issues/2673

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
