### PR TITLE
DO NOT MERGE Add option to control parallelism getting items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix repo connect not working without a config file
 - Fix item re-download on expired links silently being skipped
+- Improved permissions backup and restore for OneDrive
+- CLI calls default to a 10-day context deadline to avoid letting graph api restrict requests to a 100 second deadline.
+
+### Known Issues
+- Owner (Full control) or empty (Restricted View) roles cannot be restored for OneDrive
 
 ## [v0.5.0] (beta) - 2023-03-13
 

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
@@ -146,8 +147,12 @@ func BuildCommandTree(cmd *cobra.Command) {
 
 // Handle builds and executes the cli processor.
 func Handle() {
+	tenDays := time.Now().Add(time.Hour * 24 * 10)
 	//nolint:forbidigo
-	ctx := config.Seed(context.Background())
+	ctx, cancel := context.WithDeadline(context.Background(), tenDays)
+	defer cancel()
+
+	ctx = config.Seed(ctx)
 	ctx = print.SetRootCmd(ctx, corsoCmd)
 	observe.SeedWriter(ctx, print.StderrWriter(ctx), observe.PreloadFlags())
 

--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -22,16 +22,18 @@ import (
 )
 
 const (
-	logGraphRequestsEnvKey  = "LOG_GRAPH_REQUESTS"
-	numberOfRetries         = 3
-	retryAttemptHeader      = "Retry-Attempt"
-	retryAfterHeader        = "Retry-After"
-	defaultMaxRetries       = 3
-	defaultDelay            = 3 * time.Second
-	absoluteMaxDelaySeconds = 180
-	rateLimitHeader         = "RateLimit-Limit"
-	rateRemainingHeader     = "RateLimit-Remaining"
-	rateResetHeader         = "RateLimit-Reset"
+	logGraphRequestsEnvKey    = "LOG_GRAPH_REQUESTS"
+	log2xxGraphRequestsEnvKey = "LOG_2XX_GRAPH_REQUESTS"
+	numberOfRetries           = 3
+	retryAttemptHeader        = "Retry-Attempt"
+	retryAfterHeader          = "Retry-After"
+	defaultMaxRetries         = 3
+	defaultDelay              = 3 * time.Second
+	absoluteMaxDelaySeconds   = 180
+	rateLimitHeader           = "RateLimit-Limit"
+	rateRemainingHeader       = "RateLimit-Remaining"
+	rateResetHeader           = "RateLimit-Reset"
+	defaultHTTPClientTimeout  = 1 * time.Hour
 )
 
 // AllMetadataFileNames produces the standard set of filenames used to store graph
@@ -195,7 +197,7 @@ func HTTPClient(opts ...option) *http.Client {
 	noOfRetries, minRetryDelay := clientconfig.applyMiddlewareConfig()
 	middlewares := GetKiotaMiddlewares(&clientOptions, noOfRetries, minRetryDelay)
 	httpClient := msgraphgocore.GetDefaultClient(&clientOptions, middlewares...)
-	httpClient.Timeout = time.Minute * 3
+	httpClient.Timeout = defaultHTTPClientTimeout
 
 	clientconfig.apply(httpClient)
 

--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -320,7 +320,8 @@ func (handler *LoggingMiddleware) Intercept(
 				"url", req.URL,
 				"limit", resp.Header.Get(rateLimitHeader),
 				"remaining", resp.Header.Get(rateRemainingHeader),
-				"reset", resp.Header.Get(rateResetHeader))
+				"reset", resp.Header.Get(rateResetHeader),
+				"retry-after", resp.Header.Get(retryAfterHeader))
 		} else if resp.StatusCode == http.StatusBadRequest {
 			respDump, _ := httputil.DumpResponse(resp, true)
 			logger.Ctx(ctx).Infow(

--- a/src/internal/connector/graph/service_test.go
+++ b/src/internal/connector/graph/service_test.go
@@ -3,7 +3,6 @@ package graph
 import (
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/stretchr/testify/assert"
@@ -54,7 +53,7 @@ func (suite *GraphUnitSuite) TestHTTPClient() {
 			name: "no options",
 			opts: []option{},
 			check: func(t *testing.T, c *http.Client) {
-				assert.Equal(t, 3*time.Minute, c.Timeout, "default timeout")
+				assert.Equal(t, defaultHTTPClientTimeout, c.Timeout, "default timeout")
 			},
 		},
 		{

--- a/src/pkg/control/options.go
+++ b/src/pkg/control/options.go
@@ -6,12 +6,13 @@ import (
 
 // Options holds the optional configurations for a process
 type Options struct {
-	Collision          CollisionPolicy `json:"-"`
-	DisableMetrics     bool            `json:"disableMetrics"`
-	FailFast           bool            `json:"failFast"`
-	RestorePermissions bool            `json:"restorePermissions"`
-	SkipReduce         bool            `json:"skipReduce"`
-	ToggleFeatures     Toggles         `json:"ToggleFeatures"`
+	Collision            CollisionPolicy `json:"-"`
+	DisableMetrics       bool            `json:"disableMetrics"`
+	FailFast             bool            `json:"failFast"`
+	RestorePermissions   bool            `json:"restorePermissions"`
+	SkipReduce           bool            `json:"skipReduce"`
+	ItemFetchParallelism int             `json:"itemFetchParallelism"`
+	ToggleFeatures       Toggles         `json:"ToggleFeatures"`
 }
 
 // Defaults provides an Options with the default values set.


### PR DESCRIPTION
This option is only consumed by Exchange right now and will control the number of items fetched in parallel per collection. Note that the total number of parallel item fetches may be higher is kopia is concurrently uploading multiple collections.

This PR does not expose this option at the CLI layer

Manually tested to ensure it
* uses the default if options value is 0
* uses the default if options value > default
* uses option value otherwise

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
