### PR TITLE
move and rename common/time.go

### DIFF
--- a/src/cli/restore/exchange.go
+++ b/src/cli/restore/exchange.go
@@ -9,7 +9,7 @@ import (
 	"github.com/alcionai/corso/src/cli/options"
 	. "github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/cli/utils"
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/pkg/control"
 )
@@ -95,7 +95,7 @@ func restoreExchangeCmd(cmd *cobra.Command, args []string) error {
 
 	defer utils.CloseRepo(ctx, r)
 
-	dest := control.DefaultRestoreDestination(common.SimpleDateTime)
+	dest := control.DefaultRestoreDestination(dttm.HumanReadable)
 	Infof(ctx, "Restoring to folder %s", dest.ContainerName)
 
 	sel := utils.IncludeExchangeRestoreDataSelectors(opts)

--- a/src/cli/restore/onedrive.go
+++ b/src/cli/restore/onedrive.go
@@ -9,7 +9,7 @@ import (
 	"github.com/alcionai/corso/src/cli/options"
 	. "github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/cli/utils"
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/pkg/control"
 )
@@ -97,7 +97,7 @@ func restoreOneDriveCmd(cmd *cobra.Command, args []string) error {
 
 	defer utils.CloseRepo(ctx, r)
 
-	dest := control.DefaultRestoreDestination(common.SimpleDateTimeOneDrive)
+	dest := control.DefaultRestoreDestination(dttm.HumanReadableDriveItem)
 	Infof(ctx, "Restoring to folder %s", dest.ContainerName)
 
 	sel := utils.IncludeOneDriveRestoreDataSelectors(opts)

--- a/src/cli/restore/sharepoint.go
+++ b/src/cli/restore/sharepoint.go
@@ -9,7 +9,7 @@ import (
 	"github.com/alcionai/corso/src/cli/options"
 	. "github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/cli/utils"
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/pkg/control"
 )
@@ -96,7 +96,7 @@ func restoreSharePointCmd(cmd *cobra.Command, args []string) error {
 
 	defer utils.CloseRepo(ctx, r)
 
-	dest := control.DefaultRestoreDestination(common.SimpleDateTimeOneDrive)
+	dest := control.DefaultRestoreDestination(dttm.HumanReadableDriveItem)
 	Infof(ctx, "Restoring to folder %s", dest.ContainerName)
 
 	sel := utils.IncludeSharePointRestoreDataSelectors(ctx, opts)

--- a/src/cli/utils/exchange_test.go
+++ b/src/cli/utils/exchange_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/cli/utils"
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/selectors"
 )
@@ -42,7 +42,7 @@ func (suite *ExchangeUtilsSuite) TestValidateRestoreFlags() {
 		{
 			name:     "valid time",
 			backupID: "bid",
-			opts:     utils.ExchangeOpts{EmailReceivedAfter: common.Now()},
+			opts:     utils.ExchangeOpts{EmailReceivedAfter: dttm.Now()},
 			expect:   assert.NoError,
 		},
 		{

--- a/src/cli/utils/flags.go
+++ b/src/cli/utils/flags.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
@@ -198,7 +198,7 @@ func GetPopulatedFlags(cmd *cobra.Command) PopulatedFlags {
 // IsValidTimeFormat returns true if the input is recognized as a
 // supported format by the common time parser.
 func IsValidTimeFormat(in string) bool {
-	_, err := common.ParseTime(in)
+	_, err := dttm.ParseTime(in)
 	return err == nil
 }
 

--- a/src/cli/utils/sharepoint_test.go
+++ b/src/cli/utils/sharepoint_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/cli/utils"
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/selectors"
 )
@@ -280,10 +280,10 @@ func (suite *SharePointUtilsSuite) TestValidateSharePointRestoreFlags() {
 			backupID: "id",
 			opts: utils.SharePointOpts{
 				WebURL:             []string{"www.corsobackup.io/sites/foo"},
-				FileCreatedAfter:   common.Now(),
-				FileCreatedBefore:  common.Now(),
-				FileModifiedAfter:  common.Now(),
-				FileModifiedBefore: common.Now(),
+				FileCreatedAfter:   dttm.Now(),
+				FileCreatedBefore:  dttm.Now(),
+				FileModifiedAfter:  dttm.Now(),
+				FileModifiedBefore: dttm.Now(),
 				Populated: utils.PopulatedFlags{
 					utils.SiteFN:               {},
 					utils.FileCreatedAfterFN:   {},

--- a/src/cli/utils/testdata/opts.go
+++ b/src/cli/utils/testdata/opts.go
@@ -7,7 +7,7 @@ import (
 	"github.com/alcionai/clues"
 
 	"github.com/alcionai/corso/src/cli/utils"
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/backup/details/testdata"
@@ -195,7 +195,7 @@ var (
 			Name:     "MailReceivedTime",
 			Expected: []details.Entry{testdata.ExchangeEmailItems[0]},
 			Opts: utils.ExchangeOpts{
-				EmailReceivedBefore: common.FormatTime(testdata.Time1.Add(time.Second)),
+				EmailReceivedBefore: dttm.Format(testdata.Time1.Add(time.Second)),
 			},
 		},
 		{
@@ -430,7 +430,7 @@ var (
 			Name:     "CreatedBefore",
 			Expected: []details.Entry{testdata.OneDriveItems[1]},
 			Opts: utils.OneDriveOpts{
-				FileCreatedBefore: common.FormatTime(testdata.Time1.Add(time.Second)),
+				FileCreatedBefore: dttm.Format(testdata.Time1.Add(time.Second)),
 			},
 		},
 	}
@@ -556,7 +556,7 @@ var (
 		// 	Name:     "CreatedBefore",
 		// 	Expected: []details.DetailsEntry{testdata.SharePointLibraryItems[1]},
 		// 	Opts: utils.SharePointOpts{
-		// 		FileCreatedBefore: common.FormatTime(testdata.Time1.Add(time.Second)),
+		// 		FileCreatedBefore: dttm.Format(testdata.Time1.Add(time.Second)),
 		// 	},
 		// },
 	}

--- a/src/cmd/factory/impl/common.go
+++ b/src/cmd/factory/impl/common.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/connector"
@@ -68,8 +69,8 @@ func generateAndRestoreItems(
 
 	for i := 0; i < howMany; i++ {
 		var (
-			now       = common.Now()
-			nowLegacy = common.FormatLegacyTime(time.Now())
+			now       = dttm.Now()
+			nowLegacy = dttm.FormatToLegacy(time.Now())
 			id        = uuid.NewString()
 			subject   = "automated " + now[:16] + " - " + id[:8]
 			body      = "automated " + cat.String() + " generation for " + userID + " at " + now + " - " + id
@@ -87,7 +88,7 @@ func generateAndRestoreItems(
 		items:        items,
 	}}
 
-	dest := control.DefaultRestoreDestination(common.SimpleTimeTesting)
+	dest := control.DefaultRestoreDestination(dttm.SafeForTesting)
 	dest.ContainerName = destFldr
 	print.Infof(ctx, "Restoring to folder %s", dest.ContainerName)
 
@@ -269,7 +270,7 @@ func generateAndRestoreOnedriveItems(
 	ctx, flush := tester.NewContext()
 	defer flush()
 
-	dest := control.DefaultRestoreDestination(common.SimpleTimeTesting)
+	dest := control.DefaultRestoreDestination(dttm.SafeForTesting)
 	dest.ContainerName = destFldr
 	print.Infof(ctx, "Restoring to folder %s", dest.ContainerName)
 

--- a/src/cmd/purge/purge.go
+++ b/src/cmd/purge/purge.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/cli/utils"
 	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/connector"
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/onedrive"
@@ -226,8 +227,8 @@ func purgeFolders(
 		// compare the folder time to the deletion boundary time first
 		displayName := *fld.GetDisplayName()
 
-		dnTime, err := common.ExtractTime(displayName)
-		if err != nil && !errors.Is(err, common.ErrNoTimeString) {
+		dnTime, err := dttm.ExtractTime(displayName)
+		if err != nil && !errors.Is(err, dttm.ErrNoTimeString) {
 			err = clues.Wrap(err, "!! Error: parsing container: "+displayName)
 			Info(ctx, err)
 
@@ -282,7 +283,7 @@ func getBoundaryTime(ctx context.Context) (time.Time, error) {
 	)
 
 	if len(before) > 0 {
-		boundaryTime, err = common.ParseTime(before)
+		boundaryTime, err = dttm.ParseTime(before)
 		if err != nil {
 			return time.Time{}, Only(ctx, clues.Wrap(err, "parsing before flag to time"))
 		}

--- a/src/cmd/sanity_test/sanity_tests.go
+++ b/src/cmd/sanity_test/sanity_tests.go
@@ -15,7 +15,7 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
 	"golang.org/x/exp/slices"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/tester"
@@ -644,12 +644,12 @@ func fatal(ctx context.Context, msg string, err error) {
 }
 
 func mustGetTimeFromName(ctx context.Context, name string) (time.Time, bool) {
-	t, err := common.ExtractTime(name)
-	if err != nil && !errors.Is(err, common.ErrNoTimeString) {
+	t, err := dttm.ExtractTime(name)
+	if err != nil && !errors.Is(err, dttm.ErrNoTimeString) {
 		fatal(ctx, "extracting time from name: "+name, err)
 	}
 
-	return t, !errors.Is(err, common.ErrNoTimeString)
+	return t, !errors.Is(err, dttm.ErrNoTimeString)
 }
 
 func isWithinTimeBound(ctx context.Context, bound, check time.Time, hasTime bool) bool {

--- a/src/internal/common/dttm/dttm.go
+++ b/src/internal/common/dttm/dttm.go
@@ -1,4 +1,4 @@
-package common
+package dttm
 
 import (
 	"regexp"
@@ -10,8 +10,8 @@ import (
 type TimeFormat string
 
 const (
-	// StandardTime is the canonical format used for all data storage in corso
-	StandardTime TimeFormat = time.RFC3339Nano
+	// Standard is the canonical format used for all data storage in corso
+	Standard TimeFormat = time.RFC3339Nano
 
 	// DateOnly is accepted by the CLI as a valid input for timestamp-based
 	// filters.  Time and timezone are assumed to be 00:00:00 and UTC.
@@ -21,23 +21,23 @@ const (
 	// non-json cli outputs.
 	TabularOutput TimeFormat = "2006-01-02T15:04:05Z"
 
-	// LegacyTime is used in /exchange/service_restore to comply with certain
+	// Legacy is used in /exchange/service_restore to comply with certain
 	// graphAPI time format requirements.
-	LegacyTime TimeFormat = time.RFC3339
+	Legacy TimeFormat = time.RFC3339
 
-	// SimpleDateTime is the default value appended to the root restoration folder name.
-	SimpleDateTime TimeFormat = "02-Jan-2006_15:04:05"
-	// SimpleDateTimeOneDrive modifies SimpleDateTimeFormat to comply with onedrive folder
+	// HumanReadable is the default value appended to the root restoration folder name.
+	HumanReadable TimeFormat = "02-Jan-2006_15:04:05"
+	// HumanReadableDriveItem modifies SimpleDateTimeFormat to comply with onedrive folder
 	// restrictions: primarily swapping `-` instead of `:` which is a reserved character.
-	SimpleDateTimeOneDrive TimeFormat = "02-Jan-2006_15-04-05"
+	HumanReadableDriveItem TimeFormat = "02-Jan-2006_15-04-05"
 
 	// m365 will remove the :00 second suffix on folder names, resulting in the following formats.
-	ClippedSimple         TimeFormat = "02-Jan-2006_15:04"
-	ClippedSimpleOneDrive TimeFormat = "02-Jan-2006_15-04"
+	ClippedHuman          TimeFormat = "02-Jan-2006_15:04"
+	ClippedHumanDriveItem TimeFormat = "02-Jan-2006_15-04"
 
-	// SimpleTimeTesting is used for testing restore destination folders.
+	// SafeForTesting is used for testing restore destination folders.
 	// Microsecond granularity prevents collisions in parallel package or workflow runs.
-	SimpleTimeTesting TimeFormat = SimpleDateTimeOneDrive + ".000000"
+	SafeForTesting TimeFormat = HumanReadableDriveItem + ".000000"
 
 	// M365dateTimeTimeZoneTimeFormat is the format used by M365 for datetimetimezone resource
 	// https://learn.microsoft.com/en-us/graph/api/resources/datetimetimezone?view=graph-rest-1.0
@@ -48,42 +48,42 @@ const (
 // identify the folders produced in external data during automated testing.  For safety, each
 // time format described above should have a matching regexp.
 var (
-	clippedSimpleRE         = regexp.MustCompile(`.*(\d{2}-[a-zA-Z]{3}-\d{4}_\d{2}:\d{2}).*`)
-	clippedSimpleOneDriveRE = regexp.MustCompile(`.*(\d{2}-[a-zA-Z]{3}-\d{4}_\d{2}-\d{2}).*`)
-	dateOnlyRE              = regexp.MustCompile(`.*(\d{4}-\d{2}-\d{2}).*`)
-	legacyTimeRE            = regexp.MustCompile(
+	clippedHumanRE         = regexp.MustCompile(`.*(\d{2}-[a-zA-Z]{3}-\d{4}_\d{2}:\d{2}).*`)
+	clippedHumanOneDriveRE = regexp.MustCompile(`.*(\d{2}-[a-zA-Z]{3}-\d{4}_\d{2}-\d{2}).*`)
+	dateOnlyRE             = regexp.MustCompile(`.*(\d{4}-\d{2}-\d{2}).*`)
+	legacyRE               = regexp.MustCompile(
 		`.*(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?([Zz]|[a-zA-Z]{2}|([\+|\-]([01]\d|2[0-3])))).*`)
-	simpleTimeTestingRE      = regexp.MustCompile(`.*(\d{2}-[a-zA-Z]{3}-\d{4}_\d{2}-\d{2}-\d{2}.\d{6}).*`)
-	simpleDateTimeRE         = regexp.MustCompile(`.*(\d{2}-[a-zA-Z]{3}-\d{4}_\d{2}:\d{2}:\d{2}).*`)
-	simpleDateTimeOneDriveRE = regexp.MustCompile(`.*(\d{2}-[a-zA-Z]{3}-\d{4}_\d{2}-\d{2}-\d{2}).*`)
-	standardTimeRE           = regexp.MustCompile(
+	SafeForTestingRE        = regexp.MustCompile(`.*(\d{2}-[a-zA-Z]{3}-\d{4}_\d{2}-\d{2}-\d{2}.\d{6}).*`)
+	HumanReadableRE         = regexp.MustCompile(`.*(\d{2}-[a-zA-Z]{3}-\d{4}_\d{2}:\d{2}:\d{2}).*`)
+	HumanReadableOneDriveRE = regexp.MustCompile(`.*(\d{2}-[a-zA-Z]{3}-\d{4}_\d{2}-\d{2}-\d{2}).*`)
+	standardRE              = regexp.MustCompile(
 		`.*(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?([Zz]|[a-zA-Z]{2}|([\+|\-]([01]\d|2[0-3])))).*`)
-	tabularOutputTimeRE = regexp.MustCompile(`.*(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}([Zz]|[a-zA-Z]{2})).*`)
+	tabularOutputRE = regexp.MustCompile(`.*(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}([Zz]|[a-zA-Z]{2})).*`)
 )
 
 var (
 	// shortened formats (clipped*, DateOnly) must follow behind longer formats, otherwise they'll
 	// get eagerly chosen as the parsable format, slicing out some data.
 	formats = []TimeFormat{
-		StandardTime,
-		SimpleTimeTesting,
-		SimpleDateTime,
-		SimpleDateTimeOneDrive,
-		LegacyTime,
+		Standard,
+		SafeForTesting,
+		HumanReadable,
+		HumanReadableDriveItem,
+		Legacy,
 		TabularOutput,
-		ClippedSimple,
-		ClippedSimpleOneDrive,
+		ClippedHuman,
+		ClippedHumanDriveItem,
 		DateOnly,
 	}
 	regexes = []*regexp.Regexp{
-		standardTimeRE,
-		simpleTimeTestingRE,
-		simpleDateTimeRE,
-		simpleDateTimeOneDriveRE,
-		legacyTimeRE,
-		tabularOutputTimeRE,
-		clippedSimpleRE,
-		clippedSimpleOneDriveRE,
+		standardRE,
+		SafeForTestingRE,
+		HumanReadableRE,
+		HumanReadableOneDriveRE,
+		legacyRE,
+		tabularOutputRE,
+		clippedHumanRE,
+		clippedHumanOneDriveRE,
 		dateOnlyRE,
 	}
 )
@@ -95,43 +95,43 @@ var (
 
 // Now produces the current time as a string in the standard format.
 func Now() string {
-	return FormatNow(StandardTime)
+	return FormatNow(Standard)
 }
 
 // FormatNow produces the current time in UTC using the provided
 // time format.
 func FormatNow(fmt TimeFormat) string {
-	return FormatTimeWith(time.Now(), fmt)
+	return FormatTo(time.Now(), fmt)
 }
 
-// FormatTimeWith produces the a datetime with the given format.
-func FormatTimeWith(t time.Time, fmt TimeFormat) string {
+// FormatTo produces the a datetime with the given format.
+func FormatTo(t time.Time, fmt TimeFormat) string {
 	return t.UTC().Format(string(fmt))
 }
 
-// FormatTime produces the standard format for corso time values.
+// Format produces the standard format for corso time values.
 // Always formats into the UTC timezone.
-func FormatTime(t time.Time) string {
-	return FormatTimeWith(t, StandardTime)
+func Format(t time.Time) string {
+	return FormatTo(t, Standard)
 }
 
-// FormatSimpleDateTime produces a simple datetime of the format
+// FormatToHumanReadable produces a simple datetime of the format
 // "02-Jan-2006_15:04:05"
-func FormatSimpleDateTime(t time.Time) string {
-	return FormatTimeWith(t, SimpleDateTime)
+func FormatToHumanReadable(t time.Time) string {
+	return FormatTo(t, HumanReadable)
 }
 
-// FormatTabularDisplayTime produces the standard format for displaying
+// FormatToTabularDisplay produces the standard format for displaying
 // a timestamp as part of user-readable cli output.
 // "2016-01-02T15:04:05Z"
-func FormatTabularDisplayTime(t time.Time) string {
-	return FormatTimeWith(t, TabularOutput)
+func FormatToTabularDisplay(t time.Time) string {
+	return FormatTo(t, TabularOutput)
 }
 
-// FormatLegacyTime produces standard format for string values
+// FormatToLegacy produces standard format for string values
 // that are placed in SingleValueExtendedProperty tags
-func FormatLegacyTime(t time.Time) string {
-	return FormatTimeWith(t, LegacyTime)
+func FormatToLegacy(t time.Time) string {
+	return FormatTo(t, Legacy)
 }
 
 // ParseTime makes a best attempt to produce a time value from

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -12,7 +12,7 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/graph/api"
@@ -407,7 +407,7 @@ func EventInfo(evt models.Eventable) *details.ExchangeInfo {
 		// DateTime is not: time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC)
 		startTime := ptr.Val(evt.GetStart().GetDateTime()) + "Z"
 
-		output, err := common.ParseTime(startTime)
+		output, err := dttm.ParseTime(startTime)
 		if err == nil {
 			start = output
 		}
@@ -418,7 +418,7 @@ func EventInfo(evt models.Eventable) *details.ExchangeInfo {
 		// DateTime is not: time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC)
 		endTime := ptr.Val(evt.GetEnd().GetDateTime()) + "Z"
 
-		output, err := common.ParseTime(endTime)
+		output, err := dttm.ParseTime(endTime)
 		if err == nil {
 			end = output
 		}

--- a/src/internal/connector/exchange/api/events_test.go
+++ b/src/internal/connector/exchange/api/events_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	exchMock "github.com/alcionai/corso/src/internal/connector/exchange/mock"
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/tester"
@@ -31,7 +31,7 @@ func (suite *EventsAPIUnitSuite) TestEventInfo() {
 	// Exchange stores start/end times in UTC and the below compares hours
 	// directly so we need to "normalize" the timezone here.
 	initial := time.Now().UTC()
-	now := common.FormatTimeWith(initial, common.M365DateTimeTimeZone)
+	now := dttm.FormatTo(initial, dttm.M365DateTimeTimeZone)
 
 	suite.T().Logf("Initial: %v\nFormatted: %v\n", initial, now)
 
@@ -87,7 +87,7 @@ func (suite *EventsAPIUnitSuite) TestEventInfo() {
 				startTime.SetDateTime(&now)
 				event.SetStart(startTime)
 
-				nowp30m := common.FormatTimeWith(initial.Add(30*time.Minute), common.M365DateTimeTimeZone)
+				nowp30m := dttm.FormatTo(initial.Add(30*time.Minute), dttm.M365DateTimeTimeZone)
 				endTime.SetDateTime(&nowp30m)
 				event.SetEnd(endTime)
 

--- a/src/internal/connector/exchange/mock/event.go
+++ b/src/internal/connector/exchange/mock/event.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 )
 
 // Order of fields to fill in:
@@ -221,8 +221,8 @@ func EventBytes(subject string) []byte {
 func EventWithSubjectBytes(subject string) []byte {
 	tomorrow := time.Now().UTC().AddDate(0, 0, 1)
 	at := time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), tomorrow.Hour(), 0, 0, 0, time.UTC)
-	atTime := common.FormatTime(at)
-	endTime := common.FormatTime(at.Add(30 * time.Minute))
+	atTime := dttm.Format(at)
+	endTime := dttm.Format(at.Add(30 * time.Minute))
 
 	return EventWith(
 		defaultEventOrganizer, subject,
@@ -234,7 +234,7 @@ func EventWithSubjectBytes(subject string) []byte {
 func EventWithAttachment(subject string) []byte {
 	tomorrow := time.Now().UTC().AddDate(0, 0, 1)
 	at := time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), tomorrow.Hour(), 0, 0, 0, time.UTC)
-	atTime := common.FormatTime(at)
+	atTime := dttm.Format(at)
 
 	return EventWith(
 		defaultEventOrganizer, subject,
@@ -246,7 +246,7 @@ func EventWithAttachment(subject string) []byte {
 func EventWithRecurrenceBytes(subject, recurrenceTimeZone string) []byte {
 	tomorrow := time.Now().UTC().AddDate(0, 0, 1)
 	at := time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), tomorrow.Hour(), 0, 0, 0, time.UTC)
-	atTime := common.FormatTime(at)
+	atTime := dttm.Format(at)
 	timeSlice := strings.Split(atTime, "T")
 
 	recurrence := string(fmt.Sprintf(
@@ -265,7 +265,7 @@ func EventWithRecurrenceBytes(subject, recurrenceTimeZone string) []byte {
 func EventWithAttendeesBytes(subject string) []byte {
 	tomorrow := time.Now().UTC().AddDate(0, 0, 1)
 	at := time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), tomorrow.Hour(), 0, 0, 0, time.UTC)
-	atTime := common.FormatTime(at)
+	atTime := dttm.Format(at)
 
 	return EventWith(
 		defaultEventOrganizer, subject,

--- a/src/internal/connector/exchange/mock/mail.go
+++ b/src/internal/connector/exchange/mock/mail.go
@@ -11,7 +11,7 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/stretchr/testify/require"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 )
 
 //nolint:lll
@@ -107,7 +107,7 @@ const (
 // Contents verified as working with sample data from kiota-serialization-json-go v0.5.5
 func MessageBytes(subject string) []byte {
 	return MessageWithBodyBytes(
-		"TPS Report "+subject+" "+common.FormatNow(common.SimpleDateTime),
+		"TPS Report "+subject+" "+dttm.FormatNow(dttm.HumanReadable),
 		defaultMessageBody, defaultMessagePreview)
 }
 

--- a/src/internal/connector/exchange/restore_test.go
+++ b/src/internal/connector/exchange/restore_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/connector/exchange/api"
 	exchMock "github.com/alcionai/corso/src/internal/connector/exchange/mock"
@@ -68,7 +68,7 @@ func (suite *ExchangeRestoreSuite) TestRestoreContact() {
 		t          = suite.T()
 		userID     = tester.M365UserID(t)
 		now        = time.Now()
-		folderName = "TestRestoreContact: " + common.FormatTimeWith(now, common.SimpleTimeTesting)
+		folderName = "TestRestoreContact: " + dttm.FormatTo(now, dttm.SafeForTesting)
 	)
 
 	aFolder, err := suite.ac.Contacts().CreateContactFolder(ctx, userID, folderName)
@@ -102,7 +102,7 @@ func (suite *ExchangeRestoreSuite) TestRestoreEvent() {
 	var (
 		t       = suite.T()
 		userID  = tester.M365UserID(t)
-		subject = "TestRestoreEvent: " + common.FormatNow(common.SimpleTimeTesting)
+		subject = "TestRestoreEvent: " + dttm.FormatNow(dttm.SafeForTesting)
 	)
 
 	calendar, err := suite.ac.Events().CreateCalendar(ctx, userID, subject)
@@ -184,7 +184,7 @@ func (suite *ExchangeRestoreSuite) TestRestoreExchangeObject() {
 			bytes:    exchMock.MessageBytes("Restore Exchange Object"),
 			category: path.EmailCategory,
 			destination: func(t *testing.T, ctx context.Context) string {
-				folderName := "TestRestoreMailObject: " + common.FormatTimeWith(now, common.SimpleTimeTesting)
+				folderName := "TestRestoreMailObject: " + dttm.FormatTo(now, dttm.SafeForTesting)
 				folder, err := suite.ac.Mail().CreateMailFolder(ctx, userID, folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
@@ -196,7 +196,7 @@ func (suite *ExchangeRestoreSuite) TestRestoreExchangeObject() {
 			bytes:    exchMock.MessageWithDirectAttachment("Restore 1 Attachment"),
 			category: path.EmailCategory,
 			destination: func(t *testing.T, ctx context.Context) string {
-				folderName := "TestRestoreMailwithAttachment: " + common.FormatTimeWith(now, common.SimpleTimeTesting)
+				folderName := "TestRestoreMailwithAttachment: " + dttm.FormatTo(now, dttm.SafeForTesting)
 				folder, err := suite.ac.Mail().CreateMailFolder(ctx, userID, folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
@@ -208,7 +208,7 @@ func (suite *ExchangeRestoreSuite) TestRestoreExchangeObject() {
 			bytes:    exchMock.MessageWithItemAttachmentEvent("Event Item Attachment"),
 			category: path.EmailCategory,
 			destination: func(t *testing.T, ctx context.Context) string {
-				folderName := "TestRestoreEventItemAttachment: " + common.FormatTimeWith(now, common.SimpleTimeTesting)
+				folderName := "TestRestoreEventItemAttachment: " + dttm.FormatTo(now, dttm.SafeForTesting)
 				folder, err := suite.ac.Mail().CreateMailFolder(ctx, userID, folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
@@ -220,7 +220,7 @@ func (suite *ExchangeRestoreSuite) TestRestoreExchangeObject() {
 			bytes:    exchMock.MessageWithItemAttachmentMail("Mail Item Attachment"),
 			category: path.EmailCategory,
 			destination: func(t *testing.T, ctx context.Context) string {
-				folderName := "TestRestoreMailItemAttachment: " + common.FormatTimeWith(now, common.SimpleTimeTesting)
+				folderName := "TestRestoreMailItemAttachment: " + dttm.FormatTo(now, dttm.SafeForTesting)
 				folder, err := suite.ac.Mail().CreateMailFolder(ctx, userID, folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
@@ -235,7 +235,7 @@ func (suite *ExchangeRestoreSuite) TestRestoreExchangeObject() {
 			),
 			category: path.EmailCategory,
 			destination: func(t *testing.T, ctx context.Context) string {
-				folderName := "TestRestoreMailBasicItemAttachment: " + common.FormatTimeWith(now, common.SimpleTimeTesting)
+				folderName := "TestRestoreMailBasicItemAttachment: " + dttm.FormatTo(now, dttm.SafeForTesting)
 				folder, err := suite.ac.Mail().CreateMailFolder(ctx, userID, folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
@@ -250,7 +250,7 @@ func (suite *ExchangeRestoreSuite) TestRestoreExchangeObject() {
 			),
 			category: path.EmailCategory,
 			destination: func(t *testing.T, ctx context.Context) string {
-				folderName := "ItemMailAttachmentwAttachment " + common.FormatTimeWith(now, common.SimpleTimeTesting)
+				folderName := "ItemMailAttachmentwAttachment " + dttm.FormatTo(now, dttm.SafeForTesting)
 				folder, err := suite.ac.Mail().CreateMailFolder(ctx, userID, folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
@@ -265,7 +265,7 @@ func (suite *ExchangeRestoreSuite) TestRestoreExchangeObject() {
 			),
 			category: path.EmailCategory,
 			destination: func(t *testing.T, ctx context.Context) string {
-				folderName := "ItemMailAttachment_Contact " + common.FormatTimeWith(now, common.SimpleTimeTesting)
+				folderName := "ItemMailAttachment_Contact " + dttm.FormatTo(now, dttm.SafeForTesting)
 				folder, err := suite.ac.Mail().CreateMailFolder(ctx, userID, folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
@@ -277,7 +277,7 @@ func (suite *ExchangeRestoreSuite) TestRestoreExchangeObject() {
 			bytes:    exchMock.MessageWithNestedItemAttachmentEvent("Nested Item Attachment"),
 			category: path.EmailCategory,
 			destination: func(t *testing.T, ctx context.Context) string {
-				folderName := "TestRestoreNestedEventItemAttachment: " + common.FormatTimeWith(now, common.SimpleTimeTesting)
+				folderName := "TestRestoreNestedEventItemAttachment: " + dttm.FormatTo(now, dttm.SafeForTesting)
 				folder, err := suite.ac.Mail().CreateMailFolder(ctx, userID, folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
@@ -289,7 +289,7 @@ func (suite *ExchangeRestoreSuite) TestRestoreExchangeObject() {
 			bytes:    exchMock.MessageWithLargeAttachment("Restore Large Attachment"),
 			category: path.EmailCategory,
 			destination: func(t *testing.T, ctx context.Context) string {
-				folderName := "TestRestoreMailwithLargeAttachment: " + common.FormatTimeWith(now, common.SimpleTimeTesting)
+				folderName := "TestRestoreMailwithLargeAttachment: " + dttm.FormatTo(now, dttm.SafeForTesting)
 				folder, err := suite.ac.Mail().CreateMailFolder(ctx, userID, folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
@@ -301,7 +301,7 @@ func (suite *ExchangeRestoreSuite) TestRestoreExchangeObject() {
 			bytes:    exchMock.MessageWithTwoAttachments("Restore 2 Attachments"),
 			category: path.EmailCategory,
 			destination: func(t *testing.T, ctx context.Context) string {
-				folderName := "TestRestoreMailwithAttachments: " + common.FormatTimeWith(now, common.SimpleTimeTesting)
+				folderName := "TestRestoreMailwithAttachments: " + dttm.FormatTo(now, dttm.SafeForTesting)
 				folder, err := suite.ac.Mail().CreateMailFolder(ctx, userID, folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
@@ -313,7 +313,7 @@ func (suite *ExchangeRestoreSuite) TestRestoreExchangeObject() {
 			bytes:    exchMock.MessageWithOneDriveAttachment("Restore Reference(OneDrive) Attachment"),
 			category: path.EmailCategory,
 			destination: func(t *testing.T, ctx context.Context) string {
-				folderName := "TestRestoreMailwithReferenceAttachment: " + common.FormatTimeWith(now, common.SimpleTimeTesting)
+				folderName := "TestRestoreMailwithReferenceAttachment: " + dttm.FormatTo(now, dttm.SafeForTesting)
 				folder, err := suite.ac.Mail().CreateMailFolder(ctx, userID, folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
@@ -326,7 +326,7 @@ func (suite *ExchangeRestoreSuite) TestRestoreExchangeObject() {
 			bytes:    exchMock.ContactBytes("Test_Omega"),
 			category: path.ContactsCategory,
 			destination: func(t *testing.T, ctx context.Context) string {
-				folderName := "TestRestoreContactObject: " + common.FormatTimeWith(now, common.SimpleTimeTesting)
+				folderName := "TestRestoreContactObject: " + dttm.FormatTo(now, dttm.SafeForTesting)
 				folder, err := suite.ac.Contacts().CreateContactFolder(ctx, userID, folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
@@ -338,7 +338,7 @@ func (suite *ExchangeRestoreSuite) TestRestoreExchangeObject() {
 			bytes:    exchMock.EventBytes("Restored Event Object"),
 			category: path.EventsCategory,
 			destination: func(t *testing.T, ctx context.Context) string {
-				calendarName := "TestRestoreEventObject: " + common.FormatTimeWith(now, common.SimpleTimeTesting)
+				calendarName := "TestRestoreEventObject: " + dttm.FormatTo(now, dttm.SafeForTesting)
 				calendar, err := suite.ac.Events().CreateCalendar(ctx, userID, calendarName)
 				require.NoError(t, err, clues.ToCore(err))
 
@@ -350,7 +350,7 @@ func (suite *ExchangeRestoreSuite) TestRestoreExchangeObject() {
 			bytes:    exchMock.EventWithAttachment("Restored Event Attachment"),
 			category: path.EventsCategory,
 			destination: func(t *testing.T, ctx context.Context) string {
-				calendarName := "TestRestoreEventObject_" + common.FormatTimeWith(now, common.SimpleTimeTesting)
+				calendarName := "TestRestoreEventObject_" + dttm.FormatTo(now, dttm.SafeForTesting)
 				calendar, err := suite.ac.Events().CreateCalendar(ctx, userID, calendarName)
 				require.NoError(t, err, clues.ToCore(err))
 

--- a/src/internal/connector/exchange/service_restore.go
+++ b/src/internal/connector/exchange/service_restore.go
@@ -10,7 +10,7 @@ import (
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/connector/exchange/api"
 	"github.com/alcionai/corso/src/internal/connector/graph"
@@ -194,7 +194,7 @@ func RestoreMailMessage(
 
 	if clone.GetSentDateTime() != nil {
 		sv2 := models.NewSingleValueLegacyExtendedProperty()
-		sendPropertyValue := common.FormatLegacyTime(ptr.Val(clone.GetSentDateTime()))
+		sendPropertyValue := dttm.FormatToLegacy(ptr.Val(clone.GetSentDateTime()))
 		sendPropertyTag := MailSendDateTimeOverrideProperty
 		sv2.SetId(&sendPropertyTag)
 		sv2.SetValue(&sendPropertyValue)
@@ -204,7 +204,7 @@ func RestoreMailMessage(
 
 	if clone.GetReceivedDateTime() != nil {
 		sv3 := models.NewSingleValueLegacyExtendedProperty()
-		recvPropertyValue := common.FormatLegacyTime(ptr.Val(clone.GetReceivedDateTime()))
+		recvPropertyValue := dttm.FormatToLegacy(ptr.Val(clone.GetReceivedDateTime()))
 		recvPropertyTag := MailReceiveDateTimeOverriveProperty
 		sv3.SetId(&recvPropertyTag)
 		sv3.SetValue(&recvPropertyValue)

--- a/src/internal/connector/onedrive/drive_test.go
+++ b/src/internal/connector/onedrive/drive_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/onedrive/api"
@@ -302,7 +302,7 @@ func (suite *OneDriveSuite) TestCreateGetDeleteFolder() {
 	var (
 		t              = suite.T()
 		folderIDs      = []string{}
-		folderName1    = "Corso_Folder_Test_" + common.FormatNow(common.SimpleTimeTesting)
+		folderName1    = "Corso_Folder_Test_" + dttm.FormatNow(dttm.SafeForTesting)
 		folderElements = []string{folderName1}
 		gs             = loadTestService(t)
 	)
@@ -340,7 +340,7 @@ func (suite *OneDriveSuite) TestCreateGetDeleteFolder() {
 
 	folderIDs = append(folderIDs, folderID)
 
-	folderName2 := "Corso_Folder_Test_" + common.FormatNow(common.SimpleTimeTesting)
+	folderName2 := "Corso_Folder_Test_" + dttm.FormatNow(dttm.SafeForTesting)
 	restoreFolders = restoreFolders.Append(folderName2)
 
 	folderID, err = CreateRestoreFolders(ctx, gs, driveID, ptr.Val(rootFolder.GetId()), restoreFolders, NewFolderCache())

--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/onedrive/api"
@@ -158,7 +158,7 @@ func (suite *ItemIntegrationSuite) TestItemWriter() {
 			folder, err := api.GetFolderByName(ctx, srv, test.driveID, ptr.Val(root.GetId()), "Test Folder")
 			require.NoError(t, err, clues.ToCore(err))
 
-			newFolderName := "testfolder_" + common.FormatNow(common.SimpleTimeTesting)
+			newFolderName := "testfolder_" + dttm.FormatNow(dttm.SafeForTesting)
 			t.Logf("Test will create folder %s", newFolderName)
 
 			newFolder, err := CreateItem(
@@ -170,7 +170,7 @@ func (suite *ItemIntegrationSuite) TestItemWriter() {
 			require.NoError(t, err, clues.ToCore(err))
 			require.NotNil(t, newFolder.GetId())
 
-			newItemName := "testItem_" + common.FormatNow(common.SimpleTimeTesting)
+			newItemName := "testItem_" + dttm.FormatNow(dttm.SafeForTesting)
 			t.Logf("Test will create item %s", newItemName)
 
 			newItem, err := CreateItem(

--- a/src/internal/connector/sharepoint/api/pages_test.go
+++ b/src/internal/connector/sharepoint/api/pages_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/connector/sharepoint"
 	"github.com/alcionai/corso/src/internal/connector/sharepoint/api"
 	spMock "github.com/alcionai/corso/src/internal/connector/sharepoint/mock"
@@ -81,7 +81,7 @@ func (suite *SharePointPageSuite) TestRestoreSinglePage() {
 
 	t := suite.T()
 
-	destName := "Corso_Restore_" + common.FormatNow(common.SimpleTimeTesting)
+	destName := "Corso_Restore_" + dttm.FormatNow(dttm.SafeForTesting)
 	testName := "MockPage"
 
 	// Create Test Page

--- a/src/internal/connector/sharepoint/collection_test.go
+++ b/src/internal/connector/sharepoint/collection_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/connector/sharepoint/api"
 	spMock "github.com/alcionai/corso/src/internal/connector/sharepoint/mock"
@@ -193,7 +193,7 @@ func (suite *SharePointCollectionSuite) TestListCollection_Restore() {
 		info: sharePointListInfo(listing, int64(len(byteArray))),
 	}
 
-	destName := "Corso_Restore_" + common.FormatNow(common.SimpleTimeTesting)
+	destName := "Corso_Restore_" + dttm.FormatNow(dttm.SafeForTesting)
 
 	deets, err := restoreListItem(ctx, service, listData, suite.siteID, destName)
 	assert.NoError(t, err, clues.ToCore(err))

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -7,8 +7,8 @@ import (
 	"github.com/alcionai/clues"
 	"github.com/google/uuid"
 
-	"github.com/alcionai/corso/src/internal/common"
 	"github.com/alcionai/corso/src/internal/common/crash"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/diagnostics"
@@ -872,10 +872,10 @@ func (op *BackupOperation) createBackupModels(
 			events.BackupID:   b.ID,
 			events.DataStored: op.Results.BytesUploaded,
 			events.Duration:   op.Results.CompletedAt.Sub(op.Results.StartedAt),
-			events.EndTime:    common.FormatTime(op.Results.CompletedAt),
+			events.EndTime:    dttm.Format(op.Results.CompletedAt),
 			events.Resources:  op.Results.ResourceOwners,
 			events.Service:    op.Selectors.PathService().String(),
-			events.StartTime:  common.FormatTime(op.Results.StartedAt),
+			events.StartTime:  dttm.Format(op.Results.StartedAt),
 			events.Status:     op.Status.String(),
 		})
 

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/exp/maps"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/common/idname"
 	inMock "github.com/alcionai/corso/src/internal/common/idname/mock"
 	"github.com/alcionai/corso/src/internal/common/ptr"
@@ -375,7 +375,7 @@ func generateContainerOfItems(
 		items:       items,
 	}}
 
-	dest := control.DefaultRestoreDestination(common.SimpleTimeTesting)
+	dest := control.DefaultRestoreDestination(dttm.SafeForTesting)
 	dest.ContainerName = destFldr
 
 	dataColls := buildCollections(
@@ -410,8 +410,8 @@ func generateItemData(
 	dbf dataBuilderFunc,
 ) (string, []byte) {
 	var (
-		now       = common.Now()
-		nowLegacy = common.FormatLegacyTime(time.Now())
+		now       = dttm.Now()
+		nowLegacy = dttm.FormatToLegacy(time.Now())
 		id        = uuid.NewString()
 		subject   = "incr_test " + now[:16] + " - " + id[:8]
 		body      = "incr_test " + category.String() + " generation for " + resourceOwner + " at " + now + " - " + id
@@ -702,7 +702,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchangeIncrementals() {
 		acct       = tester.NewM365Account(t)
 		ffs        = control.Toggles{}
 		mb         = evmock.NewBus()
-		now        = common.Now()
+		now        = dttm.Now()
 		categories = map[path.CategoryType][]string{
 			path.EmailCategory:    exchange.MetadataFileNames(path.EmailCategory),
 			path.ContactsCategory: exchange.MetadataFileNames(path.ContactsCategory),
@@ -1232,7 +1232,7 @@ func runDriveIncrementalTest(
 
 		// `now` has to be formatted with SimpleDateTimeTesting as
 		// some drives cannot have `:` in file/folder names
-		now = common.FormatNow(common.SimpleTimeTesting)
+		now = dttm.FormatNow(dttm.SafeForTesting)
 
 		categories = map[path.CategoryType][]string{
 			category: {graph.DeltaURLsFileName, graph.PreviousPathFileName},

--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -8,8 +8,8 @@ import (
 	"github.com/alcionai/clues"
 	"github.com/google/uuid"
 
-	"github.com/alcionai/corso/src/internal/common"
 	"github.com/alcionai/corso/src/internal/common/crash"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/connector/onedrive"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/diagnostics"
@@ -289,13 +289,13 @@ func (op *RestoreOperation) persistResults(
 			events.BackupID:      op.BackupID,
 			events.DataRetrieved: op.Results.BytesRead,
 			events.Duration:      op.Results.CompletedAt.Sub(op.Results.StartedAt),
-			events.EndTime:       common.FormatTime(op.Results.CompletedAt),
+			events.EndTime:       dttm.Format(op.Results.CompletedAt),
 			events.ItemsRead:     op.Results.ItemsRead,
 			events.ItemsWritten:  op.Results.ItemsWritten,
 			events.Resources:     op.Results.ResourceOwners,
 			events.RestoreID:     opStats.restoreID,
 			events.Service:       op.Selectors.Service.String(),
-			events.StartTime:     common.FormatTime(op.Results.StartedAt),
+			events.StartTime:     dttm.Format(op.Results.StartedAt),
 			events.Status:        op.Status.String(),
 		},
 	)

--- a/src/internal/operations/restore_test.go
+++ b/src/internal/operations/restore_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	inMock "github.com/alcionai/corso/src/internal/common/idname/mock"
 	"github.com/alcionai/corso/src/internal/connector"
 	"github.com/alcionai/corso/src/internal/connector/exchange"
@@ -404,7 +404,7 @@ func (suite *RestoreOpIntegrationSuite) TestRestore_Run() {
 		{
 			name:  "SharePoint_Restore",
 			owner: tester.M365SiteID(suite.T()),
-			dest:  control.DefaultRestoreDestination(common.SimpleTimeTesting),
+			dest:  control.DefaultRestoreDestination(dttm.SafeForTesting),
 			getSelector: func(t *testing.T, owners []string) selectors.Selector {
 				rsel := selectors.NewSharePointRestore(owners)
 				rsel.Include(rsel.AllData())

--- a/src/internal/tester/cli.go
+++ b/src/internal/tester/cli.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/pkg/logger"
 )
 
@@ -17,7 +17,7 @@ import (
 // the root command for integration testing on the CLI
 func StubRootCmd(args ...string) *cobra.Command {
 	id := uuid.NewString()
-	now := common.FormatTime(time.Now())
+	now := dttm.Format(time.Now())
 	cmdArg := "testing-corso"
 	c := &cobra.Command{
 		Use:   cmdArg,

--- a/src/internal/tester/restore_destination.go
+++ b/src/internal/tester/restore_destination.go
@@ -1,11 +1,11 @@
 package tester
 
 import (
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/pkg/control"
 )
 
 func DefaultTestRestoreDestination() control.RestoreDestination {
 	// Use microsecond granularity to help reduce collisions.
-	return control.DefaultRestoreDestination(common.SimpleTimeTesting)
+	return control.DefaultRestoreDestination(dttm.SafeForTesting)
 }

--- a/src/pkg/backup/backup.go
+++ b/src/pkg/backup/backup.go
@@ -10,7 +10,7 @@ import (
 	"github.com/dustin/go-humanize"
 
 	"github.com/alcionai/corso/src/cli/print"
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/internal/stats"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -264,7 +264,7 @@ func (b Backup) Values() []string {
 
 	return []string{
 		string(b.ID),
-		common.FormatTabularDisplayTime(b.StartedAt),
+		dttm.FormatToTabularDisplay(b.StartedAt),
 		bs.EndedAt.Sub(bs.StartedAt).String(),
 		status,
 		name,

--- a/src/pkg/backup/backup_test.go
+++ b/src/pkg/backup/backup_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/internal/stats"
 	"github.com/alcionai/corso/src/internal/tester"
@@ -74,7 +74,7 @@ func (suite *BackupUnitSuite) TestBackup_HeadersValues() {
 			"Status",
 			"Resource Owner",
 		}
-		nowFmt   = common.FormatTabularDisplayTime(now)
+		nowFmt   = dttm.FormatToTabularDisplay(now)
 		expectVs = []string{
 			"id",
 			nowFmt,

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/alcionai/corso/src/cli/print"
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/connector/onedrive/metadata"
 	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -804,8 +804,8 @@ func (i ExchangeInfo) Values() []string {
 		return []string{
 			i.Organizer,
 			i.Subject,
-			common.FormatTabularDisplayTime(i.EventStart),
-			common.FormatTabularDisplayTime(i.EventEnd),
+			dttm.FormatToTabularDisplay(i.EventStart),
+			dttm.FormatToTabularDisplay(i.EventEnd),
 			strconv.FormatBool(i.EventRecurs),
 		}
 
@@ -815,7 +815,7 @@ func (i ExchangeInfo) Values() []string {
 	case ExchangeMail:
 		return []string{
 			i.Sender, i.ParentPath, i.Subject,
-			common.FormatTabularDisplayTime(i.Received),
+			dttm.FormatToTabularDisplay(i.Received),
 		}
 	}
 
@@ -887,8 +887,8 @@ func (i SharePointInfo) Values() []string {
 		i.ParentPath,
 		humanize.Bytes(uint64(i.Size)),
 		i.Owner,
-		common.FormatTabularDisplayTime(i.Created),
-		common.FormatTabularDisplayTime(i.Modified),
+		dttm.FormatToTabularDisplay(i.Created),
+		dttm.FormatToTabularDisplay(i.Modified),
 	}
 }
 
@@ -944,8 +944,8 @@ func (i OneDriveInfo) Values() []string {
 		i.ParentPath,
 		humanize.Bytes(uint64(i.Size)),
 		i.Owner,
-		common.FormatTabularDisplayTime(i.Created),
-		common.FormatTabularDisplayTime(i.Modified),
+		dttm.FormatToTabularDisplay(i.Created),
+		dttm.FormatToTabularDisplay(i.Modified),
 	}
 }
 

--- a/src/pkg/backup/details/details_test.go
+++ b/src/pkg/backup/details/details_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/connector/onedrive/metadata"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/version"
@@ -34,8 +34,8 @@ func TestDetailsUnitSuite(t *testing.T) {
 
 func (suite *DetailsUnitSuite) TestDetailsEntry_HeadersValues() {
 	initial := time.Now()
-	nowStr := common.FormatTimeWith(initial, common.TabularOutput)
-	now, err := common.ParseTime(nowStr)
+	nowStr := dttm.FormatTo(initial, dttm.TabularOutput)
+	now, err := dttm.ParseTime(nowStr)
 	require.NoError(suite.T(), err, clues.ToCore(err))
 
 	table := []struct {

--- a/src/pkg/control/options.go
+++ b/src/pkg/control/options.go
@@ -1,7 +1,7 @@
 package control
 
 import (
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/pkg/control/repository"
 )
 
@@ -83,9 +83,9 @@ type RestoreDestination struct {
 	ContainerName string
 }
 
-func DefaultRestoreDestination(timeFormat common.TimeFormat) RestoreDestination {
+func DefaultRestoreDestination(timeFormat dttm.TimeFormat) RestoreDestination {
 	return RestoreDestination{
-		ContainerName: defaultRestoreLocation + common.FormatNow(timeFormat),
+		ContainerName: defaultRestoreLocation + dttm.FormatNow(timeFormat),
 	}
 }
 

--- a/src/pkg/selectors/exchange.go
+++ b/src/pkg/selectors/exchange.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/alcionai/clues"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/filters"
@@ -776,7 +776,7 @@ func (s ExchangeScope) matchesInfo(dii details.ItemInfo) bool {
 	case ExchangeInfoEventRecurs:
 		i = strconv.FormatBool(info.EventRecurs)
 	case ExchangeInfoEventStartsAfter, ExchangeInfoEventStartsBefore:
-		i = common.FormatTime(info.EventStart)
+		i = dttm.Format(info.EventStart)
 	case ExchangeInfoEventSubject:
 		i = info.Subject
 	case ExchangeInfoMailSender:
@@ -784,7 +784,7 @@ func (s ExchangeScope) matchesInfo(dii details.ItemInfo) bool {
 	case ExchangeInfoMailSubject:
 		i = info.Subject
 	case ExchangeInfoMailReceivedAfter, ExchangeInfoMailReceivedBefore:
-		i = common.FormatTime(info.Received)
+		i = dttm.Format(info.Received)
 	}
 
 	return s.Matches(infoCat, i)

--- a/src/pkg/selectors/exchange_test.go
+++ b/src/pkg/selectors/exchange_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -642,25 +642,25 @@ func (suite *ExchangeSelectorSuite) TestExchangeScope_MatchesInfo() {
 		{"mail with a different subject", details.ExchangeMail, es.MailSubject("fancy"), assert.False},
 		{"mail with the matching subject", details.ExchangeMail, es.MailSubject(subject), assert.True},
 		{"mail with a substring subject match", details.ExchangeMail, es.MailSubject(subject[5:9]), assert.True},
-		{"mail received after the epoch", details.ExchangeMail, es.MailReceivedAfter(common.FormatTime(epoch)), assert.True},
-		{"mail received after now", details.ExchangeMail, es.MailReceivedAfter(common.FormatTime(now)), assert.False},
+		{"mail received after the epoch", details.ExchangeMail, es.MailReceivedAfter(dttm.Format(epoch)), assert.True},
+		{"mail received after now", details.ExchangeMail, es.MailReceivedAfter(dttm.Format(now)), assert.False},
 		{
 			"mail received after sometime later",
 			details.ExchangeMail,
-			es.MailReceivedAfter(common.FormatTime(future)),
+			es.MailReceivedAfter(dttm.Format(future)),
 			assert.False,
 		},
 		{
 			"mail received before the epoch",
 			details.ExchangeMail,
-			es.MailReceivedBefore(common.FormatTime(epoch)),
+			es.MailReceivedBefore(dttm.Format(epoch)),
 			assert.False,
 		},
-		{"mail received before now", details.ExchangeMail, es.MailReceivedBefore(common.FormatTime(now)), assert.False},
+		{"mail received before now", details.ExchangeMail, es.MailReceivedBefore(dttm.Format(now)), assert.False},
 		{
 			"mail received before sometime later",
 			details.ExchangeMail,
-			es.MailReceivedBefore(common.FormatTime(future)),
+			es.MailReceivedBefore(dttm.Format(future)),
 			assert.True,
 		},
 		{"event with any organizer", details.ExchangeEvent, es.EventOrganizer(AnyTgt), assert.True},
@@ -669,25 +669,25 @@ func (suite *ExchangeSelectorSuite) TestExchangeScope_MatchesInfo() {
 		{"event with the matching organizer", details.ExchangeEvent, es.EventOrganizer(organizer), assert.True},
 		{"event that recurs", details.ExchangeEvent, es.EventRecurs("true"), assert.True},
 		{"event that does not recur", details.ExchangeEvent, es.EventRecurs("false"), assert.False},
-		{"event starting after the epoch", details.ExchangeEvent, es.EventStartsAfter(common.FormatTime(epoch)), assert.True},
-		{"event starting after now", details.ExchangeEvent, es.EventStartsAfter(common.FormatTime(now)), assert.False},
+		{"event starting after the epoch", details.ExchangeEvent, es.EventStartsAfter(dttm.Format(epoch)), assert.True},
+		{"event starting after now", details.ExchangeEvent, es.EventStartsAfter(dttm.Format(now)), assert.False},
 		{
 			"event starting after sometime later",
 			details.ExchangeEvent,
-			es.EventStartsAfter(common.FormatTime(future)),
+			es.EventStartsAfter(dttm.Format(future)),
 			assert.False,
 		},
 		{
 			"event starting before the epoch",
 			details.ExchangeEvent,
-			es.EventStartsBefore(common.FormatTime(epoch)),
+			es.EventStartsBefore(dttm.Format(epoch)),
 			assert.False,
 		},
-		{"event starting before now", details.ExchangeEvent, es.EventStartsBefore(common.FormatTime(now)), assert.False},
+		{"event starting before now", details.ExchangeEvent, es.EventStartsBefore(dttm.Format(now)), assert.False},
 		{
 			"event starting before sometime later",
 			details.ExchangeEvent,
-			es.EventStartsBefore(common.FormatTime(future)),
+			es.EventStartsBefore(dttm.Format(future)),
 			assert.True,
 		},
 		{"event with any subject", details.ExchangeEvent, es.EventSubject(AnyTgt), assert.True},

--- a/src/pkg/selectors/onedrive.go
+++ b/src/pkg/selectors/onedrive.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/alcionai/clues"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/filters"
@@ -543,9 +543,9 @@ func (s OneDriveScope) matchesInfo(dii details.ItemInfo) bool {
 
 	switch infoCat {
 	case FileInfoCreatedAfter, FileInfoCreatedBefore:
-		i = common.FormatTime(info.Created)
+		i = dttm.Format(info.Created)
 	case FileInfoModifiedAfter, FileInfoModifiedBefore:
-		i = common.FormatTime(info.Modified)
+		i = dttm.Format(info.Modified)
 	}
 
 	return s.Matches(infoCat, i)

--- a/src/pkg/selectors/onedrive_test.go
+++ b/src/pkg/selectors/onedrive_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -406,18 +406,18 @@ func (suite *OneDriveSelectorSuite) TestOneDriveScope_MatchesInfo() {
 		scope  []OneDriveScope
 		expect assert.BoolAssertionFunc
 	}{
-		{"file create after the epoch", ods.CreatedAfter(common.FormatTime(epoch)), assert.True},
-		{"file create after now", ods.CreatedAfter(common.FormatTime(now)), assert.False},
-		{"file create after later", ods.CreatedAfter(common.FormatTime(future)), assert.False},
-		{"file create before future", ods.CreatedBefore(common.FormatTime(future)), assert.True},
-		{"file create before now", ods.CreatedBefore(common.FormatTime(now)), assert.False},
-		{"file create before epoch", ods.CreatedBefore(common.FormatTime(now)), assert.False},
-		{"file modified after the epoch", ods.ModifiedAfter(common.FormatTime(epoch)), assert.True},
-		{"file modified after now", ods.ModifiedAfter(common.FormatTime(now)), assert.False},
-		{"file modified after later", ods.ModifiedAfter(common.FormatTime(future)), assert.False},
-		{"file modified before future", ods.ModifiedBefore(common.FormatTime(future)), assert.True},
-		{"file modified before now", ods.ModifiedBefore(common.FormatTime(now)), assert.False},
-		{"file modified before epoch", ods.ModifiedBefore(common.FormatTime(now)), assert.False},
+		{"file create after the epoch", ods.CreatedAfter(dttm.Format(epoch)), assert.True},
+		{"file create after now", ods.CreatedAfter(dttm.Format(now)), assert.False},
+		{"file create after later", ods.CreatedAfter(dttm.Format(future)), assert.False},
+		{"file create before future", ods.CreatedBefore(dttm.Format(future)), assert.True},
+		{"file create before now", ods.CreatedBefore(dttm.Format(now)), assert.False},
+		{"file create before epoch", ods.CreatedBefore(dttm.Format(now)), assert.False},
+		{"file modified after the epoch", ods.ModifiedAfter(dttm.Format(epoch)), assert.True},
+		{"file modified after now", ods.ModifiedAfter(dttm.Format(now)), assert.False},
+		{"file modified after later", ods.ModifiedAfter(dttm.Format(future)), assert.False},
+		{"file modified before future", ods.ModifiedBefore(dttm.Format(future)), assert.True},
+		{"file modified before now", ods.ModifiedBefore(dttm.Format(now)), assert.False},
+		{"file modified before epoch", ods.ModifiedBefore(dttm.Format(now)), assert.False},
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {

--- a/src/pkg/selectors/selectors_reduce_test.go
+++ b/src/pkg/selectors/selectors_reduce_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/backup/details/testdata"
@@ -97,7 +97,7 @@ func (suite *SelectorReduceSuite) TestReduce() {
 			selFunc: func() selectors.Reducer {
 				sel := selectors.NewExchangeRestore(selectors.Any())
 				sel.Filter(sel.MailReceivedBefore(
-					common.FormatTime(testdata.Time1.Add(time.Second)),
+					dttm.Format(testdata.Time1.Add(time.Second)),
 				))
 
 				return sel

--- a/src/pkg/selectors/sharepoint.go
+++ b/src/pkg/selectors/sharepoint.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/alcionai/clues"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/filters"
@@ -703,9 +703,9 @@ func (s SharePointScope) matchesInfo(dii details.ItemInfo) bool {
 	case SharePointWebURL:
 		i = info.WebURL
 	case SharePointInfoCreatedAfter, SharePointInfoCreatedBefore:
-		i = common.FormatTime(info.Created)
+		i = dttm.Format(info.Created)
 	case SharePointInfoModifiedAfter, SharePointInfoModifiedBefore:
-		i = common.FormatTime(info.Modified)
+		i = dttm.Format(info.Modified)
 	case SharePointInfoLibraryDrive:
 		ds := []string{}
 

--- a/src/pkg/selectors/sharepoint_test.go
+++ b/src/pkg/selectors/sharepoint_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/exp/slices"
 
-	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -524,19 +524,19 @@ func (suite *SharePointSelectorSuite) TestSharePointScope_MatchesInfo() {
 		{"host does not contain substring", host, sel.WebURL([]string{"website"}), assert.False},
 		{"url does not suffix substring", url, sel.WebURL([]string{"oo"}, SuffixMatch()), assert.False},
 		{"host mismatch", host, sel.WebURL([]string{"www.google.com"}), assert.False},
-		{"file create after the epoch", host, sel.CreatedAfter(common.FormatTime(epoch)), assert.True},
-		{"file create after now", host, sel.CreatedAfter(common.FormatTime(now)), assert.False},
-		{"file create after later", url, sel.CreatedAfter(common.FormatTime(future)), assert.False},
-		{"file create before future", host, sel.CreatedBefore(common.FormatTime(future)), assert.True},
-		{"file create before now", host, sel.CreatedBefore(common.FormatTime(now)), assert.False},
-		{"file create before modification", host, sel.CreatedBefore(common.FormatTime(modification)), assert.True},
-		{"file create before epoch", host, sel.CreatedBefore(common.FormatTime(now)), assert.False},
-		{"file modified after the epoch", host, sel.ModifiedAfter(common.FormatTime(epoch)), assert.True},
-		{"file modified after now", host, sel.ModifiedAfter(common.FormatTime(now)), assert.True},
-		{"file modified after later", host, sel.ModifiedAfter(common.FormatTime(future)), assert.False},
-		{"file modified before future", host, sel.ModifiedBefore(common.FormatTime(future)), assert.True},
-		{"file modified before now", host, sel.ModifiedBefore(common.FormatTime(now)), assert.False},
-		{"file modified before epoch", host, sel.ModifiedBefore(common.FormatTime(now)), assert.False},
+		{"file create after the epoch", host, sel.CreatedAfter(dttm.Format(epoch)), assert.True},
+		{"file create after now", host, sel.CreatedAfter(dttm.Format(now)), assert.False},
+		{"file create after later", url, sel.CreatedAfter(dttm.Format(future)), assert.False},
+		{"file create before future", host, sel.CreatedBefore(dttm.Format(future)), assert.True},
+		{"file create before now", host, sel.CreatedBefore(dttm.Format(now)), assert.False},
+		{"file create before modification", host, sel.CreatedBefore(dttm.Format(modification)), assert.True},
+		{"file create before epoch", host, sel.CreatedBefore(dttm.Format(now)), assert.False},
+		{"file modified after the epoch", host, sel.ModifiedAfter(dttm.Format(epoch)), assert.True},
+		{"file modified after now", host, sel.ModifiedAfter(dttm.Format(now)), assert.True},
+		{"file modified after later", host, sel.ModifiedAfter(dttm.Format(future)), assert.False},
+		{"file modified before future", host, sel.ModifiedBefore(dttm.Format(future)), assert.True},
+		{"file modified before now", host, sel.ModifiedBefore(dttm.Format(now)), assert.False},
+		{"file modified before epoch", host, sel.ModifiedBefore(dttm.Format(now)), assert.False},
 		{"in library", host, sel.Library("included-library"), assert.True},
 		{"not in library", host, sel.Library("not-included-library"), assert.False},
 		{"library id", host, sel.Library("1234"), assert.True},


### PR DESCRIPTION
moves common/time.go to common/dttm/dttm.go, and renames many of the consts and funcs with names that better explain their design and intent of usage.

Only code movement, no logical changes.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
