### PR TITLE
Fix progress folder display for Exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SharePoint now correctly displays site urls on `backup list`, instead of the site id.
 - Drives with a directory containing a folder named 'folder' will now restore without error.
 - The CORSO_LOG_FILE env is appropriately utilized if no --log-file flag is provided.
+- Fixed Exchange events progress output to show calendar names instead of IDs.
 
 ### Known Issues
 - Restoring a OneDrive or SharePoint file with the same name as a file with that name as its M365 ID may restore both items.
+- Exchange event restores will display calendar IDs instead of names in the progress output.
 
 ## [v0.6.1] (beta) - 2023-03-21
 

--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -182,8 +182,7 @@ func (col *Collection) streamItems(ctx context.Context, errs *fault.Bus) {
 		colProgress, closer = observe.CollectionProgress(
 			ctx,
 			col.fullPath.Category().String(),
-			// TODO(keepers): conceal compliance in path, drop Hide()
-			clues.Hide(col.fullPath.Folder(false)))
+			col.LocationPath().Elements())
 
 		go closer()
 


### PR DESCRIPTION
---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* closes #3013

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
