### PR TITLE
Make sharepoint cli public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] (beta)
 
+### Added
+- Sharepoint library (document files) support: backup, list, details, and restore.  
+
 ### Fixed
 - Fix repo connect not working without a config file
 

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -62,6 +62,7 @@ corso backup delete sharepoint --backup 1234abcd-12ab-cd34-56de-1234abcd`
 corso backup details sharepoint --backup 1234abcd-12ab-cd34-56de-1234abcd --web-url https://example.com
 
 # Find all site files that were created before a certain date.
+
 corso backup details sharepoint --backup 1234abcd-12ab-cd34-56de-1234abcd \
       --web-url https://example.com --file-created-before 2015-01-01T00:00:00
 `

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -124,7 +124,7 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 		fs.StringVar(
 			&utils.Library,
 			utils.LibraryFN, "",
-			"Select backup details within a library.  Defaults includes all libraries.")
+			"Select backup details within a library. Defaults includes all libraries.")
 
 		fs.StringSliceVar(
 			&utils.FolderPaths,

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -97,6 +97,7 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 			utils.DataFN, nil,
 			"Select one or more types of data to backup: "+dataLibraries+" or "+dataPages+".")
 		cobra.CheckErr(fs.MarkHidden(utils.DataFN))
+
 		options.AddOperationFlags(c)
 
 	case listCommand:
@@ -150,11 +151,13 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 			&pageFolders,
 			utils.PageFolderFN, nil,
 			"Select backup data by folder name; accepts '"+utils.Wildcard+"' to select all folders.")
+		cobra.CheckErr(fs.MarkHidden(utils.PageFolderFN))
 
 		fs.StringSliceVar(
 			&page,
 			utils.PagesFN, nil,
 			"Select backup data by file name; accepts '"+utils.Wildcard+"' to select all pages within the site.")
+		cobra.CheckErr(fs.MarkHidden(utils.PagesFN))
 
 		// sharepoint info flags
 

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -77,7 +77,7 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 
 	switch cmd.Use {
 	case createCommand:
-		c, fs = utils.AddCommand(cmd, sharePointCreateCmd(), utils.MarkPreReleaseCommand())
+		c, fs = utils.AddCommand(cmd, sharePointCreateCmd())
 
 		c.Use = c.Use + " " + sharePointServiceCommandCreateUseSuffix
 		c.Example = sharePointServiceCommandCreateExamples
@@ -96,17 +96,18 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 			&sharepointData,
 			utils.DataFN, nil,
 			"Select one or more types of data to backup: "+dataLibraries+" or "+dataPages+".")
+		cobra.CheckErr(fs.MarkHidden(utils.DataFN))
 		options.AddOperationFlags(c)
 
 	case listCommand:
-		c, fs = utils.AddCommand(cmd, sharePointListCmd(), utils.MarkPreReleaseCommand())
+		c, fs = utils.AddCommand(cmd, sharePointListCmd())
 
 		fs.StringVar(&backupID,
 			utils.BackupFN, "",
 			"ID of the backup to retrieve.")
 
 	case detailsCommand:
-		c, fs = utils.AddCommand(cmd, sharePointDetailsCmd(), utils.MarkPreReleaseCommand())
+		c, fs = utils.AddCommand(cmd, sharePointDetailsCmd())
 
 		c.Use = c.Use + " " + sharePointServiceCommandDetailsUseSuffix
 		c.Example = sharePointServiceCommandDetailsExamples
@@ -177,7 +178,7 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 			"Select backup details modified before this datetime.")
 
 	case deleteCommand:
-		c, fs = utils.AddCommand(cmd, sharePointDeleteCmd(), utils.MarkPreReleaseCommand())
+		c, fs = utils.AddCommand(cmd, sharePointDeleteCmd())
 
 		c.Use = c.Use + " " + sharePointServiceCommandDeleteUseSuffix
 		c.Example = sharePointServiceCommandDeleteExamples

--- a/src/cli/restore/sharepoint.go
+++ b/src/cli/restore/sharepoint.go
@@ -60,7 +60,7 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 		fs.StringVar(
 			&utils.Library,
 			utils.LibraryFN, "",
-			"Restore files within a library.  Default includes all libraries.")
+			"Restore files within a library. Default includes all libraries.")
 
 		fs.StringSliceVar(
 			&utils.FolderPaths,

--- a/src/cli/restore/sharepoint.go
+++ b/src/cli/restore/sharepoint.go
@@ -76,21 +76,25 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 			&listPaths,
 			utils.ListFN, nil,
 			"Restore list items by SharePoint list ID")
+		cobra.CheckErr(fs.MarkHidden(utils.ListFN))
 
 		fs.StringSliceVar(
 			&listItems,
 			utils.ListItemFN, nil,
 			"Restore list items by ID")
+		cobra.CheckErr(fs.MarkHidden(utils.ListItemFN))
 
 		fs.StringSliceVar(
 			&pageFolders,
 			utils.PageFolderFN, nil,
 			"Restore Site pages by page folder name")
+		cobra.CheckErr(fs.MarkHidden(utils.PageFolderFN))
 
 		fs.StringSliceVar(
 			&pages,
 			utils.PagesFN, nil,
 			"Restore site pages by file name(s)")
+		cobra.CheckErr(fs.MarkHidden(utils.PagesFN))
 
 		// sharepoint info flags
 

--- a/src/cli/restore/sharepoint.go
+++ b/src/cli/restore/sharepoint.go
@@ -31,7 +31,7 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 
 	switch cmd.Use {
 	case restoreCommand:
-		c, fs = utils.AddCommand(cmd, sharePointRestoreCmd(), utils.MarkPreReleaseCommand())
+		c, fs = utils.AddCommand(cmd, sharePointRestoreCmd())
 
 		c.Use = c.Use + " " + sharePointServiceCommandUseSuffix
 

--- a/src/internal/observe/display.go
+++ b/src/internal/observe/display.go
@@ -1,0 +1,7 @@
+package observe
+
+// Display holds display-only configuration.  Primarily for passing along
+// aliased values when we have a pair of more-and-less user friendly
+type Display struct {
+	ResourceOwner string
+}


### PR DESCRIPTION
Unhide sharepoint CLI commands, and do not
mark them as pre-release.  Hides the --data flag
since we only currently support libraries.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #2757

#### Test Plan

- [x] :zap: Unit test
