### PR TITLE
ShortRef uniqueness fixup

### DIFF
--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -313,7 +313,19 @@ func (d *Details) add(
 			filename = info.SharePoint.ItemName
 		}
 
-		entry.ShortRef = p.ToBuilder().Append(filename).ShortRef()
+		// Make the new path be all of the display names and then the M365 item ID.
+		// This ensures the path will be unique, thus ensuring the ShortRef will be
+		// unique.
+		//
+		// If we just appended the file display name to the path then it's possible
+		// the user could have a folder in the parent directory with a display name
+		// equal to the M365 ID of this file and have a file in the folder with a
+		// display name the same as this file's. That would cause a ShortRef
+		// collision because the generated paths for the file in the theoretical
+		// folder and this item would be the same.
+		elements := p.Elements()
+		elements = append(append(elements[:len(elements)-1], filename), p.Item())
+		entry.ShortRef = path.Builder{}.Append(elements...).ShortRef()
 	}
 
 	d.Entries = append(d.Entries, entry)

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -313,18 +313,17 @@ func (d *Details) add(
 			filename = info.SharePoint.ItemName
 		}
 
-		// Make the new path be all of the display names and then the M365 item ID.
+		// Make the new path contain all display names and then the M365 item ID.
 		// This ensures the path will be unique, thus ensuring the ShortRef will be
 		// unique.
 		//
-		// If we just appended the file display name to the path then it's possible
-		// the user could have a folder in the parent directory with a display name
-		// equal to the M365 ID of this file and have a file in the folder with a
-		// display name the same as this file's. That would cause a ShortRef
-		// collision because the generated paths for the file in the theoretical
-		// folder and this item would be the same.
+		// If we appended the file's display name to the path then it's possible
+		// for a folder in the parent directory to have the same display name as the
+		// M365 ID of this file and also have a subfolder in the folder with a
+		// display name that matches the file's display name. That would result in
+		// duplicate ShortRefs, which we can't allow.
 		elements := p.Elements()
-		elements = append(append(elements[:len(elements)-1], filename), p.Item())
+		elements = append(elements[:len(elements)-1], filename, p.Item())
 		entry.ShortRef = path.Builder{}.Append(elements...).ShortRef()
 	}
 

--- a/src/pkg/backup/details/details_test.go
+++ b/src/pkg/backup/details/details_test.go
@@ -407,6 +407,21 @@ func (suite *DetailsUnitSuite) TestDetails_Add_ShortRefs() {
 			expectedUniqueRefs: len(itemNames),
 		},
 		{
+			name:     "SharePoint List",
+			service:  path.SharePointService,
+			category: path.ListsCategory,
+			itemInfoFunc: func(name string) ItemInfo {
+				return ItemInfo{
+					SharePoint: &SharePointInfo{
+						ItemType: SharePointList,
+						ItemName: name,
+					},
+				}
+			},
+			// Should all end up as the starting shortref.
+			expectedUniqueRefs: 1,
+		},
+		{
 			name:     "Exchange no change",
 			service:  path.ExchangeService,
 			category: path.EmailCategory,

--- a/src/pkg/backup/details/details_test.go
+++ b/src/pkg/backup/details/details_test.go
@@ -525,14 +525,14 @@ func (suite *DetailsUnitSuite) TestDetails_Add_ShortRefs_Unique_From_Folder() {
 		},
 	)
 
-	require.NoError(t, b.Add(
+	err := b.Add(
 		itemPath.String(),
 		"deadbeef",
 		itemPath.ToBuilder().Dir().String(),
 		itemPath.String(),
 		false,
-		info,
-	))
+		info)
+	require.NoError(t, err)
 
 	items := b.Details().Items()
 	require.Len(t, items, 1)

--- a/src/pkg/backup/details/details_test.go
+++ b/src/pkg/backup/details/details_test.go
@@ -484,6 +484,64 @@ func (suite *DetailsUnitSuite) TestDetails_Add_ShortRefs() {
 	}
 }
 
+func (suite *DetailsUnitSuite) TestDetails_Add_ShortRefs_Unique_From_Folder() {
+	t := suite.T()
+
+	b := Builder{}
+	name := "itemName"
+	info := ItemInfo{
+		OneDrive: &OneDriveInfo{
+			ItemType: OneDriveItem,
+			ItemName: name,
+		},
+	}
+
+	itemPath := makeItemPath(
+		t,
+		path.OneDriveService,
+		path.FilesCategory,
+		"a-tenant",
+		"a-user",
+		[]string{
+			"drive-id",
+			"root:",
+			"folder",
+			name + "-id",
+		},
+	)
+
+	otherItemPath := makeItemPath(
+		t,
+		path.OneDriveService,
+		path.FilesCategory,
+		"a-tenant",
+		"a-user",
+		[]string{
+			"drive-id",
+			"root:",
+			"folder",
+			name + "-id",
+			name,
+		},
+	)
+
+	require.NoError(t, b.Add(
+		itemPath.String(),
+		"deadbeef",
+		itemPath.ToBuilder().Dir().String(),
+		itemPath.String(),
+		false,
+		info,
+	))
+
+	items := b.Details().Items()
+	require.Len(t, items, 1)
+
+	// If the ShortRefs match then it means it's possible for the user to
+	// construct folder names such that they'll generate a ShortRef collision.
+	assert.NotEqual(t, otherItemPath.ShortRef(), items[0].ShortRef, "same ShortRef as subfolder item")
+}
+
 func (suite *DetailsUnitSuite) TestDetails_AddFolders() {
 	itemTime := time.Date(2022, 10, 21, 10, 0, 0, 0, time.UTC)
 	folderTimeOlderThanItem := time.Date(2022, 9, 21, 10, 0, 0, 0, time.UTC)


### PR DESCRIPTION
Ensure OneDrive/SharePoint ShortRefs are unique
after munging by generating with
displayName/kopiaFileName instead of the other
way around. Doing it this way allows us to
piggyback on OneDrive's requirement that all
files and subfolders in a given folder must be
unique

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #1535

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
