### PR TITLE
Skip large OneNote items that cannot be downloaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable compression for all data uploaded by kopia.
 - SharePoint --folder selectors correctly return items.
 - Fix Exchange cli args for filtering items
+- Skip huge OneNote items that Graph API prevents us from downloading
 
 ## [v0.6.1] (beta) - 2023-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SharePoint --folder selectors correctly return items.
 - Fix Exchange cli args for filtering items
 - Skip huge OneNote items that Graph API prevents us from downloading
+- Skip OneNote items bigger than 2GB (Graph API prevents us from downloading them)
 
 ## [v0.6.1] (beta) - 2023-03-21
 

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -145,7 +145,7 @@ func NewCollection(
 	statusUpdater support.StatusUpdater,
 	source driveSource,
 	ctrlOpts control.Options,
-	colKind collectionScope,
+	colScope collectionScope,
 	doNotMergeItems bool,
 ) *Collection {
 	c := &Collection{
@@ -160,7 +160,7 @@ func NewCollection(
 		statusUpdater:   statusUpdater,
 		ctrl:            ctrlOpts,
 		state:           data.StateOf(prevPath, folderPath),
-		scope:           colKind,
+		scope:           colScope,
 		doNotMergeItems: doNotMergeItems,
 	}
 

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -43,7 +43,7 @@ const (
 	DataFileSuffix    = ".data"
 
 	// Used to compare in case of OneNote files
-	Size2GB = 2 * 1024 * 1024 * 1024
+	MaxOneNoteFileSize = 2 * 1024 * 1024 * 1024
 )
 
 func IsMetaFile(name string) bool {
@@ -360,13 +360,13 @@ func (oc *Collection) getDriveItemContent(
 
 		// Skip big OneNote files as they can't be downloaded
 		if clues.HasLabel(err, graph.LabelStatus(http.StatusServiceUnavailable)) &&
-			oc.kind == CollectionKindPackage && *item.GetSize() >= Size2GB {
+			oc.kind == CollectionKindPackage && *item.GetSize() >= MaxOneNoteFileSize {
 			// FIXME: It is possible that in case of a OneNote file we
 			// will end up just backing up the `onetoc2` file without
 			// the one file which is the important part of the OneNote
-			// "item". This will have to be handed during the restore,
-			// or we have to handle it separately by somehow deleting
-			// the entire collection.
+			// "item". This will have to be handled during the
+			// restore, or we have to handle it separately by somehow
+			// deleting the entire collection.
 			logger.CtxErr(ctx, err).With("skipped_reason", fault.SkipBigOneNote).Error("invalid file")
 			el.AddSkip(fault.FileSkip(fault.SkipBigOneNote, itemID, itemName, graph.ItemInfo(item)))
 

--- a/src/internal/connector/onedrive/collection_test.go
+++ b/src/internal/connector/onedrive/collection_test.go
@@ -214,7 +214,7 @@ func (suite *CollectionUnitTestSuite) TestCollection() {
 				suite.testStatusUpdater(&wg, &collStatus),
 				test.source,
 				control.Options{ToggleFeatures: control.Toggles{EnablePermissionsBackup: true}},
-				CollectionKindFolder,
+				CollectionScopeFolder,
 				true)
 			require.NotNil(t, coll)
 			assert.Equal(t, folderPath, coll.FullPath())
@@ -354,7 +354,7 @@ func (suite *CollectionUnitTestSuite) TestCollectionReadError() {
 				suite.testStatusUpdater(&wg, &collStatus),
 				test.source,
 				control.Options{ToggleFeatures: control.Toggles{EnablePermissionsBackup: true}},
-				CollectionKindFolder,
+				CollectionScopeFolder,
 				true)
 
 			mockItem := models.NewDriveItem()
@@ -444,7 +444,7 @@ func (suite *CollectionUnitTestSuite) TestCollectionReadUnauthorizedErrorRetry()
 				suite.testStatusUpdater(&wg, &collStatus),
 				test.source,
 				control.Options{ToggleFeatures: control.Toggles{EnablePermissionsBackup: true}},
-				CollectionKindFolder,
+				CollectionScopeFolder,
 				true)
 
 			mockItem := models.NewDriveItem()
@@ -544,7 +544,7 @@ func (suite *CollectionUnitTestSuite) TestCollectionPermissionBackupLatestModTim
 				suite.testStatusUpdater(&wg, &collStatus),
 				test.source,
 				control.Options{ToggleFeatures: control.Toggles{EnablePermissionsBackup: true}},
-				CollectionKindFolder,
+				CollectionScopeFolder,
 				true)
 
 			mtime := time.Now().AddDate(0, -1, 0)
@@ -615,33 +615,33 @@ func (suite *GetDriveItemUnitTestSuite) TestGetDriveItemError() {
 
 	table := []struct {
 		name           string
-		collectionKind collectionKind
+		collectionKind collectionScope
 		itemSize       int64
 		labels         []string
 		err            error
 	}{
 		{
 			name:           "Simple item fetch no error",
-			collectionKind: CollectionKindFolder,
+			collectionKind: CollectionScopeFolder,
 			itemSize:       10,
 			err:            nil,
 		},
 		{
 			name:           "Simple item fetch error",
-			collectionKind: CollectionKindFolder,
+			collectionKind: CollectionScopeFolder,
 			itemSize:       10,
 			err:            assert.AnError,
 		},
 		{
 			name:           "malware error",
-			collectionKind: CollectionKindFolder,
+			collectionKind: CollectionScopeFolder,
 			itemSize:       10,
 			err:            clues.New("test error").Label(graph.LabelsMalware),
 			labels:         []string{graph.LabelsMalware, graph.LabelsSkippable},
 		},
 		{
 			name:           "file not found error",
-			collectionKind: CollectionKindFolder,
+			collectionKind: CollectionScopeFolder,
 			itemSize:       10,
 			err:            clues.New("test error").Label(graph.LabelStatus(http.StatusNotFound)),
 			labels:         []string{graph.LabelStatus(http.StatusNotFound), graph.LabelsSkippable},
@@ -649,14 +649,14 @@ func (suite *GetDriveItemUnitTestSuite) TestGetDriveItemError() {
 		{
 			// This should create an error that stops the backup
 			name:           "small OneNote file",
-			collectionKind: CollectionKindPackage,
+			collectionKind: CollectionScopePackage,
 			itemSize:       10,
 			err:            clues.New("test error").Label(graph.LabelStatus(http.StatusServiceUnavailable)),
 			labels:         []string{graph.LabelStatus(http.StatusServiceUnavailable)},
 		},
 		{
 			name:           "big OneNote file",
-			collectionKind: CollectionKindPackage,
+			collectionKind: CollectionScopePackage,
 			itemSize:       MaxOneNoteFileSize,
 			err:            clues.New("test error").Label(graph.LabelStatus(http.StatusServiceUnavailable)),
 			labels:         []string{graph.LabelStatus(http.StatusServiceUnavailable), graph.LabelsSkippable},
@@ -664,7 +664,7 @@ func (suite *GetDriveItemUnitTestSuite) TestGetDriveItemError() {
 		{
 			// This should block backup, only big OneNote files should be a problem
 			name:           "big file",
-			collectionKind: CollectionKindFolder,
+			collectionKind: CollectionScopeFolder,
 			itemSize:       MaxOneNoteFileSize,
 			err:            clues.New("test error").Label(graph.LabelStatus(http.StatusServiceUnavailable)),
 			labels:         []string{graph.LabelStatus(http.StatusServiceUnavailable)},
@@ -680,7 +680,7 @@ func (suite *GetDriveItemUnitTestSuite) TestGetDriveItemError() {
 				t    = suite.T()
 				errs = fault.New(false)
 				item = models.NewDriveItem()
-				col  = &Collection{kind: test.collectionKind}
+				col  = &Collection{scope: test.collectionKind}
 			)
 
 			item.SetId(&strval)

--- a/src/internal/connector/onedrive/collection_test.go
+++ b/src/internal/connector/onedrive/collection_test.go
@@ -614,60 +614,60 @@ func (suite *GetDriveItemUnitTestSuite) TestGetDriveItemError() {
 	strval := "not-important"
 
 	table := []struct {
-		name           string
-		collectionKind collectionScope
-		itemSize       int64
-		labels         []string
-		err            error
+		name     string
+		colScope collectionScope
+		itemSize int64
+		labels   []string
+		err      error
 	}{
 		{
-			name:           "Simple item fetch no error",
-			collectionKind: CollectionScopeFolder,
-			itemSize:       10,
-			err:            nil,
+			name:     "Simple item fetch no error",
+			colScope: CollectionScopeFolder,
+			itemSize: 10,
+			err:      nil,
 		},
 		{
-			name:           "Simple item fetch error",
-			collectionKind: CollectionScopeFolder,
-			itemSize:       10,
-			err:            assert.AnError,
+			name:     "Simple item fetch error",
+			colScope: CollectionScopeFolder,
+			itemSize: 10,
+			err:      assert.AnError,
 		},
 		{
-			name:           "malware error",
-			collectionKind: CollectionScopeFolder,
-			itemSize:       10,
-			err:            clues.New("test error").Label(graph.LabelsMalware),
-			labels:         []string{graph.LabelsMalware, graph.LabelsSkippable},
+			name:     "malware error",
+			colScope: CollectionScopeFolder,
+			itemSize: 10,
+			err:      clues.New("test error").Label(graph.LabelsMalware),
+			labels:   []string{graph.LabelsMalware, graph.LabelsSkippable},
 		},
 		{
-			name:           "file not found error",
-			collectionKind: CollectionScopeFolder,
-			itemSize:       10,
-			err:            clues.New("test error").Label(graph.LabelStatus(http.StatusNotFound)),
-			labels:         []string{graph.LabelStatus(http.StatusNotFound), graph.LabelsSkippable},
+			name:     "file not found error",
+			colScope: CollectionScopeFolder,
+			itemSize: 10,
+			err:      clues.New("test error").Label(graph.LabelStatus(http.StatusNotFound)),
+			labels:   []string{graph.LabelStatus(http.StatusNotFound), graph.LabelsSkippable},
 		},
 		{
 			// This should create an error that stops the backup
-			name:           "small OneNote file",
-			collectionKind: CollectionScopePackage,
-			itemSize:       10,
-			err:            clues.New("test error").Label(graph.LabelStatus(http.StatusServiceUnavailable)),
-			labels:         []string{graph.LabelStatus(http.StatusServiceUnavailable)},
+			name:     "small OneNote file",
+			colScope: CollectionScopePackage,
+			itemSize: 10,
+			err:      clues.New("test error").Label(graph.LabelStatus(http.StatusServiceUnavailable)),
+			labels:   []string{graph.LabelStatus(http.StatusServiceUnavailable)},
 		},
 		{
-			name:           "big OneNote file",
-			collectionKind: CollectionScopePackage,
-			itemSize:       MaxOneNoteFileSize,
-			err:            clues.New("test error").Label(graph.LabelStatus(http.StatusServiceUnavailable)),
-			labels:         []string{graph.LabelStatus(http.StatusServiceUnavailable), graph.LabelsSkippable},
+			name:     "big OneNote file",
+			colScope: CollectionScopePackage,
+			itemSize: MaxOneNoteFileSize,
+			err:      clues.New("test error").Label(graph.LabelStatus(http.StatusServiceUnavailable)),
+			labels:   []string{graph.LabelStatus(http.StatusServiceUnavailable), graph.LabelsSkippable},
 		},
 		{
 			// This should block backup, only big OneNote files should be a problem
-			name:           "big file",
-			collectionKind: CollectionScopeFolder,
-			itemSize:       MaxOneNoteFileSize,
-			err:            clues.New("test error").Label(graph.LabelStatus(http.StatusServiceUnavailable)),
-			labels:         []string{graph.LabelStatus(http.StatusServiceUnavailable)},
+			name:     "big file",
+			colScope: CollectionScopeFolder,
+			itemSize: MaxOneNoteFileSize,
+			err:      clues.New("test error").Label(graph.LabelStatus(http.StatusServiceUnavailable)),
+			labels:   []string{graph.LabelStatus(http.StatusServiceUnavailable)},
 		},
 	}
 
@@ -680,7 +680,7 @@ func (suite *GetDriveItemUnitTestSuite) TestGetDriveItemError() {
 				t    = suite.T()
 				errs = fault.New(false)
 				item = models.NewDriveItem()
-				col  = &Collection{scope: test.collectionKind}
+				col  = &Collection{scope: test.colScope}
 			)
 
 			item.SetId(&strval)

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -33,6 +33,20 @@ const (
 	SharePointSource
 )
 
+type collectionKind int
+
+const (
+	// CollectionKindUnknown is used when we don't know and don't need
+	// to know the kind, like in the case of deletes
+	CollectionKindUnknown collectionKind = iota
+
+	// CollectionKindFolder is used for regular folder collections
+	CollectionKindFolder
+
+	// CollectionKindPackage is used to represent OneNote items
+	CollectionKindPackage
+)
+
 const (
 	restrictedDirectory = "Site Pages"
 	rootDrivePattern    = "/drives/%s/root:"
@@ -411,6 +425,7 @@ func (c *Collections) Get(
 				c.statusUpdater,
 				c.source,
 				c.ctrl,
+				CollectionKindUnknown,
 				true)
 
 			c.CollectionMap[driveID][fldID] = col
@@ -572,6 +587,7 @@ func (c *Collections) handleDelete(
 		c.statusUpdater,
 		c.source,
 		c.ctrl,
+		CollectionKindUnknown,
 		// DoNotMerge is not checked for deleted items.
 		false)
 
@@ -744,6 +760,11 @@ func (c *Collections) UpdateCollections(
 				continue
 			}
 
+			collectionKind := CollectionKindFolder
+			if item.GetPackage() != nil {
+				collectionKind = CollectionKindPackage
+			}
+
 			col := NewCollection(
 				c.itemClient,
 				collectionPath,
@@ -753,6 +774,7 @@ func (c *Collections) UpdateCollections(
 				c.statusUpdater,
 				c.source,
 				c.ctrl,
+				collectionKind,
 				invalidPrevDelta,
 			)
 			col.driveName = driveName

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -33,18 +33,18 @@ const (
 	SharePointSource
 )
 
-type collectionKind int
+type collectionScope int
 
 const (
-	// CollectionKindUnknown is used when we don't know and don't need
+	// CollectionScopeUnknown is used when we don't know and don't need
 	// to know the kind, like in the case of deletes
-	CollectionKindUnknown collectionKind = iota
+	CollectionScopeUnknown collectionScope = iota
 
-	// CollectionKindFolder is used for regular folder collections
-	CollectionKindFolder
+	// CollectionScopeFolder is used for regular folder collections
+	CollectionScopeFolder
 
-	// CollectionKindPackage is used to represent OneNote items
-	CollectionKindPackage
+	// CollectionScopePackage is used to represent OneNote items
+	CollectionScopePackage
 )
 
 const (
@@ -425,7 +425,7 @@ func (c *Collections) Get(
 				c.statusUpdater,
 				c.source,
 				c.ctrl,
-				CollectionKindUnknown,
+				CollectionScopeUnknown,
 				true)
 
 			c.CollectionMap[driveID][fldID] = col
@@ -587,7 +587,7 @@ func (c *Collections) handleDelete(
 		c.statusUpdater,
 		c.source,
 		c.ctrl,
-		CollectionKindUnknown,
+		CollectionScopeUnknown,
 		// DoNotMerge is not checked for deleted items.
 		false)
 
@@ -760,9 +760,9 @@ func (c *Collections) UpdateCollections(
 				continue
 			}
 
-			collectionKind := CollectionKindFolder
+			collectionKind := CollectionScopeFolder
 			if item.GetPackage() != nil {
-				collectionKind = CollectionKindPackage
+				collectionKind = CollectionScopePackage
 			}
 
 			col := NewCollection(

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -760,9 +760,9 @@ func (c *Collections) UpdateCollections(
 				continue
 			}
 
-			collectionKind := CollectionScopeFolder
+			colScope := CollectionScopeFolder
 			if item.GetPackage() != nil {
-				collectionKind = CollectionScopePackage
+				colScope = CollectionScopePackage
 			}
 
 			col := NewCollection(
@@ -774,7 +774,7 @@ func (c *Collections) UpdateCollections(
 				c.statusUpdater,
 				c.source,
 				c.ctrl,
-				collectionKind,
+				colScope,
 				invalidPrevDelta,
 			)
 			col.driveName = driveName

--- a/src/internal/stats/stats.go
+++ b/src/internal/stats/stats.go
@@ -30,7 +30,8 @@ func (bc *ByteCounter) Count(i int64) {
 }
 
 type SkippedCounts struct {
-	TotalSkippedItems int `json:"totalSkippedItems"`
-	SkippedMalware    int `json:"skippedMalware"`
-	SkippedNotFound   int `json:"skippedNotFound"`
+	TotalSkippedItems         int `json:"totalSkippedItems"`
+	SkippedMalware            int `json:"skippedMalware"`
+	SkippedNotFound           int `json:"skippedNotFound"`
+	SkippedInvalidOneNoteFile int `json:"skippedInvalidOneNoteFile"`
 }

--- a/src/pkg/backup/backup_test.go
+++ b/src/pkg/backup/backup_test.go
@@ -153,17 +153,30 @@ func (suite *BackupUnitSuite) TestBackup_Values_statusVariations() {
 			expect: "test (42 errors, 1 skipped: 1 not found)",
 		},
 		{
-			name: "errors, malware, notFound",
+			name: "errors and invalid OneNote",
 			bup: backup.Backup{
 				Status:     "test",
 				ErrorCount: 42,
 				SkippedCounts: stats.SkippedCounts{
-					TotalSkippedItems: 1,
-					SkippedMalware:    1,
-					SkippedNotFound:   1,
+					TotalSkippedItems:         1,
+					SkippedInvalidOneNoteFile: 1,
 				},
 			},
-			expect: "test (42 errors, 1 skipped: 1 malware, 1 not found)",
+			expect: "test (42 errors, 1 skipped: 1 invalid OneNote file)",
+		},
+		{
+			name: "errors, malware, notFound, invalid OneNote",
+			bup: backup.Backup{
+				Status:     "test",
+				ErrorCount: 42,
+				SkippedCounts: stats.SkippedCounts{
+					TotalSkippedItems:         1,
+					SkippedMalware:            1,
+					SkippedNotFound:           1,
+					SkippedInvalidOneNoteFile: 1,
+				},
+			},
+			expect: "test (42 errors, 1 skipped: 1 malware, 1 not found, 1 invalid OneNote file)",
 		},
 	}
 	for _, test := range table {

--- a/src/pkg/fault/item.go
+++ b/src/pkg/fault/item.go
@@ -156,6 +156,13 @@ const (
 	// SkipNotFound identifies that a file was skipped because we could
 	// not find it when trying to download contents
 	SkipNotFound skipCause = "file_not_found"
+
+	// SkipBigOneNote identifies that a file was skipped because it
+	// was big OneNote file and we can only download OneNote files which
+	// are less that 2GB in size.
+	//nolint:lll
+	// https://support.microsoft.com/en-us/office/restrictions-and-limitations-in-onedrive-and-sharepoint-64883a5d-228e-48f5-b3d2-eb39e07630fa#onenotenotebooks
+	SkipBigOneNote skipCause = "big_one_note_file"
 )
 
 var _ print.Printable = &Skipped{}


### PR DESCRIPTION
OneNote files >2GB cannot be downloaded via the graph API. This change will gracefully skip them and prevent the backup from erroring out.

A OneNote file is represented by a Package(folder) which contains two file within it, `<file>.one` and `<file>.onetoc2`.  From what I can tell the `onetoc2` file is the metadata file and the `one` file is the one that contains data and can get big.

**The current implementation has a limitation(or feature depending on how you see it) in that we will end up doing a partial backup with just the `onetoc2` file but avoiding the big `one` file if that is big.**

I did not try to change the behaviour as even currently if for somehow we ended up with an error like 404 when trying to backup one of these files, we do skip it. I've added a comment in for now, let me know if we should go back and revisit the behaviour. *The main issue is the fact that we only hit this problem once it reaches kopia and removing it at that point is harder.*

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* fixes https://github.com/alcionai/corso/issues/2910

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
