### PR TITLE
Rename folder metadata files to just `.dirmeta`

### DIFF
--- a/src/internal/connector/graph_connector_onedrive_test.go
+++ b/src/internal/connector/graph_connector_onedrive_test.go
@@ -192,7 +192,8 @@ func (c *onedriveCollection) withFile(name string, fileData []byte, perm permDat
 			name+onedrive.DataFileSuffix,
 			fileData))
 
-	case version.OneDrive1DataAndMetaFiles, 2, version.OneDrive3IsMetaMarker, version.OneDrive4DirIncludesPermissions:
+	case version.OneDrive1DataAndMetaFiles, 2, version.OneDrive3IsMetaMarker,
+		version.OneDrive4DirIncludesPermissions, version.OneDrive5DirMetaName:
 		c.items = append(c.items, onedriveItemWithData(
 			c.t,
 			name+onedrive.DataFileSuffix,
@@ -217,7 +218,7 @@ func (c *onedriveCollection) withFile(name string, fileData []byte, perm permDat
 
 func (c *onedriveCollection) withFolder(name string, perm permData) *onedriveCollection {
 	switch c.backupVersion {
-	case 0, version.OneDrive4DirIncludesPermissions:
+	case 0, version.OneDrive4DirIncludesPermissions, version.OneDrive5DirMetaName:
 		return c
 
 	case version.OneDrive1DataAndMetaFiles, 2, version.OneDrive3IsMetaMarker:
@@ -247,6 +248,12 @@ func (c *onedriveCollection) withPermissions(perm permData) *onedriveCollection 
 	}
 
 	name := c.pathElements[len(c.pathElements)-1]
+	metaName := name
+
+	if c.backupVersion >= version.OneDrive5DirMetaName {
+		// We switched to just .dirmeta for metadata file names.
+		metaName = ""
+	}
 
 	if name == "root:" {
 		return c
@@ -255,7 +262,7 @@ func (c *onedriveCollection) withPermissions(perm permData) *onedriveCollection 
 	metadata := onedriveMetadata(
 		c.t,
 		name,
-		name+onedrive.DirMetaFileSuffix,
+		metaName+onedrive.DirMetaFileSuffix,
 		perm,
 		c.backupVersion >= versionPermissionSwitchedToID)
 

--- a/src/internal/connector/graph_connector_onedrive_test.go
+++ b/src/internal/connector/graph_connector_onedrive_test.go
@@ -193,7 +193,7 @@ func (c *onedriveCollection) withFile(name string, fileData []byte, perm permDat
 			fileData))
 
 	case version.OneDrive1DataAndMetaFiles, 2, version.OneDrive3IsMetaMarker,
-		version.OneDrive4DirIncludesPermissions, version.OneDrive5DirMetaName:
+		version.OneDrive4DirIncludesPermissions, version.OneDrive5DirMetaNoName:
 		c.items = append(c.items, onedriveItemWithData(
 			c.t,
 			name+onedrive.DataFileSuffix,
@@ -218,7 +218,7 @@ func (c *onedriveCollection) withFile(name string, fileData []byte, perm permDat
 
 func (c *onedriveCollection) withFolder(name string, perm permData) *onedriveCollection {
 	switch c.backupVersion {
-	case 0, version.OneDrive4DirIncludesPermissions, version.OneDrive5DirMetaName:
+	case 0, version.OneDrive4DirIncludesPermissions, version.OneDrive5DirMetaNoName:
 		return c
 
 	case version.OneDrive1DataAndMetaFiles, 2, version.OneDrive3IsMetaMarker:
@@ -250,7 +250,7 @@ func (c *onedriveCollection) withPermissions(perm permData) *onedriveCollection 
 	name := c.pathElements[len(c.pathElements)-1]
 	metaName := name
 
-	if c.backupVersion >= version.OneDrive5DirMetaName {
+	if c.backupVersion >= version.OneDrive5DirMetaNoName {
 		// We switched to just .dirmeta for metadata file names.
 		metaName = ""
 	}

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -336,6 +336,7 @@ func (oc *Collection) populateItems(ctx context.Context, errs *fault.Bus) {
 				itemInfo     details.ItemInfo
 				itemMeta     io.ReadCloser
 				itemMetaSize int
+				metaFileName string
 				metaSuffix   string
 			)
 
@@ -361,10 +362,12 @@ func (oc *Collection) populateItems(ctx context.Context, errs *fault.Bus) {
 			if isFile {
 				atomic.AddInt64(&itemsFound, 1)
 
+				metaFileName = itemName
 				metaSuffix = MetaFileSuffix
 			} else {
 				atomic.AddInt64(&dirsFound, 1)
 
+				// metaFileName not set for directories so we get just ".dirmeta"
 				metaSuffix = DirMetaFileSuffix
 			}
 
@@ -469,7 +472,7 @@ func (oc *Collection) populateItems(ctx context.Context, errs *fault.Bus) {
 				})
 
 				oc.data <- &metadataItem{
-					id:      itemName + metaSuffix,
+					id:      metaFileName + metaSuffix,
 					data:    metaReader,
 					modTime: time.Now(),
 				}

--- a/src/internal/connector/onedrive/permission.go
+++ b/src/internal/connector/onedrive/permission.go
@@ -68,11 +68,13 @@ func getCollectionMetadata(
 
 	// Root folder doesn't have a metadata file associated with it.
 	folders := collectionPath.Folders()
+	metaName := folders[len(folders)-1] + DirMetaFileSuffix
 
-	meta, err := fetchAndReadMetadata(
-		ctx,
-		dc,
-		folders[len(folders)-1]+DirMetaFileSuffix)
+	if backupVersion >= version.OneDrive5DirMetaName {
+		metaName = DirMetaFileSuffix
+	}
+
+	meta, err := fetchAndReadMetadata(ctx, dc, metaName)
 	if err != nil {
 		return Metadata{}, clues.Wrap(err, "collection metadata")
 	}

--- a/src/internal/connector/onedrive/permission.go
+++ b/src/internal/connector/onedrive/permission.go
@@ -70,7 +70,7 @@ func getCollectionMetadata(
 	folders := collectionPath.Folders()
 	metaName := folders[len(folders)-1] + DirMetaFileSuffix
 
-	if backupVersion >= version.OneDrive5DirMetaName {
+	if backupVersion >= version.OneDrive5DirMetaNoName {
 		metaName = DirMetaFileSuffix
 	}
 

--- a/src/internal/version/backup.go
+++ b/src/internal/version/backup.go
@@ -2,7 +2,7 @@ package version
 
 import "math"
 
-const Backup = 4
+const Backup = 5
 
 // Various labels to refer to important version changes.
 // Labels don't need 1:1 service:version representation.  Add a new
@@ -24,6 +24,11 @@ const (
 	// OneDrive4IncludesPermissions includes permissions for folders in the same
 	// collection as the folder itself.
 	OneDrive4DirIncludesPermissions = 4
+
+	// OneDrive5DirMetaName changed the directory metadata file name from
+	// <dirname>.dirmeta to just .dirmeta to avoid issues with folder renames
+	// during incremental backups.
+	OneDrive5DirMetaName = 5
 
 	// OneDriveXNameInMeta points to the backup format version where we begin
 	// storing files in kopia with their item ID instead of their OneDrive file

--- a/src/internal/version/backup.go
+++ b/src/internal/version/backup.go
@@ -25,10 +25,10 @@ const (
 	// collection as the folder itself.
 	OneDrive4DirIncludesPermissions = 4
 
-	// OneDrive5DirMetaName changed the directory metadata file name from
+	// OneDrive5DirMetaNoName changed the directory metadata file name from
 	// <dirname>.dirmeta to just .dirmeta to avoid issues with folder renames
 	// during incremental backups.
-	OneDrive5DirMetaName = 5
+	OneDrive5DirMetaNoName = 5
 
 	// OneDriveXNameInMeta points to the backup format version where we begin
 	// storing files in kopia with their item ID instead of their OneDrive file


### PR DESCRIPTION
Removing the folder name from the dirmeta file name
plays better with upcoming incremental backup changes
because we no longer have to discover what the old
name of the metadata file was

Bumps the Corso backup version number

Contains minor changes to how tests detect root
folder's metadata

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* closes #2754

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
