### PR TITLE
Fix disable-incrementals flag in OneDrive

### DIFF
--- a/src/cli/backup/exchange_test.go
+++ b/src/cli/backup/exchange_test.go
@@ -30,23 +30,58 @@ func (suite *ExchangeSuite) TestAddExchangeCommands() {
 		use         string
 		expectUse   string
 		expectShort string
+		flags       []string
 		expectRunE  func(*cobra.Command, []string) error
 	}{
 		{
-			"create exchange", createCommand, expectUse + " " + exchangeServiceCommandCreateUseSuffix,
-			exchangeCreateCmd().Short, createExchangeCmd,
+			"create exchange",
+			createCommand,
+			expectUse + " " + exchangeServiceCommandCreateUseSuffix,
+			exchangeCreateCmd().Short,
+			[]string{"user", "data", "disable-incrementals", "fail-fast", "fetch-parallelism", "skip-reduce", "no-stats"},
+			createExchangeCmd,
 		},
 		{
-			"list exchange", listCommand, expectUse,
-			exchangeListCmd().Short, listExchangeCmd,
+			"list exchange",
+			listCommand,
+			expectUse,
+			exchangeListCmd().Short,
+			[]string{"backup", "failed-items", "skipped-items", "recovered-errors"},
+			listExchangeCmd,
 		},
 		{
-			"details exchange", detailsCommand, expectUse + " " + exchangeServiceCommandDetailsUseSuffix,
-			exchangeDetailsCmd().Short, detailsExchangeCmd,
+			"details exchange",
+			detailsCommand,
+			expectUse + " " + exchangeServiceCommandDetailsUseSuffix,
+			exchangeDetailsCmd().Short,
+			[]string{
+				"backup",
+				"email",
+				"email-folder",
+				"email-subject",
+				"email-sender",
+				"email-received-after",
+				"email-received-before",
+				"event",
+				"event-calendar",
+				"event-subject",
+				"event-organizer",
+				"event-recurs",
+				"event-starts-after",
+				"event-starts-before",
+				"contact",
+				"contact-folder",
+				"contact-name",
+			},
+			detailsExchangeCmd,
 		},
 		{
-			"delete exchange", deleteCommand, expectUse + " " + exchangeServiceCommandDeleteUseSuffix,
-			exchangeDeleteCmd().Short, deleteExchangeCmd,
+			"delete exchange",
+			deleteCommand,
+			expectUse + " " + exchangeServiceCommandDeleteUseSuffix,
+			exchangeDeleteCmd().Short,
+			[]string{"backup"},
+			deleteExchangeCmd,
 		},
 	}
 	for _, test := range table {

--- a/src/cli/backup/exchange_test.go
+++ b/src/cli/backup/exchange_test.go
@@ -14,15 +14,15 @@ import (
 	"github.com/alcionai/corso/src/internal/tester"
 )
 
-type ExchangeSuite struct {
+type ExchangeUnitSuite struct {
 	tester.Suite
 }
 
-func TestExchangeSuite(t *testing.T) {
-	suite.Run(t, &ExchangeSuite{Suite: tester.NewUnitSuite(t)})
+func TestExchangeUnitSuite(t *testing.T) {
+	suite.Run(t, &ExchangeUnitSuite{Suite: tester.NewUnitSuite(t)})
 }
 
-func (suite *ExchangeSuite) TestAddExchangeCommands() {
+func (suite *ExchangeUnitSuite) TestAddExchangeCommands() {
 	expectUse := exchangeServiceCommand
 
 	table := []struct {
@@ -104,7 +104,7 @@ func (suite *ExchangeSuite) TestAddExchangeCommands() {
 	}
 }
 
-func (suite *ExchangeSuite) TestValidateBackupCreateFlags() {
+func (suite *ExchangeUnitSuite) TestValidateBackupCreateFlags() {
 	table := []struct {
 		name       string
 		user, data []string
@@ -141,7 +141,7 @@ func (suite *ExchangeSuite) TestValidateBackupCreateFlags() {
 	}
 }
 
-func (suite *ExchangeSuite) TestExchangeBackupCreateSelectors() {
+func (suite *ExchangeUnitSuite) TestExchangeBackupCreateSelectors() {
 	table := []struct {
 		name             string
 		user, data       []string
@@ -256,7 +256,7 @@ func (suite *ExchangeSuite) TestExchangeBackupCreateSelectors() {
 	}
 }
 
-func (suite *ExchangeSuite) TestExchangeBackupDetailsSelectors() {
+func (suite *ExchangeUnitSuite) TestExchangeBackupDetailsSelectors() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 
@@ -276,7 +276,7 @@ func (suite *ExchangeSuite) TestExchangeBackupDetailsSelectors() {
 	}
 }
 
-func (suite *ExchangeSuite) TestExchangeBackupDetailsSelectorsBadFormats() {
+func (suite *ExchangeUnitSuite) TestExchangeBackupDetailsSelectorsBadFormats() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 

--- a/src/cli/backup/exchange_test.go
+++ b/src/cli/backup/exchange_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/cli/options"
 	"github.com/alcionai/corso/src/cli/utils"
 	"github.com/alcionai/corso/src/cli/utils/testdata"
 	"github.com/alcionai/corso/src/internal/tester"
@@ -38,7 +39,15 @@ func (suite *ExchangeUnitSuite) TestAddExchangeCommands() {
 			createCommand,
 			expectUse + " " + exchangeServiceCommandCreateUseSuffix,
 			exchangeCreateCmd().Short,
-			[]string{"user", "data", "disable-incrementals", "fail-fast", "fetch-parallelism", "skip-reduce", "no-stats"},
+			[]string{
+				utils.UserFN,
+				utils.CategoryDataFN,
+				options.DisableIncrementalsFN,
+				options.FailFastFN,
+				options.FetchParallelismFN,
+				options.SkipReduceFN,
+				options.NoStatsFN,
+			},
 			createExchangeCmd,
 		},
 		{
@@ -46,7 +55,12 @@ func (suite *ExchangeUnitSuite) TestAddExchangeCommands() {
 			listCommand,
 			expectUse,
 			exchangeListCmd().Short,
-			[]string{"backup", "failed-items", "skipped-items", "recovered-errors"},
+			[]string{
+				utils.BackupFN,
+				failedItemsFN,
+				skippedItemsFN,
+				recoveredErrorsFN,
+			},
 			listExchangeCmd,
 		},
 		{
@@ -55,23 +69,23 @@ func (suite *ExchangeUnitSuite) TestAddExchangeCommands() {
 			expectUse + " " + exchangeServiceCommandDetailsUseSuffix,
 			exchangeDetailsCmd().Short,
 			[]string{
-				"backup",
-				"email",
-				"email-folder",
-				"email-subject",
-				"email-sender",
-				"email-received-after",
-				"email-received-before",
-				"event",
-				"event-calendar",
-				"event-subject",
-				"event-organizer",
-				"event-recurs",
-				"event-starts-after",
-				"event-starts-before",
-				"contact",
-				"contact-folder",
-				"contact-name",
+				utils.BackupFN,
+				utils.ContactFN,
+				utils.ContactFolderFN,
+				utils.ContactNameFN,
+				utils.EmailFN,
+				utils.EmailFolderFN,
+				utils.EmailReceivedAfterFN,
+				utils.EmailReceivedBeforeFN,
+				utils.EmailSenderFN,
+				utils.EmailSubjectFN,
+				utils.EventFN,
+				utils.EventCalendarFN,
+				utils.EventOrganizerFN,
+				utils.EventRecursFN,
+				utils.EventStartsAfterFN,
+				utils.EventStartsBeforeFN,
+				utils.EventSubjectFN,
 			},
 			detailsExchangeCmd,
 		},
@@ -80,7 +94,7 @@ func (suite *ExchangeUnitSuite) TestAddExchangeCommands() {
 			deleteCommand,
 			expectUse + " " + exchangeServiceCommandDeleteUseSuffix,
 			exchangeDeleteCmd().Short,
-			[]string{"backup"},
+			[]string{utils.BackupFN},
 			deleteExchangeCmd,
 		},
 	}

--- a/src/cli/backup/onedrive.go
+++ b/src/cli/backup/onedrive.go
@@ -73,6 +73,7 @@ func addOneDriveCommands(cmd *cobra.Command) *cobra.Command {
 
 		utils.AddUserFlag(c)
 		options.AddFailFastFlag(c)
+		options.AddDisableIncrementalsFlag(c)
 
 	case listCommand:
 		c, fs = utils.AddCommand(cmd, oneDriveListCmd())

--- a/src/cli/backup/onedrive_test.go
+++ b/src/cli/backup/onedrive_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/cli/options"
+	"github.com/alcionai/corso/src/cli/utils"
 	"github.com/alcionai/corso/src/cli/utils/testdata"
 	"github.com/alcionai/corso/src/internal/tester"
 )
@@ -37,7 +39,11 @@ func (suite *OneDriveUnitSuite) TestAddOneDriveCommands() {
 			createCommand,
 			expectUse + " " + oneDriveServiceCommandCreateUseSuffix,
 			oneDriveCreateCmd().Short,
-			[]string{"user", "disable-incrementals", "fail-fast"},
+			[]string{
+				utils.UserFN,
+				options.DisableIncrementalsFN,
+				options.FailFastFN,
+			},
 			createOneDriveCmd,
 		},
 		{
@@ -45,7 +51,12 @@ func (suite *OneDriveUnitSuite) TestAddOneDriveCommands() {
 			listCommand,
 			expectUse,
 			oneDriveListCmd().Short,
-			[]string{"backup", "failed-items", "skipped-items", "recovered-errors"},
+			[]string{
+				utils.BackupFN,
+				failedItemsFN,
+				skippedItemsFN,
+				recoveredErrorsFN,
+			},
 			listOneDriveCmd,
 		},
 		{
@@ -54,13 +65,13 @@ func (suite *OneDriveUnitSuite) TestAddOneDriveCommands() {
 			expectUse + " " + oneDriveServiceCommandDetailsUseSuffix,
 			oneDriveDetailsCmd().Short,
 			[]string{
-				"backup",
-				"folder",
-				"file",
-				"file-created-after",
-				"file-created-before",
-				"file-modified-after",
-				"file-modified-before",
+				utils.BackupFN,
+				utils.FolderFN,
+				utils.FileFN,
+				utils.FileCreatedAfterFN,
+				utils.FileCreatedBeforeFN,
+				utils.FileModifiedAfterFN,
+				utils.FileModifiedBeforeFN,
 			},
 			detailsOneDriveCmd,
 		},
@@ -69,7 +80,7 @@ func (suite *OneDriveUnitSuite) TestAddOneDriveCommands() {
 			deleteCommand,
 			expectUse + " " + oneDriveServiceCommandDeleteUseSuffix,
 			oneDriveDeleteCmd().Short,
-			[]string{"backup"},
+			[]string{utils.BackupFN},
 			deleteOneDriveCmd,
 		},
 	}

--- a/src/cli/backup/onedrive_test.go
+++ b/src/cli/backup/onedrive_test.go
@@ -13,15 +13,15 @@ import (
 	"github.com/alcionai/corso/src/internal/tester"
 )
 
-type OneDriveSuite struct {
+type OneDriveUnitSuite struct {
 	tester.Suite
 }
 
-func TestOneDriveSuite(t *testing.T) {
-	suite.Run(t, &OneDriveSuite{Suite: tester.NewUnitSuite(t)})
+func TestOneDriveUnitSuite(t *testing.T) {
+	suite.Run(t, &OneDriveUnitSuite{Suite: tester.NewUnitSuite(t)})
 }
 
-func (suite *OneDriveSuite) TestAddOneDriveCommands() {
+func (suite *OneDriveUnitSuite) TestAddOneDriveCommands() {
 	expectUse := oneDriveServiceCommand
 
 	table := []struct {
@@ -68,7 +68,7 @@ func (suite *OneDriveSuite) TestAddOneDriveCommands() {
 	}
 }
 
-func (suite *OneDriveSuite) TestValidateOneDriveBackupCreateFlags() {
+func (suite *OneDriveUnitSuite) TestValidateOneDriveBackupCreateFlags() {
 	table := []struct {
 		name   string
 		user   []string
@@ -92,7 +92,7 @@ func (suite *OneDriveSuite) TestValidateOneDriveBackupCreateFlags() {
 	}
 }
 
-func (suite *OneDriveSuite) TestOneDriveBackupDetailsSelectors() {
+func (suite *OneDriveUnitSuite) TestOneDriveBackupDetailsSelectors() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 
@@ -112,7 +112,7 @@ func (suite *OneDriveSuite) TestOneDriveBackupDetailsSelectors() {
 	}
 }
 
-func (suite *OneDriveSuite) TestOneDriveBackupDetailsSelectorsBadFormats() {
+func (suite *OneDriveUnitSuite) TestOneDriveBackupDetailsSelectorsBadFormats() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 

--- a/src/cli/backup/onedrive_test.go
+++ b/src/cli/backup/onedrive_test.go
@@ -37,7 +37,7 @@ func (suite *OneDriveUnitSuite) TestAddOneDriveCommands() {
 			createCommand,
 			expectUse + " " + oneDriveServiceCommandCreateUseSuffix,
 			oneDriveCreateCmd().Short,
-			[]string{"user", "disable-incrementals"},
+			[]string{"user", "disable-incrementals", "fail-fast"},
 			createOneDriveCmd,
 		},
 		{

--- a/src/cli/backup/onedrive_test.go
+++ b/src/cli/backup/onedrive_test.go
@@ -29,25 +29,51 @@ func (suite *OneDriveUnitSuite) TestAddOneDriveCommands() {
 		use         string
 		expectUse   string
 		expectShort string
+		flags       []string
 		expectRunE  func(*cobra.Command, []string) error
 	}{
 		{
-			"create onedrive", createCommand, expectUse + " " + oneDriveServiceCommandCreateUseSuffix,
-			oneDriveCreateCmd().Short, createOneDriveCmd,
+			"create onedrive",
+			createCommand,
+			expectUse + " " + oneDriveServiceCommandCreateUseSuffix,
+			oneDriveCreateCmd().Short,
+			[]string{"user", "disable-incrementals"},
+			createOneDriveCmd,
 		},
 		{
-			"list onedrive", listCommand, expectUse,
-			oneDriveListCmd().Short, listOneDriveCmd,
+			"list onedrive",
+			listCommand,
+			expectUse,
+			oneDriveListCmd().Short,
+			[]string{"backup", "failed-items", "skipped-items", "recovered-errors"},
+			listOneDriveCmd,
 		},
 		{
-			"details onedrive", detailsCommand, expectUse + " " + oneDriveServiceCommandDetailsUseSuffix,
-			oneDriveDetailsCmd().Short, detailsOneDriveCmd,
+			"details onedrive",
+			detailsCommand,
+			expectUse + " " + oneDriveServiceCommandDetailsUseSuffix,
+			oneDriveDetailsCmd().Short,
+			[]string{
+				"backup",
+				"folder",
+				"file",
+				"file-created-after",
+				"file-created-before",
+				"file-modified-after",
+				"file-modified-before",
+			},
+			detailsOneDriveCmd,
 		},
 		{
-			"delete onedrive", deleteCommand, expectUse + " " + oneDriveServiceCommandDeleteUseSuffix,
-			oneDriveDeleteCmd().Short, deleteOneDriveCmd,
+			"delete onedrive",
+			deleteCommand,
+			expectUse + " " + oneDriveServiceCommandDeleteUseSuffix,
+			oneDriveDeleteCmd().Short,
+			[]string{"backup"},
+			deleteOneDriveCmd,
 		},
 	}
+
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
@@ -64,6 +90,10 @@ func (suite *OneDriveUnitSuite) TestAddOneDriveCommands() {
 			assert.Equal(t, test.expectUse, child.Use)
 			assert.Equal(t, test.expectShort, child.Short)
 			tester.AreSameFunc(t, test.expectRunE, child.RunE)
+
+			for _, f := range test.flags {
+				assert.NotNil(t, c.Flag(f), f+" flag")
+			}
 		})
 	}
 }

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -84,6 +84,7 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 		utils.AddSiteIDFlag(c)
 		utils.AddDataFlag(c, []string{dataLibraries}, true)
 		options.AddFailFastFlag(c)
+		options.AddDisableIncrementalsFlag(c)
 
 	case listCommand:
 		c, fs = utils.AddCommand(cmd, sharePointListCmd())

--- a/src/cli/backup/sharepoint_test.go
+++ b/src/cli/backup/sharepoint_test.go
@@ -32,23 +32,49 @@ func (suite *SharePointSuite) TestAddSharePointCommands() {
 		use         string
 		expectUse   string
 		expectShort string
+		flags       []string
 		expectRunE  func(*cobra.Command, []string) error
 	}{
 		{
-			"create sharepoint", createCommand, expectUse + " " + sharePointServiceCommandCreateUseSuffix,
-			sharePointCreateCmd().Short, createSharePointCmd,
+			"create sharepoint",
+			createCommand,
+			expectUse + " " + sharePointServiceCommandCreateUseSuffix,
+			sharePointCreateCmd().Short,
+			[]string{"site", "disable-incrementals", "fail-fast"},
+			createSharePointCmd,
 		},
 		{
-			"list sharepoint", listCommand, expectUse,
-			sharePointListCmd().Short, listSharePointCmd,
+			"list sharepoint",
+			listCommand,
+			expectUse,
+			sharePointListCmd().Short,
+			[]string{"backup", "failed-items", "skipped-items", "recovered-errors"},
+			listSharePointCmd,
 		},
 		{
-			"details sharepoint", detailsCommand, expectUse + " " + sharePointServiceCommandDetailsUseSuffix,
-			sharePointDetailsCmd().Short, detailsSharePointCmd,
+			"details sharepoint",
+			detailsCommand,
+			expectUse + " " + sharePointServiceCommandDetailsUseSuffix,
+			sharePointDetailsCmd().Short,
+			[]string{
+				"backup",
+				"library",
+				"folder",
+				"file",
+				"file-created-after",
+				"file-created-before",
+				"file-modified-after",
+				"file-modified-before",
+			},
+			detailsSharePointCmd,
 		},
 		{
-			"delete sharepoint", deleteCommand, expectUse + " " + sharePointServiceCommandDeleteUseSuffix,
-			sharePointDeleteCmd().Short, deleteSharePointCmd,
+			"delete sharepoint",
+			deleteCommand,
+			expectUse + " " + sharePointServiceCommandDeleteUseSuffix,
+			sharePointDeleteCmd().Short,
+			[]string{"backup"},
+			deleteSharePointCmd,
 		},
 	}
 	for _, test := range table {
@@ -67,6 +93,10 @@ func (suite *SharePointSuite) TestAddSharePointCommands() {
 			assert.Equal(t, test.expectUse, child.Use)
 			assert.Equal(t, test.expectShort, child.Short)
 			tester.AreSameFunc(t, test.expectRunE, child.RunE)
+
+			for _, f := range test.flags {
+				assert.NotNil(t, c.Flag(f), f+" flag")
+			}
 		})
 	}
 }

--- a/src/cli/backup/sharepoint_test.go
+++ b/src/cli/backup/sharepoint_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/cli/options"
 	"github.com/alcionai/corso/src/cli/utils"
 	"github.com/alcionai/corso/src/cli/utils/testdata"
 	"github.com/alcionai/corso/src/internal/common"
@@ -40,7 +41,11 @@ func (suite *SharePointUnitSuite) TestAddSharePointCommands() {
 			createCommand,
 			expectUse + " " + sharePointServiceCommandCreateUseSuffix,
 			sharePointCreateCmd().Short,
-			[]string{"site", "disable-incrementals", "fail-fast"},
+			[]string{
+				utils.SiteFN,
+				options.DisableIncrementalsFN,
+				options.FailFastFN,
+			},
 			createSharePointCmd,
 		},
 		{
@@ -48,7 +53,12 @@ func (suite *SharePointUnitSuite) TestAddSharePointCommands() {
 			listCommand,
 			expectUse,
 			sharePointListCmd().Short,
-			[]string{"backup", "failed-items", "skipped-items", "recovered-errors"},
+			[]string{
+				utils.BackupFN,
+				failedItemsFN,
+				skippedItemsFN,
+				recoveredErrorsFN,
+			},
 			listSharePointCmd,
 		},
 		{
@@ -57,14 +67,14 @@ func (suite *SharePointUnitSuite) TestAddSharePointCommands() {
 			expectUse + " " + sharePointServiceCommandDetailsUseSuffix,
 			sharePointDetailsCmd().Short,
 			[]string{
-				"backup",
-				"library",
-				"folder",
-				"file",
-				"file-created-after",
-				"file-created-before",
-				"file-modified-after",
-				"file-modified-before",
+				utils.BackupFN,
+				utils.LibraryFN,
+				utils.FolderFN,
+				utils.FileFN,
+				utils.FileCreatedAfterFN,
+				utils.FileCreatedBeforeFN,
+				utils.FileModifiedAfterFN,
+				utils.FileModifiedBeforeFN,
 			},
 			detailsSharePointCmd,
 		},
@@ -73,7 +83,7 @@ func (suite *SharePointUnitSuite) TestAddSharePointCommands() {
 			deleteCommand,
 			expectUse + " " + sharePointServiceCommandDeleteUseSuffix,
 			sharePointDeleteCmd().Short,
-			[]string{"backup"},
+			[]string{utils.BackupFN},
 			deleteSharePointCmd,
 		},
 	}

--- a/src/cli/backup/sharepoint_test.go
+++ b/src/cli/backup/sharepoint_test.go
@@ -16,15 +16,15 @@ import (
 	"github.com/alcionai/corso/src/pkg/selectors"
 )
 
-type SharePointSuite struct {
+type SharePointUnitSuite struct {
 	tester.Suite
 }
 
-func TestSharePointSuite(t *testing.T) {
-	suite.Run(t, &SharePointSuite{tester.NewUnitSuite(t)})
+func TestSharePointUnitSuite(t *testing.T) {
+	suite.Run(t, &SharePointUnitSuite{tester.NewUnitSuite(t)})
 }
 
-func (suite *SharePointSuite) TestAddSharePointCommands() {
+func (suite *SharePointUnitSuite) TestAddSharePointCommands() {
 	expectUse := sharePointServiceCommand
 
 	table := []struct {
@@ -101,7 +101,7 @@ func (suite *SharePointSuite) TestAddSharePointCommands() {
 	}
 }
 
-func (suite *SharePointSuite) TestValidateSharePointBackupCreateFlags() {
+func (suite *SharePointUnitSuite) TestValidateSharePointBackupCreateFlags() {
 	table := []struct {
 		name   string
 		site   []string
@@ -137,7 +137,7 @@ func (suite *SharePointSuite) TestValidateSharePointBackupCreateFlags() {
 	}
 }
 
-func (suite *SharePointSuite) TestSharePointBackupCreateSelectors() {
+func (suite *SharePointUnitSuite) TestSharePointBackupCreateSelectors() {
 	const (
 		id1  = "id_1"
 		id2  = "id_2"
@@ -245,7 +245,7 @@ func (suite *SharePointSuite) TestSharePointBackupCreateSelectors() {
 	}
 }
 
-func (suite *SharePointSuite) TestSharePointBackupDetailsSelectors() {
+func (suite *SharePointUnitSuite) TestSharePointBackupDetailsSelectors() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 
@@ -265,7 +265,7 @@ func (suite *SharePointSuite) TestSharePointBackupDetailsSelectors() {
 	}
 }
 
-func (suite *SharePointSuite) TestSharePointBackupDetailsSelectorsBadFormats() {
+func (suite *SharePointUnitSuite) TestSharePointBackupDetailsSelectorsBadFormats() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 

--- a/src/cli/options/options.go
+++ b/src/cli/options/options.go
@@ -28,11 +28,12 @@ func Control() control.Options {
 // ---------------------------------------------------------------------------
 
 const (
-	failFastFN           = "fail-fast"
-	fetchParallelismFN   = "fetch-parallelism"
-	noStatsFN            = "no-stats"
-	restorePermissionsFN = "restore-permissions"
-	skipReduceFN         = "skip-reduce"
+	FailFastFN            = "fail-fast"
+	FetchParallelismFN    = "fetch-parallelism"
+	NoStatsFN             = "no-stats"
+	RestorePermissionsFN  = "restore-permissions"
+	SkipReduceFN          = "skip-reduce"
+	DisableIncrementalsFN = "disable-incrementals"
 )
 
 var (
@@ -46,29 +47,29 @@ var (
 // AddGlobalOperationFlags adds the global operations flag set.
 func AddGlobalOperationFlags(cmd *cobra.Command) {
 	fs := cmd.PersistentFlags()
-	fs.BoolVar(&noStatsFV, noStatsFN, false, "disable anonymous usage statistics gathering")
+	fs.BoolVar(&noStatsFV, NoStatsFN, false, "disable anonymous usage statistics gathering")
 }
 
 // AddFailFastFlag adds a flag to toggle fail-fast error handling behavior.
 func AddFailFastFlag(cmd *cobra.Command) {
 	fs := cmd.Flags()
-	fs.BoolVar(&failFastFV, failFastFN, false, "stop processing immediately if any error occurs")
+	fs.BoolVar(&failFastFV, FailFastFN, false, "stop processing immediately if any error occurs")
 	// TODO: reveal this flag when fail-fast support is implemented
-	cobra.CheckErr(fs.MarkHidden(failFastFN))
+	cobra.CheckErr(fs.MarkHidden(FailFastFN))
 }
 
 // AddRestorePermissionsFlag adds OneDrive flag for restoring permissions
 func AddRestorePermissionsFlag(cmd *cobra.Command) {
 	fs := cmd.Flags()
-	fs.BoolVar(&restorePermissionsFV, restorePermissionsFN, false, "Restore permissions for files and folders")
+	fs.BoolVar(&restorePermissionsFV, RestorePermissionsFN, false, "Restore permissions for files and folders")
 }
 
 // AddSkipReduceFlag adds a hidden flag that allows callers to skip the selector
 // reduction step.  Currently only intended for details commands, not restore.
 func AddSkipReduceFlag(cmd *cobra.Command) {
 	fs := cmd.Flags()
-	fs.BoolVar(&skipReduceFV, skipReduceFN, false, "Skip the selector reduce filtering")
-	cobra.CheckErr(fs.MarkHidden(skipReduceFN))
+	fs.BoolVar(&skipReduceFV, SkipReduceFN, false, "Skip the selector reduce filtering")
+	cobra.CheckErr(fs.MarkHidden(SkipReduceFN))
 }
 
 // AddFetchParallelismFlag adds a hidden flag that allows callers to reduce call
@@ -77,17 +78,15 @@ func AddFetchParallelismFlag(cmd *cobra.Command) {
 	fs := cmd.Flags()
 	fs.IntVar(
 		&fetchParallelismFV,
-		fetchParallelismFN,
+		FetchParallelismFN,
 		4,
 		"Control the number of concurrent data fetches for Exchange. Valid range is [1-4]. Default: 4")
-	cobra.CheckErr(fs.MarkHidden(fetchParallelismFN))
+	cobra.CheckErr(fs.MarkHidden(FetchParallelismFN))
 }
 
 // ---------------------------------------------------------------------------
 // Feature Flags
 // ---------------------------------------------------------------------------
-
-const disableIncrementalsFN = "disable-incrementals"
 
 var disableIncrementalsFV bool
 
@@ -97,8 +96,8 @@ func AddDisableIncrementalsFlag(cmd *cobra.Command) {
 	fs := cmd.Flags()
 	fs.BoolVar(
 		&disableIncrementalsFV,
-		disableIncrementalsFN,
+		DisableIncrementalsFN,
 		false,
 		"Disable incremental data retrieval in backups.")
-	cobra.CheckErr(fs.MarkHidden(disableIncrementalsFN))
+	cobra.CheckErr(fs.MarkHidden(DisableIncrementalsFN))
 }

--- a/src/cli/options/options_test.go
+++ b/src/cli/options/options_test.go
@@ -26,12 +26,12 @@ func (suite *OptionsUnitSuite) TestAddExchangeCommands() {
 	cmd := &cobra.Command{
 		Use: "test",
 		Run: func(cmd *cobra.Command, args []string) {
-			assert.True(t, failFastFV, failFastFN)
-			assert.True(t, disableIncrementalsFV, disableIncrementalsFN)
-			assert.True(t, noStatsFV, noStatsFN)
-			assert.True(t, restorePermissionsFV, restorePermissionsFN)
-			assert.True(t, skipReduceFV, skipReduceFN)
-			assert.Equal(t, 2, fetchParallelismFV, fetchParallelismFN)
+			assert.True(t, failFastFV, FailFastFN)
+			assert.True(t, disableIncrementalsFV, DisableIncrementalsFN)
+			assert.True(t, noStatsFV, NoStatsFN)
+			assert.True(t, restorePermissionsFV, RestorePermissionsFN)
+			assert.True(t, skipReduceFV, SkipReduceFN)
+			assert.Equal(t, 2, fetchParallelismFV, FetchParallelismFN)
 		},
 	}
 
@@ -48,13 +48,13 @@ func (suite *OptionsUnitSuite) TestAddExchangeCommands() {
 	// Test arg parsing for few args
 	cmd.SetArgs([]string{
 		"test",
-		"--" + failFastFN,
-		"--" + disableIncrementalsFN,
-		"--" + noStatsFN,
-		"--" + restorePermissionsFN,
-		"--" + skipReduceFN,
+		"--" + FailFastFN,
+		"--" + DisableIncrementalsFN,
+		"--" + NoStatsFN,
+		"--" + RestorePermissionsFN,
+		"--" + SkipReduceFN,
 
-		"--" + fetchParallelismFN, "2",
+		"--" + FetchParallelismFN, "2",
 	})
 
 	err := cmd.Execute()


### PR DESCRIPTION
It seems to have been accidentally removed in e4be050.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
