### PR TITLE
allow dir movements without locations

### DIFF
--- a/src/internal/connector/graph/collections_test.go
+++ b/src/internal/connector/graph/collections_test.go
@@ -1,0 +1,100 @@
+package graph
+
+import (
+	"testing"
+
+	"github.com/alcionai/clues"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/path"
+)
+
+type CollectionsUnitSuite struct {
+	tester.Suite
+}
+
+func TestCollectionsUnitSuite(t *testing.T) {
+	suite.Run(t, &CollectionsUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *CollectionsUnitSuite) TestNewPrefixCollection() {
+	t := suite.T()
+	serv := path.OneDriveService
+	cat := path.FilesCategory
+
+	p1, err := path.ServicePrefix("t", "ro1", serv, cat)
+	require.NoError(t, err, clues.ToCore(err))
+
+	p2, err := path.ServicePrefix("t", "ro2", serv, cat)
+	require.NoError(t, err, clues.ToCore(err))
+
+	items, err := path.Build("t", "ro", serv, cat, true, "fld", "itm")
+	require.NoError(t, err, clues.ToCore(err))
+
+	folders, err := path.Build("t", "ro", serv, cat, false, "fld")
+	require.NoError(t, err, clues.ToCore(err))
+
+	table := []struct {
+		name      string
+		prev      path.Path
+		full      path.Path
+		expectErr require.ErrorAssertionFunc
+	}{
+		{
+			name:      "not moved",
+			prev:      p1,
+			full:      p1,
+			expectErr: require.NoError,
+		},
+		{
+			name:      "moved",
+			prev:      p1,
+			full:      p2,
+			expectErr: require.NoError,
+		},
+		{
+			name:      "deleted",
+			prev:      p1,
+			full:      nil,
+			expectErr: require.Error,
+		},
+		{
+			name:      "new",
+			prev:      nil,
+			full:      p2,
+			expectErr: require.Error,
+		},
+		{
+			name:      "prev has items",
+			prev:      items,
+			full:      p1,
+			expectErr: require.Error,
+		},
+		{
+			name:      "prev has folders",
+			prev:      folders,
+			full:      p1,
+			expectErr: require.Error,
+		},
+		{
+			name:      "full has items",
+			prev:      p1,
+			full:      items,
+			expectErr: require.Error,
+		},
+		{
+			name:      "full has folders",
+			prev:      p1,
+			full:      folders,
+			expectErr: require.Error,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			_, err := NewPrefixCollection(test.prev, test.full, nil)
+			test.expectErr(suite.T(), err, clues.ToCore(err))
+		})
+	}
+}

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -322,17 +322,21 @@ func (oc Collection) PreviousLocationPath() details.LocationIDer {
 		return nil
 	}
 
+	var ider details.LocationIDer
+
 	switch oc.source {
 	case OneDriveSource:
-		return details.NewOneDriveLocationIDer(
+		ider = details.NewOneDriveLocationIDer(
 			oc.driveID,
 			oc.prevLocPath.Elements()...)
 
 	default:
-		return details.NewSharePointLocationIDer(
+		ider = details.NewSharePointLocationIDer(
 			oc.driveID,
 			oc.prevLocPath.Elements()...)
 	}
+
+	return ider
 }
 
 func (oc Collection) State() data.CollectionState {

--- a/src/internal/connector/onedrive/data_collections.go
+++ b/src/internal/connector/onedrive/data_collections.go
@@ -165,16 +165,7 @@ func migrationCollections(
 		return nil, clues.Wrap(err, "creating user name migration path")
 	}
 
-	mgn, err := NewCollectionPrefix(
-		nil,
-		mc, mpc,
-		"",
-		svc,
-		su,
-		OneDriveSource,
-		ctrlOpts,
-		CollectionScopeUnknown,
-		false)
+	mgn, err := graph.NewPrefixCollection(mpc, mc, su)
 	if err != nil {
 		return nil, clues.Wrap(err, "creating migration collection")
 	}

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -1712,7 +1712,10 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveOwnerMigration() {
 	require.NoError(t, err, clues.ToCore(err))
 
 	for _, ent := range deets.Entries {
-		assert.Contains(t, ent.RepoRef, uid)
+		// 46 is the tenant uuid + "onedrive" + two slashes
+		if len(ent.RepoRef) > 46 {
+			assert.Contains(t, ent.RepoRef, uid)
+		}
 	}
 }
 

--- a/src/pkg/backup/details/mock/location_ider.go
+++ b/src/pkg/backup/details/mock/location_ider.go
@@ -1,0 +1,16 @@
+package mock
+
+import "github.com/alcionai/corso/src/pkg/path"
+
+type LocationIDer struct {
+	Unique  *path.Builder
+	Details *path.Builder
+}
+
+func (li LocationIDer) ID() *path.Builder {
+	return li.Unique
+}
+
+func (li LocationIDer) InDetails() *path.Builder {
+	return li.Details
+}


### PR DESCRIPTION
Allow for a corner case where a directory movement has no location refs in either the previous or current path.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix
- [x] :robot: Supportability/Tests

#### Issue(s)

* #2825

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
