### PR TITLE
introduce fault items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Show owner information when doing backup list in json format
-- Onedrive files that are flagged as malware get skipped during backup.
 - Permissions for groups can now be backed up and restored
+- Onedrive files that are flagged as malware get skipped during backup.  Skipped files are listed in the backup results as part of the status, eg: "Completed (0 errors, 1 skipped)".
 
 ### Fixed
 - Corso-generated .meta files and permissions no longer appear in the backup details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Show owner information when doing backup list in json format
 - Permissions for groups can now be backed up and restored
-- Onedrive files that are flagged as malware get skipped during backup.  Skipped files are listed in the backup results as part of the status, eg: "Completed (0 errors, 1 skipped)".
+- Onedrive files that are flagged as malware get skipped during backup.  Skipped files are listed in the backup results as part of the status, including a reference to their categorization, eg: "Completed (0 errors, 1 skipped: 1 malware)".
 
 ### Fixed
 - Corso-generated .meta files and permissions no longer appear in the backup details.

--- a/src/internal/connector/graph/errors.go
+++ b/src/internal/connector/graph/errors.go
@@ -9,12 +9,14 @@ import (
 	"os"
 	"strings"
 
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 	"github.com/pkg/errors"
 	"golang.org/x/exp/slices"
 
 	"github.com/alcionai/clues"
 	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
 )
 
@@ -251,4 +253,33 @@ func appendIf(a []any, k string, v *string) []any {
 	}
 
 	return append(a, k, *v)
