### PR TITLE
Add option to control parallelism getting items

### DIFF
--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -198,7 +198,7 @@ func (col *Collection) streamItems(ctx context.Context, errs *fault.Bus) {
 
 	// Limit the max number of active requests to GC
 	fetchParallelism := col.ctrl.ItemFetchParallelism
-	if fetchParallelism == 0 || fetchParallelism > urlPrefetchChannelBufferSize {
+	if fetchParallelism < 1 || fetchParallelism > urlPrefetchChannelBufferSize {
 		fetchParallelism = urlPrefetchChannelBufferSize
 		logger.Ctx(ctx).Infow(
 			"fetch parallelism value not set or out of bounds, using default",

--- a/src/pkg/control/options.go
+++ b/src/pkg/control/options.go
@@ -6,12 +6,13 @@ import (
 
 // Options holds the optional configurations for a process
 type Options struct {
-	Collision          CollisionPolicy `json:"-"`
-	DisableMetrics     bool            `json:"disableMetrics"`
-	FailFast           bool            `json:"failFast"`
-	RestorePermissions bool            `json:"restorePermissions"`
-	SkipReduce         bool            `json:"skipReduce"`
-	ToggleFeatures     Toggles         `json:"ToggleFeatures"`
+	Collision            CollisionPolicy `json:"-"`
+	DisableMetrics       bool            `json:"disableMetrics"`
+	FailFast             bool            `json:"failFast"`
+	RestorePermissions   bool            `json:"restorePermissions"`
+	SkipReduce           bool            `json:"skipReduce"`
+	ItemFetchParallelism int             `json:"itemFetchParallelism"`
+	ToggleFeatures       Toggles         `json:"ToggleFeatures"`
 }
 
 // Defaults provides an Options with the default values set.


### PR DESCRIPTION
This option is only consumed by Exchange right now and will control the number of items fetched in parallel per collection. Note that the total number of parallel item fetches may be higher is kopia is concurrently uploading multiple collections.

This PR does not expose this option at the CLI layer

Manually tested to ensure it
* uses the default if options value is 0
* uses the default if options value > default
* uses option value otherwise

There's another PR open for this but it's not expected to main. We still
want to make sure the change goes in though, hence this PR.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Test
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
