### PR TITLE
adds a subtree migration iface to kopia

### DIFF
--- a/src/internal/data/data_collection.go
+++ b/src/internal/data/data_collection.go
@@ -132,7 +132,7 @@ func StateOf(prev, curr path.Path) CollectionState {
 		return NewState
 	}
 
-	if curr.Folder(false) != prev.Folder(false) {
+	if curr.String() != prev.String() {
 		return MovedState
 	}
 

--- a/src/internal/kopia/migrations.go
+++ b/src/internal/kopia/migrations.go
@@ -1,0 +1,40 @@
+package kopia
+
+import (
+	"strings"
+
+	"github.com/alcionai/corso/src/pkg/path"
+)
+
+type SubtreeMigrator interface {
+	// GetNewSubtree potentially transforms a given subtree (repo tree prefix
+	// corresponding to a kopia Reason (eg: resource owner, service, category)
+	// into a new subtree when merging items from the base tree.
+	GetNewSubtree(oldSubtree *path.Builder) *path.Builder
+}
+
+type subtreeOwnerMigrator struct {
+	new, old string
+}
+
+// migrates any subtree with a matching old owner onto the new owner
+func (om subtreeOwnerMigrator) GetNewSubtree(old *path.Builder) *path.Builder {
+	if old == nil {
+		return nil
+	}
+
+	elems := old.Elements()
+	if len(elems) < 4 {
+		return old
+	}
+
+	if strings.EqualFold(elems[2], om.old) {
+		elems[2] = om.new
+	}
+
+	return path.Builder{}.Append(elems...)
+}
+
+func NewSubtreeOwnerMigration(new, old string) *subtreeOwnerMigrator {
+	return &subtreeOwnerMigrator{new, old}
+}

--- a/src/internal/kopia/migrations_test.go
+++ b/src/internal/kopia/migrations_test.go
@@ -1,0 +1,62 @@
+package kopia
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/path"
+)
+
+type MigrationsUnitSuite struct {
+	tester.Suite
+}
+
+func TestMigrationsUnitSuite(t *testing.T) {
+	suite.Run(t, &MigrationsUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *MigrationsUnitSuite) TestSubtreeOwnerMigration_GetNewSubtree() {
+	table := []struct {
+		name   string
+		input  *path.Builder
+		expect *path.Builder
+	}{
+		{
+			name: "nil builder",
+		},
+		{
+			name:   "builder too small",
+			input:  path.Builder{}.Append("foo"),
+			expect: path.Builder{}.Append("foo"),
+		},
+		{
+			name:   "non-matching owner",
+			input:  path.Builder{}.Append("foo", "bar", "ownerronwo", "baz"),
+			expect: path.Builder{}.Append("foo", "bar", "ownerronwo", "baz"),
+		},
+		{
+			name:   "migrated",
+			input:  path.Builder{}.Append("foo", "bar", "owner", "baz"),
+			expect: path.Builder{}.Append("foo", "bar", "migrated", "baz"),
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			var (
+				t      = suite.T()
+				stm    = NewSubtreeOwnerMigration("migrated", "owner")
+				result = stm.GetNewSubtree(test.input)
+			)
+
+			if result == nil {
+				assert.Nil(t, test.expect)
+				return
+			}
+
+			assert.Equal(t, test.expect.String(), result.String())
+		})
+	}
+}

--- a/src/internal/kopia/path_encoder.go
+++ b/src/internal/kopia/path_encoder.go
@@ -20,6 +20,22 @@ func encodeElements(elements ...string) []string {
 	return encoded
 }
 
