### PR TITLE
Exit early if context is marked as done

### DIFF
--- a/src/internal/connector/graph/retry_middleware.go
+++ b/src/internal/connector/graph/retry_middleware.go
@@ -47,9 +47,8 @@ func (middleware RetryHandler) retryRequest(
 		select {
 		case <-ctx.Done():
 			// Don't retry if the context is marked as done, it will just error out
-			// when we attempt to send the retry anyway. I guess return the original
-			// response and the error?
-			return resp, ctx.Err()
+			// when we attempt to send the retry anyway.
+			return nil, ctx.Err()
 
 		// Will exit switch-block so the remainder of the code doesn't need to be
 		// indented.

--- a/src/internal/connector/graph/retry_middleware.go
+++ b/src/internal/connector/graph/retry_middleware.go
@@ -48,7 +48,7 @@ func (middleware RetryHandler) retryRequest(
 		case <-ctx.Done():
 			// Don't retry if the context is marked as done, it will just error out
 			// when we attempt to send the retry anyway.
-			return nil, ctx.Err()
+			return resp, ctx.Err()
 
 		// Will exit switch-block so the remainder of the code doesn't need to be
 		// indented.


### PR DESCRIPTION
Keeps the code from blocking and then failing immediately without sending a retry.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* closes #2882

#### Test Plan

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
