### PR TITLE
add an accessor for backup errors

### DIFF
--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -428,7 +428,7 @@ func runDetailsExchangeCmd(
 
 	ctx = clues.Add(ctx, "backup_id", backupID)
 
-	d, _, errs := r.BackupDetails(ctx, backupID)
+	d, _, errs := r.GetBackupDetails(ctx, backupID)
 	// TODO: log/track recoverable errors
 	if errs.Failure() != nil {
 		if errors.Is(errs.Failure(), data.ErrNotFound) {

--- a/src/cli/backup/exchange_e2e_test.go
+++ b/src/cli/backup/exchange_e2e_test.go
@@ -331,7 +331,7 @@ func (suite *PreparedBackupExchangeE2ESuite) SetupSuite() {
 		b, err := suite.repo.Backup(ctx, bop.Results.BackupID)
 		require.NoError(t, err, "retrieving recent backup by ID")
 		require.Equal(t, bIDs, string(b.ID), "repo backup matches results id")
-		_, b, errs := suite.repo.BackupDetails(ctx, bIDs)
+		_, b, errs := suite.repo.GetBackupDetails(ctx, bIDs)
 		require.NoError(t, errs.Failure(), "retrieving recent backup details by ID")
 		require.Empty(t, errs.Recovered(), "retrieving recent backup details by ID")
 		require.Equal(t, bIDs, string(b.ID), "repo details matches results id")
@@ -440,7 +440,7 @@ func (suite *PreparedBackupExchangeE2ESuite) TestExchangeDetailsCmd() {
 			bID := suite.backupOps[set]
 
 			// fetch the details from the repo first
-			deets, _, errs := suite.repo.BackupDetails(ctx, string(bID))
+			deets, _, errs := suite.repo.GetBackupDetails(ctx, string(bID))
 			require.NoError(t, errs.Failure())
 			require.Empty(t, errs.Recovered())
 

--- a/src/cli/backup/onedrive.go
+++ b/src/cli/backup/onedrive.go
@@ -314,7 +314,7 @@ func runDetailsOneDriveCmd(
 
 	ctx = clues.Add(ctx, "backup_id", backupID)
 
-	d, _, errs := r.BackupDetails(ctx, backupID)
+	d, _, errs := r.GetBackupDetails(ctx, backupID)
 	// TODO: log/track recoverable errors
 	if errs.Failure() != nil {
 		if errors.Is(errs.Failure(), data.ErrNotFound) {

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -67,11 +67,7 @@ corso backup delete sharepoint --backup 1234abcd-12ab-cd34-56de-1234abcd`
 	sharePointServiceCommandDetailsExamples = `# Explore <site>'s files from backup 1234abcd-12ab-cd34-56de-1234abcd
 
 corso backup details sharepoint --backup 1234abcd-12ab-cd34-56de-1234abcd --site <site_id>
-<<<<<<< HEAD
-# Explore site's files created before end of 2015 from a specific backup
-=======
 # Find all site files that were created before a certain date.
->>>>>>> main
 corso backup details sharepoint --backup 1234abcd-12ab-cd34-56de-1234abcd \
       --web-url https://example.com --file-created-before 2015-01-01T00:00:00
 `
@@ -449,7 +445,7 @@ func runDetailsSharePointCmd(
 
 	ctx = clues.Add(ctx, "backup_id", backupID)
 
-	d, _, errs := r.BackupDetails(ctx, backupID)
+	d, _, errs := r.GetBackupDetails(ctx, backupID)
 	// TODO: log/track recoverable errors
 	if errs.Failure() != nil {
 		if errors.Is(errs.Failure(), data.ErrNotFound) {

--- a/src/cli/restore/exchange_e2e_test.go
+++ b/src/cli/restore/exchange_e2e_test.go
@@ -110,7 +110,7 @@ func (suite *RestoreExchangeE2ESuite) SetupSuite() {
 		_, err = suite.repo.Backup(ctx, bop.Results.BackupID)
 		require.NoError(t, err, "retrieving recent backup by ID")
 
-		_, _, errs := suite.repo.BackupDetails(ctx, string(bop.Results.BackupID))
+		_, _, errs := suite.repo.GetBackupDetails(ctx, string(bop.Results.BackupID))
 		require.NoError(t, errs.Failure(), "retrieving recent backup details by ID")
 		require.Empty(t, errs.Recovered(), "retrieving recent backup details by ID")
 	}

--- a/src/cli/utils/testdata/opts.go
+++ b/src/cli/utils/testdata/opts.go
@@ -489,7 +489,9 @@ var (
 // (selectors/testdata.GetDetailsSet(), nil, nil) when BackupDetails is called
 // on the nil instance. If an instance is given or Backups is called returns an
 // error.
-type MockBackupGetter struct{}
+type MockBackupGetter struct {
+	failure, recovered, skipped bool
+}
 
 func (MockBackupGetter) Backup(
 	context.Context,
@@ -512,12 +514,24 @@ func (MockBackupGetter) BackupsByTag(
 	return nil, errors.New("unexpected call to mock")
 }
 
-func (bg *MockBackupGetter) BackupDetails(
+func (bg *MockBackupGetter) GetBackupDetails(
 	ctx context.Context,
 	backupID string,
 ) (*details.Details, *backup.Backup, *fault.Bus) {
 	if bg == nil {
 		return testdata.GetDetailsSet(), nil, fault.New(true)
+	}
+
+	return nil, nil, fault.New(false).Fail(errors.New("unexpected call to mock"))
+}
+
+func (bg *MockBackupGetter) GetBackupErrors(
+	ctx context.Context,
+	backupID string,
+) (*fault.Errors, *backup.Backup, *fault.Bus) {
+	if bg == nil {
+		fe := testdata.MakeErrors(bg.failure, bg.recovered, bg.skipped)
+		return &fe, nil, fault.New(true)
 	}
 
 	return nil, nil, fault.New(false).Fail(errors.New("unexpected call to mock"))

--- a/src/internal/streamstore/fault_errors_test.go
+++ b/src/internal/streamstore/fault_errors_test.go
@@ -45,17 +45,8 @@ func (suite *StreamFaultItemsIntegrationSuite) TestFaultItems() {
 	defer kw.Close(ctx)
 
 	fe := fault.New(false)
-	fe.AddRecoverable(fault.FileErr(
-		assert.AnError,
-		"id",
-		"name",
-		nil))
-
-	fe.AddSkip(fault.FileSkip(
-		fault.SkipMalware,
-		"id2",
-		"name2",
-		nil))
+	fe.AddRecoverable(fault.FileErr(assert.AnError, "id", "name", nil))
+	fe.AddSkip(fault.FileSkip(fault.SkipMalware, "id2", "name2", nil))
 
 	var (
 		errs = fe.Errors()

--- a/src/pkg/backup/details/testdata/testdata.go
+++ b/src/pkg/backup/details/testdata/testdata.go
@@ -1,13 +1,10 @@
 package testdata
 
 import (
-	stdpath "path"
 	"time"
 
 	"github.com/alcionai/corso/src/pkg/backup/details"
-	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
-	"github.com/stretchr/testify/assert"
 )
 
 // mustParsePath takes a string representing a resource path and returns a path
@@ -324,22 +321,4 @@ func GetDetailsSet() *details.Details {
 			Entries: entries,
 		},
 	}
-}
-
-func MakeErrors(failure, recovered, skipped bool) fault.Errors {
-	fe := fault.Errors{}
-
-	if failure {
-		fe.Failure = assert.AnError
-	}
-
-	if recovered {
-		fe.Recovered = []error{assert.AnError}
-	}
-
-	if skipped {
-		fe.Skipped = []fault.Skipped{*fault.FileSkip(fault.SkipMalware, "id", "name", nil)}
-	}
-
-	return fe
 }

--- a/src/pkg/fault/testdata/testdata.go
+++ b/src/pkg/fault/testdata/testdata.go
@@ -1,0 +1,26 @@
+package testdata
+
+import (
+	"github.com/stretchr/testify/assert"
+
+	"github.com/alcionai/clues"
+	"github.com/alcionai/corso/src/pkg/fault"
+)
+
+func MakeErrors(failure, recovered, skipped bool) fault.Errors {
+	fe := fault.Errors{}
+
+	if failure {
+		fe.Failure = assert.AnError
+	}
+
+	if recovered {
+		fe.Recovered = []error{clues.New("recoverable")}
+	}
+
+	if skipped {
+		fe.Skipped = []fault.Skipped{*fault.FileSkip(fault.SkipMalware, "id", "name", nil)}
+	}
+
+	return fe
+}

--- a/src/pkg/repository/loadtest/repository_load_test.go
+++ b/src/pkg/repository/loadtest/repository_load_test.go
@@ -247,7 +247,7 @@ func runBackupDetailsLoadTest(
 		)
 
 		pprof.Do(ctx, labels, func(ctx context.Context) {
-			ds, b, errs = r.BackupDetails(ctx, backupID)
+			ds, b, errs = r.GetBackupDetails(ctx, backupID)
 		})
 
 		require.NoError(t, errs.Failure(), "retrieving details in backup "+backupID)

--- a/src/pkg/repository/repository_test.go
+++ b/src/pkg/repository/repository_test.go
@@ -19,15 +19,15 @@ import (
 // unit tests
 // ---------------
 
-type RepositorySuite struct {
+type RepositoryUnitSuite struct {
 	tester.Suite
 }
 
-func TestRepositorySuite(t *testing.T) {
-	suite.Run(t, &RepositorySuite{Suite: tester.NewUnitSuite(t)})
+func TestRepositoryUnitSuite(t *testing.T) {
+	suite.Run(t, &RepositoryUnitSuite{Suite: tester.NewUnitSuite(t)})
 }
 
-func (suite *RepositorySuite) TestInitialize() {
+func (suite *RepositoryUnitSuite) TestInitialize() {
 	table := []struct {
 		name     string
 		storage  func() (storage.Storage, error)
@@ -60,7 +60,7 @@ func (suite *RepositorySuite) TestInitialize() {
 
 // repository.Connect involves end-to-end communication with kopia, therefore this only
 // tests expected error cases
-func (suite *RepositorySuite) TestConnect() {
+func (suite *RepositoryUnitSuite) TestConnect() {
 	table := []struct {
 		name     string
 		storage  func() (storage.Storage, error)

--- a/src/pkg/repository/repository_unexported_test.go
+++ b/src/pkg/repository/repository_unexported_test.go
@@ -22,47 +22,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/store"
 )
 
-// type RepoModelIntgSuite struct {
-// 	tester.Suite
-// }
-
-// func TestRepoModelIntgSuite(t *testing.T) {
-// 	suite.Run(t, &RepoModelIntgSuite{
-// 		Suite: tester.NewIntegrationSuite(
-// 			t,
-// 			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
-// 			tester.CorsoRepositoryTests,
-// 		),
-// 	})
-// }
-
-// func (suite *RepoModelIntgSuite) TestWriteGetModel() {
-// 	ctx, flush := tester.NewContext()
-// 	defer flush()
-
-// 	var (
-// 		t = suite.T()
-// 		s = tester.NewPrefixedS3Storage(t)
-// 		k = kopia.NewConn(s)
-// 	)
-
-// 	require.NoError(t, k.Initialize(ctx))
-// 	require.NoError(t, k.Connect(ctx))
-
-// 	defer k.Close(ctx)
-
-// 	ms, err := kopia.NewModelStore(k)
-// 	require.NoError(t, err)
-
-// 	defer ms.Close(ctx)
-
-// 	require.NoError(t, newRepoModel(ctx, ms, "fnords"))
-
-// 	got, err := getRepoModel(ctx, ms)
-// 	require.NoError(t, err)
-// 	assert.Equal(t, "fnords", string(got.ID))
-// }
-
 type RepositoryModelIntgSuite struct {
 	tester.Suite
 	kw          *kopia.Wrapper
@@ -123,6 +82,33 @@ func (suite *RepositoryModelIntgSuite) TearDownSuite() {
 	if suite.kopiaCloser != nil {
 		suite.kopiaCloser(ctx)
 	}
+}
+
+func (suite *RepositoryModelIntgSuite) TestWriteGetModel() {
+	ctx, flush := tester.NewContext()
+	defer flush()
+
+	var (
+		t = suite.T()
+		s = tester.NewPrefixedS3Storage(t)
+		k = kopia.NewConn(s)
+	)
+
+	require.NoError(t, k.Initialize(ctx))
+	require.NoError(t, k.Connect(ctx))
+
+	defer k.Close(ctx)
+
+	ms, err := kopia.NewModelStore(k)
+	require.NoError(t, err)
+
+	defer ms.Close(ctx)
+
+	require.NoError(t, newRepoModel(ctx, ms, "fnords"))
+
+	got, err := getRepoModel(ctx, ms)
+	require.NoError(t, err)
+	assert.Equal(t, "fnords", string(got.ID))
 }
 
 // helper func for writing backups

--- a/src/pkg/repository/repository_unexported_test.go
+++ b/src/pkg/repository/repository_unexported_test.go
@@ -83,7 +83,7 @@ func (suite *RepositoryModelIntgSuite) TearDownSuite() {
 	}
 }
 
-func (suite *RepositoryModelIntgSuite) TestWriteGetModel() {
+func (suite *RepositoryModelIntgSuite) TestGetRepositoryModel() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 
@@ -111,11 +111,9 @@ func (suite *RepositoryModelIntgSuite) TestWriteGetModel() {
 }
 
 // helper func for writing backups
-//
-//revive:disable:context-as-argument
 func writeBackup(
 	t *testing.T,
-	ctx context.Context,
+	ctx context.Context, //revive:disable-line:context-as-argument
 	kw *kopia.Wrapper,
 	sw *store.Wrapper,
 	tID, snapID, backupID string,
@@ -124,7 +122,6 @@ func writeBackup(
 	errors fault.Errors,
 	errs *fault.Bus,
 ) *backup.Backup {
-	//revive:enable:context-as-argument
 	var (
 		serv         = sel.PathService()
 		detailsStore = streamstore.NewDetails(kw, tID, serv)
@@ -276,19 +273,19 @@ func (suite *RepositoryModelIntgSuite) TestGetBackupErrors() {
 					tenantID, "snapID", test.writeBupID,
 					selectors.NewExchangeBackup([]string{"brunhilda"}).Selector,
 					test.deets,
-					fault.Errors{},
+					*test.errors,
 					fault.New(true))
 			)
 
-			rDeets, rBup, err := getBackupDetails(ctx, test.readBupID, tenantID, suite.kw, suite.sw, fault.New(true))
+			rErrors, rBup, err := getBackupErrors(ctx, test.readBupID, tenantID, suite.kw, suite.sw, fault.New(true))
 			test.expectErr(t, err)
 
 			if err != nil {
 				return
 			}
 
-			assert.Equal(t, b.DetailsID, rBup.DetailsID, "returned details ID matches")
-			assert.Equal(t, test.deets, rDeets, "returned details ID matches")
+			assert.Equal(t, b.ErrorsID, rBup.ErrorsID, "returned errors ID matches")
+			assert.Equal(t, test.deets, rErrors, "returned details ID matches")
 		})
 	}
 }

--- a/src/pkg/repository/repository_unexported_test.go
+++ b/src/pkg/repository/repository_unexported_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -192,22 +191,25 @@ func (suite *RepositoryModelIntgSuite) TestGetBackupDetails() {
 			defer flush()
 
 			var (
-				t     = suite.T()
-				bupID = uuid.NewString()
-				b     = writeBackup(
+				t = suite.T()
+				b = writeBackup(
 					t,
 					ctx,
 					suite.kw,
 					suite.sw,
-					tenantID, "snapID", bupID,
+					tenantID, "snapID", test.writeBupID,
 					selectors.NewExchangeBackup([]string{"brunhilda"}).Selector,
 					test.deets,
 					fault.Errors{},
 					fault.New(true))
 			)
 
-			rDeets, rBup, err := getBackupDetails(ctx, bupID, tenantID, suite.kw, suite.sw, fault.New(true))
+			rDeets, rBup, err := getBackupDetails(ctx, test.readBupID, tenantID, suite.kw, suite.sw, fault.New(true))
 			test.expectErr(t, err)
+
+			if err != nil {
+				return
+			}
 
 			assert.Equal(t, b.DetailsID, rBup.DetailsID, "returned details ID matches")
 			assert.Equal(t, test.deets, rDeets, "returned details ID matches")
@@ -245,8 +247,8 @@ func (suite *RepositoryModelIntgSuite) TestGetBackupErrors() {
 		},
 		{
 			name:       "nil errors",
-			writeBupID: "error_squirrels",
-			readBupID:  "error_squirrels",
+			writeBupID: "error_marmots",
+			readBupID:  "error_marmots",
 			deets:      builder.Details(),
 			errors:     nil,
 			expectErr:  require.NoError,
@@ -265,22 +267,25 @@ func (suite *RepositoryModelIntgSuite) TestGetBackupErrors() {
 			defer flush()
 
 			var (
-				t     = suite.T()
-				bupID = uuid.NewString()
-				b     = writeBackup(
+				t = suite.T()
+				b = writeBackup(
 					t,
 					ctx,
 					suite.kw,
 					suite.sw,
-					tenantID, "snapID", bupID,
+					tenantID, "snapID", test.writeBupID,
 					selectors.NewExchangeBackup([]string{"brunhilda"}).Selector,
 					test.deets,
 					fault.Errors{},
 					fault.New(true))
 			)
 
-			rDeets, rBup, err := getBackupDetails(ctx, bupID, tenantID, suite.kw, suite.sw, fault.New(true))
+			rDeets, rBup, err := getBackupDetails(ctx, test.readBupID, tenantID, suite.kw, suite.sw, fault.New(true))
 			test.expectErr(t, err)
+
+			if err != nil {
+				return
+			}
 
 			assert.Equal(t, b.DetailsID, rBup.DetailsID, "returned details ID matches")
 			assert.Equal(t, test.deets, rDeets, "returned details ID matches")

--- a/src/pkg/repository/repository_unexported_test.go
+++ b/src/pkg/repository/repository_unexported_test.go
@@ -1,22 +1,78 @@
 package repository
 
 import (
+	"context"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/kopia"
+	"github.com/alcionai/corso/src/internal/model"
+	"github.com/alcionai/corso/src/internal/operations"
+	"github.com/alcionai/corso/src/internal/stats"
+	"github.com/alcionai/corso/src/internal/streamstore"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/backup"
+	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/selectors"
+	"github.com/alcionai/corso/src/pkg/store"
 )
 
-type RepositoryModelSuite struct {
+// type RepoModelIntgSuite struct {
+// 	tester.Suite
+// }
+
+// func TestRepoModelIntgSuite(t *testing.T) {
+// 	suite.Run(t, &RepoModelIntgSuite{
+// 		Suite: tester.NewIntegrationSuite(
+// 			t,
+// 			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
+// 			tester.CorsoRepositoryTests,
+// 		),
+// 	})
+// }
+
+// func (suite *RepoModelIntgSuite) TestWriteGetModel() {
+// 	ctx, flush := tester.NewContext()
+// 	defer flush()
+
+// 	var (
+// 		t = suite.T()
+// 		s = tester.NewPrefixedS3Storage(t)
+// 		k = kopia.NewConn(s)
+// 	)
+
+// 	require.NoError(t, k.Initialize(ctx))
+// 	require.NoError(t, k.Connect(ctx))
+
+// 	defer k.Close(ctx)
+
+// 	ms, err := kopia.NewModelStore(k)
+// 	require.NoError(t, err)
+
+// 	defer ms.Close(ctx)
+
+// 	require.NoError(t, newRepoModel(ctx, ms, "fnords"))
+
+// 	got, err := getRepoModel(ctx, ms)
+// 	require.NoError(t, err)
+// 	assert.Equal(t, "fnords", string(got.ID))
+// }
+
+type RepositoryModelIntgSuite struct {
 	tester.Suite
+	kw          *kopia.Wrapper
+	ms          *kopia.ModelStore
+	sw          *store.Wrapper
+	kopiaCloser func(ctx context.Context)
 }
 
-func TestRepositoryModelSuite(t *testing.T) {
-	suite.Run(t, &RepositoryModelSuite{
+func TestRepositoryModelIntgSuite(t *testing.T) {
+	suite.Run(t, &RepositoryModelIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
 			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
@@ -25,29 +81,223 @@ func TestRepositoryModelSuite(t *testing.T) {
 	})
 }
 
-func (suite *RepositoryModelSuite) TestWriteGetModel() {
+func (suite *RepositoryModelIntgSuite) SetupSuite() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 
 	var (
-		t        = suite.T()
-		s        = tester.NewPrefixedS3Storage(t)
-		kopiaRef = kopia.NewConn(s)
+		t   = suite.T()
+		s   = tester.NewPrefixedS3Storage(t)
+		k   = kopia.NewConn(s)
+		err error
 	)
 
-	require.NoError(t, kopiaRef.Initialize(ctx))
-	require.NoError(t, kopiaRef.Connect(ctx))
+	require.NotNil(t, k)
+	require.NoError(t, k.Initialize(ctx))
 
-	defer kopiaRef.Close(ctx)
+	suite.kopiaCloser = func(ctx context.Context) {
+		k.Close(ctx)
+	}
 
-	ms, err := kopia.NewModelStore(kopiaRef)
+	suite.kw, err = kopia.NewWrapper(k)
 	require.NoError(t, err)
 
-	defer ms.Close(ctx)
-
-	require.NoError(t, newRepoModel(ctx, ms, "fnords"))
-
-	got, err := getRepoModel(ctx, ms)
+	suite.ms, err = kopia.NewModelStore(k)
 	require.NoError(t, err)
-	assert.Equal(t, "fnords", string(got.ID))
+
+	suite.sw = store.NewKopiaStore(suite.ms)
+}
+
+func (suite *RepositoryModelIntgSuite) TearDownSuite() {
+	ctx, flush := tester.NewContext()
+	defer flush()
+
+	if suite.ms != nil {
+		suite.ms.Close(ctx)
+	}
+
+	if suite.kw != nil {
+		suite.kw.Close(ctx)
+	}
+
+	if suite.kopiaCloser != nil {
+		suite.kopiaCloser(ctx)
+	}
+}
+
+// helper func for writing backups
+//
+//revive:disable:context-as-argument
+func writeBackup(
+	t *testing.T,
+	ctx context.Context,
+	kw *kopia.Wrapper,
+	sw *store.Wrapper,
+	tID, snapID, backupID string,
+	sel selectors.Selector,
+	deets *details.Details,
+	errors fault.Errors,
+	errs *fault.Bus,
+) *backup.Backup {
+	//revive:enable:context-as-argument
+	var (
+		serv         = sel.PathService()
+		detailsStore = streamstore.NewDetails(kw, tID, serv)
+		errorsStore  = streamstore.NewFaultErrors(kw, tID, serv)
+	)
+
+	detailsID, err := detailsStore.Write(ctx, deets, errs)
+	require.NoError(t, err, "writing details to streamstore")
+
+	errorsID, err := errorsStore.Write(ctx, errs.Errors(), errs)
+	require.NoError(t, err, "writing errors to streamstore")
+
+	b := backup.New(
+		snapID, detailsID, errorsID,
+		operations.Completed.String(),
+		model.StableID(backupID),
+		sel,
+		stats.ReadWrites{},
+		stats.StartAndEndTime{},
+		errs)
+
+	require.NoError(t, sw.Put(ctx, model.BackupSchema, b))
+
+	return b
+}
+
+func (suite *RepositoryModelIntgSuite) TestGetBackupDetails() {
+	const tenantID = "tenant"
+
+	info := details.ItemInfo{
+		Folder: &details.FolderInfo{
+			DisplayName: "test",
+		},
+	}
+
+	builder := &details.Builder{}
+	builder.Add("ref", "short", "pref", "lref", false, info)
+
+	table := []struct {
+		name       string
+		writeBupID string
+		readBupID  string
+		deets      *details.Details
+		expectErr  require.ErrorAssertionFunc
+	}{
+		{
+			name:       "good",
+			writeBupID: "squirrels",
+			readBupID:  "squirrels",
+			deets:      builder.Details(),
+			expectErr:  require.NoError,
+		},
+		{
+			name:       "missing backup",
+			writeBupID: "chipmunks",
+			readBupID:  "weasels",
+			deets:      builder.Details(),
+			expectErr:  require.Error,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			ctx, flush := tester.NewContext()
+			defer flush()
+
+			var (
+				t     = suite.T()
+				bupID = uuid.NewString()
+				b     = writeBackup(
+					t,
+					ctx,
+					suite.kw,
+					suite.sw,
+					tenantID, "snapID", bupID,
+					selectors.NewExchangeBackup([]string{"brunhilda"}).Selector,
+					test.deets,
+					fault.Errors{},
+					fault.New(true))
+			)
+
+			rDeets, rBup, err := getBackupDetails(ctx, bupID, tenantID, suite.kw, suite.sw, fault.New(true))
+			test.expectErr(t, err)
+
+			assert.Equal(t, b.DetailsID, rBup.DetailsID, "returned details ID matches")
+			assert.Equal(t, test.deets, rDeets, "returned details ID matches")
+		})
+	}
+}
+
+func (suite *RepositoryModelIntgSuite) TestGetBackupErrors() {
+	const tenantID = "tenant"
+
+	info := details.ItemInfo{
+		Folder: &details.FolderInfo{
+			DisplayName: "test",
+		},
+	}
+
+	builder := &details.Builder{}
+	builder.Add("ref", "short", "pref", "lref", false, info)
+
+	table := []struct {
+		name       string
+		writeBupID string
+		readBupID  string
+		deets      *details.Details
+		errors     *fault.Errors
+		expectErr  require.ErrorAssertionFunc
+	}{
+		{
+			name:       "good",
+			writeBupID: "error_squirrels",
+			readBupID:  "error_squirrels",
+			deets:      builder.Details(),
+			errors:     &fault.Errors{Failure: assert.AnError},
+			expectErr:  require.NoError,
+		},
+		{
+			name:       "nil errors",
+			writeBupID: "error_squirrels",
+			readBupID:  "error_squirrels",
+			deets:      builder.Details(),
+			errors:     nil,
+			expectErr:  require.NoError,
+		},
+		{
+			name:       "missing backup",
+			writeBupID: "error_chipmunks",
+			readBupID:  "error_weasels",
+			deets:      builder.Details(),
+			expectErr:  require.Error,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			ctx, flush := tester.NewContext()
+			defer flush()
+
+			var (
+				t     = suite.T()
+				bupID = uuid.NewString()
+				b     = writeBackup(
+					t,
+					ctx,
+					suite.kw,
+					suite.sw,
+					tenantID, "snapID", bupID,
+					selectors.NewExchangeBackup([]string{"brunhilda"}).Selector,
+					test.deets,
+					fault.Errors{},
+					fault.New(true))
+			)
+
+			rDeets, rBup, err := getBackupDetails(ctx, bupID, tenantID, suite.kw, suite.sw, fault.New(true))
+			test.expectErr(t, err)
+
+			assert.Equal(t, b.DetailsID, rBup.DetailsID, "returned details ID matches")
+			assert.Equal(t, test.deets, rDeets, "returned details ID matches")
+		})
+	}
 }

--- a/src/pkg/selectors/selectors_reduce_test.go
+++ b/src/pkg/selectors/selectors_reduce_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/alcionai/corso/src/internal/common"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/backup/details/testdata"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/selectors"
-	"github.com/alcionai/corso/src/pkg/selectors/testdata"
 )
 
 type SelectorReduceSuite struct {

--- a/src/pkg/selectors/testdata/details.go
+++ b/src/pkg/selectors/testdata/details.go
@@ -338,7 +338,7 @@ func MakeErrors(failure, recovered, skipped bool) fault.Errors {
 	}
 
 	if skipped {
-		fe.Skipped = []fault.Skipped{*fault.FileSkip(fault.SkipMalware, "id", "name", "cid", "cname")}
+		fe.Skipped = []fault.Skipped{*fault.FileSkip(fault.SkipMalware, "id", "name", nil)}
 	}
 
 	return fe

--- a/src/pkg/selectors/testdata/details.go
+++ b/src/pkg/selectors/testdata/details.go
@@ -5,7 +5,9 @@ import (
 	"time"
 
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/stretchr/testify/assert"
 )
 
 // mustParsePath takes a string representing a resource path and returns a path
@@ -322,4 +324,22 @@ func GetDetailsSet() *details.Details {
 			Entries: entries,
 		},
 	}
+}
+
+func MakeErrors(failure, recovered, skipped bool) fault.Errors {
+	fe := fault.Errors{}
+
+	if failure {
+		fe.Failure = assert.AnError
+	}
+
+	if recovered {
+		fe.Recovered = []error{assert.AnError}
+	}
+
+	if skipped {
+		fe.Skipped = []fault.Skipped{*fault.FileSkip(fault.SkipMalware, "id", "name", "cid", "cname")}
+	}
+
+	return fe
 }


### PR DESCRIPTION
adds a way to retrieve the fault errors from the backup model, via the streamstore.  Also refactors the funcs so that they can be directly tested via an integration test.  Plus a minor naming refactor to prepend Get onto the details and errors getter funcs.

---

#### Does this PR need a docs update or release note?

- [x] :clock1: Yes, but in a later PR

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #2708

#### Test Plan

- [x] :green_heart: E2E
