### PR TITLE
observe resourceOwner once, at top

### DIFF
--- a/src/internal/connector/exchange/data_collections.go
+++ b/src/internal/connector/exchange/data_collections.go
@@ -259,10 +259,9 @@ func createCollections(
 		Credentials:   creds,
 	}
 
-	foldersComplete, closer := observe.MessageWithCompletion(ctx, observe.Bulletf(
-		"%s - %s",
-		observe.Safe(qp.Category.String()),
-		observe.PII(user)))
+	foldersComplete, closer := observe.MessageWithCompletion(
+		ctx,
+		observe.Bulletf("%s", observe.Safe(qp.Category.String())))
 	defer closer()
 	defer close(foldersComplete)
 

--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -186,7 +186,6 @@ func (col *Collection) streamItems(ctx context.Context, errs *fault.Bus) {
 		colProgress, closer = observe.CollectionProgress(
 			ctx,
 			col.fullPath.Category().String(),
-			observe.PII(user),
 			observe.PII(col.fullPath.Folder(false)))
 
 		go closer()

--- a/src/internal/connector/exchange/service_restore.go
+++ b/src/internal/connector/exchange/service_restore.go
@@ -391,7 +391,6 @@ func restoreCollection(
 	colProgress, closer := observe.CollectionProgress(
 		ctx,
 		category.String(),
-		observe.PII(user),
 		observe.PII(directory.Folder(false)))
 	defer closer()
 	defer close(colProgress)

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -263,10 +263,7 @@ func (c *Collections) Get(
 		return nil, nil, err
 	}
 
-	driveComplete, closer := observe.MessageWithCompletion(ctx, observe.Bulletf(
-		"%s - %s",
-		observe.Safe("files"),
-		observe.PII(c.resourceOwner)))
+	driveComplete, closer := observe.MessageWithCompletion(ctx, observe.Bulletf("files"))
 	defer closer()
 	defer close(driveComplete)
 

--- a/src/internal/connector/sharepoint/collection.go
+++ b/src/internal/connector/sharepoint/collection.go
@@ -186,7 +186,6 @@ func (sc *Collection) runPopulate(ctx context.Context, errs *fault.Bus) (support
 	colProgress, closer := observe.CollectionProgress(
 		ctx,
 		sc.fullPath.Category().String(),
-		observe.Safe("name"),
 		observe.PII(sc.fullPath.Folder(false)))
 	go closer()
 

--- a/src/internal/connector/sharepoint/data_collections.go
+++ b/src/internal/connector/sharepoint/data_collections.go
@@ -54,10 +54,9 @@ func DataCollections(
 			break
 		}
 
-		foldersComplete, closer := observe.MessageWithCompletion(ctx, observe.Bulletf(
-			"%s - %s",
-			observe.Safe(scope.Category().PathType().String()),
-			observe.PII(site)))
+		foldersComplete, closer := observe.MessageWithCompletion(
+			ctx,
+			observe.Bulletf("%s", observe.Safe(scope.Category().PathType().String())))
 		defer closer()
 		defer close(foldersComplete)
 

--- a/src/internal/observe/display.go
+++ b/src/internal/observe/display.go
@@ -1,7 +1,0 @@
-package observe
-
-// Display holds display-only configuration.  Primarily for passing along
-// aliased values when we have a pair of more-and-less user friendly
-type Display struct {
-	ResourceOwner string
-}

--- a/src/internal/observe/observe_test.go
+++ b/src/internal/observe/observe_test.go
@@ -105,7 +105,7 @@ func (suite *ObserveProgressUnitSuite) TestCollectionProgress_unblockOnCtxCancel
 		SeedWriter(context.Background(), nil, nil)
 	}()
 
-	progCh, closer := CollectionProgress(ctx, "test", testcat, testertons)
+	progCh, closer := CollectionProgress(ctx, testcat.clean(), testertons)
 	require.NotNil(t, progCh)
 	require.NotNil(t, closer)
 
@@ -140,7 +140,7 @@ func (suite *ObserveProgressUnitSuite) TestCollectionProgress_unblockOnChannelCl
 		SeedWriter(context.Background(), nil, nil)
 	}()
 
-	progCh, closer := CollectionProgress(ctx, "test", testcat, testertons)
+	progCh, closer := CollectionProgress(ctx, testcat.clean(), testertons)
 	require.NotNil(t, progCh)
 	require.NotNil(t, closer)
 

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -148,6 +148,8 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 	// Execution
 	// -----
 
+	observe.Message(ctx, observe.Safe("Backing Up"), observe.Bullet, observe.PII(op.ResourceOwner))
+
 	deets, err := op.do(
 		ctx,
 		&opStats,

--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -193,6 +193,8 @@ func (op *RestoreOperation) do(
 		return nil, errors.Wrap(err, "getting backup and details")
 	}
 
+	observe.Message(ctx, observe.Safe("Restoring"), observe.Bullet, observe.PII(bup.Selector.DiscreteOwner))
+
 	paths, err := formatDetailsForRestoration(ctx, bup.Version, op.Selectors, deets, op.Errors)
 	if err != nil {
 		return nil, errors.Wrap(err, "formatting paths from details")


### PR DESCRIPTION
we transitioned backups from multi-user to single- user some time ago, but never went back to
remove the resource-owner identification from
every progress bar on display.  This ends up
creating a lot of duplication of the same owner
in a single run, when we could use that space
for more valuable information such as item
or folder details.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #2871

#### Test Plan

- [x] :muscle: Manual
