### PR TITLE
add stringers and concealers for selectors

### DIFF
--- a/src/pkg/selectors/exchange.go
+++ b/src/pkg/selectors/exchange.go
@@ -2,6 +2,7 @@ package selectors
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"github.com/alcionai/clues"
@@ -120,6 +121,15 @@ func (s exchange) PathCategories() selectorPathCategories {
 		Includes: pathCategoriesIn[ExchangeScope, exchangeCategory](s.Includes),
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Stringers and Concealers
+// ---------------------------------------------------------------------------
+
+func (s ExchangeScope) Conceal() string             { return conceal(s) }
+func (s ExchangeScope) Format(fs fmt.State, r rune) { format(s, fs, r) }
+func (s ExchangeScope) String() string              { return conceal(s) }
+func (s ExchangeScope) PlainString() string         { return plainString(s) }
 
 // -------------------
 // Exclude/Includes

--- a/src/pkg/selectors/helpers_test.go
+++ b/src/pkg/selectors/helpers_test.go
@@ -1,6 +1,7 @@
 package selectors
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -95,8 +96,8 @@ type mockScope scope
 
 var _ scoper = &mockScope{}
 
-func (ms mockScope) categorizer() categorizer {
-	switch ms[scopeKeyCategory].Identity {
+func (s mockScope) categorizer() categorizer {
+	switch s[scopeKeyCategory].Identity {
 	case rootCatStub.String():
 		return rootCatStub
 	case leafCatStub.String():
@@ -106,11 +107,11 @@ func (ms mockScope) categorizer() categorizer {
 	return unknownCatStub
 }
 
-func (ms mockScope) matchesInfo(dii details.ItemInfo) bool {
-	return ms[shouldMatch].Target == "true"
+func (s mockScope) matchesInfo(dii details.ItemInfo) bool {
+	return s[shouldMatch].Target == "true"
 }
 
-func (ms mockScope) setDefaults() {}
+func (s mockScope) setDefaults() {}
 
 const (
 	shouldMatch = "should-match-entry"
@@ -143,6 +144,15 @@ func stubInfoScope(match string) mockScope {
 
 	return sc
 }
+
+// ---------------------------------------------------------------------------
+// Stringers and Concealers
+// ---------------------------------------------------------------------------
+
+func (s mockScope) Conceal() string             { return conceal(s) }
+func (s mockScope) Format(fs fmt.State, r rune) { format(s, fs, r) }
+func (s mockScope) String() string              { return conceal(s) }
+func (s mockScope) PlainString() string         { return plainString(s) }
 
 // ---------------------------------------------------------------------------
 // selectors

--- a/src/pkg/selectors/onedrive.go
+++ b/src/pkg/selectors/onedrive.go
@@ -2,6 +2,7 @@ package selectors
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/alcionai/clues"
 
@@ -119,6 +120,15 @@ func (s oneDrive) PathCategories() selectorPathCategories {
 		Includes: pathCategoriesIn[OneDriveScope, oneDriveCategory](s.Includes),
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Stringers and Concealers
+// ---------------------------------------------------------------------------
+
+func (s OneDriveScope) Conceal() string             { return conceal(s) }
+func (s OneDriveScope) Format(fs fmt.State, r rune) { format(s, fs, r) }
+func (s OneDriveScope) String() string              { return conceal(s) }
+func (s OneDriveScope) PlainString() string         { return plainString(s) }
 
 // -------------------
 // Scope Factories

--- a/src/pkg/selectors/selectors_test.go
+++ b/src/pkg/selectors/selectors_test.go
@@ -1,6 +1,7 @@
 package selectors
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/alcionai/clues"
@@ -26,6 +27,16 @@ func (suite *SelectorSuite) TestNewSelector() {
 	assert.NotNil(t, s)
 	assert.Equal(t, s.Service, ServiceUnknown)
 	assert.NotNil(t, s.Includes)
+}
+
+// set the clues hashing to mask for the span of this suite
+func (suite *SelectorSuite) SetupSuite() {
+	clues.SetHasher(clues.HashCfg{HashAlg: clues.Flatmask})
+}
+
+// revert clues hashing to plaintext for all other tests
+func (suite *SelectorSuite) TeardownSuite() {
+	clues.SetHasher(clues.NoHash())
 }
 
 func (suite *SelectorSuite) TestBadCastErr() {
@@ -359,6 +370,84 @@ func (suite *SelectorSuite) TestPathCategories_includes() {
 			}
 
 			test.isErr(t, err, clues.ToCore(err))
+		})
+	}
+}
+
+func (suite *SelectorSuite) TestSelector_pii() {
+	table := []struct {
+		name        string
+		sel         func() Selector
+		expect      string
+		expectPlain string
+	}{
+		{
+			name:        "empty selector",
+			sel:         func() Selector { return Selector{} },
+			expect:      `{"resourceOwners":"UnknownComparison:"}`,
+			expectPlain: `{"resourceOwners":"UnknownComparison:"}`,
+		},
+		{
+			name: "no scopes",
+			sel: func() Selector {
+				return Selector{
+					Service:        ServiceUnknown,
+					DiscreteOwner:  "owner",
+					ResourceOwners: filterFor(scopeConfig{}, "owner_1", "owner_2"),
+				}
+			},
+			expect:      `{"resourceOwners":"Cont:***,***","discreteOwner":"***"}`,
+			expectPlain: `{"resourceOwners":"Cont:owner_1,owner_2","discreteOwner":"owner"}`,
+		},
+		{
+			name: "one scope each type",
+			sel: func() Selector {
+				s := NewExchangeBackup([]string{"owner_1", "owner_2"})
+				s.DiscreteOwner = "owner"
+
+				s.Exclude(s.MailFolders([]string{"e"}))
+				s.Filter(s.MailFolders([]string{"f"}, SuffixMatch()))
+				s.Include(s.MailFolders([]string{"i"}, PrefixMatch()))
+
+				return s.Selector
+			},
+			//nolint:lll
+			expect: `{"service":1,` +
+				`"resourceOwners":"Cont:***,***",` +
+				`"discreteOwner":"***",` +
+				`"exclusions":[{"ExchangeMail":"Pass","ExchangeMailFolder":"PathCont:***","category":"Identity:***","type":"Identity:***"}],` +
+				`"filters":[{"ExchangeMail":"Pass","ExchangeMailFolder":"PathSfx:***","category":"Identity:***","type":"Identity:***"}],` +
+				`"includes":[{"ExchangeMail":"Pass","ExchangeMailFolder":"PathPfx:***","category":"Identity:***","type":"Identity:***"}]}`,
+			//nolint:lll
+			expectPlain: `{"service":1,` +
+				`"resourceOwners":"Cont:owner_1,owner_2",` +
+				`"discreteOwner":"owner",` +
+				`"exclusions":[{"ExchangeMail":"Pass","ExchangeMailFolder":"PathCont:e","category":"Identity:ExchangeMailFolder","type":"Identity:ExchangeMail"}],` +
+				`"filters":[{"ExchangeMail":"Pass","ExchangeMailFolder":"PathSfx:f","category":"Identity:ExchangeMailFolder","type":"Identity:ExchangeMail"}],` +
+				`"includes":[{"ExchangeMail":"Pass","ExchangeMailFolder":"PathPfx:i","category":"Identity:ExchangeMailFolder","type":"Identity:ExchangeMail"}]}`,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			result := test.sel().Conceal()
+			assert.Equal(t, test.expect, result, "conceal")
+
+			result = test.sel().String()
+			assert.Equal(t, test.expect, result, "string")
+
+			result = test.sel().PlainString()
+			assert.Equal(t, test.expectPlain, result, "plainString")
+
+			result = fmt.Sprintf("%s", test.sel())
+			assert.Equal(t, test.expect, result, "fmt %%s")
+
+			result = fmt.Sprintf("%v", test.sel())
+			assert.Equal(t, test.expect, result, "fmt %%v")
+
+			result = fmt.Sprintf("%+v", test.sel())
+			assert.Equal(t, test.expect, result, "fmt %%+v")
 		})
 	}
 }

--- a/src/pkg/selectors/sharepoint.go
+++ b/src/pkg/selectors/sharepoint.go
@@ -2,6 +2,7 @@ package selectors
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/alcionai/clues"
 
@@ -119,6 +120,15 @@ func (s sharePoint) PathCategories() selectorPathCategories {
 		Includes: pathCategoriesIn[SharePointScope, sharePointCategory](s.Includes),
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Stringers and Concealers
+// ---------------------------------------------------------------------------
+
+func (s SharePointScope) Conceal() string             { return conceal(s) }
+func (s SharePointScope) Format(fs fmt.State, r rune) { format(s, fs, r) }
+func (s SharePointScope) String() string              { return conceal(s) }
+func (s SharePointScope) PlainString() string         { return plainString(s) }
 
 // -------------------
 // Scope Factories


### PR DESCRIPTION
Adds pii controlled stringers and concealers for
logging selectors and scopes.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Supportability/Tests

#### Issue(s)

* #2024

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
