### PR TITLE
add itemref to details entry

### DIFF
--- a/src/internal/connector/exchange/service_restore.go
+++ b/src/internal/connector/exchange/service_restore.go
@@ -452,6 +452,7 @@ func restoreCollection(
 				itemPath.ShortRef(),
 				"",
 				locationRef,
+				itemPath.Item(),
 				true,
 				details.ItemInfo{
 					Exchange: info,

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -248,6 +248,7 @@ func RestoreCollection(
 				itemPath.ShortRef(),
 				"",
 				"", // TODO: implement locationRef
+				itemPath.Item(),
 				true,
 				itemInfo)
 			if err != nil {

--- a/src/internal/connector/sharepoint/restore.go
+++ b/src/internal/connector/sharepoint/restore.go
@@ -267,6 +267,7 @@ func RestoreListCollection(
 				itemPath.ShortRef(),
 				"",
 				"", // TODO: implement locationRef
+				itemPath.Item(),
 				true,
 				itemInfo)
 			if err != nil {
@@ -357,6 +358,7 @@ func RestorePageCollection(
 				itemPath.ShortRef(),
 				"",
 				"", // TODO: implement locationRef
+				itemPath.Item(),
 				true,
 				itemInfo)
 			if err != nil {

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -216,6 +216,7 @@ func (cp *corsoProgress) FinishedFile(relativePath string, err error) {
 		d.repoPath.String(),
 		d.repoPath.ShortRef(),
 		parent.ShortRef(),
+		d.repoPath.Item(),
 		locationFolders,
 		!d.cached,
 		*d.info)

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -595,6 +595,7 @@ func mergeDetails(
 				newPath.ShortRef(),
 				newPath.ToBuilder().Dir().ShortRef(),
 				newLocStr,
+				newPath.Item(),
 				itemUpdated,
 				item)
 			if err != nil {

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -239,6 +239,7 @@ func makeFolderEntry(
 		RepoRef:     pb.String(),
 		ShortRef:    pb.ShortRef(),
 		ParentRef:   pb.Dir().ShortRef(),
+		ItemRef:     pb.LastElem(),
 		LocationRef: pb.PopFront().PopFront().PopFront().PopFront().Dir().String(),
 		ItemInfo: details.ItemInfo{
 			Folder: &details.FolderInfo{
@@ -280,6 +281,7 @@ func makeDetailsEntry(
 		RepoRef:     p.String(),
 		ShortRef:    p.ShortRef(),
 		ParentRef:   p.ToBuilder().Dir().ShortRef(),
+		ItemRef:     p.Item(),
 		LocationRef: lr,
 		ItemInfo:    details.ItemInfo{},
 		Updated:     updated,

--- a/src/internal/streamstore/collectables_test.go
+++ b/src/internal/streamstore/collectables_test.go
@@ -81,7 +81,7 @@ func (suite *StreamStoreIntgSuite) TestStreamer() {
 			deets: func(t *testing.T) *details.Details {
 				deetsBuilder := &details.Builder{}
 				require.NoError(t, deetsBuilder.Add(
-					"rr", "sr", "pr", "lr",
+					"rr", "sr", "pr", "lr", "ir",
 					true,
 					details.ItemInfo{
 						Exchange: &details.ExchangeInfo{Subject: "hello world"},
@@ -112,7 +112,7 @@ func (suite *StreamStoreIntgSuite) TestStreamer() {
 			deets: func(t *testing.T) *details.Details {
 				deetsBuilder := &details.Builder{}
 				require.NoError(t, deetsBuilder.Add(
-					"rr", "sr", "pr", "lr",
+					"rr", "sr", "pr", "lr", "ir",
 					true,
 					details.ItemInfo{
 						Exchange: &details.ExchangeInfo{Subject: "hello world"},
@@ -179,6 +179,7 @@ func (suite *StreamStoreIntgSuite) TestStreamer() {
 				assert.Equal(t, deets.Entries[0].ShortRef, readDeets.Entries[0].ShortRef)
 				assert.Equal(t, deets.Entries[0].RepoRef, readDeets.Entries[0].RepoRef)
 				assert.Equal(t, deets.Entries[0].LocationRef, readDeets.Entries[0].LocationRef)
+				assert.Equal(t, deets.Entries[0].ItemRef, readDeets.Entries[0].ItemRef)
 				assert.Equal(t, deets.Entries[0].Updated, readDeets.Entries[0].Updated)
 				assert.NotNil(t, readDeets.Entries[0].Exchange)
 				assert.Equal(t, *deets.Entries[0].Exchange, *readDeets.Entries[0].Exchange)

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -21,6 +21,7 @@ type folderEntry struct {
 	ShortRef    string
 	ParentRef   string
 	LocationRef string
+	ItemRef     string
 	Updated     bool
 	Info        ItemInfo
 }
@@ -144,7 +145,7 @@ type Builder struct {
 }
 
 func (b *Builder) Add(
-	repoRef, shortRef, parentRef, locationRef string,
+	repoRef, shortRef, parentRef, locationRef, itemRef string,
 	updated bool,
 	info ItemInfo,
 ) error {
@@ -355,6 +356,12 @@ type DetailsEntry struct {
 	// repoRef.
 	// Currently only implemented for Exchange Calendars.
 	LocationRef string `json:"locationRef,omitempty"`
+
+	// ItemRef contains the stable id of the item itself.  ItemRef is not
+	// guaranteed to be unique within a repository.  Uniqueness guarantees
+	// maximally inherit from the source item. Eg: Entries for m365 mail items
+	// are only as unique as m365 mail item IDs themselves.
+	ItemRef string `json:"itemRef,omitempty"`
 
 	// Indicates the item was added or updated in this backup
 	// Always `true` for full backups

--- a/src/pkg/backup/details/details_test.go
+++ b/src/pkg/backup/details/details_test.go
@@ -46,6 +46,7 @@ func (suite *DetailsUnitSuite) TestDetailsEntry_HeadersValues() {
 				RepoRef:     "reporef",
 				ShortRef:    "deadbeef",
 				LocationRef: "locationref",
+				ItemRef:     "itemref",
 			},
 			expectHs: []string{"ID"},
 			expectVs: []string{"deadbeef"},
@@ -56,6 +57,7 @@ func (suite *DetailsUnitSuite) TestDetailsEntry_HeadersValues() {
 				RepoRef:     "reporef",
 				ShortRef:    "deadbeef",
 				LocationRef: "locationref",
+				ItemRef:     "itemref",
 				ItemInfo: ItemInfo{
 					Exchange: &ExchangeInfo{
 						ItemType:    ExchangeEvent,
@@ -76,6 +78,7 @@ func (suite *DetailsUnitSuite) TestDetailsEntry_HeadersValues() {
 				RepoRef:     "reporef",
 				ShortRef:    "deadbeef",
 				LocationRef: "locationref",
+				ItemRef:     "itemref",
 				ItemInfo: ItemInfo{
 					Exchange: &ExchangeInfo{
 						ItemType:    ExchangeContact,
@@ -92,6 +95,7 @@ func (suite *DetailsUnitSuite) TestDetailsEntry_HeadersValues() {
 				RepoRef:     "reporef",
 				ShortRef:    "deadbeef",
 				LocationRef: "locationref",
+				ItemRef:     "itemref",
 				ItemInfo: ItemInfo{
 					Exchange: &ExchangeInfo{
 						ItemType:   ExchangeMail,
@@ -112,6 +116,7 @@ func (suite *DetailsUnitSuite) TestDetailsEntry_HeadersValues() {
 				RepoRef:     "reporef",
 				ShortRef:    "deadbeef",
 				LocationRef: "locationref",
+				ItemRef:     "itemref",
 				ItemInfo: ItemInfo{
 					SharePoint: &SharePointInfo{
 						ItemName:   "itemName",
@@ -143,6 +148,7 @@ func (suite *DetailsUnitSuite) TestDetailsEntry_HeadersValues() {
 				RepoRef:     "reporef",
 				ShortRef:    "deadbeef",
 				LocationRef: "locationref",
+				ItemRef:     "itemref",
 				ItemInfo: ItemInfo{
 					OneDrive: &OneDriveInfo{
 						ItemName:   "itemName",
@@ -189,6 +195,7 @@ var pathItemsTable = []struct {
 			{
 				RepoRef:     "abcde",
 				LocationRef: "locationref",
+				ItemRef:     "itemref",
 			},
 		},
 		expectRepoRefs:     []string{"abcde"},
@@ -200,10 +207,12 @@ var pathItemsTable = []struct {
 			{
 				RepoRef:     "abcde",
 				LocationRef: "locationref",
+				ItemRef:     "itemref",
 			},
 			{
 				RepoRef:     "12345",
 				LocationRef: "locationref2",
+				ItemRef:     "itemref2",
 			},
 		},
 		expectRepoRefs:     []string{"abcde", "12345"},
@@ -215,10 +224,12 @@ var pathItemsTable = []struct {
 			{
 				RepoRef:     "abcde",
 				LocationRef: "locationref",
+				ItemRef:     "itemref",
 			},
 			{
 				RepoRef:     "12345",
 				LocationRef: "locationref2",
+				ItemRef:     "itemref2",
 			},
 			{
 				RepoRef:     "deadbeef",
@@ -243,6 +254,7 @@ var pathItemsTable = []struct {
 			{
 				RepoRef:     "foo.meta",
 				LocationRef: "locationref.dirmeta",
+				ItemRef:     "itemref.meta",
 				ItemInfo: ItemInfo{
 					OneDrive: &OneDriveInfo{IsMeta: false},
 				},
@@ -250,6 +262,7 @@ var pathItemsTable = []struct {
 			{
 				RepoRef:     "is-meta-file",
 				LocationRef: "locationref-meta-file",
+				ItemRef:     "itemref-meta-file",
 				ItemInfo: ItemInfo{
 					OneDrive: &OneDriveInfo{IsMeta: true},
 				},
@@ -264,14 +277,17 @@ var pathItemsTable = []struct {
 			{
 				RepoRef:     "abcde",
 				LocationRef: "locationref",
+				ItemRef:     "itemref",
 			},
 			{
 				RepoRef:     "12345",
 				LocationRef: "locationref2",
+				ItemRef:     "itemref2",
 			},
 			{
 				RepoRef:     "foo.meta",
 				LocationRef: "locationref.dirmeta",
+				ItemRef:     "itemref.dirmeta",
 				ItemInfo: ItemInfo{
 					OneDrive: &OneDriveInfo{IsMeta: false},
 				},
@@ -279,6 +295,7 @@ var pathItemsTable = []struct {
 			{
 				RepoRef:     "is-meta-file",
 				LocationRef: "locationref-meta-file",
+				ItemRef:     "itemref-meta-file",
 				ItemInfo: ItemInfo{
 					OneDrive: &OneDriveInfo{IsMeta: true},
 				},
@@ -286,6 +303,7 @@ var pathItemsTable = []struct {
 			{
 				RepoRef:     "deadbeef",
 				LocationRef: "locationref3",
+				ItemRef:     "itemref3",
 				ItemInfo: ItemInfo{
 					Folder: &FolderInfo{
 						DisplayName: "test folder",
@@ -469,9 +487,9 @@ func (suite *DetailsUnitSuite) TestDetails_Add_ShortRefs() {
 					"deadbeef",
 					itemPath.ToBuilder().Dir().String(),
 					itemPath.String(),
+					itemPath.Item(),
 					false,
-					item,
-				))
+					item))
 			}
 
 			deets := b.Details()
@@ -509,8 +527,7 @@ func (suite *DetailsUnitSuite) TestDetails_Add_ShortRefs_Unique_From_Folder() {
 			"root:",
 			"folder",
 			name + "-id",
-		},
-	)
+		})
 
 	otherItemPath := makeItemPath(
 		t,
@@ -524,14 +541,14 @@ func (suite *DetailsUnitSuite) TestDetails_Add_ShortRefs_Unique_From_Folder() {
 			"folder",
 			name + "-id",
 			name,
-		},
-	)
+		})
 
 	err := b.Add(
 		itemPath.String(),
 		"deadbeef",
 		itemPath.ToBuilder().Dir().String(),
 		itemPath.String(),
+		itemPath.Item(),
 		false,
 		info)
 	require.NoError(t, err)
@@ -570,6 +587,7 @@ func (suite *DetailsUnitSuite) TestDetails_AddFolders() {
 					ShortRef:    "sr1",
 					ParentRef:   "pr1",
 					LocationRef: "lr1",
+					ItemRef:     "ir1",
 					Info: ItemInfo{
 						Folder: &FolderInfo{
 							Modified: folderTimeOlderThanItem,
@@ -581,6 +599,7 @@ func (suite *DetailsUnitSuite) TestDetails_AddFolders() {
 					ShortRef:    "sr2",
 					ParentRef:   "pr2",
 					LocationRef: "lr2",
+					ItemRef:     "ir2",
 					Info: ItemInfo{
 						Folder: &FolderInfo{
 							Modified: folderTimeNewerThanItem,
@@ -602,6 +621,7 @@ func (suite *DetailsUnitSuite) TestDetails_AddFolders() {
 					ShortRef:    "sr1",
 					ParentRef:   "pr1",
 					LocationRef: "lr1",
+					ItemRef:     "ir1",
 					Info: ItemInfo{
 						Folder: &FolderInfo{
 							Modified: folderTimeOlderThanItem,
@@ -613,6 +633,7 @@ func (suite *DetailsUnitSuite) TestDetails_AddFolders() {
 					ShortRef:    "sr2",
 					ParentRef:   "pr2",
 					LocationRef: "lr2",
+					ItemRef:     "ir2",
 					Info: ItemInfo{
 						Folder: &FolderInfo{
 							Modified: folderTimeOlderThanItem,
@@ -624,6 +645,7 @@ func (suite *DetailsUnitSuite) TestDetails_AddFolders() {
 					ShortRef:    "sr1",
 					ParentRef:   "pr1",
 					LocationRef: "lr1",
+					ItemRef:     "ir1",
 					Info: ItemInfo{
 						Folder: &FolderInfo{
 							Modified: folderTimeOlderThanItem,
@@ -635,6 +657,7 @@ func (suite *DetailsUnitSuite) TestDetails_AddFolders() {
 					ShortRef:    "sr3",
 					ParentRef:   "pr3",
 					LocationRef: "lr3",
+					ItemRef:     "ir3",
 					Info: ItemInfo{
 						Folder: &FolderInfo{
 							Modified: folderTimeNewerThanItem,
@@ -688,6 +711,7 @@ func (suite *DetailsUnitSuite) TestDetails_AddFoldersUpdate() {
 					ShortRef:    "sr1",
 					ParentRef:   "pr1",
 					LocationRef: "lr1",
+					ItemRef:     "ir1",
 					Info: ItemInfo{
 						Folder: &FolderInfo{},
 					},
@@ -698,6 +722,7 @@ func (suite *DetailsUnitSuite) TestDetails_AddFoldersUpdate() {
 					ShortRef:    "sr2",
 					ParentRef:   "pr2",
 					LocationRef: "lr2",
+					ItemRef:     "ir2",
 					Info: ItemInfo{
 						Folder: &FolderInfo{},
 					},
@@ -717,6 +742,7 @@ func (suite *DetailsUnitSuite) TestDetails_AddFoldersUpdate() {
 					ShortRef:    "sr1",
 					ParentRef:   "pr1",
 					LocationRef: "lr1",
+					ItemRef:     "ir1",
 					Info: ItemInfo{
 						Folder: &FolderInfo{},
 					},
@@ -726,6 +752,7 @@ func (suite *DetailsUnitSuite) TestDetails_AddFoldersUpdate() {
 					ShortRef:    "sr2",
 					ParentRef:   "pr2",
 					LocationRef: "lr2",
+					ItemRef:     "ir2",
 					Info: ItemInfo{
 						Folder: &FolderInfo{},
 					},

--- a/src/pkg/backup/details/testdata/testdata.go
+++ b/src/pkg/backup/details/testdata/testdata.go
@@ -60,6 +60,7 @@ var (
 			RepoRef:   ExchangeEmailItemPath1.String(),
 			ShortRef:  ExchangeEmailItemPath1.ShortRef(),
 			ParentRef: ExchangeEmailItemPath1.ToBuilder().Dir().ShortRef(),
+			ItemRef:   ExchangeEmailItemPath1.Item(),
 			ItemInfo: details.ItemInfo{
 				Exchange: &details.ExchangeInfo{
 					ItemType: details.ExchangeMail,
@@ -73,6 +74,7 @@ var (
 			RepoRef:   ExchangeEmailItemPath2.String(),
 			ShortRef:  ExchangeEmailItemPath2.ShortRef(),
 			ParentRef: ExchangeEmailItemPath2.ToBuilder().Dir().ShortRef(),
+			ItemRef:   ExchangeEmailItemPath2.Item(),
 			ItemInfo: details.ItemInfo{
 				Exchange: &details.ExchangeInfo{
 					ItemType: details.ExchangeMail,
@@ -86,6 +88,7 @@ var (
 			RepoRef:   ExchangeEmailItemPath3.String(),
 			ShortRef:  ExchangeEmailItemPath3.ShortRef(),
 			ParentRef: ExchangeEmailItemPath3.ToBuilder().Dir().ShortRef(),
+			ItemRef:   ExchangeEmailItemPath3.Item(),
 			ItemInfo: details.ItemInfo{
 				Exchange: &details.ExchangeInfo{
 					ItemType: details.ExchangeMail,
@@ -108,6 +111,7 @@ var (
 			RepoRef:   ExchangeContactsItemPath1.String(),
 			ShortRef:  ExchangeContactsItemPath1.ShortRef(),
 			ParentRef: ExchangeContactsItemPath1.ToBuilder().Dir().ShortRef(),
+			ItemRef:   ExchangeEmailItemPath1.Item(),
 			ItemInfo: details.ItemInfo{
 				Exchange: &details.ExchangeInfo{
 					ItemType:    details.ExchangeContact,
@@ -119,6 +123,7 @@ var (
 			RepoRef:   ExchangeContactsItemPath2.String(),
 			ShortRef:  ExchangeContactsItemPath2.ShortRef(),
 			ParentRef: ExchangeContactsItemPath2.ToBuilder().Dir().ShortRef(),
+			ItemRef:   ExchangeEmailItemPath2.Item(),
 			ItemInfo: details.ItemInfo{
 				Exchange: &details.ExchangeInfo{
 					ItemType:    details.ExchangeContact,
@@ -139,6 +144,7 @@ var (
 			RepoRef:   ExchangeEventsItemPath1.String(),
 			ShortRef:  ExchangeEventsItemPath1.ShortRef(),
 			ParentRef: ExchangeEventsItemPath1.ToBuilder().Dir().ShortRef(),
+			ItemRef:   ExchangeEmailItemPath2.Item(),
 			ItemInfo: details.ItemInfo{
 				Exchange: &details.ExchangeInfo{
 					ItemType:    details.ExchangeEvent,
@@ -153,6 +159,7 @@ var (
 			RepoRef:   ExchangeEventsItemPath2.String(),
 			ShortRef:  ExchangeEventsItemPath2.ShortRef(),
 			ParentRef: ExchangeEventsItemPath2.ToBuilder().Dir().ShortRef(),
+			ItemRef:   ExchangeEmailItemPath2.Item(),
 			ItemInfo: details.ItemInfo{
 				Exchange: &details.ExchangeInfo{
 					ItemType:    details.ExchangeEvent,
@@ -183,6 +190,7 @@ var (
 			RepoRef:   OneDriveItemPath1.String(),
 			ShortRef:  OneDriveItemPath1.ShortRef(),
 			ParentRef: OneDriveItemPath1.ToBuilder().Dir().ShortRef(),
+			ItemRef:   OneDriveItemPath1.Item(),
 			ItemInfo: details.ItemInfo{
 				OneDrive: &details.OneDriveInfo{
 					ItemType:   details.OneDriveItem,
@@ -199,6 +207,7 @@ var (
 			RepoRef:   OneDriveItemPath2.String(),
 			ShortRef:  OneDriveItemPath2.ShortRef(),
 			ParentRef: OneDriveItemPath2.ToBuilder().Dir().ShortRef(),
+			ItemRef:   OneDriveItemPath2.Item(),
 			ItemInfo: details.ItemInfo{
 				OneDrive: &details.OneDriveInfo{
 					ItemType:   details.OneDriveItem,
@@ -215,6 +224,7 @@ var (
 			RepoRef:   OneDriveItemPath3.String(),
 			ShortRef:  OneDriveItemPath3.ShortRef(),
 			ParentRef: OneDriveItemPath3.ToBuilder().Dir().ShortRef(),
+			ItemRef:   OneDriveItemPath3.Item(),
 			ItemInfo: details.ItemInfo{
 				OneDrive: &details.OneDriveInfo{
 					ItemType:   details.OneDriveItem,
@@ -247,6 +257,7 @@ var (
 			RepoRef:   SharePointLibraryItemPath1.String(),
 			ShortRef:  SharePointLibraryItemPath1.ShortRef(),
 			ParentRef: SharePointLibraryItemPath1.ToBuilder().Dir().ShortRef(),
+			ItemRef:   SharePointItemPath1.Item(),
 			ItemInfo: details.ItemInfo{
 				SharePoint: &details.SharePointInfo{
 					ItemType:   details.SharePointLibrary,
@@ -263,6 +274,7 @@ var (
 			RepoRef:   SharePointLibraryItemPath2.String(),
 			ShortRef:  SharePointLibraryItemPath2.ShortRef(),
 			ParentRef: SharePointLibraryItemPath2.ToBuilder().Dir().ShortRef(),
+			ItemRef:   SharePointItemPath2.Item(),
 			ItemInfo: details.ItemInfo{
 				SharePoint: &details.SharePointInfo{
 					ItemType:   details.SharePointLibrary,
@@ -279,6 +291,7 @@ var (
 			RepoRef:   SharePointLibraryItemPath3.String(),
 			ShortRef:  SharePointLibraryItemPath3.ShortRef(),
 			ParentRef: SharePointLibraryItemPath3.ToBuilder().Dir().ShortRef(),
+			ItemRef:   SharePointItemPath3.Item(),
 			ItemInfo: details.ItemInfo{
 				SharePoint: &details.SharePointInfo{
 					ItemType:   details.SharePointLibrary,

--- a/src/pkg/repository/repository_unexported_test.go
+++ b/src/pkg/repository/repository_unexported_test.go
@@ -341,7 +341,7 @@ func (suite *RepositoryModelIntgSuite) TestGetBackupDetails() {
 	}
 
 	builder := &details.Builder{}
-	require.NoError(suite.T(), builder.Add("ref", "short", "pref", "lref", false, info))
+	require.NoError(suite.T(), builder.Add("ref", "short", "pref", "lref", "iref", false, info))
 
 	table := []struct {
 		name       string
@@ -419,7 +419,7 @@ func (suite *RepositoryModelIntgSuite) TestGetBackupErrors() {
 
 	builder := &details.Builder{}
 
-	require.NoError(suite.T(), builder.Add("ref", "short", "pref", "lref", false, info))
+	require.NoError(suite.T(), builder.Add("ref", "short", "pref", "lref", "iref", false, info))
 
 	table := []struct {
 		name         string

--- a/src/pkg/selectors/example_selectors_test.go
+++ b/src/pkg/selectors/example_selectors_test.go
@@ -125,6 +125,7 @@ var (
 				{
 					RepoRef:  "tID/exchange/your-user-id/email/example/itemID",
 					ShortRef: "xyz",
+					ItemRef:  "123",
 					ItemInfo: details.ItemInfo{
 						Exchange: &details.ExchangeInfo{
 							ItemType: details.ExchangeMail,

--- a/src/pkg/selectors/exchange_test.go
+++ b/src/pkg/selectors/exchange_test.go
@@ -724,6 +724,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeScope_MatchesPath() {
 		ent   = details.DetailsEntry{
 			RepoRef:     repo.String(),
 			ShortRef:    short,
+			ItemRef:     mail,
 			LocationRef: loc,
 		}
 	)
@@ -1308,13 +1309,17 @@ func (suite *ExchangeSelectorSuite) TestScopesByCategory() {
 }
 
 func (suite *ExchangeSelectorSuite) TestPasses() {
-	short := "thisisahashofsomekind"
-	entry := details.DetailsEntry{ShortRef: short}
 
 	const (
 		mid = "mailID"
 		cat = ExchangeMail
 	)
+
+	short := "thisisahashofsomekind"
+	entry := details.DetailsEntry{
+		ShortRef: short,
+		ItemRef:  mid,
+	}
 
 	var (
 		es        = NewExchangeRestore(Any())
@@ -1488,6 +1493,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeCategory_PathValues() {
 			ent := details.DetailsEntry{
 				RepoRef:  test.path.String(),
 				ShortRef: "short",
+				ItemRef:  test.path.Item(),
 			}
 
 			pvs, err := test.cat.pathValues(test.path, ent)

--- a/src/pkg/selectors/onedrive_test.go
+++ b/src/pkg/selectors/onedrive_test.go
@@ -262,8 +262,9 @@ func (suite *OneDriveSelectorSuite) TestOneDriveCategory_PathValues() {
 	t := suite.T()
 
 	fileName := "file"
+	fileID := fileName + "-id"
 	shortRef := "short"
-	elems := []string{"drive", "driveID", "root:", "dir1", "dir2", fileName + "-id"}
+	elems := []string{"drive", "driveID", "root:", "dir1", "dir2", fileID}
 
 	filePath, err := path.Build("tenant", "user", path.OneDriveService, path.FilesCategory, true, elems...)
 	require.NoError(t, err, clues.ToCore(err))
@@ -276,6 +277,7 @@ func (suite *OneDriveSelectorSuite) TestOneDriveCategory_PathValues() {
 	ent := details.DetailsEntry{
 		RepoRef:  filePath.String(),
 		ShortRef: shortRef,
+		ItemRef:  fileID,
 		ItemInfo: details.ItemInfo{
 			OneDrive: &details.OneDriveInfo{
 				ItemName: fileName,

--- a/src/pkg/selectors/sharepoint_test.go
+++ b/src/pkg/selectors/sharepoint_test.go
@@ -377,6 +377,7 @@ func (suite *SharePointSelectorSuite) TestSharePointCategory_PathValues() {
 			ent := details.DetailsEntry{
 				RepoRef:  itemPath.String(),
 				ShortRef: shortRef,
+				ItemRef:  itemPath.Item(),
 				ItemInfo: details.ItemInfo{
 					SharePoint: &details.SharePointInfo{
 						ItemName: itemName,


### PR DESCRIPTION
Adds an new details entry field: itemRef.
This holds a stable, semi-unique identifier
to the item represented by that entry.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #3027

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
