### PR TITLE
get users for cli backup without getting info

### DIFF
--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -17,7 +17,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/repository"
 	"github.com/alcionai/corso/src/pkg/selectors"
-	"github.com/alcionai/corso/src/pkg/services/m365"
 )
 
 // ------------------------------------------------------------------------------------------------
@@ -161,10 +160,7 @@ func createExchangeCmd(cmd *cobra.Command, args []string) error {
 
 	sel := exchangeBackupCreateSelectors(utils.UserFV, utils.CategoryDataFV)
 
-	// TODO: log/print recoverable errors
-	errs := fault.New(false)
-
-	ins, err := m365.UsersMap(ctx, *acct, errs)
+	ins, err := utils.UsersMap(ctx, *acct, fault.New(true))
 	if err != nil {
 		return Only(ctx, clues.Wrap(err, "Failed to retrieve M365 users"))
 	}

--- a/src/cli/backup/onedrive.go
+++ b/src/cli/backup/onedrive.go
@@ -17,7 +17,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/repository"
 	"github.com/alcionai/corso/src/pkg/selectors"
-	"github.com/alcionai/corso/src/pkg/services/m365"
 )
 
 // ------------------------------------------------------------------------------------------------
@@ -144,10 +143,7 @@ func createOneDriveCmd(cmd *cobra.Command, args []string) error {
 
 	sel := oneDriveBackupCreateSelectors(utils.UserFV)
 
-	// TODO: log/print recoverable errors
-	errs := fault.New(false)
-
-	ins, err := m365.UsersMap(ctx, *acct, errs)
+	ins, err := utils.UsersMap(ctx, *acct, fault.New(true))
 	if err != nil {
 		return Only(ctx, clues.Wrap(err, "Failed to retrieve M365 users"))
 	}

--- a/src/cli/utils/users.go
+++ b/src/cli/utils/users.go
@@ -1,0 +1,56 @@
+package utils
+
+import (
+	"context"
+	"strings"
+
+	"github.com/alcionai/clues"
+
+	"github.com/alcionai/corso/src/internal/common/idname"
+	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/pkg/account"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+)
+
+// usersMap retrieves all users in the tenant and returns them in an idname.Cacher
+func UsersMap(
+	ctx context.Context,
+	acct account.Account,
+	errs *fault.Bus,
+) (idname.Cacher, error) {
+	au, err := makeUserAPI(acct)
+	if err != nil {
+		return nil, clues.Wrap(err, "constructing a graph client")
+	}
+
+	users, err := au.GetAll(ctx, errs)
+	if err != nil {
+		return nil, clues.Wrap(err, "getting all users")
+	}
+
+	idToName := make(map[string]string, len(users))
+
+	for _, u := range users {
+		id := strings.ToLower(ptr.Val(u.GetId()))
+		name := strings.ToLower(ptr.Val(u.GetUserPrincipalName()))
+
+		idToName[id] = name
+	}
+
+	return idname.NewCache(idToName), nil
+}
+
+func makeUserAPI(acct account.Account) (api.Users, error) {
+	creds, err := acct.M365Config()
+	if err != nil {
+		return api.Users{}, clues.Wrap(err, "getting m365 account creds")
+	}
+
+	cli, err := api.NewClient(creds)
+	if err != nil {
+		return api.Users{}, clues.Wrap(err, "constructing api client")
+	}
+
+	return cli.Users(), nil
+}

--- a/src/pkg/services/m365/m365.go
+++ b/src/pkg/services/m365/m365.go
@@ -2,7 +2,6 @@ package m365
 
 import (
 	"context"
-	"strings"
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -95,34 +94,6 @@ func parseUser(item models.Userable) (*User, error) {
 	}
 
 	return u, nil
-}
-
-// UsersMap retrieves all users in the tenant, and returns two maps: one id-to-principalName,
-// and one principalName-to-id.
-func UsersMap(
-	ctx context.Context,
-	acct account.Account,
-	errs *fault.Bus,
-) (idname.Cacher, error) {
-	users, err := Users(ctx, acct, errs)
-	if err != nil {
-		return idname.NewCache(nil), err
-	}
-
-	var (
-		idToName = make(map[string]string, len(users))
-		nameToID = make(map[string]string, len(users))
-	)
-
-	for _, u := range users {
-		id, name := strings.ToLower(u.ID), strings.ToLower(u.PrincipalName)
-		idToName[id] = name
-		nameToID[name] = id
-	}
-
-	ins := idname.NewCache(idToName)
-
-	return ins, nil
 }
 
 // UserInfo returns the corso-specific set of user metadata.


### PR DESCRIPTION
When the cli aggregates all users, it doesn't need to look up user info for anyone, it only needs their id and PN.  The rest of the info (such as service support) will get looked up on a one-by-one basis in connector during backup run.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
