### PR TITLE
Fixup OneDrive selectors for different file names

### DIFF
--- a/src/cli/utils/testdata/opts.go
+++ b/src/cli/utils/testdata/opts.go
@@ -388,6 +388,28 @@ var (
 			},
 		},
 		{
+			Name:     "SingleItem",
+			Expected: []details.DetailsEntry{testdata.OneDriveItems[0]},
+			Opts: utils.OneDriveOpts{
+				Names: []string{
+					testdata.OneDriveItems[0].OneDrive.ItemName,
+				},
+			},
+		},
+		{
+			Name: "MultipleItems",
+			Expected: []details.DetailsEntry{
+				testdata.OneDriveItems[0],
+				testdata.OneDriveItems[1],
+			},
+			Opts: utils.OneDriveOpts{
+				Names: []string{
+					testdata.OneDriveItems[0].OneDrive.ItemName,
+					testdata.OneDriveItems[1].OneDrive.ItemName,
+				},
+			},
+		},
+		{
 			Name:     "CreatedBefore",
 			Expected: []details.DetailsEntry{testdata.OneDriveItems[1]},
 			Opts: utils.OneDriveOpts{
@@ -472,6 +494,28 @@ var (
 				LibraryItems: []string{
 					testdata.SharePointLibraryItems[0].ShortRef,
 					testdata.SharePointLibraryItems[1].ShortRef,
+				},
+			},
+		},
+		{
+			Name:     "SingleItem",
+			Expected: []details.DetailsEntry{testdata.SharePointLibraryItems[0]},
+			Opts: utils.SharePointOpts{
+				LibraryItems: []string{
+					testdata.SharePointLibraryItems[0].SharePoint.ItemName,
+				},
+			},
+		},
+		{
+			Name: "MultipleItems",
+			Expected: []details.DetailsEntry{
+				testdata.SharePointLibraryItems[0],
+				testdata.SharePointLibraryItems[1],
+			},
+			Opts: utils.SharePointOpts{
+				LibraryItems: []string{
+					testdata.SharePointLibraryItems[0].SharePoint.ItemName,
+					testdata.SharePointLibraryItems[1].SharePoint.ItemName,
 				},
 			},
 		},

--- a/src/pkg/selectors/exchange.go
+++ b/src/pkg/selectors/exchange.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"strconv"
 
+	"github.com/alcionai/clues"
+
 	"github.com/alcionai/corso/src/internal/common"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -580,7 +582,10 @@ func (ec exchangeCategory) isLeaf() bool {
 // Example:
 // [tenantID, service, userPN, category, mailFolder, mailID]
 // => {exchMailFolder: mailFolder, exchMail: mailID}
-func (ec exchangeCategory) pathValues(repo path.Path, ent details.DetailsEntry) map[categorizer][]string {
+func (ec exchangeCategory) pathValues(
+	repo path.Path,
+	ent details.DetailsEntry,
+) (map[categorizer][]string, error) {
 	var folderCat, itemCat categorizer
 
 	switch ec {
@@ -594,7 +599,7 @@ func (ec exchangeCategory) pathValues(repo path.Path, ent details.DetailsEntry) 
 		folderCat, itemCat = ExchangeMailFolder, ExchangeMail
 
 	default:
-		return map[categorizer][]string{}
+		return nil, clues.New("bad exchanageCategory").With("category", ec)
 	}
 
 	result := map[categorizer][]string{
@@ -606,7 +611,7 @@ func (ec exchangeCategory) pathValues(repo path.Path, ent details.DetailsEntry) 
 		result[folderCat] = append(result[folderCat], ent.LocationRef)
 	}
 
-	return result
+	return result, nil
 }
 
 // pathKeys returns the path keys recognized by the receiver's leaf type.

--- a/src/pkg/selectors/exchange_test.go
+++ b/src/pkg/selectors/exchange_test.go
@@ -764,7 +764,9 @@ func (suite *ExchangeSelectorSuite) TestExchangeScope_MatchesPath() {
 			scopes := setScopesToDefault(test.scope)
 			var aMatch bool
 			for _, scope := range scopes {
-				pvs := ExchangeMail.pathValues(repo, ent)
+				pvs, err := ExchangeMail.pathValues(repo, ent)
+				require.NoError(t, err)
+
 				if matchesPathValues(scope, ExchangeMail, pvs) {
 					aMatch = true
 					break
@@ -1345,7 +1347,8 @@ func (suite *ExchangeSelectorSuite) TestPasses() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			pvs := cat.pathValues(repo, ent)
+			pvs, err := cat.pathValues(repo, ent)
+			require.NoError(t, err)
 
 			result := passes(
 				cat,
@@ -1486,7 +1489,8 @@ func (suite *ExchangeSelectorSuite) TestExchangeCategory_PathValues() {
 				ShortRef: "short",
 			}
 
-			pvs := test.cat.pathValues(test.path, ent)
+			pvs, err := test.cat.pathValues(test.path, ent)
+			require.NoError(t, err)
 			assert.Equal(t, test.expect, pvs)
 		})
 	}

--- a/src/pkg/selectors/helpers_test.go
+++ b/src/pkg/selectors/helpers_test.go
@@ -55,11 +55,14 @@ func (mc mockCategorizer) isLeaf() bool {
 	return mc == leafCatStub
 }
 
-func (mc mockCategorizer) pathValues(repo path.Path, ent details.DetailsEntry) map[categorizer][]string {
+func (mc mockCategorizer) pathValues(
+	repo path.Path,
+	ent details.DetailsEntry,
+) (map[categorizer][]string, error) {
 	return map[categorizer][]string{
 		rootCatStub: {"root"},
 		leafCatStub: {"leaf"},
-	}
+	}, nil
 }
 
 func (mc mockCategorizer) pathKeys() []categorizer {

--- a/src/pkg/selectors/onedrive_test.go
+++ b/src/pkg/selectors/onedrive_test.go
@@ -175,6 +175,7 @@ func (suite *OneDriveSelectorSuite) TestOneDriveRestore_Reduce() {
 					ItemInfo: details.ItemInfo{
 						OneDrive: &details.OneDriveInfo{
 							ItemType: details.OneDriveItem,
+							ItemName: "fileName",
 						},
 					},
 				},
@@ -183,6 +184,7 @@ func (suite *OneDriveSelectorSuite) TestOneDriveRestore_Reduce() {
 					ItemInfo: details.ItemInfo{
 						OneDrive: &details.OneDriveInfo{
 							ItemType: details.OneDriveItem,
+							ItemName: "fileName2",
 						},
 					},
 				},
@@ -191,6 +193,7 @@ func (suite *OneDriveSelectorSuite) TestOneDriveRestore_Reduce() {
 					ItemInfo: details.ItemInfo{
 						OneDrive: &details.OneDriveInfo{
 							ItemType: details.OneDriveItem,
+							ItemName: "fileName3",
 						},
 					},
 				},
@@ -223,7 +226,7 @@ func (suite *OneDriveSelectorSuite) TestOneDriveRestore_Reduce() {
 			deets,
 			func() *OneDriveRestore {
 				odr := NewOneDriveRestore(Any())
-				odr.Include(odr.Items(Any(), []string{"file2"}))
+				odr.Include(odr.Items(Any(), []string{"fileName2"}))
 				return odr
 			},
 			arr(file2),
@@ -257,21 +260,30 @@ func (suite *OneDriveSelectorSuite) TestOneDriveRestore_Reduce() {
 func (suite *OneDriveSelectorSuite) TestOneDriveCategory_PathValues() {
 	t := suite.T()
 
-	pathBuilder := path.Builder{}.Append("drive", "driveID", "root:", "dir1", "dir2", "file")
+	fileName := "file"
+	shortRef := "short"
+
+	pathBuilder := path.Builder{}.Append("drive", "driveID", "root:", "dir1", "dir2", fileName+"-id")
 	filePath, err := pathBuilder.ToDataLayerOneDrivePath("tenant", "user", true)
 	require.NoError(t, err)
 
 	expected := map[categorizer][]string{
 		OneDriveFolder: {"dir1/dir2"},
-		OneDriveItem:   {"file", "short"},
+		OneDriveItem:   {fileName, shortRef},
 	}
 
 	ent := details.DetailsEntry{
 		RepoRef:  filePath.String(),
-		ShortRef: "short",
+		ShortRef: shortRef,
+		ItemInfo: details.ItemInfo{
+			OneDrive: &details.OneDriveInfo{
+				ItemName: fileName,
+			},
+		},
 	}
 
-	r := OneDriveItem.pathValues(filePath, ent)
+	r, err := OneDriveItem.pathValues(filePath, ent)
+	require.NoError(t, err)
 	assert.Equal(t, expected, r)
 }
 

--- a/src/pkg/selectors/scopes.go
+++ b/src/pkg/selectors/scopes.go
@@ -328,9 +328,11 @@ func reduce[T scopeT, C categoryT](
 
 	// for each entry, compare that entry against the scopes of the same data type
 	for _, ent := range deets.Items() {
+		ictx := clues.Add(ctx, "short_ref", ent.ShortRef)
+
 		repoPath, err := path.FromDataLayerPath(ent.RepoRef, true)
 		if err != nil {
-			el.AddRecoverable(clues.Wrap(err, "transforming repoRef to path").WithClues(ctx))
+			el.AddRecoverable(clues.Wrap(err, "transforming repoRef to path").WithClues(ictx))
 			continue
 		}
 
@@ -353,7 +355,7 @@ func reduce[T scopeT, C categoryT](
 
 		pv, err := dc.pathValues(repoPath, *ent)
 		if err != nil {
-			el.AddRecoverable(clues.Wrap(err, "getting path values").WithClues(ctx))
+			el.AddRecoverable(clues.Wrap(err, "getting path values").WithClues(ictx))
 			continue
 		}
 

--- a/src/pkg/selectors/scopes.go
+++ b/src/pkg/selectors/scopes.go
@@ -88,7 +88,7 @@ type (
 		//   folderCat: folder,
 		//   itemCat:   itemID,
 		// }
-		pathValues(path.Path, details.DetailsEntry) map[categorizer][]string
+		pathValues(path.Path, details.DetailsEntry) (map[categorizer][]string, error)
 
 		// pathKeys produces a list of categorizers that can be used as keys in the pathValues
 		// map.  The combination of the two funcs generically interprets the context of the
@@ -351,7 +351,11 @@ func reduce[T scopeT, C categoryT](
 			continue
 		}
 
-		pv := dc.pathValues(repoPath, *ent)
+		pv, err := dc.pathValues(repoPath, *ent)
+		if err != nil {
+			el.AddRecoverable(clues.Wrap(err, "getting path values").WithClues(ctx))
+			continue
+		}
 
 		passed := passes(dc, pv, *ent, e, f, i)
 		if passed {

--- a/src/pkg/selectors/scopes_test.go
+++ b/src/pkg/selectors/scopes_test.go
@@ -360,8 +360,10 @@ func (suite *SelectorScopesSuite) TestPasses() {
 		entry = details.DetailsEntry{
 			RepoRef: pth.String(),
 		}
-		pvs = cat.pathValues(pth, entry)
 	)
+
+	pvs, err := cat.pathValues(pth, entry)
+	require.NoError(suite.T(), err)
 
 	for _, test := range reduceTestTable {
 		suite.Run(test.name, func() {

--- a/src/pkg/selectors/sharepoint.go
+++ b/src/pkg/selectors/sharepoint.go
@@ -503,7 +503,7 @@ func (c sharePointCategory) pathValues(
 		folderCat, itemCat = SharePointPageFolder, SharePointPage
 
 	default:
-		return nil, clues.New("bad sharePointCategory").With("category", c)
+		return nil, clues.New("unrecognized sharePointCategory").With("category", c)
 	}
 
 	result := map[categorizer][]string{

--- a/src/pkg/selectors/sharepoint_test.go
+++ b/src/pkg/selectors/sharepoint_test.go
@@ -215,6 +215,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 					ItemInfo: details.ItemInfo{
 						SharePoint: &details.SharePointInfo{
 							ItemType: details.SharePointLibrary,
+							ItemName: "itemName",
 						},
 					},
 				},
@@ -223,6 +224,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 					ItemInfo: details.ItemInfo{
 						SharePoint: &details.SharePointInfo{
 							ItemType: details.SharePointLibrary,
+							ItemName: "itemName2",
 						},
 					},
 				},
@@ -231,6 +233,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 					ItemInfo: details.ItemInfo{
 						SharePoint: &details.SharePointInfo{
 							ItemType: details.SharePointLibrary,
+							ItemName: "itemName3",
 						},
 					},
 				},
@@ -239,6 +242,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 					ItemInfo: details.ItemInfo{
 						SharePoint: &details.SharePointInfo{
 							ItemType: details.SharePointPage,
+							ItemName: "itemName4",
 						},
 					},
 				},
@@ -247,6 +251,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 					ItemInfo: details.ItemInfo{
 						SharePoint: &details.SharePointInfo{
 							ItemType: details.SharePointPage,
+							ItemName: "itemName5",
 						},
 					},
 				},
@@ -279,7 +284,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 			deets: deets,
 			makeSelector: func() *SharePointRestore {
 				odr := NewSharePointRestore(Any())
-				odr.Include(odr.LibraryItems(Any(), []string{"item2"}))
+				odr.Include(odr.LibraryItems(Any(), []string{"itemName2"}))
 				return odr
 			},
 			expect: arr(item2),
@@ -321,7 +326,9 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 }
 
 func (suite *SharePointSelectorSuite) TestSharePointCategory_PathValues() {
-	pathBuilder := path.Builder{}.Append("dir1", "dir2", "item")
+	itemName := "item"
+	shortRef := "short"
+	pathBuilder := path.Builder{}.Append("dir1", "dir2", itemName+"-id")
 
 	table := []struct {
 		name     string
@@ -333,7 +340,7 @@ func (suite *SharePointSelectorSuite) TestSharePointCategory_PathValues() {
 			sc:   SharePointLibraryItem,
 			expected: map[categorizer][]string{
 				SharePointLibrary:     {"dir1/dir2"},
-				SharePointLibraryItem: {"item", "short"},
+				SharePointLibraryItem: {itemName, shortRef},
 			},
 		},
 		{
@@ -341,7 +348,7 @@ func (suite *SharePointSelectorSuite) TestSharePointCategory_PathValues() {
 			sc:   SharePointListItem,
 			expected: map[categorizer][]string{
 				SharePointList:     {"dir1/dir2"},
-				SharePointListItem: {"item", "short"},
+				SharePointListItem: {"item-id", shortRef},
 			},
 		},
 	}
@@ -359,10 +366,16 @@ func (suite *SharePointSelectorSuite) TestSharePointCategory_PathValues() {
 
 			ent := details.DetailsEntry{
 				RepoRef:  itemPath.String(),
-				ShortRef: "short",
+				ShortRef: shortRef,
+				ItemInfo: details.ItemInfo{
+					SharePoint: &details.SharePointInfo{
+						ItemName: itemName,
+					},
+				},
 			}
 
-			pv := test.sc.pathValues(itemPath, ent)
+			pv, err := test.sc.pathValues(itemPath, ent)
+			require.NoError(t, err)
 			assert.Equal(t, test.expected, pv)
 		})
 	}


### PR DESCRIPTION
Update selectors to match on the OneDrive/SharePoint
file name specified in backup details instead of the
path. Path name matching is disabled completely as the
name in kopia is never displayed to the user

Plan is to merge this PR into #1535 and then merge into
main when that's ready so this all goes in at once

Manually tested restoring a OneDrive file by file name
and had no trouble

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #1535

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
