### PR TITLE
Improve  handling of permissions using sharing field

### DIFF
--- a/src/internal/connector/graph_connector_onedrive_test.go
+++ b/src/internal/connector/graph_connector_onedrive_test.go
@@ -885,7 +885,7 @@ func (suite *GraphConnectorOneDriveIntegrationSuite) TestPermissionsRestoreAndNo
 
 // This is similar to TestPermissionsRestoreAndBackup but tests purely
 // for inheritance and that too only with newer versions
-func (suite *GraphConnectorOneDriveIntegrationSuite) TestPermissionsInheritenceRestoreAndBackup() {
+func (suite *GraphConnectorOneDriveIntegrationSuite) TestPermissionsInheritanceRestoreAndBackup() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 
@@ -899,7 +899,6 @@ func (suite *GraphConnectorOneDriveIntegrationSuite) TestPermissionsInheritenceR
 
 	folderAName := "custom"
 	folderBName := "inherited"
-	folderCName := "empty"
 
 	rootPath := []string{
 		"drives",
@@ -926,13 +925,6 @@ func (suite *GraphConnectorOneDriveIntegrationSuite) TestPermissionsInheritenceR
 		folderAName,
 		folderBName,
 	}
-	subfolderCPath := []string{
-		"drives",
-		driveID,
-		"root:",
-		folderAName,
-		folderCName,
-	}
 
 	fileSet := []itemData{
 		{
@@ -952,32 +944,18 @@ func (suite *GraphConnectorOneDriveIntegrationSuite) TestPermissionsInheritenceR
 				sharingMode: onedrive.SharingModeInherited,
 			},
 		},
-		{
-			name: "file-empty",
-			data: fileAData,
-			perms: permData{
-				sharingMode: onedrive.SharingModeEmpty,
-			},
-		},
 	}
 
 	// Here is what this test is testing
 	// - custom-permission-folder
 	//   - custom-permission-file
-	//   - empty-permissions-file
 	//   - inherted-permission-file
 	//   - custom-permission-folder
-	// 	- custom-permission-file
-	// 	- empty-permissions-file
-	// 	- inherted-permission-file
-	//   - empty-permissions-folder
-	// 	- custom-permission-file
-	// 	- empty-permissions-file
-	// 	- inherted-permission-file
+	// 	   - custom-permission-file
+	// 	   - inherted-permission-file
 	//   - inherted-permission-folder
-	// 	- custom-permission-file
-	// 	- empty-permissions-file
-	// 	- inherted-permission-file
+	// 	   - custom-permission-file
+	// 	   - inherted-permission-file
 
 	// No reason why it couldn't work with previous versions, but this
 	// is when it got introduced.
@@ -1001,7 +979,6 @@ func (suite *GraphConnectorOneDriveIntegrationSuite) TestPermissionsInheritenceR
 				folders: []itemData{
 					{name: folderAName},
 					{name: folderBName},
-					{name: folderCName},
 				},
 				perms: permData{
 					user:     suite.secondaryUser,
@@ -1024,13 +1001,6 @@ func (suite *GraphConnectorOneDriveIntegrationSuite) TestPermissionsInheritenceR
 				files:        fileSet,
 				perms: permData{
 					sharingMode: onedrive.SharingModeInherited,
-				},
-			},
-			{
-				pathElements: subfolderCPath,
-				files:        fileSet,
-				perms: permData{
-					sharingMode: onedrive.SharingModeEmpty,
 				},
 			},
 		},

