### PR TITLE
Fix flags for Exchange and OneDrive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Items not being deleted if they were created and deleted during item enumeration of a OneDrive backup.
 - Enable compression for all data uploaded by kopia.
 - SharePoint --folder selectors correctly return items.
+- Fix Exchange cli args for filtering items
 
 ## [v0.6.1] (beta) - 2023-03-21
 

--- a/src/cli/backup/backup.go
+++ b/src/cli/backup/backup.go
@@ -60,13 +60,6 @@ func AddCommands(cmd *cobra.Command) {
 // common flags and flag attachers for commands
 // ---------------------------------------------------------------------------
 
-var (
-	fileCreatedAfter   string
-	fileCreatedBefore  string
-	fileModifiedAfter  string
-	fileModifiedBefore string
-)
-
 // list output filter flags
 var (
 	failedItemsFN       = "failed-items"

--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -86,7 +86,7 @@ func addExchangeCommands(cmd *cobra.Command) *cobra.Command {
 		// Flags addition ordering should follow the order we want them to appear in help and docs:
 		// More generic (ex: --user) and more frequently used flags take precedence.
 		utils.AddUserFlag(c)
-		utils.AddDataFlag(cmd, []string{dataEmail, dataContacts, dataEvents}, false)
+		utils.AddDataFlag(c, []string{dataEmail, dataContacts, dataEvents}, false)
 		options.AddFetchParallelismFlag(c)
 		options.AddOperationFlags(c)
 

--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -76,6 +76,8 @@ func addExchangeCommands(cmd *cobra.Command) *cobra.Command {
 	switch cmd.Use {
 	case createCommand:
 		c, fs = utils.AddCommand(cmd, exchangeCreateCmd())
+		fs.SortFlags = false
+
 		options.AddFeatureToggle(cmd, options.DisableIncrementals())
 
 		c.Use = c.Use + " " + exchangeServiceCommandCreateUseSuffix
@@ -98,7 +100,8 @@ func addExchangeCommands(cmd *cobra.Command) *cobra.Command {
 		addRecoveredErrorsFN(c)
 
 	case detailsCommand:
-		c, _ = utils.AddCommand(cmd, exchangeDetailsCmd())
+		c, fs = utils.AddCommand(cmd, exchangeDetailsCmd())
+		fs.SortFlags = false
 
 		c.Use = c.Use + " " + exchangeServiceCommandDetailsUseSuffix
 		c.Example = exchangeServiceCommandDetailsExamples
@@ -111,7 +114,8 @@ func addExchangeCommands(cmd *cobra.Command) *cobra.Command {
 		utils.AddExchangeDetailsAndRestoreFlags(c)
 
 	case deleteCommand:
-		c, _ = utils.AddCommand(cmd, exchangeDeleteCmd())
+		c, fs = utils.AddCommand(cmd, exchangeDeleteCmd())
+		fs.SortFlags = false
 
 		c.Use = c.Use + " " + exchangeServiceCommandDeleteUseSuffix
 		c.Example = exchangeServiceCommandDeleteExamples

--- a/src/cli/backup/exchange_e2e_test.go
+++ b/src/cli/backup/exchange_e2e_test.go
@@ -184,7 +184,7 @@ func (suite *BackupExchangeE2ESuite) TestExchangeBackupCmd() {
 				"backup", "create", "exchange",
 				"--config-file", suite.cfgFP,
 				"--"+utils.UserFN, suite.m365UserID,
-				"--"+utils.DataFN, set.String())
+				"--"+utils.CategoryDataFN, set.String())
 			cli.BuildCommandTree(cmd)
 
 			cmd.SetOut(&recorder)
@@ -221,7 +221,7 @@ func (suite *BackupExchangeE2ESuite) TestExchangeBackupCmd_UserNotInTenant() {
 				"backup", "create", "exchange",
 				"--config-file", suite.cfgFP,
 				"--"+utils.UserFN, "foo@nothere.com",
-				"--"+utils.DataFN, set.String())
+				"--"+utils.CategoryDataFN, set.String())
 			cli.BuildCommandTree(cmd)
 
 			cmd.SetOut(&recorder)

--- a/src/cli/backup/onedrive.go
+++ b/src/cli/backup/onedrive.go
@@ -219,17 +219,7 @@ func detailsOneDriveCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := cmd.Context()
-	opts := utils.OneDriveOpts{
-		Users:              utils.User,
-		FileNames:          utils.FileName,
-		FolderPaths:        utils.FolderPath,
-		FileCreatedAfter:   utils.FileCreatedAfter,
-		FileCreatedBefore:  utils.FileCreatedBefore,
-		FileModifiedAfter:  utils.FileModifiedAfter,
-		FileModifiedBefore: utils.FileModifiedBefore,
-
-		Populated: utils.GetPopulatedFlags(cmd),
-	}
+	opts := utils.MakeOneDriveOpts(cmd)
 
 	r, _, err := getAccountAndConnect(ctx)
 	if err != nil {

--- a/src/cli/backup/onedrive.go
+++ b/src/cli/backup/onedrive.go
@@ -65,7 +65,9 @@ func addOneDriveCommands(cmd *cobra.Command) *cobra.Command {
 
 	switch cmd.Use {
 	case createCommand:
-		c, _ = utils.AddCommand(cmd, oneDriveCreateCmd())
+		c, fs = utils.AddCommand(cmd, oneDriveCreateCmd())
+		fs.SortFlags = false
+
 		options.AddFeatureToggle(cmd, options.EnablePermissionsBackup())
 
 		c.Use = c.Use + " " + oneDriveServiceCommandCreateUseSuffix
@@ -84,7 +86,8 @@ func addOneDriveCommands(cmd *cobra.Command) *cobra.Command {
 		addRecoveredErrorsFN(c)
 
 	case detailsCommand:
-		c, _ = utils.AddCommand(cmd, oneDriveDetailsCmd())
+		c, fs = utils.AddCommand(cmd, oneDriveDetailsCmd())
+		fs.SortFlags = false
 
 		c.Use = c.Use + " " + oneDriveServiceCommandDetailsUseSuffix
 		c.Example = oneDriveServiceCommandDetailsExamples
@@ -94,7 +97,8 @@ func addOneDriveCommands(cmd *cobra.Command) *cobra.Command {
 		utils.AddOneDriveDetailsAndRestoreFlags(c)
 
 	case deleteCommand:
-		c, _ = utils.AddCommand(cmd, oneDriveDeleteCmd())
+		c, fs = utils.AddCommand(cmd, oneDriveDeleteCmd())
+		fs.SortFlags = false
 
 		c.Use = c.Use + " " + oneDriveServiceCommandDeleteUseSuffix
 		c.Example = oneDriveServiceCommandDeleteExamples

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -25,9 +25,6 @@ import (
 // setup and globals
 // ------------------------------------------------------------------------------------------------
 
-// sharePoint bucket info from flags
-var sharepointData []string
-
 const (
 	dataLibraries = "libraries"
 	dataPages     = "pages"
@@ -82,12 +79,7 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 
 		utils.AddSiteFlag(c)
 		utils.AddSiteIDFlag(c)
-
-		fs.StringSliceVar(
-			&sharepointData,
-			utils.DataFN, nil,
-			"Select one or more types of data to backup: "+dataLibraries+" or "+dataPages+".")
-		cobra.CheckErr(fs.MarkHidden(utils.DataFN))
+		utils.AddDataFlag(c, []string{dataLibraries}, true)
 
 		options.AddOperationFlags(c)
 
@@ -145,7 +137,7 @@ func createSharePointCmd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	if err := validateSharePointBackupCreateFlags(utils.SiteID, utils.WebURL, sharepointData); err != nil {
+	if err := validateSharePointBackupCreateFlags(utils.SiteID, utils.WebURL, utils.CategoryData); err != nil {
 		return err
 	}
 
@@ -164,7 +156,7 @@ func createSharePointCmd(cmd *cobra.Command, args []string) error {
 		return Only(ctx, clues.Wrap(err, "Failed to connect to Microsoft APIs"))
 	}
 
-	sel, err := sharePointBackupCreateSelectors(ctx, utils.SiteID, utils.WebURL, sharepointData, gc)
+	sel, err := sharePointBackupCreateSelectors(ctx, utils.SiteID, utils.WebURL, utils.CategoryData, gc)
 	if err != nil {
 		return Only(ctx, clues.Wrap(err, "Retrieving up sharepoint sites by ID and URL"))
 	}
@@ -325,19 +317,7 @@ func detailsSharePointCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := cmd.Context()
-	opts := utils.SharePointOpts{
-		FolderPath:         utils.FolderPath,
-		FileName:           utils.FileName,
-		Library:            utils.Library,
-		SiteID:             utils.SiteID,
-		WebURL:             utils.WebURL,
-		FileCreatedAfter:   fileCreatedAfter,
-		FileCreatedBefore:  fileCreatedBefore,
-		FileModifiedAfter:  fileModifiedAfter,
-		FileModifiedBefore: fileModifiedBefore,
-
-		Populated: utils.GetPopulatedFlags(cmd),
-	}
+	opts := utils.MakeSharePointOpts(cmd)
 
 	r, _, err := getAccountAndConnect(ctx)
 	if err != nil {

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -73,6 +73,7 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 	switch cmd.Use {
 	case createCommand:
 		c, fs = utils.AddCommand(cmd, sharePointCreateCmd())
+		fs.SortFlags = false
 
 		c.Use = c.Use + " " + sharePointServiceCommandCreateUseSuffix
 		c.Example = sharePointServiceCommandCreateExamples
@@ -93,7 +94,8 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 		addRecoveredErrorsFN(c)
 
 	case detailsCommand:
-		c, _ = utils.AddCommand(cmd, sharePointDetailsCmd())
+		c, fs = utils.AddCommand(cmd, sharePointDetailsCmd())
+		fs.SortFlags = false
 
 		c.Use = c.Use + " " + sharePointServiceCommandDetailsUseSuffix
 		c.Example = sharePointServiceCommandDetailsExamples
@@ -103,7 +105,8 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 		utils.AddSharePointDetailsAndRestoreFlags(c)
 
 	case deleteCommand:
-		c, _ = utils.AddCommand(cmd, sharePointDeleteCmd())
+		c, fs = utils.AddCommand(cmd, sharePointDeleteCmd())
+		fs.SortFlags = false
 
 		c.Use = c.Use + " " + sharePointServiceCommandDeleteUseSuffix
 		c.Example = sharePointServiceCommandDeleteExamples

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -121,6 +121,7 @@ func CorsoCommand() *cobra.Command {
 func BuildCommandTree(cmd *cobra.Command) {
 	// want to order flags explicitly
 	cmd.PersistentFlags().SortFlags = false
+	utils.AddRunModeFlag(cmd, true)
 
 	cmd.Flags().BoolP("version", "v", false, "current version info")
 	cmd.PersistentPreRunE = preRun
@@ -129,7 +130,6 @@ func BuildCommandTree(cmd *cobra.Command) {
 	observe.AddProgressBarFlags(cmd)
 	print.AddOutputFlag(cmd)
 	options.AddGlobalOperationFlags(cmd)
-
 	cmd.SetUsageTemplate(indentExamplesTemplate(corsoCmd.UsageTemplate()))
 
 	cmd.CompletionOptions.DisableDefaultCmd = true

--- a/src/cli/config/config.go
+++ b/src/cli/config/config.go
@@ -75,9 +75,7 @@ func AddConfigFlags(cmd *cobra.Command) {
 	fs := cmd.PersistentFlags()
 	fs.StringVar(
 		&configFilePathFlag,
-		"config-file",
-		displayDefaultFP,
-		"config file location")
+		"config-file", displayDefaultFP, "config file location")
 }
 
 // ---------------------------------------------------------------------------------------------------------

--- a/src/cli/restore/exchange.go
+++ b/src/cli/restore/exchange.go
@@ -16,30 +16,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/repository"
 )
 
-// exchange bucket info from flags
-var (
-	user []string
-
-	contact       []string
-	contactFolder []string
-	contactName   string
-
-	email               []string
-	emailFolder         []string
-	emailReceivedAfter  string
-	emailReceivedBefore string
-	emailSender         string
-	emailSubject        string
-
-	event             []string
-	eventCalendar     []string
-	eventOrganizer    string
-	eventRecurs       string
-	eventStartsAfter  string
-	eventStartsBefore string
-	eventSubject      string
-)
-
 // called by restore.go to map subcommands to provider-specific handling.
 func addExchangeCommands(cmd *cobra.Command) *cobra.Command {
 	var (
@@ -107,23 +83,23 @@ func restoreExchangeCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	opts := utils.ExchangeOpts{
-		Contact:             contact,
-		ContactFolder:       contactFolder,
-		Email:               email,
-		EmailFolder:         emailFolder,
-		Event:               event,
-		EventCalendar:       eventCalendar,
-		Users:               user,
-		ContactName:         contactName,
-		EmailReceivedAfter:  emailReceivedAfter,
-		EmailReceivedBefore: emailReceivedBefore,
-		EmailSender:         emailSender,
-		EmailSubject:        emailSubject,
-		EventOrganizer:      eventOrganizer,
-		EventRecurs:         eventRecurs,
-		EventStartsAfter:    eventStartsAfter,
-		EventStartsBefore:   eventStartsBefore,
-		EventSubject:        eventSubject,
+		Contact:             utils.Contact,
+		ContactFolder:       utils.ContactFolder,
+		Email:               utils.Email,
+		EmailFolder:         utils.EmailFolder,
+		Event:               utils.Event,
+		EventCalendar:       utils.EventCalendar,
+		Users:               utils.User,
+		ContactName:         utils.ContactName,
+		EmailReceivedAfter:  utils.EmailReceivedAfter,
+		EmailReceivedBefore: utils.EmailReceivedBefore,
+		EmailSender:         utils.EmailSender,
+		EmailSubject:        utils.EmailSubject,
+		EventOrganizer:      utils.EventOrganizer,
+		EventRecurs:         utils.EventRecurs,
+		EventStartsAfter:    utils.EventStartsAfter,
+		EventStartsBefore:   utils.EventStartsBefore,
+		EventSubject:        utils.EventSubject,
 
 		Populated: utils.GetPopulatedFlags(cmd),
 	}

--- a/src/cli/restore/exchange.go
+++ b/src/cli/restore/exchange.go
@@ -74,15 +74,8 @@ func exchangeRestoreCmd() *cobra.Command {
 	}
 }
 
-// processes an exchange service restore.
-func restoreExchangeCmd(cmd *cobra.Command, args []string) error {
-	ctx := cmd.Context()
-
-	if utils.HasNoFlagsAndShownHelp(cmd) {
-		return nil
-	}
-
-	opts := utils.ExchangeOpts{
+func getRestoreExchangeCmdOpts(cmd *cobra.Command) utils.ExchangeOpts {
+	return utils.ExchangeOpts{
 		Contact:             utils.Contact,
 		ContactFolder:       utils.ContactFolder,
 		Email:               utils.Email,
@@ -103,6 +96,17 @@ func restoreExchangeCmd(cmd *cobra.Command, args []string) error {
 
 		Populated: utils.GetPopulatedFlags(cmd),
 	}
+}
+
+// processes an exchange service restore.
+func restoreExchangeCmd(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	if utils.HasNoFlagsAndShownHelp(cmd) {
+		return nil
+	}
+
+	opts := getRestoreExchangeCmdOpts(cmd)
 
 	if err := utils.ValidateExchangeRestoreFlags(utils.BackupID, opts); err != nil {
 		return err

--- a/src/cli/restore/exchange.go
+++ b/src/cli/restore/exchange.go
@@ -74,30 +74,6 @@ func exchangeRestoreCmd() *cobra.Command {
 	}
 }
 
-func getRestoreExchangeCmdOpts(cmd *cobra.Command) utils.ExchangeOpts {
-	return utils.ExchangeOpts{
-		Contact:             utils.Contact,
-		ContactFolder:       utils.ContactFolder,
-		Email:               utils.Email,
-		EmailFolder:         utils.EmailFolder,
-		Event:               utils.Event,
-		EventCalendar:       utils.EventCalendar,
-		Users:               utils.User,
-		ContactName:         utils.ContactName,
-		EmailReceivedAfter:  utils.EmailReceivedAfter,
-		EmailReceivedBefore: utils.EmailReceivedBefore,
-		EmailSender:         utils.EmailSender,
-		EmailSubject:        utils.EmailSubject,
-		EventOrganizer:      utils.EventOrganizer,
-		EventRecurs:         utils.EventRecurs,
-		EventStartsAfter:    utils.EventStartsAfter,
-		EventStartsBefore:   utils.EventStartsBefore,
-		EventSubject:        utils.EventSubject,
-
-		Populated: utils.GetPopulatedFlags(cmd),
-	}
-}
-
 // processes an exchange service restore.
 func restoreExchangeCmd(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
@@ -106,7 +82,11 @@ func restoreExchangeCmd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	opts := getRestoreExchangeCmdOpts(cmd)
+	opts := utils.MakeExchangeOpts(cmd)
+
+	if utils.RunMode == utils.RunModeFlagTest {
+		return nil
+	}
 
 	if err := utils.ValidateExchangeRestoreFlags(utils.BackupID, opts); err != nil {
 		return err

--- a/src/cli/restore/exchange_test.go
+++ b/src/cli/restore/exchange_test.go
@@ -4,11 +4,14 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/alcionai/clues"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/cli/utils"
+	"github.com/alcionai/corso/src/cli/utils/testdata"
 	"github.com/alcionai/corso/src/internal/tester"
 )
 
@@ -38,6 +41,10 @@ func (suite *ExchangeUnitSuite) TestAddExchangeCommands() {
 
 			cmd := &cobra.Command{Use: test.use}
 
+			// normally a persisten flag from the root.
+			// required to ensure a dry run.
+			utils.AddRunModeFlag(cmd, true)
+
 			c := addExchangeCommands(cmd)
 			require.NotNil(t, c)
 
@@ -52,23 +59,55 @@ func (suite *ExchangeUnitSuite) TestAddExchangeCommands() {
 			// Test arg parsing for few args
 			cmd.SetArgs([]string{
 				"exchange",
-				"--email", "email-id",
-				"--email-folder", "folder-id",
-				"--event", "event-id",
-				"--contact", "contact-id",
-				"--help",
+				"--" + utils.RunModeFN, utils.RunModeFlagTest,
+				"--" + utils.BackupFN, testdata.BackupInpt,
+
+				"--" + utils.ContactFN, testdata.FlgInpts(testdata.ContactInpt),
+				"--" + utils.ContactFolderFN, testdata.FlgInpts(testdata.ContactFldInpt),
+				"--" + utils.ContactNameFN, testdata.ContactNameInpt,
+
+				"--" + utils.EmailFN, testdata.FlgInpts(testdata.EmailInpt),
+				"--" + utils.EmailFolderFN, testdata.FlgInpts(testdata.EmailFldInpt),
+				"--" + utils.EmailReceivedAfterFN, testdata.EmailReceivedAfterInpt,
+				"--" + utils.EmailReceivedBeforeFN, testdata.EmailReceivedBeforeInpt,
+				"--" + utils.EmailSenderFN, testdata.EmailSenderInpt,
+				"--" + utils.EmailSubjectFN, testdata.EmailSubjectInpt,
+
+				"--" + utils.EventFN, testdata.FlgInpts(testdata.EventInpt),
+				"--" + utils.EventCalendarFN, testdata.FlgInpts(testdata.EventCalInpt),
+				"--" + utils.EventOrganizerFN, testdata.EventOrganizerInpt,
+				"--" + utils.EventRecursFN, testdata.EventRecursInpt,
+				"--" + utils.EventStartsAfterFN, testdata.EventStartsAfterInpt,
+				"--" + utils.EventStartsBeforeFN, testdata.EventStartsBeforeInpt,
+				"--" + utils.EventSubjectFN, testdata.EventSubjectInpt,
 			})
 
 			cmd.SetOut(new(bytes.Buffer)) // drop output
 			cmd.SetErr(new(bytes.Buffer)) // drop output
 			err := cmd.Execute()
-			assert.NoError(t, err, "no error")
+			assert.NoError(t, err, clues.ToCore(err))
 
-			opts := getRestoreExchangeCmdOpts(cmd)
-			assert.ElementsMatch(t, []string{"email-id"}, opts.Email, "email-id")
-			assert.ElementsMatch(t, []string{"folder-id"}, opts.EmailFolder, "folder-id")
-			assert.ElementsMatch(t, []string{"event-id"}, opts.Event, "event-id")
-			assert.ElementsMatch(t, []string{"contact-id"}, opts.Contact, "contact-id")
+			opts := utils.MakeExchangeOpts(cmd)
+			assert.Equal(t, testdata.BackupInpt, utils.BackupID)
+
+			assert.ElementsMatch(t, testdata.ContactInpt, opts.Contact)
+			assert.ElementsMatch(t, testdata.ContactFldInpt, opts.ContactFolder)
+			assert.Equal(t, testdata.ContactNameInpt, opts.ContactName)
+
+			assert.ElementsMatch(t, testdata.EmailInpt, opts.Email)
+			assert.ElementsMatch(t, testdata.EmailFldInpt, opts.EmailFolder)
+			assert.Equal(t, testdata.EmailReceivedAfterInpt, opts.EmailReceivedAfter)
+			assert.Equal(t, testdata.EmailReceivedBeforeInpt, opts.EmailReceivedBefore)
+			assert.Equal(t, testdata.EmailSenderInpt, opts.EmailSender)
+			assert.Equal(t, testdata.EmailSubjectInpt, opts.EmailSubject)
+
+			assert.ElementsMatch(t, testdata.EventInpt, opts.Event)
+			assert.ElementsMatch(t, testdata.EventCalInpt, opts.EventCalendar)
+			assert.Equal(t, testdata.EventOrganizerInpt, opts.EventOrganizer)
+			assert.Equal(t, testdata.EventRecursInpt, opts.EventRecurs)
+			assert.Equal(t, testdata.EventStartsAfterInpt, opts.EventStartsAfter)
+			assert.Equal(t, testdata.EventStartsBeforeInpt, opts.EventStartsBefore)
+			assert.Equal(t, testdata.EventSubjectInpt, opts.EventSubject)
 		})
 	}
 }

--- a/src/cli/restore/exchange_test.go
+++ b/src/cli/restore/exchange_test.go
@@ -1,6 +1,7 @@
 package restore
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -47,6 +48,27 @@ func (suite *ExchangeUnitSuite) TestAddExchangeCommands() {
 			assert.Equal(t, test.expectUse, child.Use)
 			assert.Equal(t, test.expectShort, child.Short)
 			tester.AreSameFunc(t, test.expectRunE, child.RunE)
+
+			// Test arg parsing for few args
+			cmd.SetArgs([]string{
+				"exchange",
+				"--email", "email-id",
+				"--email-folder", "folder-id",
+				"--event", "event-id",
+				"--contact", "contact-id",
+				"--help",
+			})
+
+			cmd.SetOut(new(bytes.Buffer)) // drop output
+			cmd.SetErr(new(bytes.Buffer)) // drop output
+			err := cmd.Execute()
+			assert.NoError(t, err, "no error")
+
+			opts := getRestoreExchangeCmdOpts(cmd)
+			assert.ElementsMatch(t, []string{"email-id"}, opts.Email, "email-id")
+			assert.ElementsMatch(t, []string{"folder-id"}, opts.EmailFolder, "folder-id")
+			assert.ElementsMatch(t, []string{"event-id"}, opts.Event, "event-id")
+			assert.ElementsMatch(t, []string{"contact-id"}, opts.Contact, "contact-id")
 		})
 	}
 }

--- a/src/cli/restore/onedrive.go
+++ b/src/cli/restore/onedrive.go
@@ -85,7 +85,7 @@ func restoreOneDriveCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	opts := utils.OneDriveOpts{
-		Users:              user,
+		Users:              utils.User,
 		FileNames:          utils.FileName,
 		FolderPaths:        utils.FolderPath,
 		FileCreatedAfter:   utils.FileCreatedAfter,

--- a/src/cli/restore/onedrive.go
+++ b/src/cli/restore/onedrive.go
@@ -84,16 +84,10 @@ func restoreOneDriveCmd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	opts := utils.OneDriveOpts{
-		Users:              utils.User,
-		FileNames:          utils.FileName,
-		FolderPaths:        utils.FolderPath,
-		FileCreatedAfter:   utils.FileCreatedAfter,
-		FileCreatedBefore:  utils.FileCreatedBefore,
-		FileModifiedAfter:  utils.FileModifiedAfter,
-		FileModifiedBefore: utils.FileModifiedBefore,
+	opts := utils.MakeOneDriveOpts(cmd)
 
-		Populated: utils.GetPopulatedFlags(cmd),
+	if utils.RunMode == utils.RunModeFlagTest {
+		return nil
 	}
 
 	if err := utils.ValidateOneDriveRestoreFlags(utils.BackupID, opts); err != nil {

--- a/src/cli/restore/onedrive_test.go
+++ b/src/cli/restore/onedrive_test.go
@@ -1,14 +1,17 @@
 package restore
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/alcionai/clues"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/cli/utils"
+	"github.com/alcionai/corso/src/cli/utils/testdata"
 	"github.com/alcionai/corso/src/internal/tester"
 )
 
@@ -38,6 +41,10 @@ func (suite *OneDriveUnitSuite) TestAddOneDriveCommands() {
 
 			cmd := &cobra.Command{Use: test.use}
 
+			// normally a persisten flag from the root.
+			// required to ensure a dry run.
+			utils.AddRunModeFlag(cmd, true)
+
 			c := addOneDriveCommands(cmd)
 			require.NotNil(t, c)
 
@@ -49,8 +56,33 @@ func (suite *OneDriveUnitSuite) TestAddOneDriveCommands() {
 			assert.Equal(t, test.expectShort, child.Short)
 			tester.AreSameFunc(t, test.expectRunE, child.RunE)
 
-			assert.NotNil(t, c.Flag(utils.BackupFN))
-			assert.NotNil(t, c.Flag("restore-permissions"))
+			cmd.SetArgs([]string{
+				"onedrive",
+				"--" + utils.RunModeFN, utils.RunModeFlagTest,
+				"--" + utils.BackupFN, testdata.BackupInpt,
+
+				"--" + utils.FileFN, testdata.FlgInpts(testdata.FileNamesInpt),
+				"--" + utils.FolderFN, testdata.FlgInpts(testdata.FolderPathsInpt),
+				"--" + utils.FileCreatedAfterFN, testdata.FileCreatedAfterInpt,
+				"--" + utils.FileCreatedBeforeFN, testdata.FileCreatedBeforeInpt,
+				"--" + utils.FileModifiedAfterFN, testdata.FileModifiedAfterInpt,
+				"--" + utils.FileModifiedBeforeFN, testdata.FileModifiedBeforeInpt,
+			})
+
+			cmd.SetOut(new(bytes.Buffer)) // drop output
+			cmd.SetErr(new(bytes.Buffer)) // drop output
+			err := cmd.Execute()
+			assert.NoError(t, err, clues.ToCore(err))
+
+			opts := utils.MakeOneDriveOpts(cmd)
+			assert.Equal(t, testdata.BackupInpt, utils.BackupID)
+
+			assert.ElementsMatch(t, testdata.FileNamesInpt, opts.FileNames)
+			assert.ElementsMatch(t, testdata.FolderPathsInpt, opts.FolderPaths)
+			assert.Equal(t, testdata.FileCreatedAfterInpt, opts.FileCreatedAfter)
+			assert.Equal(t, testdata.FileCreatedBeforeInpt, opts.FileCreatedBefore)
+			assert.Equal(t, testdata.FileModifiedAfterInpt, opts.FileModifiedAfter)
+			assert.Equal(t, testdata.FileModifiedBeforeInpt, opts.FileModifiedBefore)
 		})
 	}
 }

--- a/src/cli/restore/sharepoint.go
+++ b/src/cli/restore/sharepoint.go
@@ -16,13 +16,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/repository"
 )
 
-var (
-	listItems   []string
-	listPaths   []string
-	pageFolders []string
-	pages       []string
-)
-
 // called by restore.go to map subcommands to provider-specific handling.
 func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 	var (
@@ -90,21 +83,10 @@ func restoreSharePointCmd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	opts := utils.SharePointOpts{
-		FileName:           utils.FileName,
-		FolderPath:         utils.FolderPath,
-		Library:            utils.Library,
-		ListItem:           listItems,
-		ListPath:           listPaths,
-		PageFolder:         pageFolders,
-		Page:               pages,
-		SiteID:             utils.SiteID,
-		WebURL:             utils.WebURL,
-		FileCreatedAfter:   utils.FileCreatedAfter,
-		FileCreatedBefore:  utils.FileCreatedBefore,
-		FileModifiedAfter:  utils.FileModifiedAfter,
-		FileModifiedBefore: utils.FileModifiedBefore,
-		Populated:          utils.GetPopulatedFlags(cmd),
+	opts := utils.MakeSharePointOpts(cmd)
+
+	if utils.RunMode == utils.RunModeFlagTest {
+		return nil
 	}
 
 	if err := utils.ValidateSharePointRestoreFlags(utils.BackupID, opts); err != nil {

--- a/src/cli/restore/sharepoint_test.go
+++ b/src/cli/restore/sharepoint_test.go
@@ -1,13 +1,17 @@
 package restore
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/alcionai/clues"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/cli/utils"
+	"github.com/alcionai/corso/src/cli/utils/testdata"
 	"github.com/alcionai/corso/src/internal/tester"
 )
 
@@ -37,6 +41,10 @@ func (suite *SharePointUnitSuite) TestAddSharePointCommands() {
 
 			cmd := &cobra.Command{Use: test.use}
 
+			// normally a persisten flag from the root.
+			// required to ensure a dry run.
+			utils.AddRunModeFlag(cmd, true)
+
 			c := addSharePointCommands(cmd)
 			require.NotNil(t, c)
 
@@ -47,6 +55,48 @@ func (suite *SharePointUnitSuite) TestAddSharePointCommands() {
 			assert.Equal(t, test.expectUse, child.Use)
 			assert.Equal(t, test.expectShort, child.Short)
 			tester.AreSameFunc(t, test.expectRunE, child.RunE)
+
+			cmd.SetArgs([]string{
+				"sharepoint",
+				"--" + utils.RunModeFN, utils.RunModeFlagTest,
+				"--" + utils.BackupFN, testdata.BackupInpt,
+
+				"--" + utils.LibraryFN, testdata.LibraryInpt,
+				"--" + utils.FileFN, testdata.FlgInpts(testdata.FileNamesInpt),
+				"--" + utils.FolderFN, testdata.FlgInpts(testdata.FolderPathsInpt),
+				"--" + utils.FileCreatedAfterFN, testdata.FileCreatedAfterInpt,
+				"--" + utils.FileCreatedBeforeFN, testdata.FileCreatedBeforeInpt,
+				"--" + utils.FileModifiedAfterFN, testdata.FileModifiedAfterInpt,
+				"--" + utils.FileModifiedBeforeFN, testdata.FileModifiedBeforeInpt,
+
+				"--" + utils.ListItemFN, testdata.FlgInpts(testdata.ListItemInpt),
+				"--" + utils.ListFolderFN, testdata.FlgInpts(testdata.ListFolderInpt),
+
+				"--" + utils.PageFN, testdata.FlgInpts(testdata.PageInpt),
+				"--" + utils.PageFolderFN, testdata.FlgInpts(testdata.PageFolderInpt),
+			})
+
+			cmd.SetOut(new(bytes.Buffer)) // drop output
+			cmd.SetErr(new(bytes.Buffer)) // drop output
+			err := cmd.Execute()
+			assert.NoError(t, err, clues.ToCore(err))
+
+			opts := utils.MakeSharePointOpts(cmd)
+			assert.Equal(t, testdata.BackupInpt, utils.BackupID)
+
+			assert.Equal(t, testdata.LibraryInpt, opts.Library)
+			assert.ElementsMatch(t, testdata.FileNamesInpt, opts.FileName)
+			assert.ElementsMatch(t, testdata.FolderPathsInpt, opts.FolderPath)
+			assert.Equal(t, testdata.FileCreatedAfterInpt, opts.FileCreatedAfter)
+			assert.Equal(t, testdata.FileCreatedBeforeInpt, opts.FileCreatedBefore)
+			assert.Equal(t, testdata.FileModifiedAfterInpt, opts.FileModifiedAfter)
+			assert.Equal(t, testdata.FileModifiedBeforeInpt, opts.FileModifiedBefore)
+
+			assert.ElementsMatch(t, testdata.ListItemInpt, opts.ListItem)
+			assert.ElementsMatch(t, testdata.ListFolderInpt, opts.ListFolder)
+
+			assert.ElementsMatch(t, testdata.PageInpt, opts.Page)
+			assert.ElementsMatch(t, testdata.PageFolderInpt, opts.PageFolder)
 		})
 	}
 }

--- a/src/cli/utils/exchange.go
+++ b/src/cli/utils/exchange.go
@@ -52,25 +52,56 @@ var (
 )
 
 type ExchangeOpts struct {
-	Contact             []string
-	ContactFolder       []string
+	Users []string
+
+	Contact       []string
+	ContactFolder []string
+	ContactName   string
+
 	Email               []string
 	EmailFolder         []string
-	Event               []string
-	EventCalendar       []string
-	Users               []string
-	ContactName         string
 	EmailReceivedAfter  string
 	EmailReceivedBefore string
 	EmailSender         string
 	EmailSubject        string
-	EventOrganizer      string
-	EventRecurs         string
-	EventStartsAfter    string
-	EventStartsBefore   string
-	EventSubject        string
+
+	Event             []string
+	EventCalendar     []string
+	EventOrganizer    string
+	EventRecurs       string
+	EventStartsAfter  string
+	EventStartsBefore string
+	EventSubject      string
 
 	Populated PopulatedFlags
+}
+
+// populates an ExchangeOpts struct with the command's current flags.
+func MakeExchangeOpts(cmd *cobra.Command) ExchangeOpts {
+	return ExchangeOpts{
+		Users: User,
+
+		Contact:       Contact,
+		ContactFolder: ContactFolder,
+		ContactName:   ContactName,
+
+		Email:               Email,
+		EmailFolder:         EmailFolder,
+		EmailReceivedAfter:  EmailReceivedAfter,
+		EmailReceivedBefore: EmailReceivedBefore,
+		EmailSender:         EmailSender,
+		EmailSubject:        EmailSubject,
+
+		Event:             Event,
+		EventCalendar:     EventCalendar,
+		EventOrganizer:    EventOrganizer,
+		EventRecurs:       EventRecurs,
+		EventStartsAfter:  EventStartsAfter,
+		EventStartsBefore: EventStartsBefore,
+		EventSubject:      EventSubject,
+
+		Populated: GetPopulatedFlags(cmd),
+	}
 }
 
 // AddExchangeDetailsAndRestoreFlags adds flags that are common to both the

--- a/src/cli/utils/onedrive.go
+++ b/src/cli/utils/onedrive.go
@@ -8,7 +8,8 @@ import (
 )
 
 type OneDriveOpts struct {
-	Users              []string
+	Users []string
+
 	FileNames          []string
 	FolderPaths        []string
 	FileCreatedAfter   string
@@ -17,6 +18,21 @@ type OneDriveOpts struct {
 	FileModifiedBefore string
 
 	Populated PopulatedFlags
+}
+
+func MakeOneDriveOpts(cmd *cobra.Command) OneDriveOpts {
+	return OneDriveOpts{
+		Users: User,
+
+		FileNames:          FileName,
+		FolderPaths:        FolderPath,
+		FileCreatedAfter:   FileCreatedAfter,
+		FileCreatedBefore:  FileCreatedBefore,
+		FileModifiedAfter:  FileModifiedAfter,
+		FileModifiedBefore: FileModifiedBefore,
+
+		Populated: GetPopulatedFlags(cmd),
+	}
 }
 
 // AddOneDriveDetailsAndRestoreFlags adds flags that are common to both the

--- a/src/cli/utils/sharepoint_test.go
+++ b/src/cli/utils/sharepoint_test.go
@@ -56,7 +56,7 @@ func (suite *SharePointUtilsSuite) TestIncludeSharePointRestoreDataSelectors() {
 				FileName:   single,
 				FolderPath: single,
 				ListItem:   single,
-				ListPath:   single,
+				ListFolder: single,
 				SiteID:     single,
 				WebURL:     single,
 			},
@@ -108,7 +108,7 @@ func (suite *SharePointUtilsSuite) TestIncludeSharePointRestoreDataSelectors() {
 				FileName:   empty,
 				FolderPath: empty,
 				ListItem:   empty,
-				ListPath:   containsOnly,
+				ListFolder: containsOnly,
 				SiteID:     empty,
 				WebURL:     empty,
 			},
@@ -117,14 +117,14 @@ func (suite *SharePointUtilsSuite) TestIncludeSharePointRestoreDataSelectors() {
 		{
 			name: "list prefixes",
 			opts: utils.SharePointOpts{
-				ListPath: prefixOnly,
+				ListFolder: prefixOnly,
 			},
 			expectIncludeLen: 1,
 		},
 		{
 			name: "list prefixes and contains",
 			opts: utils.SharePointOpts{
-				ListPath: containsAndPrefix,
+				ListFolder: containsAndPrefix,
 			},
 			expectIncludeLen: 2,
 		},

--- a/src/cli/utils/testdata/flags.go
+++ b/src/cli/utils/testdata/flags.go
@@ -1,0 +1,46 @@
+package testdata
+
+import "strings"
+
+func FlgInpts(in []string) string { return strings.Join(in, ",") }
+
+var (
+	BackupInpt = "backup-id"
+
+	UsersInpt  = []string{"users1", "users2"}
+	SiteIDInpt = []string{"siteID1", "siteID2"}
+	WebURLInpt = []string{"webURL1", "webURL2"}
+
+	ContactInpt     = []string{"contact1", "contact2"}
+	ContactFldInpt  = []string{"contactFld1", "contactFld2"}
+	ContactNameInpt = "contactName"
+
+	EmailInpt               = []string{"mail1", "mail2"}
+	EmailFldInpt            = []string{"mailFld1", "mailFld2"}
+	EmailReceivedAfterInpt  = "mailReceivedAfter"
+	EmailReceivedBeforeInpt = "mailReceivedBefore"
+	EmailSenderInpt         = "mailSender"
+	EmailSubjectInpt        = "mailSubjet"
+
+	EventInpt             = []string{"event1", "event2"}
+	EventCalInpt          = []string{"eventCal1", "eventCal2"}
+	EventOrganizerInpt    = "eventOrganizer"
+	EventRecursInpt       = "eventRecurs"
+	EventStartsAfterInpt  = "eventStartsAfter"
+	EventStartsBeforeInpt = "eventStartsBefore"
+	EventSubjectInpt      = "eventSubject"
+
+	LibraryInpt            = "library"
+	FileNamesInpt          = []string{"fileName1", "fileName2"}
+	FolderPathsInpt        = []string{"folderPath1", "folderPath2"}
+	FileCreatedAfterInpt   = "fileCreatedAfter"
+	FileCreatedBeforeInpt  = "fileCreatedBefore"
+	FileModifiedAfterInpt  = "fileModifiedAfter"
+	FileModifiedBeforeInpt = "fileModifiedBefore"
+
+	ListFolderInpt = []string{"listFolder1", "listFolder2"}
+	ListItemInpt   = []string{"listItem1", "listItem2"}
+
+	PageFolderInpt = []string{"pageFolder1", "pageFolder2"}
+	PageInpt       = []string{"page1", "page2"}
+)


### PR DESCRIPTION
While we were reading flags from the cli, they were not being passed onto the restore path.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
