### PR TITLE
Re add --restore-permissions flag

### DIFF
--- a/src/cli/restore/exchange_test.go
+++ b/src/cli/restore/exchange_test.go
@@ -11,15 +11,15 @@ import (
 	"github.com/alcionai/corso/src/internal/tester"
 )
 
-type ExchangeSuite struct {
+type ExchangeUnitSuite struct {
 	tester.Suite
 }
 
-func TestExchangeSuite(t *testing.T) {
-	suite.Run(t, &ExchangeSuite{Suite: tester.NewUnitSuite(t)})
+func TestExchangeUnitSuite(t *testing.T) {
+	suite.Run(t, &ExchangeUnitSuite{Suite: tester.NewUnitSuite(t)})
 }
 
-func (suite *ExchangeSuite) TestAddExchangeCommands() {
+func (suite *ExchangeUnitSuite) TestAddExchangeCommands() {
 	expectUse := exchangeServiceCommand + " " + exchangeServiceCommandUseSuffix
 
 	table := []struct {

--- a/src/cli/restore/onedrive.go
+++ b/src/cli/restore/onedrive.go
@@ -36,6 +36,9 @@ func addOneDriveCommands(cmd *cobra.Command) *cobra.Command {
 		utils.AddBackupIDFlag(c, true)
 		utils.AddOneDriveDetailsAndRestoreFlags(c)
 
+		// restore permissions
+		options.AddRestorePermissionsFlag(c)
+
 		// others
 		options.AddOperationFlags(c)
 	}

--- a/src/cli/restore/onedrive_test.go
+++ b/src/cli/restore/onedrive_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/cli/utils"
 	"github.com/alcionai/corso/src/internal/tester"
 )
 
@@ -47,35 +48,9 @@ func (suite *OneDriveUnitSuite) TestAddOneDriveCommands() {
 			assert.Equal(t, test.expectUse, child.Use)
 			assert.Equal(t, test.expectShort, child.Short)
 			tester.AreSameFunc(t, test.expectRunE, child.RunE)
-		})
-	}
-}
 
-func (suite *OneDriveUnitSuite) TestAddOneDriveCommands_hasRestoreFlag() {
-	expectUse := oneDriveServiceCommand + " " + oneDriveServiceCommandUseSuffix
-
-	table := []struct {
-		name        string
-		use         string
-		expectUse   string
-		expectShort string
-		expectRunE  func(*cobra.Command, []string) error
-	}{
-		{"restore onedrive", restoreCommand, expectUse, oneDriveRestoreCmd().Short, restoreOneDriveCmd},
-	}
-	for _, test := range table {
-		suite.Run(test.name, func() {
-			t := suite.T()
-
-			cmd := &cobra.Command{Use: test.use}
-
-			c := addOneDriveCommands(cmd)
-			require.NotNil(t, c)
-
-			cmd.SetArgs([]string{"onedrive", "--restore-permissions"})
-
-			err := cmd.Execute()
-			assert.NotEqual(t, err.Error(), `unknown flag: --restore-permissions`)
+			assert.NotNil(t, c.Flag(utils.BackupFN))
+			assert.NotNil(t, c.Flag("restore-permissions"))
 		})
 	}
 }

--- a/src/cli/restore/onedrive_test.go
+++ b/src/cli/restore/onedrive_test.go
@@ -11,15 +11,15 @@ import (
 	"github.com/alcionai/corso/src/internal/tester"
 )
 
-type OneDriveSuite struct {
+type OneDriveUnitSuite struct {
 	tester.Suite
 }
 
-func TestOneDriveSuite(t *testing.T) {
-	suite.Run(t, &OneDriveSuite{Suite: tester.NewUnitSuite(t)})
+func TestOneDriveUnitSuite(t *testing.T) {
+	suite.Run(t, &OneDriveUnitSuite{Suite: tester.NewUnitSuite(t)})
 }
 
-func (suite *OneDriveSuite) TestAddOneDriveCommands() {
+func (suite *OneDriveUnitSuite) TestAddOneDriveCommands() {
 	expectUse := oneDriveServiceCommand + " " + oneDriveServiceCommandUseSuffix
 
 	table := []struct {
@@ -47,6 +47,35 @@ func (suite *OneDriveSuite) TestAddOneDriveCommands() {
 			assert.Equal(t, test.expectUse, child.Use)
 			assert.Equal(t, test.expectShort, child.Short)
 			tester.AreSameFunc(t, test.expectRunE, child.RunE)
+		})
+	}
+}
+
+func (suite *OneDriveUnitSuite) TestAddOneDriveCommands_hasRestoreFlag() {
+	expectUse := oneDriveServiceCommand + " " + oneDriveServiceCommandUseSuffix
+
+	table := []struct {
+		name        string
+		use         string
+		expectUse   string
+		expectShort string
+		expectRunE  func(*cobra.Command, []string) error
+	}{
+		{"restore onedrive", restoreCommand, expectUse, oneDriveRestoreCmd().Short, restoreOneDriveCmd},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			cmd := &cobra.Command{Use: test.use}
+
+			c := addOneDriveCommands(cmd)
+			require.NotNil(t, c)
+
+			cmd.SetArgs([]string{"onedrive", "--restore-permissions"})
+
+			err := cmd.Execute()
+			assert.NotEqual(t, err.Error(), `unknown flag: --restore-permissions`)
 		})
 	}
 }

--- a/src/cli/restore/sharepoint_test.go
+++ b/src/cli/restore/sharepoint_test.go
@@ -11,15 +11,15 @@ import (
 	"github.com/alcionai/corso/src/internal/tester"
 )
 
-type SharePointSuite struct {
+type SharePointUnitSuite struct {
 	tester.Suite
 }
 
-func TestSharePointSuite(t *testing.T) {
-	suite.Run(t, &SharePointSuite{Suite: tester.NewUnitSuite(t)})
+func TestSharePointUnitSuite(t *testing.T) {
+	suite.Run(t, &SharePointUnitSuite{Suite: tester.NewUnitSuite(t)})
 }
 
-func (suite *SharePointSuite) TestAddSharePointCommands() {
+func (suite *SharePointUnitSuite) TestAddSharePointCommands() {
 	expectUse := sharePointServiceCommand + " " + sharePointServiceCommandUseSuffix
 
 	table := []struct {


### PR DESCRIPTION
This seems to have accidentally removed in 285f8f0

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
