### PR TITLE
move graph connector creation to new op

### DIFF
--- a/src/internal/connector/graph_connector.go
+++ b/src/internal/connector/graph_connector.go
@@ -227,11 +227,18 @@ func (gc *GraphConnector) AwaitStatus() *support.ConnectorOperationStatus {
 	defer func() {
 		if gc.region != nil {
 			gc.region.End()
+			gc.region = nil
 		}
 	}()
 	gc.wg.Wait()
 
-	return &gc.status
+	// clean up and reset statefulness
+	status := gc.status
+
+	gc.wg = &sync.WaitGroup{}
+	gc.status = support.ConnectorOperationStatus{}
+
+	return &status
 }
 
 // UpdateStatus is used by gc initiated tasks to indicate completion

--- a/src/internal/connector/graph_connector_disconnected_test.go
+++ b/src/internal/connector/graph_connector_disconnected_test.go
@@ -111,17 +111,17 @@ func (suite *DisconnectedGraphConnectorSuite) TestGraphConnector_Status() {
 	go statusTestTask(&gc, 4, 1, 1)
 	go statusTestTask(&gc, 4, 1, 1)
 
-	gc.AwaitStatus()
+	status := gc.AwaitStatus()
 
 	t := suite.T()
 
 	assert.NotEmpty(t, gc.PrintableStatus())
 	// Expect 8 objects
-	assert.Equal(t, 8, gc.Status().Metrics.Objects)
+	assert.Equal(t, 8, status.Metrics.Objects)
 	// Expect 2 success
-	assert.Equal(t, 2, gc.Status().Metrics.Successes)
+	assert.Equal(t, 2, status.Metrics.Successes)
 	// Expect 2 folders
-	assert.Equal(t, 2, gc.Status().Folders)
+	assert.Equal(t, 2, status.Folders)
 }
 
 func (suite *DisconnectedGraphConnectorSuite) TestVerifyBackupInputs_allServices() {

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -394,6 +394,8 @@ func generateContainerOfItems(
 		fault.New(true))
 	require.NoError(t, err, clues.ToCore(err))
 
+	gc.AwaitStatus()
+
 	return deets
 }
 
@@ -1093,6 +1095,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchangeIncrementals() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
+			fmt.Printf("\n-----\ntest %+v\n-----\n", test.name)
 			var (
 				t     = suite.T()
 				incMB = evmock.NewBus()

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -68,10 +68,12 @@ func prepNewTestBackupOp(
 	func(),
 ) {
 	//revive:enable:context-as-argument
-	acct := tester.NewM365Account(t)
-	// need to initialize the repository before we can test connecting to it.
-	st := tester.NewPrefixedS3Storage(t)
-	k := kopia.NewConn(st)
+	var (
+		acct = tester.NewM365Account(t)
+		// need to initialize the repository before we can test connecting to it.
+		st = tester.NewPrefixedS3Storage(t)
+		k  = kopia.NewConn(st)
+	)
 
 	err := k.Initialize(ctx)
 	require.NoError(t, err, clues.ToCore(err))
@@ -103,11 +105,16 @@ func prepNewTestBackupOp(
 		ms.Close(ctx)
 	}
 
+	connectorResource := connector.Users
+	if sel.Service == selectors.ServiceSharePoint {
+		connectorResource = connector.Sites
+	}
+
 	gc, err := connector.NewGraphConnector(
 		ctx,
 		graph.HTTPClient(graph.NoTimeout()),
 		acct,
-		connector.Users,
+		connectorResource,
 		fault.New(true))
 	if !assert.NoError(t, err, clues.ToCore(err)) {
 		closer()

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/connector"
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/data"
 	evmock "github.com/alcionai/corso/src/internal/events/mock"
@@ -359,6 +360,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_PersistResults() {
 	var (
 		kw   = &kopia.Wrapper{}
 		sw   = &store.Wrapper{}
+		gc   = &connector.GraphConnector{}
 		acct = account.Account{}
 		now  = time.Now()
 	)
@@ -413,6 +415,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_PersistResults() {
 				control.Options{},
 				kw,
 				sw,
+				gc,
 				acct,
 				sel,
 				sel.DiscreteOwner,

--- a/src/internal/operations/operation.go
+++ b/src/internal/operations/operation.go
@@ -91,7 +91,7 @@ func (op operation) validate() error {
 	}
 
 	if op.gc == nil {
-		return errors.New("missing graph connector")
+		return clues.New("missing graph connector")
 	}
 
 	return nil

--- a/src/internal/operations/operation_test.go
+++ b/src/internal/operations/operation_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/connector"
 	"github.com/alcionai/corso/src/internal/events"
 	"github.com/alcionai/corso/src/internal/kopia"
 	"github.com/alcionai/corso/src/internal/tester"
@@ -25,27 +26,30 @@ func TestOperationSuite(t *testing.T) {
 
 func (suite *OperationSuite) TestNewOperation() {
 	t := suite.T()
-	op := newOperation(control.Options{}, events.Bus{}, nil, nil)
+	op := newOperation(control.Options{}, events.Bus{}, nil, nil, nil)
 	assert.Greater(t, op.CreatedAt, time.Time{})
 }
 
 func (suite *OperationSuite) TestOperation_Validate() {
 	kwStub := &kopia.Wrapper{}
 	swStub := &store.Wrapper{}
+	gcStub := &connector.GraphConnector{}
 
 	table := []struct {
 		name     string
 		kw       *kopia.Wrapper
 		sw       *store.Wrapper
+		gc       *connector.GraphConnector
 		errCheck assert.ErrorAssertionFunc
 	}{
-		{"good", kwStub, swStub, assert.NoError},
-		{"missing kopia wrapper", nil, swStub, assert.Error},
-		{"missing store wrapper", kwStub, nil, assert.Error},
+		{"good", kwStub, swStub, gcStub, assert.NoError},
+		{"missing kopia wrapper", nil, swStub, gcStub, assert.Error},
+		{"missing store wrapper", kwStub, nil, gcStub, assert.Error},
+		{"missing graph connector", kwStub, swStub, nil, assert.Error},
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			err := newOperation(control.Options{}, events.Bus{}, test.kw, test.sw).validate()
+			err := newOperation(control.Options{}, events.Bus{}, test.kw, test.sw, test.gc).validate()
 			test.errCheck(suite.T(), err, clues.ToCore(err))
 		})
 	}

--- a/src/internal/operations/restore_test.go
+++ b/src/internal/operations/restore_test.go
@@ -149,9 +149,6 @@ type bupResults struct {
 type RestoreOpIntegrationSuite struct {
 	tester.Suite
 
-	exchange   bupResults
-	sharepoint bupResults
-
 	kopiaCloser func(ctx context.Context)
 	acct        account.Account
 	kw          *kopia.Wrapper


### PR DESCRIPTION
Moves the generation of graphConnector to the
NewBackupOp and NewRestoreOp constructors
inside the repository.  This removes gc creation
from the backup and restore operations, and
requires a reference to gc to exist in operations.

This sets up two changes: 1/ mocking of GC
within operation (the next PR will replace it with
an interface).  2/ the ability to perform a gc
validation step within the operation construction,
and thus the capacity to look up a resource owner
display name or id, and vice versa.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #2825

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
