### PR TITLE
clean metadata suffix from itemRef

### DIFF
--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -317,6 +317,7 @@ func runDetailsExchangeCmd(
 
 	if !skipReduce {
 		sel := utils.IncludeExchangeRestoreDataSelectors(opts)
+		sel.Configure(selectors.Config{OnlyMatchItemNames: true})
 		utils.FilterExchangeRestoreInfoSelectors(sel, opts)
 		d = sel.Reduce(ctx, d, errs)
 	}

--- a/src/cli/backup/onedrive.go
+++ b/src/cli/backup/onedrive.go
@@ -278,6 +278,7 @@ func runDetailsOneDriveCmd(
 
 	if !skipReduce {
 		sel := utils.IncludeOneDriveRestoreDataSelectors(opts)
+		sel.Configure(selectors.Config{OnlyMatchItemNames: true})
 		utils.FilterOneDriveRestoreInfoSelectors(sel, opts)
 		d = sel.Reduce(ctx, d, errs)
 	}

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -362,6 +362,7 @@ func runDetailsSharePointCmd(
 
 	if !skipReduce {
 		sel := utils.IncludeSharePointRestoreDataSelectors(ctx, opts)
+		sel.Configure(selectors.Config{OnlyMatchItemNames: true})
 		utils.FilterSharePointRestoreInfoSelectors(sel, opts)
 		d = sel.Reduce(ctx, d, errs)
 	}

--- a/src/cli/utils/testdata/opts.go
+++ b/src/cli/utils/testdata/opts.go
@@ -2,14 +2,12 @@ package testdata
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/alcionai/clues"
 
 	"github.com/alcionai/corso/src/cli/utils"
 	"github.com/alcionai/corso/src/internal/common"
-	"github.com/alcionai/corso/src/internal/connector/onedrive/metadata"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/backup/details/testdata"
@@ -201,10 +199,10 @@ var (
 			},
 		},
 		{
-			Name:     "MailID",
+			Name:     "MailItemRef",
 			Expected: []details.DetailsEntry{testdata.ExchangeEmailItems[0]},
 			Opts: utils.ExchangeOpts{
-				Email: []string{testdata.ExchangeEmailItemPath1.Item()},
+				Email: []string{testdata.ExchangeEmailItems[0].ItemRef},
 			},
 		},
 		{
@@ -413,13 +411,11 @@ var (
 			},
 		},
 		{
-			Name: "SelectRepoItemName",
-			Expected: []details.DetailsEntry{
-				testdata.OneDriveItems[0],
-			},
+			Name:     "ItemRefMatchesNothing",
+			Expected: []details.DetailsEntry{},
 			Opts: utils.OneDriveOpts{
 				FileName: []string{
-					strings.TrimSuffix(testdata.OneDriveItemPath1.Item(), metadata.DataFileSuffix),
+					testdata.OneDriveItems[0].ItemRef,
 				},
 			},
 		},
@@ -534,13 +530,11 @@ var (
 			},
 		},
 		{
-			Name: "SelectRepoItemName",
-			Expected: []details.DetailsEntry{
-				testdata.SharePointLibraryItems[0],
-			},
+			Name:     "ItemRefMatchesNothing",
+			Expected: []details.DetailsEntry{},
 			Opts: utils.SharePointOpts{
 				FileName: []string{
-					strings.TrimSuffix(testdata.SharePointLibraryItemPath1.Item(), metadata.DataFileSuffix),
+					testdata.SharePointLibraryItems[0].ItemRef,
 				},
 			},
 		},

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 
 	"github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/connector/onedrive/metadata"
 	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/path"
 )
@@ -419,6 +421,9 @@ func (d *Details) add(
 		elements := repoRef.Elements()
 		elements = append(elements[:len(elements)-1], filename, repoRef.Item())
 		entry.ShortRef = path.Builder{}.Append(elements...).ShortRef()
+
+		// clean metadata suffixes from item refs
+		entry.ItemRef = withoutMetadataSuffix(entry.ItemRef)
 	}
 
 	d.Entries = append(d.Entries, entry)
@@ -436,6 +441,16 @@ func UnmarshalTo(d *Details) func(io.ReadCloser) error {
 	return func(rc io.ReadCloser) error {
 		return json.NewDecoder(rc).Decode(d)
 	}
+}
+
+// remove metadata file suffixes from the string.
+// assumes only one suffix is applied to any given id.
+func withoutMetadataSuffix(id string) string {
+	id = strings.TrimSuffix(id, metadata.DirMetaFileSuffix)
+	id = strings.TrimSuffix(id, metadata.MetaFileSuffix)
+	id = strings.TrimSuffix(id, metadata.DataFileSuffix)
+
+	return id
 }
 
 // --------------------------------------------------------------------------------

--- a/src/pkg/backup/details/details_test.go
+++ b/src/pkg/backup/details/details_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/connector/onedrive/metadata"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -193,6 +195,7 @@ func exchangeEntry(t *testing.T, id string, size int, it ItemType) DetailsEntry 
 		ShortRef:    rr.ShortRef(),
 		ParentRef:   rr.ToBuilder().Dir().ShortRef(),
 		LocationRef: rr.Folder(true),
