### PR TITLE
Rework itemPager interfaces to handle delta and non-delta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ParentPath of json output for Exchange calendar now shows names instead of IDs.
 - Fixed failure when downloading huge amount of attachments
 - Graph API requests that return an ECONNRESET error are now retried.
+- Fix fetching of items when users exchange is full
 
 ### Known Issues
 - Restoring a OneDrive or SharePoint file with the same name as a file with that name as its M365 ID may restore both items.

--- a/src/internal/connector/exchange/api/contacts.go
+++ b/src/internal/connector/exchange/api/contacts.go
@@ -207,7 +207,6 @@ type contactPager struct {
 func NewContactPager(
 	gs graph.Servicer,
 	user, directoryID, deltaURL string,
-	nonDelta bool,
 	immutableIDs bool,
 ) (contactPager, error) {
 	options, err := optionsForContactFoldersItem([]string{"parentFolderId"}, immutableIDs)
@@ -229,7 +228,7 @@ func NewContactPager(
 		gs:          gs,
 		user:        user,
 		directoryID: directoryID,
-		nonDelta:    nonDelta,
+		nonDelta:    false,
 
 		// for non-delta based pagination
 		builder: gs.Client().UsersById(user).ContactFoldersById(directoryID).Contacts(),
@@ -319,7 +318,7 @@ func (c Contacts) GetAddedAndRemovedItemIDs(
 		"category", selectors.ExchangeContact,
 		"container_id", directoryID)
 
-	pgr, err := NewContactPager(service, user, directoryID, oldDelta, false, immutableIDs)
+	pgr, err := NewContactPager(service, user, directoryID, oldDelta, immutableIDs)
 	if err != nil {
 		return nil, nil, DeltaUpdate{}, err
 	}

--- a/src/internal/connector/exchange/api/contacts.go
+++ b/src/internal/connector/exchange/api/contacts.go
@@ -295,10 +295,6 @@ func (p *contactPager) getNextPage(ctx context.Context) ([]getIDAndAddtler, bool
 	return p.getNextPageDelta(ctx)
 }
 
-func (p *contactPager) valuesIn(pl api.DeltaPageLinker) ([]getIDAndAddtler, error) {
-	return toValues[models.Messageable](pl)
-}
-
 func (p *contactPager) reset(nonDelta bool) {
 	if nonDelta {
 		p.nonDelta = true

--- a/src/internal/connector/exchange/api/contacts.go
+++ b/src/internal/connector/exchange/api/contacts.go
@@ -323,7 +323,6 @@ func (c Contacts) GetAddedAndRemovedItemIDs(
 		"category", selectors.ExchangeContact,
 		"container_id", directoryID)
 
-	// TODO(meain): Check if exchange if full here and start with non-delta if possible
 	pgr, err := NewContactPager(service, user, directoryID, oldDelta, false, immutableIDs)
 	if err != nil {
 		return nil, nil, DeltaUpdate{}, err

--- a/src/internal/connector/exchange/api/contacts_test.go
+++ b/src/internal/connector/exchange/api/contacts_test.go
@@ -1,14 +1,21 @@
-package api
+package api_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/h2non/gock"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/clues"
+	"github.com/alcionai/corso/src/internal/connector/exchange/api"
+	"github.com/alcionai/corso/src/internal/connector/exchange/api/mock"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 )
 
@@ -62,7 +69,121 @@ func (suite *ContactsAPIUnitSuite) TestContactInfo() {
 	for _, test := range tests {
 		suite.Run(test.name, func() {
 			contact, expected := test.contactAndRP()
-			assert.Equal(suite.T(), expected, ContactInfo(contact))
+			assert.Equal(suite.T(), expected, api.ContactInfo(contact))
+		})
+	}
+}
+
+type ContactAPIE2ESuite struct {
+	tester.Suite
+	credentials account.M365Config
+	ac          api.Client
+	user        string
+}
+
+// We do end up mocking the actual request, but creating the rest
+// similar to E2E suite
+func TestContactAPIE2ESuite(t *testing.T) {
+	suite.Run(t, &ContactAPIE2ESuite{
+		Suite: tester.NewIntegrationSuite(
+			t,
+			[][]string{tester.M365AcctCredEnvs},
+		),
+	})
+}
+
+func (suite *ContactAPIE2ESuite) SetupSuite() {
+	t := suite.T()
+
+	a := tester.NewM365Account(t)
+	m365, err := a.M365Config()
+	require.NoError(t, err, clues.ToCore(err))
+
+	suite.credentials = m365
+	suite.ac, err = mock.NewClient(m365)
+	require.NoError(t, err, clues.ToCore(err))
+
+	suite.user = tester.M365UserID(suite.T())
+}
+
+func (suite *ContactAPIE2ESuite) TestPaginationErrorConditions() {
+	did := "directory-id"
+
+	type errResp struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+
+	tests := []struct {
+		name      string
+		prevDelta bool
+		setupf    func()
+	}{
+		{
+			name: "direct error on dleta",
+			setupf: func() {
+				gock.New("https://graph.microsoft.com").
+					Get("/v1.0/users/" + suite.user + "/contactFolders/" + did + "/contacts/microsoft.graph.delta..$").
+					Reply(404)
+			},
+		},
+		{
+			name:      "delta reset",
+			prevDelta: true,
+			setupf: func() {
+				gock.New("https://graph.microsoft.com").
+					Get("/fakedelta").
+					Reply(403).
+					JSON(map[string]errResp{"error": {Code: "SyncStateNotFound", Message: "..."}})
+
+				gock.New("https://graph.microsoft.com").
+					Get("/v1.0/users/" + suite.user + "/contactFolders/" + did + "/contacts/microsoft.graph.delta..$").
+					Reply(404)
+			},
+		},
+		{
+			name:      "box full",
+			prevDelta: true,
+			setupf: func() {
+				gock.New("https://graph.microsoft.com").
+					Get("/fakedelta").
+					Reply(403).
+					JSON(map[string]errResp{
+						"error": {
+							Code:    "ErrorQuotaExceeded",
+							Message: "The process failed to get the correct properties.",
+						},
+					})
+
+				gock.New("https://graph.microsoft.com").
+					Get("/v1.0/users/" + suite.user + "/contactFolders/" + did + "/contacts$").
+					Reply(404)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			ctx, flush := tester.NewContext()
+			defer flush()
+
+			defer gock.Off()
+			tt.setupf()
+
+			delta := ""
+			if tt.prevDelta {
+				delta = "https://graph.microsoft.com/fakedelta"
+			}
+
+			pgr, err := api.NewContactPager(suite.ac.Stable, suite.user, did, delta, false, false)
+			require.NoError(suite.T(), err, "create pager")
+
+			_, _, _, err = api.GetAddedAndRemovedItemIDsFromPager(ctx, delta, &pgr)
+			fmt.Println("shared_test.go:118 err:", err)
+
+			// just a unique enough check
+			assert.True(suite.T(), err.Error() == "The server returned an unexpected status code with no response body: 404", "get 404")
+			assert.True(suite.T(), gock.IsDone(), "all mocks used")
 		})
 	}
 }

--- a/src/internal/connector/exchange/api/contacts_test.go
+++ b/src/internal/connector/exchange/api/contacts_test.go
@@ -174,7 +174,7 @@ func (suite *ContactAPIE2ESuite) TestPaginationErrorConditions() {
 				delta = "https://graph.microsoft.com/fakedelta"
 			}
 
-			pgr, err := api.NewContactPager(suite.ac.Stable, suite.user, did, delta, false, false)
+			pgr, err := api.NewContactPager(suite.ac.Stable, suite.user, did, delta, false)
 			require.NoError(suite.T(), err, "create pager")
 
 			_, _, _, err = api.GetAddedAndRemovedItemIDsFromPager(ctx, delta, &pgr)

--- a/src/internal/connector/exchange/api/contacts_test.go
+++ b/src/internal/connector/exchange/api/contacts_test.go
@@ -1,17 +1,16 @@
 package api_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
+	"github.com/alcionai/clues"
 	"github.com/h2non/gock"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/alcionai/clues"
 	"github.com/alcionai/corso/src/internal/connector/exchange/api"
 	"github.com/alcionai/corso/src/internal/connector/exchange/api/mock"
 	"github.com/alcionai/corso/src/internal/tester"
@@ -179,10 +178,13 @@ func (suite *ContactAPIE2ESuite) TestPaginationErrorConditions() {
 			require.NoError(suite.T(), err, "create pager")
 
 			_, _, _, err = api.GetAddedAndRemovedItemIDsFromPager(ctx, delta, &pgr)
-			fmt.Println("shared_test.go:118 err:", err)
 
 			// just a unique enough check
-			assert.True(suite.T(), err.Error() == "The server returned an unexpected status code with no response body: 404", "get 404")
+			assert.True(
+				suite.T(),
+				err.Error() == "The server returned an unexpected status code with no response body: 404",
+				"get 404",
+			)
 			assert.True(suite.T(), gock.IsDone(), "all mocks used")
 		})
 	}

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -259,7 +259,6 @@ func getEventDeltaBuilder(
 func NewEventPager(
 	gs graph.Servicer,
 	user, calendarID, deltaURL string,
-	nonDelta bool,
 	immutableIDs bool,
 ) (eventPager, error) {
 	var deltaBuilder *users.ItemCalendarsItemEventsDeltaRequestBuilder
@@ -273,7 +272,7 @@ func NewEventPager(
 		gs:         gs,
 		user:       user,
 		calendarID: calendarID,
-		nonDelta:   nonDelta,
+		nonDelta:   false,
 
 		// for non-delta based pagination
 		builder: gs.Client().UsersById(user).CalendarsById(calendarID).Events(),
@@ -366,7 +365,7 @@ func (c Events) GetAddedAndRemovedItemIDs(
 		ctx,
 		"container_id", calendarID)
 
-	pgr, err := NewEventPager(service, user, calendarID, oldDelta, false, immutableIDs)
+	pgr, err := NewEventPager(service, user, calendarID, oldDelta, immutableIDs)
 	if err != nil {
 		return nil, nil, DeltaUpdate{}, err
 	}

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -343,10 +343,6 @@ func (p *eventPager) getNextPage(ctx context.Context) ([]getIDAndAddtler, bool, 
 	return p.getNextPageDelta(ctx)
 }
 
-func (p *eventPager) valuesIn(pl api.DeltaPageLinker) ([]getIDAndAddtler, error) {
-	return toValues[models.Messageable](pl)
-}
-
 func (p *eventPager) reset(nonDelta bool) {
 	if nonDelta {
 		p.nonDelta = true

--- a/src/internal/connector/exchange/api/events_test.go
+++ b/src/internal/connector/exchange/api/events_test.go
@@ -1,7 +1,6 @@
 package api_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -287,10 +286,13 @@ func (suite *EventAPIE2ESuite) TestPaginationErrorConditions() {
 			require.NoError(suite.T(), err, "create pager")
 
 			_, _, _, err = api.GetAddedAndRemovedItemIDsFromPager(ctx, delta, &pgr)
-			fmt.Println("shared_test.go:118 err:", err)
 
 			// just a unique enough check
-			assert.True(suite.T(), err.Error() == "The server returned an unexpected status code with no response body: 404", "get 404")
+			assert.True(
+				suite.T(),
+				err.Error() == "The server returned an unexpected status code with no response body: 404",
+				"get 404",
+			)
 			assert.True(suite.T(), gock.IsDone(), "all mocks used")
 		})
 	}

--- a/src/internal/connector/exchange/api/events_test.go
+++ b/src/internal/connector/exchange/api/events_test.go
@@ -282,7 +282,7 @@ func (suite *EventAPIE2ESuite) TestPaginationErrorConditions() {
 				delta = "https://graph.microsoft.com/fakedelta"
 			}
 
-			pgr, err := api.NewEventPager(suite.ac.Stable, suite.user, did, delta, false, false)
+			pgr, err := api.NewEventPager(suite.ac.Stable, suite.user, did, delta, false)
 			require.NoError(suite.T(), err, "create pager")
 
 			_, _, _, err = api.GetAddedAndRemovedItemIDsFromPager(ctx, delta, &pgr)

--- a/src/internal/connector/exchange/api/events_test.go
+++ b/src/internal/connector/exchange/api/events_test.go
@@ -1,19 +1,24 @@
-package api
+package api_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/alcionai/clues"
+	"github.com/h2non/gock"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/connector/exchange/api"
+	"github.com/alcionai/corso/src/internal/connector/exchange/api/mock"
 	exchMock "github.com/alcionai/corso/src/internal/connector/exchange/mock"
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 )
 
@@ -147,7 +152,7 @@ func (suite *EventsAPIUnitSuite) TestEventInfo() {
 			t := suite.T()
 
 			event, expected := test.evtAndRP()
-			result := EventInfo(event)
+			result := api.EventInfo(event)
 
 			assert.Equal(t, expected.Subject, result.Subject, "subject")
 			assert.Equal(t, expected.Sender, result.Sender, "sender")
@@ -173,6 +178,120 @@ func (suite *EventsAPIUnitSuite) TestEventInfo() {
 			assert.Equal(t, expEndHr, recvEndHr, "hour")
 			assert.Equal(t, expEndMin, recvEndMin, "minute")
 			assert.Equal(t, expEndSec, recvEndSec, "second")
+		})
+	}
+}
+
+type EventAPIE2ESuite struct {
+	tester.Suite
+	credentials account.M365Config
+	ac          api.Client
+	user        string
+}
+
+// We do end up mocking the actual request, but creating the rest
+// similar to E2E suite
+func TestEventAPIE2ESuite(t *testing.T) {
+	suite.Run(t, &EventAPIE2ESuite{
+		Suite: tester.NewIntegrationSuite(
+			t,
+			[][]string{tester.M365AcctCredEnvs},
+		),
+	})
+}
+
+func (suite *EventAPIE2ESuite) SetupSuite() {
+	t := suite.T()
+
+	a := tester.NewM365Account(t)
+	m365, err := a.M365Config()
+	require.NoError(t, err, clues.ToCore(err))
+
+	suite.credentials = m365
+	suite.ac, err = mock.NewClient(m365)
+	require.NoError(t, err, clues.ToCore(err))
+
+	suite.user = tester.M365UserID(suite.T())
+}
+
+func (suite *EventAPIE2ESuite) TestPaginationErrorConditions() {
+	did := "directory-id"
+
+	type errResp struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+
+	tests := []struct {
+		name      string
+		prevDelta bool
+		setupf    func()
+	}{
+		{
+			name: "direct error on dleta",
+			setupf: func() {
+				gock.New("https://graph.microsoft.com").
+					Get("/beta/users/" + suite.user + "/calendars/" + did + "/events/delta$").
+					Reply(404)
+			},
+		},
+		{
+			name:      "delta reset",
+			prevDelta: true,
+			setupf: func() {
+				gock.New("https://graph.microsoft.com").
+					Get("/fakedelta").
+					Reply(403).
+					JSON(map[string]errResp{"error": {Code: "SyncStateNotFound", Message: "..."}})
+
+				gock.New("https://graph.microsoft.com").
+					Get("/beta/users/" + suite.user + "/calendars/" + did + "/events/delta$").
+					Reply(404)
+			},
+		},
+		{
+			name:      "box full",
+			prevDelta: true,
+			setupf: func() {
+				gock.New("https://graph.microsoft.com").
+					Get("/fakedelta").
+					Reply(403).
+					JSON(map[string]errResp{
+						"error": {
+							Code:    "ErrorQuotaExceeded",
+							Message: "The process failed to get the correct properties.",
+						},
+					})
+
+				gock.New("https://graph.microsoft.com").
+					Get("/v1.0/users/" + suite.user + "/calendars/" + did + "/events$").
+					Reply(404)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			ctx, flush := tester.NewContext()
+			defer flush()
+
+			defer gock.Off()
+			tt.setupf()
+
+			delta := ""
+			if tt.prevDelta {
+				delta = "https://graph.microsoft.com/fakedelta"
+			}
+
+			pgr, err := api.NewEventPager(suite.ac.Stable, suite.user, did, delta, false, false)
+			require.NoError(suite.T(), err, "create pager")
+
+			_, _, _, err = api.GetAddedAndRemovedItemIDsFromPager(ctx, delta, &pgr)
+			fmt.Println("shared_test.go:118 err:", err)
+
+			// just a unique enough check
+			assert.True(suite.T(), err.Error() == "The server returned an unexpected status code with no response body: 404", "get 404")
+			assert.True(suite.T(), gock.IsDone(), "all mocks used")
 		})
 	}
 }

--- a/src/internal/connector/exchange/api/mail.go
+++ b/src/internal/connector/exchange/api/mail.go
@@ -305,7 +305,6 @@ type mailPager struct {
 func NewMailPager(
 	gs graph.Servicer,
 	user, directoryID, deltaURL string,
-	nonDelta bool,
 	immutableIDs bool,
 ) (mailPager, error) {
 	options, err := optionsForFolderMessages([]string{"isRead"}, immutableIDs)
@@ -327,7 +326,7 @@ func NewMailPager(
 		gs:          gs,
 		user:        user,
 		directoryID: directoryID,
-		nonDelta:    nonDelta,
+		nonDelta:    false,
 
 		// for non-delta based pagination
 		builder: gs.Client().UsersById(user).MailFoldersById(directoryID).Messages(),
@@ -417,7 +416,7 @@ func (c Mail) GetAddedAndRemovedItemIDs(
 		"category", selectors.ExchangeMail,
 		"container_id", directoryID)
 
-	pgr, err := NewMailPager(service, user, directoryID, oldDelta, false, immutableIDs)
+	pgr, err := NewMailPager(service, user, directoryID, oldDelta, immutableIDs)
 	if err != nil {
 		return nil, nil, DeltaUpdate{}, err
 	}

--- a/src/internal/connector/exchange/api/mail.go
+++ b/src/internal/connector/exchange/api/mail.go
@@ -393,10 +393,6 @@ func (p *mailPager) getNextPage(ctx context.Context) ([]getIDAndAddtler, bool, s
 	return p.getNextPageDelta(ctx)
 }
 
-func (p *mailPager) valuesIn(pl api.DeltaPageLinker) ([]getIDAndAddtler, error) {
-	return toValues[models.Messageable](pl)
-}
-
 func (p *mailPager) reset(nonDelta bool) {
 	if nonDelta {
 		p.nonDelta = true

--- a/src/internal/connector/exchange/api/mail_test.go
+++ b/src/internal/connector/exchange/api/mail_test.go
@@ -2,7 +2,6 @@ package api_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 	"time"
 
@@ -429,10 +428,13 @@ func (suite *MailAPIE2ESuite) TestPaginationErrorConditions() {
 			require.NoError(suite.T(), err, "create pager")
 
 			_, _, _, err = api.GetAddedAndRemovedItemIDsFromPager(ctx, delta, &pgr)
-			fmt.Println("shared_test.go:118 err:", err)
 
 			// just a unique enough check
-			assert.True(suite.T(), err.Error() == "The server returned an unexpected status code with no response body: 404", "get 404")
+			assert.True(
+				suite.T(),
+				err.Error() == "The server returned an unexpected status code with no response body: 404",
+				"get 404",
+			)
 			assert.True(suite.T(), gock.IsDone(), "all mocks used")
 		})
 	}

--- a/src/internal/connector/exchange/api/mail_test.go
+++ b/src/internal/connector/exchange/api/mail_test.go
@@ -424,7 +424,7 @@ func (suite *MailAPIE2ESuite) TestPaginationErrorConditions() {
 				delta = "https://graph.microsoft.com/fakedelta"
 			}
 
-			pgr, err := api.NewMailPager(suite.ac.Stable, suite.user, did, delta, false, false)
+			pgr, err := api.NewMailPager(suite.ac.Stable, suite.user, did, delta, false)
 			require.NoError(suite.T(), err, "create pager")
 
 			_, _, _, err = api.GetAddedAndRemovedItemIDsFromPager(ctx, delta, &pgr)

--- a/src/internal/connector/exchange/api/options.go
+++ b/src/internal/connector/exchange/api/options.go
@@ -96,6 +96,27 @@ func optionsForFolderMessagesDelta(
 	return options, nil
 }
 
+func optionsForFolderMessages(
+	moreOps []string,
+	immutableIDs bool,
+) (*users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration, error) {
+	selecting, err := buildOptions(moreOps, fieldsForMessages)
+	if err != nil {
+		return nil, err
+	}
+
+	requestParameters := &users.ItemMailFoldersItemMessagesRequestBuilderGetQueryParameters{
+		Select: selecting,
+	}
+
+	options := &users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration{
+		QueryParameters: requestParameters,
+		Headers:         buildPreferHeaders(true, immutableIDs),
+	}
+
+	return options, nil
+}
+
 // optionsForCalendars places allowed options for exchange.Calendar object
 // @param moreOps should reflect elements from fieldsForCalendars
 // @return is first call in Calendars().GetWithRequestConfigurationAndResponseHandler
@@ -194,6 +215,27 @@ func optionsForContactFoldersItemDelta(
 	}
 
 	options := &users.ItemContactFoldersItemContactsDeltaRequestBuilderGetRequestConfiguration{
+		QueryParameters: requestParameters,
+		Headers:         buildPreferHeaders(true, immutableIDs),
+	}
+
+	return options, nil
+}
+
+func optionsForContactFoldersItem(
+	moreOps []string,
+	immutableIDs bool,
+) (*users.ItemContactFoldersItemContactsRequestBuilderGetRequestConfiguration, error) {
+	selecting, err := buildOptions(moreOps, fieldsForContacts)
+	if err != nil {
+		return nil, err
+	}
+
+	requestParameters := &users.ItemContactFoldersItemContactsRequestBuilderGetQueryParameters{
+		Select: selecting,
+	}
+
+	options := &users.ItemContactFoldersItemContactsRequestBuilderGetRequestConfiguration{
 		QueryParameters: requestParameters,
 		Headers:         buildPreferHeaders(true, immutableIDs),
 	}

--- a/src/internal/connector/exchange/api/shared.go
+++ b/src/internal/connector/exchange/api/shared.go
@@ -73,6 +73,8 @@ func GetAddedAndRemovedItemIDsFromPager(
 	if graph.IsErrQuotaExceeded(err) {
 		pgr.reset(true)
 
+		logger.CtxErr(ctx, err).Info("switching to non-delta pagination")
+
 		added, removed, deltaURL, err = getItemsAddedAndRemovedFromContainer(ctx, pgr)
 		if err == nil {
 			// TODO(meain): Should we return resetDelta here? Will
@@ -86,6 +88,8 @@ func GetAddedAndRemovedItemIDsFromPager(
 	// empty, reset and retry
 	if graph.IsErrInvalidDelta(err) && len(oldDelta) != 0 {
 		pgr.reset(false)
+
+		logger.CtxErr(ctx, err).Info("resetting delta pagination")
 
 		added, removed, deltaURL, err = getItemsAddedAndRemovedFromContainer(ctx, pgr)
 		if err == nil {

--- a/src/internal/connector/exchange/api/shared.go
+++ b/src/internal/connector/exchange/api/shared.go
@@ -109,6 +109,9 @@ func getItemsAddedAndRemovedFromContainer(
 		addedIDs   = []string{}
 		removedIDs = []string{}
 		deltaURL   string
+		items      []getIDAndAddtler
+		lastPage   bool
+		err        error
 	)
 
 	itemCount := 0
@@ -116,7 +119,7 @@ func getItemsAddedAndRemovedFromContainer(
 
 	for {
 		// get the next page of data, check for standard errors
-		items, lastPage, deltaURL, err := pager.getNextPage(ctx)
+		items, lastPage, deltaURL, err = pager.getNextPage(ctx)
 		if err != nil {
 			return nil, nil, deltaURL, graph.Stack(ctx, err)
 		}

--- a/src/internal/connector/exchange/api/shared_test.go
+++ b/src/internal/connector/exchange/api/shared_test.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/tester"
+)
+
+type SharedAPIUnitSuite struct {
+	tester.Suite
+}
+
+func TestSharedAPIUnitSuite(t *testing.T) {
+	suite.Run(t, &SharedAPIUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+type dummyPager struct{}
+
+func (p *dummyPager) getNextPage(ctx context.Context) ([]getIDAndAddtler, bool, string, error) {
+	return []getIDAndAddtler{}, true, "delta-url", nil
+}
+
+func (p *dummyPager) reset(nonDelta bool) {}
+
+func (suite *SharedAPIUnitSuite) TestGetItemsAddedAndRemovedFromContainer_ensureDeltaUrl() {
+	ctx, flush := tester.NewContext()
+	defer flush()
+
+	_, _, deltaURL, _ := getItemsAddedAndRemovedFromContainer(ctx, &dummyPager{})
+	require.Equal(suite.T(), deltaURL, "delta-url", "get delta url")
+}

--- a/src/internal/connector/graph/errors.go
+++ b/src/internal/connector/graph/errors.go
@@ -34,6 +34,7 @@ const (
 	errCodeMalwareDetected             = "malwareDetected"
 	errCodeSyncFolderNotFound          = "ErrorSyncFolderNotFound"
 	errCodeSyncStateNotFound           = "SyncStateNotFound"
+	errCodeQuotaExceeded               = "ErrorQuotaExceeded"
 	errCodeSyncStateInvalid            = "SyncStateInvalid"
 	errCodeResourceNotFound            = "ResourceNotFound"
 	errCodeRequestResourceNotFound     = "Request_ResourceNotFound"
@@ -96,6 +97,10 @@ func IsErrDeletedInFlight(err error) bool {
 func IsErrInvalidDelta(err error) bool {
 	return hasErrorCode(err, errCodeSyncStateNotFound, errCodeResyncRequired, errCodeSyncStateInvalid) ||
 		errors.Is(err, ErrInvalidDelta)
+}
+
+func IsErrQuotaExceeded(err error) bool {
+	return hasErrorCode(err, errCodeQuotaExceeded)
 }
 
 func IsErrExchangeMailFolderNotFound(err error) bool {


### PR DESCRIPTION
When the user has a full mailbox, delta queries does not work, we need to use non delta endpoints. This changes all of the exchange backup options to revert to non delta queries when delta query fails with quota exceeded error.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
