### PR TITLE
check backup version on onedrive migration

### DIFF
--- a/src/internal/connector/data_collections.go
+++ b/src/internal/connector/data_collections.go
@@ -37,6 +37,7 @@ func (gc *GraphConnector) ProduceBackupCollections(
 	owner common.IDNamer,
 	sels selectors.Selector,
 	metadata []data.RestoreCollection,
+	priorVersion int,
 	ctrlOpts control.Options,
 	errs *fault.Bus,
 ) ([]data.BackupCollection, map[string]map[string]struct{}, error) {
@@ -99,6 +100,7 @@ func (gc *GraphConnector) ProduceBackupCollections(
 			sels,
 			sels,
 			metadata,
+			priorVersion,
 			gc.credentials.AzureTenantID,
 			gc.itemClient,
 			gc.Service,

--- a/src/internal/connector/data_collections.go
+++ b/src/internal/connector/data_collections.go
@@ -37,7 +37,7 @@ func (gc *GraphConnector) ProduceBackupCollections(
 	owner common.IDNamer,
 	sels selectors.Selector,
 	metadata []data.RestoreCollection,
-	priorVersion int,
+	lastBackupVersion int,
 	ctrlOpts control.Options,
 	errs *fault.Bus,
 ) ([]data.BackupCollection, map[string]map[string]struct{}, error) {
@@ -100,7 +100,7 @@ func (gc *GraphConnector) ProduceBackupCollections(
 			sels,
 			sels,
 			metadata,
-			priorVersion,
+			lastBackupVersion,
 			gc.credentials.AzureTenantID,
 			gc.itemClient,
 			gc.Service,

--- a/src/internal/connector/data_collections_test.go
+++ b/src/internal/connector/data_collections_test.go
@@ -208,6 +208,7 @@ func (suite *DataCollectionIntgSuite) TestDataCollections_invalidResourceOwner()
 				test.getSelector(t),
 				test.getSelector(t),
 				nil,
+				-1,
 				control.Options{},
 				fault.New(true))
 			assert.Error(t, err, clues.ToCore(err))
@@ -345,6 +346,7 @@ func (suite *SPCollectionIntgSuite) TestCreateSharePointCollection_Libraries() {
 		sel.Selector,
 		sel.Selector,
 		nil,
+		-1,
 		control.Options{},
 		fault.New(true))
 	require.NoError(t, err, clues.ToCore(err))
@@ -389,6 +391,7 @@ func (suite *SPCollectionIntgSuite) TestCreateSharePointCollection_Lists() {
 		sel.Selector,
 		sel.Selector,
 		nil,
+		-1,
 		control.Options{},
 		fault.New(true))
 	require.NoError(t, err, clues.ToCore(err))

--- a/src/internal/connector/graph_connector_test.go
+++ b/src/internal/connector/graph_connector_test.go
@@ -576,6 +576,7 @@ func runBackupAndCompare(
 		backupSel,
 		backupSel,
 		nil,
+		-1,
 		config.opts,
 		fault.New(true))
 	require.NoError(t, err, clues.ToCore(err))
@@ -1116,6 +1117,7 @@ func (suite *GraphConnectorIntegrationSuite) TestMultiFolderBackupDifferentNames
 				backupSel,
 				backupSel,
 				nil,
+				-1,
 				control.Options{
 					RestorePermissions: true,
 					ToggleFeatures:     control.Toggles{},
@@ -1274,6 +1276,7 @@ func (suite *GraphConnectorIntegrationSuite) TestBackup_CreatesPrefixCollections
 				backupSel,
 				backupSel,
 				nil,
+				-1,
 				control.Options{
 					RestorePermissions: false,
 					ToggleFeatures:     control.Toggles{},

--- a/src/internal/connector/mockconnector/mock_data_connector.go
+++ b/src/internal/connector/mockconnector/mock_data_connector.go
@@ -28,6 +28,7 @@ func (gc GraphConnector) ProduceBackupCollections(
 	_ common.IDNamer,
 	_ selectors.Selector,
 	_ []data.RestoreCollection,
+	_ int,
 	_ control.Options,
 	_ *fault.Bus,
 ) (

--- a/src/internal/connector/onedrive/data_collections.go
+++ b/src/internal/connector/onedrive/data_collections.go
@@ -38,7 +38,7 @@ func DataCollections(
 	selector selectors.Selector,
 	user common.IDNamer,
 	metadata []data.RestoreCollection,
-	priorVersion int,
+	lastBackupVersion int,
 	tenant string,
 	itemClient *http.Client,
 	service graph.Servicer,
@@ -96,7 +96,7 @@ func DataCollections(
 
 	mcs, err := migrationCollections(
 		service,
-		priorVersion,
+		lastBackupVersion,
 		tenant,
 		user,
 		su,
@@ -130,17 +130,18 @@ func DataCollections(
 // adds data migrations to the collection set.
 func migrationCollections(
 	svc graph.Servicer,
-	priorVersion int,
+	lastBackupVersion int,
 	tenant string,
 	user common.IDNamer,
 	su support.StatusUpdater,
 	ctrlOpts control.Options,
 ) ([]data.BackupCollection, error) {
-	if priorVersion < 1 {
+	// assume a version < 1 implies no prior backup, thus nothing to migrate.
+	if lastBackupVersion < 1 {
 		return nil, nil
 	}
 
-	if priorVersion >= version.OneDrive7MigrateUserPNToID {
+	if lastBackupVersion >= version.All7MigrateUserPNToID {
 		return nil, nil
 	}
 

--- a/src/internal/connector/onedrive/data_collections_test.go
+++ b/src/internal/connector/onedrive/data_collections_test.go
@@ -1,0 +1,106 @@
+package onedrive
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alcionai/clues"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/version"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/selectors"
+)
+
+type DataCollectionsUnitSuite struct {
+	tester.Suite
+}
+
+func TestDataCollectionsUnitSuite(t *testing.T) {
+	suite.Run(t, &DataCollectionsUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *DataCollectionsUnitSuite) TestMigrationCollections() {
+	u := selectors.Selector{}
+	u = u.SetDiscreteOwnerIDName("i", "n")
+
+	od := path.OneDriveService.String()
+	fc := path.FilesCategory.String()
+
+	type migr struct {
+		full string
+		prev string
+	}
+
+	table := []struct {
+		name            string
+		version         int
+		expectLen       int
+		expectMigration []migr
+	}{
+		{
+			name:            "zero version",
+			version:         0,
+			expectLen:       0,
+			expectMigration: []migr{},
+		},
+		{
+			name:            "above current version",
+			version:         version.Backup + 5,
+			expectLen:       0,
+			expectMigration: []migr{},
+		},
+		{
+			name:      "user pn to id",
+			version:   version.OneDrive7MigrateUserPNToID - 1,
+			expectLen: 1,
+			expectMigration: []migr{
+				{
+					full: strings.Join([]string{"t", od, "i", fc}, "/"),
+					prev: strings.Join([]string{"t", od, "n", fc}, "/"),
+				},
+			},
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			mc, err := migrationCollections(nil, test.version, "t", u, nil, control.Options{})
+			require.NoError(t, err, clues.ToCore(err))
+
+			if test.expectLen == 0 {
+				assert.Nil(t, mc)
+				return
+			}
+
+			assert.LessOrEqual(t, test.expectLen, len(mc))
+
+			migrs := make([]bool, len(test.expectMigration))
+
+			for _, col := range mc {
+				oc, ok := col.(*Collection)
+				require.True(t, ok, "casting backupCollection iface to *onedrive.Collection")
+
+				fp := oc.FullPath().String()
+				pp := oc.prevPath.String()
+
+				t.Logf("Found migration collection:\n* full: %s\n* prev: %s\n", fp, pp)
+
+				for i, cm := range test.expectMigration {
+					if cm.full == fp && cm.prev == pp {
+						migrs[i] = true
+					}
+				}
+			}
+
+			for i, m := range migrs {
+				assert.Truef(t, m, "expected to find migration: %+v", test.expectMigration[i])
+			}
+		})
+	}
+}

--- a/src/internal/connector/onedrive/data_collections_test.go
+++ b/src/internal/connector/onedrive/data_collections_test.go
@@ -86,8 +86,15 @@ func (suite *DataCollectionsUnitSuite) TestMigrationCollections() {
 				oc, ok := col.(*Collection)
 				require.True(t, ok, "casting backupCollection iface to *onedrive.Collection")
 
-				fp := oc.FullPath().String()
-				pp := oc.prevPath.String()
+				var fp, pp string
+
+				if oc.FullPath() != nil {
+					fp = oc.FullPath().String()
+				}
+
+				if oc.prevPath != nil {
+					pp = oc.prevPath.String()
+				}
 
 				t.Logf("Found migration collection:\n* full: %s\n* prev: %s\n", fp, pp)
 

--- a/src/internal/connector/onedrive/data_collections_test.go
+++ b/src/internal/connector/onedrive/data_collections_test.go
@@ -56,7 +56,7 @@ func (suite *DataCollectionsUnitSuite) TestMigrationCollections() {
 		},
 		{
 			name:      "user pn to id",
-			version:   version.OneDrive7MigrateUserPNToID - 1,
+			version:   version.All7MigrateUserPNToID - 1,
 			expectLen: 1,
 			expectMigration: []migr{
 				{
@@ -83,17 +83,14 @@ func (suite *DataCollectionsUnitSuite) TestMigrationCollections() {
 			migrs := make([]bool, len(test.expectMigration))
 
 			for _, col := range mc {
-				oc, ok := col.(*Collection)
-				require.True(t, ok, "casting backupCollection iface to *onedrive.Collection")
-
 				var fp, pp string
 
-				if oc.FullPath() != nil {
-					fp = oc.FullPath().String()
+				if col.FullPath() != nil {
+					fp = col.FullPath().String()
 				}
 
-				if oc.prevPath != nil {
-					pp = oc.prevPath.String()
+				if col.PreviousPath() != nil {
+					pp = col.PreviousPath().String()
 				}
 
 				t.Logf("Found migration collection:\n* full: %s\n* prev: %s\n", fp, pp)

--- a/src/internal/kopia/model_store.go
+++ b/src/internal/kopia/model_store.go
@@ -130,7 +130,7 @@ func putInner(
 		base.ID = model.StableID(uuid.NewString())
 	}
 
-	tmpTags, err := tagsForModelWithID(s, base.ID, base.Version, base.Tags)
+	tmpTags, err := tagsForModelWithID(s, base.ID, base.ModelVersion, base.Tags)
 	if err != nil {
 		// Will be wrapped at a higher layer.
 		return clues.Stack(err).WithClues(ctx)
@@ -158,7 +158,7 @@ func (ms *ModelStore) Put(
 		return clues.Stack(errUnrecognizedSchema)
 	}
 
-	m.Base().Version = ms.modelVersion
+	m.Base().ModelVersion = ms.modelVersion
 
 	err := repo.WriteSession(
 		ctx,
@@ -205,7 +205,7 @@ func (ms ModelStore) populateBaseModelFromMetadata(
 
 	base.ModelStoreID = m.ID
 	base.ID = model.StableID(id)
-	base.Version = v
+	base.ModelVersion = v
 	base.Tags = m.Labels
 
 	stripHiddenTags(base.Tags)
@@ -424,7 +424,7 @@ func (ms *ModelStore) Update(
 		return clues.Stack(errNoModelStoreID).WithClues(ctx)
 	}
 
-	base.Version = ms.modelVersion
+	base.ModelVersion = ms.modelVersion
 
 	// TODO(ashmrtnz): Can remove if bottleneck.
 	if err := ms.checkPrevModelVersion(ctx, s, base); err != nil {

--- a/src/internal/kopia/model_store_test.go
+++ b/src/internal/kopia/model_store_test.go
@@ -264,7 +264,7 @@ func (suite *ModelStoreIntegrationSuite) TestPutGet() {
 
 			require.NotEmpty(t, foo.ModelStoreID)
 			require.NotEmpty(t, foo.ID)
-			require.Equal(t, globalModelVersion, foo.Version)
+			require.Equal(t, globalModelVersion, foo.ModelVersion)
 
 			returned := &fooModel{}
 			err = suite.m.Get(suite.ctx, test.s, foo.ID, returned)
@@ -569,14 +569,14 @@ func (suite *ModelStoreIntegrationSuite) TestPutUpdate() {
 			name: "NoTags",
 			mutator: func(m *fooModel) {
 				m.Bar = "baz"
-				m.Version = 42
+				m.ModelVersion = 42
 			},
 		},
 		{
 			name: "WithTags",
 			mutator: func(m *fooModel) {
 				m.Bar = "baz"
-				m.Version = 42
+				m.ModelVersion = 42
 				m.Tags = map[string]string{
 					"a": "42",
 				}
@@ -607,7 +607,7 @@ func (suite *ModelStoreIntegrationSuite) TestPutUpdate() {
 
 			oldModelID := foo.ModelStoreID
 			oldStableID := foo.ID
-			oldVersion := foo.Version
+			oldVersion := foo.ModelVersion
 
 			test.mutator(foo)
 
@@ -616,7 +616,7 @@ func (suite *ModelStoreIntegrationSuite) TestPutUpdate() {
 			assert.Equal(t, oldStableID, foo.ID)
 			// The version in the model store has not changed so we get the old
 			// version back.
-			assert.Equal(t, oldVersion, foo.Version)
+			assert.Equal(t, oldVersion, foo.ModelVersion)
 
 			returned := &fooModel{}
 
@@ -627,7 +627,7 @@ func (suite *ModelStoreIntegrationSuite) TestPutUpdate() {
 			ids, err := m.GetIDsForType(ctx, theModelType, nil)
 			require.NoError(t, err, clues.ToCore(err))
 			require.Len(t, ids, 1)
-			assert.Equal(t, globalModelVersion, ids[0].Version)
+			assert.Equal(t, globalModelVersion, ids[0].ModelVersion)
 
 			if oldModelID == foo.ModelStoreID {
 				// Unlikely, but we don't control ModelStoreID generation and can't

--- a/src/internal/kopia/snapshot_manager.go
+++ b/src/internal/kopia/snapshot_manager.go
@@ -39,6 +39,11 @@ func (r Reason) TagKeys() []string {
 	}
 }
 
+// Key is the concatenation of the ResourceOwner, Service, and Category.
+func (r Reason) Key() string {
+	return r.ResourceOwner + r.Service.String() + r.Category.String()
+}
+
 type ManifestEntry struct {
 	*snapshot.Manifest
 	// Reason contains the ResourceOwners and Service/Categories that caused this

--- a/src/internal/model/model.go
+++ b/src/internal/model/model.go
@@ -59,9 +59,9 @@ type BaseModel struct {
 	// to refer to this one. This field may change if the model is updated. This
 	// field should be treated as read-only by users.
 	ModelStoreID manifest.ID `json:"-"`
-	// Version is a version number that can help track changes across models.
+	// ModelVersion is a version number that can help track changes across models.
 	// TODO(ashmrtn): Reference version control documentation.
-	Version int `json:"-"`
+	ModelVersion int `json:"-"`
 	// Tags associated with this model in the store to facilitate lookup. Tags in
 	// the struct are not serialized directly into the stored model, but are part
 	// of the metadata for the model.

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -250,12 +250,18 @@ func (op *BackupOperation) do(
 		return nil, clues.Wrap(err, "producing manifests and metadata")
 	}
 
+	_, priorVersion, err := lastCompleteBackups(ctx, op.store, mans)
+	if err != nil {
+		return nil, clues.Wrap(err, "retrieving prior backups")
+	}
+
 	cs, excludes, err := produceBackupDataCollections(
 		ctx,
 		op.bp,
 		op.ResourceOwner,
 		op.Selectors,
 		mdColls,
+		priorVersion,
 		op.Options,
 		op.Errors)
 	if err != nil {
@@ -333,6 +339,7 @@ func produceBackupDataCollections(
 	resourceOwner common.IDNamer,
 	sel selectors.Selector,
 	metadata []data.RestoreCollection,
+	priorVersion int,
 	ctrlOpts control.Options,
 	errs *fault.Bus,
 ) ([]data.BackupCollection, map[string]map[string]struct{}, error) {
@@ -343,7 +350,7 @@ func produceBackupDataCollections(
 		closer()
 	}()
 
-	return bp.ProduceBackupCollections(ctx, resourceOwner, sel, metadata, ctrlOpts, errs)
+	return bp.ProduceBackupCollections(ctx, resourceOwner, sel, metadata, priorVersion, ctrlOpts, errs)
 }
 
 // ---------------------------------------------------------------------------
@@ -547,6 +554,56 @@ func getNewPathRefs(
 	return newPath, newLocPrefix, newLocPrefix.String() != entry.LocationRef, nil
 }
 
+func lastCompleteBackups(
+	ctx context.Context,
+	ms *store.Wrapper,
+	mans []*kopia.ManifestEntry,
+) (map[string]*backup.Backup, int, error) {
+	var (
+		oldestBackupVersion int
+		result              = map[string]*backup.Backup{}
+	)
+
+	if len(mans) == 0 {
+		return result, -1, nil
+	}
+
+	for _, man := range mans {
+		// For now skip snapshots that aren't complete. We will need to revisit this
+		// when we tackle restartability.
+		if len(man.IncompleteReason) > 0 {
+			continue
+		}
+
+		var (
+			mctx    = clues.Add(ctx, "base_manifest_id", man.ID)
+			reasons = man.Reasons
+		)
+
+		bID, ok := man.GetTag(kopia.TagBackupID)
+		if !ok {
+			return result, -1, clues.New("no backup ID in snapshot manifest").WithClues(mctx)
+		}
+
+		mctx = clues.Add(mctx, "base_manifest_backup_id", bID)
+
+		bup, err := getBackupFromID(mctx, model.StableID(bID), ms)
+		if err != nil {
+			return result, -1, err
+		}
+
+		for _, r := range reasons {
+			result[r.Key()] = bup
+		}
+
+		if bup.Version < oldestBackupVersion {
+			oldestBackupVersion = bup.Version
+		}
+	}
+
+	return result, oldestBackupVersion, nil
+}
+
 func mergeDetails(
 	ctx context.Context,
 	ms *store.Wrapper,
@@ -589,7 +646,7 @@ func mergeDetails(
 			detailsStore,
 			errs)
 		if err != nil {
-			return clues.New("fetching base details for backup").WithClues(mctx)
+			return clues.New("fetching base details for backup")
 		}
 
 		for _, entry := range baseDeets.Items() {

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -250,7 +250,7 @@ func (op *BackupOperation) do(
 		return nil, clues.Wrap(err, "producing manifests and metadata")
 	}
 
-	_, priorVersion, err := lastCompleteBackups(ctx, op.store, mans)
+	_, lastBackupVersion, err := lastCompleteBackups(ctx, op.store, mans)
 	if err != nil {
 		return nil, clues.Wrap(err, "retrieving prior backups")
 	}
@@ -261,7 +261,7 @@ func (op *BackupOperation) do(
 		op.ResourceOwner,
 		op.Selectors,
 		mdColls,
-		priorVersion,
+		lastBackupVersion,
 		op.Options,
 		op.Errors)
 	if err != nil {
@@ -339,7 +339,7 @@ func produceBackupDataCollections(
 	resourceOwner common.IDNamer,
 	sel selectors.Selector,
 	metadata []data.RestoreCollection,
-	priorVersion int,
+	lastBackupVersion int,
 	ctrlOpts control.Options,
 	errs *fault.Bus,
 ) ([]data.BackupCollection, map[string]map[string]struct{}, error) {
@@ -350,7 +350,7 @@ func produceBackupDataCollections(
 		closer()
 	}()
 
-	return bp.ProduceBackupCollections(ctx, resourceOwner, sel, metadata, priorVersion, ctrlOpts, errs)
+	return bp.ProduceBackupCollections(ctx, resourceOwner, sel, metadata, lastBackupVersion, ctrlOpts, errs)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/internal/operations/common.go
+++ b/src/internal/operations/common.go
@@ -13,6 +13,19 @@ import (
 	"github.com/alcionai/corso/src/pkg/store"
 )
 
+func getBackupFromID(
+	ctx context.Context,
+	backupID model.StableID,
+	ms *store.Wrapper,
+) (*backup.Backup, error) {
+	bup, err := ms.GetBackup(ctx, backupID)
+	if err != nil {
+		return nil, clues.Wrap(err, "getting backup")
+	}
+
+	return bup, nil
+}
+
 func getBackupAndDetailsFromID(
 	ctx context.Context,
 	backupID model.StableID,
@@ -22,7 +35,7 @@ func getBackupAndDetailsFromID(
 ) (*backup.Backup, *details.Details, error) {
 	bup, err := ms.GetBackup(ctx, backupID)
 	if err != nil {
-		return nil, nil, clues.Wrap(err, "getting backup details ID")
+		return nil, nil, clues.Wrap(err, "getting backup")
 	}
 
 	var (

--- a/src/internal/operations/inject/inject.go
+++ b/src/internal/operations/inject/inject.go
@@ -21,6 +21,7 @@ type (
 			resourceOwner common.IDNamer,
 			sels selectors.Selector,
 			metadata []data.RestoreCollection,
+			priorVersion int,
 			ctrlOpts control.Options,
 			errs *fault.Bus,
 		) ([]data.BackupCollection, map[string]map[string]struct{}, error)

--- a/src/internal/operations/inject/inject.go
+++ b/src/internal/operations/inject/inject.go
@@ -21,7 +21,7 @@ type (
 			resourceOwner common.IDNamer,
 			sels selectors.Selector,
 			metadata []data.RestoreCollection,
-			priorVersion int,
+			lastBackupVersion int,
 			ctrlOpts control.Options,
 			errs *fault.Bus,
 		) ([]data.BackupCollection, map[string]map[string]struct{}, error)

--- a/src/internal/version/backup.go
+++ b/src/internal/version/backup.go
@@ -1,6 +1,6 @@
 package version
 
-const Backup = 6
+const Backup = 7
 
 // Various labels to refer to important version changes.
 // Labels don't need 1:1 service:version representation.  Add a new
@@ -35,6 +35,10 @@ const (
 	// storing files in kopia with their item ID instead of their OneDrive file
 	// name.
 	OneDrive6NameInMeta = 6
+
+	// OneDrive7MigrateUserPNToID marks when we migrated repo refs from the user's
+	// PrincipalName to their ID for stability.
+	OneDrive7MigrateUserPNToID = 7
 
 	// OneDriveXLocationRef provides LocationRef information for Exchange,
 	// OneDrive, and SharePoint libraries.

--- a/src/internal/version/backup.go
+++ b/src/internal/version/backup.go
@@ -36,9 +36,9 @@ const (
 	// name.
 	OneDrive6NameInMeta = 6
 
-	// OneDrive7MigrateUserPNToID marks when we migrated repo refs from the user's
+	// All7MigrateUserPNToID marks when we migrated repo refs from the user's
 	// PrincipalName to their ID for stability.
-	OneDrive7MigrateUserPNToID = 7
+	All7MigrateUserPNToID = 7
 
 	// OneDriveXLocationRef provides LocationRef information for Exchange,
 	// OneDrive, and SharePoint libraries.


### PR DESCRIPTION
pre-fetches the prior backups from the manifests and passes down the oldest version into the backup producer as a way to check whether a migration is necessary or not.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #2825

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
