### PR TITLE
Remove `--enable-permissions-backup` flag from sanity tests

### DIFF
--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -237,7 +237,6 @@ jobs:
           ./corso backup create onedrive \
           --hide-progress \
           --user "${CORSO_M365_TEST_USER_ID}" \
-          --enable-permissions-backup \
           --json \
           2>&1 | tee $TEST_RESULT/backup_onedrive.txt 
 
@@ -308,7 +307,6 @@ jobs:
           ./corso backup create onedrive \
           --hide-progress \
           --user "${CORSO_M365_TEST_USER_ID}" \
-          --enable-permissions-backup \
           --json \
           2>&1 | tee $TEST_RESULT/backup_onedrive_incremental.txt 
           


### PR DESCRIPTION
Permissions backup is now default, but this flag was never removed from sanity-tests CI.

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
