### PR TITLE
backup malware catch

### DIFF
--- a/src/internal/common/ptr/pointer.go
+++ b/src/internal/common/ptr/pointer.go
@@ -43,7 +43,3 @@ func OrNow(t *time.Time) time.Time {
 
 	return *t
 }
-
-func To[T any](t T) *T {
-	return &t
-}

--- a/src/internal/common/ptr/pointer.go
+++ b/src/internal/common/ptr/pointer.go
@@ -43,3 +43,7 @@ func OrNow(t *time.Time) time.Time {
 
 	return *t
 }
+
+func To[T any](t T) *T {
+	return &t
+}

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -416,13 +416,13 @@ func (oc *Collection) populateItems(ctx context.Context, errs *fault.Bus) {
 
 					// check for errors following retries
 					if err != nil {
-						if item.GetMalware() != nil {
-							logger.Ctx(ctx).With("error", err.Error(), "malware", true).Error("downloading item")
+						if clues.HasLabel(err, graph.LabelsMalware) {
+							logger.Ctx(ctx).Infow("malware item", clues.InErr(err).Slice()...)
 						} else {
 							logger.Ctx(ctx).With("error", err.Error()).Error("downloading item")
+							el.AddRecoverable(clues.Stack(err).WithClues(ctx).Label(fault.LabelForceNoBackupCreation))
 						}
 
-						el.AddRecoverable(clues.Stack(err).WithClues(ctx).Label(fault.LabelForceNoBackupCreation))
 						return nil, err
 					}
 

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -91,7 +91,7 @@ func drives(
 		for i := 0; i <= numberOfRetries; i++ {
 			page, err = pager.GetPage(ctx)
 			if err != nil {
-				if clues.HasLabel(err, graph.Labels.MysiteNotFound) {
+				if clues.HasLabel(err, graph.LabelsMysiteNotFound) {
 					logger.Ctx(ctx).Infof("resource owner does not have a drive")
 					return make([]models.Driveable, 0), nil // no license or drives.
 				}

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kopia/kopia/snapshot/snapshotfs"
 	"github.com/pkg/errors"
 
+	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/graph/metadata"
 	"github.com/alcionai/corso/src/internal/data"
 	D "github.com/alcionai/corso/src/internal/diagnostics"
@@ -262,6 +263,14 @@ func (cp *corsoProgress) CachedFile(fname string, size int64) {
 // during the upload process. This could be from reading a file or something
 // else.
 func (cp *corsoProgress) Error(relpath string, err error, isIgnored bool) {
+	// The malware case is an artifact of being unable to skip the item
+	// if we catch detection at a late enough stage in collection enumeration.
+	// This is our next point of error handling, where we can identify and
+	// skip over the case.
+	if clues.HasLabel(err, graph.LabelsMalware) {
+		return
+	}
+
 	defer cp.UploadProgress.Error(relpath, err, isIgnored)
 
 	cp.errs.AddRecoverable(clues.Wrap(err, "kopia reported error").
@@ -382,7 +391,8 @@ func collectionEntries(
 				modTime,
 				newBackupStreamReader(serializationVersion, e.ToReader()))
 
-			if err := cb(ctx, entry); err != nil {
+			err = cb(ctx, entry)
+			if err != nil {
 				// Kopia's uploader swallows errors in most cases, so if we see
 				// something here it's probably a big issue and we should return.
 				return seen, clues.Wrap(err, "executing callback").WithClues(ctx).With("item_path", itemPath)

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -52,8 +52,10 @@ type BackupStats struct {
 	CachedFileCount     int
 	UncachedFileCount   int
 	TotalDirectoryCount int
-	IgnoredErrorCount   int
 	ErrorCount          int
+
+	IgnoredErrorCount         int
+	ExpectedIgnoredErrorCount int
 
 	Incomplete       bool
 	IncompleteReason string
@@ -74,8 +76,10 @@ func manifestToStats(
 		CachedFileCount:     int(man.Stats.CachedFiles),
 		UncachedFileCount:   int(man.Stats.NonCachedFiles),
 		TotalDirectoryCount: int(man.Stats.TotalDirectoryCount),
-		IgnoredErrorCount:   int(man.Stats.IgnoredErrorCount),
 		ErrorCount:          int(man.Stats.ErrorCount),
+
+		IgnoredErrorCount:         int(man.Stats.IgnoredErrorCount),
+		ExpectedIgnoredErrorCount: progress.expectedIgnoredErrors,
 
 		Incomplete:       man.IncompleteReason != "",
 		IncompleteReason: man.IncompleteReason,

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -474,7 +474,8 @@ func consumeBackupDataCollections(
 			"kopia_ignored_errors", kopiaStats.IgnoredErrorCount)
 	}
 
-	if kopiaStats.ErrorCount > 0 || kopiaStats.IgnoredErrorCount > 0 {
+	if kopiaStats.ErrorCount > 0 ||
+		(kopiaStats.IgnoredErrorCount > kopiaStats.ExpectedIgnoredErrorCount) {
 		err = clues.New("building kopia snapshot").With(
 			"kopia_errors", kopiaStats.ErrorCount,
 			"kopia_ignored_errors", kopiaStats.IgnoredErrorCount)


### PR DESCRIPTION
assuming it's possible for a graph
item to skip the malware detection,
we still want to catch and handle
400's from attempted malware
downloads downstream.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature

#### Issue(s)

* #2701

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
