### PR TITLE
Handle SyncStateInvalid error when ImmutableIDs are enabled after initial backup

### DIFF
--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -88,6 +88,7 @@ func addExchangeCommands(cmd *cobra.Command) *cobra.Command {
 		options.AddFetchParallelismFlag(c)
 		options.AddFailFastFlag(c)
 		options.AddDisableIncrementalsFlag(c)
+		options.AddEnableImmutableIDFlag(c)
 
 	case listCommand:
 		c, fs = utils.AddCommand(cmd, exchangeListCmd())

--- a/src/cli/options/options.go
+++ b/src/cli/options/options.go
@@ -18,6 +18,7 @@ func Control() control.Options {
 	opt.RestorePermissions = restorePermissionsFV
 	opt.SkipReduce = skipReduceFV
 	opt.ToggleFeatures.DisableIncrementals = disableIncrementalsFV
+	opt.ToggleFeatures.ExchangeImmutableIDs = enableImmutableID
 	opt.ItemFetchParallelism = fetchParallelismFV
 
 	return opt
@@ -34,6 +35,7 @@ const (
 	RestorePermissionsFN  = "restore-permissions"
 	SkipReduceFN          = "skip-reduce"
 	DisableIncrementalsFN = "disable-incrementals"
+	EnableImmutableIDFN   = "enable-immutable-id"
 )
 
 var (
@@ -100,4 +102,18 @@ func AddDisableIncrementalsFlag(cmd *cobra.Command) {
 		false,
 		"Disable incremental data retrieval in backups.")
 	cobra.CheckErr(fs.MarkHidden(DisableIncrementalsFN))
+}
+
+var enableImmutableID bool
+
+// Adds the hidden '--enable-immutable-id' cli flag which, when set, enables
+// immutable IDs for Exchange
+func AddEnableImmutableIDFlag(cmd *cobra.Command) {
+	fs := cmd.Flags()
+	fs.BoolVar(
+		&enableImmutableID,
+		EnableImmutableIDFN,
+		false,
+		"Enable exchange immutable ID.")
+	cobra.CheckErr(fs.MarkHidden(EnableImmutableIDFN))
 }

--- a/src/internal/connector/graph/errors.go
+++ b/src/internal/connector/graph/errors.go
@@ -34,6 +34,7 @@ const (
 	errCodeMalwareDetected             = "malwareDetected"
 	errCodeSyncFolderNotFound          = "ErrorSyncFolderNotFound"
 	errCodeSyncStateNotFound           = "SyncStateNotFound"
+	errCodeSyncStateInvalid            = "SyncStateInvalid"
 	errCodeResourceNotFound            = "ResourceNotFound"
 	errCodeRequestResourceNotFound     = "Request_ResourceNotFound"
 	errCodeMailboxNotEnabledForRESTAPI = "MailboxNotEnabledForRESTAPI"
@@ -93,7 +94,7 @@ func IsErrDeletedInFlight(err error) bool {
 }
 
 func IsErrInvalidDelta(err error) bool {
-	return hasErrorCode(err, errCodeSyncStateNotFound, errCodeResyncRequired) ||
+	return hasErrorCode(err, errCodeSyncStateNotFound, errCodeResyncRequired, errCodeSyncStateInvalid) ||
 		errors.Is(err, ErrInvalidDelta)
 }
 

--- a/src/internal/connector/graph/errors_test.go
+++ b/src/internal/connector/graph/errors_test.go
@@ -137,6 +137,11 @@ func (suite *GraphErrorsUnitSuite) TestIsErrInvalidDelta() {
 			err:    odErr(errCodeResyncRequired),
 			expect: assert.True,
 		},
+		{
+			name:   "sync state invalid oDataErr",
+			err:    odErr(errCodeSyncStateInvalid),
+			expect: assert.True,
+		},
 		// next two tests are to make sure the checks are case insensitive
 		{
 			name:   "resync-required oDataErr camelcase",


### PR DESCRIPTION
Handles the `SyncStateInvalid` error if a delta URL constructed without the immutable ID header is used.

This will fallback to full backup similar to how we handle other sync errors for delta queries.

Also adds a hidden flag so we can test this using the CLI.

*Note*: Enabling immutable IDs for exchange is not yet supported

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
