### PR TITLE
continue if collection path is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed permissions restore in latest backup version
-- Panic during an incremental OneDrive backup if the delta token expired and a folder was seen and deleted in the course of item enumeration for the backup.
+- Incremental OneDrive backups could panic if the delta token expired and a folder was seen and deleted in the course of item enumeration for the backup.
 
 ## [v0.6.1] (beta) - 2023-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed permissions restore in latest backup version
+- Panic during an incremental OneDrive backup if the delta token expired and a folder was seen and deleted in the course of item enumeration for the backup.
 
 ## [v0.6.1] (beta) - 2023-03-21
 

--- a/src/go.sum
+++ b/src/go.sum
@@ -266,8 +266,6 @@ github.com/matttproud/golang_protobuf_extensions v1.0.2 h1:hAHbPm5IJGijwng3PWk09
 github.com/matttproud/golang_protobuf_extensions v1.0.2/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
-github.com/microsoft/kiota-abstractions-go v0.17.3 h1:RmQ9RXzXFkQh8QnFcQ31QM2ou8MJksQe0/H8shz8CNI=
-github.com/microsoft/kiota-abstractions-go v0.17.3/go.mod h1:0lbPErVO6Rj3HHpntNYW/OFmHhJJ1ewPdsi1xPxYIMc=
 github.com/microsoft/kiota-abstractions-go v0.18.0 h1:H1kQE5hAq/7Q8gENPJ1Y7DuvG9QqKCpglN8D7TJi9qY=
 github.com/microsoft/kiota-abstractions-go v0.18.0/go.mod h1:0lbPErVO6Rj3HHpntNYW/OFmHhJJ1ewPdsi1xPxYIMc=
 github.com/microsoft/kiota-authentication-azure-go v0.6.0 h1:Il9bLO34J6D8DY89xYAXoGh9muvlphayqG4eihyT6B8=

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -178,13 +178,13 @@ func (oc *Collection) Add(item models.DriveItemable) bool {
 }
 
 // Remove removes a item from the collection
-func (oc *Collection) Remove(item models.DriveItemable) bool {
-	_, found := oc.driveItems[ptr.Val(item.GetId())]
+func (oc *Collection) Remove(itemID string) bool {
+	_, found := oc.driveItems[itemID]
 	if !found {
 		return false
 	}
 
-	delete(oc.driveItems, ptr.Val(item.GetId()))
+	delete(oc.driveItems, itemID)
 
 	return true
 }

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -381,6 +381,7 @@ func (c *Collections) Get(
 		// Set all folders in previous backup but not in the current
 		// one with state deleted
 		modifiedPaths := map[string]struct{}{}
+
 		for _, p := range c.CollectionMap[driveID] {
 			if p.FullPath() != nil {
 				modifiedPaths[p.FullPath().String()] = struct{}{}

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -350,31 +350,31 @@ func (c *Collections) Get(
 			"num_deltas_entries", numDeltas,
 			"delta_reset", delta.Reset)
 
-		if !delta.Reset {
-			if len(excluded) > 0 {
-				p, err := GetCanonicalPath(
-					fmt.Sprintf(rootDrivePattern, driveID),
-					c.tenant,
-					c.resourceOwner,
-					c.source)
-				if err != nil {
-					return nil, nil,
-						clues.Wrap(err, "making exclude prefix").WithClues(ictx)
-				}
-
-				pstr := p.String()
-
-				eidi, ok := excludedItems[pstr]
-				if !ok {
-					eidi = map[string]struct{}{}
-				}
-
-				maps.Copy(eidi, excluded)
-				excludedItems[pstr] = eidi
+		// For both cases we don't need to do set difference on folder map if the
+		// delta token was valid because we should see all the changes.
+		if !delta.Reset && len(excluded) == 0 {
+			continue
+		} else if !delta.Reset {
+			p, err := GetCanonicalPath(
+				fmt.Sprintf(rootDrivePattern, driveID),
+				c.tenant,
+				c.resourceOwner,
+				c.source)
+			if err != nil {
+				return nil, nil,
+					clues.Wrap(err, "making exclude prefix").WithClues(ictx)
 			}
 
-			// Don't need to do set difference on folder map if the delta token was
-			// valid because we should see all the changes.
+			pstr := p.String()
+
+			eidi, ok := excludedItems[pstr]
+			if !ok {
+				eidi = map[string]struct{}{}
+			}
+
+			maps.Copy(eidi, excluded)
+			excludedItems[pstr] = eidi
+
 			continue
 		}
 

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -377,7 +377,9 @@ func (c *Collections) Get(
 		// one with state deleted
 		modifiedPaths := map[string]struct{}{}
 		for _, p := range c.CollectionMap[driveID] {
-			modifiedPaths[p.FullPath().String()] = struct{}{}
+			if p.FullPath() != nil {
+				modifiedPaths[p.FullPath().String()] = struct{}{}
+			}
 		}
 
 		for fldID, p := range oldPaths {
@@ -671,6 +673,8 @@ func (c *Collections) UpdateCollections(
 			el.AddRecoverable(clues.Stack(err).
 				WithClues(ictx).
 				Label(fault.LabelForceNoBackupCreation))
+
+			continue
 		}
 
 		// Skip items that don't match the folder selectors we were given.


### PR DESCRIPTION
Currently code panics if it tries to find FullPath for a drive item and its not present.
Added a continue and skipped the item if FullPath is not present.

Root cause of bug is caused by having a folder in the previous paths map, having
the delta token expire, and seeing the folder be deleted in the delta results

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
