### PR TITLE
GC: OneDrive: Efficient Drive Name Update

### DIFF
--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -354,18 +354,7 @@ func (oc *Collection) populateItems(ctx context.Context, errs *fault.Bus) {
 				"backup_item_size", itemSize,
 			)
 
-			if oc.source == SharePointSource {
-				l.Lock()
-
-				pr, err = updateParentReference(ctx, oc.service, item.GetParentReference(), driveMap, l)
-				if err != nil {
-					el.AddRecoverable(clues.Wrap(err, "getting parent reference").Label(fault.LabelForceNoBackupCreation))
-					return
-				}
-			} else {
-				pr = updateParentReferenceOneDrive(item.GetParentReference(), oc.driveName)
-			}
-
+			pr = updateParentReferenceOneDrive(item.GetParentReference(), oc.driveName)
 			item.SetParentReference(pr)
 
 			isFile := item.GetFile() != nil

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -336,7 +336,6 @@ func (oc *Collection) populateItems(ctx context.Context, errs *fault.Bus) {
 				itemID       = ptr.Val(item.GetId())
 				itemName     = ptr.Val(item.GetName())
 				itemSize     = ptr.Val(item.GetSize())
-				pr           models.ItemReferenceable
 				itemInfo     details.ItemInfo
 				itemMeta     io.ReadCloser
 				itemMetaSize int
@@ -350,8 +349,7 @@ func (oc *Collection) populateItems(ctx context.Context, errs *fault.Bus) {
 				"backup_item_size", itemSize,
 			)
 
-			pr = updateParentReferenceOneDrive(item.GetParentReference(), oc.driveName)
-			item.SetParentReference(pr)
+			item.SetParentReference(setName(item.GetParentReference(), oc.driveName))
 
 			isFile := item.GetFile() != nil
 

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -351,8 +351,8 @@ func (oc *Collection) populateItems(ctx context.Context, errs *fault.Bus) {
 			)
 
 			l.Lock()
-			pr, err := updateParentReference(ctx, oc.service, item.GetParentReference(), driveMap, l)
 
+			pr, err := updateParentReference(ctx, oc.service, item.GetParentReference(), driveMap, l)
 			if err != nil {
 				el.AddRecoverable(clues.Wrap(err, "getting parent reference").Label(fault.LabelForceNoBackupCreation))
 				return

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -388,6 +388,13 @@ func (c *Collections) Get(
 					clues.Wrap(err, "invalid previous path").WithClues(ctx).With("deleted_path", p)
 			}
 
+			// driveName, err := fetchDriveName(ctx, c.service, driveID)
+			// if err != nil {
+			// 	return nil, map[string]struct{}{},
+			// 		clues.Wrap(err, "unable to get driveMap information").
+			// 			With("driveID", driveID)
+			// }
+
 			col := NewCollection(
 				c.itemClient,
 				nil,
@@ -399,6 +406,8 @@ func (c *Collections) Get(
 				c.ctrl,
 				true,
 			)
+
+			col.driveMap[driveID] = driveName
 			c.CollectionMap[i] = col
 		}
 	}
@@ -531,7 +540,6 @@ func (c *Collections) handleDelete(
 		// DoNotMerge is not checked for deleted items.
 		false,
 	)
-
 	c.CollectionMap[itemID] = col
 
 	return nil
@@ -609,6 +617,8 @@ func (c *Collections) UpdateCollections(
 	errs *fault.Bus,
 ) error {
 	el := errs.Local()
+	driveMap := make(map[string]string)
+	driveMap[driveID] = driveName
 
 	for _, item := range items {
 		if el.Failure() != nil {
@@ -708,6 +718,10 @@ func (c *Collections) UpdateCollections(
 				c.ctrl,
 				invalidPrevDelta,
 			)
+			for k, v := range driveMap {
+				col.driveMap[k] = v
+			}
+
 			c.CollectionMap[itemID] = col
 			c.NumContainers++
 

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -407,7 +407,7 @@ func (c *Collections) Get(
 				true,
 			)
 
-			col.driveMap[driveID] = driveName
+			col.driveName = driveName
 			c.CollectionMap[i] = col
 		}
 	}
@@ -617,8 +617,6 @@ func (c *Collections) UpdateCollections(
 	errs *fault.Bus,
 ) error {
 	el := errs.Local()
-	driveMap := make(map[string]string)
-	driveMap[driveID] = driveName
 
 	for _, item := range items {
 		if el.Failure() != nil {
@@ -718,10 +716,8 @@ func (c *Collections) UpdateCollections(
 				c.ctrl,
 				invalidPrevDelta,
 			)
-			for k, v := range driveMap {
-				col.driveMap[k] = v
-			}
 
+			col.driveName = driveName
 			c.CollectionMap[itemID] = col
 			c.NumContainers++
 

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -350,13 +350,25 @@ func (c *Collections) Get(
 			"num_deltas_entries", numDeltas)
 
 		if !delta.Reset {
-			eidi, ok := excludedItems[driveID]
+			p, err := GetCanonicalPath(
+				fmt.Sprintf(rootDrivePattern, driveID),
+				c.tenant,
+				c.resourceOwner,
+				c.source)
+			if err != nil {
+				return nil, nil,
+					clues.Wrap(err, "making exclude prefix").WithClues(ctx)
+			}
+
+			pstr := p.String()
+
+			eidi, ok := excludedItems[pstr]
 			if !ok {
 				eidi = map[string]struct{}{}
 			}
 
 			maps.Copy(eidi, excluded)
-			excludedItems[driveID] = eidi
+			excludedItems[pstr] = eidi
 
 			continue
 		}

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -284,7 +284,7 @@ func (c *Collections) Get(
 		// Drive ID -> folder ID -> folder path
 		folderPaths = map[string]map[string]string{}
 		// Items that should be excluded when sourcing data from the base backup.
-		// Drive ID -> item ID -> {}
+		// Parent Path -> item ID -> {}
 		excludedItems = map[string]map[string]struct{}{}
 	)
 

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -289,7 +289,6 @@ func (c *Collections) Get(
 	collections := make([]data.BackupCollection, 0)
 
 	for _, d := range drives {
-
 		var (
 			driveID     = ptr.Val(d.GetId())
 			driveName   = ptr.Val(d.GetName())

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -388,13 +388,6 @@ func (c *Collections) Get(
 					clues.Wrap(err, "invalid previous path").WithClues(ctx).With("deleted_path", p)
 			}
 
-			// driveName, err := fetchDriveName(ctx, c.service, driveID)
-			// if err != nil {
-			// 	return nil, map[string]struct{}{},
-			// 		clues.Wrap(err, "unable to get driveMap information").
-			// 			With("driveID", driveID)
-			// }
-
 			col := NewCollection(
 				c.itemClient,
 				nil,
@@ -407,7 +400,6 @@ func (c *Collections) Get(
 				true,
 			)
 
-			col.driveName = driveName
 			c.CollectionMap[i] = col
 		}
 	}
@@ -717,7 +709,6 @@ func (c *Collections) UpdateCollections(
 				invalidPrevDelta,
 			)
 
-			col.driveName = driveName
 			c.CollectionMap[itemID] = col
 			c.NumContainers++
 
@@ -746,6 +737,8 @@ func (c *Collections) UpdateCollections(
 			if !found {
 				return clues.New("item seen before parent folder").WithClues(ictx)
 			}
+
+			//collection.driveName = driveName
 
 			// Delete the file from previous collection. This will
 			// only kick in if the file was moved multiple times

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -381,13 +381,11 @@ func (c *Collections) Get(
 		}
 
 		for fldID, p := range oldPaths {
-			_, found := paths[fldID]
-			if found {
+			if _, ok := paths[fldID]; ok {
 				continue
 			}
 
-			_, found = modifiedPaths[p]
-			if found {
+			if _, ok := modifiedPaths[p]; ok {
 				// Original folder was deleted and new folder with the
 				// same name/path was created in its place
 				continue
@@ -419,7 +417,7 @@ func (c *Collections) Get(
 	observe.Message(ctx, observe.Safe(fmt.Sprintf("Discovered %d items to backup", c.NumItems)))
 
 	// Add an extra for the metadata collection.
-	collections := make([]data.BackupCollection, 0, len(c.CollectionMap))
+	collections := []data.BackupCollection{}
 
 	for _, driveColls := range c.CollectionMap {
 		for _, coll := range driveColls {

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -357,7 +357,7 @@ func (c *Collections) Get(
 				c.source)
 			if err != nil {
 				return nil, nil,
-					clues.Wrap(err, "making exclude prefix").WithClues(ctx)
+					clues.Wrap(err, "making exclude prefix").WithClues(ictx)
 			}
 
 			pstr := p.String()

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -289,7 +289,6 @@ func (c *Collections) Get(
 	collections := make([]data.BackupCollection, 0)
 
 	for _, d := range drives {
-		c.CollectionMap = make(map[string]*Collection)
 
 		var (
 			driveID     = ptr.Val(d.GetId())
@@ -410,6 +409,8 @@ func (c *Collections) Get(
 		for _, coll := range c.CollectionMap {
 			collections = append(collections, coll)
 		}
+
+		c.CollectionMap = make(map[string]*Collection)
 	}
 
 	observe.Message(ctx, observe.Safe(fmt.Sprintf("Discovered %d items to backup", c.NumItems)))

--- a/src/internal/connector/onedrive/collections_test.go
+++ b/src/internal/connector/onedrive/collections_test.go
@@ -1897,10 +1897,6 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 			c.drivePagerFunc = drivePagerFunc
 			c.itemPagerFunc = itemPagerFunc
 
-			for driveID := range test.items {
-				c.CollectionMap[driveID] = map[string]*Collection{}
-			}
-
 			prevDelta := "prev-delta"
 			mc, err := graph.MakeMetadataCollection(
 				tenant,

--- a/src/internal/connector/onedrive/data_collections.go
+++ b/src/internal/connector/onedrive/data_collections.go
@@ -77,12 +77,12 @@ func DataCollections(
 
 		collections = append(collections, odcs...)
 
-		for k, v := range excludes {
+		for k, ex := range excludes {
 			if _, ok := allExcludes[k]; !ok {
 				allExcludes[k] = map[string]struct{}{}
 			}
 
-			maps.Copy(allExcludes[k], v)
+			maps.Copy(allExcludes[k], ex)
 		}
 	}
 

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -137,7 +137,7 @@ type itemCollector func(
 	oldPaths map[string]string,
 	newPaths map[string]string,
 	excluded map[string]struct{},
-	fileCollectionMap map[string]string,
+	itemCollections map[string]map[string]string,
 	validPrevDelta bool,
 	errs *fault.Bus,
 ) error
@@ -199,7 +199,10 @@ func collectItems(
 		// file belongs to. This is useful to delete a file from the
 		// collection it was previously in, in case it was moved to a
 		// different collection within the same delta query
-		itemCollection = map[string]string{}
+		// drive ID -> item ID -> item ID
+		itemCollection = map[string]map[string]string{
+			driveID: {},
+		}
 	)
 
 	if !invalidPrevDelta {
@@ -373,15 +376,15 @@ func GetAllFolders(
 
 		ictx := clues.Add(ctx, "drive_id", id, "drive_name", name) // TODO: pii
 		collector := func(
-			innerCtx context.Context,
-			driveID, driveName string,
+			_ context.Context,
+			_, _ string,
 			items []models.DriveItemable,
-			oldPaths map[string]string,
-			newPaths map[string]string,
-			excluded map[string]struct{},
-			itemCollection map[string]string,
-			doNotMergeItems bool,
-			errs *fault.Bus,
+			_ map[string]string,
+			_ map[string]string,
+			_ map[string]struct{},
+			_ map[string]map[string]string,
+			_ bool,
+			_ *fault.Bus,
 		) error {
 			for _, item := range items {
 				// Skip the root item.
@@ -412,7 +415,15 @@ func GetAllFolders(
 			return nil
 		}
 
-		_, _, _, err = collectItems(ictx, defaultItemPager(gs, id, ""), id, name, collector, map[string]string{}, "", errs)
+		_, _, _, err = collectItems(
+			ictx,
+			defaultItemPager(gs, id, ""),
+			id,
+			name,
+			collector,
+			map[string]string{},
+			"",
+			errs)
 		if err != nil {
 			el.AddRecoverable(clues.Wrap(err, "enumerating items in drive"))
 		}

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -405,10 +405,7 @@ func constructWebURL(adtl map[string]any) string {
 	return url
 }
 
-func updateParentReferenceOneDrive(
-	orig models.ItemReferenceable,
-	driveName string,
-) models.ItemReferenceable {
+func setName(orig models.ItemReferenceable, driveName string) models.ItemReferenceable {
 	if orig == nil {
 		return nil
 	}

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -457,8 +456,6 @@ func updateParentReference(
 	if inMap {
 		mu.Unlock()
 	} else {
-		logger.Ctx(ctx).Infof("Drive Name not in given map: Retrieving\nID: %s\n Map: %v", driveID, driveMap)
-		fmt.Printf("ID Given: %s\nMap: %v\n", driveID, driveMap)
 
 		name, err = fetchDriveName(ctx, service, driveID)
 		if err != nil {
@@ -467,6 +464,7 @@ func updateParentReference(
 
 		drives[driveID] = name
 		mu.Unlock()
+		logger.Ctx(ctx).Infof("Drive Name not in given map: Retrieved: %s", name)
 	}
 
 	orig.SetName(&name)

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -471,3 +471,16 @@ func updateParentReference(
 
 	return orig, nil
 }
+
+func updateParentReferenceOneDrive(
+	orig models.ItemReferenceable,
+	driveName string,
+) models.ItemReferenceable {
+	if orig == nil {
+		return nil
+	}
+
+	orig.SetName(&driveName)
+
+	return orig
+}

--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -67,15 +67,15 @@ func (suite *ItemIntegrationSuite) TestItemReader_oneDrive() {
 	var driveItem models.DriveItemable
 	// This item collector tries to find "a" drive item that is a file to test the reader function
 	itemCollector := func(
-		ctx context.Context,
-		driveID, driveName string,
+		_ context.Context,
+		_, _ string,
 		items []models.DriveItemable,
-		oldPaths map[string]string,
-		newPaths map[string]string,
-		excluded map[string]struct{},
-		itemCollection map[string]string,
-		doNotMergeItems bool,
-		errs *fault.Bus,
+		_ map[string]string,
+		_ map[string]string,
+		_ map[string]struct{},
+		_ map[string]map[string]string,
+		_ bool,
+		_ *fault.Bus,
 	) error {
 		for _, item := range items {
 			if item.GetFile() != nil {
@@ -91,8 +91,7 @@ func (suite *ItemIntegrationSuite) TestItemReader_oneDrive() {
 		defaultItemPager(
 			suite.service,
 			suite.userDriveID,
-			"",
-		),
+			""),
 		suite.userDriveID,
 		"General",
 		itemCollector,


### PR DESCRIPTION
<!-- Insert PR description-->
Updates the call for `populateItems()` for OneDrive. Reduces the overall amount of calls made to obtain the Drive Name. 
---
### Brief Description
- DriveName is saved with a collection field driveMap. 
- The driveMap is a map where the key is the M365ID and the value is the display name for the drive
- During `populateItems()`, the driveName the map is sufficient for OneDrive but requires an update for SharePoint. During SharePoint process, the map is updated as additional driveLibraries are referenced. 

#### Does this PR need a docs update or release note?


- [x] :no_entry: No

#### Type of change


- [x] :bug: Bugfix
#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* closes  #2732<issue>

#### Test Plan

- [x] :zap: Unit test
