### PR TITLE
add filtered details regression test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Corso-generated .meta files and permissions no longer appear in the backup details.
+- repo.BackupDetails from the SDK now filter out meta and dirmeta files, and empty folders, by standard.
 
 ### Known Issues
 - Folders and Calendars containing zero items or subfolders are not included in the backup.

--- a/src/internal/common/ptr/pointer.go
+++ b/src/internal/common/ptr/pointer.go
@@ -43,3 +43,10 @@ func OrNow(t *time.Time) time.Time {
 
 	return *t
 }
+
+// To makes it easy to get a pointer to ad-hoc primitives
+// without needing to declare additional variables.
+// ex: ptr.To("a string")
+func To[T any](t T) *T {
+	return &t
+}

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -272,7 +272,7 @@ func (c *Collections) Get(
 
 	retry := c.source == OneDriveSource
 
-	drives, err := drives(ctx, pager, retry)
+	drives, err := Drives(ctx, pager, retry)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -72,7 +72,7 @@ func PagerForSource(
 	}
 }
 
-func drives(
+func Drives(
 	ctx context.Context,
 	pager drivePager,
 	retry bool,
@@ -362,7 +362,7 @@ func GetAllFolders(
 	prefix string,
 	errs *fault.Bus,
 ) ([]*Displayable, error) {
-	drives, err := drives(ctx, pager, true)
+	drives, err := Drives(ctx, pager, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting OneDrive folders")
 	}

--- a/src/internal/connector/onedrive/drive_test.go
+++ b/src/internal/connector/onedrive/drive_test.go
@@ -313,7 +313,7 @@ func (suite *OneDriveUnitSuite) TestDrives() {
 				toReturn: test.pagerResults,
 			}
 
-			drives, err := drives(ctx, pager, test.retry)
+			drives, err := Drives(ctx, pager, test.retry)
 			test.expectedErr(t, err)
 
 			assert.ElementsMatch(t, test.expectedResults, drives)
@@ -355,7 +355,7 @@ func (suite *OneDriveSuite) TestCreateGetDeleteFolder() {
 	pager, err := PagerForSource(OneDriveSource, gs, suite.userID, nil)
 	require.NoError(t, err)
 
-	drives, err := drives(ctx, pager, true)
+	drives, err := Drives(ctx, pager, true)
 	require.NoError(t, err)
 	require.NotEmpty(t, drives)
 

--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -46,7 +46,7 @@ func (suite *ItemIntegrationSuite) SetupSuite() {
 	pager, err := PagerForSource(OneDriveSource, suite.service, suite.user, nil)
 	require.NoError(t, err)
 
-	odDrives, err := drives(ctx, pager, true)
+	odDrives, err := Drives(ctx, pager, true)
 	require.NoError(t, err)
 	// Test Requirement 1: Need a drive
 	require.Greaterf(t, len(odDrives), 0, "user %s does not have a drive", suite.user)

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -305,6 +305,84 @@ func (d *Details) addFolder(folder folderEntry) {
 	})
 }
 
+// FilterMetaFiles returns a new Details struct with a copy of the DetailsModel
+// that has had all .meta and .dirmeta files stripped out.
+func (d *Details) FilterMetaFiles() *Details {
+	return &Details{
+		DetailsModel: d.DetailsModel.FilterMetaFiles(),
+	}
+}
+
+// FilterEmptyContainers returns a new Details struct all empty (ie: containing no
+// items) stripped out.  If meta files have not been filtered out already, they
+// will continue to count as a "populated" container.
+func (d *Details) FilterEmptyContainers() *Details {
+	type entCount struct {
+		ent       DetailsEntry
+		itemCount int
+	}
+
+	var (
+		// shortRef: entCount
+		srec  = map[string]entCount{}
+		items = []DetailsEntry{}
+	)
+
+	// split the entries into items and folders.
+	// folders are stored in a map by their shortRef for lookup.
+	for _, ent := range d.Entries {
+		if ent.Folder == nil {
+			items = append(items, ent)
+		} else {
+			srec[ent.ShortRef] = entCount{ent, 0}
+		}
+	}
+
+	// for every item, add a count to the owning folder.
+	// this assumes item parentRef == folder shortRef.
+	for _, ent := range items {
+		if len(ent.ParentRef) == 0 {
+			continue
+		}
+
+		ec := srec[ent.ParentRef]
+		ec.itemCount++
+		srec[ent.ParentRef] = ec
+
+		// to maintain a hierarchical count so that we don't
+		// slice parent folders, this loop walks the tree upward
+		// by parent ref, adding one count to each parent up
+		// to the root.
+		parentRef := ec.ent.ParentRef
+		parentCount := 0
+
+		for len(parentRef) > 0 && parentCount == 0 {
+			ec := srec[parentRef]
+
+			// minor optimization: if the parentCount is already
+			// >zero, then all of its parents are guaranteed >zero.
+			parentCount = ec.itemCount
+
+			ec.itemCount++
+			srec[parentRef] = ec
+
+			parentRef = ec.ent.ParentRef
+		}
+	}
+
+	// walk the map of folder entries; every folder with one or more
+	// items gets added back to the items slice to be returned.
+	for _, ec := range srec {
+		if ec.itemCount > 0 {
+			items = append(items, ec.ent)
+		}
+	}
+
+	return &Details{
+		DetailsModel: DetailsModel{items},
+	}
+}
+
 // --------------------------------------------------------------------------------
 // Entry
 // --------------------------------------------------------------------------------

--- a/src/pkg/repository/loadtest/repository_load_test.go
+++ b/src/pkg/repository/loadtest/repository_load_test.go
@@ -395,7 +395,7 @@ func normalizeCategorySet(t *testing.T, cats map[string]struct{}) []string {
 // multiple users
 
 type RepositoryLoadTestExchangeSuite struct {
-	suite.Suite
+	tester.Suite
 	ctx            context.Context
 	repo           repository.Repository
 	acct           account.Account //lint:ignore U1000 future test use

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/alcionai/clues"
@@ -10,14 +9,12 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/alcionai/corso/src/internal/common/crash"
-	"github.com/alcionai/corso/src/internal/connector/onedrive"
 	"github.com/alcionai/corso/src/internal/events"
 	"github.com/alcionai/corso/src/internal/kopia"
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/internal/observe"
 	"github.com/alcionai/corso/src/internal/operations"
 	"github.com/alcionai/corso/src/internal/streamstore"
-	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
@@ -361,21 +358,7 @@ func (r repository) BackupDetails(
 		return nil, nil, errs.Fail(err)
 	}
 
-	// Retroactively fill in isMeta information for items in older
-	// backup versions without that info
-	// version.Restore2 introduces the IsMeta flag, so only v1 needs a check.
-	if b.Version >= version.OneDrive1DataAndMetaFiles && b.Version < version.OneDrive3IsMetaMarker {
-		for _, d := range deets.Entries {
-			if d.OneDrive != nil {
-				if strings.HasSuffix(d.RepoRef, onedrive.MetaFileSuffix) ||
-					strings.HasSuffix(d.RepoRef, onedrive.DirMetaFileSuffix) {
-					d.OneDrive.IsMeta = true
-				}
-			}
-		}
-	}
-
-	return deets, b, errs
+	return deets.FilterMetaFiles().FilterEmptyContainers(), b, errs
 }
 
 // DeleteBackup removes the backup from both the model store and the backup storage.

--- a/src/pkg/repository/repository_test.go
+++ b/src/pkg/repository/repository_test.go
@@ -262,7 +262,6 @@ func (suite *RepositoryIntegrationSuite) TestBackupDetails_regression() {
 	fld := models.Folder{}
 	fld.SetChildCount(ptr.To[int32](0))
 	body.SetFolder(&fld)
-	// body.SetWebUrl(ptr.To(ptr.Val(d0.GetWebUrl()) + "/" + dest))
 
 	_, err = srv.Client().
 		UsersById(suite.userID).


### PR DESCRIPTION
extends testing for filtered details results by
adding a regression test that crates a folder
with zero items, backs it up, and calls the
repo.BackupDetails to ensure that the folder
and its dirmeta files are not present.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Test

#### Issue(s)

* #2675

#### Test Plan

- [x] :green_heart: E2E
