### PR TITLE
split in pwsh, not gh action

### DIFF
--- a/.github/actions/purge-m365-user-data/action.yml
+++ b/.github/actions/purge-m365-user-data/action.yml
@@ -47,7 +47,7 @@ runs:
         AZURE_CLIENT_SECRET: ${{ inputs.azure-client-secret }}
         AZURE_TENANT_ID: ${{ inputs.azure-tenant-id }}
       run: |
-        ./exchangePurge.ps1 -User ${{ inputs.user }} -FolderNamePurgeList PersonMetadata -FolderPrefixPurgeList "${{ inputs.folder-prefix }}".Split(",") -PurgeBeforeTimestamp ${{ inputs.older-than }}
+        ./exchangePurge.ps1 -User ${{ inputs.user }} -FolderNamePurgeList PersonMetadata -FolderPrefixPurgeList ${{ inputs.folder-prefix }} -PurgeBeforeTimestamp ${{ inputs.older-than }}
     
     - name: Run the OneDrive purge scripts for user
       if: ${{ inputs.user != '' }}
@@ -57,7 +57,7 @@ runs:
         M365_TENANT_ADMIN_USER: ${{ inputs.m365-admin-user }}
         M365_TENANT_ADMIN_PASSWORD: ${{ inputs.m365-admin-password }}
       run: |
-        ./onedrivePurge.ps1 -User ${{ inputs.user }} -FolderPrefixPurgeList "${{ inputs.folder-prefix }}".Split(",") -PurgeBeforeTimestamp ${{ inputs.older-than }}
+        ./onedrivePurge.ps1 -User ${{ inputs.user }} -FolderPrefixPurgeList ${{ inputs.folder-prefix }} -PurgeBeforeTimestamp ${{ inputs.older-than }}
 
     - name: Run SharePoint purge script
       if: ${{ inputs.user == '' }}
@@ -67,7 +67,7 @@ runs:
         M365_TENANT_ADMIN_USER: ${{ inputs.m365-admin-user }}
         M365_TENANT_ADMIN_PASSWORD: ${{ inputs.m365-admin-password }}
       run: |
-        ./onedrivePurge.ps1 -Site ${{ inputs.site }} -LibraryNameList "${{ inputs.libraries }}".split(",") -FolderPrefixPurgeList ${{ inputs.folder-prefix }} -PurgeBeforeTimestamp ${{ inputs.older-than }}
+        ./onedrivePurge.ps1 -Site ${{ inputs.site }} -LibraryNameList ${{ inputs.libraries }} -FolderPrefixPurgeList ${{ inputs.folder-prefix }} -PurgeBeforeTimestamp ${{ inputs.older-than }}
 
     - name: Reset retention for all mailboxes to 0
       if: ${{ inputs.user == '' }}

--- a/.github/actions/purge-m365-user-data/action.yml
+++ b/.github/actions/purge-m365-user-data/action.yml
@@ -47,7 +47,7 @@ runs:
         AZURE_CLIENT_SECRET: ${{ inputs.azure-client-secret }}
         AZURE_TENANT_ID: ${{ inputs.azure-tenant-id }}
       run: |
-        ./exchangePurge.ps1 -User ${{ inputs.user }} -FolderNamePurgeList PersonMetadata -FolderPrefixPurgeList ${{ inputs.folder-prefix }} -PurgeBeforeTimestamp ${{ inputs.older-than }}
+        ./exchangePurge.ps1 -User ${{ inputs.user }} -FolderNamePurgeList PersonMetadata -FolderPrefixPurgeList "${{ inputs.folder-prefix }}".Split(",") -PurgeBeforeTimestamp ${{ inputs.older-than }}
     
     - name: Run the OneDrive purge scripts for user
       if: ${{ inputs.user != '' }}
@@ -57,7 +57,7 @@ runs:
         M365_TENANT_ADMIN_USER: ${{ inputs.m365-admin-user }}
         M365_TENANT_ADMIN_PASSWORD: ${{ inputs.m365-admin-password }}
       run: |
