### PR TITLE
Only set repo configuration on init

### DIFF
--- a/src/internal/kopia/conn.go
+++ b/src/internal/kopia/conn.go
@@ -90,13 +90,22 @@ func (w *conn) Initialize(ctx context.Context) error {
 		return clues.Wrap(err, "initialzing repo").WithClues(ctx)
 	}
 
-	return w.commonConnect(
+	err = w.commonConnect(
 		ctx,
 		cfg.KopiaCfgDir,
 		bst,
 		cfg.CorsoPassphrase,
 		defaultCompressor,
 	)
+	if err != nil {
+		return err
+	}
+
+	if err := w.setDefaultConfigValues(ctx); err != nil {
+		return clues.Stack(err).WithClues(ctx)
+	}
+
+	return nil
 }
 
 func (w *conn) Connect(ctx context.Context) error {
@@ -151,10 +160,6 @@ func (w *conn) commonConnect(
 	}
 
 	if err := w.open(ctx, cfgFile, password); err != nil {
-		return clues.Stack(err).WithClues(ctx)
-	}
-
-	if err := w.setDefaultConfigValues(ctx); err != nil {
 		return clues.Stack(err).WithClues(ctx)
 	}
 


### PR DESCRIPTION
Setting the repository policy calls `policy.SetPolicy` in Kopia which involves repository scan. This is an
expensive operation if the repository has a lot of snapshots.
 
This commit changes Corso behavior to only call this on repository init and not on every connect.

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [x] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