+		ItemRef:     rr.Item(),
 		ItemInfo: ItemInfo{
 			Exchange: &ExchangeInfo{
 				ItemType: it,
@@ -254,11 +257,14 @@ func oneDriveishEntry(t *testing.T, id string, size int, it ItemType) DetailsEnt
 		ShortRef:    rr.ShortRef(),
 		ParentRef:   rr.ToBuilder().Dir().ShortRef(),
 		LocationRef: loc.String(),
+		ItemRef:     rr.Item(),
 		ItemInfo:    info,
 	}
 }
 
 func (suite *DetailsUnitSuite) TestDetailsAdd_NoLocationFolders() {
+	itemID := "foo"
+
 	t := suite.T()
 	table := []struct {
 		name  string
@@ -272,23 +278,23 @@ func (suite *DetailsUnitSuite) TestDetailsAdd_NoLocationFolders() {
 	}{
 		{
 			name:          "Exchange Email",
-			entry:         exchangeEntry(t, "foo", 42, ExchangeMail),
+			entry:         exchangeEntry(t, itemID, 42, ExchangeMail),
 			shortRefEqual: assert.Equal,
 		},
 		{
 			name:          "OneDrive File",
-			entry:         oneDriveishEntry(t, "foo", 42, OneDriveItem),
+			entry:         oneDriveishEntry(t, itemID, 42, OneDriveItem),
 			shortRefEqual: assert.NotEqual,
 		},
 		{
 			name:          "SharePoint File",
-			entry:         oneDriveishEntry(t, "foo", 42, SharePointLibrary),
+			entry:         oneDriveishEntry(t, itemID, 42, SharePointLibrary),
 			shortRefEqual: assert.NotEqual,
 		},
 		{
 			name: "Legacy SharePoint File",
 			entry: func() DetailsEntry {
-				res := oneDriveishEntry(t, "foo", 42, SharePointLibrary)
+				res := oneDriveishEntry(t, itemID, 42, SharePointLibrary)
 				res.SharePoint.ItemType = OneDriveItem
 
 				return res
@@ -930,7 +936,7 @@ func (suite *DetailsUnitSuite) TestDetailsModel_FilterMetaFiles() {
 	assert.Len(t, d.Entries, 3)
 }
 
-func (suite *DetailsUnitSuite) TestDetails_Add_ShortRefs_Unique_From_Folder() {
+func (suite *DetailsUnitSuite) TestBuilder_Add_shortRefsUniqueFromFolder() {
 	t := suite.T()
 
 	b := Builder{}
@@ -977,7 +983,7 @@ func (suite *DetailsUnitSuite) TestDetails_Add_ShortRefs_Unique_From_Folder() {
 		&path.Builder{},
 		false,
 		info)
-	require.NoError(t, err)
+	require.NoError(t, err, clues.ToCore(err))
 
 	items := b.Details().Items()
 	require.Len(t, items, 1)
@@ -985,6 +991,45 @@ func (suite *DetailsUnitSuite) TestDetails_Add_ShortRefs_Unique_From_Folder() {
 	// If the ShortRefs match then it means it's possible for the user to
 	// construct folder names such that they'll generate a ShortRef collision.
 	assert.NotEqual(t, otherItemPath.ShortRef(), items[0].ShortRef, "same ShortRef as subfolder item")
+}
+
+func (suite *DetailsUnitSuite) TestBuilder_Add_cleansFileIDSuffixes() {
+	var (
+		t    = suite.T()
+		b    = Builder{}
+		svc  = path.OneDriveService
+		cat  = path.FilesCategory
+		info = ItemInfo{
+			OneDrive: &OneDriveInfo{
+				ItemType:  OneDriveItem,
+				ItemName:  "in",
+				DriveName: "dn",
+				DriveID:   "d",
+			},
+		}
+
+		dataSfx    = makeItemPath(t, svc, cat, "t", "u", []string{"d", "r:", "f", "i1" + metadata.DataFileSuffix})
+		dirMetaSfx = makeItemPath(t, svc, cat, "t", "u", []string{"d", "r:", "f", "i1" + metadata.DirMetaFileSuffix})
+		metaSfx    = makeItemPath(t, svc, cat, "t", "u", []string{"d", "r:", "f", "i1" + metadata.MetaFileSuffix})
+	)
+
+	// Don't need to generate folders for this entry, we just want the itemRef
+	loc := &path.Builder{}
+
+	err := b.Add(dataSfx, loc, false, info)
+	require.NoError(t, err, clues.ToCore(err))
+
+	err = b.Add(dirMetaSfx, loc, false, info)
+	require.NoError(t, err, clues.ToCore(err))
+
+	err = b.Add(metaSfx, loc, false, info)
+	require.NoError(t, err, clues.ToCore(err))
+
+	for _, ent := range b.Details().Items() {
+		assert.False(t, strings.HasSuffix(ent.ItemRef, metadata.DirMetaFileSuffix))
+		assert.False(t, strings.HasSuffix(ent.ItemRef, metadata.MetaFileSuffix))
+		assert.False(t, strings.HasSuffix(ent.ItemRef, metadata.DataFileSuffix))
+	}
 }
 
 func makeItemPath(


### PR DESCRIPTION
Ensures that all added details entries have the metadata suffix removed from the itemRef, for any service that applies a metadata suffix to the items.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #3027

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