-        ./onedrivePurge.ps1 -User ${{ inputs.user }} -FolderPrefixPurgeList ${{ inputs.folder-prefix }} -PurgeBeforeTimestamp ${{ inputs.older-than }}
+        ./onedrivePurge.ps1 -User ${{ inputs.user }} -FolderPrefixPurgeList "${{ inputs.folder-prefix }}".Split(",") -PurgeBeforeTimestamp ${{ inputs.older-than }}
 
     - name: Run SharePoint purge script
       if: ${{ inputs.user == '' }}
@@ -67,7 +67,7 @@ runs:
         M365_TENANT_ADMIN_USER: ${{ inputs.m365-admin-user }}
         M365_TENANT_ADMIN_PASSWORD: ${{ inputs.m365-admin-password }}
       run: |
-        ./onedrivePurge.ps1 -Site ${{ inputs.site }} -LibraryNameList ${{ inputs.libraries }} -FolderPrefixPurgeList ${{ inputs.folder-prefix }} -PurgeBeforeTimestamp ${{ inputs.older-than }}
+        ./onedrivePurge.ps1 -Site ${{ inputs.site }} -LibraryNameList "${{ inputs.libraries }}".split(",") -FolderPrefixPurgeList ${{ inputs.folder-prefix }} -PurgeBeforeTimestamp ${{ inputs.older-than }}
 
     - name: Reset retention for all mailboxes to 0
       if: ${{ inputs.user == '' }}

--- a/src/cmd/purge/scripts/exchangePurge.ps1
+++ b/src/cmd/purge/scripts/exchangePurge.ps1
@@ -112,7 +112,7 @@ function IsNameMatch {
         [string[]]$FolderNamePurgeList = @()
     )
 
