### PR TITLE
add tracking for skipped malware files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Show owner information when doing backup list in json format
-- Onedrive files that are flagged as malware get skipped during backup.
 - Permissions for groups can now be backed up and restored
+- Onedrive files that are flagged as malware get skipped during backup.  Skipped files are listed in the backup results as part of the status, eg: "Completed (0 errors, 1 skipped)".
 
 ### Fixed
 - Corso-generated .meta files and permissions no longer appear in the backup details.

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -418,7 +418,8 @@ func (oc *Collection) populateItems(ctx context.Context, errs *fault.Bus) {
 					if err != nil {
 						if item.GetMalware() != nil {
 							logger.Ctx(ctx).With("error", err.Error(), "malware", true).Error("downloading item")
-							el.AddSkip(fault.FileSkip(fault.SkipMalware, itemID, itemName, ptr.Val(pr.GetId()), ptr.Val(pr.GetName())))
+							// el.AddSkip(fault.FileSkip(fault.SkipMalware, itemID, itemName, ptr.Val(pr.GetId()), ptr.Val(pr.GetName())))
+							el.AddSkip(fault.FileSkip(fault.SkipMalware, itemID, itemName, "container-id", "container-name"))
 						} else {
 							logger.Ctx(ctx).With("error", err.Error()).Error("downloading item")
 							el.AddRecoverable(clues.Stack(err).WithClues(ctx).Label(fault.LabelForceNoBackupCreation))

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -418,11 +418,12 @@ func (oc *Collection) populateItems(ctx context.Context, errs *fault.Bus) {
 					if err != nil {
 						if item.GetMalware() != nil {
 							logger.Ctx(ctx).With("error", err.Error(), "malware", true).Error("downloading item")
+							el.AddSkip(fault.FileSkip(fault.SkipMalware, itemID, itemName, ptr.Val(pr.GetId()), ptr.Val(pr.GetName())))
 						} else {
 							logger.Ctx(ctx).With("error", err.Error()).Error("downloading item")
+							el.AddRecoverable(clues.Stack(err).WithClues(ctx).Label(fault.LabelForceNoBackupCreation))
 						}
 
-						el.AddRecoverable(clues.Stack(err).WithClues(ctx).Label(fault.LabelForceNoBackupCreation))
 						return nil, err
 					}
 

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -425,6 +425,8 @@ func (oc *Collection) populateItems(ctx context.Context, errs *fault.Bus) {
 							el.AddRecoverable(clues.Stack(err).WithClues(ctx).Label(fault.LabelForceNoBackupCreation))
 						}
 
+						// return err, not el.Err(), because the lazy reader needs to communicate to
+						// the data consumer that this item is unreadable, regardless of the fault state.
 						return nil, err
 					}
 

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -171,6 +171,11 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 			Errorf("doing backup: recoverable error %d of %d", i+1, recoverableCount)
 	}
 
+	skippedCount := len(op.Errors.Skipped())
+	for i, skip := range op.Errors.Skipped() {
+		logger.Ctx(ctx).With("skip", skip).Infof("doing backup: skipped item %d of %d", i+1, skippedCount)
+	}
+
 	// -----
 	// Persistence
 	// -----

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -678,8 +678,7 @@ func (op *BackupOperation) createBackupModels(
 		op.Selectors,
 		op.Results.ReadWrites,
 		op.Results.StartAndEndTime,
-		op.Errors,
-	)
+		op.Errors)
 
 	if err = op.store.Put(ctx, model.BackupSchema, b); err != nil {
 		return clues.Wrap(err, "creating backup model").WithClues(ctx)
@@ -699,8 +698,7 @@ func (op *BackupOperation) createBackupModels(
 			events.Service:    op.Selectors.PathService().String(),
 			events.StartTime:  common.FormatTime(op.Results.StartedAt),
 			events.Status:     op.Status.String(),
-		},
-	)
+		})
 
 	return nil
 }

