### PR TITLE
Quick ci fix

### DIFF
--- a/src/cmd/purge/scripts/onedrivePurge.ps1
+++ b/src/cmd/purge/scripts/onedrivePurge.ps1
@@ -112,10 +112,6 @@ function Purge-Library {
 
 ######## MAIN #########
 
-# ensure that there are no unexpanded entries in the list of parameters
-$LibraryNameList = $LibraryNameList | ForEach-Object { @($_.Split(',').Trim()) }
-$FolderPrefixPurgeList = $FolderPrefixPurgeList | ForEach-Object { @($_.Split(',').Trim()) }
-
 # Setup SharePointPnP
 if (-not (Get-Module -ListAvailable -Name PnP.PowerShell)) {
     $ProgressPreference = 'SilentlyContinue'
@@ -172,6 +168,10 @@ $cred = New-Object -TypeName System.Management.Automation.PSCredential -Argument
 Write-Host "`nAuthenticating and connecting to $SiteUrl"
 Connect-PnPOnline -Url $siteUrl -Credential $cred
 Write-Host "Connected to $siteUrl`n"
+
+# ensure that there are no unexpanded entries in the list of parameters
+$LibraryNameList = $LibraryNameList | ForEach-Object { @($_.Split(',').Trim()) }
+$FolderPrefixPurgeList = $FolderPrefixPurgeList | ForEach-Object { @($_.Split(',').Trim()) }
 
 foreach ($library in $LibraryNameList) {
     Purge-Library -LibraryName $library -PurgeBeforeTimestamp $PurgeBeforeTimestamp -FolderPrefixPurgeList $FolderPrefixPurgeList -SiteSuffix $siteSiffix


### PR DESCRIPTION
The defensive flattening of the inputs was at the wrong place.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [x] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
