### PR TITLE
remove getDetailsIDByBackup func

### DIFF
--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/alcionai/clues"
 	"github.com/alcionai/corso/src/cli/options"
 	. "github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/cli/utils"
@@ -424,6 +425,8 @@ func runDetailsExchangeCmd(
 	if err := utils.ValidateExchangeRestoreFlags(backupID, opts); err != nil {
 		return nil, err
 	}
+
+	ctx = clues.Add(ctx, "backup_id", backupID)
 
 	d, _, errs := r.BackupDetails(ctx, backupID)
 	// TODO: log/track recoverable errors

--- a/src/cli/backup/onedrive.go
+++ b/src/cli/backup/onedrive.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/alcionai/clues"
 	"github.com/alcionai/corso/src/cli/options"
 	. "github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/cli/utils"
@@ -310,6 +311,8 @@ func runDetailsOneDriveCmd(
 	if err := utils.ValidateOneDriveRestoreFlags(backupID, opts); err != nil {
 		return nil, err
 	}
+
+	ctx = clues.Add(ctx, "backup_id", backupID)
 
 	d, _, errs := r.BackupDetails(ctx, backupID)
 	// TODO: log/track recoverable errors

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/alcionai/clues"
 	"github.com/alcionai/corso/src/cli/options"
 	. "github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/cli/utils"
@@ -445,6 +446,8 @@ func runDetailsSharePointCmd(
 	if err := utils.ValidateSharePointRestoreFlags(backupID, opts); err != nil {
 		return nil, err
 	}
+
+	ctx = clues.Add(ctx, "backup_id", backupID)
 
 	d, _, errs := r.BackupDetails(ctx, backupID)
 	// TODO: log/track recoverable errors

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -507,8 +507,7 @@ func mergeDetails(
 	deets *details.Builder,
 	errs *fault.Bus,
 ) error {
-	// Don't bother loading any of the base details if there's nothing we need to
-	// merge.
+	// Don't bother loading any of the base details if there's nothing we need to merge.
 	if len(shortRefsFromPrevBackup) == 0 {
 		return nil
 	}

--- a/src/internal/operations/common.go
+++ b/src/internal/operations/common.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/alcionai/clues"
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/internal/streamstore"
 	"github.com/alcionai/corso/src/pkg/backup"
@@ -20,18 +21,23 @@ func getBackupAndDetailsFromID(
 	detailsStore streamstore.Reader,
 	errs *fault.Bus,
 ) (*backup.Backup, *details.Details, error) {
-	dID, bup, err := ms.GetDetailsIDFromBackupID(ctx, backupID)
+	bup, err := ms.GetBackup(ctx, backupID)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "getting backup details ID")
 	}
 
 	var (
-		deets details.Details
-		umt   = details.UnmarshalTo(&deets)
+		deets     details.Details
+		umt       = details.UnmarshalTo(&deets)
+		detailsID = bup.DetailsID
 	)
 
-	if err := detailsStore.Read(ctx, dID, umt, errs); err != nil {
-		return nil, nil, errors.Wrap(err, "getting backup details data")
+	if len(detailsID) == 0 {
+		return bup, nil, clues.New("no details in backup").WithClues(ctx)
+	}
+
+	if err := detailsStore.Read(ctx, detailsID, umt, errs); err != nil {
+		return nil, nil, errors.Wrap(err, "reading backup details")
 	}
 
 	return bup, &deets, nil

--- a/src/internal/operations/common.go
+++ b/src/internal/operations/common.go
@@ -3,9 +3,9 @@ package operations
 import (
 	"context"
 
+	"github.com/alcionai/clues"
 	"github.com/pkg/errors"
 
-	"github.com/alcionai/clues"
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/internal/streamstore"
 	"github.com/alcionai/corso/src/pkg/backup"

--- a/src/internal/operations/manifests.go
+++ b/src/internal/operations/manifests.go
@@ -94,14 +94,14 @@ func produceManifestsAndMetadata(
 		mctx = clues.Add(mctx, "manifest_backup_id", man.ID)
 
 		bup, err := gb.GetBackup(mctx, model.StableID(bID))
-		if err != nil || len(bup.DetailsID) == 0 {
-			// if no backup exists for any of the complete manifests, we want
-			// to fall back to a complete backup.
-			if errors.Is(err, data.ErrNotFound) {
-				logger.Ctx(ctx).Infow("backup missing, falling back to full backup", clues.In(mctx).Slice()...)
-				return ms, nil, false, nil
-			}
+		// if no backup exists for any of the complete manifests, we want
+		// to fall back to a complete backup.
+		if errors.Is(err, data.ErrNotFound) {
+			logger.Ctx(ctx).Infow("backup missing, falling back to full backup", clues.In(mctx).Slice()...)
+			return ms, nil, false, nil
+		}
 
+		if err != nil {
 			return nil, nil, false, errors.Wrap(err, "retrieving prior backup data")
 		}
 

--- a/src/internal/operations/manifests_test.go
+++ b/src/internal/operations/manifests_test.go
@@ -36,16 +36,16 @@ func (mmr mockManifestRestorer) FetchPrevSnapshotManifests(
 	return mmr.mans, mmr.mrErr
 }
 
-type mockGetDetailsIDer struct {
+type mockGetBackuper struct {
 	detailsID string
 	err       error
 }
 
-func (mg mockGetDetailsIDer) GetDetailsIDFromBackupID(
+func (mg mockGetBackuper) GetBackup(
 	ctx context.Context,
 	backupID model.StableID,
-) (string, *backup.Backup, error) {
-	return mg.detailsID, nil, mg.err
+) (*backup.Backup, error) {
+	return &backup.Backup{DetailsID: mg.detailsID}, mg.err
 }
 
 type mockColl struct {
@@ -431,7 +431,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 	table := []struct {
 		name          string
 		mr            mockManifestRestorer
-		gdi           mockGetDetailsIDer
+		gb            mockGetBackuper
 		reasons       []kopia.Reason
 		getMeta       bool
 		assertErr     assert.ErrorAssertionFunc
@@ -445,7 +445,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				mockRestorer: mockRestorer{},
 				mans:         []*kopia.ManifestEntry{},
 			},
-			gdi:       mockGetDetailsIDer{detailsID: did},
+			gb:        mockGetBackuper{detailsID: did},
 			reasons:   []kopia.Reason{},
 			getMeta:   false,
 			assertErr: assert.NoError,
@@ -458,7 +458,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				mockRestorer: mockRestorer{},
 				mans:         []*kopia.ManifestEntry{makeMan(path.EmailCategory, "", "", "")},
 			},
-			gdi:       mockGetDetailsIDer{detailsID: did},
+			gb:        mockGetBackuper{detailsID: did},
 			reasons:   []kopia.Reason{},
 			getMeta:   false,
 			assertErr: assert.NoError,
@@ -471,7 +471,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				mockRestorer: mockRestorer{},
 				mans:         []*kopia.ManifestEntry{makeMan(path.EmailCategory, "", "ir", "")},
 			},
-			gdi:       mockGetDetailsIDer{detailsID: did},
+			gb:        mockGetBackuper{detailsID: did},
 			reasons:   []kopia.Reason{},
 			getMeta:   false,
 			assertErr: assert.NoError,
@@ -484,7 +484,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				mockRestorer: mockRestorer{},
 				mrErr:        assert.AnError,
 			},
-			gdi:       mockGetDetailsIDer{detailsID: did},
+			gb:        mockGetBackuper{detailsID: did},
 			reasons:   []kopia.Reason{},
 			getMeta:   true,
 			assertErr: assert.Error,
@@ -500,7 +500,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 					makeMan(path.EmailCategory, "", "", ""),
 				},
 			},
-			gdi:       mockGetDetailsIDer{detailsID: did},
+			gb:        mockGetBackuper{detailsID: did},
 			reasons:   []kopia.Reason{},
 			getMeta:   true,
 			assertErr: assert.NoError, // No error, even though verify failed.
@@ -513,7 +513,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				mockRestorer: mockRestorer{},
 				mans:         []*kopia.ManifestEntry{},
 			},
-			gdi:       mockGetDetailsIDer{detailsID: did},
+			gb:        mockGetBackuper{detailsID: did},
 			reasons:   []kopia.Reason{},
 			getMeta:   true,
 			assertErr: assert.NoError,
@@ -529,7 +529,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 					makeMan(path.ContactsCategory, "", "ir", ""),
 				},
 			},
-			gdi:       mockGetDetailsIDer{detailsID: did},
+			gb:        mockGetBackuper{detailsID: did},
 			reasons:   []kopia.Reason{},
 			getMeta:   true,
 			assertErr: assert.NoError,
@@ -544,7 +544,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				}},
 				mans: []*kopia.ManifestEntry{makeMan(path.EmailCategory, "id", "", "")},
 			},
