### PR TITLE
Remove unnecessary indirection for retries

### DIFF
--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -251,11 +251,10 @@ func (col *Collection) streamItems(ctx context.Context, errs *fault.Bus) {
 			defer wg.Done()
 			defer func() { <-semaphoreCh }()
 
-			item, info, err := getItemWithRetries(
+			item, info, err := col.items.GetItem(
 				ctx,
 				user,
 				id,
-				col.items,
 				fault.New(true)) // temporary way to force a failFast error
 			if err != nil {
 				// Don't report errors for deleted items as there's no way for us to
@@ -298,21 +297,6 @@ func (col *Collection) streamItems(ctx context.Context, errs *fault.Bus) {
 	}
 
 	wg.Wait()
-}
-
-// get an item while handling retry and backoff.
-func getItemWithRetries(
-	ctx context.Context,
-	userID, itemID string,
-	items itemer,
-	errs *fault.Bus,
-) (serialization.Parsable, *details.ExchangeInfo, error) {
-	item, info, err := items.GetItem(ctx, userID, itemID, errs)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return item, info, nil
 }
 
 // terminatePopulateSequence is a utility function used to close a Collection's data channel

--- a/src/internal/connector/exchange/exchange_data_collection_test.go
+++ b/src/internal/connector/exchange/exchange_data_collection_test.go
@@ -228,7 +228,7 @@ func (suite *ExchangeDataCollectionSuite) TestGetItemWithRetries() {
 			defer flush()
 
 			// itemer is mocked, so only the errors are configured atm.
-			_, _, err := getItemWithRetries(ctx, "userID", "itemID", test.items, fault.New(true))
+			_, _, err := test.items.GetItem(ctx, "userID", "itemID", fault.New(true))
 			test.expectErr(suite.T(), err)
 		})
 	}


### PR DESCRIPTION
This was previously used to add retry logic which is no more the case as is a completely unnecessary indirection.

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
