### PR TITLE
Always make empty collections for prefix directories

### DIFF
--- a/src/internal/connector/data_collections_test.go
+++ b/src/internal/connector/data_collections_test.go
@@ -117,9 +117,9 @@ func (suite *ConnectorDataCollectionIntegrationSuite) TestExchangeDataCollection
 			}
 
 			// Categories with delta endpoints will produce a collection for metadata
-			// as well as the actual data pulled.
+			// as well as the actual data pulled, and the "temp" root collection.
 			assert.GreaterOrEqual(t, len(collections), 1, "expected 1 <= num collections <= 2")
-			assert.GreaterOrEqual(t, 2, len(collections), "expected 1 <= num collections <= 2")
+			assert.GreaterOrEqual(t, 3, len(collections), "expected 1 <= num collections <= 3")
 
 			for _, col := range collections {
 				for object := range col.Items(ctx, fault.New(true)) {

--- a/src/internal/connector/data_collections_test.go
+++ b/src/internal/connector/data_collections_test.go
@@ -343,17 +343,21 @@ func (suite *ConnectorCreateSharePointCollectionIntegrationSuite) TestCreateShar
 		control.Options{},
 		fault.New(true))
 	require.NoError(t, err, clues.ToCore(err))
-	assert.Len(t, cols, 1)
+	require.Len(t, cols, 2) // 1 collection, 1 path prefix directory to ensure the root path exists.
 	// No excludes yet as this isn't an incremental backup.
 	assert.Empty(t, excludes)
 
-	for _, collection := range cols {
-		t.Logf("Path: %s\n", collection.FullPath().String())
-		assert.Equal(
-			t,
-			path.SharePointMetadataService.String(),
-			collection.FullPath().Service().String())
-	}
+	t.Logf("cols[0] Path: %s\n", cols[0].FullPath().String())
+	assert.Equal(
+		t,
+		path.SharePointMetadataService.String(),
+		cols[0].FullPath().Service().String())
+
+	t.Logf("cols[1] Path: %s\n", cols[1].FullPath().String())
+	assert.Equal(
+		t,
+		path.SharePointService.String(),
+		cols[1].FullPath().Service().String())
 }
 
 func (suite *ConnectorCreateSharePointCollectionIntegrationSuite) TestCreateSharePointCollection_Lists() {

--- a/src/internal/connector/exchange/data_collections.go
+++ b/src/internal/connector/exchange/data_collections.go
@@ -221,7 +221,7 @@ func DataCollections(
 			su,
 			errs)
 		if err != nil {
-			return collections, nil, err
+			return nil, nil, err
 		}
 
 		collections = append(collections, baseCols...)

--- a/src/internal/connector/exchange/data_collections.go
+++ b/src/internal/connector/exchange/data_collections.go
@@ -179,6 +179,7 @@ func DataCollections(
 		user        = selector.DiscreteOwner
 		collections = []data.BackupCollection{}
 		el          = errs.Local()
+		categories  = map[path.CategoryType]struct{}{}
 	)
 
 	cdps, err := parseMetadataCollections(ctx, metadata, errs)
@@ -205,8 +206,22 @@ func DataCollections(
 			continue
 		}
 
+		categories[scope.Category().PathType()] = struct{}{}
+
 		collections = append(collections, dcs...)
 	}
+
+	baseCols, baseErrs := graph.BaseCollections(
+		acct.AzureTenantID,
+		user,
+		path.ExchangeService,
+		categories,
+		su)
+	if baseErrs != nil {
+		return collections, nil, baseErrs
+	}
+
+	collections = append(collections, baseCols...)
 
 	return collections, nil, el.Failure()
 }

--- a/src/internal/connector/exchange/data_collections.go
+++ b/src/internal/connector/exchange/data_collections.go
@@ -211,17 +211,21 @@ func DataCollections(
 		collections = append(collections, dcs...)
 	}
 
-	baseCols, baseErrs := graph.BaseCollections(
-		acct.AzureTenantID,
-		user,
-		path.ExchangeService,
-		categories,
-		su)
-	if baseErrs != nil {
-		return collections, nil, baseErrs
-	}
+	if len(collections) > 0 {
+		baseCols, err := graph.BaseCollections(
+			ctx,
+			acct.AzureTenantID,
+			user,
+			path.ExchangeService,
+			categories,
+			su,
+			errs)
+		if err != nil {
+			return collections, nil, err
+		}
 
-	collections = append(collections, baseCols...)
+		collections = append(collections, baseCols...)
+	}
 
 	return collections, nil, el.Failure()
 }

