### PR TITLE
remove model.StableID from repository iface

### DIFF
--- a/src/cli/backup/backup.go
+++ b/src/cli/backup/backup.go
@@ -14,7 +14,6 @@ import (
 	. "github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/cli/utils"
 	"github.com/alcionai/corso/src/internal/data"
-	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/logger"
@@ -197,7 +196,7 @@ func runBackups(
 	selectorSet []selectors.Selector,
 ) error {
 	var (
-		bIDs []model.StableID
+		bIDs []string
 		errs = []error{}
 	)
 
@@ -223,7 +222,7 @@ func runBackups(
 			continue
 		}
 
-		bIDs = append(bIDs, bo.Results.BackupID)
+		bIDs = append(bIDs, string(bo.Results.BackupID))
 		Infof(ctx, "Done - ID: %v\n", bo.Results.BackupID)
 	}
 
@@ -265,7 +264,7 @@ func genericDeleteCommand(cmd *cobra.Command, bID, designation string, args []st
 
 	defer utils.CloseRepo(ctx, r)
 
-	if err := r.DeleteBackup(ctx, model.StableID(bID)); err != nil {
+	if err := r.DeleteBackup(ctx, bID); err != nil {
 		return Only(ctx, clues.Wrap(err, "Deleting backup "+bID))
 	}
 

--- a/src/cli/backup/exchange_e2e_test.go
+++ b/src/cli/backup/exchange_e2e_test.go
@@ -330,7 +330,7 @@ func (suite *PreparedBackupExchangeE2ESuite) SetupSuite() {
 		bIDs := string(bop.Results.BackupID)
 
 		// sanity check, ensure we can find the backup and its details immediately
-		b, err := suite.repo.Backup(ctx, bop.Results.BackupID)
+		b, err := suite.repo.Backup(ctx, string(bop.Results.BackupID))
 		require.NoError(t, err, "retrieving recent backup by ID")
 		require.Equal(t, bIDs, string(b.ID), "repo backup matches results id")
 		_, b, errs := suite.repo.GetBackupDetails(ctx, bIDs)

--- a/src/cli/restore/exchange_e2e_test.go
+++ b/src/cli/restore/exchange_e2e_test.go
@@ -109,7 +109,7 @@ func (suite *RestoreExchangeE2ESuite) SetupSuite() {
 		suite.backupOps[set] = bop
 
 		// sanity check, ensure we can find the backup and its details immediately
-		_, err = suite.repo.Backup(ctx, bop.Results.BackupID)
+		_, err = suite.repo.Backup(ctx, string(bop.Results.BackupID))
 		require.NoError(t, err, "retrieving recent backup by ID", clues.ToCore(err))
 
 		_, _, errs := suite.repo.GetBackupDetails(ctx, string(bop.Results.BackupID))

--- a/src/cli/utils/testdata/opts.go
+++ b/src/cli/utils/testdata/opts.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/alcionai/corso/src/cli/utils"
 	"github.com/alcionai/corso/src/internal/common"
-	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/backup/details/testdata"
@@ -559,14 +558,14 @@ type MockBackupGetter struct {
 
 func (MockBackupGetter) Backup(
 	context.Context,
-	model.StableID,
+	string,
 ) (*backup.Backup, error) {
 	return nil, clues.New("unexpected call to mock")
 }
 
 func (MockBackupGetter) Backups(
 	context.Context,
-	[]model.StableID,
+	[]string,
 ) ([]*backup.Backup, *fault.Bus) {
 	return nil, fault.New(false).Fail(clues.New("unexpected call to mock"))
 }

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -35,8 +35,8 @@ var ErrorRepoAlreadyExists = clues.New("a repository was already initialized wit
 // BackupGetter deals with retrieving metadata about backups from the
 // repository.
 type BackupGetter interface {
-	Backup(ctx context.Context, id model.StableID) (*backup.Backup, error)
-	Backups(ctx context.Context, ids []model.StableID) ([]*backup.Backup, *fault.Bus)
+	Backup(ctx context.Context, id string) (*backup.Backup, error)
+	Backups(ctx context.Context, ids []string) ([]*backup.Backup, *fault.Bus)
 	BackupsByTag(ctx context.Context, fs ...store.FilterOption) ([]*backup.Backup, error)
 	GetBackupDetails(
 		ctx context.Context,
@@ -61,7 +61,7 @@ type Repository interface {
 		sel selectors.Selector,
 		dest control.RestoreDestination,
 	) (operations.RestoreOperation, error)
-	DeleteBackup(ctx context.Context, id model.StableID) error
+	DeleteBackup(ctx context.Context, id string) error
 	BackupGetter
 }
 
@@ -330,14 +330,14 @@ func (r repository) NewRestore(
 }
 
 // backups lists a backup by id
-func (r repository) Backup(ctx context.Context, id model.StableID) (*backup.Backup, error) {
+func (r repository) Backup(ctx context.Context, id string) (*backup.Backup, error) {
 	sw := store.NewKopiaStore(r.modelStore)
-	return sw.GetBackup(ctx, id)
+	return sw.GetBackup(ctx, model.StableID(id))
 }
 
 // BackupsByID lists backups by ID. Returns as many backups as possible with
 // errors for the backups it was unable to retrieve.
-func (r repository) Backups(ctx context.Context, ids []model.StableID) ([]*backup.Backup, *fault.Bus) {
+func (r repository) Backups(ctx context.Context, ids []string) ([]*backup.Backup, *fault.Bus) {
 	var (
 		bups []*backup.Backup
 		errs = fault.New(false)
@@ -345,9 +345,11 @@ func (r repository) Backups(ctx context.Context, ids []model.StableID) ([]*backu
 	)
 
 	for _, id := range ids {
-		b, err := sw.GetBackup(ctx, id)
+		ictx := clues.Add(ctx, "backup_id", id)
+
+		b, err := sw.GetBackup(ictx, model.StableID(id))
 		if err != nil {
-			errs.AddRecoverable(clues.Stack(err).With("backup_id", id))
+			errs.AddRecoverable(clues.Stack(err))
 		}
 
 		bups = append(bups, b)
@@ -486,7 +488,7 @@ func getBackupErrors(
 }
 
 // DeleteBackup removes the backup from both the model store and the backup storage.
-func (r repository) DeleteBackup(ctx context.Context, id model.StableID) error {
+func (r repository) DeleteBackup(ctx context.Context, id string) error {
 	bu, err := r.Backup(ctx, id)
 	if err != nil {
 		return err
@@ -510,7 +512,7 @@ func (r repository) DeleteBackup(ctx context.Context, id model.StableID) error {
 
 	sw := store.NewKopiaStore(r.modelStore)
 
-	return sw.DeleteBackup(ctx, id)
+	return sw.DeleteBackup(ctx, model.StableID(id))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
model.StableID is an internal value.  SDK facing
interfaces should only need to provide strings.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
