### PR TITLE
add fault.item serialization to backup

### DIFF
--- a/src/pkg/backup/backup.go
+++ b/src/pkg/backup/backup.go
@@ -37,13 +37,21 @@ type Backup struct {
 	Version int `json:"version"`
 
 	// Errors contains all errors aggregated during a backup operation.
+	// the fault.Errors struct is generally unserializable; it's values
+	// get propagated into ErrorCount, Failure, and FailedItems.
 	Errors     fault.Errors `json:"errors"`
 	ErrorCount int          `json:"errorCount"`
+	// the non-recoverable failure message, only non-zero if one occurred.
+	Failure string `json:"failure"`
+	// individual items (files, containers, resource owners) tracked as failed.
+	FailedItems []fault.Item `json:"failedItems"`
 
 	// stats are embedded so that the values appear as top-level properties
-	stats.Errs // Deprecated, replaced with Errors.
 	stats.ReadWrites
 	stats.StartAndEndTime
+
+	// Deprecated
+	stats.Errs // replaced with fault.Errors
 }
 
 // interface compliance checks
@@ -59,6 +67,7 @@ func New(
 ) *Backup {
 	errData := errs.Errors()
 
+	// TODO: count errData.Items(), not all recovered errors.
 	errCount := len(errs.Errors().Recovered)
 	if errData.Failure != nil {
 		errCount++
@@ -78,6 +87,8 @@ func New(
 		Selector:        selector,
 		Errors:          errData,
 		ErrorCount:      errCount,
+		Failure:         errData.Failure.Error(),
+		FailedItems:     errData.Items(),
 		ReadWrites:      rw,
 		StartAndEndTime: se,
 		Version:         version.Backup,

--- a/src/pkg/backup/backup_test.go
+++ b/src/pkg/backup/backup_test.go
@@ -45,10 +45,13 @@ func stubBackup(t time.Time) backup.Backup {
 		Errors: fault.Errors{
 			Recovered: []error{errors.New("read"), errors.New("write")},
 		},
-		Errs: stats.Errs{
-			ReadErrors:  errors.New("1"),
-			WriteErrors: errors.New("1"),
-		},
+		ErrorCount: 2,
+		Failure:    "read, write",
+		FailedItems: []fault.Item{*fault.FileErr(
+			errors.New("read"),
+			"id", "name",
+			"containerID", "containerName",
+		)},
 		ReadWrites: stats.ReadWrites{
 			BytesRead:     301,
 			BytesUploaded: 301,
@@ -58,6 +61,11 @@ func stubBackup(t time.Time) backup.Backup {
 		StartAndEndTime: stats.StartAndEndTime{
 			StartedAt:   t,
 			CompletedAt: t,
+		},
+		// deprecated
+		Errs: stats.Errs{
+			ReadErrors:  errors.New("1"),
+			WriteErrors: errors.New("1"),
 		},
 	}
 }

--- a/src/pkg/fault/item.go
+++ b/src/pkg/fault/item.go
@@ -8,6 +8,8 @@ const (
 	ResourceOwnerType itemType = "resource_owner"
 )
 
+var _ error = &Item{}
+
 // Item contains a concrete reference to a thing that failed
 // during processing.  The categorization of the item is determined
 // by its Type: file, container, or reourceOwner.
@@ -54,7 +56,11 @@ func (i *Item) Error() string {
 	return string("processing " + i.Type)
 }
 
-// ContainerErr constructs a Container-type Item.
+// ---------------------------------------------------------------------------
+// Constructors
+// ---------------------------------------------------------------------------
+
+// ContainerErr produces a Container-type Item.
 func ContainerErr(cause error, id, name, containerID, containerName string) *Item {
 	return &Item{
 		ID:            id,


### PR DESCRIPTION
Adds new fields to the backup for serializing fault items as an alternative to serializing the errors
themselves.  This should allow users to track items that were lost during the backup after runtime completes.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #2708

#### Test Plan

- [x] :zap: Unit test
