### PR TITLE
Add immutable ID header to Get requests

### DIFF
--- a/src/cmd/getM365/exchange/get_item.go
+++ b/src/cmd/getM365/exchange/get_item.go
@@ -98,11 +98,11 @@ func runDisplayM365JSON(
 
 	switch cat {
 	case path.EmailCategory:
-		bs, err = getItem(ctx, ac.Mail(), user, itemID, errs)
+		bs, err = getItem(ctx, ac.Mail(), user, itemID, true, errs)
 	case path.EventsCategory:
-		bs, err = getItem(ctx, ac.Events(), user, itemID, errs)
+		bs, err = getItem(ctx, ac.Events(), user, itemID, true, errs)
 	case path.ContactsCategory:
-		bs, err = getItem(ctx, ac.Contacts(), user, itemID, errs)
+		bs, err = getItem(ctx, ac.Contacts(), user, itemID, true, errs)
 	default:
 		return fmt.Errorf("unable to process category: %s", cat)
 	}
@@ -132,6 +132,7 @@ type itemer interface {
 	GetItem(
 		ctx context.Context,
 		user, itemID string,
+		immutableID bool,
 		errs *fault.Bus,
 	) (serialization.Parsable, *details.ExchangeInfo, error)
 	Serialize(
@@ -145,9 +146,10 @@ func getItem(
 	ctx context.Context,
 	itm itemer,
 	user, itemID string,
+	immutableIDs bool,
 	errs *fault.Bus,
 ) ([]byte, error) {
-	sp, _, err := itm.GetItem(ctx, user, itemID, errs)
+	sp, _, err := itm.GetItem(ctx, user, itemID, immutableIDs, errs)
 	if err != nil {
 		return nil, clues.Wrap(err, "getting item")
 	}

--- a/src/internal/connector/exchange/api/contacts.go
+++ b/src/internal/connector/exchange/api/contacts.go
@@ -81,7 +81,11 @@ func (c Contacts) GetItem(
 	user, itemID string,
 	_ *fault.Bus, // no attachments to iterate over, so this goes unused
 ) (serialization.Parsable, *details.ExchangeInfo, error) {
-	cont, err := c.Stable.Client().UsersById(user).ContactsById(itemID).Get(ctx, nil)
+	options := &users.ItemContactsContactItemRequestBuilderGetRequestConfiguration{
+		Headers: buildPreferHeaders(false, true),
+	}
+
+	cont, err := c.Stable.Client().UsersById(user).ContactsById(itemID).Get(ctx, options)
 	if err != nil {
 		return nil, nil, graph.Stack(ctx, err)
 	}

--- a/src/internal/connector/exchange/api/contacts.go
+++ b/src/internal/connector/exchange/api/contacts.go
@@ -79,10 +79,11 @@ func (c Contacts) DeleteContainer(
 func (c Contacts) GetItem(
 	ctx context.Context,
 	user, itemID string,
+	immutableIDs bool,
 	_ *fault.Bus, // no attachments to iterate over, so this goes unused
 ) (serialization.Parsable, *details.ExchangeInfo, error) {
 	options := &users.ItemContactsContactItemRequestBuilderGetRequestConfiguration{
-		Headers: buildPreferHeaders(false, true),
+		Headers: buildPreferHeaders(false, immutableIDs),
 	}
 
 	cont, err := c.Stable.Client().UsersById(user).ContactsById(itemID).Get(ctx, options)
@@ -214,6 +215,7 @@ func (p *contactPager) valuesIn(pl api.DeltaPageLinker) ([]getIDAndAddtler, erro
 func (c Contacts) GetAddedAndRemovedItemIDs(
 	ctx context.Context,
 	user, directoryID, oldDelta string,
+	immutableIDs bool,
 ) ([]string, []string, DeltaUpdate, error) {
 	service, err := c.service()
 	if err != nil {
@@ -227,7 +229,9 @@ func (c Contacts) GetAddedAndRemovedItemIDs(
 		"category", selectors.ExchangeContact,
 		"container_id", directoryID)
 
-	options, err := optionsForContactFoldersItemDelta([]string{"parentFolderId"})
+	options, err := optionsForContactFoldersItemDelta(
+		[]string{"parentFolderId"},
+		immutableIDs)
 	if err != nil {
 		return nil,
 			nil,

--- a/src/internal/connector/exchange/api/mail.go
+++ b/src/internal/connector/exchange/api/mail.go
@@ -131,10 +131,11 @@ func (c Mail) GetContainerByID(
 func (c Mail) GetItem(
 	ctx context.Context,
 	user, itemID string,
+	immutableIDs bool,
 	errs *fault.Bus,
 ) (serialization.Parsable, *details.ExchangeInfo, error) {
 	// Will need adjusted if attachments start allowing paging.
-	headers := buildPreferHeaders(false, true)
+	headers := buildPreferHeaders(false, immutableIDs)
 	itemOpts := &users.ItemMessagesMessageItemRequestBuilderGetRequestConfiguration{
 		Headers: headers,
 	}
@@ -312,6 +313,7 @@ func (p *mailPager) valuesIn(pl api.DeltaPageLinker) ([]getIDAndAddtler, error) 
 func (c Mail) GetAddedAndRemovedItemIDs(
 	ctx context.Context,
 	user, directoryID, oldDelta string,
+	immutableIDs bool,
 ) ([]string, []string, DeltaUpdate, error) {
 	service, err := c.service()
 	if err != nil {
@@ -328,7 +330,7 @@ func (c Mail) GetAddedAndRemovedItemIDs(
 		"category", selectors.ExchangeMail,
 		"container_id", directoryID)
 
-	options, err := optionsForFolderMessagesDelta([]string{"isRead"})
+	options, err := optionsForFolderMessagesDelta([]string{"isRead"}, immutableIDs)
 	if err != nil {
 		return nil,
 			nil,

--- a/src/internal/connector/exchange/api/mail.go
+++ b/src/internal/connector/exchange/api/mail.go
@@ -133,7 +133,13 @@ func (c Mail) GetItem(
 	user, itemID string,
 	errs *fault.Bus,
 ) (serialization.Parsable, *details.ExchangeInfo, error) {
-	mail, err := c.Stable.Client().UsersById(user).MessagesById(itemID).Get(ctx, nil)
+	// Will need adjusted if attachments start allowing paging.
+	headers := buildPreferHeaders(false, true)
+	itemOpts := &users.ItemMessagesMessageItemRequestBuilderGetRequestConfiguration{
+		Headers: headers,
+	}
+
+	mail, err := c.Stable.Client().UsersById(user).MessagesById(itemID).Get(ctx, itemOpts)
 	if err != nil {
 		return nil, nil, graph.Stack(ctx, err)
 	}
@@ -146,6 +152,7 @@ func (c Mail) GetItem(
 		QueryParameters: &users.ItemMessagesItemAttachmentsRequestBuilderGetQueryParameters{
 			Expand: []string{"microsoft.graph.itemattachment/item"},
 		},
+		Headers: headers,
 	}
 
 	attached, err := c.LargeItem.
@@ -190,6 +197,7 @@ func (c Mail) GetItem(
 			QueryParameters: &users.ItemMessagesItemAttachmentsAttachmentItemRequestBuilderGetQueryParameters{
 				Expand: []string{"microsoft.graph.itemattachment/item"},
 			},
+			Headers: headers,
 		}
 
 		att, err := c.Stable.

--- a/src/internal/connector/exchange/api/mail_test.go
+++ b/src/internal/connector/exchange/api/mail_test.go
@@ -342,7 +342,7 @@ func (suite *MailAPIE2ESuite) TestHugeAttachmentListDownload() {
 			defer gock.Off()
 			tt.setupf()
 
-			item, _, err := suite.ac.Mail().GetItem(ctx, "user", mid, fault.New(true))
+			item, _, err := suite.ac.Mail().GetItem(ctx, "user", mid, false, fault.New(true))
 			tt.expect(suite.T(), err)
 
 			it, ok := item.(models.Messageable)

--- a/src/internal/connector/exchange/api/options.go
+++ b/src/internal/connector/exchange/api/options.go
@@ -77,6 +77,7 @@ const (
 
 func optionsForFolderMessagesDelta(
 	moreOps []string,
+	immutableIDs bool,
 ) (*users.ItemMailFoldersItemMessagesDeltaRequestBuilderGetRequestConfiguration, error) {
 	selecting, err := buildOptions(moreOps, fieldsForMessages)
 	if err != nil {
@@ -89,7 +90,7 @@ func optionsForFolderMessagesDelta(
 
 	options := &users.ItemMailFoldersItemMessagesDeltaRequestBuilderGetRequestConfiguration{
 		QueryParameters: requestParameters,
-		Headers:         buildPreferHeaders(true, true),
+		Headers:         buildPreferHeaders(true, immutableIDs),
 	}
 
 	return options, nil
@@ -181,6 +182,7 @@ func optionsForMailFoldersItem(
 
 func optionsForContactFoldersItemDelta(
 	moreOps []string,
+	immutableIDs bool,
 ) (*users.ItemContactFoldersItemContactsDeltaRequestBuilderGetRequestConfiguration, error) {
 	selecting, err := buildOptions(moreOps, fieldsForContacts)
 	if err != nil {
@@ -193,7 +195,7 @@ func optionsForContactFoldersItemDelta(
 
 	options := &users.ItemContactFoldersItemContactsDeltaRequestBuilderGetRequestConfiguration{
 		QueryParameters: requestParameters,
-		Headers:         buildPreferHeaders(true, true),
+		Headers:         buildPreferHeaders(true, immutableIDs),
 	}
 
 	return options, nil

--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -45,6 +45,7 @@ type itemer interface {
 	GetItem(
 		ctx context.Context,
 		user, itemID string,
+		immutableIDs bool,
 		errs *fault.Bus,
 	) (serialization.Parsable, *details.ExchangeInfo, error)
 	Serialize(
@@ -256,6 +257,7 @@ func (col *Collection) streamItems(ctx context.Context, errs *fault.Bus) {
 				ctx,
 				user,
 				id,
+				col.ctrl.ToggleFeatures.ExchangeImmutableIDs,
 				fault.New(true)) // temporary way to force a failFast error
 			if err != nil {
 				// Don't report errors for deleted items as there's no way for us to

--- a/src/internal/connector/exchange/exchange_data_collection_test.go
+++ b/src/internal/connector/exchange/exchange_data_collection_test.go
@@ -30,6 +30,7 @@ type mockItemer struct {
 func (mi *mockItemer) GetItem(
 	context.Context,
 	string, string,
+	bool,
 	*fault.Bus,
 ) (serialization.Parsable, *details.ExchangeInfo, error) {
 	mi.getCount++
@@ -228,7 +229,7 @@ func (suite *ExchangeDataCollectionSuite) TestGetItemWithRetries() {
 			defer flush()
 
 			// itemer is mocked, so only the errors are configured atm.
-			_, _, err := test.items.GetItem(ctx, "userID", "itemID", fault.New(true))
+			_, _, err := test.items.GetItem(ctx, "userID", "itemID", false, fault.New(true))
 			test.expectErr(suite.T(), err)
 		})
 	}

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -22,6 +22,7 @@ type addedAndRemovedItemIDsGetter interface {
 	GetAddedAndRemovedItemIDs(
 		ctx context.Context,
 		user, containerID, oldDeltaToken string,
+		immutableIDs bool,
 	) ([]string, []string, api.DeltaUpdate, error)
 }
 
@@ -108,7 +109,12 @@ func filterContainersAndFillCollections(
 
 		ictx = clues.Add(ictx, "previous_path", prevPath)
 
-		added, removed, newDelta, err := getter.GetAddedAndRemovedItemIDs(ictx, qp.ResourceOwner.ID(), cID, prevDelta)
+		added, removed, newDelta, err := getter.GetAddedAndRemovedItemIDs(
+			ictx,
+			qp.ResourceOwner.ID(),
+			cID,
+			prevDelta,
+			ctrlOpts.ToggleFeatures.ExchangeImmutableIDs)
 		if err != nil {
 			if !graph.IsErrDeletedInFlight(err) {
 				el.AddRecoverable(clues.Stack(err).Label(fault.LabelForceNoBackupCreation))

--- a/src/internal/connector/exchange/service_iterators_test.go
+++ b/src/internal/connector/exchange/service_iterators_test.go
@@ -41,6 +41,7 @@ type (
 func (mg mockGetter) GetAddedAndRemovedItemIDs(
 	ctx context.Context,
 	userID, cID, prevDelta string,
+	_ bool,
 ) (
 	[]string,
 	[]string,

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -1080,7 +1080,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchangeIncrementals() {
 
 					switch category {
 					case path.EmailCategory:
-						ids, _, _, err := ac.Mail().GetAddedAndRemovedItemIDs(ctx, suite.user, containerID, "")
+						ids, _, _, err := ac.Mail().GetAddedAndRemovedItemIDs(ctx, suite.user, containerID, "", false)
 						require.NoError(t, err, "getting message ids", clues.ToCore(err))
 						require.NotEmpty(t, ids, "message ids in folder")
 
@@ -1088,7 +1088,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchangeIncrementals() {
 						require.NoError(t, err, "deleting email item", clues.ToCore(err))
 
 					case path.ContactsCategory:
-						ids, _, _, err := ac.Contacts().GetAddedAndRemovedItemIDs(ctx, suite.user, containerID, "")
+						ids, _, _, err := ac.Contacts().GetAddedAndRemovedItemIDs(ctx, suite.user, containerID, "", false)
 						require.NoError(t, err, "getting contact ids", clues.ToCore(err))
 						require.NotEmpty(t, ids, "contact ids in folder")
 
@@ -1096,7 +1096,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchangeIncrementals() {
 						require.NoError(t, err, "deleting contact item", clues.ToCore(err))
 
 					case path.EventsCategory:
-						ids, _, _, err := ac.Events().GetAddedAndRemovedItemIDs(ctx, suite.user, containerID, "")
+						ids, _, _, err := ac.Events().GetAddedAndRemovedItemIDs(ctx, suite.user, containerID, "", false)
 						require.NoError(t, err, "getting event ids", clues.ToCore(err))
 						require.NotEmpty(t, ids, "event ids in folder")
 

--- a/src/pkg/control/options.go
+++ b/src/pkg/control/options.go
@@ -88,4 +88,8 @@ type Toggles struct {
 	// DisableIncrementals prevents backups from using incremental lookups,
 	// forcing a new, complete backup of all data regardless of prior state.
 	DisableIncrementals bool `json:"exchangeIncrementals,omitempty"`
+	// ExchangeImmutableIDs denotes whether Corso should store items with
+	// immutable Exchange IDs. This is only safe to set if the previous backup for
+	// incremental backups used immutable IDs or if a full backup is being done.
+	ExchangeImmutableIDs bool `json:"exchangeImmutableIDs,omitempty"`
 }


### PR DESCRIPTION
This allows using immutable IDs for Exchange objects. It does not add this header to put requests as we don't record the IDs of restored objects anywhere.

May slightly increase performance of events backups as
it now sets the delta query page size to 200 like with
other requests

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #2861

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
