### PR TITLE
add pii supporting stringers to filters

### DIFF
--- a/src/pkg/filters/filters_test.go
+++ b/src/pkg/filters/filters_test.go
@@ -1,8 +1,11 @@
 package filters_test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/alcionai/clues"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
@@ -16,6 +19,16 @@ type FiltersSuite struct {
 
 func TestFiltersSuite(t *testing.T) {
 	suite.Run(t, &FiltersSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+// set the clues hashing to mask for the span of this suite
+func (suite *FiltersSuite) SetupSuite() {
+	clues.SetHasher(clues.HashCfg{HashAlg: clues.Flatmask})
+}
+
+// revert clues hashing to plaintext for all other tests
+func (suite *FiltersSuite) TeardownSuite() {
+	clues.SetHasher(clues.NoHash())
 }
 
 func sl(s ...string) []string {
@@ -597,6 +610,98 @@ func (suite *FiltersSuite) TestPathEquals_NormalizedTargets() {
 
 			f := filters.PathEquals(test.targets)
 			assert.Equal(t, test.expect, f.NormalizedTargets)
+		})
+	}
+}
+
+func (suite *FiltersSuite) TestFilter_pii() {
+	targets := []string{"fnords", "smarf", "*"}
+
+	table := []struct {
+		name string
+		f    filters.Filter
+	}{
+		{"equal", filters.Equal(targets)},
+		{"contains", filters.Contains(targets)},
+		{"greater", filters.Greater(targets)},
+		{"less", filters.Less(targets)},
+		{"prefix", filters.Prefix(targets)},
+		{"suffix", filters.Suffix(targets)},
+		{"pathprefix", filters.PathPrefix(targets)},
+		{"pathsuffix", filters.PathSuffix(targets)},
+		{"pathcontains", filters.PathContains(targets)},
+		{"pathequals", filters.PathEquals(targets)},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			var (
+				t           = suite.T()
+				expect      = test.f.Comparator.String() + ":***,***,*"
+				expectPlain = test.f.Comparator.String() + ":" + strings.Join(targets, ",")
+			)
+
+			result := test.f.Conceal()
+			assert.Equal(t, expect, result, "conceal")
+
+			result = test.f.String()
+			assert.Equal(t, expect, result, "string")
+
+			result = test.f.PlainString()
+			assert.Equal(t, expectPlain, result, "plainString")
+
+			result = fmt.Sprintf("%s", test.f)
+			assert.Equal(t, expect, result, "fmt %%s")
+
+			result = fmt.Sprintf("%v", test.f)
+			assert.Equal(t, expect, result, "fmt %%v")
+
+			result = fmt.Sprintf("%+v", test.f)
+			assert.Equal(t, expect, result, "fmt %%+v")
+		})
+	}
+
+	table2 := []struct {
+		name        string
+		f           filters.Filter
+		expect      string
+		expectPlain string
+	}{
+		{"pass", filters.Pass(), "Pass", "Pass"},
+		{"fail", filters.Fail(), "Fail", "Fail"},
+		{
+			"identity",
+			filters.Identity("id"),
+			filters.IdentityValue.String() + ":***",
+			filters.IdentityValue.String() + ":id",
+		},
+		{
+			"identity",
+			filters.Identity("*"),
+			filters.IdentityValue.String() + ":*",
+			filters.IdentityValue.String() + ":*",
+		},
+	}
+	for _, test := range table2 {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			result := test.f.Conceal()
+			assert.Equal(t, test.expect, result, "conceal")
+
+			result = test.f.String()
+			assert.Equal(t, test.expect, result, "string")
+
+			result = test.f.PlainString()
+			assert.Equal(t, test.expectPlain, result, "plainString")
+
+			result = fmt.Sprintf("%s", test.f)
+			assert.Equal(t, test.expect, result, "fmt %%s")
+
+			result = fmt.Sprintf("%v", test.f)
+			assert.Equal(t, test.expect, result, "fmt %%v")
+
+			result = fmt.Sprintf("%+v", test.f)
+			assert.Equal(t, test.expect, result, "fmt %%+v")
 		})
 	}
 }

