### PR TITLE
Backup owner and empty permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved permissions backup and restore for OneDrive
 
 ### Known Issues
-- Owner(Full control) or empty(Restricted View) roles cannot be restored for OneDrive
+- Owner (Full control) or empty (Restricted View) roles cannot be restored for OneDrive
 
 ## [v0.5.0] (beta) - 2023-03-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix repo connect not working without a config file
 - Fix item re-download on expired links silently being skipped
+- Improved permissions backup and restore for OneDrive
+
+### Known Issues
+- Owner(Full control) or empty(Restricted View) roles cannot be restored for OneDrive
 
 ## [v0.5.0] (beta) - 2023-03-13
 

--- a/src/internal/connector/graph_connector_helper_test.go
+++ b/src/internal/connector/graph_connector_helper_test.go
@@ -785,10 +785,19 @@ func compareOneDriveItem(
 			return true
 		}
 
+		// We cannot restore owner permissions, so skip checking them
+		itemPerms := []onedrive.UserPermission{}
+
+		for _, p := range itemMeta.Permissions {
+			if p.Roles[0] != "owner" {
+				itemPerms = append(itemPerms, p)
+			}
+		}
+
 		testElementsMatch(
 			t,
 			expectedMeta.Permissions,
-			itemMeta.Permissions,
+			itemPerms,
 			permissionEqual,
 		)
 

--- a/src/internal/connector/graph_connector_onedrive_test.go
+++ b/src/internal/connector/graph_connector_onedrive_test.go
@@ -150,6 +150,8 @@ var (
 	fileEData = []byte(strings.Repeat("e", 257))
 
 	writePerm = []string{"write"}
+	ownerPerm = []string{"owner"}
+	emptyPerm = []string{}
 	readPerm  = []string{"read"}
 )
 
@@ -556,6 +558,24 @@ func (suite *GraphConnectorOneDriveIntegrationSuite) TestPermissionsRestoreAndBa
 						// no permissions.
 						name: fileName2,
 						data: fileBData,
+					},
+					{
+						name: "test-file3.txt",
+						data: fileBData,
+						perms: permData{
+							user:     suite.secondaryUser,
+							entityID: suite.secondaryUserID,
+							roles:    ownerPerm,
+						},
+					},
+					{
+						name: "test-file4.txt",
+						data: fileBData,
+						perms: permData{
+							user:     suite.secondaryUser,
+							entityID: suite.secondaryUserID,
+							roles:    emptyPerm,
+						},
 					},
 				},
 				folders: []itemData{

--- a/src/internal/connector/graph_connector_onedrive_test.go
+++ b/src/internal/connector/graph_connector_onedrive_test.go
@@ -149,9 +149,8 @@ var (
 	fileDData = []byte(strings.Repeat("d", 257))
 	fileEData = []byte(strings.Repeat("e", 257))
 
+	// Cannot restore owner or empty permissions and so not testing them
 	writePerm = []string{"write"}
-	ownerPerm = []string{"owner"}
-	emptyPerm = []string{}
 	readPerm  = []string{"read"}
 )
 
@@ -558,24 +557,6 @@ func (suite *GraphConnectorOneDriveIntegrationSuite) TestPermissionsRestoreAndBa
 						// no permissions.
 						name: fileName2,
 						data: fileBData,
-					},
-					{
-						name: "test-file3.txt",
-						data: fileBData,
-						perms: permData{
-							user:     suite.secondaryUser,
-							entityID: suite.secondaryUserID,
-							roles:    ownerPerm,
-						},
-					},
-					{
-						name: "test-file4.txt",
-						data: fileBData,
-						perms: permData{
-							user:     suite.secondaryUser,
-							entityID: suite.secondaryUserID,
-							roles:    emptyPerm,
-						},
 					},
 				},
 				folders: []itemData{

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -256,18 +256,15 @@ func filterUserPermissions(ctx context.Context, perms []models.Permissionable) [
 		}
 
 		gv2 := p.GetGrantedToV2()
-		roles := []string{}
 
-		for _, r := range p.GetRoles() {
-			// Skip if the only role available in owner
-			if r != "owner" {
-				roles = append(roles, r)
-			}
-		}
-
-		if len(roles) == 0 {
-			continue
-		}
+		// Below are the mapping from roles to "Advanced" permissions
+		// screen entries:
+		//
+		// owner - Full Control
+		// write - Design | Edit | Contribute (no difference in /permissions api)
+		// read  - Read
+		// empty - Restricted View
+		roles := p.GetRoles()
 
 		entityID := ""
 		if gv2.GetUser() != nil {
@@ -275,7 +272,7 @@ func filterUserPermissions(ctx context.Context, perms []models.Permissionable) [
 		} else if gv2.GetGroup() != nil {
 			entityID = ptr.Val(gv2.GetGroup().GetId())
 		} else {
-			// TODO Add appliction permissions when adding permissions for SharePoint
+			// TODO Add application permissions when adding permissions for SharePoint
 			// https://devblogs.microsoft.com/microsoft365dev/controlling-app-access-on-specific-sharepoint-site-collections/
 			logm := logger.Ctx(ctx)
 			if gv2.GetApplication() != nil {

--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -291,6 +291,7 @@ func (suite *ItemUnitTestSuite) TestOneDrivePermissionsFilter() {
 	userID := "fakeuser@provider.com"
 	userID2 := "fakeuser2@provider.com"
 
+	userOwnerPerm, userOwnerUperm := getPermsUperms(permID, userID, "user", []string{"owner"})
 	userReadPerm, userReadUperm := getPermsUperms(permID, userID, "user", []string{"read"})
 	userReadWritePerm, userReadWriteUperm := getPermsUperms(permID, userID2, "user", []string{"read", "write"})
 
@@ -321,6 +322,11 @@ func (suite *ItemUnitTestSuite) TestOneDrivePermissionsFilter() {
 			name:              "user with read permissions",
 			graphPermissions:  []models.Permissionable{userReadPerm},
 			parsedPermissions: []UserPermission{userReadUperm},
+		},
+		{
+			name:              "user with owner permissions",
+			graphPermissions:  []models.Permissionable{userOwnerPerm},
+			parsedPermissions: []UserPermission{userOwnerUperm},
 		},
 		{
 			name:              "user with read and write permissions",

--- a/src/internal/connector/onedrive/permission.go
+++ b/src/internal/connector/onedrive/permission.go
@@ -209,7 +209,8 @@ func restorePermissions(
 		// We are not able to restore permissions when there are no
 		// roles or for owner, this seems to be restriction in graph
 		roles := []string{}
-		for _, r := range roles {
+
+		for _, r := range p.Roles {
 			if r != "owner" {
 				roles = append(roles, r)
 			}

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -183,7 +183,7 @@ func RestoreCollection(
 	restoreFolderID, err := createRestoreFoldersWithPermissions(
 		ctx,
 		service,
-		drivePath.DriveID,
+		drivePath,
 		restoreFolderElements,
 		colMeta,
 		permissionIDMappings,


### PR DESCRIPTION
Backup owner and empty permissions, we cannot restore them though (refer https://github.com/alcionai/corso/issues/2789#issuecomment-1471787829) . Previous we were just skipping even backing them up. It might be good idea to have this data in case we find that we are able to restore them in the future.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* closes https://github.com/alcionai/corso/issues/2789

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