-    return ($FolderName -in $FolderNamePurgeList)
+    return ($FolderName -in $FolderNamePurgeList.Split(","))
 }
 
 function Get-TimestampFromName {
@@ -163,7 +163,7 @@ function IsPrefixAndAgeMatch {
     $folderTimestamp = Get-TimestampFromName -name $FolderName -defaultTimestamp $FolderCreateTime
     
     if ($PurgeBeforeTimestamp -gt $folderTimestamp ) {
-        foreach ($prefix in $FolderPrefixPurgeList) {
+        foreach ($prefix in $FolderPrefixPurgeList.Split(',')) {
             if ($FolderName -like "$prefix*") {
                 return $true
             }
@@ -373,7 +373,7 @@ function Purge-Folders {
 
     if ($FolderPrefixPurgeList.count -gt 0 -and $PurgeBeforeTimestamp -ne $null) {
         Write-Host "Folders older than $PurgeBeforeTimestamp with prefix:"
-        foreach ($folder in $FolderPrefixPurgeList) {
+        foreach ($folder in $FolderPrefixPurgeList.Split(",")) {
             Write-Host "• $folder"
         }
     }

--- a/src/cmd/purge/scripts/exchangePurge.ps1
+++ b/src/cmd/purge/scripts/exchangePurge.ps1
@@ -112,7 +112,7 @@ function IsNameMatch {
         [string[]]$FolderNamePurgeList = @()
     )
 
-    return ($FolderName -in $FolderNamePurgeList.Split(","))
+    return ($FolderName -in $FolderNamePurgeList)
 }
 
 function Get-TimestampFromName {
@@ -163,7 +163,7 @@ function IsPrefixAndAgeMatch {
     $folderTimestamp = Get-TimestampFromName -name $FolderName -defaultTimestamp $FolderCreateTime
     
     if ($PurgeBeforeTimestamp -gt $folderTimestamp ) {
-        foreach ($prefix in $FolderPrefixPurgeList.Split(',')) {
+        foreach ($prefix in $FolderPrefixPurgeList) {
             if ($FolderName -like "$prefix*") {
                 return $true
             }
@@ -373,7 +373,7 @@ function Purge-Folders {
 
     if ($FolderPrefixPurgeList.count -gt 0 -and $PurgeBeforeTimestamp -ne $null) {
         Write-Host "Folders older than $PurgeBeforeTimestamp with prefix:"
-        foreach ($folder in $FolderPrefixPurgeList.Split(",")) {
+        foreach ($folder in $FolderPrefixPurgeList) {
             Write-Host "• $folder"
         }
     }

--- a/src/cmd/purge/scripts/exchangePurge.ps1
+++ b/src/cmd/purge/scripts/exchangePurge.ps1
@@ -618,6 +618,10 @@ function Purge-Items {
 Write-Host 'Authenticating with Exchange Web Services ...'
 $global:Token = Get-AccessToken | ConvertTo-SecureString -AsPlainText -Force 
 
+# ensure that there are no unexpanded entries in the list of parameters
+$FolderNamePurgeList = $FolderNamePurgeList | ForEach-Object { @($_.Split(',').Trim()) }
+$FolderPrefixPurgeList = $FolderPrefixPurgeList | ForEach-Object { @($_.Split(',').Trim()) }
+
 $purgeFolderParams = @{
     'WellKnownRoot'         = "root";
     'FolderNamePurgeList'   = $FolderNamePurgeList;

--- a/src/cmd/purge/scripts/onedrivePurge.ps1
+++ b/src/cmd/purge/scripts/onedrivePurge.ps1
@@ -80,7 +80,7 @@ function Purge-Library {
         $createTime = Get-TimestampFromName -Folder $f
 
         if ($PurgeBeforeTimestamp -gt $createTime) {
-            foreach ($p in $FolderPrefixPurgeList.Split(",")) {
+            foreach ($p in $FolderPrefixPurgeList) {
                 if ($folderName -like "$p*") {
                     $foldersToPurge += $f
                 }
@@ -169,6 +169,6 @@ Write-Host "`nAuthenticating and connecting to $SiteUrl"
 Connect-PnPOnline -Url $siteUrl -Credential $cred
 Write-Host "Connected to $siteUrl`n"
 
-foreach ($library in $LibraryNameList.Split(",")) {
+foreach ($library in $LibraryNameList) {
     Purge-Library -LibraryName $library -PurgeBeforeTimestamp $PurgeBeforeTimestamp -FolderPrefixPurgeList $FolderPrefixPurgeList -SiteSuffix $siteSiffix
 }

--- a/src/cmd/purge/scripts/onedrivePurge.ps1
+++ b/src/cmd/purge/scripts/onedrivePurge.ps1
@@ -112,6 +112,10 @@ function Purge-Library {
 
 ######## MAIN #########
 
+# ensure that there are no unexpanded entries in the list of parameters
+$LibraryNameList = $LibraryNameList | ForEach-Object { @($_.Split(',').Trim()) }
+$FolderPrefixPurgeList = $FolderPrefixPurgeList | ForEach-Object { @($_.Split(',').Trim()) }
+
 # Setup SharePointPnP
 if (-not (Get-Module -ListAvailable -Name PnP.PowerShell)) {
     $ProgressPreference = 'SilentlyContinue'

--- a/src/cmd/purge/scripts/onedrivePurge.ps1
+++ b/src/cmd/purge/scripts/onedrivePurge.ps1
@@ -80,7 +80,7 @@ function Purge-Library {
         $createTime = Get-TimestampFromName -Folder $f
 
         if ($PurgeBeforeTimestamp -gt $createTime) {
-            foreach ($p in $FolderPrefixPurgeList) {
+            foreach ($p in $FolderPrefixPurgeList.Split(",")) {
                 if ($folderName -like "$p*") {
                     $foldersToPurge += $f
                 }
@@ -169,6 +169,6 @@ Write-Host "`nAuthenticating and connecting to $SiteUrl"
 Connect-PnPOnline -Url $siteUrl -Credential $cred
 Write-Host "Connected to $siteUrl`n"
 
-foreach ($library in $LibraryNameList) {
+foreach ($library in $LibraryNameList.Split(",")) {
     Purge-Library -LibraryName $library -PurgeBeforeTimestamp $PurgeBeforeTimestamp -FolderPrefixPurgeList $FolderPrefixPurgeList -SiteSuffix $siteSiffix
 }


### PR DESCRIPTION
Couldn't figure out why the inputs in my local purges weren't working.
It's because we split the input in gh, not in powershell.
