### PR TITLE
match sites with a url path suffix

### DIFF
--- a/src/internal/connector/graph_connector.go
+++ b/src/internal/connector/graph_connector.go
@@ -236,8 +236,10 @@ type getOwnerIDAndNamer interface {
 // (PrincipalName for users, WebURL for sites).
 //
 // Consumers are allowed to pass in a path suffix (eg: /sites/foo) as a site
-// owner, but only if they also pass in a nameToID map.  A nil map will cascade
-// to the fallback, which will fail for having a malformed id value.
+// owner, but only if they also pass in a nameToID map.  A nil map will fallback
+// to a lookup by id using the suffix, which will fail for being malformed.
+// Suffix matching follows filter PathSuffix rules: only complete elements match,
+// case-independant, leading/tailing slashes are optional.
 func (r resourceClient) getOwnerIDAndNameFrom(
 	ctx context.Context,
 	discovery api.Client,
@@ -261,7 +263,7 @@ func (r resourceClient) getOwnerIDAndNameFrom(
 
 	// check if the provided owner is a suffix of a weburl in the lookup map
 	if r.enum == Sites {
-		url, _, ok := filters.PathSuffix([]string{owner}).CompareAny(ins.Names()...)
+		url, ok := filters.PathSuffix([]string{owner}).CompareAny(ins.Names()...)
 		if ok {
 			id, _ := ins.IDOf(url)
 			return id, url, nil

--- a/src/internal/connector/graph_connector_test.go
+++ b/src/internal/connector/graph_connector_test.go
@@ -65,7 +65,8 @@ func (suite *GraphConnectorUnitSuite) TestPopulateOwnerIDAndNamesFrom() {
 			enum:   Users,
 			getter: &mockNameIDGetter{id: id, name: name},
 		}
-		noLookup = &resourceClient{enum: Users, getter: &mockNameIDGetter{}}
+		noLookup   = &resourceClient{enum: Users, getter: &mockNameIDGetter{}}
+		siteLookup = &resourceClient{enum: Sites, getter: &mockNameIDGetter{}}
 	)
 
 	table := []struct {
@@ -247,6 +248,18 @@ func (suite *GraphConnectorUnitSuite) TestPopulateOwnerIDAndNamesFrom() {
 			rc:         lookup,
 			expectID:   id,
 			expectName: name,
+			expectErr:  require.NoError,
+		},
+		{
+			name:  "site suffix lookup",
+			owner: "/url/path",
+			rc:    siteLookup,
+			ins: common.IDsNames{
+				IDToName: nil,
+				NameToID: map[string]string{"http://some/site/url/path": id},
+			},
+			expectID:   id,
+			expectName: "http://some/site/url/path",
 			expectErr:  require.NoError,
 		},
 	}

--- a/src/pkg/filters/filters.go
+++ b/src/pkg/filters/filters.go
@@ -360,22 +360,21 @@ func newSliceFilter(c comparator, targets, normTargets []string, negate bool) Fi
 
 // CompareAny checks whether any one of all the provided
 // inputs passes the filter.  If one passes, that value is
-// returned, as well as its index in the input range.
-// If nothing matches, returns ("", -1, false)
+// returned.  If nothing matches, returns ("", false)
 //
 // Note that, as a gotcha, CompareAny can resolve truthily
 // for both the standard and negated versions of a filter.
 // Ex: consider the input CompareAny(true, false), which
 // will return true for both Equals(true) and NotEquals(true),
 // because at least one element matches for both filters.
-func (f Filter) CompareAny(inputs ...string) (string, int, bool) {
-	for i, in := range inputs {
+func (f Filter) CompareAny(inputs ...string) (string, bool) {
+	for _, in := range inputs {
 		if f.Compare(in) {
-			return in, i, true
+			return in, true
 		}
 	}
 
-	return "", -1, false
+	return "", false
 }
 
 // Compare checks whether the input passes the filter.

--- a/src/pkg/filters/filters.go
+++ b/src/pkg/filters/filters.go
@@ -359,21 +359,23 @@ func newSliceFilter(c comparator, targets, normTargets []string, negate bool) Fi
 // ----------------------------------------------------------------------------------------------------
 
 // CompareAny checks whether any one of all the provided
-// inputs passes the filter.
+// inputs passes the filter.  If one passes, that value is
+// returned, as well as its index in the input range.
+// If nothing matches, returns ("", -1, false)
 //
 // Note that, as a gotcha, CompareAny can resolve truthily
 // for both the standard and negated versions of a filter.
 // Ex: consider the input CompareAny(true, false), which
 // will return true for both Equals(true) and NotEquals(true),
 // because at least one element matches for both filters.
-func (f Filter) CompareAny(inputs ...string) bool {
-	for _, in := range inputs {
+func (f Filter) CompareAny(inputs ...string) (string, int, bool) {
+	for i, in := range inputs {
 		if f.Compare(in) {
-			return true
+			return in, i, true
 		}
 	}
 
-	return false
+	return "", -1, false
 }
 
 // Compare checks whether the input passes the filter.
@@ -441,6 +443,48 @@ func (f Filter) Compare(input string) bool {
 
 	return res
 }
+
+// Matches extends Compare by not only checking if
+// the input passes the filter, but if it passes, the
+// target which matched and its index are returned as well.
+// If more than one value matches the input, only the
+// first is returned.
+// returns ("", -1, false) if no match is found.
+// TODO: only partially implemented.
+// func (f Filter) Matches(input string) (string, int, bool) {
+// 	var (
+// 		cmp     func(string, string) bool
+// 		res     bool
+// 		targets = f.NormalizedTargets
+// 	)
+
+// 	switch f.Comparator {
+// 	case TargetPathPrefix:
+// 		cmp = pathPrefix
+// 	case TargetPathContains:
+// 		cmp = pathContains
+// 	case TargetPathSuffix:
+// 		cmp = pathSuffix
+// 	case TargetPathEquals:
+// 		cmp = pathEquals
+// 	default:
+// 		return "", -1, false
+// 	}
+
+// 	for i, tgt := range targets {
+// 		res = cmp(norm(tgt), norm(input))
+
+// 		if !f.Negate && res {
+// 			return f.Targets[i], i, true
+// 		}
+
+// 		if f.Negate && !res {
+// 			return f.Targets[i], i, true
+// 		}
+// 	}
+
+// 	return "", -1, false
+// }
 
 // true if t == i
 func equals(target, input string) bool {

--- a/src/pkg/filters/filters_test.go
+++ b/src/pkg/filters/filters_test.go
@@ -45,20 +45,49 @@ func (suite *FiltersSuite) TestEquals_any() {
 	nf := filters.NotEqual("foo")
 
 	table := []struct {
-		name     string
-		input    []string
-		expectF  assert.BoolAssertionFunc
-		expectNF assert.BoolAssertionFunc
+		name        string
+		input       []string
+		expectF     assert.BoolAssertionFunc
+		expectFVal  string
+		expectFIdx  int
+		expectNF    assert.BoolAssertionFunc
+		expectNFVal string
+		expectNFIdx int
 	}{
-		{"includes target", []string{"foo", "bar"}, assert.True, assert.True},
-		{"not includes target", []string{"baz", "qux"}, assert.False, assert.True},
+		{
+			name:        "includes target",
+			input:       []string{"foo", "bar"},
+			expectF:     assert.True,
+			expectFVal:  "foo",
+			expectFIdx:  0,
+			expectNF:    assert.True,
+			expectNFVal: "bar",
+			expectNFIdx: 1,
+		},
+		{
+			name:        "not includes target",
+			input:       []string{"baz", "qux"},
+			expectF:     assert.False,
+			expectFVal:  "",
+			expectFIdx:  -1,
+			expectNF:    assert.True,
+			expectNFVal: "baz",
+			expectNFIdx: 0,
+		},
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			test.expectF(t, f.CompareAny(test.input...), "filter")
-			test.expectNF(t, nf.CompareAny(test.input...), "negated filter")
+			v, i, b := f.CompareAny(test.input...)
+			test.expectF(t, b, "filter")
+			assert.Equal(t, test.expectFIdx, i, "index")
+			assert.Equal(t, test.expectFVal, v, "value")
+
+			v, i, b = nf.CompareAny(test.input...)
+			test.expectNF(t, b, "neg-filter")
+			assert.Equal(t, test.expectNFIdx, i, "neg-index")
+			assert.Equal(t, test.expectNFVal, v, "neg-value")
 		})
 	}
 }

--- a/src/pkg/filters/filters_test.go
+++ b/src/pkg/filters/filters_test.go
@@ -79,14 +79,12 @@ func (suite *FiltersSuite) TestEquals_any() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			v, i, b := f.CompareAny(test.input...)
+			v, b := f.CompareAny(test.input...)
 			test.expectF(t, b, "filter")
-			assert.Equal(t, test.expectFIdx, i, "index")
 			assert.Equal(t, test.expectFVal, v, "value")
 
-			v, i, b = nf.CompareAny(test.input...)
+			v, b = nf.CompareAny(test.input...)
 			test.expectNF(t, b, "neg-filter")
-			assert.Equal(t, test.expectNFIdx, i, "neg-index")
 			assert.Equal(t, test.expectNFVal, v, "neg-value")
 		})
 	}

--- a/src/pkg/selectors/scopes.go
+++ b/src/pkg/selectors/scopes.go
@@ -223,7 +223,7 @@ func matchesAny[T scopeT, C categoryT](s T, cat C, inpts []string) bool {
 		return false
 	}
 
-	_, _, pass := s[cat.String()].CompareAny(inpts...)
+	_, pass := s[cat.String()].CompareAny(inpts...)
 
 	return pass
 }

--- a/src/pkg/selectors/scopes.go
+++ b/src/pkg/selectors/scopes.go
@@ -223,7 +223,9 @@ func matchesAny[T scopeT, C categoryT](s T, cat C, inpts []string) bool {
 		return false
 	}
 
-	return s[cat.String()].CompareAny(inpts...)
+	_, _, pass := s[cat.String()].CompareAny(inpts...)
+
+	return pass
 }
 
 // getCategory returns the scope's category value.


### PR DESCRIPTION
Adds suffix matching to the site owner id/name
lookup process.  This allows consumers to query
for a site by only its path (ex: "/sites/foo") and still end up with a well formed id, name tuple.  One
gotcha is that this requires the lookup maps to
be populated.  If a lookup map is not passed in
with a suffix matcher, the fallback lookup will fail.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #2825

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
