### PR TITLE
Folder display name fix

### DIFF
--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -2,7 +2,6 @@ package backup
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/alcionai/clues"
 	"github.com/pkg/errors"
@@ -169,8 +168,6 @@ func createExchangeCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return Only(ctx, clues.Wrap(err, "Failed to retrieve M365 users"))
 	}
-
-	fmt.Printf("\n-----\nINS %+v\n-----\n", ins)
 
 	selectorSet := []selectors.Selector{}
 

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -171,7 +171,7 @@ func (b *Builder) Details() *Details {
 // AddFoldersForItem, and unexport AddFoldersForItem.
 func FolderEntriesForPath(parent, location *path.Builder) []folderEntry {
 	folders := []folderEntry{}
-	lfs := locationRefOf(location)
+	lfs := location
 
 	for len(parent.Elements()) > 0 {
 		var (
@@ -211,21 +211,6 @@ func FolderEntriesForPath(parent, location *path.Builder) []folderEntry {
 	}
 
 	return folders
-}
-
-// assumes the pb contains a path like:
-// <tenant>/<service>/<owner>/<category>/<logical_containers>...
-// and returns a string with only <logical_containers>/...
-func locationRefOf(pb *path.Builder) *path.Builder {
-	if pb == nil {
-		return nil
-	}
-
-	for i := 0; i < 4; i++ {
-		pb = pb.PopFront()
-	}
-
-	return pb
 }
 
 // AddFoldersForItem adds entries for the given folders. It skips adding entries that

--- a/src/pkg/backup/details/details_test.go
+++ b/src/pkg/backup/details/details_test.go
@@ -1139,12 +1139,6 @@ func (suite *DetailsUnitSuite) TestFolderEntriesForPath() {
 			expect: baseFolderEnts,
 		},
 		{
-			name:     "base path with location",
-			parent:   basePath,
-			location: basePath,
-			expect:   baseFolderEnts,
-		},
-		{
 			name:   "single depth parent only",
 			parent: basePath.Append(fnords...),
 			expect: folderEntriesFor(fnords, nil),
@@ -1152,7 +1146,7 @@ func (suite *DetailsUnitSuite) TestFolderEntriesForPath() {
 		{
 			name:     "single depth with location",
 			parent:   basePath.Append(fnords...),
-			location: basePath.Append(beau...),
+			location: path.Builder{}.Append(beau...),
 			expect:   folderEntriesFor(fnords, beau),
 		},
 		{
@@ -1163,13 +1157,13 @@ func (suite *DetailsUnitSuite) TestFolderEntriesForPath() {
 		{
 			name:     "two depth with location",
 			parent:   basePath.Append(smarf...),
-			location: basePath.Append(regard...),
+			location: path.Builder{}.Append(regard...),
 			expect:   folderEntriesFor(smarf, regard),
 		},
 		{
 			name:     "mismatched depth, parent longer",
 			parent:   basePath.Append(smarf...),
-			location: basePath.Append(beau...),
+			location: path.Builder{}.Append(beau...),
 			expect:   folderEntriesFor(smarf, beau),
 		},
 		// We can't handle this right now.  But we don't have any cases


### PR DESCRIPTION
Fixes folder display names in backup details.
They got off when locations were switched to
returning path builders instead of full paths

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue
- closes #3061

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
