### PR TITLE
introduce the resource owner name to op.backup

### DIFF
--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -35,10 +35,12 @@ import (
 type BackupOperation struct {
 	operation
 
-	ResourceOwner string             `json:"resourceOwner"`
-	Results       BackupResults      `json:"results"`
-	Selectors     selectors.Selector `json:"selectors"`
-	Version       string             `json:"version"`
+	ResourceOwner     string `json:"resourceOwner"`
+	ResourceOwnerName string `json:"resourceOwnerName"`
+
+	Results   BackupResults      `json:"results"`
+	Selectors selectors.Selector `json:"selectors"`
+	Version   string             `json:"version"`
 
 	account account.Account
 
@@ -61,15 +63,17 @@ func NewBackupOperation(
 	sw *store.Wrapper,
 	acct account.Account,
 	selector selectors.Selector,
+	ownerName string,
 	bus events.Eventer,
 ) (BackupOperation, error) {
 	op := BackupOperation{
-		operation:     newOperation(opts, bus, kw, sw),
-		ResourceOwner: selector.DiscreteOwner,
-		Selectors:     selector,
-		Version:       "v0",
-		account:       acct,
-		incremental:   useIncrementalBackup(selector, opts),
+		operation:         newOperation(opts, bus, kw, sw),
+		ResourceOwner:     selector.DiscreteOwner,
+		ResourceOwnerName: ownerName,
+		Selectors:         selector,
+		Version:           "v0",
+		account:           acct,
+		incremental:       useIncrementalBackup(selector, opts),
 	}
 	if err := op.validate(); err != nil {
 		return BackupOperation{}, err
@@ -676,7 +680,7 @@ func (op *BackupOperation) createBackupModels(
 	ctx = clues.Add(ctx, "snapshot_id", snapID, "backup_id", backupID)
 	// generate a new fault bus so that we can maintain clean
 	// separation between the errors we serialize and those that
-	// are generated during the serialization process.
+	// are generated during the serialization process.c
 	errs := fault.New(true)
 
 	if deets == nil {
@@ -707,6 +711,8 @@ func (op *BackupOperation) createBackupModels(
 		op.Status.String(),
 		backupID,
 		op.Selectors,
+		op.ResourceOwner,
+		op.ResourceOwnerName,
 		op.Results.ReadWrites,
 		op.Results.StartAndEndTime,
 		op.Errors.Errors())

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -680,7 +680,7 @@ func (op *BackupOperation) createBackupModels(
 	ctx = clues.Add(ctx, "snapshot_id", snapID, "backup_id", backupID)
 	// generate a new fault bus so that we can maintain clean
 	// separation between the errors we serialize and those that
-	// are generated during the serialization process.c
+	// are generated during the serialization process.
 	errs := fault.New(true)
 
 	if deets == nil {

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -127,7 +127,7 @@ func newTestBackupOp(
 
 	opts.ToggleFeatures = featureToggles
 
-	bo, err := NewBackupOperation(ctx, opts, kw, sw, acct, sel, bus)
+	bo, err := NewBackupOperation(ctx, opts, kw, sw, acct, sel, sel.DiscreteOwner, bus)
 	if !assert.NoError(t, err, clues.ToCore(err)) {
 		closer()
 		t.FailNow()
@@ -508,6 +508,7 @@ func (suite *BackupOpIntegrationSuite) TestNewBackupOperation() {
 				test.sw,
 				test.acct,
 				selectors.Selector{DiscreteOwner: "test"},
+				"test",
 				evmock.NewBus())
 			test.errCheck(suite.T(), err, clues.ToCore(err))
 		})

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -508,7 +508,7 @@ func (suite *BackupOpIntegrationSuite) TestNewBackupOperation() {
 				test.sw,
 				test.acct,
 				selectors.Selector{DiscreteOwner: "test"},
-				"test",
+				"test-name",
 				evmock.NewBus())
 			test.errCheck(suite.T(), err, clues.ToCore(err))
 		})

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -408,6 +408,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_PersistResults() {
 				sw,
 				acct,
 				sel,
+				sel.DiscreteOwner,
 				evmock.NewBus())
 			require.NoError(t, err, clues.ToCore(err))
 

--- a/src/internal/operations/restore_test.go
+++ b/src/internal/operations/restore_test.go
@@ -209,6 +209,7 @@ func (suite *RestoreOpIntegrationSuite) SetupSuite() {
 		sw,
 		acct,
 		bsel.Selector,
+		bsel.Selector.DiscreteOwner,
 		evmock.NewBus())
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -236,6 +237,7 @@ func (suite *RestoreOpIntegrationSuite) SetupSuite() {
 		sw,
 		acct,
 		csel.Selector,
+		csel.Selector.DiscreteOwner,
 		evmock.NewBus())
 	require.NoError(t, err, clues.ToCore(err))
 

--- a/src/pkg/backup/backup.go
+++ b/src/pkg/backup/backup.go
@@ -32,6 +32,10 @@ type Backup struct {
 	// Selector used in this operation
 	Selector selectors.Selector `json:"selectors"`
 
+	// ResourceOwner reference
+	ResourceOwnerID   string `json:"resourceOwnerID"`
+	ResourceOwnerName string `json:"resourceOwnerName"`
+
 	// Version represents the version of the backup format
 	Version int `json:"version"`
 
@@ -61,6 +65,7 @@ func New(
 	snapshotID, streamStoreID, status string,
 	id model.StableID,
 	selector selectors.Selector,
+	ownerID, ownerName string,
 	rw stats.ReadWrites,
 	se stats.StartAndEndTime,
 	fe *fault.Errors,

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -292,6 +292,7 @@ func (r repository) NewBackup(
 		store.NewKopiaStore(r.modelStore),
 		r.Account,
 		selector,
+		selector.DiscreteOwner,
 		r.Bus)
 }
 

--- a/src/pkg/repository/repository_unexported_test.go
+++ b/src/pkg/repository/repository_unexported_test.go
@@ -127,6 +127,7 @@ func writeBackup(
 	sw *store.Wrapper,
 	tID, snapID, backupID string,
 	sel selectors.Selector,
+	ownerID, ownerName string,
 	deets *details.Details,
 	fe *fault.Errors,
 	errs *fault.Bus,
@@ -150,6 +151,7 @@ func writeBackup(
 		operations.Completed.String(),
 		model.StableID(backupID),
 		sel,
+		ownerID, ownerName,
 		stats.ReadWrites{},
 		stats.StartAndEndTime{},
 		fe)
@@ -161,7 +163,10 @@ func writeBackup(
 }
 
 func (suite *RepositoryModelIntgSuite) TestGetBackupDetails() {
-	const tenantID = "tenant"
+	const (
+		brunhilda = "brunhilda"
+		tenantID  = "tenant"
+	)
 
 	info := details.ItemInfo{
 		Folder: &details.FolderInfo{
@@ -207,7 +212,8 @@ func (suite *RepositoryModelIntgSuite) TestGetBackupDetails() {
 					suite.kw,
 					suite.sw,
 					tenantID, "snapID", test.writeBupID,
-					selectors.NewExchangeBackup([]string{"brunhilda"}).Selector,
+					selectors.NewExchangeBackup([]string{brunhilda}).Selector,
+					brunhilda, brunhilda,
 					test.deets,
 					&fault.Errors{},
 					fault.New(true))
@@ -228,8 +234,9 @@ func (suite *RepositoryModelIntgSuite) TestGetBackupDetails() {
 
 func (suite *RepositoryModelIntgSuite) TestGetBackupErrors() {
 	const (
-		tenantID = "tenant"
-		failFast = true
+		tenantID  = "tenant"
+		failFast  = true
+		brunhilda = "brunhilda"
 	)
 
 	var (
@@ -309,7 +316,8 @@ func (suite *RepositoryModelIntgSuite) TestGetBackupErrors() {
 					suite.kw,
 					suite.sw,
 					tenantID, "snapID", test.writeBupID,
-					selectors.NewExchangeBackup([]string{"brunhilda"}).Selector,
+					selectors.NewExchangeBackup([]string{brunhilda}).Selector,
+					brunhilda, brunhilda,
 					test.deets,
 					test.errors,
 					fault.New(failFast))


### PR DESCRIPTION
adds a resourceOwnerName property to the op
backup struct.  Also adds a resource owner id
and owner name to the backup.backup.  These
values will be used for both identification and for
end user display.  Values are not currently populated
reliably, nor are they used.  This change only
allows them to exist.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #2825

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
