### PR TITLE
Expose ErrResourceOwnerNotFound in err package

### DIFF
--- a/src/pkg/errs/err.go
+++ b/src/pkg/errs/err.go
@@ -13,18 +13,20 @@ import (
 type errEnum string
 
 const (
-	RepoAlreadyExists errEnum = "repository-already-exists"
-	BackupNotFound    errEnum = "backup-not-found"
-	ServiceNotEnabled errEnum = "service-not-enabled"
+	RepoAlreadyExists     errEnum = "repository-already-exists"
+	BackupNotFound        errEnum = "backup-not-found"
+	ServiceNotEnabled     errEnum = "service-not-enabled"
+	ResourceOwnerNotFound errEnum = "resource-owner-not-found"
 )
 
 // map of enums to errors.  We might want to re-use an enum for multiple
 // internal errors (ex: "ServiceNotEnabled" may exist in both graph and
 // non-graph producers).
 var internalToExternal = map[errEnum][]error{
-	RepoAlreadyExists: {repository.ErrorRepoAlreadyExists},
-	BackupNotFound:    {repository.ErrorBackupNotFound},
-	ServiceNotEnabled: {graph.ErrServiceNotEnabled},
+	RepoAlreadyExists:     {repository.ErrorRepoAlreadyExists},
+	BackupNotFound:        {repository.ErrorBackupNotFound},
+	ServiceNotEnabled:     {graph.ErrServiceNotEnabled},
+	ResourceOwnerNotFound: {graph.ErrResourceOwnerNotFound},
 }
 
 // Is checks if the provided error contains an internal error that matches

--- a/src/pkg/errs/errs_test.go
+++ b/src/pkg/errs/errs_test.go
@@ -27,6 +27,7 @@ func (suite *ErrUnitSuite) TestIs() {
 		{RepoAlreadyExists, repository.ErrorRepoAlreadyExists},
 		{BackupNotFound, repository.ErrorBackupNotFound},
 		{ServiceNotEnabled, graph.ErrServiceNotEnabled},
+		{ResourceOwnerNotFound, graph.ErrResourceOwnerNotFound},
 	}
 	for _, test := range table {
 		suite.Run(string(test.is), func() {


### PR DESCRIPTION
<!-- PR description-->

Expose `ErrResourceOwnerNotFound` in `err` package to make for neat error handling

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #COR-74

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