+func decodeElements(elements ...string) []string {
+	decoded := make([]string, 0, len(elements))
+
+	for _, e := range elements {
+		bs, err := encoder.DecodeString(e)
+		if err != nil {
+			decoded = append(decoded, "error decoding: "+e)
+			continue
+		}
+
+		decoded = append(decoded, string(bs))
+	}
+
+	return decoded
+}
+
 // encodeAsPath takes a set of elements and returns the concatenated elements as
 // if they were a path. The elements are joined with the separator in the golang
 // path package.

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -137,6 +137,7 @@ func (w Wrapper) ConsumeBackupCollections(
 	globalExcludeSet map[string]map[string]struct{},
 	tags map[string]string,
 	buildTreeWithBase bool,
+	stm SubtreeMigrator,
 	errs *fault.Bus,
 ) (*BackupStats, *details.Builder, DetailsMergeInfoer, error) {
 	if w.c == nil {
@@ -155,6 +156,7 @@ func (w Wrapper) ConsumeBackupCollections(
 		deets:   &details.Builder{},
 		toMerge: newMergeDetails(),
 		errs:    errs,
+		stm:     stm,
 	}
 
 	// When running an incremental backup, we need to pass the prior

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -283,6 +283,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 				nil,
 				tags,
 				true,
+				nil,
 				fault.New(true))
 			assert.NoError(t, err, clues.ToCore(err))
 
@@ -430,6 +431,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_NoDetailsForMeta() {
 				nil,
 				tags,
 				true,
+				nil,
 				fault.New(true))
 			assert.NoError(t, err, clues.ToCore(err))
 
@@ -528,6 +530,7 @@ func (suite *KopiaIntegrationSuite) TestRestoreAfterCompressionChange() {
 		nil,
 		tags,
 		true,
+		nil,
 		fault.New(true))
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -647,6 +650,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_ReaderError() {
 		nil,
 		tags,
 		true,
+		nil,
 		fault.New(true))
 	require.Error(t, err, clues.ToCore(err))
 	assert.Equal(t, 0, stats.ErrorCount)
@@ -709,6 +713,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollectionsHandlesNoCollections() 
 				nil,
 				nil,
 				true,
+				nil,
 				fault.New(true))
 			require.NoError(t, err, clues.ToCore(err))
 
@@ -869,6 +874,7 @@ func (suite *KopiaSimpleRepoIntegrationSuite) SetupTest() {
 		nil,
 		tags,
 		false,
+		nil,
 		fault.New(true))
 	require.NoError(t, err, clues.ToCore(err))
 	require.Equal(t, stats.ErrorCount, 0)
@@ -1028,6 +1034,7 @@ func (suite *KopiaSimpleRepoIntegrationSuite) TestBackupExcludeItem() {
 				excluded,
 				tags,
 				true,
+				nil,
 				fault.New(true))
 			require.NoError(t, err, clues.ToCore(err))
 			assert.Equal(t, test.expectedCachedItems, stats.CachedFileCount)

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -101,6 +101,7 @@ func (mbu mockBackupConsumer) ConsumeBackupCollections(
 	excluded map[string]map[string]struct{},
 	tags map[string]string,
 	buildTreeWithBase bool,
+	_ kopia.SubtreeMigrator,
 	errs *fault.Bus,
 ) (*kopia.BackupStats, *details.Builder, kopia.DetailsMergeInfoer, error) {
 	if mbu.checkFunc != nil {
@@ -624,6 +625,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_ConsumeBackupDataCollections
 				nil,
 				model.StableID(""),
 				true,
+				nil,
 				fault.New(true))
 		})
 	}

--- a/src/internal/operations/inject/inject.go
+++ b/src/internal/operations/inject/inject.go
@@ -36,6 +36,7 @@ type (
 			excluded map[string]map[string]struct{},
 			tags map[string]string,
 			buildTreeWithBase bool,
+			stm kopia.SubtreeMigrator,
 			errs *fault.Bus,
 		) (*kopia.BackupStats, *details.Builder, kopia.DetailsMergeInfoer, error)
 	}

--- a/src/internal/streamstore/streamstore.go
+++ b/src/internal/streamstore/streamstore.go
@@ -235,6 +235,7 @@ func write(
 		nil,
 		nil,
 		false,
+		nil,
 		errs)
 	if err != nil {
 		return "", clues.Wrap(err, "storing marshalled bytes in repository")

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -27,7 +27,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
-	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/storage"
 	"github.com/alcionai/corso/src/pkg/store"
@@ -317,11 +316,6 @@ func (r repository) NewBackupWithLookup(
 	ownerID, ownerName, err := gc.PopulateOwnerIDAndNamesFrom(ctx, sel.DiscreteOwner, ins)
 	if err != nil {
 		return operations.BackupOperation{}, errors.Wrap(err, "resolving resource owner details")
-	}
-
-	// Exchange and OneDrive need to maintain the user PN as the ID until we're ready to migrate
-	if sel.PathService() != path.SharePointService {
-		ownerID = ownerName
 	}
 
 	// TODO: retrieve display name from gc


### PR DESCRIPTION
Introdudces the user pn to id migration. Since
onedrive doesn't enumerate folders on backup,
we have to force the migration by introducing a
subtree migrator in kopia.

---

#### Does this PR need a docs update or release note?

- [ ] :clock1: Yes, but in a later PR

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #2825

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