-			gdi:           mockGetDetailsIDer{detailsID: did},
+			gb:            mockGetBackuper{detailsID: did},
 			reasons:       []kopia.Reason{},
 			getMeta:       true,
 			assertErr:     assert.Error,
@@ -557,7 +557,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				mockRestorer: mockRestorer{},
 				mans:         []*kopia.ManifestEntry{makeMan(path.EmailCategory, "", "", "bid")},
 			},
-			gdi:       mockGetDetailsIDer{},
+			gb:        mockGetBackuper{},
 			reasons:   []kopia.Reason{},
 			getMeta:   true,
 			assertErr: assert.NoError,
@@ -575,7 +575,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 					makeMan(path.EmailCategory, "incmpl_id", "ir", ""),
 				},
 			},
-			gdi:       mockGetDetailsIDer{detailsID: did},
+			gb:        mockGetBackuper{detailsID: did},
 			reasons:   []kopia.Reason{},
 			getMeta:   true,
 			assertErr: assert.NoError,
@@ -590,7 +590,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				}},
 				mans: []*kopia.ManifestEntry{makeMan(path.EmailCategory, "id", "", "bid")},
 			},
-			gdi:       mockGetDetailsIDer{detailsID: did},
+			gb:        mockGetBackuper{detailsID: did},
 			reasons:   []kopia.Reason{},
 			getMeta:   true,
 			assertErr: assert.NoError,
