### PR TITLE
--web-url to --site

### DIFF
--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -34,20 +34,20 @@ const (
 
 const (
 	sharePointServiceCommand                 = "sharepoint"
-	sharePointServiceCommandCreateUseSuffix  = "--web-url <siteURL> | '" + utils.Wildcard + "'"
+	sharePointServiceCommandCreateUseSuffix  = "--site <siteURL> | '" + utils.Wildcard + "'"
 	sharePointServiceCommandDeleteUseSuffix  = "--backup <backupId>"
 	sharePointServiceCommandDetailsUseSuffix = "--backup <backupId>"
 )
 
 const (
 	sharePointServiceCommandCreateExamples = `# Backup SharePoint data for a Site
-corso backup create sharepoint --web-url <siteURL>
+corso backup create sharepoint --site <siteURL>
 
 # Backup SharePoint for two sites: HR and Team
-corso backup create sharepoint --web-url https://example.com/hr,https://example.com/team
+corso backup create sharepoint --site https://example.com/hr,https://example.com/team
 
 # Backup all SharePoint data for all Sites
-corso backup create sharepoint --web-url '*'`
+corso backup create sharepoint --site '*'`
 
 	sharePointServiceCommandDeleteExamples = `# Delete SharePoint backup with ID 1234abcd-12ab-cd34-56de-1234abcd
 corso backup delete sharepoint --backup 1234abcd-12ab-cd34-56de-1234abcd`
@@ -78,16 +78,8 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 
 		c.Use = c.Use + " " + sharePointServiceCommandCreateUseSuffix
 		c.Example = sharePointServiceCommandCreateExamples
-
-		fs.StringArrayVar(
-			&utils.Site,
-			utils.SiteFN, nil,
-			"Backup SharePoint data by site ID; accepts '"+utils.Wildcard+"' to select all sites.")
-
-		fs.StringSliceVar(
-			&utils.WebURL,
-			utils.WebURLFN, nil,
-			"Restore data by site web URL; accepts '"+utils.Wildcard+"' to select all sites.")
+		utils.AddSiteFlag(cmd)
+		utils.AddSiteIDFlag(cmd)
 
 		fs.StringSliceVar(
 			&sharepointData,
@@ -167,7 +159,7 @@ func createSharePointCmd(cmd *cobra.Command, args []string) error {
 
 	sel, err := sharePointBackupCreateSelectors(ctx, utils.Site, utils.WebURL, sharepointData, gc)
 	if err != nil {
-		return Only(ctx, errors.Wrap(err, "Retrieving up sharepoint sites by ID and Web URL"))
+		return Only(ctx, errors.Wrap(err, "Retrieving up sharepoint sites by ID and URL"))
 	}
 
 	selectorSet := []selectors.Selector{}
@@ -188,8 +180,7 @@ func validateSharePointBackupCreateFlags(sites, weburls, cats []string) error {
 	if len(sites) == 0 && len(weburls) == 0 {
 		return errors.New(
 			"requires one or more --" +
-				utils.SiteFN + " ids, --" +
-				utils.WebURLFN + " urls, or the wildcard --" +
+				utils.SiteFN + " urls, or the wildcard --" +
 				utils.SiteFN + " *",
 		)
 	}

--- a/src/cli/utils/flags.go
+++ b/src/cli/utils/flags.go
@@ -34,9 +34,9 @@ const (
 	BackupFN  = "backup"
 	DataFN    = "data"
 	LibraryFN = "library"
-	SiteFN    = "site"
+	SiteFN    = "site"    // site only accepts WebURL values
+	SiteIDFN  = "site-id" // site-id accepts actual site ids
 	UserFN    = "user"
-	WebURLFN  = "web-url"
 
 	FileFN   = "file"
 	FolderFN = "folder"
@@ -63,6 +63,30 @@ func AddUserFlag(cmd *cobra.Command) {
 		UserFN, nil,
 		"Backup a specific user's data; accepts '"+Wildcard+"' to select all users.")
 	cobra.CheckErr(cmd.MarkFlagRequired(UserFN))
+}
+
+// AddSiteIDFlag adds the --site-id flag, which accepts site ID values.
+// This flag is hidden, since we expect users to prefer the --site url
+// and do not want to encourage confusion.
+func AddSiteIDFlag(cmd *cobra.Command) {
+	fs := cmd.Flags()
+
+	// note string ARRAY var.  IDs naturally contain commas, so we cannot accept
+	// duplicate values within a flag declaration.  ie: --site-id a,b,c does not
+	// work.  Users must call --site-id a --site-id b --site-id c.
+	fs.StringArrayVar(
+		&Site,
+		SiteIDFN, nil,
+		"Backup data by site ID; accepts '"+Wildcard+"' to select all sites.")
+	cobra.CheckErr(fs.MarkHidden(SiteIDFN))
+}
+
+// AddSiteFlag adds the --site flag, which accepts webURL values.
+func AddSiteFlag(cmd *cobra.Command) {
+	cmd.Flags().StringSliceVar(
+		&WebURL,
+		SiteFN, nil,
+		"Backup data by site URL; accepts '"+Wildcard+"' to select all sites.")
 }
 
 type PopulatedFlags map[string]struct{}

--- a/src/cli/utils/flags.go
+++ b/src/cli/utils/flags.go
@@ -77,7 +77,8 @@ func AddSiteIDFlag(cmd *cobra.Command) {
 	fs.StringArrayVar(
 		&Site,
 		SiteIDFN, nil,
-		"Backup data by site ID; accepts '"+Wildcard+"' to select all sites.")
+		//nolint:lll
+		"Backup data by site ID; accepts '"+Wildcard+"' to select all sites.  Args cannot be comma-delimited and must use multiple flags.")
 	cobra.CheckErr(fs.MarkHidden(SiteIDFN))
 }
 


### PR DESCRIPTION
Changes ---web-url to --site, and changes --site
to --site-id.  Site-id is hidden to prevent confusion for end users.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #2786

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
