### PR TITLE
enable user pn->id migrations for reporef prefix

### DIFF
--- a/src/internal/connector/onedrive/data_collections.go
+++ b/src/internal/connector/onedrive/data_collections.go
@@ -135,16 +135,12 @@ func migrationCollections(
 	su support.StatusUpdater,
 	ctrlOpts control.Options,
 ) ([]data.BackupCollection, error) {
-	if !ctrlOpts.ToggleFeatures.RunMigrations {
-		return nil, nil
-	}
-
 	// assume a version < 0 implies no prior backup, thus nothing to migrate.
 	if version.IsNoBackup(lastBackupVersion) {
 		return nil, nil
 	}
 
-	if lastBackupVersion >= version.AllXMigrateUserPNToID {
+	if lastBackupVersion >= version.All8MigrateUserPNToID {
 		return nil, nil
 	}
 

--- a/src/internal/connector/onedrive/data_collections_test.go
+++ b/src/internal/connector/onedrive/data_collections_test.go
@@ -59,7 +59,7 @@ func (suite *DataCollectionsUnitSuite) TestMigrationCollections() {
 		},
 		{
 			name:      "user pn to id",
-			version:   version.AllXMigrateUserPNToID - 1,
+			version:   version.All8MigrateUserPNToID - 1,
 			forceSkip: false,
 			expectLen: 1,
 			expectMigration: []migr{
@@ -82,9 +82,7 @@ func (suite *DataCollectionsUnitSuite) TestMigrationCollections() {
 			t := suite.T()
 
 			opts := control.Options{
-				ToggleFeatures: control.Toggles{
-					RunMigrations: !test.forceSkip,
-				},
+				ToggleFeatures: control.Toggles{},
 			}
 
 			mc, err := migrationCollections(nil, test.version, "t", u, nil, opts)

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -1618,8 +1618,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveOwnerMigration() {
 	// ensure the initial owner uses name in both cases
 	bo.ResourceOwner = oldsel.SetDiscreteOwnerIDName(uname, uname)
 	// required, otherwise we don't run the migration
-	bo.backupVersion = version.AllXMigrateUserPNToID - 1
-	bo.Options.ToggleFeatures.RunMigrations = false
+	bo.backupVersion = version.All8MigrateUserPNToID - 1
 
 	require.Equalf(
 		t,
@@ -1641,8 +1640,6 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveOwnerMigration() {
 		// the incremental backup op should have a proper user ID for the id.
 		incBO = newTestBackupOp(t, ctx, kw, ms, gc, acct, sel, incMB, ffs, closer)
 	)
-
-	incBO.Options.ToggleFeatures.RunMigrations = true
 
 	require.NotEqualf(
 		t,

--- a/src/internal/version/backup.go
+++ b/src/internal/version/backup.go
@@ -1,6 +1,6 @@
 package version
 
-const Backup = 7
+const Backup = 8
 
 // Various labels to refer to important version changes.
 // Labels don't need 1:1 service:version representation.  Add a new
@@ -43,9 +43,9 @@ const (
 	// OneDrive, and SharePoint libraries.
 	OneDrive7LocationRef = 7
 
-	// AllXMigrateUserPNToID marks when we migrated repo refs from the user's
+	// All8MigrateUserPNToID marks when we migrated repo refs from the user's
 	// PrincipalName to their ID for stability.
-	AllXMigrateUserPNToID = Backup + 1
+	All8MigrateUserPNToID = 8
 )
 
 // IsNoBackup returns true if the version implies that no prior backup exists.

--- a/src/pkg/control/options.go
+++ b/src/pkg/control/options.go
@@ -103,6 +103,4 @@ type Toggles struct {
 	// immutable Exchange IDs. This is only safe to set if the previous backup for
 	// incremental backups used immutable IDs or if a full backup is being done.
 	ExchangeImmutableIDs bool `json:"exchangeImmutableIDs,omitempty"`
-
-	RunMigrations bool `json:"runMigrations"`
 }

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -26,7 +26,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
-	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/storage"
 	"github.com/alcionai/corso/src/pkg/store"
@@ -316,11 +315,6 @@ func (r repository) NewBackupWithLookup(
 	ownerID, ownerName, err := gc.PopulateOwnerIDAndNamesFrom(ctx, sel.DiscreteOwner, ins)
 	if err != nil {
 		return operations.BackupOperation{}, errors.Wrap(err, "resolving resource owner details")
-	}
-
-	// Exchange and OneDrive need to maintain the user PN as the ID until we're ready to migrate
-	if sel.PathService() != path.SharePointService {
-		ownerID = ownerName
 	}
 
 	// TODO: retrieve display name from gc


### PR DESCRIPTION
Enables migrations of all user-based repoRef prefixes away from the user's PrincipalName and onto the user's ID for a more stable reference.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #2825

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