+}
+
+// MalwareInfo gathers potentially useful information about a malware infected
+// drive item, and aggregates that data into a map.
+func MalwareInfo(item models.DriveItemable) map[string]any {
+	m := map[string]any{}
+
+	creator := item.GetCreatedByUser()
+	if creator != nil {
+		m[fault.AddtlCreatedBy] = ptr.Val(creator.GetId())
+	}
+
+	lastmodder := item.GetLastModifiedByUser()
+	if lastmodder != nil {
+		m[fault.AddtlLastModBy] = ptr.Val(lastmodder.GetId())
+	}
+
+	parent := item.GetParentReference()
+	if parent != nil {
+		m[fault.AddtlContainerID] = ptr.Val(parent.GetId())
+		m[fault.AddtlContainerName] = ptr.Val(parent.GetName())
+	}
+
+	malware := item.GetMalware()
+	if malware != nil {
+		m[fault.AddtlMalwareDesc] = ptr.Val(malware.GetDescription())
+	}
+
+	return m
 }

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -429,8 +429,7 @@ func (oc *Collection) populateItems(ctx context.Context, errs *fault.Bus) {
 					if err != nil {
 						if item.GetMalware() != nil || clues.HasLabel(err, graph.LabelsMalware) {
 							logger.Ctx(ctx).With("error", err.Error(), "malware", true).Error("downloading item")
-							// el.AddSkip(fault.FileSkip(fault.SkipMalware, itemID, itemName, ptr.Val(pr.GetId()), ptr.Val(pr.GetName())))
-							el.AddSkip(fault.FileSkip(fault.SkipMalware, itemID, itemName, "container-id", "container-name"))
+							el.AddSkip(fault.FileSkip(fault.SkipMalware, itemID, itemName, graph.MalwareInfo(item)))
 						} else {
 							logger.Ctx(ctx).With("error", err.Error()).Error("downloading item")
 							el.AddRecoverable(clues.Stack(err).WithClues(ctx).Label(fault.LabelForceNoBackupCreation))

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -427,13 +427,17 @@ func (oc *Collection) populateItems(ctx context.Context, errs *fault.Bus) {
 
 					// check for errors following retries
 					if err != nil {
-						if clues.HasLabel(err, graph.LabelsMalware) {
-							logger.Ctx(ctx).Infow("malware item", clues.InErr(err).Slice()...)
+						if item.GetMalware() != nil || clues.HasLabel(err, graph.LabelsMalware) {
+							logger.Ctx(ctx).With("error", err.Error(), "malware", true).Error("downloading item")
+							// el.AddSkip(fault.FileSkip(fault.SkipMalware, itemID, itemName, ptr.Val(pr.GetId()), ptr.Val(pr.GetName())))
+							el.AddSkip(fault.FileSkip(fault.SkipMalware, itemID, itemName, "container-id", "container-name"))
 						} else {
 							logger.Ctx(ctx).With("error", err.Error()).Error("downloading item")
 							el.AddRecoverable(clues.Stack(err).WithClues(ctx).Label(fault.LabelForceNoBackupCreation))
 						}
 
+						// return err, not el.Err(), because the lazy reader needs to communicate to
+						// the data consumer that this item is unreadable, regardless of the fault state.
 						return nil, err
 					}
 

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -608,27 +608,39 @@ func (c *Collections) UpdateCollections(
 			break
 		}
 
+		var (
+			itemID   = ptr.Val(item.GetId())
+			itemName = ptr.Val(item.GetName())
+			ictx     = clues.Add(ctx, "item_id", itemID, "item_name", itemName)
+			isFolder = item.GetFolder() != nil || item.GetPackage() != nil
+		)
+
 		if item.GetMalware() != nil {
 			// TODO: track the item as skipped; logging alone might
 			// slice out the data from tracking.
 			// https://learn.microsoft.com/en-us/graph/api/resources/malware?view=graph-rest-1.0
 			logger.Ctx(ctx).Infow("malware detected", "malware_description", ptr.Val(item.GetMalware().GetDescription()))
+
+			var (
+				pr     = item.GetParentReference()
+				prID   string
+				prName string
+			)
+
+			if pr != nil {
+				prID = ptr.Val(pr.GetId())
+				prName = ptr.Val(pr.GetName())
+			}
+
+			skip := fault.FileSkip(fault.SkipMalware, itemID, itemName, prID, prName)
+			if isFolder {
+				skip = fault.ContainerSkip(fault.SkipMalware, itemID, itemName, prID, prName)
+			}
+
+			errs.AddSkip(skip)
+
 			continue
 		}
-
-		var (
-			itemID   = ptr.Val(item.GetId())
-			ictx     = clues.Add(ctx, "update_item_id", itemID)
-			isFolder = item.GetFolder() != nil || item.GetPackage() != nil
-		)
-
-		// TODO(meain): Use `@microsoft.graph.sharedChanged` in
-		// item.GetAdditionalData() to optimize fetching
-		// permissions. When permissions change, this flags is
-		// present, if only data changes, it is not present.  Have to
-		// add `oneDrive.sharedChanged` in `$select` in delta
-		// https://learn.microsoft.com/en-us/onedrive/developer/rest-api
-		// /concepts/scan-guidance#scanning-permissions-hierarchies
 
 		// Deleted file or folder.
 		if item.GetDeleted() != nil {

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -170,6 +170,11 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 			Errorf("doing backup: recoverable error %d of %d", i+1, recoverableCount)
 	}
 
+	skippedCount := len(op.Errors.Skipped())
+	for i, skip := range op.Errors.Skipped() {
+		logger.Ctx(ctx).With("skip", skip).Infof("doing backup: skipped item %d of %d", i+1, skippedCount)
+	}
+
 	// -----
 	// Persistence
 	// -----
@@ -673,8 +678,7 @@ func (op *BackupOperation) createBackupModels(
 		op.Selectors,
 		op.Results.ReadWrites,
 		op.Results.StartAndEndTime,
-		op.Errors,
-	)
+		op.Errors)
 
 	if err = op.store.Put(ctx, model.BackupSchema, b); err != nil {
 		return clues.Wrap(err, "creating backup model").WithClues(ctx)
@@ -694,8 +698,7 @@ func (op *BackupOperation) createBackupModels(
 			events.Service:    op.Selectors.PathService().String(),
 			events.StartTime:  common.FormatTime(op.Results.StartedAt),
 			events.Status:     op.Status.String(),
-		},
-	)
+		})
 
 	return nil
 }

--- a/src/internal/stats/stats.go
+++ b/src/internal/stats/stats.go
@@ -28,3 +28,8 @@ type ByteCounter struct {
 func (bc *ByteCounter) Count(i int64) {
 	atomic.AddInt64(&bc.NumBytes, i)
 }
+
+type SkippedCounts struct {
+	TotalSkippedItems int `json:"totalSkippedItems"`
+	SkippedMalware    int `json:"skippedMalware"`
+}

--- a/src/pkg/backup/backup.go
+++ b/src/pkg/backup/backup.go
@@ -36,12 +36,21 @@ type Backup struct {
 	Version int `json:"version"`
 
 	// Errors contains all errors aggregated during a backup operation.
+	// the fault.Errors struct is generally unserializable; it's values
+	// get propagated into ErrorCount, Failure, and FailedItems.
 	Errors     fault.Errors `json:"errors"`
 	ErrorCount int          `json:"errorCount"`
+	// the non-recoverable failure message, only non-zero if one occurred.
+	Failure string `json:"failure"`
+	// individual items (files, containers, resource owners) tracked as failed.
+	FailedItems []fault.Item `json:"failedItems"`
 
 	// stats are embedded so that the values appear as top-level properties
 	stats.ReadWrites
 	stats.StartAndEndTime
+
+	// Deprecated
+	stats.Errs // replaced with fault.Errors
 }
 
 // interface compliance checks
@@ -57,6 +66,7 @@ func New(
 ) *Backup {
 	errData := errs.Errors()
 
+	// TODO: count errData.Items(), not all recovered errors.
 	errCount := len(errs.Errors().Recovered)
 	if errData.Failure != nil {
 		errCount++
@@ -76,6 +86,8 @@ func New(
 		Selector:        selector,
 		Errors:          errData,
 		ErrorCount:      errCount,
+		Failure:         errData.Failure.Error(),
+		FailedItems:     errData.Items(),
 		ReadWrites:      rw,
 		StartAndEndTime: se,
 		Version:         version.Backup,

--- a/src/pkg/backup/backup.go
+++ b/src/pkg/backup/backup.go
@@ -35,20 +35,18 @@ type Backup struct {
 	// Version represents the version of the backup format
 	Version int `json:"version"`
 
-	// Errors contains all errors aggregated during a backup operation.
-	// the fault.Errors struct is generally unserializable; it's values
-	// get propagated into ErrorCount, Failure, and FailedItems.
-	FailFast   bool `json:"failFast"`
-	ErrorCount int  `json:"errorCount"`
-	// the non-recoverable failure message, only non-zero if one occurred.
+	FailFast bool `json:"failFast"`
+
+	// the quantity of errors, both hard failure and recoverable.
+	ErrorCount int `json:"errorCount"`
+
+	// the non-recoverable failure message, only populated if one occurred.
 	Failure string `json:"failure"`
-	// individual items (files, containers, resource owners) tracked as failed.
-	FailedItems  []fault.Item    `json:"failedItems"`
-	SkippedItems []fault.Skipped `json:"skippedItems"`
 
 	// stats are embedded so that the values appear as top-level properties
 	stats.ReadWrites
 	stats.StartAndEndTime
+	stats.SkippedCounts
 }
 
 // interface compliance checks
@@ -62,17 +60,26 @@ func New(
 	se stats.StartAndEndTime,
 	errs *fault.Bus,
 ) *Backup {
-	ee := errs.Errors()
+	var (
+		ee = errs.Errors()
+		// TODO: count errData.Items(), not all recovered errors.
+		errCount   = len(ee.Recovered)
+		failMsg    string
+		malware    int
+		otherSkips int
+	)
 
-	// TODO: count errData.Items(), not all recovered errors.
-	errCount := len(errs.Errors().Recovered)
 	if ee.Failure != nil {
+		failMsg = ee.Failure.Error()
 		errCount++
 	}
 
-	var failMsg string
-	if ee.Failure != nil {
-		failMsg = ee.Failure.Error()
+	for _, s := range ee.Skipped {
+		if s.HasCause(fault.SkipMalware) {
+			malware++
+		} else {
+			otherSkips++
+		}
 	}
 
 	return &Backup{
@@ -82,19 +89,26 @@ func New(
 				model.ServiceTag: selector.PathService().String(),
 			},
 		},
-		CreationTime:    time.Now(),
-		SnapshotID:      snapshotID,
-		DetailsID:       detailsID,
-		Status:          status,
-		Selector:        selector,
-		FailFast:        ee.FailFast,
-		ErrorCount:      errCount,
-		Failure:         failMsg,
-		FailedItems:     ee.Items,
-		SkippedItems:    ee.Skipped,
+
+		Version:    version.Backup,
+		SnapshotID: snapshotID,
+		DetailsID:  detailsID,
+
+		CreationTime: time.Now(),
+		Status:       status,
+
+		Selector: selector,
+		FailFast: errs.FailFast(),
+
+		ErrorCount: errCount,
+		Failure:    failMsg,
+
 		ReadWrites:      rw,
 		StartAndEndTime: se,
-		Version:         version.Backup,
+		SkippedCounts: stats.SkippedCounts{
+			TotalSkippedItems: len(ee.Skipped),
+			SkippedMalware:    malware,
+		},
 	}
 }
 
@@ -137,7 +151,7 @@ type Printable struct {
 func (b Backup) MinimumPrintable() any {
 	return Printable{
 		ID:            b.ID,
-		ErrorCount:    b.countErrors(),
+		ErrorCount:    b.ErrorCount,
 		StartedAt:     b.StartedAt,
 		Status:        b.Status,
 		Version:       "0",
@@ -161,23 +175,12 @@ func (b Backup) Headers() []string {
 // Values returns the values matching the Headers list for printing
 // out to a terminal in a columnar display.
 func (b Backup) Values() []string {
-	status := b.Status
-
 	var (
-		errCount   = b.countErrors()
-		malware    int
-		otherSkips int
+		status   = b.Status
+		errCount = b.ErrorCount
 	)
 
-	for _, s := range b.SkippedItems {
-		if s.HasCause(fault.SkipMalware) {
-			malware++
-		} else {
-			otherSkips++
-		}
-	}
-
-	if errCount+len(b.SkippedItems) > 0 {
+	if errCount+b.TotalSkippedItems > 0 {
 		status += (" (")
 	}
 
@@ -185,27 +188,23 @@ func (b Backup) Values() []string {
 		status += fmt.Sprintf("%d errors", errCount)
 	}
 
-	if errCount > 0 && len(b.SkippedItems) > 0 {
+	if errCount > 0 && b.TotalSkippedItems > 0 {
 		status += ", "
 	}
 
-	if len(b.SkippedItems) > 0 {
-		status += fmt.Sprintf("%d skipped: ", len(b.SkippedItems))
+	if b.TotalSkippedItems > 0 {
+		status += fmt.Sprintf("%d skipped", b.TotalSkippedItems)
 	}
 
-	if malware > 0 {
-		status += fmt.Sprintf("%d malware", malware)
+	if b.TotalSkippedItems > 0 && b.SkippedMalware > 0 {
+		status += ": "
 	}
 
-	if malware > 0 && otherSkips > 0 {
-		status += ", "
+	if b.SkippedMalware > 0 {
+		status += fmt.Sprintf("%d malware", b.SkippedMalware)
 	}
 
-	if otherSkips > 0 {
-		status += fmt.Sprintf("%d other", otherSkips)
-	}
-
-	if errCount+len(b.SkippedItems) > 0 {
+	if errCount+b.TotalSkippedItems > 0 {
 		status += (")")
 	}
 
@@ -215,22 +214,4 @@ func (b Backup) Values() []string {
 		status,
 		b.Selector.DiscreteOwner,
 	}
-}
-
-func (b Backup) countErrors() int {
-	if b.ErrorCount > 0 {
-		return b.ErrorCount
-	}
-
-	var errCount int
-
-	if len(b.Failure) > 0 || len(b.FailedItems) > 0 {
-		if len(b.Failure) > 0 {
-			errCount++
-		}
-
-		errCount += len(b.FailedItems)
-	}
-
-	return errCount
 }

--- a/src/pkg/backup/backup.go
+++ b/src/pkg/backup/backup.go
@@ -43,7 +43,8 @@ type Backup struct {
 	// the non-recoverable failure message, only non-zero if one occurred.
 	Failure string `json:"failure"`
 	// individual items (files, containers, resource owners) tracked as failed.
-	FailedItems []fault.Item `json:"failedItems"`
+	FailedItems  []fault.Item    `json:"failedItems"`
+	SkippedItems []fault.Skipped `json:"skippedItems"`
 
 	// stats are embedded so that the values appear as top-level properties
 	stats.ReadWrites
@@ -88,6 +89,7 @@ func New(
 		ErrorCount:      errCount,
 		Failure:         errData.Failure.Error(),
 		FailedItems:     errData.Items(),
+		SkippedItems:    errData.Skipped,
 		ReadWrites:      rw,
 		StartAndEndTime: se,
 		Version:         version.Backup,

--- a/src/pkg/backup/backup.go
+++ b/src/pkg/backup/backup.go
@@ -49,9 +49,6 @@ type Backup struct {
 	// stats are embedded so that the values appear as top-level properties
 	stats.ReadWrites
 	stats.StartAndEndTime
-
-	// Deprecated
-	stats.Errs // replaced with fault.Errors
 }
 
 // interface compliance checks

--- a/src/pkg/backup/backup_test.go
+++ b/src/pkg/backup/backup_test.go
@@ -52,6 +52,11 @@ func stubBackup(t time.Time) backup.Backup {
 			"id", "name",
 			"containerID", "containerName",
 		)},
+		SkippedItems: []fault.Skipped{*fault.FileSkip(
+			fault.SkipMalware,
+			"id", "name",
+			"containerID", "containerName",
+		)},
 		ReadWrites: stats.ReadWrites{
 			BytesRead:     301,
 			BytesUploaded: 301,

--- a/src/pkg/backup/backup_test.go
+++ b/src/pkg/backup/backup_test.go
@@ -47,12 +47,12 @@ func stubBackup(t time.Time) backup.Backup {
 		FailedItems: []fault.Item{*fault.FileErr(
 			errors.New("read"),
 			"id", "name",
-			"containerID", "containerName",
+			map[string]any{"foo": "bar"},
 		)},
 		SkippedItems: []fault.Skipped{*fault.FileSkip(
 			fault.SkipMalware,
 			"id", "name",
-			"containerID", "containerName",
+			map[string]any{"foo": "bar"},
 		)},
 		ReadWrites: stats.ReadWrites{
 			BytesRead:     301,
@@ -63,11 +63,6 @@ func stubBackup(t time.Time) backup.Backup {
 		StartAndEndTime: stats.StartAndEndTime{
 			StartedAt:   t,
 			CompletedAt: t,
-		},
-		// deprecated
-		Errs: stats.Errs{
-			ReadErrors:  errors.New("1"),
-			WriteErrors: errors.New("1"),
 		},
 	}
 }
@@ -101,6 +96,8 @@ func (suite *BackupUnitSuite) TestBackup_HeadersValues() {
 }
 
 func (suite *BackupUnitSuite) TestBackup_Values_statusVariations() {
+	addtl := map[string]any{"foo": "bar"}
+
 	table := []struct {
 		name   string
 		bup    backup.Backup
@@ -126,7 +123,7 @@ func (suite *BackupUnitSuite) TestBackup_Values_statusVariations() {
 				SkippedItems: []fault.Skipped{*fault.FileSkip(
 					fault.SkipMalware,
 					"id", "name",
-					"containerID", "containerName",
+					addtl,
 				)},
 			},
 			expect: "test (1 skipped: 1 malware)",
@@ -139,7 +136,7 @@ func (suite *BackupUnitSuite) TestBackup_Values_statusVariations() {
 				SkippedItems: []fault.Skipped{*fault.FileSkip(
 					fault.SkipMalware,
 					"id", "name",
-					"containerID", "containerName",
+					addtl,
 				)},
 			},
 			expect: "test (42 errors, 1 skipped: 1 malware)",

--- a/src/pkg/backup/backup_test.go
+++ b/src/pkg/backup/backup_test.go
@@ -45,6 +45,13 @@ func stubBackup(t time.Time) backup.Backup {
 		Errors: fault.Errors{
 			Recovered: []error{errors.New("read"), errors.New("write")},
 		},
+		ErrorCount: 2,
+		Failure:    "read, write",
+		FailedItems: []fault.Item{*fault.FileErr(
+			errors.New("read"),
+			"id", "name",
+			"containerID", "containerName",
+		)},
 		ReadWrites: stats.ReadWrites{
 			BytesRead:     301,
 			BytesUploaded: 301,
@@ -54,6 +61,11 @@ func stubBackup(t time.Time) backup.Backup {
 		StartAndEndTime: stats.StartAndEndTime{
 			StartedAt:   t,
 			CompletedAt: t,
+		},
+		// deprecated
+		Errs: stats.Errs{
+			ReadErrors:  errors.New("1"),
+			WriteErrors: errors.New("1"),
 		},
 	}
 }

--- a/src/pkg/backup/backup_test.go
+++ b/src/pkg/backup/backup_test.go
@@ -42,11 +42,8 @@ func stubBackup(t time.Time) backup.Backup {
 		DetailsID:    "details",
 		Status:       "status",
 		Selector:     sel.Selector,
-		Errors: fault.Errors{
-			Recovered: []error{errors.New("read"), errors.New("write")},
-		},
-		ErrorCount: 2,
-		Failure:    "read, write",
+		ErrorCount:   2,
+		Failure:      "read, write",
 		FailedItems: []fault.Item{*fault.FileErr(
 			errors.New("read"),
 			"id", "name",

--- a/src/pkg/fault/example_fault_test.go
+++ b/src/pkg/fault/example_fault_test.go
@@ -417,3 +417,25 @@ func ExampleErrors_Failure_return() {
 	// Output: direct: caught one
 	// recoverable: caught one
 }
+
+// ExampleBus_AddSkip showcases when to use AddSkip instead of an error.
+func ExampleBus_AddSkip() {
+	errs := fault.New(false)
+
+	// Some conditions cause well-known problems that we want Corso to skip
+	// over, instead of error out.  An initial case is when Graph API identifies
+	// a file as containing malware.  We can't download the file: it'll always
+	// error.  Our only option is to skip it.
+	errs.AddSkip(fault.FileSkip(
+		fault.SkipMalware,
+		"file-id",
+		"file-name",
+		"parent-folder-id",
+		"parent-folder-name",
+	))
+
+	// later on, after processing, end users can scrutinize the skipped items.
+	fmt.Println(errs.Skipped()[0])
+
+	// Output: skipped processing file: malware_detected
+}

--- a/src/pkg/fault/example_fault_test.go
+++ b/src/pkg/fault/example_fault_test.go
@@ -430,8 +430,7 @@ func ExampleBus_AddSkip() {
 		fault.SkipMalware,
 		"file-id",
 		"file-name",
-		"parent-folder-id",
-		"parent-folder-name",
+		map[string]any{"foo": "bar"},
 	))
 
 	// later on, after processing, end users can scrutinize the skipped items.

--- a/src/pkg/fault/example_fault_test.go
+++ b/src/pkg/fault/example_fault_test.go
@@ -435,7 +435,7 @@ func ExampleBus_AddSkip() {
 	))
 
 	// later on, after processing, end users can scrutinize the skipped items.
-	fmt.Println(errs.Skipped()[0])
+	fmt.Println(errs.Skipped()[0].String())
 
 	// Output: skipped processing file: malware_detected
 }

--- a/src/pkg/fault/fault.go
+++ b/src/pkg/fault/fault.go
@@ -45,6 +45,11 @@ func New(failFast bool) *Bus {
 	}
 }
 
+// FailFast returs the failFast flag in the bus.
+func (e *Bus) FailFast() bool {
+	return e.failFast
+}
+
 // Failure returns the primary error.  If not nil, this
 // indicates the operation exited prior to completion.
 func (e *Bus) Failure() error {

--- a/src/pkg/fault/fault_test.go
+++ b/src/pkg/fault/fault_test.go
@@ -194,7 +194,7 @@ func (suite *FaultErrorsUnitSuite) TestAddSkip() {
 	n.AddRecoverable(assert.AnError)
 	assert.Len(t, n.Skipped(), 0)
 
-	n.AddSkip(fault.OwnerSkip(fault.SkipMalware, "id", "name"))
+	n.AddSkip(fault.OwnerSkip(fault.SkipMalware, "id", "name", nil))
 	assert.Len(t, n.Skipped(), 1)
 }
 
@@ -230,6 +230,7 @@ func (suite *FaultErrorsUnitSuite) TestErrors() {
 
 func (suite *FaultErrorsUnitSuite) TestErrors_Items() {
 	ae := assert.AnError
+	addtl := map[string]any{"foo": "bar", "baz": 1}
 
 	table := []struct {
 		name   string
@@ -258,49 +259,49 @@ func (suite *FaultErrorsUnitSuite) TestErrors_Items() {
 			name: "failure item",
 			errs: func() fault.Errors {
 				b := fault.New(false)
-				b.Fail(fault.OwnerErr(ae, "id", "name"))
+				b.Fail(fault.OwnerErr(ae, "id", "name", addtl))
 				b.AddRecoverable(ae)
 
 				return b.Errors()
 			},
-			expect: []fault.Item{*fault.OwnerErr(ae, "id", "name")},
+			expect: []fault.Item{*fault.OwnerErr(ae, "id", "name", addtl)},
 		},
 		{
 			name: "recoverable item",
 			errs: func() fault.Errors {
 				b := fault.New(false)
 				b.Fail(ae)
-				b.AddRecoverable(fault.OwnerErr(ae, "id", "name"))
+				b.AddRecoverable(fault.OwnerErr(ae, "id", "name", addtl))
 
 				return b.Errors()
 			},
-			expect: []fault.Item{*fault.OwnerErr(ae, "id", "name")},
+			expect: []fault.Item{*fault.OwnerErr(ae, "id", "name", addtl)},
 		},
 		{
 			name: "two items",
 			errs: func() fault.Errors {
 				b := fault.New(false)
-				b.Fail(fault.OwnerErr(ae, "oid", "name"))
-				b.AddRecoverable(fault.FileErr(ae, "fid", "name", "cid", "cname"))
+				b.Fail(fault.OwnerErr(ae, "oid", "name", addtl))
+				b.AddRecoverable(fault.FileErr(ae, "fid", "name", addtl))
 
 				return b.Errors()
 			},
 			expect: []fault.Item{
-				*fault.OwnerErr(ae, "oid", "name"),
-				*fault.FileErr(ae, "fid", "name", "cid", "cname"),
+				*fault.OwnerErr(ae, "oid", "name", addtl),
+				*fault.FileErr(ae, "fid", "name", addtl),
 			},
 		},
 		{
 			name: "duplicate items - failure priority",
 			errs: func() fault.Errors {
 				b := fault.New(false)
-				b.Fail(fault.OwnerErr(ae, "id", "name"))
-				b.AddRecoverable(fault.FileErr(ae, "id", "name", "cid", "cname"))
+				b.Fail(fault.OwnerErr(ae, "id", "name", addtl))
+				b.AddRecoverable(fault.FileErr(ae, "id", "name", addtl))
 
 				return b.Errors()
 			},
 			expect: []fault.Item{
-				*fault.OwnerErr(ae, "id", "name"),
+				*fault.OwnerErr(ae, "id", "name", addtl),
 			},
 		},
 		{
@@ -308,13 +309,13 @@ func (suite *FaultErrorsUnitSuite) TestErrors_Items() {
 			errs: func() fault.Errors {
 				b := fault.New(false)
 				b.Fail(ae)
-				b.AddRecoverable(fault.FileErr(ae, "fid", "name", "cid", "cname"))
-				b.AddRecoverable(fault.FileErr(ae, "fid", "name2", "cid2", "cname2"))
+				b.AddRecoverable(fault.FileErr(ae, "fid", "name", addtl))
+				b.AddRecoverable(fault.FileErr(ae, "fid", "name2", addtl))
 
 				return b.Errors()
 			},
 			expect: []fault.Item{
-				*fault.FileErr(ae, "fid", "name2", "cid2", "cname2"),
+				*fault.FileErr(ae, "fid", "name2", addtl),
 			},
 		},
 	}

--- a/src/pkg/fault/fault_test.go
+++ b/src/pkg/fault/fault_test.go
@@ -320,7 +320,7 @@ func (suite *FaultErrorsUnitSuite) TestErrors_Items() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			assert.ElementsMatch(suite.T(), test.expect, test.errs().Items())
+			assert.ElementsMatch(suite.T(), test.expect, test.errs().Items)
 		})
 	}
 }

--- a/src/pkg/fault/fault_test.go
+++ b/src/pkg/fault/fault_test.go
@@ -182,6 +182,22 @@ func (suite *FaultErrorsUnitSuite) TestAdd() {
 	assert.Len(t, n.Recovered(), 2)
 }
 
+func (suite *FaultErrorsUnitSuite) TestAddSkip() {
+	t := suite.T()
+
+	n := fault.New(true)
+	require.NotNil(t, n)
+
+	n.Fail(assert.AnError)
+	assert.Len(t, n.Skipped(), 0)
+
+	n.AddRecoverable(assert.AnError)
+	assert.Len(t, n.Skipped(), 0)
+
+	n.AddSkip(fault.OwnerSkip(fault.SkipMalware, "id", "name"))
+	assert.Len(t, n.Skipped(), 1)
+}
+
 func (suite *FaultErrorsUnitSuite) TestErrors() {
 	t := suite.T()
 

--- a/src/pkg/fault/item.go
+++ b/src/pkg/fault/item.go
@@ -8,6 +8,8 @@ const (
 	ResourceOwnerType itemType = "resource_owner"
 )
 
+var _ error = &Item{}
+
 // Item contains a concrete reference to a thing that failed
 // during processing.  The categorization of the item is determined
 // by its Type: file, container, or reourceOwner.
@@ -54,7 +56,11 @@ func (i *Item) Error() string {
 	return string("processing " + i.Type)
 }
 
-// ContainerErr constructs a Container-type Item.
+// ---------------------------------------------------------------------------
+// Constructors
+// ---------------------------------------------------------------------------
+
+// ContainerErr produces a Container-type Item.
 func ContainerErr(cause error, id, name, containerID, containerName string) *Item {
 	return &Item{
 		ID:            id,

--- a/src/pkg/fault/item.go
+++ b/src/pkg/fault/item.go
@@ -127,7 +127,7 @@ type Skipped struct {
 	item Item
 }
 
-// String complies with the stringer interface. func (s *Skipped) String() string {
+// String complies with the stringer interface.
 func (s *Skipped) String() string {
 	if s == nil {
 		return "<nil>"

--- a/src/pkg/fault/item.go
+++ b/src/pkg/fault/item.go
@@ -60,7 +60,7 @@ func (i *Item) Error() string {
 // Constructors
 // ---------------------------------------------------------------------------
 
-// ContainerErr produces a Container-type Item.
+// ContainerErr produces a Container-type Item for tracking erronous items
 func ContainerErr(cause error, id, name, containerID, containerName string) *Item {
 	return &Item{
 		ID:            id,
@@ -72,7 +72,7 @@ func ContainerErr(cause error, id, name, containerID, containerName string) *Ite
 	}
 }
 
-// FileErr constructs a File-type Item.
+// FileErr produces a File-type Item for tracking erronous items.
 func FileErr(cause error, id, name, containerID, containerName string) *Item {
 	return &Item{
 		ID:            id,
@@ -84,12 +84,94 @@ func FileErr(cause error, id, name, containerID, containerName string) *Item {
 	}
 }
 
-// OnwerErr constructs a ResourceOwner-type Item.
+// OnwerErr produces a ResourceOwner-type Item for tracking erronous items.
 func OwnerErr(cause error, id, name string) *Item {
 	return &Item{
 		ID:    id,
 		Name:  name,
 		Type:  ResourceOwnerType,
 		Cause: cause.Error(),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Skipped Items
+// ---------------------------------------------------------------------------
+
+// skipCause identifies the well-known conditions to Skip an item.  It is
+// important that skip cause enumerations do not overlap with general error
+// handling.  Skips must be well known, well documented, and consistent.
+// Transient failures, undocumented or unknown conditions, and arbitrary
+// handling should never produce a skipped item. Those cases should get
+// handled as normal errors.
+type skipCause string
+
+// SkipMalware identifies a malware detection case.  Files that graph api
+// identifies as malware cannot be downloaded or uploaded, and will permanently
+// fail any attempts to backup or restore.
+const SkipMalware skipCause = "malware_detected"
+
+// Skipped items are permanently unprocessable due to well-known conditions.
+// In order to skip an item, the following conditions should be met:
+// 1. The conditions for skipping the item are well-known and
+// well-documented.  End users need to be able to understand
+// both the conditions and identifications of skips.
+// 2. Skipping avoids a permanent and consistent failure.  If
+// the underlying reason is transient or otherwise recoverable,
+// the item should not be skipped.
+//
+// Skipped wraps Item primarily to minimze confusion when sharing the
+// fault interface.  Skipped items are not errors, and Item{} errors are
+// not the basis for a Skip.
+type Skipped struct {
+	item Item
+}
+
+// String complies with the stringer interface. func (s *Skipped) String() string {
+func (s *Skipped) String() string {
+	if s == nil {
+		return "<nil>"
+	}
+
+	return "skipped " + s.item.Error() + ": " + s.item.Cause
+}
+
+// ContainerSkip produces a Container-kind Item for tracking skipped items.
+func ContainerSkip(cause skipCause, id, name, containerID, containerName string) *Skipped {
+	return &Skipped{
+		item: Item{
+			ID:            id,
+			Name:          name,
+			ContainerID:   containerID,
+			ContainerName: containerName,
+			Type:          ContainerType,
+			Cause:         string(cause),
+		},
+	}
+}
+
+// FileSkip produces a File-kind Item for tracking skipped items.
+func FileSkip(cause skipCause, id, name, containerID, containerName string) *Skipped {
+	return &Skipped{
+		item: Item{
+			ID:            id,
+			Name:          name,
+			ContainerID:   containerID,
+			ContainerName: containerName,
+			Type:          FileType,
+			Cause:         string(cause),
+		},
+	}
+}
+
+// OnwerSkip produces a ResourceOwner-kind Item for tracking skipped items.
+func OwnerSkip(cause skipCause, id, name string) *Skipped {
+	return &Skipped{
+		item: Item{
+			ID:    id,
+			Name:  name,
+			Type:  ResourceOwnerType,
+			Cause: string(cause),
+		},
 	}
 }

--- a/src/pkg/fault/item.go
+++ b/src/pkg/fault/item.go
@@ -1,16 +1,16 @@
 package fault
 
-type itemKind string
+type itemType string
 
 const (
-	ItemKindFile          itemKind = "file"
-	ItemKindContainer     itemKind = "container"
-	ItemKindResourceOwner itemKind = "resource_owner"
+	FileType          itemType = "file"
+	ContainerType     itemType = "container"
+	ResourceOwnerType itemType = "resource_owner"
 )
 
 // Item contains a concrete reference to a thing that failed
 // during processing.  The categorization of the item is determined
-// by its Kind: file, container, or reourceOwner.
+// by its Type: file, container, or reourceOwner.
 //
 // Item is compliant with the error interface so that it can be
 // aggregated with the fault bus, and deserialized using the
@@ -33,7 +33,7 @@ type Item struct {
 	ContainerID   string `json:"containerID"`
 
 	// tracks the type of item represented by this entry.
-	Kind itemKind `json:"kind"`
+	Type itemType `json:"type"`
 
 	// Error() of the causal error, or a sentinel if this is the
 	// source of the error.  In case of ID collisions, the first
@@ -47,43 +47,43 @@ func (i *Item) Error() string {
 		return "<nil>"
 	}
 
-	if len(i.Kind) == 0 {
-		return "processing item of unknown kind"
+	if len(i.Type) == 0 {
+		return "processing item of unknown type"
 	}
 
-	return string("processing " + i.Kind)
+	return string("processing " + i.Type)
 }
 
-// ContainerErr constructs a Container-kind Item.
+// ContainerErr constructs a Container-type Item.
 func ContainerErr(cause error, id, name, containerID, containerName string) *Item {
 	return &Item{
 		ID:            id,
 		Name:          name,
 		ContainerID:   containerID,
 		ContainerName: containerName,
-		Kind:          ItemKindContainer,
+		Type:          ContainerType,
 		Cause:         cause.Error(),
 	}
 }
 
-// FileErr constructs a File-kind Item.
+// FileErr constructs a File-type Item.
 func FileErr(cause error, id, name, containerID, containerName string) *Item {
 	return &Item{
 		ID:            id,
 		Name:          name,
 		ContainerID:   containerID,
 		ContainerName: containerName,
-		Kind:          ItemKindFile,
+		Type:          FileType,
 		Cause:         cause.Error(),
 	}
 }
 
-// OnwerErr constructs a ResourceOwner-kind Item.
+// OnwerErr constructs a ResourceOwner-type Item.
 func OwnerErr(cause error, id, name string) *Item {
 	return &Item{
 		ID:    id,
 		Name:  name,
-		Kind:  ItemKindResourceOwner,
+		Type:  ResourceOwnerType,
 		Cause: cause.Error(),
 	}
 }

--- a/src/pkg/fault/item.go
+++ b/src/pkg/fault/item.go
@@ -136,6 +136,15 @@ func (s *Skipped) String() string {
 	return "skipped " + s.item.Error() + ": " + s.item.Cause
 }
 
+// HasCause compares the underlying cause against the parameter.
+func (s *Skipped) HasCause(c skipCause) bool {
+	if s == nil {
+		return false
+	}
+
+	return s.item.Cause == string(c)
+}
+
 // ContainerSkip produces a Container-kind Item for tracking skipped items.
 func ContainerSkip(cause skipCause, id, name, containerID, containerName string) *Skipped {
 	return &Skipped{

--- a/src/pkg/fault/item.go
+++ b/src/pkg/fault/item.go
@@ -1,0 +1,79 @@
+package fault
+
+type itemKind string
+
+const (
+	ItemKindFile          itemKind = "file"
+	ItemKindContainer     itemKind = "container"
+	ItemKindResourceOwner itemKind = "resource_owner"
+)
+
+// in pkg fault.  eg: fault.Item{}
+type Item struct {
+	// deduplication identifier; the ID of the item under scrutiny.
+	ID string `json:"id"`
+
+	// a human-readable reference: file/container name, email, etc
+	Name string `json:"name"`
+
+	// the name and id of the container inside which this item is
+	// stored.  May be empty if the item is not stored within a
+	// container (ex: resourceOwner)
+	ContainerName string `json:"containerName"`
+	ContainerID   string `json:"containerID"`
+
+	// tracks the type of item represented by this entry.
+	Kind itemKind `json:"kind"`
+
+	// Error() of the causal error, or a sentinel if this is the
+	// source of the error.  In case of ID collisions, the first
+	// item takes priority.
+	Cause string `json:"cause"`
+}
+
+// Error complies with the error interface.
+func (i *Item) Error() string {
+	if i == nil {
+		return "<nil>"
+	}
+
+	if len(i.Kind) == 0 {
+		return "processing item of unknown kind"
+	}
+
+	return string("processing " + i.Kind)
+}
+
+// ContainerItem produces a Container-kind Item.
+func ContainerItem(cause error, id, name, containerID, containerName string) *Item {
+	return &Item{
+		ID:            id,
+		Name:          name,
+		ContainerID:   containerID,
+		ContainerName: containerName,
+		Kind:          ItemKindContainer,
+		Cause:         cause.Error(),
+	}
+}
+
+// FileItem produces a File-kind Item.
+func FileItem(cause error, id, name, containerID, containerName string) *Item {
+	return &Item{
+		ID:            id,
+		Name:          name,
+		ContainerID:   containerID,
+		ContainerName: containerName,
+		Kind:          ItemKindFile,
+		Cause:         cause.Error(),
+	}
+}
+
+// OnwerItem produces a ResourceOwner-kind Item.
+func OwnerItem(cause error, id, name string) *Item {
+	return &Item{
+		ID:    id,
+		Name:  name,
+		Kind:  ItemKindResourceOwner,
+		Cause: cause.Error(),
+	}
+}

--- a/src/pkg/fault/item.go
+++ b/src/pkg/fault/item.go
@@ -44,8 +44,8 @@ func (i *Item) Error() string {
 	return string("processing " + i.Kind)
 }
 
-// ContainerItem produces a Container-kind Item.
-func ContainerItem(cause error, id, name, containerID, containerName string) *Item {
+// ContainerErr produces a Container-kind Item.
+func ContainerErr(cause error, id, name, containerID, containerName string) *Item {
 	return &Item{
 		ID:            id,
 		Name:          name,
@@ -56,8 +56,8 @@ func ContainerItem(cause error, id, name, containerID, containerName string) *It
 	}
 }
 
-// FileItem produces a File-kind Item.
-func FileItem(cause error, id, name, containerID, containerName string) *Item {
+// FileErr produces a File-kind Item.
+func FileErr(cause error, id, name, containerID, containerName string) *Item {
 	return &Item{
 		ID:            id,
 		Name:          name,
@@ -68,8 +68,8 @@ func FileItem(cause error, id, name, containerID, containerName string) *Item {
 	}
 }
 
-// OnwerItem produces a ResourceOwner-kind Item.
-func OwnerItem(cause error, id, name string) *Item {
+// OnwerErr produces a ResourceOwner-kind Item.
+func OwnerErr(cause error, id, name string) *Item {
 	return &Item{
 		ID:    id,
 		Name:  name,

--- a/src/pkg/fault/item_test.go
+++ b/src/pkg/fault/item_test.go
@@ -30,8 +30,8 @@ func (suite *ItemUnitSuite) TestItem_Error() {
 	i = &fault.Item{}
 	assert.Contains(t, i.Error(), "unknown kind")
 
-	i = &fault.Item{Kind: fault.ItemKindFile}
-	assert.Contains(t, i.Error(), fault.ItemKindFile)
+	i = &fault.Item{Type: fault.FileType}
+	assert.Contains(t, i.Error(), fault.FileType)
 }
 
 func (suite *ItemUnitSuite) TestContainerErr() {
@@ -44,7 +44,7 @@ func (suite *ItemUnitSuite) TestContainerErr() {
 		Name:          "name",
 		ContainerID:   "containerID",
 		ContainerName: "containerName",
-		Kind:          fault.ItemKindContainer,
+		Type:          fault.ContainerType,
 		Cause:         "foo",
 	}
 
@@ -61,7 +61,7 @@ func (suite *ItemUnitSuite) TestFileErr() {
 		Name:          "name",
 		ContainerID:   "containerID",
 		ContainerName: "containerName",
-		Kind:          fault.ItemKindFile,
+		Type:          fault.FileType,
 		Cause:         "foo",
 	}
 
@@ -76,7 +76,7 @@ func (suite *ItemUnitSuite) TestOwnerErr() {
 	expect := fault.Item{
 		ID:    "id",
 		Name:  "name",
-		Kind:  fault.ItemKindResourceOwner,
+		Type:  fault.ResourceOwnerType,
 		Cause: "foo",
 	}
 

--- a/src/pkg/fault/item_test.go
+++ b/src/pkg/fault/item_test.go
@@ -1,0 +1,84 @@
+package fault_test
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/fault"
+)
+
+type ItemUnitSuite struct {
+	tester.Suite
+}
+
+func TestItemUnitSuite(t *testing.T) {
+	suite.Run(t, &ItemUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *ItemUnitSuite) TestItem_Error() {
+	var (
+		t = suite.T()
+		i *fault.Item
+	)
+
+	assert.Contains(t, i.Error(), "nil")
+
+	i = &fault.Item{}
+	assert.Contains(t, i.Error(), "unknown kind")
+
+	i = &fault.Item{Kind: fault.ItemKindFile}
+	assert.Contains(t, i.Error(), fault.ItemKindFile)
+}
+
+func (suite *ItemUnitSuite) TestContainerItem() {
+	t := suite.T()
+
+	i := fault.ContainerItem(errors.New("foo"), "id", "name", "containerID", "containerName")
+
+	expect := fault.Item{
+		ID:            "id",
+		Name:          "name",
+		ContainerID:   "containerID",
+		ContainerName: "containerName",
+		Kind:          fault.ItemKindContainer,
+		Cause:         "foo",
+	}
+
+	assert.Equal(t, expect, *i)
+}
+
+func (suite *ItemUnitSuite) TestFileItem() {
+	t := suite.T()
+
+	i := fault.FileItem(errors.New("foo"), "id", "name", "containerID", "containerName")
+
+	expect := fault.Item{
+		ID:            "id",
+		Name:          "name",
+		ContainerID:   "containerID",
+		ContainerName: "containerName",
+		Kind:          fault.ItemKindFile,
+		Cause:         "foo",
+	}
+
+	assert.Equal(t, expect, *i)
+}
+
+func (suite *ItemUnitSuite) TestOwnerItem() {
+	t := suite.T()
+
+	i := fault.OwnerItem(errors.New("foo"), "id", "name")
+
+	expect := fault.Item{
+		ID:    "id",
+		Name:  "name",
+		Kind:  fault.ItemKindResourceOwner,
+		Cause: "foo",
+	}
+
+	assert.Equal(t, expect, *i)
+}

--- a/src/pkg/fault/item_test.go
+++ b/src/pkg/fault/item_test.go
@@ -34,10 +34,10 @@ func (suite *ItemUnitSuite) TestItem_Error() {
 	assert.Contains(t, i.Error(), fault.ItemKindFile)
 }
 
-func (suite *ItemUnitSuite) TestContainerItem() {
+func (suite *ItemUnitSuite) TestContainerErr() {
 	t := suite.T()
 
-	i := fault.ContainerItem(errors.New("foo"), "id", "name", "containerID", "containerName")
+	i := fault.ContainerErr(errors.New("foo"), "id", "name", "containerID", "containerName")
 
 	expect := fault.Item{
 		ID:            "id",
@@ -51,10 +51,10 @@ func (suite *ItemUnitSuite) TestContainerItem() {
 	assert.Equal(t, expect, *i)
 }
 
-func (suite *ItemUnitSuite) TestFileItem() {
+func (suite *ItemUnitSuite) TestFileErr() {
 	t := suite.T()
 
-	i := fault.FileItem(errors.New("foo"), "id", "name", "containerID", "containerName")
+	i := fault.FileErr(errors.New("foo"), "id", "name", "containerID", "containerName")
 
 	expect := fault.Item{
 		ID:            "id",
@@ -68,10 +68,10 @@ func (suite *ItemUnitSuite) TestFileItem() {
 	assert.Equal(t, expect, *i)
 }
 
-func (suite *ItemUnitSuite) TestOwnerItem() {
+func (suite *ItemUnitSuite) TestOwnerErr() {
 	t := suite.T()
 
-	i := fault.OwnerItem(errors.New("foo"), "id", "name")
+	i := fault.OwnerErr(errors.New("foo"), "id", "name")
 
 	expect := fault.Item{
 		ID:    "id",

--- a/src/pkg/fault/item_test.go
+++ b/src/pkg/fault/item_test.go
@@ -35,16 +35,15 @@ func (suite *ItemUnitSuite) TestItem_Error() {
 
 func (suite *ItemUnitSuite) TestContainerErr() {
 	t := suite.T()
-
-	i := ContainerErr(errors.New("foo"), "id", "name", "containerID", "containerName")
+	addtl := map[string]any{"foo": "bar"}
+	i := ContainerErr(errors.New("foo"), "id", "name", addtl)
 
 	expect := Item{
-		ID:            "id",
-		Name:          "name",
-		ContainerID:   "containerID",
-		ContainerName: "containerName",
-		Type:          ContainerType,
-		Cause:         "foo",
+		ID:         "id",
+		Name:       "name",
+		Type:       ContainerType,
+		Cause:      "foo",
+		Additional: addtl,
 	}
 
 	assert.Equal(t, expect, *i)
@@ -52,16 +51,15 @@ func (suite *ItemUnitSuite) TestContainerErr() {
 
 func (suite *ItemUnitSuite) TestFileErr() {
 	t := suite.T()
-
-	i := FileErr(errors.New("foo"), "id", "name", "containerID", "containerName")
+	addtl := map[string]any{"foo": "bar"}
+	i := FileErr(errors.New("foo"), "id", "name", addtl)
 
 	expect := Item{
-		ID:            "id",
-		Name:          "name",
-		ContainerID:   "containerID",
-		ContainerName: "containerName",
-		Type:          FileType,
-		Cause:         "foo",
+		ID:         "id",
+		Name:       "name",
+		Type:       FileType,
+		Cause:      "foo",
+		Additional: addtl,
 	}
 
 	assert.Equal(t, expect, *i)
@@ -69,14 +67,15 @@ func (suite *ItemUnitSuite) TestFileErr() {
 
 func (suite *ItemUnitSuite) TestOwnerErr() {
 	t := suite.T()
-
-	i := OwnerErr(errors.New("foo"), "id", "name")
+	addtl := map[string]any{"foo": "bar"}
+	i := OwnerErr(errors.New("foo"), "id", "name", addtl)
 
 	expect := Item{
-		ID:    "id",
-		Name:  "name",
-		Type:  ResourceOwnerType,
-		Cause: "foo",
+		ID:         "id",
+		Name:       "name",
+		Type:       ResourceOwnerType,
+		Cause:      "foo",
+		Additional: addtl,
 	}
 
 	assert.Equal(t, expect, *i)
@@ -99,16 +98,15 @@ func (suite *ItemUnitSuite) TestSkipped_String() {
 
 func (suite *ItemUnitSuite) TestContainerSkip() {
 	t := suite.T()
-
-	i := ContainerSkip(SkipMalware, "id", "name", "containerID", "containerName")
+	addtl := map[string]any{"foo": "bar"}
+	i := ContainerSkip(SkipMalware, "id", "name", addtl)
 
 	expect := Item{
-		ID:            "id",
-		Name:          "name",
-		ContainerID:   "containerID",
-		ContainerName: "containerName",
-		Type:          ContainerType,
-		Cause:         string(SkipMalware),
+		ID:         "id",
+		Name:       "name",
+		Type:       ContainerType,
+		Cause:      string(SkipMalware),
+		Additional: addtl,
 	}
 
 	assert.Equal(t, Skipped{expect}, *i)
@@ -116,16 +114,15 @@ func (suite *ItemUnitSuite) TestContainerSkip() {
 
 func (suite *ItemUnitSuite) TestFileSkip() {
 	t := suite.T()
-
-	i := FileSkip(SkipMalware, "id", "name", "containerID", "containerName")
+	addtl := map[string]any{"foo": "bar"}
+	i := FileSkip(SkipMalware, "id", "name", addtl)
 
 	expect := Item{
-		ID:            "id",
-		Name:          "name",
-		ContainerID:   "containerID",
-		ContainerName: "containerName",
-		Type:          FileType,
-		Cause:         string(SkipMalware),
+		ID:         "id",
+		Name:       "name",
+		Type:       FileType,
+		Cause:      string(SkipMalware),
+		Additional: addtl,
 	}
 
 	assert.Equal(t, Skipped{expect}, *i)
@@ -133,14 +130,15 @@ func (suite *ItemUnitSuite) TestFileSkip() {
 
 func (suite *ItemUnitSuite) TestOwnerSkip() {
 	t := suite.T()
-
-	i := OwnerSkip(SkipMalware, "id", "name")
+	addtl := map[string]any{"foo": "bar"}
+	i := OwnerSkip(SkipMalware, "id", "name", addtl)
 
 	expect := Item{
-		ID:    "id",
-		Name:  "name",
-		Type:  ResourceOwnerType,
-		Cause: string(SkipMalware),
+		ID:         "id",
+		Name:       "name",
+		Type:       ResourceOwnerType,
+		Cause:      string(SkipMalware),
+		Additional: addtl,
 	}
 
 	assert.Equal(t, Skipped{expect}, *i)

--- a/src/pkg/fault/item_test.go
+++ b/src/pkg/fault/item_test.go
@@ -82,16 +82,16 @@ func (suite *ItemUnitSuite) TestOwnerErr() {
 	assert.Equal(t, expect, *i)
 }
 
-func (suite *ItemUnitSuite) TestSkipped_Error() {
+func (suite *ItemUnitSuite) TestSkipped_String() {
 	var (
 		t = suite.T()
 		i *Skipped
 	)
 
-	assert.Contains(t, i.item.Error(), "nil")
+	assert.Contains(t, i.String(), "nil")
 
 	i = &Skipped{Item{}}
-	assert.Contains(t, i.item.Error(), "unknown kind")
+	assert.Contains(t, i.String(), "unknown kind")
 
 	i = &Skipped{Item{Type: FileType}}
 	assert.Contains(t, i.item.Error(), FileType)

--- a/src/pkg/fault/item_test.go
+++ b/src/pkg/fault/item_test.go
@@ -27,7 +27,7 @@ func (suite *ItemUnitSuite) TestItem_Error() {
 	assert.Contains(t, i.Error(), "nil")
 
 	i = &Item{}
-	assert.Contains(t, i.Error(), "unknown kind")
+	assert.Contains(t, i.Error(), "unknown type")
 
 	i = &Item{Type: FileType}
 	assert.Contains(t, i.Error(), FileType)
@@ -91,7 +91,7 @@ func (suite *ItemUnitSuite) TestSkipped_String() {
 	assert.Contains(t, i.String(), "nil")
 
 	i = &Skipped{Item{}}
-	assert.Contains(t, i.String(), "unknown kind")
+	assert.Contains(t, i.String(), "unknown type")
 
 	i = &Skipped{Item{Type: FileType}}
 	assert.Contains(t, i.item.Error(), FileType)


### PR DESCRIPTION
Adds the item struct to the fault package for tracking serializable and dedupliatable error sources.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature

#### Issue(s)

* #2708

#### Test Plan

- [x] :zap: Unit test
