### PR TITLE
add sensitive info flag to cli

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -56,8 +56,8 @@ func preRun(cc *cobra.Command, args []string) error {
 		"corso", "env", "help", "backup", "details", "list", "restore", "delete", "repo", "init", "connect",
 	}
 
-	if len(logger.LogFileFV) > 0 && !slices.Contains(avoidTheseCommands, cc.Use) {
-		print.Info(ctx, "Logging to file: "+logger.LogFileFV)
+	if len(logger.LogFile) > 0 && !slices.Contains(avoidTheseCommands, cc.Use) {
+		print.Info(ctx, "Logging to file: "+logger.LogFile)
 	}
 
 	avoidTheseDescription := []string{

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -56,8 +56,8 @@ func preRun(cc *cobra.Command, args []string) error {
 		"corso", "env", "help", "backup", "details", "list", "restore", "delete", "repo", "init", "connect",
 	}
 
-	if len(logger.LogFile) > 0 && !slices.Contains(avoidTheseCommands, cc.Use) {
-		print.Info(ctx, "Logging to file: "+logger.LogFile)
+	if len(logger.LogFileFV) > 0 && !slices.Contains(avoidTheseCommands, cc.Use) {
+		print.Info(ctx, "Logging to file: "+logger.LogFileFV)
 	}
 
 	avoidTheseDescription := []string{
@@ -153,8 +153,7 @@ func Handle() {
 
 	BuildCommandTree(corsoCmd)
 
-	loglevel, logfile := logger.PreloadLoggingFlags()
-	ctx, log := logger.Seed(ctx, loglevel, logfile)
+	ctx, log := logger.Seed(ctx, logger.PreloadLoggingFlags())
 
 	defer func() {
 		_ = log.Sync() // flush all logs in the buffer

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -146,6 +146,7 @@ func BuildCommandTree(cmd *cobra.Command) {
 
 // Handle builds and executes the cli processor.
 func Handle() {
+	//nolint:forbidigo
 	ctx := config.Seed(context.Background())
 	ctx = print.SetRootCmd(ctx, corsoCmd)
 
@@ -153,7 +154,7 @@ func Handle() {
 
 	BuildCommandTree(corsoCmd)
 
-	ctx, log := logger.Seed(ctx, logger.PreloadLoggingFlags())
+	ctx, log := logger.Seed(ctx, logger.PreloadLoggingFlags(os.Args[1:]))
 
 	defer func() {
 		_ = log.Sync() // flush all logs in the buffer

--- a/src/cmd/sanity_test/sanity_tests.go
+++ b/src/cmd/sanity_test/sanity_tests.go
@@ -41,7 +41,13 @@ const (
 // ---------------------------------------------------------------------------
 
 func main() {
-	ctx, log := logger.Seed(context.Background(), "info", logger.GetLogFile(""))
+	ls := logger.Settings{
+		File:        logger.GetLogFile(""),
+		Level:       logger.LLInfo,
+		PIIHandling: logger.PIIPlainText,
+	}
+
+	ctx, log := logger.Seed(context.Background(), ls)
 	defer func() {
 		_ = log.Sync() // flush all logs in the buffer
 	}()

--- a/src/internal/connector/graph/middleware.go
+++ b/src/internal/connector/graph/middleware.go
@@ -122,7 +122,7 @@ func (handler *LoggingMiddleware) Intercept(
 	// Return immediately if the response is good (2xx).
 	// If api logging is toggled, log a body-less dump of the request/resp.
 	if (resp.StatusCode / 100) == 2 {
-		if logger.DebugAPI || os.Getenv(log2xxGraphRequestsEnvKey) != "" {
+		if logger.DebugAPIFV || os.Getenv(log2xxGraphRequestsEnvKey) != "" {
 			log.Debugw("2xx graph api resp", "response", getRespDump(ctx, resp, os.Getenv(log2xxGraphResponseEnvKey) != ""))
 		}
 
@@ -133,7 +133,7 @@ func (handler *LoggingMiddleware) Intercept(
 	// When debugging is toggled, every non-2xx is recorded with a response dump.
 	// Otherwise, throttling cases and other non-2xx responses are logged
 	// with a slimmer reference for telemetry/supportability purposes.
-	if logger.DebugAPI || os.Getenv(logGraphRequestsEnvKey) != "" {
+	if logger.DebugAPIFV || os.Getenv(logGraphRequestsEnvKey) != "" {
 		log.Errorw("non-2xx graph api response", "response", getRespDump(ctx, resp, true))
 		return resp, err
 	}

--- a/src/pkg/logger/example_logger_test.go
+++ b/src/pkg/logger/example_logger_test.go
@@ -14,11 +14,7 @@ import (
 // mock helpers
 // ---------------------------------------------------------------------------
 
-const (
-	loglevel = "info"
-	logfile  = logger.Stderr
-	itemID   = "item_id"
-)
+const itemID = "item_id"
 
 var (
 	err         error
@@ -35,7 +31,14 @@ func Example_seed() {
 	// the context.  Seeding only needs to be done once.  For example
 	// Corso's CLI layer seeds the logger in the cli initialization.
 	ctx := context.Background()
-	ctx, log := logger.Seed(ctx, loglevel, logfile)
+
+	ls := logger.Settings{
+		File:        logger.Stderr,
+		Level:       logger.LLInfo,
+		PIIHandling: logger.PIIPlainText,
+	}
+
+	ctx, log := logger.Seed(ctx, ls)
 
 	// SDK consumers who configure their own zap logger can Set their logger
 	// into the context directly, instead of Seeding a new one.

--- a/src/pkg/logger/logger.go
+++ b/src/pkg/logger/logger.go
@@ -47,7 +47,7 @@ var (
 	logFileFV       = ""
 	LogLevelFV      = "info"
 	ReadableLogsFV  bool
-	SensitiveInfoFV = PIIHash
+	SensitiveInfoFV = PIIPlainText
 
 	LogFile string // logFileFV after processing
 )
@@ -109,7 +109,7 @@ func addFlags(fs *pflag.FlagSet, defaultFile string) {
 	fs.StringVar(
 		&SensitiveInfoFV,
 		SensitiveInfoFN,
-		PIIHash,
+		PIIPlainText,
 		fmt.Sprintf("set the format for sensitive info in logs to %s|%s|%s", PIIHash, PIIMask, PIIPlainText))
 }
 

--- a/src/pkg/logger/logger_test.go
+++ b/src/pkg/logger/logger_test.go
@@ -32,9 +32,12 @@ func (suite *LoggerUnitSuite) TestAddLoggingFlags() {
 		Run: func(cmd *cobra.Command, args []string) {
 			assert.True(t, logger.DebugAPIFV, logger.DebugAPIFN)
 			assert.True(t, logger.ReadableLogsFV, logger.ReadableLogsFN)
-			assert.Equal(t, "log-file", logger.LogFile, logger.LogFileFN)
 			assert.Equal(t, logger.LLError, logger.LogLevelFV, logger.LogLevelFN)
 			assert.Equal(t, logger.PIIMask, logger.SensitiveInfoFV, logger.SensitiveInfoFN)
+			// empty assertion here, instead of matching "log-file", because the LogFile
+			// var isn't updated by running the command (this is expected and correct),
+			// while the logFileFV remains unexported.
+			assert.Empty(t, logger.LogFile, logger.LogFileFN)
 		},
 	}
 

--- a/src/pkg/logger/logger_test.go
+++ b/src/pkg/logger/logger_test.go
@@ -32,7 +32,7 @@ func (suite *LoggerUnitSuite) TestAddLoggingFlags() {
 		Run: func(cmd *cobra.Command, args []string) {
 			assert.True(t, logger.DebugAPIFV, logger.DebugAPIFN)
 			assert.True(t, logger.ReadableLogsFV, logger.ReadableLogsFN)
-			assert.Equal(t, "log-file", logger.LogFileFV, logger.LogFileFN)
+			assert.Equal(t, "log-file", logger.LogFile, logger.LogFileFN)
 			assert.Equal(t, logger.LLError, logger.LogLevelFV, logger.LogLevelFN)
 			assert.Equal(t, logger.PIIMask, logger.SensitiveInfoFV, logger.SensitiveInfoFN)
 		},

--- a/src/pkg/logger/logger_test.go
+++ b/src/pkg/logger/logger_test.go
@@ -1,0 +1,78 @@
+package logger_test
+
+import (
+	"testing"
+
+	"github.com/alcionai/clues"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/logger"
+)
+
+type LoggerUnitSuite struct {
+	tester.Suite
+}
+
+func TestLoggerUnitSuite(t *testing.T) {
+	suite.Run(t, &LoggerUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *LoggerUnitSuite) TestAddLoggingFlags() {
+	t := suite.T()
+
+	logger.DebugAPIFV = false
+	logger.ReadableLogsFV = false
+
+	cmd := &cobra.Command{
+		Use: "test",
+		Run: func(cmd *cobra.Command, args []string) {
+			assert.True(t, logger.DebugAPIFV, logger.DebugAPIFN)
+			assert.True(t, logger.ReadableLogsFV, logger.ReadableLogsFN)
+			assert.Equal(t, "log-file", logger.LogFileFV, logger.LogFileFN)
+			assert.Equal(t, logger.LLError, logger.LogLevelFV, logger.LogLevelFN)
+			assert.Equal(t, logger.PIIMask, logger.SensitiveInfoFV, logger.SensitiveInfoFN)
+		},
+	}
+
+	logger.AddLoggingFlags(cmd)
+
+	// Test arg parsing for few args
+	cmd.SetArgs([]string{
+		"test",
+		"--" + logger.DebugAPIFN,
+		"--" + logger.LogFileFN, "log-file",
+		"--" + logger.LogLevelFN, logger.LLError,
+		"--" + logger.ReadableLogsFN,
+		"--" + logger.SensitiveInfoFN, logger.PIIMask,
+	})
+
+	err := cmd.Execute()
+	require.NoError(t, err, clues.ToCore(err))
+}
+
+func (suite *LoggerUnitSuite) TestPreloadLoggingFlags() {
+	t := suite.T()
+
+	logger.DebugAPIFV = false
+	logger.ReadableLogsFV = false
+
+	args := []string{
+		"--" + logger.DebugAPIFN,
+		"--" + logger.LogFileFN, "log-file",
+		"--" + logger.LogLevelFN, logger.LLError,
+		"--" + logger.ReadableLogsFN,
+		"--" + logger.SensitiveInfoFN, logger.PIIMask,
+	}
+
+	settings := logger.PreloadLoggingFlags(args)
+
+	assert.True(t, logger.DebugAPIFV, logger.DebugAPIFN)
+	assert.True(t, logger.ReadableLogsFV, logger.ReadableLogsFN)
+	assert.Equal(t, "log-file", settings.File, "settings.File")
+	assert.Equal(t, logger.LLError, settings.Level, "settings.Level")
+	assert.Equal(t, logger.PIIMask, settings.PIIHandling, "settings.PIIHandling")
+}


### PR DESCRIPTION
The sensitive-info flag allows CLI users to specify the Concealer algorithm used to handle PII and
other sensitive info in logging.  Default alg is 'hash', which produces a truncated hmacsha256 string.
'mask' for flat '***' replacement and 'plaintext'
are also available.

SDK consumer are expected to configure clues
themselves, rather than specifying a config option.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #2024

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
