### PR TITLE
Don't NPE if user isn't in tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Corso-generated .meta files and permissions no longer appear in the backup details.
+- Panic and recovery if a user didn't exist in the tenant.
 
 ### Known Issues
 - Folders and Calendars containing zero items or subfolders are not included in the backup.

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -627,6 +627,11 @@ func (op *BackupOperation) persistResults(
 		op.Status = Failed
 	}
 
+	if opStats.k == nil {
+		op.Status = Failed
+		return errors.New("backup persistence never completed")
+	}
+
 	op.Results.BytesRead = opStats.k.TotalHashedBytes
 	op.Results.BytesUploaded = opStats.k.TotalUploadedBytes
 	op.Results.ItemsWritten = opStats.k.TotalFileCount


### PR DESCRIPTION
Was causing panics when trying to access kopia stats. Panic was recovered from, but reading the error was difficult.

Add some CLI tests to hopefully stop future regressions for this specific case

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* closes #2668

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
