### PR TITLE
Set default compressor to zstd-better-compression

### DIFF
--- a/src/internal/kopia/conn.go
+++ b/src/internal/kopia/conn.go
@@ -24,7 +24,7 @@ import (
 const (
 	defaultKopiaConfigDir  = "/tmp/"
 	defaultKopiaConfigFile = "repository.config"
-	defaultCompressor      = "s2-default"
+	defaultCompressor      = "zstd-better-compression"
 	// Interval of 0 disables scheduling.
 	defaultSchedulingInterval = time.Second * 0
 )


### PR DESCRIPTION
Will only be picked up by newly created repos. Existing repos will continue to use s2-default compressor.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* closes #2840

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
