### PR TITLE
track id and display name for resource owners

### DIFF
--- a/src/internal/connector/data_collections.go
+++ b/src/internal/connector/data_collections.go
@@ -115,6 +115,7 @@ func (gc *GraphConnector) DataCollections(
 		colls, excludes, err := sharepoint.DataCollections(
 			ctx,
 			gc.itemClient,
+			gc.Sites[sels.DiscreteOwner], // siteID -> webURL lookup
 			sels,
 			gc.credentials,
 			gc.Service,

--- a/src/internal/connector/graph_connector.go
+++ b/src/internal/connector/graph_connector.go
@@ -41,7 +41,7 @@ type GraphConnector struct {
 	itemClient *http.Client // configured to handle large item downloads
 
 	tenant      string
-	Sites       map[string]string // key<???> value<???>
+	Sites       map[string]string // webURL -> siteID and siteID -> webURL
 	credentials account.M365Config
 
 	// wg is used to track completion of GC tasks
@@ -310,6 +310,7 @@ func getResources(
 		}
 
 		resources[k] = v
+		resources[v] = k
 
 		return true
 	}

--- a/src/internal/connector/sharepoint/data_collections.go
+++ b/src/internal/connector/sharepoint/data_collections.go
@@ -31,6 +31,7 @@ type statusUpdater interface {
 func DataCollections(
 	ctx context.Context,
 	itemClient *http.Client,
+	ownerName string,
 	selector selectors.Selector,
 	creds account.M365Config,
 	serv graph.Servicer,
@@ -57,7 +58,7 @@ func DataCollections(
 		foldersComplete, closer := observe.MessageWithCompletion(ctx, observe.Bulletf(
 			"%s - %s",
 			observe.Safe(scope.Category().PathType().String()),
-			observe.PII(site)))
+			observe.PII(ownerName)))
 		defer closer()
 		defer close(foldersComplete)
 


### PR DESCRIPTION
For display purposes, we want to show the site
weburl, not the ID.  however, we normally process
using the site ID.  To do both, we have to pass
both around, using the ID for queries and storage,
and the display name for cli output.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Issue(s)

* #2786

#### Test Plan

- [x] :muscle: Manual