--- a/src/internal/connector/graph/collections.go
+++ b/src/internal/connector/graph/collections.go
@@ -1,0 +1,90 @@
+package graph
+
+import (
+	"context"
+
+	"github.com/alcionai/clues"
+
+	"github.com/alcionai/corso/src/internal/connector/support"
+	"github.com/alcionai/corso/src/internal/data"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/path"
+)
+
+var _ data.BackupCollection = emptyCollection{}
+
+type emptyCollection struct {
+	p  path.Path
+	su support.StatusUpdater
+}
+
+func (c emptyCollection) Items(ctx context.Context, errs *fault.Errors) <-chan data.Stream {
+	res := make(chan data.Stream)
+	close(res)
+
+	s := support.CreateStatus(ctx, support.Backup, 0, support.CollectionMetrics{}, nil, "")
+	c.su(s)
+
+	return res
+}
+
+func (c emptyCollection) FullPath() path.Path {
+	return c.p
+}
+
+func (c emptyCollection) PreviousPath() path.Path {
+	return c.p
+}
+
+func (c emptyCollection) State() data.CollectionState {
+	// This assumes we won't change the prefix path. Could probably use MovedState
+	// as well if we do need to change things around.
+	return data.NotMovedState
+}
+
+func (c emptyCollection) DoNotMergeItems() bool {
+	return false
+}
+
+func BaseCollections(
+	tenant, user string,
+	service path.ServiceType,
+	categories map[path.CategoryType]struct{},
+	su support.StatusUpdater,
+) ([]data.BackupCollection, error) {
+	var (
+		errs = []error{}
+		res  = []data.BackupCollection{}
+	)
+
+	for cat := range categories {
+		p, err := path.Builder{}.Append("tmp").ToDataLayerPath(tenant, user, service, cat, false)
+		if err != nil {
+			// Shouldn't happen.
+			errs = append(
+				errs,
+				clues.Wrap(err, "making path").With("service", service, "category", cat))
+
+			continue
+		}
+
+		p, err = p.Dir()
+		if err != nil {
+			// Shouldn't happen.
+			errs = append(
+				errs,
+				clues.Wrap(err, "getting base prefix").With("serivce", service, "category", cat))
+
+			continue
+		}
+
+		// Pop off the last path element because we just want the prefix.
+		res = append(res, emptyCollection{p: p, su: su})
+	}
+
+	if len(errs) > 0 {
+		return res, clues.Stack(errs...)
+	}
+
+	return res, nil
+}

--- a/src/internal/connector/graph/collections.go
+++ b/src/internal/connector/graph/collections.go
@@ -73,6 +73,7 @@ func BaseCollections(
 			continue
 		}
 
+		// Pop off the last path element because we just want the prefix.
 		p, err = p.Dir()
 		if err != nil {
 			// Shouldn't happen.
@@ -83,7 +84,6 @@ func BaseCollections(
 			continue
 		}
 
-		// Pop off the last path element because we just want the prefix.
 		res = append(res, emptyCollection{p: p, su: su})
 	}
 

--- a/src/internal/connector/graph_connector_test.go
+++ b/src/internal/connector/graph_connector_test.go
@@ -1054,3 +1054,138 @@ func (suite *GraphConnectorIntegrationSuite) TestRestoreAndBackup_largeMailAttac
 		},
 	)
 }
