### PR TITLE
Corso: Exchange: Details: add parentpath 

### DIFF
--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -267,7 +267,7 @@ func (col *Collection) streamItems(ctx context.Context, errs *fault.Bus) {
 			}
 
 			info.Size = int64(len(data))
-			info.Path = strings.Join(col.fullPath.Folders(), "/")
+			info.ParentPath = strings.Join(col.fullPath.Folders(), "/")
 
 			col.data <- &Stream{
 				id:      id,

--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -266,6 +267,7 @@ func (col *Collection) streamItems(ctx context.Context, errs *fault.Bus) {
 			}
 
 			info.Size = int64(len(data))
+			info.Path = strings.Join(col.fullPath.Folders(), "/")
 
 			col.data <- &Stream{
 				id:      id,

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -516,6 +516,7 @@ type ExchangeInfo struct {
 	ItemType    ItemType  `json:"itemType,omitempty"`
 	Sender      string    `json:"sender,omitempty"`
 	Subject     string    `json:"subject,omitempty"`
+	Path        string    `json:"path,omitempty"`
 	Received    time.Time `json:"received,omitempty"`
 	EventStart  time.Time `json:"eventStart,omitempty"`
 	EventEnd    time.Time `json:"eventEnd,omitempty"`
@@ -538,7 +539,7 @@ func (i ExchangeInfo) Headers() []string {
 		return []string{"Contact Name"}
 
 	case ExchangeMail:
-		return []string{"Sender", "Subject", "Received"}
+		return []string{"Sender", "Parent Path", "Subject", "Received"}
 	}
 
 	return []string{}
@@ -562,7 +563,7 @@ func (i ExchangeInfo) Values() []string {
 
 	case ExchangeMail:
 		return []string{
-			i.Sender, i.Subject,
+			i.Sender, i.Path, i.Subject,
 			common.FormatTabularDisplayTime(i.Received),
 		}
 	}

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -516,7 +516,7 @@ type ExchangeInfo struct {
 	ItemType    ItemType  `json:"itemType,omitempty"`
 	Sender      string    `json:"sender,omitempty"`
 	Subject     string    `json:"subject,omitempty"`
-	Path        string    `json:"path,omitempty"`
+	ParentPath  string    `json:"parentPath,omitempty"`
 	Received    time.Time `json:"received,omitempty"`
 	EventStart  time.Time `json:"eventStart,omitempty"`
 	EventEnd    time.Time `json:"eventEnd,omitempty"`
@@ -539,7 +539,7 @@ func (i ExchangeInfo) Headers() []string {
 		return []string{"Contact Name"}
 
 	case ExchangeMail:
-		return []string{"Sender", "Parent Path", "Subject", "Received"}
+		return []string{"Sender", "Folder", "Subject", "Received"}
 	}
 
 	return []string{}
@@ -563,7 +563,7 @@ func (i ExchangeInfo) Values() []string {
 
 	case ExchangeMail:
 		return []string{
-			i.Sender, i.Path, i.Subject,
+			i.Sender, i.ParentPath, i.Subject,
 			common.FormatTabularDisplayTime(i.Received),
 		}
 	}

--- a/src/pkg/backup/details/details_test.go
+++ b/src/pkg/backup/details/details_test.go
@@ -93,13 +93,14 @@ func (suite *DetailsUnitSuite) TestDetailsEntry_HeadersValues() {
 					Exchange: &ExchangeInfo{
 						ItemType: ExchangeMail,
 						Sender:   "sender",
+						Path:     "Parent",
 						Subject:  "subject",
 						Received: now,
 					},
 				},
 			},
-			expectHs: []string{"ID", "Sender", "Subject", "Received"},
-			expectVs: []string{"deadbeef", "sender", "subject", nowStr},
+			expectHs: []string{"ID", "Sender", "Parent Path", "Subject", "Received"},
+			expectVs: []string{"deadbeef", "sender", "Parent", "subject", nowStr},
 		},
 		{
 			name: "sharepoint info",

--- a/src/pkg/backup/details/details_test.go
+++ b/src/pkg/backup/details/details_test.go
@@ -91,15 +91,15 @@ func (suite *DetailsUnitSuite) TestDetailsEntry_HeadersValues() {
 				LocationRef: "locationref",
 				ItemInfo: ItemInfo{
 					Exchange: &ExchangeInfo{
-						ItemType: ExchangeMail,
-						Sender:   "sender",
-						Path:     "Parent",
-						Subject:  "subject",
-						Received: now,
+						ItemType:   ExchangeMail,
+						Sender:     "sender",
+						ParentPath: "Parent",
+						Subject:    "subject",
+						Received:   now,
 					},
 				},
 			},
-			expectHs: []string{"ID", "Sender", "Parent Path", "Subject", "Received"},
+			expectHs: []string{"ID", "Sender", "Folder", "Subject", "Received"},
 			expectVs: []string{"deadbeef", "sender", "Parent", "subject", nowStr},
 		},
 		{


### PR DESCRIPTION
<!-- Insert PR description-->
Parent Path field added to  `Exchange` Backup Details 
---
- Only Exchange mail will display the path for  backup details. 
#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* closes #2352<issue>

#### Test Plan


- [x] :zap: Unit test
