### PR TITLE
GC: SharePoint: ItemType Decouple

### DIFF
--- a/src/internal/connector/sharepoint/api/pages.go
+++ b/src/internal/connector/sharepoint/api/pages.go
@@ -263,7 +263,7 @@ func PageInfo(page models.SitePageable, size int64) *details.SharePointInfo {
 	)
 
 	return &details.SharePointInfo{
-		ItemType: details.SharePointItem,
+		ItemType: details.SharePointPage,
 		ItemName: name,
 		Created:  created,
 		Modified: modified,

--- a/src/internal/connector/sharepoint/listInfo.go
+++ b/src/internal/connector/sharepoint/listInfo.go
@@ -18,7 +18,7 @@ func sharePointListInfo(lst models.Listable, size int64) *details.SharePointInfo
 	)
 
 	return &details.SharePointInfo{
-		ItemType: details.SharePointItem,
+		ItemType: details.SharePointList,
 		ItemName: name,
 		Created:  created,
 		Modified: modified,

--- a/src/internal/connector/sharepoint/listInfo_test.go
+++ b/src/internal/connector/sharepoint/listInfo_test.go
@@ -27,7 +27,7 @@ func (suite *SharePointInfoSuite) TestSharePointInfo() {
 		{
 			name: "Empty List",
 			listAndDeets: func() (models.Listable, *details.SharePointInfo) {
-				i := &details.SharePointInfo{ItemType: details.SharePointItem}
+				i := &details.SharePointInfo{ItemType: details.SharePointList}
 				return models.NewList(), i
 			},
 		}, {
@@ -37,7 +37,7 @@ func (suite *SharePointInfoSuite) TestSharePointInfo() {
 				listing := models.NewList()
 				listing.SetDisplayName(&aTitle)
 				i := &details.SharePointInfo{
-					ItemType: details.SharePointItem,
+					ItemType: details.SharePointList,
 					ItemName: aTitle,
 				}
 

--- a/src/internal/connector/sharepoint/pageInfo.go
+++ b/src/internal/connector/sharepoint/pageInfo.go
@@ -37,7 +37,7 @@ func sharePointPageInfo(page models.SitePageable, root string, size int64) *deta
 	}
 
 	return &details.SharePointInfo{
-		ItemType:   details.SharePointItem,
+		ItemType:   details.SharePointPage,
 		ItemName:   name,
 		ParentPath: root,
 		Created:    created,

--- a/src/internal/connector/sharepoint/pageInfo_test.go
+++ b/src/internal/connector/sharepoint/pageInfo_test.go
@@ -17,7 +17,7 @@ func (suite *SharePointInfoSuite) TestSharePointInfo_Pages() {
 		{
 			name: "Empty Page",
 			pageAndDeets: func() (models.SitePageable, *details.SharePointInfo) {
-				deets := &details.SharePointInfo{ItemType: details.SharePointItem}
+				deets := &details.SharePointInfo{ItemType: details.SharePointPage}
 				return models.NewSitePage(), deets
 			},
 		},
@@ -28,7 +28,7 @@ func (suite *SharePointInfoSuite) TestSharePointInfo_Pages() {
 				sPage := models.NewSitePage()
 				sPage.SetTitle(&title)
 				deets := &details.SharePointInfo{
-					ItemType: details.SharePointItem,
+					ItemType: details.SharePointPage,
 					ItemName: title,
 				}
 

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -403,7 +403,9 @@ const (
 	ExchangeEvent
 	ExchangeMail
 
-	SharePointItem ItemType = iota + 100
+	SharePointLibrary ItemType = iota + 100
+	SharePointList    ItemType = iota + 100
+	SharePointPage    ItemType = iota + 100
 
 	OneDriveItem ItemType = iota + 200
 
@@ -416,7 +418,7 @@ func UpdateItem(item *ItemInfo, repoPath path.Path) error {
 	var updatePath func(path.Path) error
 
 	switch item.infoType() {
-	case SharePointItem:
+	case SharePointLibrary:
 		updatePath = item.SharePoint.UpdateParentPath
 	case OneDriveItem:
 		updatePath = item.OneDrive.UpdateParentPath

--- a/src/pkg/backup/details/details_test.go
+++ b/src/pkg/backup/details/details_test.go
@@ -780,7 +780,7 @@ func (suite *DetailsUnitSuite) TestUpdateItem() {
 			name: "SharePoint",
 			input: ItemInfo{
 				SharePoint: &SharePointInfo{
-					ItemType:   SharePointItem,
+					ItemType:   SharePointLibrary,
 					ParentPath: folder1,
 				},
 			},
@@ -789,7 +789,7 @@ func (suite *DetailsUnitSuite) TestUpdateItem() {
 			errCheck: assert.NoError,
 			expectedItem: ItemInfo{
 				SharePoint: &SharePointInfo{
-					ItemType:   SharePointItem,
+					ItemType:   SharePointLibrary,
 					ParentPath: folder2,
 				},
 			},
@@ -810,7 +810,7 @@ func (suite *DetailsUnitSuite) TestUpdateItem() {
 			name: "SharePointBadPath",
 			input: ItemInfo{
 				SharePoint: &SharePointInfo{
-					ItemType:   SharePointItem,
+					ItemType:   SharePointLibrary,
 					ParentPath: folder1,
 				},
 			},

--- a/src/pkg/selectors/sharepoint_test.go
+++ b/src/pkg/selectors/sharepoint_test.go
@@ -214,7 +214,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 					RepoRef: item,
 					ItemInfo: details.ItemInfo{
 						SharePoint: &details.SharePointInfo{
-							ItemType: details.SharePointItem,
+							ItemType: details.SharePointLibrary,
 						},
 					},
 				},
@@ -222,7 +222,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 					RepoRef: item2,
 					ItemInfo: details.ItemInfo{
 						SharePoint: &details.SharePointInfo{
-							ItemType: details.SharePointItem,
+							ItemType: details.SharePointLibrary,
 						},
 					},
 				},
@@ -230,7 +230,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 					RepoRef: item3,
 					ItemInfo: details.ItemInfo{
 						SharePoint: &details.SharePointInfo{
-							ItemType: details.SharePointItem,
+							ItemType: details.SharePointLibrary,
 						},
 					},
 				},
@@ -238,7 +238,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 					RepoRef: item4,
 					ItemInfo: details.ItemInfo{
 						SharePoint: &details.SharePointInfo{
-							ItemType: details.SharePointItem,
+							ItemType: details.SharePointPage,
 						},
 					},
 				},
@@ -246,7 +246,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 					RepoRef: item5,
 					ItemInfo: details.ItemInfo{
 						SharePoint: &details.SharePointInfo{
-							ItemType: details.SharePointItem,
+							ItemType: details.SharePointPage,
 						},
 					},
 				},
@@ -411,7 +411,7 @@ func (suite *SharePointSelectorSuite) TestSharePointScope_MatchesInfo() {
 
 			itemInfo := details.ItemInfo{
 				SharePoint: &details.SharePointInfo{
-					ItemType: details.SharePointItem,
+					ItemType: details.SharePointPage,
 					WebURL:   test.infoURL,
 					Created:  now,
 					Modified: modification,

--- a/src/pkg/selectors/testdata/details.go
+++ b/src/pkg/selectors/testdata/details.go
@@ -249,7 +249,7 @@ var (
 			ParentRef: SharePointLibraryItemPath1.ToBuilder().Dir().ShortRef(),
 			ItemInfo: details.ItemInfo{
 				SharePoint: &details.SharePointInfo{
-					ItemType:   details.SharePointItem,
+					ItemType:   details.SharePointLibrary,
 					ParentPath: SharePointLibraryFolder,
 					ItemName:   SharePointLibraryItemPath1.Item() + "name",
 					Size:       int64(23),
@@ -265,7 +265,7 @@ var (
 			ParentRef: SharePointLibraryItemPath2.ToBuilder().Dir().ShortRef(),
 			ItemInfo: details.ItemInfo{
 				SharePoint: &details.SharePointInfo{
-					ItemType:   details.SharePointItem,
+					ItemType:   details.SharePointLibrary,
 					ParentPath: SharePointParentLibrary1,
 					ItemName:   SharePointLibraryItemPath2.Item() + "name",
 					Size:       int64(42),
@@ -281,7 +281,7 @@ var (
 			ParentRef: SharePointLibraryItemPath3.ToBuilder().Dir().ShortRef(),
 			ItemInfo: details.ItemInfo{
 				SharePoint: &details.SharePointInfo{
-					ItemType:   details.SharePointItem,
+					ItemType:   details.SharePointLibrary,
 					ParentPath: SharePointParentLibrary2,
 					ItemName:   SharePointLibraryItemPath3.Item() + "name",
 					Size:       int64(19),


### PR DESCRIPTION
<!-- Insert PR description-->
ItemTypes for SharePoint were `SharePointItem` only. This did not allow for data to be separated by category. 
Newly created categories:
- SharePointLibrary
- SharePointList
- SharePointPage

Breaks connectivity. All previous items are available during `Corso List` command. However, when using the details command with the identified backup ID, the return is:
```
no items match the specified selectors
```
---

#### Does this PR need a docs update or release note?


- [x] 📝 : Will need documentation

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature


#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* related to #2709<issue>

#### Test Plan

- [x] :zap: Unit test
