### PR TITLE
Assume that item has no attachments if there is no body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed permissions restore in latest backup version.
 - Incremental OneDrive backups could panic if the delta token expired and a folder was seen and deleted in the course of item enumeration for the backup.
 - Incorrectly moving subfolder hierarchy from a deleted folder to a new folder at the same path during OneDrive incremental backup.
-- Handle cases where calendar entries don't have body
+- Handle calendar events with no body.
 
 ## [v0.6.1] (beta) - 2023-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] (beta)
 
 ### Fixed
-- Fixed permissions restore in latest backup version
+- Fixed permissions restore in latest backup version.
 - Incremental OneDrive backups could panic if the delta token expired and a folder was seen and deleted in the course of item enumeration for the backup.
 - Incorrectly moving subfolder hierarchy from a deleted folder to a new folder at the same path during OneDrive incremental backup.
+- Handle cases where calendar entries don't have body
 
 ## [v0.6.1] (beta) - 2023-03-21
 

--- a/src/internal/connector/exchange/api/api.go
+++ b/src/internal/connector/exchange/api/api.go
@@ -135,6 +135,10 @@ func checkIDAndName(c graph.Container) error {
 }
 
 func HasAttachments(body models.ItemBodyable) bool {
+	if body == nil {
+		return false
+	}
+
 	if ct, ok := ptr.ValOK(body.GetContentType()); !ok || ct == models.TEXT_BODYTYPE {
 		return false
 	}

--- a/src/internal/connector/exchange/api/api_test.go
+++ b/src/internal/connector/exchange/api/api_test.go
@@ -208,6 +208,13 @@ func (suite *ExchangeServiceSuite) TestHasAttachments() {
 				return body
 			},
 		},
+		{
+			name:          "No body",
+			hasAttachment: assert.False,
+			getBodyable: func(t *testing.T) models.ItemBodyable {
+				return nil
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Some response from the Graph API was returning empty body. This could be something left over from older version of the platform, but this causes issues in our codebase.

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
