### PR TITLE
errant cleanups before incremental support

### DIFF
--- a/src/internal/connector/data_collections.go
+++ b/src/internal/connector/data_collections.go
@@ -19,6 +19,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/filters"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 )
@@ -79,7 +80,7 @@ func (gc *GraphConnector) ProduceBackupCollections(
 		colls, excludes, err = exchange.DataCollections(
 			ctx,
 			sels,
-			sels,
+			owner,
 			metadata,
 			gc.credentials,
 			gc.UpdateStatus,
@@ -93,7 +94,7 @@ func (gc *GraphConnector) ProduceBackupCollections(
 		colls, excludes, err = onedrive.DataCollections(
 			ctx,
 			sels,
-			sels,
+			owner,
 			metadata,
 			lastBackupVersion,
 			gc.credentials.AzureTenantID,
@@ -111,7 +112,8 @@ func (gc *GraphConnector) ProduceBackupCollections(
 			ctx,
 			gc.itemClient,
 			sels,
-			sels,
+			owner,
+			metadata,
 			gc.credentials,
 			gc.Service,
 			gc,
@@ -154,16 +156,7 @@ func verifyBackupInputs(sels selectors.Selector, siteIDs []string) error {
 
 	resourceOwner := strings.ToLower(sels.DiscreteOwner)
 
-	var found bool
-
-	for _, id := range ids {
-		if strings.ToLower(id) == resourceOwner {
-			found = true
-			break
-		}
-	}
-
-	if !found {
+	if !filters.Equal(ids).Compare(resourceOwner) {
 		return clues.Stack(graph.ErrResourceOwnerNotFound).With("missing_resource_owner", sels.DiscreteOwner)
 	}
 

--- a/src/internal/connector/data_collections_test.go
+++ b/src/internal/connector/data_collections_test.go
@@ -264,6 +264,7 @@ func (suite *DataCollectionIntgSuite) TestSharePointDataCollection() {
 				graph.NewNoTimeoutHTTPWrapper(),
 				sel,
 				sel,
+				nil,
 				connector.credentials,
 				connector.Service,
 				connector,

--- a/src/internal/connector/data_collections_test.go
+++ b/src/internal/connector/data_collections_test.go
@@ -263,6 +263,7 @@ func (suite *DataCollectionIntgSuite) TestSharePointDataCollection() {
 				ctx,
 				graph.NewNoTimeoutHTTPWrapper(),
 				sel,
+				sel,
 				connector.credentials,
 				connector.Service,
 				connector,

--- a/src/internal/connector/exchange/data_collections.go
+++ b/src/internal/connector/exchange/data_collections.go
@@ -163,8 +163,8 @@ func parseMetadataCollections(
 //	Add iota to this call -> mail, contacts, calendar,  etc.
 func DataCollections(
 	ctx context.Context,
-	user idname.Provider,
 	selector selectors.Selector,
+	user idname.Provider,
 	metadata []data.RestoreCollection,
 	acct account.M365Config,
 	su support.StatusUpdater,

--- a/src/internal/connector/graph/metadata/metadata.go
+++ b/src/internal/connector/graph/metadata/metadata.go
@@ -7,7 +7,7 @@ import (
 
 func IsMetadataFile(p path.Path) bool {
 	switch p.Service() {
-	case path.OneDriveService:
+	case path.OneDriveService, path.SharePointService:
 		return metadata.HasMetaSuffix(p.Item())
 
 	default:

--- a/src/internal/connector/graph/metadata/metadata.go
+++ b/src/internal/connector/graph/metadata/metadata.go
@@ -7,9 +7,11 @@ import (
 
 func IsMetadataFile(p path.Path) bool {
 	switch p.Service() {
-	case path.OneDriveService, path.SharePointService:
+	case path.OneDriveService:
 		return metadata.HasMetaSuffix(p.Item())
 
+	case path.SharePointService:
+		return p.Category() == path.LibrariesCategory && metadata.HasMetaSuffix(p.Item())
 	default:
 		return false
 	}

--- a/src/internal/connector/graph/metadata/metadata_test.go
+++ b/src/internal/connector/graph/metadata/metadata_test.go
@@ -61,7 +61,7 @@ var (
 		{
 			service:  path.SharePointService,
 			category: path.LibrariesCategory,
-			expected: assert.Falsef,
+			expected: assert.Truef,
 		},
 		{
 			service:  path.SharePointService,

--- a/src/internal/connector/graph_connector.go
+++ b/src/internal/connector/graph_connector.go
@@ -167,10 +167,6 @@ func (gc *GraphConnector) incrementAwaitingMessages() {
 	gc.wg.Add(1)
 }
 
-func (gc *GraphConnector) incrementMessagesBy(num int) {
-	gc.wg.Add(num)
-}
-
 // ---------------------------------------------------------------------------
 // Resource Lookup Handling
 // ---------------------------------------------------------------------------

--- a/src/internal/connector/graph_connector.go
+++ b/src/internal/connector/graph_connector.go
@@ -275,7 +275,6 @@ func (gc *GraphConnector) PopulateOwnerIDAndNamesFrom(
 	owner string, // input value, can be either id or name
 	ins idname.Cacher,
 ) (string, string, error) {
-	// move this to GC method
 	id, name, err := gc.ownerLookup.getOwnerIDAndNameFrom(ctx, gc.Discovery, owner, ins)
 	if err != nil {
 		return "", "", clues.Wrap(err, "identifying resource owner")

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -194,6 +194,7 @@ func newColl(
 ) *Collection {
 	c := &Collection{
 		itemClient:      gr,
+		itemGetter:      api.GetDriveItem,
 		folderPath:      folderPath,
 		prevPath:        prevPath,
 		driveItems:      map[string]models.DriveItemable{},
@@ -211,11 +212,9 @@ func newColl(
 	// Allows tests to set a mock populator
 	switch source {
 	case SharePointSource:
-		c.itemGetter = api.GetDriveItem
 		c.itemReader = sharePointItemReader
 		c.itemMetaReader = sharePointItemMetaReader
 	default:
-		c.itemGetter = api.GetDriveItem
 		c.itemReader = oneDriveItemReader
 		c.itemMetaReader = oneDriveItemMetaReader
 	}

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -299,7 +299,7 @@ func sharePointItemInfo(di models.DriveItemable, itemSize int64) *details.ShareP
 	}
 
 	return &details.SharePointInfo{
-		ItemType:  details.OneDriveItem,
+		ItemType:  details.SharePointLibrary,
 		ItemName:  ptr.Val(di.GetName()),
 		Created:   ptr.Val(di.GetCreatedDateTime()),
 		Modified:  ptr.Val(di.GetLastModifiedDateTime()),

--- a/src/internal/connector/sharepoint/data_collections.go
+++ b/src/internal/connector/sharepoint/data_collections.go
@@ -32,6 +32,7 @@ func DataCollections(
 	itemClient graph.Requester,
 	selector selectors.Selector,
 	site idname.Provider,
+	metadata []data.RestoreCollection,
 	creds account.M365Config,
 	serv graph.Servicer,
 	su statusUpdater,
@@ -89,6 +90,7 @@ func DataCollections(
 				serv,
 				creds.AzureTenantID,
 				site,
+				metadata,
 				scope,
 				su,
 				ctrlOpts,
@@ -193,6 +195,7 @@ func collectLibraries(
 	serv graph.Servicer,
 	tenantID string,
 	site idname.Provider,
+	metadata []data.RestoreCollection,
 	scope selectors.SharePointScope,
 	updater statusUpdater,
 	ctrlOpts control.Options,
@@ -215,7 +218,7 @@ func collectLibraries(
 
 	// TODO(ashmrtn): Pass previous backup metadata when SharePoint supports delta
 	// token-based incrementals.
-	odcs, excludes, err := colls.Get(ctx, nil, errs)
+	odcs, excludes, err := colls.Get(ctx, metadata, errs)
 	if err != nil {
 		return nil, nil, graph.Wrap(ctx, err, "getting library")
 	}

--- a/src/internal/connector/sharepoint/data_collections_test.go
+++ b/src/internal/connector/sharepoint/data_collections_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/common/idname/mock"
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/onedrive"
 	"github.com/alcionai/corso/src/internal/tester"
@@ -194,9 +195,11 @@ func (suite *SharePointPagesSuite) TestCollectPages() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 
-	t := suite.T()
-	siteID := tester.M365SiteID(t)
-	a := tester.NewM365Account(t)
+	var (
+		t      = suite.T()
+		siteID = tester.M365SiteID(t)
+		a      = tester.NewM365Account(t)
+	)
 
 	account, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
@@ -205,7 +208,7 @@ func (suite *SharePointPagesSuite) TestCollectPages() {
 		ctx,
 		account,
 		nil,
-		siteID,
+		mock.NewProvider(siteID, siteID),
 		&MockGraphService{},
 		control.Defaults(),
 		fault.New(true))

--- a/src/internal/connector/sharepoint/restore.go
+++ b/src/internal/connector/sharepoint/restore.go
@@ -97,7 +97,7 @@ func RestoreCollections(
 				deets,
 				errs)
 		default:
-			return nil, clues.Wrap(clues.New(category.String()), "category not supported")
+			return nil, clues.Wrap(clues.New(category.String()), "category not supported").With("category", category)
 		}
 
 		restoreMetrics = support.CombineMetrics(restoreMetrics, metrics)

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -308,7 +308,6 @@ func (op *BackupOperation) do(
 		mans,
 		toMerge,
 		deets,
-		op.Selectors.PathService(),
 		op.Errors)
 	if err != nil {
 		return nil, clues.Wrap(err, "merging details")
@@ -654,7 +653,6 @@ func mergeDetails(
 	mans []*kopia.ManifestEntry,
 	dataFromBackup kopia.DetailsMergeInfoer,
 	deets *details.Builder,
-	service path.ServiceType,
 	errs *fault.Bus,
 ) error {
 	// Don't bother loading any of the base details if there's nothing we need to merge.

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -1173,7 +1173,6 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveIncrementals() {
 		connector.Users,
 		path.OneDriveService,
 		path.FilesCategory,
-		sel.Selector,
 		ic,
 		gtdi)
 }
@@ -1211,7 +1210,6 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_sharePointIncrementals() {
 		connector.Sites,
 		path.SharePointService,
 		path.LibrariesCategory,
-		sel.Selector,
 		ic,
 		gtdi)
 }
@@ -1222,7 +1220,6 @@ func runDriveIncrementalTest(
 	resource connector.Resource,
 	service path.ServiceType,
 	category path.CategoryType,
-	sel selectors.Selector,
 	includeContainers func([]string) selectors.Selector,
 	getTestDriveID func(*testing.T, context.Context, graph.Servicer) string,
 ) {
@@ -1253,7 +1250,7 @@ func runDriveIncrementalTest(
 		containers = []string{container1, container2, container3}
 	)
 
-	sel = includeContainers(containers)
+	sel := includeContainers(containers)
 
 	creds, err := acct.M365Config()
 	require.NoError(t, err, clues.ToCore(err))

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -1189,7 +1189,6 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 				test.inputMans,
 				test.mdm,
 				&deets,
-				path.OneDriveService, // only used to check for sharepoint, so value doesn't matter
 				fault.New(true))
 			test.errCheck(t, err, clues.ToCore(err))
 
@@ -1303,7 +1302,6 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsFolde
 		inputMans,
 		mdm,
 		&deets,
-		path.ExchangeService, // only used to check for sharepoint, so value doesn't matter
 		fault.New(true))
 	assert.NoError(t, err, clues.ToCore(err))
 	compareDeetEntries(t, expectedEntries, deets.Details().Entries)

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -1189,6 +1189,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 				test.inputMans,
 				test.mdm,
 				&deets,
+				path.OneDriveService, // only used to check for sharepoint, so value doesn't matter
 				fault.New(true))
 			test.errCheck(t, err, clues.ToCore(err))
 
@@ -1302,6 +1303,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsFolde
 		inputMans,
 		mdm,
 		&deets,
+		path.ExchangeService, // only used to check for sharepoint, so value doesn't matter
 		fault.New(true))
 	assert.NoError(t, err, clues.ToCore(err))
 	compareDeetEntries(t, expectedEntries, deets.Details().Entries)

--- a/src/internal/operations/help_test.go
+++ b/src/internal/operations/help_test.go
@@ -24,7 +24,7 @@ func GCWithSelector(
 	sel selectors.Selector,
 	ins idname.Cacher,
 	onFail func(),
-) *connector.GraphConnector {
+) (*connector.GraphConnector, selectors.Selector) {
 	gc, err := connector.NewGraphConnector(ctx, acct, cr)
 	if !assert.NoError(t, err, clues.ToCore(err)) {
 		if onFail != nil {
@@ -43,7 +43,7 @@ func GCWithSelector(
 		t.FailNow()
 	}
 
-	sel.SetDiscreteOwnerIDName(id, name)
+	sel = sel.SetDiscreteOwnerIDName(id, name)
 
-	return gc
+	return gc, sel
 }

--- a/src/internal/operations/restore_test.go
+++ b/src/internal/operations/restore_test.go
@@ -270,16 +270,16 @@ func setupExchangeBackup(
 
 	var (
 		users = []string{owner}
-		sel   = selectors.NewExchangeBackup(users)
+		esel  = selectors.NewExchangeBackup(users)
 	)
 
-	sel.DiscreteOwner = owner
-	sel.Include(
-		sel.MailFolders([]string{exchange.DefaultMailFolder}, selectors.PrefixMatch()),
-		sel.ContactFolders([]string{exchange.DefaultContactFolder}, selectors.PrefixMatch()),
-		sel.EventCalendars([]string{exchange.DefaultCalendar}, selectors.PrefixMatch()))
+	esel.DiscreteOwner = owner
+	esel.Include(
+		esel.MailFolders([]string{exchange.DefaultMailFolder}, selectors.PrefixMatch()),
+		esel.ContactFolders([]string{exchange.DefaultContactFolder}, selectors.PrefixMatch()),
+		esel.EventCalendars([]string{exchange.DefaultCalendar}, selectors.PrefixMatch()))
 
-	gc := GCWithSelector(t, ctx, acct, connector.Users, sel.Selector, nil, nil)
+	gc, sel := GCWithSelector(t, ctx, acct, connector.Users, esel.Selector, nil, nil)
 
 	bo, err := NewBackupOperation(
 		ctx,
@@ -288,7 +288,7 @@ func setupExchangeBackup(
 		sw,
 		gc,
 		acct,
-		sel.Selector,
+		sel,
 		inMock.NewProvider(owner, owner),
 		evmock.NewBus())
 	require.NoError(t, err, clues.ToCore(err))
@@ -320,17 +320,17 @@ func setupSharePointBackup(
 
 	var (
 		sites = []string{owner}
-		sel   = selectors.NewSharePointBackup(sites)
+		ssel  = selectors.NewSharePointBackup(sites)
 	)
 
 	// assume a folder name "test" exists in the drive.
 	// this is brittle, and requires us to backfill anytime
 	// the site under test changes, but also prevents explosive
 	// growth from re-backup/restore of restored files.
-	sel.Include(sel.LibraryFolders([]string{"test"}, selectors.PrefixMatch()))
-	sel.DiscreteOwner = owner
+	ssel.Include(ssel.LibraryFolders([]string{"test"}, selectors.PrefixMatch()))
+	ssel.DiscreteOwner = owner
 
-	gc := GCWithSelector(t, ctx, acct, connector.Sites, sel.Selector, nil, nil)
+	gc, sel := GCWithSelector(t, ctx, acct, connector.Sites, ssel.Selector, nil, nil)
 
 	bo, err := NewBackupOperation(
 		ctx,
@@ -339,7 +339,7 @@ func setupSharePointBackup(
 		sw,
 		gc,
 		acct,
-		sel.Selector,
+		sel,
 		inMock.NewProvider(owner, owner),
 		evmock.NewBus())
 	require.NoError(t, err, clues.ToCore(err))


### PR DESCRIPTION
a handful of errant cleanups to help the PR for adding incremental support to sharepoint.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3136

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