--- a/src/pkg/backup/backup.go
+++ b/src/pkg/backup/backup.go
@@ -159,7 +159,32 @@ func (b Backup) Headers() []string {
 // Values returns the values matching the Headers list for printing
 // out to a terminal in a columnar display.
 func (b Backup) Values() []string {
-	status := fmt.Sprintf("%s (%d errors, %d skipped)", b.Status, b.countErrors(), len(b.SkippedItems))
+	var (
+		malware int
+		malStr  string
+		skipped int
+		skipStr string
+	)
+
+	for _, s := range b.SkippedItems {
+		if s.HasCause(fault.SkipMalware) {
+			malware++
+		} else {
+			skipped++
+		}
+	}
+
+	if malware > 0 {
+		malStr = fmt.Sprintf(", %d pieces of malware detected and skipped", malware)
+	}
+
+	if skipped > 0 {
+		skipStr = fmt.Sprintf(", %d skipped items", skipped)
+	}
+
+	status := fmt.Sprintf(
+		"%s (%d errors%s%s)",
+		b.Status, b.countErrors(), malStr, skipStr)
 
 	return []string{
 		common.FormatTabularDisplayTime(b.StartedAt),

--- a/src/pkg/backup/backup.go
+++ b/src/pkg/backup/backup.go
@@ -159,7 +159,7 @@ func (b Backup) Headers() []string {
 // Values returns the values matching the Headers list for printing
 // out to a terminal in a columnar display.
 func (b Backup) Values() []string {
-	status := fmt.Sprintf("%s (%d errors)", b.Status, b.countErrors())
+	status := fmt.Sprintf("%s (%d errors, %d skipped)", b.Status, b.countErrors(), len(b.SkippedItems))
 
 	return []string{
 		common.FormatTabularDisplayTime(b.StartedAt),

--- a/src/pkg/backup/backup.go
+++ b/src/pkg/backup/backup.go
@@ -175,7 +175,12 @@ func (b Backup) Values() []string {
 	}
 
 	if malware > 0 {
-		malStr = fmt.Sprintf(", %d pieces of malware detected and skipped", malware)
+		amt := "item"
+		if malware > 1 {
+			amt = "items"
+		}
+
+		malStr = fmt.Sprintf(", %d %s with malware detected and skipped", malware, amt)
 	}
 
 	if skipped > 0 {

--- a/src/pkg/backup/backup.go
+++ b/src/pkg/backup/backup.go
@@ -73,6 +73,11 @@ func New(
 		errCount++
 	}
 
+	var failMsg string
+	if ee.Failure != nil {
+		failMsg = ee.Failure.Error()
+	}
+
 	return &Backup{
 		BaseModel: model.BaseModel{
 			ID: id,
@@ -87,7 +92,7 @@ func New(
 		Selector:        selector,
 		FailFast:        ee.FailFast,
 		ErrorCount:      errCount,
-		Failure:         ee.Failure.Error(),
+		Failure:         failMsg,
 		FailedItems:     ee.Items,
 		SkippedItems:    ee.Skipped,
 		ReadWrites:      rw,
@@ -188,7 +193,7 @@ func (b Backup) Values() []string {
 	}
 
 	if len(b.SkippedItems) > 0 {
-		status += fmt.Sprintf("%d not attempted: ", len(b.SkippedItems))
+		status += fmt.Sprintf("%d skipped: ", len(b.SkippedItems))
 	}
 
 	if malware > 0 {

--- a/src/pkg/backup/backup_test.go
+++ b/src/pkg/backup/backup_test.go
@@ -122,7 +122,6 @@ func (suite *BackupUnitSuite) TestBackup_HeadersValues() {
 
 	vs = b.Values()
 	assert.Equal(t, expectVs, vs)
-
 }
 
 func (suite *BackupUnitSuite) TestBackup_MinimumPrintable() {

--- a/src/pkg/backup/backup_test.go
+++ b/src/pkg/backup/backup_test.go
@@ -90,7 +90,7 @@ func (suite *BackupSuite) TestBackup_HeadersValues() {
 	expectVs := []string{
 		nowFmt,
 		"id",
-		"status (2 errors)",
+		"status (2 errors, 1 skipped)",
 		"test",
 	}
 

--- a/src/pkg/backup/backup_test.go
+++ b/src/pkg/backup/backup_test.go
@@ -87,7 +87,7 @@ func (suite *BackupUnitSuite) TestBackup_HeadersValues() {
 		expectVs = []string{
 			nowFmt,
 			"id",
-			"status (2 errors, 1 item with malware detected and skipped)",
+			"status (2 errors, 1 skipped: 1 malware)",
 			"test",
 		}
 	)
@@ -129,7 +129,7 @@ func (suite *BackupUnitSuite) TestBackup_Values_statusVariations() {
 					"containerID", "containerName",
 				)},
 			},
-			expect: "test (1 not attempted: 1 malware)",
+			expect: "test (1 skipped: 1 malware)",
 		},
 		{
 			name: "errors and malware",
@@ -142,7 +142,7 @@ func (suite *BackupUnitSuite) TestBackup_Values_statusVariations() {
 					"containerID", "containerName",
 				)},
 			},
-			expect: "test (42 errors, 1 not attempted: 1 malware)",
+			expect: "test (42 errors, 1 skipped: 1 malware)",
 		},
 	}
 	for _, test := range table {

--- a/src/pkg/fault/item.go
+++ b/src/pkg/fault/item.go
@@ -136,6 +136,15 @@ func (s *Skipped) String() string {
 	return "skipped " + s.item.Error() + ": " + s.item.Cause
 }
 
+// HasCause compares the underlying cause against the parameter.
+func (s *Skipped) HasCause(c skipCause) bool {
+	if s == nil {
+		return false
+	}
+
+	return s.item.Cause == string(c)
+}
+
 // ContainerSkip produces a Container-kind Item for tracking skipped items.
 func ContainerSkip(cause skipCause, id, name, containerID, containerName string) *Skipped {
 	return &Skipped{

--- a/src/pkg/fault/item_test.go
+++ b/src/pkg/fault/item_test.go
@@ -27,7 +27,7 @@ func (suite *ItemUnitSuite) TestItem_Error() {
 	assert.Contains(t, i.Error(), "nil")
 
 	i = &Item{}
-	assert.Contains(t, i.Error(), "unknown kind")
+	assert.Contains(t, i.Error(), "unknown type")
 
 	i = &Item{Type: FileType}
 	assert.Contains(t, i.Error(), FileType)
@@ -91,7 +91,7 @@ func (suite *ItemUnitSuite) TestSkipped_String() {
 	assert.Contains(t, i.String(), "nil")
 
 	i = &Skipped{Item{}}
-	assert.Contains(t, i.String(), "unknown kind")
+	assert.Contains(t, i.String(), "unknown type")
 
 	i = &Skipped{Item{Type: FileType}}
 	assert.Contains(t, i.item.Error(), FileType)


### PR DESCRIPTION
Adds tracking for items that were skipped due to
being flagged by graph as containing malware.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #2708

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
