### PR TITLE
store errcore in fault.Errors() alongside items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Sharepoint library (document files) support: backup, list, details, and restore.
 - OneDrive item downloads that return 404 during backup (normally due to external deletion while Corso processes) are now skipped instead of quietly dropped.  These items will appear in the skipped list alongside other skipped cases such as malware detection.
-- Listing a single backup by id will also list the skipped and failed items that occurred during the backup.  These can be filtered out with the flags `--failed-items hide` and `--skipped-items hide`.
+- Listing a single backup by id will also list the skipped and failed items that occurred during the backup.  These can be filtered out with the flags `--failed-items hide`, `--skipped-items hide`, and `--recovered-errors hide`.
 
 ### Fixed
 - Fix repo connect not working without a config file

--- a/src/cli/backup/backup.go
+++ b/src/cli/backup/backup.go
@@ -66,10 +66,12 @@ var (
 
 // list output filter flags
 var (
-	failedItemsFN    = "failed-items"
-	listFailedItems  string
-	skippedItemsFN   = "skipped-items"
-	listSkippedItems string
+	failedItemsFN       = "failed-items"
+	listFailedItems     string
+	skippedItemsFN      = "skipped-items"
+	listSkippedItems    string
+	recoveredErrorsFN   = "recovered-errors"
+	listRecoveredErrors string
 )
 
 func addFailedItemsFN(cmd *cobra.Command) {
@@ -82,6 +84,12 @@ func addSkippedItemsFN(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
 		&listSkippedItems, skippedItemsFN, "show",
 		"Toggles showing or hiding the list of items that were skipped.")
+}
+
+func addRecoveredErrorsFN(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&listRecoveredErrors, recoveredErrorsFN, "show",
+		"Toggles showing or hiding the list of errors which corso recovered from.")
 }
 
 // ---------------------------------------------------------------------------
@@ -288,7 +296,7 @@ func genericListCommand(cmd *cobra.Command, bID string, service path.ServiceType
 		}
 
 		b.Print(ctx)
-		fe.PrintItems(ctx, listFailedItems != "show", listSkippedItems != "show")
+		fe.PrintItems(ctx, listFailedItems != "show", listSkippedItems != "show", listRecoveredErrors != "show")
 
 		return nil
 	}

--- a/src/cli/backup/backup.go
+++ b/src/cli/backup/backup.go
@@ -2,6 +2,7 @@ package backup
 
 import (
 	"context"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 
@@ -296,7 +297,7 @@ func genericListCommand(cmd *cobra.Command, bID string, service path.ServiceType
 		}
 
 		b.Print(ctx)
-		fe.PrintItems(ctx, listFailedItems != "show", listSkippedItems != "show", listRecoveredErrors != "show")
+		fe.PrintItems(ctx, !ifShow(listFailedItems), !ifShow(listSkippedItems), !ifShow(listRecoveredErrors))
 
 		return nil
 	}
@@ -323,4 +324,8 @@ func getAccountAndConnect(ctx context.Context) (repository.Repository, *account.
 	}
 
 	return r, &cfg.Account, nil
+}
+
+func ifShow(flag string) bool {
+	return strings.ToLower(strings.TrimSpace(flag)) == "show"
 }

