### PR TITLE
expose listing errors and skipped items in the cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Sharepoint library (document files) support: backup, list, details, and restore.
-- Listing a single backup by id will also list the skipped and failed items that occurred during the backup.  This can be filtered out with the `--no-skip` and `--no-error` flags.
+- Listing a single backup by id will also list the skipped and failed items that occurred during the backup.  These can be filtered out with the flags `--failed-items hide` and `--skipped-items hide`.
 
 ### Fixed
 - Fix repo connect not working without a config file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] (beta)
 
 ### Added
-- Sharepoint library (document files) support: backup, list, details, and restore.  
+- Sharepoint library (document files) support: backup, list, details, and restore.
+- Listing a single backup by id will also list the skipped and failed items that occurred during the backup.  This can be filtered out with the `--no-skip` and `--no-error` flags.
 
 ### Fixed
 - Fix repo connect not working without a config file

--- a/src/cli/backup/backup.go
+++ b/src/cli/backup/backup.go
@@ -21,19 +21,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ==============================================
-// Folder Object flags
-// These options are flags for indicating
-// that a time-based filter should be used for
-// within returning objects for details.
-// Used by: OneDrive, SharePoint
-// ================================================
-var (
-	fileCreatedAfter   string
-	fileCreatedBefore  string
-	fileModifiedAfter  string
-	fileModifiedBefore string
-)
+// ---------------------------------------------------------------------------
+// adding commands to cobra
+// ---------------------------------------------------------------------------
 
 var subCommandFuncs = []func() *cobra.Command{
 	createCmd,
@@ -62,6 +52,48 @@ func AddCommands(cmd *cobra.Command) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// adding flags to cobra commands
+// ---------------------------------------------------------------------------
+
+// ==============================================
+// Folder Object flags
+// These options are flags for indicating
+// that a time-based filter should be used for
+// within returning objects for details.
+// Used by: OneDrive, SharePoint
+// ================================================
+var (
+	fileCreatedAfter   string
+	fileCreatedBefore  string
+	fileModifiedAfter  string
+	fileModifiedBefore string
+)
+
+// list output filter flags
+var (
+	failedItemsFN    = "failed-items"
+	listFailedItems  string
+	skippedItemsFN   = "skipped-items"
+	listSkippedItems string
+)
+
+func addFailedItemsFN(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&listFailedItems, failedItemsFN, "show",
+		"Toggles showing or hiding the list of items that failed.")
+}
+
+func addSkippedItemsFN(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&listSkippedItems, skippedItemsFN, "show",
+		"Toggles showing or hiding the list of items that were skipped.")
+}
+
+// ---------------------------------------------------------------------------
+// commands
+// ---------------------------------------------------------------------------
 
 // The backup category of commands.
 // `corso backup [<subcommand>] [<flag>...]`
@@ -107,7 +139,7 @@ var listCommand = "list"
 func listCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   listCommand,
-		Short: "List the history of backups for a service",
+		Short: "List the history of backups",
 		RunE:  handleListCmd,
 		Args:  cobra.NoArgs,
 	}
@@ -126,7 +158,7 @@ var detailsCommand = "details"
 func detailsCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   detailsCommand,
-		Short: "Shows the details of a backup for a service",
+		Short: "Shows the details of a backup",
 		RunE:  handleDetailsCmd,
 		Args:  cobra.NoArgs,
 	}
@@ -145,7 +177,7 @@ var deleteCommand = "delete"
 func deleteCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   deleteCommand,
-		Short: "Deletes a backup for a service",
+		Short: "Deletes a backup",
 		RunE:  handleDeleteCmd,
 		Args:  cobra.NoArgs,
 	}
@@ -156,6 +188,10 @@ func deleteCmd() *cobra.Command {
 func handleDeleteCmd(cmd *cobra.Command, args []string) error {
 	return cmd.Help()
 }
+
+// ---------------------------------------------------------------------------
+// common handlers
+// ---------------------------------------------------------------------------
 
 func runBackups(
 	ctx context.Context,
@@ -176,8 +212,7 @@ func runBackups(
 				"Failed to initialize %s backup for %s %s",
 				serviceName,
 				resourceOwnerType,
-				discSel.DiscreteOwner,
-			))
+				discSel.DiscreteOwner))
 
 			continue
 		}
