### PR TITLE
Augment paths for OneDrive restore

### DIFF
--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -604,6 +604,7 @@ func getMetadata(metar io.ReadCloser) (Metadata, error) {
 // well as do any other ordering operations on the paths
 func AugmentRestorePaths(backupVersion int, paths []path.Path) ([]path.Path, error) {
 	colPaths := map[string]path.Path{}
+
 	for _, p := range paths {
 		for {
 			np, err := p.Dir()
@@ -620,10 +621,7 @@ func AugmentRestorePaths(backupVersion int, paths []path.Path) ([]path.Path, err
 				break
 			}
 
-			_, found := colPaths[np.String()]
-			if !found {
-				colPaths[np.String()] = np
-			}
+			colPaths[np.String()] = np
 			p = np
 		}
 	}
@@ -643,6 +641,7 @@ func AugmentRestorePaths(backupVersion int, paths []path.Path) ([]path.Path, err
 			if err != nil {
 				return nil, err
 			}
+
 			paths = append(paths, mPath)
 		} else if backupVersion >= version.OneDrive1DataAndMetaFiles {
 			pp, err := p.Dir()

--- a/src/internal/connector/onedrive/restore_test.go
+++ b/src/internal/connector/onedrive/restore_test.go
@@ -31,8 +31,10 @@ func (suite *RestoreUnitSuite) TestAugmentRestorePaths() {
 			version: 0,
 			input: []string{
 				"file.txt.data",
+				"file.txt", // v0 does not have `.data`
 			},
 			output: []string{
+				"file.txt", // ordering artifact of sorting
 				"file.txt.data",
 			},
 		},
@@ -41,8 +43,10 @@ func (suite *RestoreUnitSuite) TestAugmentRestorePaths() {
 			version: 0,
 			input: []string{
 				"folder/file.txt.data",
+				"folder/file.txt",
 			},
 			output: []string{
+				"folder/file.txt",
 				"folder/file.txt.data",
 			},
 		},
@@ -146,6 +150,8 @@ func (suite *RestoreUnitSuite) TestAugmentRestorePaths() {
 			actual, err := AugmentRestorePaths(test.version, inPaths)
 			require.NoError(t, err, "augmenting paths")
 
+			// Ordering of paths matter here as we need dirmeta files
+			// to show up before file in dir
 			assert.Equal(t, outPaths, actual, "augmented paths")
 		})
 	}

--- a/src/internal/connector/onedrive/restore_test.go
+++ b/src/internal/connector/onedrive/restore_test.go
@@ -1,0 +1,152 @@
+package onedrive
+
+import (
+	"testing"
+
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/version"
+	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type RestoreUnitSuite struct {
+	tester.Suite
+}
+
+func TestRestoreUnitSuite(t *testing.T) {
+	suite.Run(t, &RestoreUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *RestoreUnitSuite) TestAugmentRestorePaths() {
+	table := []struct {
+		name    string
+		version int
+		input   []string
+		output  []string
+	}{
+		{
+			name:    "no change v0",
+			version: 0,
+			input: []string{
+				"file.txt.data",
+			},
+			output: []string{
+				"file.txt.data",
+			},
+		},
+		{
+			name:    "one folder v0",
+			version: 0,
+			input: []string{
+				"folder/file.txt.data",
+			},
+			output: []string{
+				"folder/file.txt.data",
+			},
+		},
+		{
+			name:    "no change v1",
+			version: version.OneDrive1DataAndMetaFiles,
+			input: []string{
+				"file.txt.data",
+			},
+			output: []string{
+				"file.txt.data",
+			},
+		},
+		{
+			name:    "one folder v1",
+			version: version.OneDrive1DataAndMetaFiles,
+			input: []string{
+				"folder/file.txt.data",
+			},
+			output: []string{
+				"folder.dirmeta",
+				"folder/file.txt.data",
+			},
+		},
+		{
+			name:    "nested folders v1",
+			version: version.OneDrive1DataAndMetaFiles,
+			input: []string{
+				"folder/file.txt.data",
+				"folder/folder2/file.txt.data",
+			},
+			output: []string{
+				"folder.dirmeta",
+				"folder/file.txt.data",
+				"folder/folder2.dirmeta",
+				"folder/folder2/file.txt.data",
+			},
+		},
+		{
+			name:    "no change v4",
+			version: version.OneDrive4DirIncludesPermissions,
+			input: []string{
+				"file.txt.data",
+			},
+			output: []string{
+				"file.txt.data",
+			},
+		},
+		{
+			name:    "one folder v4",
+			version: version.OneDrive4DirIncludesPermissions,
+			input: []string{
+				"folder/file.txt.data",
+			},
+			output: []string{
+				"folder/file.txt.data",
+				"folder/folder.dirmeta",
+			},
+		},
+		{
+			name:    "nested folders v4",
+			version: version.OneDrive4DirIncludesPermissions,
+			input: []string{
+				"folder/file.txt.data",
+				"folder/folder2/file.txt.data",
+			},
+			output: []string{
+				"folder/file.txt.data",
+				"folder/folder.dirmeta",
+				"folder/folder2/file.txt.data",
+				"folder/folder2/folder2.dirmeta",
+			},
+		},
+	}
+
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			_, flush := tester.NewContext()
+			defer flush()
+
+			base := "id/onedrive/user/files/drives/driveID/root:/"
+
+			inPaths := []path.Path{}
+			for _, ps := range test.input {
+				p, err := path.FromDataLayerPath(base+ps, true)
+				require.NoError(t, err, "creating path")
+
+				inPaths = append(inPaths, p)
+			}
+
+			outPaths := []path.Path{}
+			for _, ps := range test.output {
+				p, err := path.FromDataLayerPath(base+ps, true)
+				require.NoError(t, err, "creating path")
+
+				outPaths = append(outPaths, p)
+			}
+
+			actual, err := AugmentRestorePaths(test.version, inPaths)
+			require.NoError(t, err, "augmenting paths")
+
+			assert.Equal(t, outPaths, actual, "augmented paths")
+		})
+	}
+}

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -38,12 +38,10 @@ type DetailsModel struct {
 // Print writes the DetailModel Entries to StdOut, in the format
 // requested by the caller.
 func (dm DetailsModel) PrintEntries(ctx context.Context) {
-	sl := dm.FilterMetaFiles()
-
 	if print.JSONFormat() {
-		printJSON(ctx, sl)
+		printJSON(ctx, dm)
 	} else {
-		printTable(ctx, sl)
+		printTable(ctx, dm)
 	}
 }
 

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -373,6 +373,8 @@ func (r repository) BackupDetails(
 		}
 	}
 
+	deets.DetailsModel = deets.FilterMetaFiles()
+
 	return &deets, b, errs
 }
 


### PR DESCRIPTION
This adds the missing .dirmeta files which are needed to make sure that permissions are being restored properly.

By adding a dirmeta entry for each folder that is part of the items, we make sure that all folders get their own collection which in turn will help us properly restore permissions for all folders.

**This also makes it so that meta items are not returned from older backups.**

*Although the newer version can fetch permissions file using the Fetch API, we still have to populate the items as it cannot fetch items from previous directories which is needed to make sure we can restore permissions correctly.*

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* fixes https://github.com/alcionai/corso/issues/2697

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
