### PR TITLE
specify backup version in backup operation

### DIFF
--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -36,9 +36,10 @@ type BackupOperation struct {
 
 	ResourceOwner common.IDNamer
 
-	Results   BackupResults      `json:"results"`
-	Selectors selectors.Selector `json:"selectors"`
-	Version   string             `json:"version"`
+	Results       BackupResults      `json:"results"`
+	Selectors     selectors.Selector `json:"selectors"`
+	Version       string             `json:"version"`
+	BackupVersion int                `json:"backupVersion"`
 
 	account account.Account
 	bp      inject.BackupProducer
@@ -71,6 +72,7 @@ func NewBackupOperation(
 		ResourceOwner: owner,
 		Selectors:     selector,
 		Version:       "v0",
+		BackupVersion: version.Backup,
 		account:       acct,
 		incremental:   useIncrementalBackup(selector, opts),
 		bp:            bp,
@@ -211,6 +213,7 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 		sstore,
 		opStats.k.SnapshotID,
 		op.Results.BackupID,
+		op.BackupVersion,
 		deets.Details())
 	if err != nil {
 		op.Errors.Fail(clues.Wrap(err, "persisting backup"))
@@ -632,7 +635,7 @@ func lastCompleteBackups(
 			result[r.Key()] = bup
 		}
 
-		if bup.Version < oldestVersion {
+		if oldestVersion == -1 || bup.Version < oldestVersion {
 			oldestVersion = bup.Version
 		}
 	}
@@ -809,6 +812,7 @@ func (op *BackupOperation) createBackupModels(
 	sscw streamstore.CollectorWriter,
 	snapID string,
 	backupID model.StableID,
+	backupVersion int,
 	deets *details.Details,
 ) error {
 	ctx = clues.Add(ctx, "snapshot_id", snapID, "backup_id", backupID)
@@ -843,6 +847,7 @@ func (op *BackupOperation) createBackupModels(
 	b := backup.New(
 		snapID, ssid,
 		op.Status.String(),
+		backupVersion,
 		backupID,
 		op.Selectors,
 		op.ResourceOwner.ID(),

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -63,6 +63,7 @@ func prepNewTestBackupOp(
 	bus events.Eventer,
 	sel selectors.Selector,
 	featureToggles control.Toggles,
+	backupVersion int,
 ) (
 	BackupOperation,
 	account.Account,
@@ -657,7 +658,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchange() {
 				ffs = control.Toggles{}
 			)
 
-			bo, acct, kw, ms, gc, closer := prepNewTestBackupOp(t, ctx, mb, sel, ffs)
+			bo, acct, kw, ms, gc, closer := prepNewTestBackupOp(t, ctx, mb, sel, ffs, version.Backup)
 			defer closer()
 
 			m365, err := acct.M365Config()
@@ -879,7 +880,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchangeIncrementals() {
 		sel.ContactFolders(containers, selectors.PrefixMatch()),
 	)
 
-	bo, _, kw, ms, gc, closer := prepNewTestBackupOp(t, ctx, mb, sel.Selector, ffs)
+	bo, _, kw, ms, gc, closer := prepNewTestBackupOp(t, ctx, mb, sel.Selector, ffs, version.Backup)
 	defer closer()
 
 	// run the initial backup
@@ -1166,7 +1167,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDrive() {
 
 	sel.Include(sel.AllData())
 
-	bo, _, _, _, _, closer := prepNewTestBackupOp(t, ctx, mb, sel.Selector, control.Toggles{})
+	bo, _, _, _, _, closer := prepNewTestBackupOp(t, ctx, mb, sel.Selector, control.Toggles{}, version.Backup)
 	defer closer()
 
 	runAndCheckBackup(t, ctx, &bo, mb, false)
@@ -1261,7 +1262,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveIncrementals() {
 	sel := selectors.NewOneDriveBackup(owners)
 	sel.Include(sel.Folders(containers, selectors.PrefixMatch()))
 
-	bo, _, kw, ms, gc, closer := prepNewTestBackupOp(t, ctx, mb, sel.Selector, ffs)
+	bo, _, kw, ms, gc, closer := prepNewTestBackupOp(t, ctx, mb, sel.Selector, ffs, version.Backup)
 	defer closer()
 
 	// run the initial backup
@@ -1615,17 +1616,9 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveOwnerMigration() {
 		ffs  = control.Toggles{}
 		mb   = evmock.NewBus()
 
-		// `now` has to be formatted with SimpleDateTimeOneDrive as
-		// some onedrive cannot have `:` in file/folder names
-		now = common.FormatNow(common.SimpleTimeTesting)
-
-		owners = []string{suite.user}
-
 		categories = map[path.CategoryType][]string{
 			path.FilesCategory: {graph.DeltaURLsFileName, graph.PreviousPathFileName},
 		}
-		container = fmt.Sprintf("%s%d_%s", incrementalsDestContainerPrefix, 1, now)
-		genDests  = []string{container}
 	)
 
 	creds, err := acct.M365Config()
@@ -1639,63 +1632,55 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveOwnerMigration() {
 		fault.New(true))
 	require.NoError(t, err, clues.ToCore(err))
 
-	driveID := mustGetDefaultDriveID(t, ctx, gc.Service, suite.user)
+	userable, err := gc.Discovery.Users().GetByID(ctx, suite.user)
+	require.NoError(t, err, clues.ToCore(err))
 
-	fileDBF := func(id, timeStamp, subject, body string) []byte {
-		return []byte(id + subject)
-	}
+	uid := ptr.Val(userable.GetId())
+	uname := ptr.Val(userable.GetUserPrincipalName())
 
-	// Populate initial test data.
-	for _, destName := range genDests {
-		generateContainerOfItems(
-			t,
-			ctx,
-			gc,
-			path.OneDriveService,
-			acct,
-			path.FilesCategory,
-			selectors.NewOneDriveRestore(owners).Selector,
-			creds.AzureTenantID, suite.user, driveID, destName,
-			2,
-			// Use an old backup version so we don't need metadata files.
-			0,
-			fileDBF)
-	}
+	oldsel := selectors.NewOneDriveBackup([]string{uname})
+	oldsel.Include(oldsel.Folders([]string{"test"}, selectors.ExactMatch()))
 
-	// container3 does not exist yet. It will get created later on
-	// during the tests.
-	containers := []string{container}
-	sel := selectors.NewOneDriveBackup(owners)
-	sel.Include(sel.Folders(containers, selectors.PrefixMatch()))
-
-	bo, _, kw, ms, gc, closer := prepNewTestBackupOp(t, ctx, mb, sel.Selector, ffs)
+	bo, _, kw, ms, gc, closer := prepNewTestBackupOp(t, ctx, mb, oldsel.Selector, ffs, 0)
 	defer closer()
 
 	// ensure the initial owner uses name in both cases
-	sel.SetDiscreteOwnerIDName(suite.user, suite.user)
-	bo.ResourceOwner = sel
+	bo.ResourceOwner = oldsel.SetDiscreteOwnerIDName(uname, uname)
+	// required, otherwise we don't run the migration
+	bo.BackupVersion = version.All7MigrateUserPNToID - 1
 
-	// TODO: ensure this equals the PN
-	require.Equal(t, bo.ResourceOwner.Name(), bo.ResourceOwner.ID(), "historical representation of user")
+	require.Equalf(
+		t,
+		bo.ResourceOwner.Name(),
+		bo.ResourceOwner.ID(),
+		"historical representation of user id [%s] should match pn [%s]",
+		bo.ResourceOwner.ID(),
+		bo.ResourceOwner.Name())
 
 	// run the initial backup
 	runAndCheckBackup(t, ctx, &bo, mb, false)
 
+	newsel := selectors.NewOneDriveBackup([]string{uid})
+	newsel.Include(newsel.Folders([]string{"test"}, selectors.ExactMatch()))
+	sel := newsel.SetDiscreteOwnerIDName(uid, uname)
+
 	var (
 		incMB = evmock.NewBus()
 		// the incremental backup op should have a proper user ID for the id.
-		incBO = newTestBackupOp(t, ctx, kw, ms, gc, acct, sel.Selector, incMB, ffs, closer)
+		incBO = newTestBackupOp(t, ctx, kw, ms, gc, acct, sel, incMB, ffs, closer)
 	)
 
-	require.NotEqual(
+	require.NotEqualf(
 		t,
 		incBO.ResourceOwner.Name(),
 		incBO.ResourceOwner.ID(),
-		"current representation of user: id should differ from PN")
+		"current representation of user: id [%s] should differ from PN [%s]",
+		incBO.ResourceOwner.ID(),
+		incBO.ResourceOwner.Name())
 
 	err = incBO.Run(ctx)
 	require.NoError(t, err, clues.ToCore(err))
-	checkBackupIsInManifests(t, ctx, kw, &incBO, sel.Selector, suite.user, maps.Keys(categories)...)
+	checkBackupIsInManifests(t, ctx, kw, &incBO, sel, uid, maps.Keys(categories)...)
 	checkMetadataFilesExist(
 		t,
 		ctx,
@@ -1703,7 +1688,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveOwnerMigration() {
 		kw,
 		ms,
 		creds.AzureTenantID,
-		suite.user,
+		uid,
 		path.OneDriveService,
 		categories)
 
@@ -1734,7 +1719,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveOwnerMigration() {
 	require.NoError(t, err, clues.ToCore(err))
 
 	for _, ent := range deets.Entries {
-		assert.Contains(t, ent.RepoRef, incBO.ResourceOwner.ID())
+		assert.Contains(t, ent.RepoRef, uid)
 	}
 }
 
@@ -1754,7 +1739,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_sharePoint() {
 
 	sel.Include(testdata.SharePointBackupFolderScope(sel))
 
-	bo, _, kw, _, _, closer := prepNewTestBackupOp(t, ctx, mb, sel.Selector, control.Toggles{})
+	bo, _, kw, _, _, closer := prepNewTestBackupOp(t, ctx, mb, sel.Selector, control.Toggles{}, version.Backup)
 	defer closer()
 
 	runAndCheckBackup(t, ctx, &bo, mb, false)

--- a/src/pkg/backup/backup.go
+++ b/src/pkg/backup/backup.go
@@ -10,7 +10,6 @@ import (
 	"github.com/alcionai/corso/src/internal/common"
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/internal/stats"
-	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/selectors"
 )
@@ -64,6 +63,7 @@ var _ print.Printable = &Backup{}
 
 func New(
 	snapshotID, streamStoreID, status string,
+	version int,
 	id model.StableID,
 	selector selectors.Selector,
 	ownerID, ownerName string,
@@ -113,7 +113,7 @@ func New(
 		ResourceOwnerID:   ownerID,
 		ResourceOwnerName: ownerName,
 
-		Version:       version.Backup,
+		Version:       version,
 		SnapshotID:    snapshotID,
 		StreamStoreID: streamStoreID,
 

--- a/src/pkg/repository/repository_unexported_test.go
+++ b/src/pkg/repository/repository_unexported_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/alcionai/corso/src/internal/stats"
 	"github.com/alcionai/corso/src/internal/streamstore"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -315,6 +316,7 @@ func writeBackup(
 	b := backup.New(
 		snapID, ssid,
 		operations.Completed.String(),
+		version.Backup,
 		model.StableID(backupID),
 		sel,
 		ownerID, ownerName,


### PR DESCRIPTION
In order to test version-based changes at the operation level, we need to control what version is persisted in the backup.  This has some edge cases, for instance: setting the backup version doesn't actually force behavior to comply with that version's behavior.  It only writes that version to the backup model.  For that reason, new backup models default to the current version, and must be manually overwritten if a test needs a different variation.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix
- [x] :robot: Supportability/Tests

#### Issue(s)

* #2825

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
