### PR TITLE
add item skips to fault

### DIFF
--- a/src/pkg/backup/backup.go
+++ b/src/pkg/backup/backup.go
@@ -44,7 +44,8 @@ type Backup struct {
 	// the non-recoverable failure message, only non-zero if one occurred.
 	Failure string `json:"failure"`
 	// individual items (files, containers, resource owners) tracked as failed.
-	FailedItems []fault.Item `json:"failedItems"`
+	FailedItems  []fault.Item    `json:"failedItems"`
+	SkippedItems []fault.Skipped `json:"skippedItems"`
 
 	// stats are embedded so that the values appear as top-level properties
 	stats.ReadWrites
@@ -89,6 +90,7 @@ func New(
 		ErrorCount:      errCount,
 		Failure:         errData.Failure.Error(),
 		FailedItems:     errData.Items(),
+		SkippedItems:    errData.Skipped,
 		ReadWrites:      rw,
 		StartAndEndTime: se,
 		Version:         version.Backup,

--- a/src/pkg/backup/backup_test.go
+++ b/src/pkg/backup/backup_test.go
@@ -52,6 +52,11 @@ func stubBackup(t time.Time) backup.Backup {
 			"id", "name",
 			"containerID", "containerName",
 		)},
+		SkippedItems: []fault.Skipped{*fault.FileSkip(
+			fault.SkipMalware,
+			"id", "name",
+			"containerID", "containerName",
+		)},
 		ReadWrites: stats.ReadWrites{
 			BytesRead:     301,
 			BytesUploaded: 301,

--- a/src/pkg/fault/example_fault_test.go
+++ b/src/pkg/fault/example_fault_test.go
@@ -417,3 +417,25 @@ func ExampleErrors_Failure_return() {
 	// Output: direct: caught one
 	// recoverable: caught one
 }
+
+// ExampleBus_AddSkip showcases when to use AddSkip instead of an error.
+func ExampleBus_AddSkip() {
+	errs := fault.New(false)
+
+	// Some conditions cause well-known problems that we want Corso to skip
+	// over, instead of error out.  An initial case is when Graph API identifies
+	// a file as containing malware.  We can't download the file: it'll always
+	// error.  Our only option is to skip it.
+	errs.AddSkip(fault.FileSkip(
+		fault.SkipMalware,
+		"file-id",
+		"file-name",
+		"parent-folder-id",
+		"parent-folder-name",
+	))
+
+	// later on, after processing, end users can scrutinize the skipped items.
+	fmt.Println(errs.Skipped()[0])
+
+	// Output: skipped processing file: malware_detected
+}

--- a/src/pkg/fault/fault.go
+++ b/src/pkg/fault/fault.go
@@ -140,8 +140,16 @@ func (e *Bus) addRecoverableErr(err error) *Bus {
 	return e
 }
 
-// AddSkip appends the skipped item to the slice of skipped
-// items (ie: bus.skipped).
+// AddSkip appends a record of a Skipped item to the fault bus.
+// Importantly, skipped items are not the same as recoverable
+// errors.  An item should only be skipped under the following
+// conditions.  All other cases should be handled as errors.
+// 1. The conditions for skipping the item are well-known and
+// well-documented.  End users need to be able to understand
+// both the conditions and identifications of skips.
+// 2. Skipping avoids a permanent and consistent failure.  If
+// the underlying reason is transient or otherwise recoverable,
+// the item should not be skipped.
 func (e *Bus) AddSkip(s *Skipped) *Bus {
 	if s == nil {
 		return e
@@ -251,6 +259,16 @@ func (e *localBus) AddRecoverable(err error) {
 	e.bus.AddRecoverable(err)
 }
 
+// AddSkip appends a record of a Skipped item to the local bus.
+// Importantly, skipped items are not the same as recoverable
+// errors.  An item should only be skipped under the following
+// conditions.  All other cases should be handled as errors.
+// 1. The conditions for skipping the item are well-known and
+// well-documented.  End users need to be able to understand
+// both the conditions and identifications of skips.
+// 2. Skipping avoids a permanent and consistent failure.  If
+// the underlying reason is transient or otherwise recoverable,
+// the item should not be skipped.
 func (e *localBus) AddSkip(s *Skipped) {
 	if s == nil {
 		return

--- a/src/pkg/fault/fault.go
+++ b/src/pkg/fault/fault.go
@@ -24,6 +24,11 @@ type Bus struct {
 	// we'd expect to see 1 error added to this slice.
 	recoverable []error
 
+	// skipped is the accumulation of skipped items.  Skipped items
+	// are not errors themselves, but instead represent some permanent
+	// inability to process an item, due to a well-known cause.
+	skipped []Skipped
+
 	// if failFast is true, the first errs addition will
 	// get promoted to the err value.  This signifies a
 	// non-recoverable processing state, causing any running
@@ -52,6 +57,12 @@ func (e *Bus) Failure() error {
 // doesn't require the entire process to end.
 func (e *Bus) Recovered() []error {
 	return e.recoverable
+}
+
+// Skipped returns the slice of items that were permanently
+// skipped during processing.
+func (e *Bus) Skipped() []Skipped {
+	return e.skipped
 }
 
 // Errors returns the plain record of errors that were aggregated
@@ -129,12 +140,31 @@ func (e *Bus) addRecoverableErr(err error) *Bus {
 	return e
 }
 
+// AddSkip appends the skipped item to the slice of skipped
+// items (ie: bus.skipped).
+func (e *Bus) AddSkip(s *Skipped) *Bus {
+	if s == nil {
+		return e
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.addSkip(s)
+}
+
+func (e *Bus) addSkip(s *Skipped) *Bus {
+	e.skipped = append(e.skipped, *s)
+	return e
+}
+
 // ---------------------------------------------------------------------------
 // Errors Data
 // ---------------------------------------------------------------------------
 
-// Errors provides the errors data alone, without sync
-// controls, allowing the data to be persisted.
+// Errors provides the errors data alone, without sync controls
+// or adders/setters.  Expected to get called at the end of processing,
+// as a way to aggregate results.
 type Errors struct {
 	// Failure identifies a non-recoverable error.  This includes
 	// non-start cases (ex: cannot connect to client), hard-
@@ -150,6 +180,11 @@ type Errors struct {
 	// items fails to be retrieved, but the rest of them succeed,
 	// we'd expect to see 1 error added to this slice.
 	Recovered []error `json:"-"`
+
+	// skipped is the accumulation of skipped items.  Skipped items
+	// are not errors themselves, but instead represent some permanent
+	// inability to process an item, due to a well-known cause.
+	Skipped []Skipped `json:"skipped"`
 
 	// If FailFast is true, then the first Recoverable error will
 	// promote to the Failure spot, causing processing to exit.
@@ -214,6 +249,17 @@ func (e *localBus) AddRecoverable(err error) {
 	}
 
 	e.bus.AddRecoverable(err)
+}
+
+func (e *localBus) AddSkip(s *Skipped) {
+	if s == nil {
+		return
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.bus.AddSkip(s)
 }
 
 // Failure returns the failure that happened within the local bus.

--- a/src/pkg/fault/fault_test.go
+++ b/src/pkg/fault/fault_test.go
@@ -182,6 +182,22 @@ func (suite *FaultErrorsUnitSuite) TestAdd() {
 	assert.Len(t, n.Recovered(), 2)
 }
 
+func (suite *FaultErrorsUnitSuite) TestAddSkip() {
+	t := suite.T()
+
+	n := fault.New(true)
+	require.NotNil(t, n)
+
+	n.Fail(assert.AnError)
+	assert.Len(t, n.Skipped(), 0)
+
+	n.AddRecoverable(assert.AnError)
+	assert.Len(t, n.Skipped(), 0)
+
+	n.AddSkip(fault.OwnerSkip(fault.SkipMalware, "id", "name"))
+	assert.Len(t, n.Skipped(), 1)
+}
+
 func (suite *FaultErrorsUnitSuite) TestErrors() {
 	t := suite.T()
 

--- a/src/pkg/fault/item.go
+++ b/src/pkg/fault/item.go
@@ -10,7 +10,17 @@ const (
 
 var _ error = &Item{}
 
-// in pkg fault.  eg: fault.Item{}
+// Item contains a concrete reference to a thing that failed
+// during processing.  The categorization of the item is determined
+// by its Type: file, container, or reourceOwner.
+//
+// Item is compliant with the error interface so that it can be
+// aggregated with the fault bus, and deserialized using the
+// errors.As() func.  The idea is that fault,Items, during
+// processing, will get packed into bus.AddRecoverable (or failure)
+// as part of standard error handling, and later deserialized
+// by the end user (cli or sdk) for surfacing human-readable and
+// identifiable points of failure.
 type Item struct {
 	// deduplication identifier; the ID of the observed item.
 	ID string `json:"id"`

--- a/src/pkg/fault/item.go
+++ b/src/pkg/fault/item.go
@@ -88,13 +88,27 @@ func OwnerErr(cause error, id, name string) *Item {
 // Skipped Items
 // ---------------------------------------------------------------------------
 
+// skipCause identifies the well-known conditions to Skip an item.  It is
+// important that skip cause enumerations do not overlap with general error
+// handling.  Skips must be well known, well documented, and consistent.
+// Transient failures, undocumented or unknown conditions, and arbitrary
+// handling should never produce a skipped item. Those cases should get
+// handled as normal errors.
 type skipCause string
 
+// SkipMalware identifies a malware detection case.  Files that graph api
+// identifies as malware cannot be downloaded or uploaded, and will permanently
+// fail any attempts to backup or restore.
 const SkipMalware skipCause = "malware_detected"
 
 // Skipped items are permanently unprocessable due to well-known conditions.
-// Instead of attempting to process them, and failing, we instead track them
-// as skipped entries.
+// In order to skip an item, the following conditions should be met:
+// 1. The conditions for skipping the item are well-known and
+// well-documented.  End users need to be able to understand
+// both the conditions and identifications of skips.
+// 2. Skipping avoids a permanent and consistent failure.  If
+// the underlying reason is transient or otherwise recoverable,
+// the item should not be skipped.
 //
 // Skipped wraps Item primarily to minimze confusion when sharing the
 // fault interface.  Skipped items are not errors, and Item{} errors are

--- a/src/pkg/fault/item.go
+++ b/src/pkg/fault/item.go
@@ -10,17 +10,7 @@ const (
 
 var _ error = &Item{}
 
-// Item contains a concrete reference to a thing that failed
-// during processing.  The categorization of the item is determined
-// by its Type: file, container, or reourceOwner.
-//
-// Item is compliant with the error interface so that it can be
-// aggregated with the fault bus, and deserialized using the
-// errors.As() func.  The idea is that fault,Items, during
-// processing, will get packed into bus.AddRecoverable (or failure)
-// as part of standard error handling, and later deserialized
-// by the end user (cli or sdk) for surfacing human-readable and
-// identifiable points of failure.
+// in pkg fault.  eg: fault.Item{}
 type Item struct {
 	// deduplication identifier; the ID of the observed item.
 	ID string `json:"id"`
@@ -60,7 +50,7 @@ func (i *Item) Error() string {
 // Constructors
 // ---------------------------------------------------------------------------
 
-// ContainerErr produces a Container-type Item.
+// ContainerErr produces a Container-kind Item.
 func ContainerErr(cause error, id, name, containerID, containerName string) *Item {
 	return &Item{
 		ID:            id,


### PR DESCRIPTION
extends the fault package to track skiped items
as well as erroneous items.  Skipped items are
assumed to be permanently unprocessable due
to well-known conditions.

---

#### Does this PR need a docs update or release note?

- [ ] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #2708

#### Test Plan

- [x] :zap: Unit test