+
+func (suite *GraphConnectorIntegrationSuite) TestBackup_CreatesPrefixCollections() {
+	table := []struct {
+		name         string
+		resource     resource
+		selectorFunc func(t *testing.T) selectors.Selector
+		service      path.ServiceType
+		categories   []string
+	}{
+		{
+			name:     "Exchange",
+			resource: Users,
+			selectorFunc: func(t *testing.T) selectors.Selector {
+				sel := selectors.NewExchangeBackup([]string{suite.user})
+				sel.Include(
+					sel.ContactFolders([]string{selectors.NoneTgt}),
+					sel.EventCalendars([]string{selectors.NoneTgt}),
+					sel.MailFolders([]string{selectors.NoneTgt}),
+				)
+
+				return sel.Selector
+			},
+			service: path.ExchangeService,
+			categories: []string{
+				path.EmailCategory.String(),
+				path.ContactsCategory.String(),
+				path.EventsCategory.String(),
+			},
+		},
+		{
+			name:     "OneDrive",
+			resource: Users,
+			selectorFunc: func(t *testing.T) selectors.Selector {
+				sel := selectors.NewOneDriveBackup([]string{suite.user})
+				sel.Include(
+					sel.Folders([]string{selectors.NoneTgt}),
+				)
+
+				return sel.Selector
+			},
+			service: path.OneDriveService,
+			categories: []string{
+				path.FilesCategory.String(),
+			},
+		},
+		// SharePoint lists and pages don't seem to check selectors as expected.
+		//{
+		//	name:     "SharePoint",
+		//	resource: Sites,
+		//	selectorFunc: func(t *testing.T) selectors.Selector {
+		//    sel := selectors.NewSharePointBackup([]string{tester.M365SiteID(t)})
+		//    sel.Include(
+		//      sel.Pages([]string{selectors.NoneTgt}),
+		//      sel.Lists([]string{selectors.NoneTgt}),
+		//      sel.Libraries([]string{selectors.NoneTgt}),
+		//    )
+
+		//    return sel.Selector
+		//	},
+		//  service: path.SharePointService,
+		//	categories: []string{
+		//		path.PagesCategory.String(),
+		//		path.ListsCategory.String(),
+		//		path.LibrariesCategory.String(),
+		//	},
+		//},
+	}
+
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext()
+			defer flush()
+
+			backupGC := loadConnector(ctx, t, graph.HTTPClient(graph.NoTimeout()), test.resource)
+			backupSel := test.selectorFunc(t)
+
+			start := time.Now()
+			dcs, excludes, err := backupGC.DataCollections(
+				ctx,
+				backupSel,
+				nil,
+				control.Options{
+					RestorePermissions: false,
+					ToggleFeatures:     control.Toggles{EnablePermissionsBackup: false},
+				},
+				fault.New(true))
+			require.NoError(t, err)
+			// No excludes yet because this isn't an incremental backup.
+			assert.Empty(t, excludes)
+
+			t.Logf("Backup enumeration complete in %v\n", time.Since(start))
+
+			// Use a map to find duplicates.
+			foundCategories := []string{}
+			for _, col := range dcs {
+				// TODO(ashmrtn): We should be able to remove the below if we change how
+				// status updates are done. Ideally we shouldn't have to fetch items in
+				// these collections to avoid deadlocking.
+				var found int
+
+				errs := fault.New(true)
+
+				// Need to iterate through this before the continue below else we'll
+				// hang checking the status.
+				for range col.Items(ctx, errs) {
+					found++
+				}
+
+				// Ignore metadata collections.
+				fullPath := col.FullPath()
+				if fullPath.Service() != test.service {
+					continue
+				}
+
+				assert.Empty(t, fullPath.Folders(), "non-prefix collection")
+				assert.NotEqual(t, col.State(), data.NewState, "prefix collection marked as new")
+				foundCategories = append(foundCategories, fullPath.Category().String())
+
+				t.Logf("looking at collection %s\n", fullPath)
+
+				assert.NoError(t, errs.Err())
+				assert.Zero(t, found, "non-empty collection")
+			}
+
+			assert.ElementsMatch(t, test.categories, foundCategories)
+
+			status := backupGC.AwaitStatus()
+
+			assert.NoError(t, status.Err, "backup status.Err")
+			assert.Zero(t, status.ErrorCount, "backup status.ErrorCount")
+		})
+	}
+}

--- a/src/internal/connector/graph_connector_test.go
+++ b/src/internal/connector/graph_connector_test.go
@@ -1174,8 +1174,6 @@ func (suite *GraphConnectorIntegrationSuite) TestBackup_CreatesPrefixCollections
 				assert.NotEqual(t, col.State(), data.NewState, "prefix collection marked as new")
 				foundCategories = append(foundCategories, fullPath.Category().String())
 
-				t.Logf("looking at collection %s\n", fullPath)
-
 				assert.Zero(t, found, "non-empty collection")
 			}
 

--- a/src/internal/connector/onedrive/data_collections.go
+++ b/src/internal/connector/onedrive/data_collections.go
@@ -98,7 +98,7 @@ func DataCollections(
 			su,
 			errs)
 		if err != nil {
-			return collections, allExcludes, err
+			return nil, nil, err
 		}
 
 		collections = append(collections, baseCols...)

--- a/src/internal/connector/onedrive/data_collections.go
+++ b/src/internal/connector/onedrive/data_collections.go
@@ -77,6 +77,8 @@ func DataCollections(
 			el.AddRecoverable(clues.Stack(err).Label(fault.LabelForceNoBackupCreation))
 		}
 
