### PR TITLE
Populate location for all Exchange data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable compression for all data uploaded by kopia.
 - SharePoint --folder selectors correctly return items.
 - Fix Exchange cli args for filtering items
-- Skip huge OneNote items that Graph API prevents us from downloading
 - Skip OneNote items bigger than 2GB (Graph API prevents us from downloading them)
+- ParentPath of json output for Exchange calendar now shows names instead of IDs.
 
 ## [v0.6.1] (beta) - 2023-03-21
 

--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -83,7 +82,6 @@ type Collection struct {
 
 	// LocationPath contains the path with human-readable display names.
 	// IE: "/Inbox/Important" instead of "/abcdxyz123/algha=lgkhal=t"
-	// Currently only implemented for Exchange Calendars.
 	locationPath path.Path
 
 	state data.CollectionState
@@ -281,7 +279,7 @@ func (col *Collection) streamItems(ctx context.Context, errs *fault.Bus) {
 			}
 
 			info.Size = int64(len(data))
-			info.ParentPath = strings.Join(col.fullPath.Folders(), "/")
+			info.ParentPath = col.locationPath.Folder(true)
 
 			col.data <- &Stream{
 				id:      id,

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -115,7 +115,6 @@ func filterContainersAndFillCollections(
 			deltaURLs[cID] = newDelta.URL
 		}
 
-
 		edc := NewCollection(
 			qp.ResourceOwner,
 			currPath,

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -115,9 +115,6 @@ func filterContainersAndFillCollections(
 			deltaURLs[cID] = newDelta.URL
 		}
 
-		if qp.Category != path.EventsCategory {
-			locPath = nil
-		}
 
 		edc := NewCollection(
 			qp.ResourceOwner,


### PR DESCRIPTION
Always populate the location field of backup details
for Exchange data types

Fix bug where ParentPath for calendar items used
folder IDs instead of display names

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #2486
* closes #2827

merge after:
* #2826
* #2808
* #2828

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
