### PR TITLE
CI Cleanup improvements

### DIFF
--- a/.github/actions/purge-m365-user-data/action.yml
+++ b/.github/actions/purge-m365-user-data/action.yml
@@ -47,7 +47,7 @@ runs:
         AZURE_CLIENT_SECRET: ${{ inputs.azure-client-secret }}
         AZURE_TENANT_ID: ${{ inputs.azure-tenant-id }}
       run: |
-        ./exchangePurge.ps1 -User ${{ inputs.user }} -FolderNamePurgeList PersonMetadata -FolderPrefixPurgeList ${{ inputs.folder-prefix }} -PurgeBeforeTimestamp ${{ inputs.older-than }}
+        ./exchangePurge.ps1 -User ${{ inputs.user }} -FolderNamePurgeList PersonMetadata -FolderPrefixPurgeList "${{ inputs.folder-prefix }}".Split(",") -PurgeBeforeTimestamp ${{ inputs.older-than }}
     
     - name: Run the OneDrive purge scripts for user
       if: ${{ inputs.user != '' }}
@@ -57,7 +57,7 @@ runs:
         M365_TENANT_ADMIN_USER: ${{ inputs.m365-admin-user }}
         M365_TENANT_ADMIN_PASSWORD: ${{ inputs.m365-admin-password }}
       run: |
-        ./onedrivePurge.ps1 -User ${{ inputs.user }} -FolderPrefixPurgeList ${{ inputs.folder-prefix }} -PurgeBeforeTimestamp ${{ inputs.older-than }}
+        ./onedrivePurge.ps1 -User ${{ inputs.user }} -FolderPrefixPurgeList "${{ inputs.folder-prefix }}".Split(",") -PurgeBeforeTimestamp ${{ inputs.older-than }}
 
     - name: Run SharePoint purge script
       if: ${{ inputs.user == '' }}

--- a/.github/workflows/ci_test_cleanup.yml
+++ b/.github/workflows/ci_test_cleanup.yml
@@ -29,9 +29,9 @@ jobs:
         with:
           user: ${{ secrets[matrix.user] }}
           site: ${{ secrets.CORSO_M365_TEST_SITE_URL}}
-          folder-prefix: "Corso_Restore_, TestRestore, testfolder, incrementals_ci_, Alcion_Restore_"
-          libraries: ${{ secrets.CORSO_M365_TEST_SITE_LIBRARIES }} 
-          older-than: ${{ env.HALF_HOUR_AGO }}
+          folder-prefix: ${{ env.CORSO_M365_TEST_PREFIXES }} 
+          libraries: ${{ vars.CORSO_M365_TEST_SITE_LIBRARIES }} 
+          older-than: ${{ vars.HALF_HOUR_AGO }}
           azure-client-id: ${{ secrets.CLIENT_ID }}
           azure-client-secret: ${{ secrets.CLIENT_SECRET }}
           azure-tenant-id: ${{ secrets.TENANT_ID }}

--- a/.github/workflows/ci_test_cleanup.yml
+++ b/.github/workflows/ci_test_cleanup.yml
@@ -29,9 +29,9 @@ jobs:
         with:
           user: ${{ secrets[matrix.user] }}
           site: ${{ secrets.CORSO_M365_TEST_SITE_URL}}
-          folder-prefix: ${{ env.CORSO_M365_TEST_PREFIXES }} 
+          folder-prefix: ${{ vars.CORSO_M365_TEST_PREFIXES }} 
           libraries: ${{ vars.CORSO_M365_TEST_SITE_LIBRARIES }} 
-          older-than: ${{ vars.HALF_HOUR_AGO }}
+          older-than: ${{ env.HALF_HOUR_AGO }}
           azure-client-id: ${{ secrets.CLIENT_ID }}
           azure-client-secret: ${{ secrets.CLIENT_SECRET }}
           azure-tenant-id: ${{ secrets.TENANT_ID }}


### PR DESCRIPTION
* Allow exchange timestamps from item/folder names based with create time as backup
* Parametrize folder prefixes and move to var from secrets for ease of management. There is nothing sensitive
---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [x] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