--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -128,6 +128,7 @@ func addExchangeCommands(cmd *cobra.Command) *cobra.Command {
 
 		addFailedItemsFN(c)
 		addSkippedItemsFN(c)
+		addRecoveredErrorsFN(c)
 
 	case detailsCommand:
 		c, fs = utils.AddCommand(cmd, exchangeDetailsCmd())

--- a/src/cli/backup/onedrive.go
+++ b/src/cli/backup/onedrive.go
@@ -85,6 +85,7 @@ func addOneDriveCommands(cmd *cobra.Command) *cobra.Command {
 
 		addFailedItemsFN(c)
 		addSkippedItemsFN(c)
+		addRecoveredErrorsFN(c)
 
 	case detailsCommand:
 		c, fs = utils.AddCommand(cmd, oneDriveDetailsCmd())

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -110,6 +110,7 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 
 		addFailedItemsFN(c)
 		addSkippedItemsFN(c)
+		addRecoveredErrorsFN(c)
 
 	case detailsCommand:
 		c, fs = utils.AddCommand(cmd, sharePointDetailsCmd())

--- a/src/cli/backup/sharepoint_e2e_test.go
+++ b/src/cli/backup/sharepoint_e2e_test.go
@@ -195,8 +195,8 @@ func (suite *BackupDeleteSharePointE2ESuite) TestSharePointBackupDeleteCmd() {
 	require.NoError(t, err, clues.ToCore(err))
 
 	result := suite.recorder.String()
-
-	assert.Equal(t, fmt.Sprintf("Deleted SharePoint backup %s\n", string(suite.backupOp.Results.BackupID)), result)
+	expect := fmt.Sprintf("Deleted SharePoint backup %s\n", string(suite.backupOp.Results.BackupID))
+	assert.Equal(t, expect, result)
 }
 
 // moved out of the func above to make the linter happy

--- a/src/cmd/purge/purge.go
+++ b/src/cmd/purge/purge.go
@@ -145,7 +145,8 @@ func runPurgeForEachUser(
 	}
 
 	if len(ferrs.Errors().Recovered) > 0 {
-		errs = multierror.Append(errs, ferrs.Errors().Recovered...)
+		// TODO(keepers): remove multierr
+		errs = multierror.Append(errs, ferrs.Recovered()...)
 	}
 
 	for _, u := range userOrUsers(user, users) {

--- a/src/go.mod
+++ b/src/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.2.0
 	github.com/alcionai/clues v0.0.0-20230314154528-c469e1adafb6
-	github.com/aws/aws-sdk-go v1.44.218
+	github.com/aws/aws-sdk-go v1.44.220
 	github.com/aws/aws-xray-sdk-go v1.8.1
 	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/google/uuid v1.3.0

--- a/src/go.sum
+++ b/src/go.sum
@@ -62,8 +62,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
-github.com/aws/aws-sdk-go v1.44.218 h1:p707+xOCazWhkSpZOeyhtTcg7Z+asxxvueGgYPSitn4=
-github.com/aws/aws-sdk-go v1.44.218/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+github.com/aws/aws-sdk-go v1.44.220 h1:yAj99qAt0Htjle9Up3DglgHfOP77lmFPrElA4jKnrBo=
+github.com/aws/aws-sdk-go v1.44.220/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-xray-sdk-go v1.8.1 h1:O4pXV+hnCskaamGsZnFpzHyAmgPGusBMN6i7nnsy0Fo=
 github.com/aws/aws-xray-sdk-go v1.8.1/go.mod h1:wMmVYzej3sykAttNBkXQHK/+clAPWTOrPiajEk7Cp3A=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=

--- a/src/internal/connector/discovery/discovery_test.go
+++ b/src/internal/connector/discovery/discovery_test.go
@@ -40,7 +40,7 @@ func (suite *DiscoveryIntegrationSuite) TestUsers() {
 	assert.NoError(t, err, clues.ToCore(err))
 
 	ferrs := errs.Errors()
-	assert.NoError(t, ferrs.Failure, clues.ToCore(ferrs.Failure))
+	assert.Nil(t, ferrs.Failure)
 	assert.Empty(t, ferrs.Recovered)
 
 	assert.Less(t, 0, len(users))

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -457,9 +457,8 @@ func (w Wrapper) DeleteSnapshot(
 	snapshotID string,
 ) error {
 	mid := manifest.ID(snapshotID)
-
 	if len(mid) == 0 {
-		return clues.New("attempt to delete unidentified snapshot").WithClues(ctx)
+		return clues.New("snapshot ID required for deletion").WithClues(ctx)
 	}
 
 	err := repo.WriteSession(

--- a/src/internal/streamstore/collectables_test.go
+++ b/src/internal/streamstore/collectables_test.go
@@ -100,7 +100,7 @@ func (suite *StreamStoreIntgSuite) TestStreamer() {
 				bus.AddSkip(fault.FileSkip(fault.SkipMalware, "file-id", "file-name", map[string]any{"foo": "bar"}))
 
 				fe := bus.Errors()
-				return &fe
+				return fe
 			},
 		},
 		{
@@ -124,7 +124,7 @@ func (suite *StreamStoreIntgSuite) TestStreamer() {
 				bus.AddSkip(fault.FileSkip(fault.SkipMalware, "file-id", "file-name", map[string]any{"foo": "bar"}))
 
 				fe := bus.Errors()
-				return &fe
+				return fe
 			},
 		},
 	}

--- a/src/pkg/backup/backup.go
+++ b/src/pkg/backup/backup.go
@@ -74,7 +74,7 @@ func New(
 	)
 
 	if ee.Failure != nil {
-		failMsg = ee.Failure.Error()
+		failMsg = ee.Failure.Msg
 		errCount++
 	}
 

--- a/src/pkg/fault/fault.go
+++ b/src/pkg/fault/fault.go
@@ -7,10 +7,10 @@ import (
 	"io"
 	"sync"
 
+	"github.com/alcionai/clues"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 
-	"github.com/alcionai/clues"
 	"github.com/alcionai/corso/src/cli/print"
 )
 

--- a/src/pkg/fault/fault.go
+++ b/src/pkg/fault/fault.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 
+	"github.com/alcionai/clues"
 	"github.com/alcionai/corso/src/cli/print"
 )
 
@@ -169,10 +170,12 @@ func (e *Bus) addSkip(s *Skipped) *Bus {
 // Errors returns the plain record of errors that were aggregated
 // within a fult Bus.
 func (e *Bus) Errors() Errors {
+	items, nonItems := itemsIn(e.failure, e.recoverable)
+
 	return Errors{
-		Failure:   e.failure,
-		Recovered: slices.Clone(e.recoverable),
-		Items:     itemsIn(e.failure, e.recoverable),
+		Failure:   clues.ToCore(e.failure),
+		Recovered: nonItems,
+		Items:     items,
 		Skipped:   slices.Clone(e.skipped),
 		FailFast:  e.failFast,
 	}
@@ -190,16 +193,14 @@ type Errors struct {
 	// non-start cases (ex: cannot connect to client), hard-
 	// stop issues (ex: credentials expired) or conscious exit
 	// cases (ex: iteration error + failFast config).
-	Failure error `json:"failure"`
+	Failure *clues.ErrCore `json:"failure"`
 
-	// Recovered errors accumulate through a runtime under
-	// best-effort processing conditions.  They imply that an
-	// error occurred, but the process was able to move on and
-	// complete afterwards.
-	// Eg: if a process is retrieving N items, and 1 of the
-	// items fails to be retrieved, but the rest of them succeed,
-	// we'd expect to see 1 error added to this slice.
-	Recovered []error `json:"-"`
+	// Recovered is the set of NON-Item errors that accumulated
+	// through a runtime under best-effort processing conditions.
+	// They imply that an error occurred, but the process was able
+	// to move on and complete afterwards.  Any error that can be
+	// serialized to a fault.Item is found in the Items set instead.
+	Recovered []*clues.ErrCore `json:"recovered"`
 
 	// Items are the reduction of all errors (both the failure and the
 	// recovered values) in the Errors struct into a slice of items,
@@ -217,14 +218,19 @@ type Errors struct {
 }
 
 // itemsIn reduces all errors (both the failure and recovered values)
-// in the Errors struct into a slice of items, deduplicated by their
-// ID.
-func itemsIn(failure error, recovered []error) []Item {
-	is := map[string]Item{}
+// in the Errors struct into a slice of items, deduplicated by their ID.
+// Any non-item error is serialized to a clues.ErrCore and returned in
+// the second list.
+func itemsIn(failure error, recovered []error) ([]Item, []*clues.ErrCore) {
+	var (
+		is  = map[string]Item{}
+		non = []*clues.ErrCore{}
+	)
 
 	for _, err := range recovered {
 		var ie *Item
 		if !errors.As(err, &ie) {
+			non = append(non, clues.ToCore(err))
 			continue
 		}
 
@@ -236,7 +242,7 @@ func itemsIn(failure error, recovered []error) []Item {
 		is[ie.ID] = *ie
 	}
 
-	return maps.Values(is)
+	return maps.Values(is), non
 }
 
 // Marshal runs json.Marshal on the errors.
@@ -254,8 +260,9 @@ func UnmarshalErrorsTo(e *Errors) func(io.ReadCloser) error {
 
 // Print writes the DetailModel Entries to StdOut, in the format
 // requested by the caller.
-func (e Errors) PrintItems(ctx context.Context, ignoreErrors, ignoreSkips bool) {
-	if len(e.Items)+len(e.Skipped) == 0 || ignoreErrors && ignoreSkips {
+func (e Errors) PrintItems(ctx context.Context, ignoreErrors, ignoreSkips, ignoreRecovered bool) {
+	if len(e.Items)+len(e.Skipped)+len(e.Recovered) == 0 ||
+		ignoreErrors && ignoreSkips && ignoreRecovered {
 		return
 	}
 
@@ -273,7 +280,40 @@ func (e Errors) PrintItems(ctx context.Context, ignoreErrors, ignoreSkips bool) 
 		}
 	}
 
+	if !ignoreRecovered {
+		for _, rcv := range e.Recovered {
+			pec := errCoreToPrintable(rcv)
+			sl = append(sl, print.Printable(&pec))
+		}
+	}
+
 	print.All(ctx, sl...)
+}
+
+var _ print.Printable = &printableErrCore{}
+
+type printableErrCore struct {
+	msg string
+}
+
+func errCoreToPrintable(ec *clues.ErrCore) printableErrCore {
+	if ec == nil {
+		return printableErrCore{"<nil>"}
+	}
+
+	return printableErrCore{ec.Msg}
+}
+
+func (pec printableErrCore) MinimumPrintable() any {
+	return pec
+}
+
+func (pec printableErrCore) Headers() []string {
+	return []string{"Error"}
+}
+
+func (pec printableErrCore) Values() []string {
+	return []string{pec.msg}
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/fault/fault.go
+++ b/src/pkg/fault/fault.go
@@ -169,10 +169,10 @@ func (e *Bus) addSkip(s *Skipped) *Bus {
 
 // Errors returns the plain record of errors that were aggregated
 // within a fult Bus.
-func (e *Bus) Errors() Errors {
+func (e *Bus) Errors() *Errors {
 	items, nonItems := itemsIn(e.failure, e.recoverable)
 
-	return Errors{
+	return &Errors{
 		Failure:   clues.ToCore(e.failure),
 		Recovered: nonItems,
 		Items:     items,
@@ -246,8 +246,9 @@ func itemsIn(failure error, recovered []error) ([]Item, []*clues.ErrCore) {
 }
 
 // Marshal runs json.Marshal on the errors.
-func (e Errors) Marshal() ([]byte, error) {
-	return json.Marshal(e)
+func (e *Errors) Marshal() ([]byte, error) {
+	bs, err := json.Marshal(e)
+	return bs, err
 }
 
 // UnmarshalErrorsTo produces a func that complies with the unmarshaller
@@ -260,7 +261,7 @@ func UnmarshalErrorsTo(e *Errors) func(io.ReadCloser) error {
 
 // Print writes the DetailModel Entries to StdOut, in the format
 // requested by the caller.
-func (e Errors) PrintItems(ctx context.Context, ignoreErrors, ignoreSkips, ignoreRecovered bool) {
+func (e *Errors) PrintItems(ctx context.Context, ignoreErrors, ignoreSkips, ignoreRecovered bool) {
 	if len(e.Items)+len(e.Skipped)+len(e.Recovered) == 0 ||
 		ignoreErrors && ignoreSkips && ignoreRecovered {
 		return

--- a/src/pkg/fault/fault_test.go
+++ b/src/pkg/fault/fault_test.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/alcionai/clues"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/alcionai/clues"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/fault"
 )

--- a/src/pkg/fault/fault_test.go
+++ b/src/pkg/fault/fault_test.go
@@ -211,8 +211,8 @@ func (suite *FaultErrorsUnitSuite) TestErrors() {
 	n.AddRecoverable(errors.New("2"))
 
 	d := n.Errors()
-	assert.Equal(t, n.Failure(), d.Failure)
-	assert.ElementsMatch(t, n.Recovered(), d.Recovered)
+	assert.Equal(t, clues.ToCore(n.Failure()), d.Failure)
+	assert.Len(t, d.Recovered, len(n.Recovered()))
 	assert.False(t, d.FailFast)
 
 	// fail-fast
@@ -224,25 +224,25 @@ func (suite *FaultErrorsUnitSuite) TestErrors() {
 	n.AddRecoverable(errors.New("2"))
 
 	d = n.Errors()
-	assert.Equal(t, n.Failure(), d.Failure)
-	assert.ElementsMatch(t, n.Recovered(), d.Recovered)
+	assert.Equal(t, clues.ToCore(n.Failure()), d.Failure)
+	assert.Len(t, d.Recovered, len(n.Recovered()))
 	assert.True(t, d.FailFast)
 }
 
 func (suite *FaultErrorsUnitSuite) TestErrors_Items() {
 	ae := clues.Stack(assert.AnError)
-	noncore := []*clues.ErrCore{clues.ToCore(ae)}
+	noncore := []*clues.ErrCore{ae.Core()}
 	addtl := map[string]any{"foo": "bar", "baz": 1}
 
 	table := []struct {
 		name              string
-		errs              func() fault.Errors
+		errs              func() *fault.Errors
 		expectItems       []fault.Item
 		expectRecoverable []*clues.ErrCore
 	}{
 		{
 			name: "no errors",
-			errs: func() fault.Errors {
+			errs: func() *fault.Errors {
 				return fault.New(false).Errors()
 			},
 			expectItems:       []fault.Item{},
@@ -250,7 +250,7 @@ func (suite *FaultErrorsUnitSuite) TestErrors_Items() {
 		},
 		{
 			name: "no items",
-			errs: func() fault.Errors {
+			errs: func() *fault.Errors {
 				b := fault.New(false)
 				b.Fail(ae)
 				b.AddRecoverable(ae)
@@ -262,7 +262,7 @@ func (suite *FaultErrorsUnitSuite) TestErrors_Items() {
 		},
 		{
 			name: "failure item",
-			errs: func() fault.Errors {
+			errs: func() *fault.Errors {
 				b := fault.New(false)
 				b.Fail(fault.OwnerErr(ae, "id", "name", addtl))
 				b.AddRecoverable(ae)
@@ -274,7 +274,7 @@ func (suite *FaultErrorsUnitSuite) TestErrors_Items() {
 		},
 		{
 			name: "recoverable item",
-			errs: func() fault.Errors {
+			errs: func() *fault.Errors {
 				b := fault.New(false)
 				b.Fail(ae)
 				b.AddRecoverable(fault.OwnerErr(ae, "id", "name", addtl))
@@ -286,7 +286,7 @@ func (suite *FaultErrorsUnitSuite) TestErrors_Items() {
 		},
 		{
 			name: "two items",
-			errs: func() fault.Errors {
+			errs: func() *fault.Errors {
 				b := fault.New(false)
 				b.Fail(fault.OwnerErr(ae, "oid", "name", addtl))
 				b.AddRecoverable(fault.FileErr(ae, "fid", "name", addtl))
@@ -301,7 +301,7 @@ func (suite *FaultErrorsUnitSuite) TestErrors_Items() {
 		},
 		{
 			name: "duplicate items - failure priority",
-			errs: func() fault.Errors {
+			errs: func() *fault.Errors {
 				b := fault.New(false)
 				b.Fail(fault.OwnerErr(ae, "id", "name", addtl))
 				b.AddRecoverable(fault.FileErr(ae, "id", "name", addtl))
@@ -315,7 +315,7 @@ func (suite *FaultErrorsUnitSuite) TestErrors_Items() {
 		},
 		{
 			name: "duplicate items - last recoverable priority",
-			errs: func() fault.Errors {
+			errs: func() *fault.Errors {
 				b := fault.New(false)
 				b.Fail(ae)
 				b.AddRecoverable(fault.FileErr(ae, "fid", "name", addtl))
@@ -330,7 +330,7 @@ func (suite *FaultErrorsUnitSuite) TestErrors_Items() {
 		},
 		{
 			name: "recoverable item and non-items",
-			errs: func() fault.Errors {
+			errs: func() *fault.Errors {
 				b := fault.New(false)
 				b.Fail(ae)
 				b.AddRecoverable(fault.FileErr(ae, "fid", "name", addtl))

--- a/src/pkg/fault/testdata/testdata.go
+++ b/src/pkg/fault/testdata/testdata.go
@@ -11,11 +11,11 @@ func MakeErrors(failure, recovered, skipped bool) fault.Errors {
 	fe := fault.Errors{}
 
 	if failure {
-		fe.Failure = assert.AnError
+		fe.Failure = clues.Wrap(assert.AnError, "wrapped").Core()
 	}
 
 	if recovered {
-		fe.Recovered = []error{clues.New("recoverable")}
+		fe.Recovered = []*clues.ErrCore{clues.New("recoverable").Core()}
 	}
 
 	if skipped {

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -481,8 +481,16 @@ func (r repository) DeleteBackup(ctx context.Context, id model.StableID) error {
 		return err
 	}
 
-	if err := r.dataLayer.DeleteSnapshot(ctx, bu.DetailsID); err != nil {
-		return err
+	if len(bu.SnapshotID) > 0 {
+		if err := r.dataLayer.DeleteSnapshot(ctx, bu.SnapshotID); err != nil {
+			return err
+		}
+	}
+
+	if len(bu.DetailsID) > 0 {
+		if err := r.dataLayer.DeleteSnapshot(ctx, bu.DetailsID); err != nil {
+			return err
+		}
 	}
 
 	sw := store.NewKopiaStore(r.modelStore)

--- a/src/pkg/repository/repository_unexported_test.go
+++ b/src/pkg/repository/repository_unexported_test.go
@@ -236,7 +236,7 @@ func (suite *RepositoryModelIntgSuite) TestGetBackupErrors() {
 	)
 
 	err := clues.Wrap(assert.AnError, "wrap")
-
+	cec := clues.ToCore(clues.Stack(assert.AnError))
 	info := details.ItemInfo{
 		Folder: &details.FolderInfo{
 			DisplayName: "test",


### PR DESCRIPTION
Now that we're persisting the failed and skipped
items, we're slicing out the other errors that
were generated during an operation.  This change
persists those non-item errors within the fault
Errors struct, so that they can be serialized
and retrieved like the other values.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #2708

#### Test Plan

- [x] :muscle: Manual
- [x] :green_heart: E2E
