### PR TITLE
Do not try to call syscall.Kill on Windows

### DIFF
--- a/src/internal/events/events.go
+++ b/src/internal/events/events.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"syscall"
 	"time"
 
 	"github.com/alcionai/clues"
@@ -231,12 +230,6 @@ func dumpMetrics(ctx context.Context, stop <-chan struct{}, sig *metrics.InmemSi
 		case <-stop:
 			return
 		}
-	}
-}
-
-func signalDump(ctx context.Context) {
-	if err := syscall.Kill(syscall.Getpid(), metrics.DefaultSignal); err != nil {
-		logger.CtxErr(ctx, err).Error("metrics interval signal")
 	}
 }
 

--- a/src/internal/events/events_signal_unix.go
+++ b/src/internal/events/events_signal_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+// +build !windows
+
+package events
+
+import (
+	"context"
+	"syscall"
+
+	"github.com/armon/go-metrics"
+
+	"github.com/alcionai/corso/src/pkg/logger"
+)
+
+func signalDump(ctx context.Context) {
+	if err := syscall.Kill(syscall.Getpid(), metrics.DefaultSignal); err != nil {
+		logger.CtxErr(ctx, err).Error("metrics interval signal")
+	}
+}

--- a/src/internal/events/events_signal_windows.go
+++ b/src/internal/events/events_signal_windows.go
@@ -1,0 +1,11 @@
+package events
+
+import (
+	"context"
+
+	"github.com/alcionai/corso/src/pkg/logger"
+)
+
+func signalDump(ctx context.Context) {
+	logger.Ctx(ctx).Warn("cannot send signal on Windows")
+}


### PR DESCRIPTION
Will create a followup to make sure we are doing the right thing on Windows. This will unblock builds for now, although we don't get the metrics for Windows(which was not working anyways).

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [x] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
