### PR TITLE
remove skipped/failed item lists from backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Show owner information when doing backup list in json format
 - Permissions for groups can now be backed up and restored
-- Onedrive files that are flagged as malware get skipped during backup.  Skipped files are listed in the backup results as part of the status, eg: "Completed (0 errors, 1 skipped)".
+- Onedrive files that are flagged as malware get skipped during backup.  Skipped files are listed in the backup results as part of the status, including a reference to their categorization, eg: "Completed (0 errors, 1 skipped: 1 malware)".
 
 ### Fixed
 - Corso-generated .meta files and permissions no longer appear in the backup details.

--- a/src/internal/stats/stats.go
+++ b/src/internal/stats/stats.go
@@ -32,5 +32,4 @@ func (bc *ByteCounter) Count(i int64) {
 type SkippedCounts struct {
 	TotalSkippedItems int `json:"totalSkippedItems"`
 	SkippedMalware    int `json:"skippedMalware"`
-	OtherSkippedItems int `json:"otherSkippedItems"`
 }

--- a/src/internal/stats/stats.go
+++ b/src/internal/stats/stats.go
@@ -28,3 +28,9 @@ type ByteCounter struct {
 func (bc *ByteCounter) Count(i int64) {
 	atomic.AddInt64(&bc.NumBytes, i)
 }
+
+type SkippedCounts struct {
+	TotalSkippedItems int `json:"totalSkippedItems"`
+	SkippedMalware    int `json:"skippedMalware"`
+	OtherSkippedItems int `json:"otherSkippedItems"`
+}

--- a/src/pkg/backup/backup.go
+++ b/src/pkg/backup/backup.go
@@ -108,7 +108,6 @@ func New(
 		SkippedCounts: stats.SkippedCounts{
 			TotalSkippedItems: len(ee.Skipped),
 			SkippedMalware:    malware,
-			OtherSkippedItems: otherSkips,
 		},
 	}
 }
@@ -194,19 +193,15 @@ func (b Backup) Values() []string {
 	}
 
 	if b.TotalSkippedItems > 0 {
-		status += fmt.Sprintf("%d skipped: ", b.TotalSkippedItems)
+		status += fmt.Sprintf("%d skipped", b.TotalSkippedItems)
+	}
+
+	if b.TotalSkippedItems > 0 && b.SkippedMalware > 0 {
+		status += ": "
 	}
 
 	if b.SkippedMalware > 0 {
 		status += fmt.Sprintf("%d malware", b.SkippedMalware)
-	}
-
-	if b.SkippedMalware > 0 && b.OtherSkippedItems > 0 {
-		status += ", "
-	}
-
-	if b.OtherSkippedItems > 0 {
-		status += fmt.Sprintf("%d other", b.OtherSkippedItems)
 	}
 
 	if errCount+b.TotalSkippedItems > 0 {

--- a/src/pkg/backup/backup_test.go
+++ b/src/pkg/backup/backup_test.go
@@ -111,22 +111,11 @@ func (suite *BackupUnitSuite) TestBackup_Values_statusVariations() {
 			bup: backup.Backup{
 				Status: "test",
 				SkippedCounts: stats.SkippedCounts{
-					TotalSkippedItems: 1,
+					TotalSkippedItems: 2,
 					SkippedMalware:    1,
 				},
 			},
-			expect: "test (1 skipped: 1 malware)",
-		},
-		{
-			name: "other skip",
-			bup: backup.Backup{
-				Status: "test",
-				SkippedCounts: stats.SkippedCounts{
-					TotalSkippedItems: 1,
-					OtherSkippedItems: 1,
-				},
-			},
-			expect: "test (1 skipped: 1 other)",
+			expect: "test (2 skipped: 1 malware)",
 		},
 		{
 			name: "errors and malware",
@@ -139,19 +128,6 @@ func (suite *BackupUnitSuite) TestBackup_Values_statusVariations() {
 				},
 			},
 			expect: "test (42 errors, 1 skipped: 1 malware)",
-		},
-		{
-			name: "errors, malware, and other",
-			bup: backup.Backup{
-				Status:     "test",
-				ErrorCount: 42,
-				SkippedCounts: stats.SkippedCounts{
-					TotalSkippedItems: 2,
-					SkippedMalware:    1,
-					OtherSkippedItems: 1,
-				},
-			},
-			expect: "test (42 errors, 2 skipped: 1 malware, 1 other)",
 		},
 	}
 	for _, test := range table {

--- a/src/pkg/backup/backup_test.go
+++ b/src/pkg/backup/backup_test.go
@@ -1,7 +1,6 @@
 package backup_test
 
 import (
-	"errors"
 	"testing"
 	"time"
 
@@ -14,7 +13,6 @@ import (
 	"github.com/alcionai/corso/src/internal/stats"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/backup"
-	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/selectors"
 )
 
@@ -44,16 +42,6 @@ func stubBackup(t time.Time) backup.Backup {
 		Selector:     sel.Selector,
 		ErrorCount:   2,
 		Failure:      "read, write",
-		FailedItems: []fault.Item{*fault.FileErr(
-			errors.New("read"),
-			"id", "name",
-			map[string]any{"foo": "bar"},
-		)},
-		SkippedItems: []fault.Skipped{*fault.FileSkip(
-			fault.SkipMalware,
-			"id", "name",
-			map[string]any{"foo": "bar"},
-		)},
 		ReadWrites: stats.ReadWrites{
 			BytesRead:     301,
 			BytesUploaded: 301,
@@ -63,6 +51,10 @@ func stubBackup(t time.Time) backup.Backup {
 		StartAndEndTime: stats.StartAndEndTime{
 			StartedAt:   t,
 			CompletedAt: t,
+		},
+		SkippedCounts: stats.SkippedCounts{
+			TotalSkippedItems: 1,
+			SkippedMalware:    1,
 		},
 	}
 }
@@ -96,8 +88,6 @@ func (suite *BackupUnitSuite) TestBackup_HeadersValues() {
 }
 
 func (suite *BackupUnitSuite) TestBackup_Values_statusVariations() {
-	addtl := map[string]any{"foo": "bar"}
-
 	table := []struct {
 		name   string
 		bup    backup.Backup
@@ -120,26 +110,48 @@ func (suite *BackupUnitSuite) TestBackup_Values_statusVariations() {
 			name: "malware",
 			bup: backup.Backup{
 				Status: "test",
-				SkippedItems: []fault.Skipped{*fault.FileSkip(
-					fault.SkipMalware,
-					"id", "name",
-					addtl,
-				)},
+				SkippedCounts: stats.SkippedCounts{
+					TotalSkippedItems: 1,
+					SkippedMalware:    1,
+				},
 			},
 			expect: "test (1 skipped: 1 malware)",
+		},
+		{
+			name: "other skip",
+			bup: backup.Backup{
+				Status: "test",
+				SkippedCounts: stats.SkippedCounts{
+					TotalSkippedItems: 1,
+					OtherSkippedItems: 1,
+				},
+			},
+			expect: "test (1 skipped: 1 other)",
 		},
 		{
 			name: "errors and malware",
 			bup: backup.Backup{
 				Status:     "test",
 				ErrorCount: 42,
-				SkippedItems: []fault.Skipped{*fault.FileSkip(
-					fault.SkipMalware,
-					"id", "name",
-					addtl,
-				)},
+				SkippedCounts: stats.SkippedCounts{
+					TotalSkippedItems: 1,
+					SkippedMalware:    1,
+				},
 			},
 			expect: "test (42 errors, 1 skipped: 1 malware)",
+		},
+		{
+			name: "errors, malware, and other",
+			bup: backup.Backup{
+				Status:     "test",
+				ErrorCount: 42,
+				SkippedCounts: stats.SkippedCounts{
+					TotalSkippedItems: 2,
+					SkippedMalware:    1,
+					OtherSkippedItems: 1,
+				},
+			},
+			expect: "test (42 errors, 2 skipped: 1 malware, 1 other)",
 		},
 	}
 	for _, test := range table {

--- a/src/pkg/fault/fault.go
+++ b/src/pkg/fault/fault.go
@@ -45,6 +45,11 @@ func New(failFast bool) *Bus {
 	}
 }
 
+// FailFast returs the failFast flag in the bus.
+func (e *Bus) FailFast() bool {
+	return e.failFast
+}
+
 // Failure returns the primary error.  If not nil, this
 // indicates the operation exited prior to completion.
 func (e *Bus) Failure() error {


### PR DESCRIPTION
The failed items and skipped items currently listed in backup will soon be stored in a snapshot using the streamstore, instead of persisting in the backup model. This change transitions those values to counts, so that the underlying quantity is easily surfaced, while implementation of storage is in progress.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #2708

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
