### PR TITLE
Add --disable-concurrency-limiter cli flag

### DIFF
--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -89,6 +89,7 @@ func addExchangeCommands(cmd *cobra.Command) *cobra.Command {
 		options.AddFailFastFlag(c)
 		options.AddDisableIncrementalsFlag(c)
 		options.AddEnableImmutableIDFlag(c)
+		options.AddDisableConcurrencyLimiterFlag(c)
 
 	case listCommand:
 		c, fs = utils.AddCommand(cmd, exchangeListCmd())

--- a/src/cli/options/options.go
+++ b/src/cli/options/options.go
@@ -123,8 +123,8 @@ func AddEnableImmutableIDFlag(cmd *cobra.Command) {
 var disableConcurrencyLimiterFV bool
 
 // AddDisableConcurrencyLimiterFlag adds a hidden '--disable-concurrency-limiter'
-// cli flag which, when set, disables the concurrency limiter package
-// This flag is only relevant for exchange backups for now
+// cli flag which, when set, removes concurrency limits when communicating with
+// graph API. This flag is only relevant for exchange backups for now
 func AddDisableConcurrencyLimiterFlag(cmd *cobra.Command) {
 	fs := cmd.Flags()
 	fs.BoolVar(

--- a/src/cli/options/options.go
+++ b/src/cli/options/options.go
@@ -19,6 +19,7 @@ func Control() control.Options {
 	opt.SkipReduce = skipReduceFV
 	opt.ToggleFeatures.DisableIncrementals = disableIncrementalsFV
 	opt.ToggleFeatures.ExchangeImmutableIDs = enableImmutableID
+	opt.ToggleFeatures.DisableConcurrencyLimiter = disableConcurrencyLimiterFV
 	opt.Parallelism.ItemFetch = fetchParallelismFV
 
 	return opt
@@ -29,13 +30,14 @@ func Control() control.Options {
 // ---------------------------------------------------------------------------
 
 const (
-	FailFastFN            = "fail-fast"
-	FetchParallelismFN    = "fetch-parallelism"
-	NoStatsFN             = "no-stats"
-	RestorePermissionsFN  = "restore-permissions"
-	SkipReduceFN          = "skip-reduce"
-	DisableIncrementalsFN = "disable-incrementals"
-	EnableImmutableIDFN   = "enable-immutable-id"
+	FailFastFN                  = "fail-fast"
+	FetchParallelismFN          = "fetch-parallelism"
+	NoStatsFN                   = "no-stats"
+	RestorePermissionsFN        = "restore-permissions"
+	SkipReduceFN                = "skip-reduce"
+	DisableIncrementalsFN       = "disable-incrementals"
+	EnableImmutableIDFN         = "enable-immutable-id"
+	DisableConcurrencyLimiterFN = "disable-concurrency-limiter"
 )
 
 var (
@@ -116,4 +118,19 @@ func AddEnableImmutableIDFlag(cmd *cobra.Command) {
 		false,
 		"Enable exchange immutable ID.")
 	cobra.CheckErr(fs.MarkHidden(EnableImmutableIDFN))
+}
+
+var disableConcurrencyLimiterFV bool
+
+// AddDisableConcurrencyLimiterFlag adds a hidden '--disable-concurrency-limiter'
+// cli flag which, when set, disables the concurrency limiter package
+// This flag is only relevant for exchange backups for now
+func AddDisableConcurrencyLimiterFlag(cmd *cobra.Command) {
+	fs := cmd.Flags()
+	fs.BoolVar(
+		&disableConcurrencyLimiterFV,
+		DisableConcurrencyLimiterFN,
+		false,
+		"Disable concurrency limiter middleware. Default: false")
+	cobra.CheckErr(fs.MarkHidden(DisableConcurrencyLimiterFN))
 }

--- a/src/cli/options/options_test.go
+++ b/src/cli/options/options_test.go
@@ -32,6 +32,7 @@ func (suite *OptionsUnitSuite) TestAddExchangeCommands() {
 			assert.True(t, restorePermissionsFV, RestorePermissionsFN)
 			assert.True(t, skipReduceFV, SkipReduceFN)
 			assert.Equal(t, 2, fetchParallelismFV, FetchParallelismFN)
+			assert.True(t, disableConcurrencyLimiterFV, DisableConcurrencyLimiterFN)
 		},
 	}
 
@@ -42,8 +43,8 @@ func (suite *OptionsUnitSuite) TestAddExchangeCommands() {
 	AddDisableIncrementalsFlag(cmd)
 	AddRestorePermissionsFlag(cmd)
 	AddSkipReduceFlag(cmd)
-
 	AddFetchParallelismFlag(cmd)
+	AddDisableConcurrencyLimiterFlag(cmd)
 
 	// Test arg parsing for few args
 	cmd.SetArgs([]string{
@@ -53,57 +54,10 @@ func (suite *OptionsUnitSuite) TestAddExchangeCommands() {
 		"--" + NoStatsFN,
 		"--" + RestorePermissionsFN,
 		"--" + SkipReduceFN,
-
 		"--" + FetchParallelismFN, "2",
+		"--" + DisableConcurrencyLimiterFN,
 	})
 
 	err := cmd.Execute()
 	require.NoError(t, err, clues.ToCore(err))
-}
-
-func (suite *OptionsUnitSuite) TestDisableConcurrencyLimiterFlag() {
-	tests := []struct {
-		name     string
-		args     []string
-		assertFn func(*testing.T, bool, string)
-		addFlag  bool
-	}{
-		{
-			name: DisableConcurrencyLimiterFN + " not set",
-			args: []string{"test"},
-			assertFn: func(t *testing.T, f bool, s string) {
-				assert.False(t, f, s)
-			},
-			addFlag: false,
-		},
-		{
-			name: DisableConcurrencyLimiterFN + " set",
-			args: []string{"test", "--" + DisableConcurrencyLimiterFN},
-			assertFn: func(t *testing.T, f bool, s string) {
-				assert.True(t, f, s)
-			},
-			addFlag: true,
-		},
-	}
-
-	for _, test := range tests {
-		suite.Run(test.name, func() {
-			t := suite.T()
-
-			cmd := &cobra.Command{
-				Use: "test",
-				Run: func(cmd *cobra.Command, args []string) {
-					test.assertFn(t, disableConcurrencyLimiterFV, DisableConcurrencyLimiterFN)
-				},
-			}
-
-			if test.addFlag {
-				AddDisableConcurrencyLimiterFlag(cmd)
-			}
-
-			cmd.SetArgs(test.args)
-			err := cmd.Execute()
-			require.NoError(t, err, clues.ToCore(err))
-		})
-	}
 }

--- a/src/cli/options/options_test.go
+++ b/src/cli/options/options_test.go
@@ -69,7 +69,7 @@ func (suite *OptionsUnitSuite) TestDisableConcurrencyLimiterFlag() {
 		addFlag  bool
 	}{
 		{
-			name: "--disable-concurrency-limiter not set",
+			name: DisableConcurrencyLimiterFN + " not set",
 			args: []string{"test"},
 			assertFn: func(t *testing.T, f bool, s string) {
 				assert.False(t, f, s)
@@ -77,8 +77,8 @@ func (suite *OptionsUnitSuite) TestDisableConcurrencyLimiterFlag() {
 			addFlag: false,
 		},
 		{
-			name: "--disable-concurrency-limiter set",
-			args: []string{"test", "--disable-concurrency-limiter"},
+			name: DisableConcurrencyLimiterFN + " set",
+			args: []string{"test", "--" + DisableConcurrencyLimiterFN},
 			assertFn: func(t *testing.T, f bool, s string) {
 				assert.True(t, f, s)
 			},

--- a/src/cli/options/options_test.go
+++ b/src/cli/options/options_test.go
@@ -60,3 +60,50 @@ func (suite *OptionsUnitSuite) TestAddExchangeCommands() {
 	err := cmd.Execute()
 	require.NoError(t, err, clues.ToCore(err))
 }
+
+func (suite *OptionsUnitSuite) TestDisableConcurrencyLimiterFlag() {
+	tests := []struct {
+		name     string
+		args     []string
+		assertFn func(*testing.T, bool, string)
+		addFlag  bool
+	}{
+		{
+			name: "--disable-concurrency-limiter not set",
+			args: []string{"test"},
+			assertFn: func(t *testing.T, f bool, s string) {
+				assert.False(t, f, s)
+			},
+			addFlag: false,
+		},
+		{
+			name: "--disable-concurrency-limiter set",
+			args: []string{"test", "--disable-concurrency-limiter"},
+			assertFn: func(t *testing.T, f bool, s string) {
+				assert.True(t, f, s)
+			},
+			addFlag: true,
+		},
+	}
+
+	for _, test := range tests {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			cmd := &cobra.Command{
+				Use: "test",
+				Run: func(cmd *cobra.Command, args []string) {
+					test.assertFn(t, disableConcurrencyLimiterFV, DisableConcurrencyLimiterFN)
+				},
+			}
+
+			if test.addFlag {
+				AddDisableConcurrencyLimiterFlag(cmd)
+			}
+
+			cmd.SetArgs(test.args)
+			err := cmd.Execute()
+			require.NoError(t, err, clues.ToCore(err))
+		})
+	}
+}

--- a/src/internal/connector/exchange/data_collections.go
+++ b/src/internal/connector/exchange/data_collections.go
@@ -182,8 +182,11 @@ func DataCollections(
 		categories  = map[path.CategoryType]struct{}{}
 	)
 
-	// TODO: Add hidden cli flag to disable this feature
-	graph.InitializeConcurrencyLimiter(ctrlOpts.Parallelism.ItemFetch)
+	// Turn on concurrency limiter middleware for exchange backups
+	// unless explicitly disabled through the --disable-concurrency-limiter cli flag
+	if !ctrlOpts.ToggleFeatures.DisableConcurrencyLimiter {
+		graph.InitializeConcurrencyLimiter(ctrlOpts.Parallelism.ItemFetch)
+	}
 
 	cdps, err := parseMetadataCollections(ctx, metadata, errs)
 	if err != nil {

--- a/src/internal/connector/exchange/data_collections.go
+++ b/src/internal/connector/exchange/data_collections.go
@@ -183,7 +183,7 @@ func DataCollections(
 	)
 
 	// Turn on concurrency limiter middleware for exchange backups
-	// unless explicitly disabled through the --disable-concurrency-limiter cli flag
+	// unless explicitly disabled through DisableConcurrencyLimiterFN cli flag
 	if !ctrlOpts.ToggleFeatures.DisableConcurrencyLimiter {
 		graph.InitializeConcurrencyLimiter(ctrlOpts.Parallelism.ItemFetch)
 	}

--- a/src/pkg/control/options.go
+++ b/src/pkg/control/options.go
@@ -105,4 +105,7 @@ type Toggles struct {
 	ExchangeImmutableIDs bool `json:"exchangeImmutableIDs,omitempty"`
 
 	RunMigrations bool `json:"runMigrations"`
+
+	// DisableConcurrencyLimiter disables the concurrency limiter package
+	DisableConcurrencyLimiter bool `json:"disableConcurrencyLimiter,omitempty"`
 }


### PR DESCRIPTION
<!-- PR description-->
The concurrency limiter middleware is enabled by default for exchange backups. Adding a hidden --disable-concurrency-limiter flag to disable this middleware.

Reasons for adding this flag:
We have done limited perf testing with the concurrency limiter. In addition, our understanding of exchange concurrency limits is also a bit fuzzy. This flag acts as a killswitch in case we start to see perf regressions in prod.

I see this as a temporary flag. Ideally we would never have to use it. Also, once we have a better way to configure concurrency limiter, we can eliminate this flag.


---

#### Does this PR need a docs update or release note?

- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature


#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->

- [ ] :zap: Unit test