@@ -609,7 +609,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 					makeMan(path.ContactsCategory, "contact", "", "bid"),
 				},
 			},
-			gdi:       mockGetDetailsIDer{detailsID: did},
+			gb:        mockGetBackuper{detailsID: did},
 			reasons:   []kopia.Reason{},
 			getMeta:   true,
 			assertErr: assert.NoError,
@@ -625,7 +625,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				mockRestorer: mockRestorer{err: assert.AnError},
 				mans:         []*kopia.ManifestEntry{makeMan(path.EmailCategory, "", "", "bid")},
 			},
-			gdi:           mockGetDetailsIDer{detailsID: did},
+			gb:            mockGetBackuper{detailsID: did},
 			reasons:       []kopia.Reason{},
 			getMeta:       true,
 			assertErr:     assert.Error,
@@ -644,7 +644,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 			mans, dcs, b, err := produceManifestsAndMetadata(
 				ctx,
 				&test.mr,
-				&test.gdi,
+				&test.gb,
 				test.reasons,
 				tid,
 				test.getMeta,

--- a/src/pkg/backup/backup.go
+++ b/src/pkg/backup/backup.go
@@ -22,11 +22,15 @@ type Backup struct {
 	// SnapshotID is the kopia snapshot ID
 	SnapshotID string `json:"snapshotID"`
 
-	// Reference to `Details`
-	// We store the ModelStoreID since Details is immutable
+	// Reference to the backup details storage location.
+	// Used to read backup.Details from the streamstore.
 	DetailsID string `json:"detailsID"`
 
-	// Status of the operation
+	// Reference to the fault errors storage location.
+	// Used to read fault.Errors from the streamstore.
+	ErrorsID string `json:"errorsID"`
+
+	// Status of the operation, eg: completed, failed, etc
 	Status string `json:"status"`
 
 	// Selector used in this operation
@@ -53,7 +57,7 @@ type Backup struct {
 var _ print.Printable = &Backup{}
 
 func New(
-	snapshotID, detailsID, status string,
+	snapshotID, detailsID, errorsID, status string,
 	id model.StableID,
 	selector selectors.Selector,
 	rw stats.ReadWrites,
@@ -93,6 +97,7 @@ func New(
 		Version:    version.Backup,
 		SnapshotID: snapshotID,
 		DetailsID:  detailsID,
+		ErrorsID:   errorsID,
 
 		CreationTime: time.Now(),
 		Status:       status,

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -338,27 +338,35 @@ func (r repository) BackupsByTag(ctx context.Context, fs ...store.FilterOption) 
 	return sw.GetBackups(ctx, fs...)
 }
 
-// BackupDetails returns the specified backup details object
+// BackupDetails returns the specified backup.Details
 func (r repository) BackupDetails(
 	ctx context.Context,
 	backupID string,
 ) (*details.Details, *backup.Backup, *fault.Bus) {
-	sw := store.NewKopiaStore(r.modelStore)
-	errs := fault.New(false)
+	var (
+		sw        = store.NewKopiaStore(r.modelStore)
+		errs      = fault.New(false)
+		detailsID string
+	)
 
-	dID, b, err := sw.GetDetailsIDFromBackupID(ctx, model.StableID(backupID))
+	b, err := sw.GetBackup(ctx, model.StableID(backupID))
 	if err != nil {
 		return nil, nil, errs.Fail(err)
+	}
+
+	detailsID = b.DetailsID
+
+	if len(detailsID) == 0 {
+		return nil, b, errs.Fail(clues.New("no details in backup").WithClues(ctx))
 	}
 
 	nd := streamstore.NewDetails(
 		r.dataLayer,
 		r.Account.ID(),
-		b.Selector.PathService(),
-	)
+		b.Selector.PathService())
 
 	var deets details.Details
-	if err := nd.Read(ctx, dID, details.UnmarshalTo(&deets), errs); err != nil {
+	if err := nd.Read(ctx, detailsID, details.UnmarshalTo(&deets), errs); err != nil {
 		return nil, nil, errs.Fail(err)
 	}
 

--- a/src/pkg/store/backup.go
+++ b/src/pkg/store/backup.go
@@ -81,16 +81,3 @@ func (w Wrapper) GetBackups(
 func (w Wrapper) DeleteBackup(ctx context.Context, backupID model.StableID) error {
 	return w.Delete(ctx, model.BackupSchema, backupID)
 }
-
-// GetDetailsFromBackupID retrieves the backup.Details within the specified backup.
-func (w Wrapper) GetDetailsIDFromBackupID(
-	ctx context.Context,
-	backupID model.StableID,
-) (string, *backup.Backup, error) {
-	b, err := w.GetBackup(ctx, backupID)
-	if err != nil {
-		return "", nil, err
-	}
-
-	return b.DetailsID, b, nil
-}

--- a/src/pkg/store/backup_test.go
+++ b/src/pkg/store/backup_test.go
@@ -142,39 +142,3 @@ func (suite *StoreBackupUnitSuite) TestDeleteBackup() {
 		})
 	}
 }
-
-func (suite *StoreBackupUnitSuite) TestGetDetailsIDFromBackupID() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
-	table := []struct {
-		name   string
-		mock   *storeMock.MockModelStore
-		expect assert.ErrorAssertionFunc
-	}{
-		{
-			name:   "gets details from backup id",
-			mock:   storeMock.NewMock(&bu, nil),
-			expect: assert.NoError,
-		},
-		{
-			name:   "errors",
-			mock:   storeMock.NewMock(&bu, assert.AnError),
-			expect: assert.Error,
-		},
-	}
-	for _, test := range table {
-		suite.Run(test.name, func() {
-			t := suite.T()
-
-			store := &store.Wrapper{Storer: test.mock}
-			dResult, bResult, err := store.GetDetailsIDFromBackupID(ctx, model.StableID(uuid.NewString()))
-			test.expect(t, err)
-			if err != nil {
-				return
-			}
-			assert.Equal(t, bu.DetailsID, dResult)
-			assert.Equal(t, bu.ID, bResult.ID)
-		})
-	}
-}


### PR DESCRIPTION
Quck cleanup to make future changes more manageable. There's no need for an interface that retrieves exported values from concrete structs.  Maintaining this pattern will cause future toil, especially as we add more fields to be exported.  The toil can be reduced by expecting callers to get the base item and extract the needed values themselves.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #2708

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
