### PR TITLE
Log if file tagged as malware by graph

### DIFF
--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -410,7 +410,12 @@ func (oc *Collection) populateItems(ctx context.Context, errs *fault.Bus) {
 
 					// check for errors following retries
 					if err != nil {
-						logger.Ctx(ctx).With("error", err.Error()).Error("downloading item")
+						if item.GetMalware() != nil {
+							logger.Ctx(ctx).With("error", err.Error(), "malware", true).Error("downloading item")
+						} else {
+							logger.Ctx(ctx).With("error", err.Error()).Error("downloading item")
+						}
+
 						el.AddRecoverable(clues.Stack(err).WithClues(ctx).Label(fault.LabelForceNoBackupCreation))
 						return nil, err
 					}

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -183,6 +183,7 @@ func defaultItemPager(
 			"sharepointIds",
 			"size",
 			"deleted",
+			"malware",
 		},
 	)
 }


### PR DESCRIPTION
Graph exposes a "malware" filed in the delta response. This just logs that if we fail to download an item.


---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
