### PR TITLE
Integration test for permissions changes

### DIFF
--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -117,7 +117,8 @@ func RestoreCollections(
 // RestoreCollection handles restoration of an individual collection.
 // returns:
 // - the collection's item and byte count metrics
-// - the context cancellation state (true if the context is canceled)
+// - the updated metadata map that include metadata for folders in this collection
+// - error, if any besides recoverable
 func RestoreCollection(
 	ctx context.Context,
 	backupVersion int,

--- a/src/internal/connector/sharepoint/restore.go
+++ b/src/internal/connector/sharepoint/restore.go
@@ -67,7 +67,7 @@ func RestoreCollections(
 
 		switch dc.FullPath().Category() {
 		case path.LibrariesCategory:
-			metrics, _, _, err = onedrive.RestoreCollection(
+			metrics, _, err = onedrive.RestoreCollection(
 				ictx,
 				backupVersion,
 				service,
@@ -76,7 +76,6 @@ func RestoreCollections(
 				onedrive.SharePointSource,
 				dest.ContainerName,
 				deets,
-				map[string]string{},
 				false,
 				errs)
 		case path.ListsCategory:

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -470,7 +470,7 @@ func mustGetDefaultDriveID(
 			With("user", userID)
 	}
 
-	require.NoError(t, err)
+	require.Nil(t, clues.ToCore(err))
 
 	id := ptr.Val(d.GetId())
 	require.NotEmpty(t, id, "drive ID not set")
@@ -1273,7 +1273,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveIncrementals() {
 						},
 					},
 				)
-				require.NoError(t, err, "add permission to file", clues.ToCore(err))
+				require.NoErrorf(t, err, "add permission to file %v", clues.ToCore(err))
 			},
 			itemsRead:    1, // .data file for newitem
 			itemsWritten: 2, // .meta for newitem, .dirmeta for parent (.data is not written as it is not updated)

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -1253,6 +1253,102 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveIncrementals() {
 			itemsWritten: 3, // .data and .meta for newitem, .dirmeta for parent
 		},
 		{
+			name: "add permission to new file",
+			updateUserData: func(t *testing.T) {
+				driveItem := models.NewDriveItem()
+				driveItem.SetName(&newFileName)
+				driveItem.SetFile(models.NewFile())
+				err = onedrive.RestorePermissions(
+					ctx,
+					gc.Service,
+					driveID,
+					*newFile.GetId(),
+					onedrive.Metadata{
+						SharingMode: onedrive.SharingModeCustom,
+						Permissions: []onedrive.UserPermission{
+							{
+								Roles:    []string{"write"},
+								EntityID: suite.user,
+							},
+						},
+					},
+				)
+				require.NoError(t, err, "add permission to file", clues.ToCore(err))
+			},
+			itemsRead:    1, // .data file for newitem
+			itemsWritten: 2, // .meta for newitem, .dirmeta for parent (.data is not written as it is not updated)
+		},
+		{
+			name: "remove permission from new file",
+			updateUserData: func(t *testing.T) {
+				driveItem := models.NewDriveItem()
+				driveItem.SetName(&newFileName)
+				driveItem.SetFile(models.NewFile())
+				err = onedrive.RestorePermissions(
+					ctx,
+					gc.Service,
+					driveID,
+					*newFile.GetId(),
+					onedrive.Metadata{
+						SharingMode: onedrive.SharingModeCustom,
+						Permissions: []onedrive.UserPermission{},
+					},
+				)
+				require.NoError(t, err, "add permission to file", clues.ToCore(err))
+			},
+			itemsRead:    1, // .data file for newitem
+			itemsWritten: 2, // .meta for newitem, .dirmeta for parent (.data is not written as it is not updated)
+		},
+		{
+			name: "add permission to container",
+			updateUserData: func(t *testing.T) {
+				targetContainer := containerIDs[container1]
+				driveItem := models.NewDriveItem()
+				driveItem.SetName(&newFileName)
+				driveItem.SetFile(models.NewFile())
+				err = onedrive.RestorePermissions(
+					ctx,
+					gc.Service,
+					driveID,
+					targetContainer,
+					onedrive.Metadata{
+						SharingMode: onedrive.SharingModeCustom,
+						Permissions: []onedrive.UserPermission{
+							{
+								Roles:    []string{"write"},
+								EntityID: suite.user,
+							},
+						},
+					},
+				)
+				require.NoError(t, err, "add permission to file", clues.ToCore(err))
+			},
+			itemsRead:    0,
+			itemsWritten: 1, // .dirmeta for collection
+		},
+		{
+			name: "remove permission from container",
+			updateUserData: func(t *testing.T) {
+				targetContainer := containerIDs[container1]
+				driveItem := models.NewDriveItem()
+				driveItem.SetName(&newFileName)
+				driveItem.SetFile(models.NewFile())
+				err = onedrive.RestorePermissions(
+					ctx,
+					gc.Service,
+					driveID,
+					targetContainer,
+					onedrive.Metadata{
+						SharingMode: onedrive.SharingModeCustom,
+						Permissions: []onedrive.UserPermission{},
+					},
+				)
+				require.NoError(t, err, "add permission to file", clues.ToCore(err))
+			},
+			itemsRead:    0,
+			itemsWritten: 1, // .dirmeta for collection
+		},
+		{
 			name: "update contents of a file",
 			updateUserData: func(t *testing.T) {
 				err := gc.Service.


### PR DESCRIPTION
This adds basic integration tests for backing up permissions in OneDrive.
*https://github.com/alcionai/corso/issues/2790 could be a good follow up to this.*

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* fixes https://github.com/alcionai/corso/issues/2772

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
