### PR TITLE
ditch userInfo middle struct

### DIFF
--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -17,7 +17,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/repository"
 	"github.com/alcionai/corso/src/pkg/selectors"
-	"github.com/alcionai/corso/src/pkg/services/m365"
 )
 
 // ------------------------------------------------------------------------------------------------
@@ -161,10 +160,7 @@ func createExchangeCmd(cmd *cobra.Command, args []string) error {
 
 	sel := exchangeBackupCreateSelectors(utils.UserFV, utils.CategoryDataFV)
 
-	// TODO: log/print recoverable errors
-	errs := fault.New(false)
-
-	ins, err := m365.UsersMap(ctx, *acct, errs)
+	ins, err := utils.UsersMap(ctx, *acct, fault.New(true))
 	if err != nil {
 		return Only(ctx, clues.Wrap(err, "Failed to retrieve M365 users"))
 	}

--- a/src/cli/backup/onedrive.go
+++ b/src/cli/backup/onedrive.go
@@ -17,7 +17,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/repository"
 	"github.com/alcionai/corso/src/pkg/selectors"
-	"github.com/alcionai/corso/src/pkg/services/m365"
 )
 
 // ------------------------------------------------------------------------------------------------
@@ -144,10 +143,7 @@ func createOneDriveCmd(cmd *cobra.Command, args []string) error {
 
 	sel := oneDriveBackupCreateSelectors(utils.UserFV)
 
-	// TODO: log/print recoverable errors
-	errs := fault.New(false)
-
-	ins, err := m365.UsersMap(ctx, *acct, errs)
+	ins, err := utils.UsersMap(ctx, *acct, fault.New(true))
 	if err != nil {
 		return Only(ctx, clues.Wrap(err, "Failed to retrieve M365 users"))
 	}

--- a/src/cli/utils/users.go
+++ b/src/cli/utils/users.go
@@ -1,0 +1,40 @@
+package utils
+
+import (
+	"context"
+
+	"github.com/alcionai/clues"
+
+	"github.com/alcionai/corso/src/internal/common/idname"
+	"github.com/alcionai/corso/src/pkg/account"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+)
+
+// UsersMap retrieves all users in the tenant and returns them in an idname.Cacher
+func UsersMap(
+	ctx context.Context,
+	acct account.Account,
+	errs *fault.Bus,
+) (idname.Cacher, error) {
+	au, err := makeUserAPI(acct)
+	if err != nil {
+		return nil, clues.Wrap(err, "constructing a graph client")
+	}
+
+	return au.GetAllIDsAndNames(ctx, errs)
+}
+
+func makeUserAPI(acct account.Account) (api.Users, error) {
+	creds, err := acct.M365Config()
+	if err != nil {
+		return api.Users{}, clues.Wrap(err, "getting m365 account creds")
+	}
+
+	cli, err := api.NewClient(creds)
+	if err != nil {
+		return api.Users{}, clues.Wrap(err, "constructing api client")
+	}
+
+	return cli.Users(), nil
+}

--- a/src/internal/connector/discovery/discovery_test.go
+++ b/src/internal/connector/discovery/discovery_test.go
@@ -193,7 +193,7 @@ func (suite *DiscoveryIntgSuite) TestUserInfo() {
 			name: "standard test user",
 			user: tester.M365UserID(t),
 			expect: &api.UserInfo{
-				DiscoveredServices: map[path.ServiceType]struct{}{
+				ServicesEnabled: map[path.ServiceType]struct{}{
 					path.ExchangeService: {},
 					path.OneDriveService: {},
 				},
@@ -208,8 +208,8 @@ func (suite *DiscoveryIntgSuite) TestUserInfo() {
 			name: "user does not exist",
 			user: uuid.NewString(),
 			expect: &api.UserInfo{
-				DiscoveredServices: map[path.ServiceType]struct{}{},
-				Mailbox:            api.MailboxInfo{},
+				ServicesEnabled: map[path.ServiceType]struct{}{},
+				Mailbox:         api.MailboxInfo{},
 			},
 			expectErr: require.NoError,
 		},
@@ -228,7 +228,7 @@ func (suite *DiscoveryIntgSuite) TestUserInfo() {
 				return
 			}
 
-			assert.Equal(t, test.expect.DiscoveredServices, result.DiscoveredServices)
+			assert.Equal(t, test.expect.ServicesEnabled, result.ServicesEnabled)
 		})
 	}
 }
