### PR TITLE
Script to set retention for all mailboxes in a tenant

### DIFF
--- a/src/cmd/purge/scripts/setRetention.ps1
+++ b/src/cmd/purge/scripts/setRetention.ps1
@@ -11,12 +11,8 @@ Param (
 )
 
 # Setup ExchangeOnline
-if (-not (Get-Module -ListAvailable -Name PSWSMan)) {
-    Install-Module -Name PSWSMan -Force
-}
-
 if (-not (Get-Module -ListAvailable -Name ExchangeOnlineManagement)) {
-    Install-Module -Name ExchangeOnlineManagement -Force
+    Install-Module -Name ExchangeOnlineManagement -MinimumVersion 3.0.0 -Force
 }
 
 $password = convertto-securestring -String "$AdminPwd" -AsPlainText -Force

--- a/src/cmd/purge/scripts/setRetention.ps1
+++ b/src/cmd/purge/scripts/setRetention.ps1
@@ -11,8 +11,13 @@ Param (
 )
 
 # Setup ExchangeOnline
-Install-Module -Name PSWSMan -Force
-Install-Module -Name ExchangeOnlineManagement -Force
+if (-not (Get-Module -ListAvailable -Name PSWSMan)) {
+    Install-Module -Name PSWSMan -Force
+}
+
+if (-not (Get-Module -ListAvailable -Name ExchangeOnlineManagement)) {
+    Install-Module -Name ExchangeOnlineManagement -Force
+}
 
 $password = convertto-securestring -String "$AdminPwd" -AsPlainText -Force
 $cred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $AdminUser, $password

--- a/src/cmd/purge/scripts/setRetention.ps1
+++ b/src/cmd/purge/scripts/setRetention.ps1
@@ -1,0 +1,23 @@
+# This is tested on Mac as well as Docker (with m365pnp/powershell image)
+# To run in Docker with the script in the current working diredctory 
+# docker run --rm -it -v "$(pwd):/usr/reset-retnention" -e M365TENANT_ADMIN_USER -e M365TENANT_ADMIN_PASSWORD \
+#                     -w /usr/reset-retnention m365pnp/powershell pwsh -c "./setRetention.ps1"
+Param (
+    [Parameter(Mandatory = $False, HelpMessage = "Exchange Admin email")]
+    [String]$AdminUser = $ENV:M365TENANT_ADMIN_USER,
+
+    [Parameter(Mandatory = $False, HelpMessage = "Exchange Admin password")]
+    [String]$AdminPwd = $ENV:M365TENANT_ADMIN_PASSWORD
+)
+
+# Setup ExchangeOnline
+Install-Module -Name PSWSMan -Force
+Install-Module -Name ExchangeOnlineManagement -Force
+
+$password = convertto-securestring -String "$AdminPwd" -AsPlainText -Force
+$cred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $AdminUser, $password
+Connect-ExchangeOnline -Credential $cred
+
+# Set retention values for all mailboxes 
+Get-Mailbox | ForEach-Object { Set-Mailbox -Identity $_.Alias -RetentionHoldEnabled $false  -LitigationHoldEnabled $false -SingleItemRecoveryEnabled $false -RetainDeletedItemsFor 0 -AuditLogAgeLimit 0 -Force }
+Get-Mailbox | ForEach-Object { Start-ManagedFolderAssistant -Identity $_.Alias }

--- a/src/cmd/purge/scripts/setRetention.ps1
+++ b/src/cmd/purge/scripts/setRetention.ps1
@@ -15,10 +15,12 @@ if (-not (Get-Module -ListAvailable -Name ExchangeOnlineManagement)) {
     Install-Module -Name ExchangeOnlineManagement -MinimumVersion 3.0.0 -Force
 }
 
+Write-Host "Connecting to Exchange..."
 $password = convertto-securestring -String "$AdminPwd" -AsPlainText -Force
 $cred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $AdminUser, $password
 Connect-ExchangeOnline -Credential $cred
 
+Write-Host "Resetting retention..."
 # Set retention values for all mailboxes 
 Get-Mailbox | ForEach-Object { Set-Mailbox -Identity $_.Alias -RetentionHoldEnabled $false  -LitigationHoldEnabled $false -SingleItemRecoveryEnabled $false -RetainDeletedItemsFor 0 -AuditLogAgeLimit 0 -Force }
 Get-Mailbox | ForEach-Object { Start-ManagedFolderAssistant -Identity $_.Alias }


### PR DESCRIPTION
The script requires authenticating with Exchange admin user name and password and will set retention to 0 for all tenant mailboxes. This helps with CI cleanup of test data

The script can be integrated with some low frequency invocation with the CI pipeline to make sure the retention is properly set. Would require setting the credentials as Git secrets

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [x] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)


#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
