### PR TITLE
Don't attempt to restore dirmeta files for newer backup versions

### DIFF
--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -615,9 +615,10 @@ func getMetadata(metar io.ReadCloser) (Metadata, error) {
 func AugmentRestorePaths(backupVersion int, paths []path.Path) ([]path.Path, error) {
 	// Nothing to do for versions where the directory metadata is stored in the
 	// directory it refers to as Corso will retrieve this data inline when
-	// restoring the collection for the directory.
-	if backupVersion >= version.OneDrive4DirIncludesPermissions {
-		return nil, nil
+	// restoring the collection for the directory. Path ordering does not matter
+	// for these versions.
+	if backupVersion == 0 || backupVersion >= version.OneDrive4DirIncludesPermissions {
+		return paths, nil
 	}
 
 	colPaths := map[string]path.Path{}

--- a/src/internal/connector/onedrive/restore_test.go
+++ b/src/internal/connector/onedrive/restore_test.go
@@ -22,10 +22,11 @@ func TestRestoreUnitSuite(t *testing.T) {
 
 func (suite *RestoreUnitSuite) TestAugmentRestorePaths() {
 	table := []struct {
-		name    string
-		version int
-		input   []string
-		output  []string
+		name        string
+		version     int
+		input       []string
+		output      []string
+		compareFunc assert.ComparisonAssertionFunc
 	}{
 		{
 			name:    "no change v0",
@@ -35,9 +36,10 @@ func (suite *RestoreUnitSuite) TestAugmentRestorePaths() {
 				"file.txt", // v0 does not have `.data`
 			},
 			output: []string{
-				"file.txt", // ordering artifact of sorting
+				"file.txt",
 				"file.txt.data",
 			},
+			compareFunc: assert.ElementsMatch,
 		},
 		{
 			name:    "one folder v0",
@@ -50,6 +52,7 @@ func (suite *RestoreUnitSuite) TestAugmentRestorePaths() {
 				"folder/file.txt",
 				"folder/file.txt.data",
 			},
+			compareFunc: assert.ElementsMatch,
 		},
 		{
 			name:    "no change v1",
@@ -60,6 +63,7 @@ func (suite *RestoreUnitSuite) TestAugmentRestorePaths() {
 			output: []string{
 				"file.txt.data",
 			},
+			compareFunc: assert.Equal,
 		},
 		{
 			name:    "one folder v1",
@@ -71,6 +75,7 @@ func (suite *RestoreUnitSuite) TestAugmentRestorePaths() {
 				"folder.dirmeta",
 				"folder/file.txt.data",
 			},
+			compareFunc: assert.Equal,
 		},
 		{
 			name:    "nested folders v1",
@@ -85,6 +90,7 @@ func (suite *RestoreUnitSuite) TestAugmentRestorePaths() {
 				"folder/folder2.dirmeta",
 				"folder/folder2/file.txt.data",
 			},
+			compareFunc: assert.Equal,
 		},
 		{
 			name:    "no change v4",
@@ -95,6 +101,7 @@ func (suite *RestoreUnitSuite) TestAugmentRestorePaths() {
 			output: []string{
 				"file.txt.data",
 			},
+			compareFunc: assert.ElementsMatch,
 		},
 		{
 			name:    "one folder v4",
@@ -104,8 +111,8 @@ func (suite *RestoreUnitSuite) TestAugmentRestorePaths() {
 			},
 			output: []string{
 				"folder/file.txt.data",
-				"folder/folder.dirmeta",
 			},
+			compareFunc: assert.ElementsMatch,
 		},
 		{
 			name:    "nested folders v4",
@@ -116,10 +123,9 @@ func (suite *RestoreUnitSuite) TestAugmentRestorePaths() {
 			},
 			output: []string{
 				"folder/file.txt.data",
-				"folder/folder.dirmeta",
 				"folder/folder2/file.txt.data",
-				"folder/folder2/folder2.dirmeta",
 			},
+			compareFunc: assert.ElementsMatch,
 		},
 	}
 
@@ -151,9 +157,9 @@ func (suite *RestoreUnitSuite) TestAugmentRestorePaths() {
 			actual, err := AugmentRestorePaths(test.version, inPaths)
 			require.NoError(t, err, "augmenting paths", clues.ToCore(err))
 
-			// Ordering of paths matter here as we need dirmeta files
+			// Ordering of paths matter here for < v4 as we need dirmeta files
 			// to show up before file in dir
-			assert.Equal(t, outPaths, actual, "augmented paths")
+			test.compareFunc(t, outPaths, actual, "augmented paths")
 		})
 	}
 }


### PR DESCRIPTION
Newer backup versions can fetch the dirmeta files
inline while restoring directories so there's no
need to add them here

Exclude backup versions 0 and > 4 from path
augmentation

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* closes #2878

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
