### PR TITLE
separate fault bus in fetch manifests

### DIFF
--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -245,8 +245,7 @@ func (op *BackupOperation) do(
 		op.store,
 		reasons, fallbackReasons,
 		op.account.ID(),
-		op.incremental,
-		op.Errors)
+		op.incremental)
 	if err != nil {
 		return nil, clues.Wrap(err, "producing manifests and metadata")
 	}

--- a/src/internal/operations/manifests.go
+++ b/src/internal/operations/manifests.go
@@ -159,15 +159,14 @@ func produceManifestsAndMetadata(
 		fb := fault.New(true)
 
 		colls, err := collectMetadata(mctx, mr, man, metadataFiles, tenantID, fb)
+		LogFaultErrors(ctx, fb.Errors(), "collecting metadata")
+
 		if err != nil && !errors.Is(err, data.ErrNotFound) {
-			LogFaultErrors(ctx, fb.Errors(), "collecting metadata")
 			// prior metadata isn't guaranteed to exist.
 			// if it doesn't, we'll just have to do a
 			// full backup for that data.
 			return nil, nil, false, err
 		}
-
-		LogFaultErrors(ctx, fb.Errors(), "collecting metadata")
 
 		collections = append(collections, colls...)
 	}

--- a/src/internal/operations/manifests_test.go
+++ b/src/internal/operations/manifests_test.go
@@ -678,8 +678,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				&test.gb,
 				test.reasons, nil,
 				tid,
-				test.getMeta,
-				fault.New(true))
+				test.getMeta)
 			test.assertErr(t, err, clues.ToCore(err))
 			test.assertB(t, b)
 
@@ -844,8 +843,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_fallb
 				[]kopia.Reason{manReason},
 				[]kopia.Reason{fbReason},
 				"tid",
-				false,
-				fault.New(true))
+				false)
 			require.NoError(t, err, clues.ToCore(err))
 			assert.False(t, b, "no-metadata is forced for this test")
 


### PR DESCRIPTION
The global aggregation of recoverable errors
causes us to mark operations as failed even in
conditions where they should have succeeded,
because higher level callers don't have sufficient
control over ignorable error conditions.  This
is a short-term fix that allows us to log and dump
fault error accumulation in a specific, scoped instance.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