+		categories[scope.Category().PathType()] = struct{}{}
+
 		collections = append(collections, odcs...)
 
 		for k, ex := range excludes {

--- a/src/internal/connector/onedrive/data_collections.go
+++ b/src/internal/connector/onedrive/data_collections.go
@@ -79,19 +79,6 @@ func DataCollections(
 
 		collections = append(collections, odcs...)
 
-		baseCols, baseErrs := graph.BaseCollections(
-			tenant,
-			user,
-			path.OneDriveService,
-			categories,
-			su)
-
-		if baseErrs != nil {
-			return collections, allExcludes, baseErrs
-		}
-
-		collections = append(collections, baseCols...)
-
 		for k, ex := range excludes {
 			if _, ok := allExcludes[k]; !ok {
 				allExcludes[k] = map[string]struct{}{}
@@ -99,6 +86,22 @@ func DataCollections(
 
 			maps.Copy(allExcludes[k], ex)
 		}
+	}
+
+	if len(collections) > 0 {
+		baseCols, err := graph.BaseCollections(
+			ctx,
+			tenant,
+			user,
+			path.OneDriveService,
+			categories,
+			su,
+			errs)
+		if err != nil {
+			return collections, allExcludes, err
+		}
+
+		collections = append(collections, baseCols...)
 	}
 
 	return collections, allExcludes, el.Failure()

--- a/src/internal/connector/onedrive/data_collections.go
+++ b/src/internal/connector/onedrive/data_collections.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
+	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"golang.org/x/exp/maps"
 )
@@ -48,6 +49,7 @@ func DataCollections(
 	var (
 		el          = errs.Local()
 		user        = selector.DiscreteOwner
+		categories  = map[path.CategoryType]struct{}{}
 		collections = []data.BackupCollection{}
 		allExcludes = map[string]map[string]struct{}{}
 	)
@@ -76,6 +78,19 @@ func DataCollections(
 		}
 
 		collections = append(collections, odcs...)
+
+		baseCols, baseErrs := graph.BaseCollections(
+			tenant,
+			user,
+			path.OneDriveService,
+			categories,
+			su)
+
+		if baseErrs != nil {
+			return collections, allExcludes, baseErrs
+		}
+
+		collections = append(collections, baseCols...)
 
 		for k, ex := range excludes {
 			if _, ok := allExcludes[k]; !ok {

--- a/src/internal/connector/sharepoint/data_collections.go
+++ b/src/internal/connector/sharepoint/data_collections.go
@@ -115,18 +115,21 @@ func DataCollections(
 		categories[scope.Category().PathType()] = struct{}{}
 	}
 
-	baseCols, baseErrs := graph.BaseCollections(
-		creds.AzureTenantID,
-		site,
-		path.SharePointService,
-		categories,
-		su.UpdateStatus)
+	if len(collections) > 0 {
+		baseCols, err := graph.BaseCollections(
+			ctx,
+			creds.AzureTenantID,
+			site,
+			path.SharePointService,
+			categories,
+			su.UpdateStatus,
+			errs)
+		if err != nil {
+			return collections, nil, err
+		}
 
-	if baseErrs != nil {
-		return collections, nil, baseErrs
+		collections = append(collections, baseCols...)
 	}
-
-	collections = append(collections, baseCols...)
 
 	return collections, nil, el.Failure()
 }

--- a/src/internal/connector/sharepoint/data_collections.go
+++ b/src/internal/connector/sharepoint/data_collections.go
@@ -47,6 +47,7 @@ func DataCollections(
 		el          = errs.Local()
 		site        = b.DiscreteOwner
 		collections = []data.BackupCollection{}
+		categories  = map[path.CategoryType]struct{}{}
 	)
 
 	for _, scope := range b.Scopes() {
@@ -110,7 +111,22 @@ func DataCollections(
 
 		collections = append(collections, spcs...)
 		foldersComplete <- struct{}{}
+
+		categories[scope.Category().PathType()] = struct{}{}
 	}
+
+	baseCols, baseErrs := graph.BaseCollections(
+		creds.AzureTenantID,
+		site,
+		path.SharePointService,
+		categories,
+		su.UpdateStatus)
+
+	if baseErrs != nil {
+		return collections, nil, baseErrs
+	}
+
+	collections = append(collections, baseCols...)
 
 	return collections, nil, el.Failure()
 }

--- a/src/internal/connector/sharepoint/data_collections.go
+++ b/src/internal/connector/sharepoint/data_collections.go
@@ -125,7 +125,7 @@ func DataCollections(
 			su.UpdateStatus,
 			errs)
 		if err != nil {
-			return collections, nil, err
+			return nil, nil, err
 		}
 
 		collections = append(collections, baseCols...)


### PR DESCRIPTION
Use empty collections to ensure the prefix directories are available in
kopia no matter what user data we find.

This helps ensure we have some set of things we can assume about
non-failed backups including:

    They have a valid snapshot ID for data
    They have a valid snapshot ID for backup details

Eventually, this will allow us to say that backups using a base that
doesn't have a prefix directory is invalid in some way

SharePoint tests are disabled because lists and pages ignore the none
target in selectors

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix

#### Issue(s)

* #2550

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
