### PR TITLE
add 10 day deadline to cli context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix repo connect not working without a config file
 - Fix item re-download on expired links silently being skipped
 - Improved permissions backup and restore for OneDrive
+- CLI calls default to a 10-day context deadline to avoid letting graph api restrict requests to a 100 second deadline.
 
 ### Known Issues
 - Owner (Full control) or empty (Restricted View) roles cannot be restored for OneDrive

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -147,8 +147,9 @@ func BuildCommandTree(cmd *cobra.Command) {
 
 // Handle builds and executes the cli processor.
 func Handle() {
+	tenDays := time.Now().Add(time.Hour * 24 * 10)
 	//nolint:forbidigo
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Hour*24*10))
+	ctx, cancel := context.WithDeadline(context.Background(), tenDays)
 	defer cancel()
 
 	ctx = config.Seed(ctx)

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
@@ -147,7 +148,10 @@ func BuildCommandTree(cmd *cobra.Command) {
 // Handle builds and executes the cli processor.
 func Handle() {
 	//nolint:forbidigo
-	ctx := config.Seed(context.Background())
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Hour*24*10))
+	defer cancel()
+
+	ctx = config.Seed(ctx)
 	ctx = print.SetRootCmd(ctx, corsoCmd)
 	observe.SeedWriter(ctx, print.StderrWriter(ctx), observe.PreloadFlags())
 

--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -199,7 +199,7 @@ func HTTPClient(opts ...option) *http.Client {
 	noOfRetries, minRetryDelay := clientconfig.applyMiddlewareConfig()
 	middlewares := GetKiotaMiddlewares(&clientOptions, noOfRetries, minRetryDelay)
 	httpClient := msgraphgocore.GetDefaultClient(&clientOptions, middlewares...)
-	httpClient.Timeout = time.Minute * 3
+	httpClient.Timeout = 1 * time.Hour
 
 	clientconfig.apply(httpClient)
 

--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -36,6 +36,7 @@ const (
 	rateLimitHeader           = "RateLimit-Limit"
 	rateRemainingHeader       = "RateLimit-Remaining"
 	rateResetHeader           = "RateLimit-Reset"
+	defaultHttpClientTimeout  = 1 * time.Hour
 )
 
 // AllMetadataFileNames produces the standard set of filenames used to store graph
@@ -199,7 +200,7 @@ func HTTPClient(opts ...option) *http.Client {
 	noOfRetries, minRetryDelay := clientconfig.applyMiddlewareConfig()
 	middlewares := GetKiotaMiddlewares(&clientOptions, noOfRetries, minRetryDelay)
 	httpClient := msgraphgocore.GetDefaultClient(&clientOptions, middlewares...)
-	httpClient.Timeout = 1 * time.Hour
+	httpClient.Timeout = defaultHttpClientTimeout
 
 	clientconfig.apply(httpClient)
 

--- a/src/internal/connector/graph/service.go
+++ b/src/internal/connector/graph/service.go
@@ -36,7 +36,7 @@ const (
 	rateLimitHeader           = "RateLimit-Limit"
 	rateRemainingHeader       = "RateLimit-Remaining"
 	rateResetHeader           = "RateLimit-Reset"
-	defaultHttpClientTimeout  = 1 * time.Hour
+	defaultHTTPClientTimeout  = 1 * time.Hour
 )
 
 // AllMetadataFileNames produces the standard set of filenames used to store graph
@@ -200,7 +200,7 @@ func HTTPClient(opts ...option) *http.Client {
 	noOfRetries, minRetryDelay := clientconfig.applyMiddlewareConfig()
 	middlewares := GetKiotaMiddlewares(&clientOptions, noOfRetries, minRetryDelay)
 	httpClient := msgraphgocore.GetDefaultClient(&clientOptions, middlewares...)
-	httpClient.Timeout = defaultHttpClientTimeout
+	httpClient.Timeout = defaultHTTPClientTimeout
 
 	clientconfig.apply(httpClient)
 

--- a/src/internal/connector/graph/service_test.go
+++ b/src/internal/connector/graph/service_test.go
@@ -53,7 +53,7 @@ func (suite *GraphUnitSuite) TestHTTPClient() {
 			name: "no options",
 			opts: []option{},
 			check: func(t *testing.T, c *http.Client) {
-				assert.Equal(t, defaultHttpClientTimeout, c.Timeout, "default timeout")
+				assert.Equal(t, defaultHTTPClientTimeout, c.Timeout, "default timeout")
 			},
 		},
 		{

--- a/src/internal/connector/graph/service_test.go
+++ b/src/internal/connector/graph/service_test.go
@@ -3,7 +3,6 @@ package graph
 import (
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/stretchr/testify/assert"
@@ -54,7 +53,7 @@ func (suite *GraphUnitSuite) TestHTTPClient() {
 			name: "no options",
 			opts: []option{},
 			check: func(t *testing.T, c *http.Client) {
-				assert.Equal(t, 3*time.Minute, c.Timeout, "default timeout")
+				assert.Equal(t, defaultHttpClientTimeout, c.Timeout, "default timeout")
 			},
 		},
 		{


### PR DESCRIPTION
Ensures all CLI usage has a context deadline so that we
don't bump into the graph api 100 second deadline.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

#### Type of change

- [x] :bug: Bugfix

#### Test Plan

- [x] :muscle: Manual