--- a/src/pkg/selectors/exchange.go
+++ b/src/pkg/selectors/exchange.go
@@ -2,6 +2,7 @@ package selectors
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"github.com/alcionai/clues"
@@ -120,6 +121,15 @@ func (s exchange) PathCategories() selectorPathCategories {
 		Includes: pathCategoriesIn[ExchangeScope, exchangeCategory](s.Includes),
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Stringers and Concealers
+// ---------------------------------------------------------------------------
+
+func (s ExchangeScope) Conceal() string             { return conceal(s) }
+func (s ExchangeScope) Format(fs fmt.State, r rune) { format(s, fs, r) }
+func (s ExchangeScope) String() string              { return conceal(s) }
+func (s ExchangeScope) PlainString() string         { return plainString(s) }
 
 // -------------------
 // Exclude/Includes

--- a/src/pkg/selectors/helpers_test.go
+++ b/src/pkg/selectors/helpers_test.go
@@ -1,6 +1,7 @@
 package selectors
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -95,8 +96,8 @@ type mockScope scope
 
 var _ scoper = &mockScope{}
 
-func (ms mockScope) categorizer() categorizer {
-	switch ms[scopeKeyCategory].Identity {
+func (s mockScope) categorizer() categorizer {
+	switch s[scopeKeyCategory].Identity {
 	case rootCatStub.String():
 		return rootCatStub
 	case leafCatStub.String():
@@ -106,11 +107,11 @@ func (ms mockScope) categorizer() categorizer {
 	return unknownCatStub
 }
 
-func (ms mockScope) matchesInfo(dii details.ItemInfo) bool {
-	return ms[shouldMatch].Target == "true"
+func (s mockScope) matchesInfo(dii details.ItemInfo) bool {
+	return s[shouldMatch].Target == "true"
 }
 
-func (ms mockScope) setDefaults() {}
+func (s mockScope) setDefaults() {}
 
 const (
 	shouldMatch = "should-match-entry"
@@ -143,6 +144,15 @@ func stubInfoScope(match string) mockScope {
 
 	return sc
 }
+
+// ---------------------------------------------------------------------------
+// Stringers and Concealers
+// ---------------------------------------------------------------------------
+
+func (s mockScope) Conceal() string             { return conceal(s) }
+func (s mockScope) Format(fs fmt.State, r rune) { format(s, fs, r) }
+func (s mockScope) String() string              { return conceal(s) }
+func (s mockScope) PlainString() string         { return plainString(s) }
 
 // ---------------------------------------------------------------------------
 // selectors

--- a/src/pkg/selectors/onedrive.go
+++ b/src/pkg/selectors/onedrive.go
@@ -2,6 +2,7 @@ package selectors
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/alcionai/clues"
 
@@ -119,6 +120,15 @@ func (s oneDrive) PathCategories() selectorPathCategories {
 		Includes: pathCategoriesIn[OneDriveScope, oneDriveCategory](s.Includes),
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Stringers and Concealers
+// ---------------------------------------------------------------------------
+
+func (s OneDriveScope) Conceal() string             { return conceal(s) }
+func (s OneDriveScope) Format(fs fmt.State, r rune) { format(s, fs, r) }
+func (s OneDriveScope) String() string              { return conceal(s) }
+func (s OneDriveScope) PlainString() string         { return plainString(s) }
 
 // -------------------
 // Scope Factories

--- a/src/pkg/selectors/selectors.go
+++ b/src/pkg/selectors/selectors.go
@@ -233,15 +233,6 @@ func splitByResourceOwner[T scopeT, C categoryT](s Selector, allOwners []string,
 	return ss
 }
 
-func (s Selector) String() string {
-	bs, err := json.Marshal(s)
-	if err != nil {
-		return "error"
-	}
-
-	return string(bs)
-}
-
 // appendScopes iterates through each scope in the list of scope slices,
 // calling setDefaults() to ensure it is completely populated, and appends
 // those scopes to the `to` slice.
@@ -326,6 +317,84 @@ func selectorAsIface[T any](s Selector) (T, error) {
 	}
 
 	return t, err
+}
+
+// ---------------------------------------------------------------------------
+// Stringers and Concealers
+// ---------------------------------------------------------------------------
+
+var _ clues.PlainConcealer = &Selector{}
+
+type loggableSelector struct {
+	Service        service             `json:"service,omitempty"`
+	ResourceOwners string              `json:"resourceOwners,omitempty"`
+	DiscreteOwner  string              `json:"discreteOwner,omitempty"`
+	Excludes       []map[string]string `json:"exclusions,omitempty"`
+	Filters        []map[string]string `json:"filters,omitempty"`
+	Includes       []map[string]string `json:"includes,omitempty"`
+}
+
+func (s Selector) Conceal() string {
+	ls := loggableSelector{
+		Service:        s.Service,
+		ResourceOwners: s.ResourceOwners.Conceal(),
+		DiscreteOwner:  clues.Conceal(s.DiscreteOwner),
+		Excludes:       toMSS(s.Excludes, false),
+		Filters:        toMSS(s.Filters, false),
+		Includes:       toMSS(s.Includes, false),
+	}
+
+	return ls.marshal()
+}
+
+func (s Selector) Format(fs fmt.State, _ rune) {
+	fmt.Fprint(fs, s.Conceal())
+}
+
+func (s Selector) String() string {
+	return s.Conceal()
+}
+
+func (s Selector) PlainString() string {
+	ls := loggableSelector{
+		Service:        s.Service,
+		ResourceOwners: s.ResourceOwners.PlainString(),
+		DiscreteOwner:  s.DiscreteOwner,
+		Excludes:       toMSS(s.Excludes, true),
+		Filters:        toMSS(s.Filters, true),
+		Includes:       toMSS(s.Includes, true),
+	}
+
+	return ls.marshal()
+}
+
+func toMSS(scs []scope, plain bool) []map[string]string {
+	mss := make([]map[string]string, 0, len(scs))
+
+	for _, s := range scs {
+		m := map[string]string{}
+
+		for k, filt := range s {
+			if plain {
+				m[k] = filt.PlainString()
+			} else {
+				m[k] = filt.Conceal()
+			}
+		}
+
+		mss = append(mss, m)
+	}
+
+	return mss
+}
+
+func (ls loggableSelector) marshal() string {
+	bs, err := json.Marshal(ls)
+	if err != nil {
+		return "error-marshalling-selector"
+	}
+
+	return string(bs)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/selectors/selectors_test.go
+++ b/src/pkg/selectors/selectors_test.go
@@ -1,6 +1,7 @@
 package selectors
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/alcionai/clues"
@@ -26,6 +27,16 @@ func (suite *SelectorSuite) TestNewSelector() {
 	assert.NotNil(t, s)
 	assert.Equal(t, s.Service, ServiceUnknown)
 	assert.NotNil(t, s.Includes)
+}
+
+// set the clues hashing to mask for the span of this suite
+func (suite *SelectorSuite) SetupSuite() {
+	clues.SetHasher(clues.HashCfg{HashAlg: clues.Flatmask})
+}
+
+// revert clues hashing to plaintext for all other tests
+func (suite *SelectorSuite) TeardownSuite() {
+	clues.SetHasher(clues.NoHash())
 }
 
 func (suite *SelectorSuite) TestBadCastErr() {
@@ -402,6 +413,84 @@ func (suite *SelectorSuite) TestPathCategories_includes() {
 			}
 
 			test.isErr(t, err, clues.ToCore(err))
+		})
+	}
+}
+
+func (suite *SelectorSuite) TestSelector_pii() {
+	table := []struct {
+		name        string
+		sel         func() Selector
+		expect      string
+		expectPlain string
+	}{
+		{
+			name:        "empty selector",
+			sel:         func() Selector { return Selector{} },
+			expect:      `{"resourceOwners":"UnknownComparison:"}`,
+			expectPlain: `{"resourceOwners":"UnknownComparison:"}`,
+		},
+		{
+			name: "no scopes",
+			sel: func() Selector {
+				return Selector{
+					Service:        ServiceUnknown,
+					DiscreteOwner:  "owner",
+					ResourceOwners: filterFor(scopeConfig{}, "owner_1", "owner_2"),
+				}
+			},
+			expect:      `{"resourceOwners":"Cont:***,***","discreteOwner":"***"}`,
+			expectPlain: `{"resourceOwners":"Cont:owner_1,owner_2","discreteOwner":"owner"}`,
+		},
+		{
+			name: "one scope each type",
+			sel: func() Selector {
+				s := NewExchangeBackup([]string{"owner_1", "owner_2"})
+				s.DiscreteOwner = "owner"
+
+				s.Exclude(s.MailFolders([]string{"e"}))
+				s.Filter(s.MailFolders([]string{"f"}, SuffixMatch()))
+				s.Include(s.MailFolders([]string{"i"}, PrefixMatch()))
+
+				return s.Selector
+			},
+			//nolint:lll
+			expect: `{"service":1,` +
+				`"resourceOwners":"Cont:***,***",` +
+				`"discreteOwner":"***",` +
+				`"exclusions":[{"ExchangeMail":"Pass","ExchangeMailFolder":"PathCont:***","category":"Identity:***","type":"Identity:***"}],` +
+				`"filters":[{"ExchangeMail":"Pass","ExchangeMailFolder":"PathSfx:***","category":"Identity:***","type":"Identity:***"}],` +
+				`"includes":[{"ExchangeMail":"Pass","ExchangeMailFolder":"PathPfx:***","category":"Identity:***","type":"Identity:***"}]}`,
+			//nolint:lll
+			expectPlain: `{"service":1,` +
+				`"resourceOwners":"Cont:owner_1,owner_2",` +
+				`"discreteOwner":"owner",` +
+				`"exclusions":[{"ExchangeMail":"Pass","ExchangeMailFolder":"PathCont:e","category":"Identity:ExchangeMailFolder","type":"Identity:ExchangeMail"}],` +
+				`"filters":[{"ExchangeMail":"Pass","ExchangeMailFolder":"PathSfx:f","category":"Identity:ExchangeMailFolder","type":"Identity:ExchangeMail"}],` +
+				`"includes":[{"ExchangeMail":"Pass","ExchangeMailFolder":"PathPfx:i","category":"Identity:ExchangeMailFolder","type":"Identity:ExchangeMail"}]}`,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			result := test.sel().Conceal()
+			assert.Equal(t, test.expect, result, "conceal")
+
+			result = test.sel().String()
+			assert.Equal(t, test.expect, result, "string")
+
+			result = test.sel().PlainString()
+			assert.Equal(t, test.expectPlain, result, "plainString")
+
+			result = fmt.Sprintf("%s", test.sel())
+			assert.Equal(t, test.expect, result, "fmt %%s")
+
+			result = fmt.Sprintf("%v", test.sel())
+			assert.Equal(t, test.expect, result, "fmt %%v")
+
+			result = fmt.Sprintf("%+v", test.sel())
+			assert.Equal(t, test.expect, result, "fmt %%+v")
 		})
 	}
 }

--- a/src/pkg/selectors/sharepoint.go
+++ b/src/pkg/selectors/sharepoint.go
@@ -2,6 +2,7 @@ package selectors
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/alcionai/clues"
 
@@ -119,6 +120,15 @@ func (s sharePoint) PathCategories() selectorPathCategories {
 		Includes: pathCategoriesIn[SharePointScope, sharePointCategory](s.Includes),
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Stringers and Concealers
+// ---------------------------------------------------------------------------
+
+func (s SharePointScope) Conceal() string             { return conceal(s) }
+func (s SharePointScope) Format(fs fmt.State, r rune) { format(s, fs, r) }
+func (s SharePointScope) String() string              { return conceal(s) }
+func (s SharePointScope) PlainString() string         { return plainString(s) }
 
 // -------------------
 // Scope Factories


### PR DESCRIPTION
Adds stringer and concealer methods to Filter
so that they can be logged or printed without
worry of exposing pii.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Supportability/Tests

#### Issue(s)

* #2024

#### Test Plan

- [x] :zap: Unit test
