### PR TITLE
[Sanity test]- skip owner permission in onedrive restore check

### DIFF
--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -51,6 +51,8 @@ jobs:
 
       - run: mkdir test_results
 
+      - run: mkdir testlog
+
       # run the tests
       - name: Version Test
         run: |

--- a/src/cmd/sanity_test/sanity_tests.go
+++ b/src/cmd/sanity_test/sanity_tests.go
@@ -354,7 +354,7 @@ func checkOnedriveRestoration(
 	getRestoreData(ctx, client, *drive.GetId(), restoreFolderID, restoreFile, restoreFolderPermission, startTime)
 
 	for folderName, permissions := range folderPermission {
-		logger.Ctx(ctx).Info("checking for folder: %s \n", folderName)
+		logger.Ctx(ctx).Info("checking for folder: ", folderName, "\n")
 		fmt.Printf("checking for folder: %s \n", folderName)
 
 		restoreFolderPerm := restoreFolderPermission[folderName]
@@ -488,17 +488,24 @@ func permissionIn(
 		}
 
 		var (
-			gv2     = perm.GetGrantedToV2()
-			perInfo = permissionInfo{}
+			gv2      = perm.GetGrantedToV2()
+			perInfo  = permissionInfo{}
+			entityID string
 		)
 
 		if gv2.GetUser() != nil {
-			perInfo.entityID = ptr.Val(gv2.GetUser().GetId())
+			entityID = ptr.Val(gv2.GetUser().GetId())
 		} else if gv2.GetGroup() != nil {
-			perInfo.entityID = ptr.Val(gv2.GetGroup().GetId())
+			entityID = ptr.Val(gv2.GetGroup().GetId())
 		}
 
-		perInfo.roles = perm.GetRoles()
+		roles := perm.GetRoles()
+		for _, role := range roles {
+			if role != "owner" {
+				perInfo.entityID = entityID
+				perInfo.roles = append(perInfo.roles, role)
+			}
+		}
 
 		slices.Sort(perInfo.roles)
 


### PR DESCRIPTION
<!-- PR description-->

for Sanity test - skip owner permission in onedrive restore check

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* https://github.com/alcionai/corso/issues/3081

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