@@ -247,7 +247,7 @@ func (suite *DiscoveryIntgSuite) TestUserWithoutDrive() {
 			name: "user without drive and exchange",
 			user: "a53c26f7-5100-4acb-a910-4d20960b2c19", // User: testevents@10rqc2.onmicrosoft.com
 			expect: &api.UserInfo{
-				DiscoveredServices: map[path.ServiceType]struct{}{},
+				ServicesEnabled: map[path.ServiceType]struct{}{},
 				Mailbox: api.MailboxInfo{
 					ErrGetMailBoxSetting: []error{api.ErrMailBoxSettingsNotFound},
 				},
@@ -257,7 +257,7 @@ func (suite *DiscoveryIntgSuite) TestUserWithoutDrive() {
 			name: "user with drive and exchange",
 			user: userID,
 			expect: &api.UserInfo{
-				DiscoveredServices: map[path.ServiceType]struct{}{
+				ServicesEnabled: map[path.ServiceType]struct{}{
 					path.ExchangeService: {},
 					path.OneDriveService: {},
 				},
@@ -277,7 +277,7 @@ func (suite *DiscoveryIntgSuite) TestUserWithoutDrive() {
 
 			result, err := discovery.GetUserInfo(ctx, acct, test.user, fault.New(true))
 			require.NoError(t, err, clues.ToCore(err))
-			assert.Equal(t, test.expect.DiscoveredServices, result.DiscoveredServices)
+			assert.Equal(t, test.expect.ServicesEnabled, result.ServicesEnabled)
 			assert.Equal(t, test.expect.Mailbox.ErrGetMailBoxSetting, result.Mailbox.ErrGetMailBoxSetting)
 			assert.Equal(t, test.expect.Mailbox.Purpose, result.Mailbox.Purpose)
 		})

--- a/src/pkg/services/m365/api/users.go
+++ b/src/pkg/services/m365/api/users.go
@@ -41,8 +41,8 @@ type Users struct {
 // ---------------------------------------------------------------------------
 
 type UserInfo struct {
-	DiscoveredServices map[path.ServiceType]struct{}
-	Mailbox            MailboxInfo
+	ServicesEnabled map[path.ServiceType]struct{}
+	Mailbox         MailboxInfo
 }
 
 type MailboxInfo struct {
@@ -88,7 +88,7 @@ type WorkingHours struct {
 
 func newUserInfo() *UserInfo {
 	return &UserInfo{
-		DiscoveredServices: map[path.ServiceType]struct{}{
+		ServicesEnabled: map[path.ServiceType]struct{}{
 			path.ExchangeService: {},
 			path.OneDriveService: {},
 		},
@@ -98,11 +98,11 @@ func newUserInfo() *UserInfo {
 // ServiceEnabled returns true if the UserInfo has an entry for the
 // service.  If no entry exists, the service is assumed to not be enabled.
 func (ui *UserInfo) ServiceEnabled(service path.ServiceType) bool {
-	if ui == nil || len(ui.DiscoveredServices) == 0 {
+	if ui == nil || len(ui.ServicesEnabled) == 0 {
 		return false
 	}
 
-	_, ok := ui.DiscoveredServices[service]
+	_, ok := ui.ServicesEnabled[service]
 
 	return ok
 }
@@ -252,7 +252,7 @@ func (c Users) GetInfo(ctx context.Context, userID string) (*UserInfo, error) {
 		}
 
 		logger.Ctx(ctx).Info("resource owner does not have a mailbox enabled")
-		delete(userInfo.DiscoveredServices, path.ExchangeService)
+		delete(userInfo.ServicesEnabled, path.ExchangeService)
 	}
 
 	if _, err := c.GetDrives(ctx, userID); err != nil {
@@ -264,7 +264,7 @@ func (c Users) GetInfo(ctx context.Context, userID string) (*UserInfo, error) {
 
 		logger.Ctx(ctx).Info("resource owner does not have a drive")
 
-		delete(userInfo.DiscoveredServices, path.OneDriveService)
+		delete(userInfo.ServicesEnabled, path.OneDriveService)
 	}
 
 	mbxInfo, err := c.getMailboxSettings(ctx, userID)

--- a/src/pkg/services/m365/m365.go
+++ b/src/pkg/services/m365/m365.go
@@ -12,7 +12,6 @@ import (
 	"github.com/alcionai/corso/src/internal/connector/discovery"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/fault"
-	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
@@ -33,10 +32,6 @@ type User struct {
 	ID            string
 	Name          string
 	Info          api.UserInfo
-}
-
-type UserInfo struct {
-	ServicesEnabled ServiceAccess
 }
 
 // UsersCompat returns a list of users in the specified M365 tenant.
@@ -135,7 +130,7 @@ func GetUserInfo(
 	ctx context.Context,
 	acct account.Account,
 	userID string,
-) (*UserInfo, error) {
+) (*api.UserInfo, error) {
 	uapi, err := makeUserAPI(acct)
 	if err != nil {
 		return nil, clues.Wrap(err, "getting user info").WithClues(ctx)
@@ -146,13 +141,7 @@ func GetUserInfo(
 		return nil, err
 	}
 
-	info := UserInfo{
-		ServicesEnabled: ServiceAccess{
-			Exchange: ui.ServiceEnabled(path.ExchangeService),
-		},
-	}
-
-	return &info, nil
+	return ui, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/services/m365/m365.go
+++ b/src/pkg/services/m365/m365.go
@@ -2,7 +2,6 @@ package m365
 
 import (
 	"context"
-	"strings"
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -95,34 +94,6 @@ func parseUser(item models.Userable) (*User, error) {
 	}
 
 	return u, nil
-}
-
-// UsersMap retrieves all users in the tenant, and returns two maps: one id-to-principalName,
-// and one principalName-to-id.
-func UsersMap(
-	ctx context.Context,
-	acct account.Account,
-	errs *fault.Bus,
-) (idname.Cacher, error) {
-	users, err := Users(ctx, acct, errs)
-	if err != nil {
-		return idname.NewCache(nil), err
-	}
-
-	var (
-		idToName = make(map[string]string, len(users))
-		nameToID = make(map[string]string, len(users))
-	)
-
-	for _, u := range users {
-		id, name := strings.ToLower(u.ID), strings.ToLower(u.PrincipalName)
-		idToName[id] = name
-		nameToID[name] = id
-	}
-
-	ins := idname.NewCache(idToName)
-
-	return ins, nil
 }
 
 // UserInfo returns the corso-specific set of user metadata.

--- a/src/pkg/services/m365/m365_test.go
+++ b/src/pkg/services/m365/m365_test.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type M365IntegrationSuite struct {
@@ -66,9 +68,9 @@ func (suite *M365IntegrationSuite) TestGetUserInfo() {
 	require.NotNil(t, info)
 	require.NotEmpty(t, info)
 
-	expect := &m365.UserInfo{
-		ServicesEnabled: m365.ServiceAccess{
-			Exchange: true,
+	expect := &api.UserInfo{
+		ServicesEnabled: map[path.ServiceType]struct{}{
+			path.ExchangeService: {},
 		},
 	}
 

--- a/src/pkg/services/m365/m365_test.go
+++ b/src/pkg/services/m365/m365_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365"
-	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type M365IntegrationSuite struct {
@@ -68,13 +67,15 @@ func (suite *M365IntegrationSuite) TestGetUserInfo() {
 	require.NotNil(t, info)
 	require.NotEmpty(t, info)
 
-	expect := &api.UserInfo{
-		ServicesEnabled: map[path.ServiceType]struct{}{
-			path.ExchangeService: {},
-		},
+	expectEnabled := map[path.ServiceType]struct{}{
+		path.ExchangeService: {},
+		path.OneDriveService: {},
 	}
 
-	assert.Equal(t, expect, info)
+	assert.NotEmpty(t, info.ServicesEnabled)
+	assert.NotEmpty(t, info.Mailbox)
+	assert.Equal(t, expectEnabled, info.ServicesEnabled)
+	assert.Equal(t, "user", info.Mailbox.Purpose)
 }
 
 func (suite *M365IntegrationSuite) TestSites() {


### PR DESCRIPTION
we don't need a m365.UserInfo when we already have an api.UserInfo

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