@@ -189,8 +224,7 @@ func runBackups(
 				"Failed to run %s backup for %s %s",
 				serviceName,
 				resourceOwnerType,
-				discSel.DiscreteOwner,
-			))
+				discSel.DiscreteOwner))
 
 			continue
 		}
@@ -261,6 +295,13 @@ func genericListCommand(cmd *cobra.Command, bID string, service path.ServiceType
 		}
 
 		b.Print(ctx)
+
+		fe, _, errs := r.GetBackupErrors(ctx, string(b.ID))
+		if errs.Failure() != nil {
+			return Only(ctx, errors.Wrap(err, "Failed to find errors in backup"))
+		}
+
+		fe.PrintItems(ctx, listFailedItems != "show", listSkippedItems != "show")
 
 		return nil
 	}

--- a/src/cli/backup/backup.go
+++ b/src/cli/backup/backup.go
@@ -54,16 +54,9 @@ func AddCommands(cmd *cobra.Command) {
 }
 
 // ---------------------------------------------------------------------------
-// adding flags to cobra commands
+// common flags and flag attachers for commands
 // ---------------------------------------------------------------------------
 
-// ==============================================
-// Folder Object flags
-// These options are flags for indicating
-// that a time-based filter should be used for
-// within returning objects for details.
-// Used by: OneDrive, SharePoint
-// ================================================
 var (
 	fileCreatedAfter   string
 	fileCreatedBefore  string

--- a/src/cli/backup/backup.go
+++ b/src/cli/backup/backup.go
@@ -284,10 +284,10 @@ func genericListCommand(cmd *cobra.Command, bID string, service path.ServiceType
 
 	defer utils.CloseRepo(ctx, r)
 
-	if len(backupID) > 0 {
-		b, err := r.Backup(ctx, model.StableID(bID))
-		if err != nil {
-			if errors.Is(err, data.ErrNotFound) {
+	if len(bID) > 0 {
+		fe, b, errs := r.GetBackupErrors(ctx, bID)
+		if errs.Failure() != nil {
+			if errors.Is(errs.Failure(), data.ErrNotFound) {
 				return Only(ctx, errors.Errorf("No backup exists with the id %s", bID))
 			}
 
@@ -295,12 +295,6 @@ func genericListCommand(cmd *cobra.Command, bID string, service path.ServiceType
 		}
 
 		b.Print(ctx)
-
-		fe, _, errs := r.GetBackupErrors(ctx, string(b.ID))
-		if errs.Failure() != nil {
-			return Only(ctx, errors.Wrap(err, "Failed to find errors in backup"))
-		}
-
 		fe.PrintItems(ctx, listFailedItems != "show", listSkippedItems != "show")
 
 		return nil

--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -124,7 +124,10 @@ func addExchangeCommands(cmd *cobra.Command) *cobra.Command {
 
 		fs.StringVar(&backupID,
 			"backup", "",
-			"ID of the backup to retrieve.")
+			"Display a specific backup, including the items that failed or were skipped during processing.")
+
+		addFailedItemsFN(c)
+		addSkippedItemsFN(c)
 
 	case detailsCommand:
 		c, fs = utils.AddCommand(cmd, exchangeDetailsCmd())

--- a/src/cli/backup/onedrive.go
+++ b/src/cli/backup/onedrive.go
@@ -80,8 +80,11 @@ func addOneDriveCommands(cmd *cobra.Command) *cobra.Command {
 		c, fs = utils.AddCommand(cmd, oneDriveListCmd())
 
 		fs.StringVar(&backupID,
-			utils.BackupFN, "",
-			"ID of the backup to retrieve.")
+			"backup", "",
+			"Display a specific backup, including the items that failed or were skipped during processing.")
+
+		addFailedItemsFN(c)
+		addSkippedItemsFN(c)
 
 	case detailsCommand:
 		c, fs = utils.AddCommand(cmd, oneDriveDetailsCmd())

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -105,8 +105,11 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 		c, fs = utils.AddCommand(cmd, sharePointListCmd())
 
 		fs.StringVar(&backupID,
-			utils.BackupFN, "",
-			"ID of the backup to retrieve.")
+			"backup", "",
+			"Display a specific backup, including the items that failed or were skipped during processing.")
+
+		addFailedItemsFN(c)
+		addSkippedItemsFN(c)
 
 	case detailsCommand:
 		c, fs = utils.AddCommand(cmd, sharePointDetailsCmd())

--- a/src/pkg/fault/fault.go
+++ b/src/pkg/fault/fault.go
@@ -254,20 +254,23 @@ func UnmarshalErrorsTo(e *Errors) func(io.ReadCloser) error {
 
 // Print writes the DetailModel Entries to StdOut, in the format
 // requested by the caller.
-func (e Errors) PrintItems(ctx context.Context) {
-	count := len(e.Items) + len(e.Skipped)
-	if count == 0 {
+func (e Errors) PrintItems(ctx context.Context, ignoreErrors, ignoreSkips bool) {
+	if len(e.Items)+len(e.Skipped) == 0 || ignoreErrors && ignoreSkips {
 		return
 	}
 
-	sl := make([]print.Printable, 0, count)
+	sl := make([]print.Printable, 0)
 
-	for _, s := range e.Skipped {
-		sl = append(sl, print.Printable(s))
+	if !ignoreSkips {
+		for _, s := range e.Skipped {
+			sl = append(sl, print.Printable(s))
+		}
 	}
 
-	for _, i := range e.Items {
-		sl = append(sl, print.Printable(i))
+	if !ignoreErrors {
+		for _, i := range e.Items {
+			sl = append(sl, print.Printable(i))
+		}
 	}
 
 	print.All(ctx, sl...)

--- a/src/pkg/fault/item.go
+++ b/src/pkg/fault/item.go
@@ -167,7 +167,7 @@ var _ print.Printable = &Skipped{}
 // fault interface.  Skipped items are not errors, and Item{} errors are
 // not the basis for a Skip.
 type Skipped struct {
-	item Item
+	Item Item `json:"item"`
 }
 
 // String complies with the stringer interface.
@@ -176,7 +176,7 @@ func (s *Skipped) String() string {
 		return "<nil>"
 	}
 
-	return "skipped " + s.item.Error() + ": " + s.item.Cause
+	return "skipped " + s.Item.Error() + ": " + s.Item.Cause
 }
 
 // HasCause compares the underlying cause against the parameter.
@@ -185,7 +185,7 @@ func (s *Skipped) HasCause(c skipCause) bool {
 		return false
 	}
 
-	return s.item.Cause == string(c)
+	return s.Item.Cause == string(c)
 }
 
 func (s Skipped) MinimumPrintable() any {
@@ -202,7 +202,7 @@ func (s Skipped) Headers() []string {
 func (s Skipped) Values() []string {
 	var cn string
 
-	acn, ok := s.item.Additional[AddtlContainerName]
+	acn, ok := s.Item.Additional[AddtlContainerName]
 	if ok {
 		str, ok := acn.(string)
 		if ok {
@@ -210,7 +210,7 @@ func (s Skipped) Values() []string {
 		}
 	}
 
-	return []string{"Skip", s.item.Type.Printable(), s.item.Name, cn, s.item.Cause}
+	return []string{"Skip", s.Item.Type.Printable(), s.Item.Name, cn, s.Item.Cause}
 }
 
 // ContainerSkip produces a Container-kind Item for tracking skipped items.
@@ -231,7 +231,7 @@ func OwnerSkip(cause skipCause, id, name string, addtl map[string]any) *Skipped 
 // itemSkip produces a Item of the provided type for tracking skipped items.
 func itemSkip(t itemType, cause skipCause, id, name string, addtl map[string]any) *Skipped {
 	return &Skipped{
-		item: Item{
+		Item: Item{
 			ID:         id,
 			Name:       name,
 			Type:       t,

--- a/src/pkg/fault/item_test.go
+++ b/src/pkg/fault/item_test.go
@@ -163,7 +163,7 @@ func (suite *ItemUnitSuite) TestSkipped_String() {
 	assert.Contains(t, i.String(), "unknown type")
 
 	i = &Skipped{Item{Type: FileType}}
-	assert.Contains(t, i.item.Error(), FileType)
+	assert.Contains(t, i.Item.Error(), FileType)
 }
 
 func (suite *ItemUnitSuite) TestContainerSkip() {


### PR DESCRIPTION
Extends the `backup list` functionality to output any failed or skipped items iff the command includes a backup ID.  These outputs can be skipped by adding the flags `--failed-items hide` or `--skipped items hide`.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #2708

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
