### PR TITLE
Remove Start-ManagedFolderAssistant call from setRetention.ps1

### DIFF
--- a/src/cmd/purge/scripts/setRetention.ps1
+++ b/src/cmd/purge/scripts/setRetention.ps1
@@ -23,4 +23,3 @@ Connect-ExchangeOnline -Credential $cred
 Write-Host "Resetting retention..."
 # Set retention values for all mailboxes 
 Get-Mailbox | ForEach-Object { Set-Mailbox -Identity $_.Alias -RetentionHoldEnabled $false  -LitigationHoldEnabled $false -SingleItemRecoveryEnabled $false -RetainDeletedItemsFor 0 -AuditLogAgeLimit 0 -Force }
-Get-Mailbox | ForEach-Object { Start-ManagedFolderAssistant -Identity $_.Alias }


### PR DESCRIPTION
Seems that Start-ManagedFolderAssistant is not supported on all domains. The setting did not seem to work anyway
---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
