### PR TITLE
add single library scope

### DIFF
--- a/src/pkg/selectors/sharepoint_test.go
+++ b/src/pkg/selectors/sharepoint_test.go
@@ -370,7 +370,7 @@ func (suite *SharePointSelectorSuite) TestSharePointCategory_PathValues() {
 
 func (suite *SharePointSelectorSuite) TestSharePointScope_MatchesInfo() {
 	var (
-		ods          = NewSharePointRestore(Any())
+		sel          = NewSharePointRestore(Any())
 		host         = "www.website.com"
 		pth          = "/foo"
 		url          = host + pth
@@ -386,29 +386,31 @@ func (suite *SharePointSelectorSuite) TestSharePointScope_MatchesInfo() {
 		scope   []SharePointScope
 		expect  assert.BoolAssertionFunc
 	}{
-		{"host match", host, ods.WebURL([]string{host}), assert.True},
-		{"url match", url, ods.WebURL([]string{url}), assert.True},
-		{"url contains host", url, ods.WebURL([]string{host}), assert.True},
-		{"host suffixes host", host, ods.WebURL([]string{host}, SuffixMatch()), assert.True},
-		{"url does not suffix host", url, ods.WebURL([]string{host}, SuffixMatch()), assert.False},
-		{"url contains path", url, ods.WebURL([]string{pth}), assert.True},
-		{"url has path suffix", url, ods.WebURL([]string{pth}, SuffixMatch()), assert.True},
-		{"host does not contain substring", host, ods.WebURL([]string{"website"}), assert.False},
-		{"url does not suffix substring", url, ods.WebURL([]string{"oo"}), assert.False},
-		{"host mismatch", host, ods.WebURL([]string{"www.google.com"}), assert.False},
-		{"file create after the epoch", host, ods.CreatedAfter(common.FormatTime(epoch)), assert.True},
-		{"file create after now", host, ods.CreatedAfter(common.FormatTime(now)), assert.False},
-		{"file create after later", url, ods.CreatedAfter(common.FormatTime(future)), assert.False},
-		{"file create before future", host, ods.CreatedBefore(common.FormatTime(future)), assert.True},
-		{"file create before now", host, ods.CreatedBefore(common.FormatTime(now)), assert.False},
-		{"file create before modification", host, ods.CreatedBefore(common.FormatTime(modification)), assert.True},
-		{"file create before epoch", host, ods.CreatedBefore(common.FormatTime(now)), assert.False},
-		{"file modified after the epoch", host, ods.ModifiedAfter(common.FormatTime(epoch)), assert.True},
-		{"file modified after now", host, ods.ModifiedAfter(common.FormatTime(now)), assert.True},
-		{"file modified after later", host, ods.ModifiedAfter(common.FormatTime(future)), assert.False},
-		{"file modified before future", host, ods.ModifiedBefore(common.FormatTime(future)), assert.True},
-		{"file modified before now", host, ods.ModifiedBefore(common.FormatTime(now)), assert.False},
-		{"file modified before epoch", host, ods.ModifiedBefore(common.FormatTime(now)), assert.False},
+		{"host match", host, sel.WebURL([]string{host}), assert.True},
+		{"url match", url, sel.WebURL([]string{url}), assert.True},
+		{"url contains host", url, sel.WebURL([]string{host}), assert.True},
+		{"host suffixes host", host, sel.WebURL([]string{host}, SuffixMatch()), assert.True},
+		{"url does not suffix host", url, sel.WebURL([]string{host}, SuffixMatch()), assert.False},
+		{"url contains path", url, sel.WebURL([]string{pth}), assert.True},
+		{"url has path suffix", url, sel.WebURL([]string{pth}, SuffixMatch()), assert.True},
+		{"host does not contain substring", host, sel.WebURL([]string{"website"}), assert.False},
+		{"url does not suffix substring", url, sel.WebURL([]string{"oo"}), assert.False},
+		{"host mismatch", host, sel.WebURL([]string{"www.google.com"}), assert.False},
+		{"file create after the epoch", host, sel.CreatedAfter(common.FormatTime(epoch)), assert.True},
+		{"file create after now", host, sel.CreatedAfter(common.FormatTime(now)), assert.False},
+		{"file create after later", url, sel.CreatedAfter(common.FormatTime(future)), assert.False},
+		{"file create before future", host, sel.CreatedBefore(common.FormatTime(future)), assert.True},
+		{"file create before now", host, sel.CreatedBefore(common.FormatTime(now)), assert.False},
+		{"file create before modification", host, sel.CreatedBefore(common.FormatTime(modification)), assert.True},
+		{"file create before epoch", host, sel.CreatedBefore(common.FormatTime(now)), assert.False},
+		{"file modified after the epoch", host, sel.ModifiedAfter(common.FormatTime(epoch)), assert.True},
+		{"file modified after now", host, sel.ModifiedAfter(common.FormatTime(now)), assert.True},
+		{"file modified after later", host, sel.ModifiedAfter(common.FormatTime(future)), assert.False},
+		{"file modified before future", host, sel.ModifiedBefore(common.FormatTime(future)), assert.True},
+		{"file modified before now", host, sel.ModifiedBefore(common.FormatTime(now)), assert.False},
+		{"file modified before epoch", host, sel.ModifiedBefore(common.FormatTime(now)), assert.False},
+		{"in library", host, sel.Library("included-library"), assert.True},
+		{"not in library", host, sel.Library("not-included-library"), assert.False},
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
@@ -416,10 +418,11 @@ func (suite *SharePointSelectorSuite) TestSharePointScope_MatchesInfo() {
 
 			itemInfo := details.ItemInfo{
 				SharePoint: &details.SharePointInfo{
-					ItemType: details.SharePointPage,
-					WebURL:   test.infoURL,
-					Created:  now,
-					Modified: modification,
+					ItemType:  details.SharePointPage,
+					WebURL:    test.infoURL,
+					Created:   now,
+					Modified:  modification,
+					DriveName: "included-library",
 				},
 			}
 


### PR DESCRIPTION
Adds a scope for sharepoint that restricts selection to a single library (aka: drive).  Currently only
supports matching on the library name.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #2757

#### Test Plan

- [x] :zap: Unit test
