### PR TITLE
Do not query repo ID if metrics are disabled

### DIFF
--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -209,12 +209,17 @@ func Connect(
 		return nil, errors.Wrap(err, "constructing event bus")
 	}
 
-	rm, err := getRepoModel(ctx, ms)
-	if err != nil {
-		return nil, errors.New("retrieving repo info")
-	}
+	rm := &repositoryModel{}
 
-	bus.SetRepoID(string(rm.ID))
+	// Do not query repo ID if metrics are disabled
+	if !opts.DisableMetrics {
+		rm, err = getRepoModel(ctx, ms)
+		if err != nil {
+			return nil, errors.New("retrieving repo info")
+		}
+
+		bus.SetRepoID(string(rm.ID))
+	}
 
 	complete <- struct{}{}
 

--- a/src/pkg/repository/repository_test.go
+++ b/src/pkg/repository/repository_test.go
@@ -219,3 +219,22 @@ func (suite *RepositoryIntegrationSuite) TestNewRestore() {
 	require.NoError(t, err)
 	require.NotNil(t, ro)
 }
+
+func (suite *RepositoryIntegrationSuite) TestConnect_DisableMetrics() {
+	ctx, flush := tester.NewContext()
+	defer flush()
+
+	t := suite.T()
+
+	// need to initialize the repository before we can test connecting to it.
+	st := tester.NewPrefixedS3Storage(t)
+
+	_, err := repository.Initialize(ctx, account.Account{}, st, control.Options{})
+	require.NoError(t, err)
+
+	// now re-connect
+	r, err := repository.Connect(ctx, account.Account{}, st, control.Options{DisableMetrics: true})
+	assert.NoError(t, err)
+
+	assert.Equal(t, "", r.GetID())
+}


### PR DESCRIPTION
This skips the call to `getRepoModel` if metrics are disabled and the repository ID is not required.

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #2802 

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
