### PR TITLE
configure selector to prefer item name for reduce

### DIFF
--- a/src/cli/backup/backup.go
+++ b/src/cli/backup/backup.go
@@ -190,6 +190,9 @@ func handleDeleteCmd(cmd *cobra.Command, args []string) error {
 // common handlers
 // ---------------------------------------------------------------------------
 
+// standard set of selector behavior that we want used in the cli
+var defaultSelectorConfig = selectors.Config{OnlyMatchItemNames: true}
+
 func runBackups(
 	ctx context.Context,
 	r repository.Repository,
@@ -203,6 +206,8 @@ func runBackups(
 	)
 
 	for _, discSel := range selectorSet {
+		discSel.Configure(defaultSelectorConfig)
+
 		var (
 			owner = discSel.DiscreteOwner
 			ictx  = clues.Add(ctx, "resource_owner", owner)

--- a/src/pkg/selectors/exchange.go
+++ b/src/pkg/selectors/exchange.go
@@ -584,6 +584,7 @@ func (ec exchangeCategory) isLeaf() bool {
 func (ec exchangeCategory) pathValues(
 	repo path.Path,
 	ent details.DetailsEntry,
+	cfg Config,
 ) (map[categorizer][]string, error) {
 	var folderCat, itemCat categorizer
 
@@ -601,9 +602,14 @@ func (ec exchangeCategory) pathValues(
 		return nil, clues.New("bad exchanageCategory").With("category", ec)
 	}
 
+	item := ent.ItemRef
+	if len(item) == 0 {
+		item = repo.Item()
+	}
+
 	result := map[categorizer][]string{
 		folderCat: {repo.Folder(false)},
-		itemCat:   {repo.Item(), ent.ShortRef},
+		itemCat:   {item, ent.ShortRef},
 	}
 
 	if len(ent.LocationRef) > 0 {

--- a/src/pkg/selectors/exchange_test.go
+++ b/src/pkg/selectors/exchange_test.go
@@ -766,7 +766,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeScope_MatchesPath() {
 			scopes := setScopesToDefault(test.scope)
 			var aMatch bool
 			for _, scope := range scopes {
-				pvs, err := ExchangeMail.pathValues(repo, ent)
+				pvs, err := ExchangeMail.pathValues(repo, ent, Config{})
 				require.NoError(t, err)
 
 				if matchesPathValues(scope, ExchangeMail, pvs) {
@@ -1352,7 +1352,7 @@ func (suite *ExchangeSelectorSuite) TestPasses() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			pvs, err := cat.pathValues(repo, ent)
+			pvs, err := cat.pathValues(repo, ent, Config{})
 			require.NoError(t, err)
 
 			result := passes(
@@ -1495,7 +1495,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeCategory_PathValues() {
 				ItemRef:  test.path.Item(),
 			}
 
-			pvs, err := test.cat.pathValues(test.path, ent)
+			pvs, err := test.cat.pathValues(test.path, ent, Config{})
 			require.NoError(t, err)
 			assert.Equal(t, test.expect, pvs)
 		})

--- a/src/pkg/selectors/helpers_test.go
+++ b/src/pkg/selectors/helpers_test.go
@@ -59,6 +59,7 @@ func (mc mockCategorizer) isLeaf() bool {
 func (mc mockCategorizer) pathValues(
 	repo path.Path,
 	ent details.DetailsEntry,
+	cfg Config,
 ) (map[categorizer][]string, error) {
 	return map[categorizer][]string{
 		rootCatStub: {"root"},

--- a/src/pkg/selectors/onedrive.go
+++ b/src/pkg/selectors/onedrive.go
@@ -382,6 +382,7 @@ func (c oneDriveCategory) isLeaf() bool {
 func (c oneDriveCategory) pathValues(
 	repo path.Path,
 	ent details.DetailsEntry,
+	cfg Config,
 ) (map[categorizer][]string, error) {
 	if ent.OneDrive == nil {
 		return nil, clues.New("no OneDrive ItemInfo in details")
@@ -390,9 +391,18 @@ func (c oneDriveCategory) pathValues(
 	// Ignore `drives/<driveID>/root:` for folder comparison
 	rFld := path.Builder{}.Append(repo.Folders()...).PopFront().PopFront().PopFront().String()
 
+	item := ent.ItemRef
+	if len(item) == 0 {
+		item = repo.Item()
+	}
+
+	if cfg.OnlyMatchItemNames {
+		item = ent.ItemInfo.OneDrive.ItemName
+	}
+
 	result := map[categorizer][]string{
 		OneDriveFolder: {rFld},
-		OneDriveItem:   {ent.OneDrive.ItemName, ent.ShortRef},
+		OneDriveItem:   {item, ent.ShortRef},
 	}
 
 	if len(ent.LocationRef) > 0 {

--- a/src/pkg/selectors/onedrive_test.go
+++ b/src/pkg/selectors/onedrive_test.go
@@ -173,6 +173,7 @@ func (suite *OneDriveSelectorSuite) TestOneDriveRestore_Reduce() {
 			Entries: []details.DetailsEntry{
 				{
 					RepoRef: file,
+					ItemRef: "file",
 					ItemInfo: details.ItemInfo{
 						OneDrive: &details.OneDriveInfo{
 							ItemType: details.OneDriveItem,
@@ -182,6 +183,7 @@ func (suite *OneDriveSelectorSuite) TestOneDriveRestore_Reduce() {
 				},
 				{
 					RepoRef: file2,
+					ItemRef: "file2",
 					ItemInfo: details.ItemInfo{
 						OneDrive: &details.OneDriveInfo{
 							ItemType: details.OneDriveItem,
@@ -191,6 +193,7 @@ func (suite *OneDriveSelectorSuite) TestOneDriveRestore_Reduce() {
 				},
 				{
 					RepoRef: file3,
+					// item ref intentionally blank to assert fallback case
 					ItemInfo: details.ItemInfo{
 						OneDrive: &details.OneDriveInfo{
 							ItemType: details.OneDriveItem,

--- a/src/pkg/selectors/onedrive_test.go
+++ b/src/pkg/selectors/onedrive_test.go
@@ -211,36 +211,69 @@ func (suite *OneDriveSelectorSuite) TestOneDriveRestore_Reduce() {
 		deets        *details.Details
 		makeSelector func() *OneDriveRestore
 		expect       []string
+		cfg          Config
 	}{
 		{
-			"all",
-			deets,
-			func() *OneDriveRestore {
+			name:  "all",
+			deets: deets,
+			makeSelector: func() *OneDriveRestore {
 				odr := NewOneDriveRestore(Any())
 				odr.Include(odr.AllData())
 				return odr
 			},
-			arr(file, file2, file3),
+			expect: arr(file, file2, file3),
 		},
 		{
-			"only match file",
-			deets,
-			func() *OneDriveRestore {
+			name:  "only match file",
+			deets: deets,
+			makeSelector: func() *OneDriveRestore {
+				odr := NewOneDriveRestore(Any())
+				odr.Include(odr.Items(Any(), []string{"file2"}))
+				return odr
+			},
+			expect: arr(file2),
+		},
+		{
+			name:  "id doesn't match name",
+			deets: deets,
+			makeSelector: func() *OneDriveRestore {
+				odr := NewOneDriveRestore(Any())
+				odr.Include(odr.Items(Any(), []string{"file2"}))
+				return odr
+			},
+			expect: []string{},
+			cfg:    Config{OnlyMatchItemNames: true},
+		},
+		{
+			name:  "only match file name",
+			deets: deets,
+			makeSelector: func() *OneDriveRestore {
 				odr := NewOneDriveRestore(Any())
 				odr.Include(odr.Items(Any(), []string{"fileName2"}))
 				return odr
 			},
-			arr(file2),
+			expect: arr(file2),
+			cfg:    Config{OnlyMatchItemNames: true},
 		},
 		{
-			"only match folder",
-			deets,
-			func() *OneDriveRestore {
+			name:  "name doesn't match id",
+			deets: deets,
+			makeSelector: func() *OneDriveRestore {
+				odr := NewOneDriveRestore(Any())
+				odr.Include(odr.Items(Any(), []string{"fileName2"}))
+				return odr
+			},
+			expect: []string{},
+		},
+		{
+			name:  "only match folder",
+			deets: deets,
+			makeSelector: func() *OneDriveRestore {
 				odr := NewOneDriveRestore([]string{"uid"})
 				odr.Include(odr.Folders([]string{"folderA/folderB", "folderA/folderC"}))
 				return odr
 			},
-			arr(file, file2),
+			expect: arr(file, file2),
 		},
 	}
 	for _, test := range table {
@@ -251,6 +284,7 @@ func (suite *OneDriveSelectorSuite) TestOneDriveRestore_Reduce() {
 			defer flush()
 
 			sel := test.makeSelector()
+			sel.Configure(test.cfg)
 			results := sel.Reduce(ctx, test.deets, fault.New(true))
 			paths := results.Paths()
 			assert.Equal(t, test.expect, paths)
@@ -269,25 +303,61 @@ func (suite *OneDriveSelectorSuite) TestOneDriveCategory_PathValues() {
 	filePath, err := path.Build("tenant", "user", path.OneDriveService, path.FilesCategory, true, elems...)
 	require.NoError(t, err, clues.ToCore(err))
 
-	expected := map[categorizer][]string{
-		OneDriveFolder: {"dir1/dir2"},
-		OneDriveItem:   {fileName, shortRef},
-	}
-
-	ent := details.DetailsEntry{
-		RepoRef:  filePath.String(),
-		ShortRef: shortRef,
-		ItemRef:  fileID,
-		ItemInfo: details.ItemInfo{
-			OneDrive: &details.OneDriveInfo{
-				ItemName: fileName,
+	table := []struct {
+		name      string
+		pathElems []string
+		expected  map[categorizer][]string
+		cfg       Config
+	}{
+		{
+			name:      "items",
+			pathElems: elems,
+			expected: map[categorizer][]string{
+				OneDriveFolder: {"dir1/dir2"},
+				OneDriveItem:   {fileID, shortRef},
 			},
+			cfg: Config{},
+		},
+		{
+			name:      "items w/ name",
+			pathElems: elems,
+			expected: map[categorizer][]string{
+				OneDriveFolder: {"dir1/dir2"},
+				OneDriveItem:   {fileName, shortRef},
+			},
+			cfg: Config{OnlyMatchItemNames: true},
 		},
 	}
 
-	r, err := OneDriveItem.pathValues(filePath, ent)
-	require.NoError(t, err)
-	assert.Equal(t, expected, r)
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			itemPath, err := path.Build(
+				"tenant",
+				"site",
+				path.OneDriveService,
+				path.FilesCategory,
+				true,
+				test.pathElems...)
+			require.NoError(t, err, clues.ToCore(err))
+
+			ent := details.DetailsEntry{
+				RepoRef:  filePath.String(),
+				ShortRef: shortRef,
+				ItemRef:  fileID,
+				ItemInfo: details.ItemInfo{
+					OneDrive: &details.OneDriveInfo{
+						ItemName: fileName,
+					},
+				},
+			}
+
+			pv, err := OneDriveItem.pathValues(itemPath, ent, test.cfg)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, pv)
+		})
+	}
 }
 
 func (suite *OneDriveSelectorSuite) TestOneDriveScope_MatchesInfo() {

--- a/src/pkg/selectors/scopes.go
+++ b/src/pkg/selectors/scopes.go
@@ -88,7 +88,7 @@ type (
 		//   folderCat: folder,
 		//   itemCat:   itemID,
 		// }
-		pathValues(path.Path, details.DetailsEntry) (map[categorizer][]string, error)
+		pathValues(path.Path, details.DetailsEntry, Config) (map[categorizer][]string, error)
 
 		// pathKeys produces a list of categorizers that can be used as keys in the pathValues
 		// map.  The combination of the two funcs generically interprets the context of the
@@ -353,7 +353,7 @@ func reduce[T scopeT, C categoryT](
 			continue
 		}
 
-		pv, err := dc.pathValues(repoPath, *ent)
+		pv, err := dc.pathValues(repoPath, *ent, s.Cfg)
 		if err != nil {
 			el.AddRecoverable(clues.Wrap(err, "getting path values").WithClues(ictx))
 			continue

--- a/src/pkg/selectors/scopes_test.go
+++ b/src/pkg/selectors/scopes_test.go
@@ -363,7 +363,7 @@ func (suite *SelectorScopesSuite) TestPasses() {
 		}
 	)
 
-	pvs, err := cat.pathValues(pth, entry)
+	pvs, err := cat.pathValues(pth, entry, Config{})
 	require.NoError(suite.T(), err)
 
 	for _, test := range reduceTestTable {

--- a/src/pkg/selectors/selectors.go
+++ b/src/pkg/selectors/selectors.go
@@ -123,6 +123,16 @@ type Selector struct {
 	// A slice of inclusion scopes.  Comparators must match either one of these,
 	// or all filters, to be included.
 	Includes []scope `json:"includes,omitempty"`
+
+	Cfg Config `json:"cfg,omitempty"`
+}
+
+// Config defines broad-scale selector behavior.
+type Config struct {
+	// OnlyMatchItemNames tells the reducer to ignore matching on itemRef values
+	// and other item IDs in favor of matching the item name.  Normal behavior only
+	// matches on itemRefs.
+	OnlyMatchItemNames bool
 }
 
 // helper for specific selector instance constructors.
@@ -139,6 +149,11 @@ func newSelector(s service, resourceOwners []string) Selector {
 		Excludes:       []scope{},
 		Includes:       []scope{},
 	}
+}
+
+// Configure sets the selector configuration.
+func (s *Selector) Configure(cfg Config) {
+	s.Cfg = cfg
 }
 
 // DiscreteResourceOwners returns the list of individual resourceOwners used

--- a/src/pkg/selectors/sharepoint.go
+++ b/src/pkg/selectors/sharepoint.go
@@ -501,10 +501,10 @@ func (c sharePointCategory) isLeaf() bool {
 func (c sharePointCategory) pathValues(
 	repo path.Path,
 	ent details.DetailsEntry,
+	cfg Config,
 ) (map[categorizer][]string, error) {
 	var (
 		folderCat, itemCat    categorizer
-		itemName              = repo.Item()
 		dropDriveFolderPrefix bool
 	)
 
@@ -516,7 +516,6 @@ func (c sharePointCategory) pathValues(
 
 		dropDriveFolderPrefix = true
 		folderCat, itemCat = SharePointLibraryFolder, SharePointLibraryItem
-		itemName = ent.SharePoint.ItemName
 
 	case SharePointList, SharePointListItem:
 		folderCat, itemCat = SharePointList, SharePointListItem
@@ -534,9 +533,18 @@ func (c sharePointCategory) pathValues(
 		rFld = path.Builder{}.Append(repo.Folders()...).PopFront().PopFront().PopFront().String()
 	}
 
+	item := ent.ItemRef
+	if len(item) == 0 {
+		item = repo.Item()
+	}
+
+	if cfg.OnlyMatchItemNames {
+		item = ent.ItemInfo.SharePoint.ItemName
+	}
+
 	result := map[categorizer][]string{
 		folderCat: {rFld},
-		itemCat:   {itemName, ent.ShortRef},
+		itemCat:   {item, ent.ShortRef},
 	}
 
 	if len(ent.LocationRef) > 0 {

--- a/src/pkg/selectors/sharepoint_test.go
+++ b/src/pkg/selectors/sharepoint_test.go
@@ -214,6 +214,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 			Entries: []details.DetailsEntry{
 				{
 					RepoRef: item,
+					ItemRef: "item",
 					ItemInfo: details.ItemInfo{
 						SharePoint: &details.SharePointInfo{
 							ItemType: details.SharePointLibrary,
@@ -223,6 +224,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 				},
 				{
 					RepoRef: item2,
+					// ItemRef intentionally blank to test fallback case
 					ItemInfo: details.ItemInfo{
 						SharePoint: &details.SharePointInfo{
 							ItemType: details.SharePointLibrary,
@@ -232,6 +234,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 				},
 				{
 					RepoRef: item3,
+					ItemRef: "item3",
 					ItemInfo: details.ItemInfo{
 						SharePoint: &details.SharePointInfo{
 							ItemType: details.SharePointLibrary,
@@ -241,6 +244,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 				},
 				{
 					RepoRef: item4,
+					ItemRef: "item4",
 					ItemInfo: details.ItemInfo{
 						SharePoint: &details.SharePointInfo{
 							ItemType: details.SharePointPage,
@@ -250,6 +254,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 				},
 				{
 					RepoRef: item5,
+					// ItemRef intentionally blank to test fallback case
 					ItemInfo: details.ItemInfo{
 						SharePoint: &details.SharePointInfo{
 							ItemType: details.SharePointPage,


### PR DESCRIPTION
add selector configuration, beginning with a toggle that tells pathValues to prefer item names (where available) instead of the item ID.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #3027

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