--- a/src/internal/connector/onedrive/api/drive.go
+++ b/src/internal/connector/onedrive/api/drive.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/alcionai/clues"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
@@ -43,7 +44,13 @@ func NewItemPager(
 	pageCount := pageSize
 
 	headers := abstractions.NewRequestHeaders()
-	headers.Add("Prefer", "deltashowremovedasdeleted,deltatraversepermissiongaps,deltashowsharingchanges,hierarchicalsharing")
+	preferHeaderItems := []string{
+		"deltashowremovedasdeleted",
+		"deltatraversepermissiongaps",
+		"deltashowsharingchanges",
+		"hierarchicalsharing",
+	}
+	headers.Add("Prefer", strings.Join(preferHeaderItems, ","))
 
 	requestConfig := &msdrives.ItemRootDeltaRequestBuilderGetRequestConfiguration{
 		Headers: headers,

--- a/src/internal/connector/onedrive/api/drive.go
+++ b/src/internal/connector/onedrive/api/drive.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/alcionai/clues"
+	abstractions "github.com/microsoft/kiota-abstractions-go"
 	msdrives "github.com/microsoftgraph/msgraph-sdk-go/drives"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	mssites "github.com/microsoftgraph/msgraph-sdk-go/sites"
@@ -40,7 +41,13 @@ func NewItemPager(
 	fields []string,
 ) *driveItemPager {
 	pageCount := pageSize
+
+	headers := abstractions.NewRequestHeaders()
+	headers.Add("Prefer", "deltashowremovedasdeleted,deltatraversepermissiongaps,deltashowsharingchanges,hierarchicalsharing")
+	// headers.Add("Prefer", "deltashowremovedasdeleted", "deltatraversepermissiongaps", "deltashowsharingchanges", "hierarchicalsharing")
+
 	requestConfig := &msdrives.ItemRootDeltaRequestBuilderGetRequestConfiguration{
+		Headers: headers,
 		QueryParameters: &msdrives.ItemRootDeltaRequestBuilderGetQueryParameters{
 			Top:    &pageCount,
 			Select: fields,

--- a/src/internal/connector/onedrive/api/drive.go
+++ b/src/internal/connector/onedrive/api/drive.go
@@ -44,7 +44,6 @@ func NewItemPager(
 
 	headers := abstractions.NewRequestHeaders()
 	headers.Add("Prefer", "deltashowremovedasdeleted,deltatraversepermissiongaps,deltashowsharingchanges,hierarchicalsharing")
-	// headers.Add("Prefer", "deltashowremovedasdeleted", "deltatraversepermissiongaps", "deltashowsharingchanges", "hierarchicalsharing")
 
 	requestConfig := &msdrives.ItemRootDeltaRequestBuilderGetRequestConfiguration{
 		Headers: headers,

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -58,7 +58,6 @@ type SharingMode int
 const (
 	SharingModeCustom = SharingMode(iota)
 	SharingModeInherited
-	SharingModeEmpty
 )
 
 // Collection represents a set of OneDrive objects retrieved from M365

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -53,6 +53,14 @@ var (
 	_ data.StreamModTime    = &metadataItem{}
 )
 
+type SharingMode int
+
+const (
+	SharingModeInherited = SharingMode(iota)
+	SharingModeEmpty
+	SharingModeCustom
+)
+
 // Collection represents a set of OneDrive objects retrieved from M365
 type Collection struct {
 	// configured to handle large item downloads
@@ -213,7 +221,12 @@ type UserPermission struct {
 // ItemMeta contains metadata about the Item. It gets stored in a
 // separate file in kopia
 type Metadata struct {
-	FileName    string           `json:"filename,omitempty"`
+	FileName string `json:"filename,omitempty"`
+	// SharingMode denotes what the current mode of sharing is for the object.
+	// - inherited: permissions same as parent permissions (no "shared" in delta)
+	// - empty: remove all permissions (empty "shared" in delta)
+	// - custom: use Permissions to set correct permissions ("shared" has value in delta)
+	SharingMode SharingMode      `json:"permissionMode,omitempty"` // TODO(meain): SharingModeInherited is removed by omitempty
 	Permissions []UserPermission `json:"permissions,omitempty"`
 }
 

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -223,7 +223,6 @@ type Metadata struct {
 	FileName string `json:"filename,omitempty"`
 	// SharingMode denotes what the current mode of sharing is for the object.
 	// - inherited: permissions same as parent permissions (no "shared" in delta)
-	// - empty: remove all permissions (empty "shared" in delta)
 	// - custom: use Permissions to set correct permissions ("shared" has value in delta)
 	SharingMode SharingMode      `json:"permissionMode,omitempty"`
 	Permissions []UserPermission `json:"permissions,omitempty"`

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -56,7 +56,8 @@ var (
 type SharingMode int
 
 const (
-	SharingModeInherited = SharingMode(iota)
+	SharingModeUnknown = SharingMode(iota) // For older versions. This will be treated similar to cutsom
+	SharingModeInherited
 	SharingModeEmpty
 	SharingModeCustom
 )

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -56,10 +56,9 @@ var (
 type SharingMode int
 
 const (
-	SharingModeUnknown = SharingMode(iota) // For older versions. This will be treated similar to cutsom
+	SharingModeCustom = SharingMode(iota)
 	SharingModeInherited
 	SharingModeEmpty
-	SharingModeCustom
 )
 
 // Collection represents a set of OneDrive objects retrieved from M365

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -227,7 +227,7 @@ type Metadata struct {
 	// - inherited: permissions same as parent permissions (no "shared" in delta)
 	// - empty: remove all permissions (empty "shared" in delta)
 	// - custom: use Permissions to set correct permissions ("shared" has value in delta)
-	SharingMode SharingMode      `json:"permissionMode,omitempty"` // TODO(meain): SharingModeInherited is removed by omitempty
+	SharingMode SharingMode      `json:"permissionMode,omitempty"`
 	Permissions []UserPermission `json:"permissions,omitempty"`
 }
 

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -625,7 +625,10 @@ func (c *Collections) UpdateCollections(
 		// TODO(meain): Use `@microsoft.graph.sharedChanged` in
 		// item.GetAdditionalData() to optimize fetching
 		// permissions. When permissions change, this flags is
-		// present, if only data changes, it is not present.
+		// present, if only data changes, it is not present.  Have to
+		// add `oneDrive.sharedChanged` in `$select` in delta
+		// https://learn.microsoft.com/en-us/onedrive/developer/rest-api
+		// /concepts/scan-guidance#scanning-permissions-hierarchies
 
 		// Deleted file or folder.
 		if item.GetDeleted() != nil {

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -622,6 +622,11 @@ func (c *Collections) UpdateCollections(
 			isFolder = item.GetFolder() != nil || item.GetPackage() != nil
 		)
 
+		// TODO(meain): Use `@microsoft.graph.sharedChanged` in
+		// item.GetAdditionalData() to optimize fetching
+		// permissions. When permissions change, this flags is
+		// present, if only data changes, it is not present.
+
 		// Deleted file or folder.
 		if item.GetDeleted() != nil {
 			if err := c.handleDelete(

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -159,6 +159,7 @@ func defaultItemPager(
 		link,
 		[]string{
 			"content.downloadUrl",
+			"content.shareChanged", // NOTE(meain)
 			"createdBy",
 			"createdDateTime",
 			"file",

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -159,9 +159,6 @@ func defaultItemPager(
 		link,
 		[]string{
 			"content.downloadUrl",
-			// https://learn.microsoft.com/en-us/onedrive/developer/rest-api
-			// /concepts/scan-guidance#scanning-permissions-hierarchies
-			"oneDrive.sharedChanged",
 			"createdBy",
 			"createdDateTime",
 			"file",

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -159,7 +159,8 @@ func defaultItemPager(
 		link,
 		[]string{
 			"content.downloadUrl",
-			"content.shareChanged", // NOTE(meain)
+			// https://learn.microsoft.com/en-us/onedrive/developer/rest-api/concepts/scan-guidance#scanning-permissions-hierarchies
+			"oneDrive.sharedChanged",
 			"createdBy",
 			"createdDateTime",
 			"file",

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -173,6 +173,7 @@ func defaultItemPager(
 			"size",
 			"deleted",
 			"malware",
+			"shared",
 		},
 	)
 }

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -159,7 +159,8 @@ func defaultItemPager(
 		link,
 		[]string{
 			"content.downloadUrl",
-			// https://learn.microsoft.com/en-us/onedrive/developer/rest-api/concepts/scan-guidance#scanning-permissions-hierarchies
+			// https://learn.microsoft.com/en-us/onedrive/developer/rest-api
+			// /concepts/scan-guidance#scanning-permissions-hierarchies
 			"oneDrive.sharedChanged",
 			"createdBy",
 			"createdDateTime",

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -87,7 +87,7 @@ func oneDriveItemMetaReader(
 	)
 
 	if meta.SharingMode == SharingModeCustom && fetchPermissions {
-		perms, err = OneDriveItemPermissionInfo(ctx, service, driveID, ptr.Val(item.GetId()))
+		perms, err = oneDriveItemPermissionInfo(ctx, service, driveID, ptr.Val(item.GetId()))
 		if err != nil {
 			// Keep this in an if-block because if it's not then we have a weird issue
 			// of having no value in error but golang thinking it's non nil because of
@@ -236,7 +236,7 @@ func oneDriveItemInfo(di models.DriveItemable, itemSize int64) *details.OneDrive
 
 // OneDriveItemPermissionInfo will fetch the permission information
 // for a drive item given a drive and item id.
-func OneDriveItemPermissionInfo(
+func oneDriveItemPermissionInfo(
 	ctx context.Context,
 	service graph.Servicer,
 	driveID string,

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -76,7 +76,6 @@ func oneDriveItemMetaReader(
 	if item.GetShared() == nil {
 		meta.SharingMode = SharingModeInherited
 	} else if item.GetShared().GetScope() == nil {
-		// NOTE(meain): See how this works when we have groups
 		meta.SharingMode = SharingModeEmpty
 	} else {
 		meta.SharingMode = SharingModeCustom

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -75,8 +75,6 @@ func oneDriveItemMetaReader(
 
 	if item.GetShared() == nil {
 		meta.SharingMode = SharingModeInherited
-	} else if item.GetShared().GetScope() == nil {
-		meta.SharingMode = SharingModeEmpty
 	} else {
 		meta.SharingMode = SharingModeCustom
 	}

--- a/src/internal/connector/onedrive/permission.go
+++ b/src/internal/connector/onedrive/permission.go
@@ -108,8 +108,8 @@ func createRestoreFoldersWithPermissions(
 	return id, err
 }
 
-func getPermissionDiff(
-	after, before []UserPermission,
+func diffPermissions(
+	before, after []UserPermission,
 	permissionIDMappings map[string]string,
 ) ([]UserPermission, []UserPermission) {
 	var (
@@ -170,10 +170,10 @@ func restorePermissions(
 	// TODO(meain): Compute this from the data that we have instead of fetching from graph
 	currentPermissions, err := oneDriveItemPermissionInfo(ctx, service, driveID, itemID)
 	if err != nil {
-		return clues.Wrap(err, "fetching current permissions").WithClues(ctx).With(graph.ErrData(err)...)
+		return graph.Wrap(ctx, err, "fetching current permissions")
 	}
 
-	permAdded, permRemoved := getPermissionDiff(meta.Permissions, currentPermissions, permissionIDMappings)
+	permAdded, permRemoved := diffPermissions(currentPermissions, meta.Permissions, permissionIDMappings)
 
 	for _, p := range permRemoved {
 		err := service.Client().

--- a/src/internal/connector/onedrive/permission.go
+++ b/src/internal/connector/onedrive/permission.go
@@ -167,11 +167,13 @@ func restorePermissions(
 
 	ctx = clues.Add(ctx, "permission_item_id", itemID)
 
+	// TODO(meain): Compute this from the data that we have instead of fetching from graph
 	currentPermissions, err := oneDriveItemPermissionInfo(ctx, service, driveID, itemID)
 	if err != nil {
 		return clues.Wrap(err, "fetching current permissions").WithClues(ctx).With(graph.ErrData(err)...)
 	}
 
+	// meta.Permissions will be empty for SharingModeEmpty
 	permAdded, permRemoved := getPermissionDiff(meta.Permissions, currentPermissions, permissionIDMappings)
 
 	for _, p := range permRemoved {

--- a/src/internal/connector/onedrive/permission.go
+++ b/src/internal/connector/onedrive/permission.go
@@ -180,7 +180,7 @@ func restorePermissions(
 		err := service.Client().
 			DrivesById(driveID).
 			ItemsById(itemID).
-			PermissionsById(permissionIDMappings[p.ID]).
+			PermissionsById(p.ID).
 			Delete(ctx, nil)
 		if err != nil {
 			return graph.Wrap(ctx, err, "removing permissions")

--- a/src/internal/connector/onedrive/permission.go
+++ b/src/internal/connector/onedrive/permission.go
@@ -173,7 +173,6 @@ func restorePermissions(
 		return clues.Wrap(err, "fetching current permissions").WithClues(ctx).With(graph.ErrData(err)...)
 	}
 
-	// meta.Permissions will be empty for SharingModeEmpty
 	permAdded, permRemoved := getPermissionDiff(meta.Permissions, currentPermissions, permissionIDMappings)
 
 	for _, p := range permRemoved {

--- a/src/internal/connector/onedrive/permission.go
+++ b/src/internal/connector/onedrive/permission.go
@@ -62,6 +62,7 @@ func getCollectionMetadata(
 		if err != nil {
 			return Metadata{}, clues.Wrap(err, "collection metadata")
 		}
+
 		return colMeta, nil
 	}
 
@@ -166,7 +167,7 @@ func restorePermissions(
 
 	ctx = clues.Add(ctx, "permission_item_id", itemID)
 
-	currentPermissions, err := OneDriveItemPermissionInfo(ctx, service, driveID, itemID)
+	currentPermissions, err := oneDriveItemPermissionInfo(ctx, service, driveID, itemID)
 	if err != nil {
 		return clues.Wrap(err, "fetching current permissions").WithClues(ctx).With(graph.ErrData(err)...)
 	}

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -3,7 +3,6 @@ package onedrive
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"runtime/trace"
 	"sort"
@@ -212,7 +211,6 @@ func RestoreCollection(
 				return metrics, folderMetas, permissionIDMappings, nil
 			}
 
-			fmt.Println(itemData.UUID())
 			itemPath, err := dc.FullPath().Append(itemData.UUID(), true)
 			if err != nil {
 				el.AddRecoverable(clues.Wrap(err, "appending item to full path").WithClues(ctx))

--- a/src/internal/connector/sharepoint/restore.go
+++ b/src/internal/connector/sharepoint/restore.go
@@ -71,7 +71,7 @@ func RestoreCollections(
 				backupVersion,
 				service,
 				dc,
-				map[string][]onedrive.UserPermission{}, // Currently permission data is not stored for sharepoint
+				map[string]onedrive.Metadata{}, // Currently permission data is not stored for sharepoint
 				onedrive.SharePointSource,
 				dest.ContainerName,
 				deets,

--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/alcionai/corso/src/internal/common"
-	"github.com/alcionai/corso/src/internal/common/crash"
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/data"
 	D "github.com/alcionai/corso/src/internal/diagnostics"
@@ -107,11 +106,11 @@ type restorer interface {
 
 // Run begins a synchronous restore operation.
 func (op *RestoreOperation) Run(ctx context.Context) (restoreDetails *details.Details, err error) {
-	defer func() {
-		if crErr := crash.Recovery(ctx, recover()); crErr != nil {
-			err = crErr
-		}
-	}()
+	// defer func() {
+	// 	if crErr := crash.Recovery(ctx, recover()); crErr != nil {
+	// 		err = crErr
+	// 	}
+	// }()
 
 	var (
 		opStats = restoreStats{

--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/crash"
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/data"
 	D "github.com/alcionai/corso/src/internal/diagnostics"
@@ -106,11 +107,11 @@ type restorer interface {
 
 // Run begins a synchronous restore operation.
 func (op *RestoreOperation) Run(ctx context.Context) (restoreDetails *details.Details, err error) {
-	// defer func() {
-	// 	if crErr := crash.Recovery(ctx, recover()); crErr != nil {
-	// 		err = crErr
-	// 	}
-	// }()
+	defer func() {
+		if crErr := crash.Recovery(ctx, recover()); crErr != nil {
+			err = crErr
+		}
+	}()
 
 	var (
 		opStats = restoreStats{


### PR DESCRIPTION
Permissions are only stored if SharingMode is custom( "sharing" field is present). This will help with delta incrementals as well.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [x] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* closes https://github.com/alcionai/corso/issues/2459

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
