### PR TITLE
Revert "force omission of meta files (#2662)"

### DIFF
--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -128,13 +127,7 @@ func (dm DetailsModel) FilterMetaFiles() DetailsModel {
 // additional data like permissions in case of OneDrive and are not to
 // be treated as regular files.
 func (de DetailsEntry) isMetaFile() bool {
-	if de.ItemInfo.OneDrive == nil {
-		return false
-	}
-
-	return de.ItemInfo.OneDrive.IsMeta ||
-		strings.HasSuffix(de.RepoRef, ".meta") ||
-		strings.HasSuffix(de.RepoRef, ".dirmeta")
+	return de.ItemInfo.OneDrive != nil && de.ItemInfo.OneDrive.IsMeta
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -127,6 +127,8 @@ func (dm DetailsModel) FilterMetaFiles() DetailsModel {
 // additional data like permissions in case of OneDrive and are not to
 // be treated as regular files.
 func (de DetailsEntry) isMetaFile() bool {
+	// TODO: Add meta file filtering to SharePoint as well once we add
+	// meta files for SharePoint.
 	return de.ItemInfo.OneDrive != nil && de.ItemInfo.OneDrive.IsMeta
 }
 

--- a/src/pkg/backup/details/details_test.go
+++ b/src/pkg/backup/details/details_test.go
@@ -255,8 +255,8 @@ var pathItemsTable = []struct {
 				},
 			},
 		},
-		expectRepoRefs:     []string{"abcde"},
-		expectLocationRefs: []string{"locationref"},
+		expectRepoRefs:     []string{"abcde", "foo.meta"},
+		expectLocationRefs: []string{"locationref", "locationref.dirmeta"},
 	},
 	{
 		name: "multiple entries with folder and meta file",
@@ -293,8 +293,8 @@ var pathItemsTable = []struct {
 				},
 			},
 		},
-		expectRepoRefs:     []string{"abcde", "12345"},
-		expectLocationRefs: []string{"locationref", "locationref2"},
+		expectRepoRefs:     []string{"abcde", "12345", "foo.meta"},
+		expectLocationRefs: []string{"locationref", "locationref2", "locationref.dirmeta"},
 	},
 }
 
@@ -363,7 +363,7 @@ func (suite *DetailsUnitSuite) TestDetailsModel_FilterMetaFiles() {
 
 	d2 := d.FilterMetaFiles()
 
-	assert.Len(t, d2.Entries, 1)
+	assert.Len(t, d2.Entries, 2)
 	assert.Len(t, d.Entries, 3)
 }
 

--- a/website/docs/support/known-issues.md
+++ b/website/docs/support/known-issues.md
@@ -19,7 +19,7 @@ Below is a list of known Corso issues and limitations:
 * Provides no guarantees about whether data moved, added, or deleted in M365
   while a backup is being created will be included in the running backup.
   Future backups run when the data isn't modified will include the data.
-  
+
 * OneDrive files ending in `.meta` or `.dirmeta` get omitted from Details and Restore commands.
 
 * Exchange Calender Event instance exceptions (changes to a single event within a recurring series) aren't


### PR DESCRIPTION
This reverts commit 1945db6b65827e6dd6d57de8ac42fe4a119db685.

We do add the `isMeta` flags for missing items at https://github.com/alcionai/corso/blob/f60207ee32811a475d7803b9aa628a9fe80cff8c/src/pkg/repository/repository.go#L363

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
