### PR TITLE
Compute parent permissions from available metadata

### DIFF
--- a/src/internal/connector/graph_connector_onedrive_test.go
+++ b/src/internal/connector/graph_connector_onedrive_test.go
@@ -2,13 +2,13 @@ package connector
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/alcionai/clues"
+	"github.com/google/uuid"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,7 +37,10 @@ func getMetadata(fileName string, perm permData, permUseID bool) onedrive.Metada
 		}
 	}
 
-	id := base64.StdEncoding.EncodeToString([]byte(perm.user + strings.Join(perm.roles, "+")))
+	// In case of permissions, the id will usually be same for same
+	// user/role combo unless deleted and readded, but we have to do
+	// this as we only have two users of which one is already taken.
+	id := uuid.NewString()
 	uperm := onedrive.UserPermission{ID: id, Roles: perm.roles}
 
 	if permUseID {

--- a/src/internal/connector/onedrive/permission.go
+++ b/src/internal/connector/onedrive/permission.go
@@ -177,6 +177,10 @@ func diffPermissions(before, after []UserPermission) ([]UserPermission, []UserPe
 	return added, removed
 }
 
+// computeParentPermissions computes the parent permissions by
+// traversing folderMetas and finding the first item with custom
+// permissions. folderMetas is expected to have all the parent
+// directory metas for this to work.
 func computeParentPermissions(itemPath path.Path, folderMetas map[string]Metadata) (Metadata, error) {
 	var (
 		parent path.Path
@@ -214,6 +218,8 @@ func computeParentPermissions(itemPath path.Path, folderMetas map[string]Metadat
 	}
 }
 
+// updatePermissions takes in the set of permission to be added and
+// removed from an item to bring it to the desired state.
 func updatePermissions(
 	ctx context.Context,
 	creds account.M365Config,
@@ -308,9 +314,10 @@ func updatePermissions(
 	return nil
 }
 
-// RestorePermissions takes in the permissions that were added and the
-// removed(ones present in parent but not in child) and adds/removes
-// the necessary permissions on onedrive objects.
+// RestorePermissions takes in the permissions of an item, computes
+// what permissions need to added and removed based on the parent
+// folder metas and uses that to add/remove the necessary permissions
+// on onedrive items.
 func RestorePermissions(
 	ctx context.Context,
 	creds account.M365Config,
@@ -340,7 +347,7 @@ func RestorePermissions(
 
 // SetPermissions is similar to RestorePermissions, but fetches the
 // current permissions from graph inorder to update the permissions on
-// an item. This is necessary in tests(any currently only used in
+// an item. This is necessary in tests (and currently only used in
 // tests) as we have to delete permissions of items that we have
 // created.
 func SetPermissions(

--- a/src/internal/connector/onedrive/permission.go
+++ b/src/internal/connector/onedrive/permission.go
@@ -98,6 +98,7 @@ func createRestoreFoldersWithPermissions(
 	folderMetadata Metadata,
 	folderMetas map[string]Metadata,
 	permissionIDMappings map[string]string,
+	restorePerms bool,
 ) (string, error) {
 	id, err := CreateRestoreFolders(ctx, service, drivePath.DriveID, restoreFolders)
 	if err != nil {
@@ -106,6 +107,10 @@ func createRestoreFoldersWithPermissions(
 
 	if len(drivePath.Folders) == 0 {
 		// No permissions for root folder
+		return id, nil
+	}
+
+	if !restorePerms {
 		return id, nil
 	}
 

--- a/src/internal/connector/onedrive/permission.go
+++ b/src/internal/connector/onedrive/permission.go
@@ -146,8 +146,7 @@ func diffPermissions(before, after []UserPermission) ([]UserPermission, []UserPe
 		found := false
 
 		for _, pp := range before {
-			if isSame(cp.Roles, pp.Roles) &&
-				cp.EntityID == pp.EntityID {
+			if pp.ID == cp.ID {
 				found = true
 				break
 			}
@@ -162,8 +161,7 @@ func diffPermissions(before, after []UserPermission) ([]UserPermission, []UserPe
 		found := false
 
 		for _, cp := range after {
-			if isSame(cp.Roles, pp.Roles) &&
-				cp.EntityID == pp.EntityID {
+			if pp.ID == cp.ID {
 				found = true
 				break
 			}
@@ -218,9 +216,9 @@ func computeParentPermissions(itemPath path.Path, folderMetas map[string]Metadat
 	}
 }
 
-// updatePermissions takes in the set of permission to be added and
+// UpdatePermissions takes in the set of permission to be added and
 // removed from an item to bring it to the desired state.
-func updatePermissions(
+func UpdatePermissions(
 	ctx context.Context,
 	creds account.M365Config,
 	service graph.Servicer,
@@ -334,7 +332,7 @@ func RestorePermissions(
 
 	permAdded, permRemoved := diffPermissions(parentPermissions.Permissions, meta.Permissions)
 
-	return updatePermissions(ctx, creds, service, driveID, itemID, permAdded, permRemoved, permissionIDMappings)
+	return UpdatePermissions(ctx, creds, service, driveID, itemID, permAdded, permRemoved, permissionIDMappings)
 }
 
 // SetPermissions is similar to RestorePermissions, but fetches the
@@ -361,6 +359,7 @@ func SetPermissions(
 		return graph.Wrap(ctx, err, "fetching current permissions")
 	}
 
+	// TODO(meain): Diff permissions should be done via ids
 	permAdded, permRemoved := diffPermissions(currentPermissions, meta.Permissions)
 
 	// Compute permissions id mappings as if we get from and backup metadata
@@ -369,5 +368,5 @@ func SetPermissions(
 		permissionIDMappings[perm.ID] = perm.ID
 	}
 
-	return updatePermissions(ctx, creds, service, driveID, itemID, permAdded, permRemoved, permissionIDMappings)
+	return UpdatePermissions(ctx, creds, service, driveID, itemID, permAdded, permRemoved, permissionIDMappings)
 }

--- a/src/internal/connector/onedrive/permission_test.go
+++ b/src/internal/connector/onedrive/permission_test.go
@@ -1,0 +1,125 @@
+package onedrive
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/path"
+)
+
+type PermissionsUnitTestSuite struct {
+	tester.Suite
+}
+
+func TestPermissionsUnitTestSuite(t *testing.T) {
+	suite.Run(t, &PermissionsUnitTestSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *PermissionsUnitTestSuite) TestComputeParentPermissions() {
+	fullPath := fmt.Sprintf(rootDrivePattern, "drive-id") + "/level0/level1/level2/entry"
+
+	pth, err := path.Build(
+		"tenant",
+		"user",
+		path.OneDriveService,
+		path.FilesCategory,
+		false,
+		strings.Split(fullPath, "/")...,
+	)
+	require.NoError(suite.T(), err, "creating path")
+
+	level2, err := pth.Dir()
+	require.NoError(suite.T(), err, "level2 path")
+
+	level1, err := level2.Dir()
+	require.NoError(suite.T(), err, "level1 path")
+
+	level0, err := level1.Dir()
+	require.NoError(suite.T(), err, "level0 path")
+
+	metadata := Metadata{
+		SharingMode: SharingModeCustom,
+		Permissions: []UserPermission{
+			{
+				Roles:    []string{"write"},
+				EntityID: "user-id",
+			},
+		},
+	}
+
+	metadata2 := Metadata{
+		SharingMode: SharingModeCustom,
+		Permissions: []UserPermission{
+			{
+				Roles:    []string{"read"},
+				EntityID: "user-id",
+			},
+		},
+	}
+
+	inherited := Metadata{
+		SharingMode: SharingModeInherited,
+		Permissions: []UserPermission{},
+	}
+
+	table := []struct {
+		name        string
+		parentPerms map[string]Metadata
+		meta        Metadata
+	}{
+		{
+			name: "direct parent perms",
+			parentPerms: map[string]Metadata{
+				level2.String(): metadata,
+			},
+			meta: metadata,
+		},
+		{
+			name: "top level parent perms",
+			parentPerms: map[string]Metadata{
+				level2.String(): inherited,
+				level1.String(): inherited,
+				level0.String(): metadata,
+			},
+			meta: metadata,
+		},
+		{
+			name: "all inherited",
+			parentPerms: map[string]Metadata{
+				level2.String(): inherited,
+				level1.String(): inherited,
+				level0.String(): inherited,
+			},
+			meta: Metadata{},
+		},
+		{
+			name: "multiple custom permission",
+			parentPerms: map[string]Metadata{
+				level2.String(): inherited,
+				level1.String(): metadata,
+				level0.String(): metadata2,
+			},
+			meta: metadata,
+		},
+	}
+
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			_, flush := tester.NewContext()
+			defer flush()
+
+			t := suite.T()
+
+			m, err := computeParentPermissions(pth, test.parentPerms)
+			require.NoError(t, err, "compute permissions")
+
+			assert.Equal(t, m, test.meta)
+		})
+	}
+}

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -46,7 +46,11 @@ func RestoreCollections(
 	var (
 		restoreMetrics support.CollectionMetrics
 		metrics        support.CollectionMetrics
-		folderMetas    map[string]Metadata
+		folderMetas    = map[string]Metadata{}
+
+		// permissionIDMappings is used to map between old and new id
+		// of permissions as we restore them
+		permissionIDMappings = map[string]string{}
 	)
 
 	ctx = clues.Add(
@@ -60,10 +64,7 @@ func RestoreCollections(
 		return dcs[i].FullPath().String() < dcs[j].FullPath().String()
 	})
 
-	var (
-		el          = errs.Local()
-		parentMetas = map[string]Metadata{}
-	)
+	el := errs.Local()
 
 	// Iterate through the data collections and restore the contents of each
 	for _, dc := range dcs {
@@ -80,13 +81,14 @@ func RestoreCollections(
 				"path", dc.FullPath())
 		)
 
-		metrics, folderMetas, err = RestoreCollection(
+		metrics, err = RestoreCollection(
 			ictx,
 			creds,
 			backupVersion,
 			service,
 			dc,
-			parentMetas,
+			folderMetas,
+			permissionIDMappings,
 			OneDriveSource,
 			dest.ContainerName,
 			deets,
@@ -94,10 +96,6 @@ func RestoreCollections(
 			errs)
 		if err != nil {
 			el.AddRecoverable(err)
-		}
-
-		for k, v := range folderMetas {
-			parentMetas[k] = v
 		}
 
 		restoreMetrics = support.CombineMetrics(restoreMetrics, metrics)
@@ -128,19 +126,19 @@ func RestoreCollection(
 	backupVersion int,
 	service graph.Servicer,
 	dc data.RestoreCollection,
-	parentMetas map[string]Metadata,
+	folderMetas map[string]Metadata,
+	permissionIDMappings map[string]string,
 	source driveSource,
 	restoreContainerName string,
 	deets *details.Builder,
 	restorePerms bool,
 	errs *fault.Bus,
-) (support.CollectionMetrics, map[string]Metadata, error) {
+) (support.CollectionMetrics, error) {
 	var (
-		metrics     = support.CollectionMetrics{}
-		copyBuffer  = make([]byte, copyBufferSize)
-		directory   = dc.FullPath()
-		folderMetas = map[string]Metadata{}
-		el          = errs.Local()
+		metrics    = support.CollectionMetrics{}
+		copyBuffer = make([]byte, copyBufferSize)
+		directory  = dc.FullPath()
+		el         = errs.Local()
 	)
 
 	ctx, end := diagnostics.Span(ctx, "gc:oneDrive:restoreCollection", diagnostics.Label("path", directory))
@@ -148,7 +146,7 @@ func RestoreCollection(
 
 	drivePath, err := path.ToOneDrivePath(directory)
 	if err != nil {
-		return metrics, folderMetas, clues.Wrap(err, "creating drive path").WithClues(ctx)
+		return metrics, clues.Wrap(err, "creating drive path").WithClues(ctx)
 	}
 
 	// Assemble folder hierarchy we're going to restore into (we recreate the folder hierarchy
@@ -171,11 +169,11 @@ func RestoreCollection(
 		ctx,
 		drivePath,
 		dc,
-		parentMetas,
+		folderMetas,
 		backupVersion,
 		restorePerms)
 	if err != nil {
-		return metrics, folderMetas, clues.Wrap(err, "getting permissions").WithClues(ctx)
+		return metrics, clues.Wrap(err, "getting permissions").WithClues(ctx)
 	}
 
 	// Create restore folders and get the folder ID of the folder the data stream will be restored in
@@ -185,11 +183,15 @@ func RestoreCollection(
 		service,
 		drivePath,
 		restoreFolderElements,
-		colMeta)
+		dc.FullPath(),
+		colMeta,
+		folderMetas,
+		permissionIDMappings)
 	if err != nil {
-		return metrics, folderMetas, clues.Wrap(err, "creating folders for restore")
+		return metrics, clues.Wrap(err, "creating folders for restore")
 	}
 
+	folderMetas[dc.FullPath().String()] = colMeta
 	items := dc.Items(ctx, errs)
 
 	for {
@@ -199,11 +201,11 @@ func RestoreCollection(
 
 		select {
 		case <-ctx.Done():
-			return metrics, folderMetas, err
+			return metrics, err
 
 		case itemData, ok := <-items:
 			if !ok {
-				return metrics, folderMetas, nil
+				return metrics, nil
 			}
 
 			itemPath, err := dc.FullPath().Append(itemData.UUID(), true)
@@ -223,6 +225,7 @@ func RestoreCollection(
 				restoreFolderID,
 				copyBuffer,
 				folderMetas,
+				permissionIDMappings,
 				restorePerms,
 				itemData,
 				itemPath)
@@ -259,7 +262,7 @@ func RestoreCollection(
 		}
 	}
 
-	return metrics, folderMetas, el.Failure()
+	return metrics, el.Failure()
 }
 
 // restores an item, according to correct backup version behavior.
@@ -275,6 +278,7 @@ func restoreItem(
 	restoreFolderID string,
 	copyBuffer []byte,
 	folderMetas map[string]Metadata,
+	permissionIDMappings map[string]string,
 	restorePerms bool,
 	itemData data.Stream,
 	itemPath path.Path,
@@ -341,6 +345,9 @@ func restoreItem(
 			restoreFolderID,
 			copyBuffer,
 			restorePerms,
+			folderMetas,
+			permissionIDMappings,
+			itemPath,
 			itemData)
 		if err != nil {
 			return details.ItemInfo{}, false, clues.Wrap(err, "v1 restore")
@@ -361,6 +368,9 @@ func restoreItem(
 		restoreFolderID,
 		copyBuffer,
 		restorePerms,
+		folderMetas,
+		permissionIDMappings,
+		itemPath,
 		itemData)
 	if err != nil {
 		return details.ItemInfo{}, false, clues.Wrap(err, "v6 restore")
@@ -408,6 +418,9 @@ func restoreV1File(
 	restoreFolderID string,
 	copyBuffer []byte,
 	restorePerms bool,
+	folderMetas map[string]Metadata,
+	permissionIDMappings map[string]string,
+	itemPath path.Path,
 	itemData data.Stream,
 ) (details.ItemInfo, error) {
 	trimmedName := strings.TrimSuffix(itemData.UUID(), DataFileSuffix)
@@ -445,7 +458,10 @@ func restoreV1File(
 		service,
 		drivePath.DriveID,
 		itemID,
-		meta)
+		itemPath,
+		meta,
+		folderMetas,
+		permissionIDMappings)
 	if err != nil {
 		return details.ItemInfo{}, clues.Wrap(err, "restoring item permissions")
 	}
@@ -463,6 +479,9 @@ func restoreV6File(
 	restoreFolderID string,
 	copyBuffer []byte,
 	restorePerms bool,
+	folderMetas map[string]Metadata,
+	permissionIDMappings map[string]string,
+	itemPath path.Path,
 	itemData data.Stream,
 ) (details.ItemInfo, error) {
 	trimmedName := strings.TrimSuffix(itemData.UUID(), DataFileSuffix)
@@ -511,7 +530,10 @@ func restoreV6File(
 		service,
 		drivePath.DriveID,
 		itemID,
-		meta)
+		itemPath,
+		meta,
+		folderMetas,
+		permissionIDMappings)
 	if err != nil {
 		return details.ItemInfo{}, clues.Wrap(err, "restoring item permissions")
 	}

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -186,7 +186,8 @@ func RestoreCollection(
 		dc.FullPath(),
 		colMeta,
 		folderMetas,
-		permissionIDMappings)
+		permissionIDMappings,
+		restorePerms)
 	if err != nil {
 		return metrics, clues.Wrap(err, "creating folders for restore")
 	}

--- a/src/internal/connector/sharepoint/restore.go
+++ b/src/internal/connector/sharepoint/restore.go
@@ -67,13 +67,14 @@ func RestoreCollections(
 
 		switch dc.FullPath().Category() {
 		case path.LibrariesCategory:
-			metrics, _, err = onedrive.RestoreCollection(
+			metrics, err = onedrive.RestoreCollection(
 				ictx,
 				creds,
 				backupVersion,
 				service,
 				dc,
 				map[string]onedrive.Metadata{}, // Currently permission data is not stored for sharepoint
+				map[string]string{},
 				onedrive.SharePointSource,
 				dest.ContainerName,
 				deets,

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -1307,7 +1307,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveIncrementals() {
 				driveItem := models.NewDriveItem()
 				driveItem.SetName(&newFileName)
 				driveItem.SetFile(models.NewFile())
-				err = onedrive.RestorePermissions(
+				err = onedrive.SetPermissions(
 					ctx,
 					creds,
 					gc.Service,
@@ -1333,7 +1333,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveIncrementals() {
 				driveItem := models.NewDriveItem()
 				driveItem.SetName(&newFileName)
 				driveItem.SetFile(models.NewFile())
-				err = onedrive.RestorePermissions(
+				err = onedrive.SetPermissions(
 					ctx,
 					creds,
 					gc.Service,
@@ -1355,7 +1355,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveIncrementals() {
 				driveItem := models.NewDriveItem()
 				driveItem.SetName(&newFileName)
 				driveItem.SetFile(models.NewFile())
-				err = onedrive.RestorePermissions(
+				err = onedrive.SetPermissions(
 					ctx,
 					creds,
 					gc.Service,
@@ -1382,7 +1382,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveIncrementals() {
 				driveItem := models.NewDriveItem()
 				driveItem.SetName(&newFileName)
 				driveItem.SetFile(models.NewFile())
-				err = onedrive.RestorePermissions(
+				err = onedrive.SetPermissions(
 					ctx,
 					creds,
 					gc.Service,

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -1264,6 +1264,13 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveIncrementals() {
 	var (
 		newFile     models.DriveItemable
 		newFileName = "new_file.txt"
+
+		permissionIDMappings = map[string]string{}
+		writePerm            = onedrive.UserPermission{
+			ID:       "perm-id",
+			Roles:    []string{"write"},
+			EntityID: suite.user,
+		}
 	)
 
 	// Although established as a table, these tests are not isolated from each other.
@@ -1307,21 +1314,16 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveIncrementals() {
 				driveItem := models.NewDriveItem()
 				driveItem.SetName(&newFileName)
 				driveItem.SetFile(models.NewFile())
-				err = onedrive.SetPermissions(
+				err = onedrive.UpdatePermissions(
 					ctx,
 					creds,
 					gc.Service,
 					driveID,
 					*newFile.GetId(),
-					onedrive.Metadata{
-						SharingMode: onedrive.SharingModeCustom,
-						Permissions: []onedrive.UserPermission{
-							{
-								Roles:    []string{"write"},
-								EntityID: suite.user,
-							},
-						},
-					})
+					[]onedrive.UserPermission{writePerm},
+					[]onedrive.UserPermission{},
+					permissionIDMappings,
+				)
 				require.NoErrorf(t, err, "add permission to file %v", clues.ToCore(err))
 			},
 			itemsRead:    1, // .data file for newitem
@@ -1333,16 +1335,16 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveIncrementals() {
 				driveItem := models.NewDriveItem()
 				driveItem.SetName(&newFileName)
 				driveItem.SetFile(models.NewFile())
-				err = onedrive.SetPermissions(
+				err = onedrive.UpdatePermissions(
 					ctx,
 					creds,
 					gc.Service,
 					driveID,
 					*newFile.GetId(),
-					onedrive.Metadata{
-						SharingMode: onedrive.SharingModeCustom,
-						Permissions: []onedrive.UserPermission{},
-					})
+					[]onedrive.UserPermission{},
+					[]onedrive.UserPermission{writePerm},
+					permissionIDMappings,
+				)
 				require.NoError(t, err, "add permission to file", clues.ToCore(err))
 			},
 			itemsRead:    1, // .data file for newitem
@@ -1355,21 +1357,16 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveIncrementals() {
 				driveItem := models.NewDriveItem()
 				driveItem.SetName(&newFileName)
 				driveItem.SetFile(models.NewFile())
-				err = onedrive.SetPermissions(
+				err = onedrive.UpdatePermissions(
 					ctx,
 					creds,
 					gc.Service,
 					driveID,
 					targetContainer,
-					onedrive.Metadata{
-						SharingMode: onedrive.SharingModeCustom,
-						Permissions: []onedrive.UserPermission{
-							{
-								Roles:    []string{"write"},
-								EntityID: suite.user,
-							},
-						},
-					})
+					[]onedrive.UserPermission{writePerm},
+					[]onedrive.UserPermission{},
+					permissionIDMappings,
+				)
 				require.NoError(t, err, "add permission to file", clues.ToCore(err))
 			},
 			itemsRead:    0,
@@ -1382,16 +1379,16 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveIncrementals() {
 				driveItem := models.NewDriveItem()
 				driveItem.SetName(&newFileName)
 				driveItem.SetFile(models.NewFile())
-				err = onedrive.SetPermissions(
+				err = onedrive.UpdatePermissions(
 					ctx,
 					creds,
 					gc.Service,
 					driveID,
 					targetContainer,
-					onedrive.Metadata{
-						SharingMode: onedrive.SharingModeCustom,
-						Permissions: []onedrive.UserPermission{},
-					})
+					[]onedrive.UserPermission{},
+					[]onedrive.UserPermission{writePerm},
+					permissionIDMappings,
+				)
 				require.NoError(t, err, "add permission to file", clues.ToCore(err))
 			},
 			itemsRead:    0,


### PR DESCRIPTION
Previously we were querying Graph to get the current permissions and then using that to compute the permission diff. This changes that to use the metadata that we have available locally to do the computation avoiding a graph call to get permissions.

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* fixes https://github.com/alcionai/corso/issues/2976

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
