### PR TITLE
Add parent path information to malware detected items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Permissions backup for OneDrive is now out of experimental (By default, only newly backed up items will have their permissions backed up. You will have to run a full backup to ensure all items have their permissions backed up.)
 - LocationRef is now populated for all services and data types. It should be used in place of RepoRef if a location for an item is required.
-- User selection for Exchange and OneDrive can accept either a user PrincipalName or the user's canonical ID.  
+- User selection for Exchange and OneDrive can accept either a user PrincipalName or the user's canonical ID.
+- Add path information to items that were skipped during backup because they were flagged as malware.
 
 ### Fixed
 - Fixed permissions restore in latest backup version.

--- a/src/internal/connector/graph/errors.go
+++ b/src/internal/connector/graph/errors.go
@@ -317,6 +317,15 @@ func ItemInfo(item models.DriveItemable) map[string]any {
 	if parent != nil {
 		m[fault.AddtlContainerID] = ptr.Val(parent.GetId())
 		m[fault.AddtlContainerName] = ptr.Val(parent.GetName())
+		containerPath := ""
+
+		// Remove the "/drives/b!vF-sdsdsds-sdsdsa-sdsd/root:" prefix
+		splitPath := strings.SplitN(ptr.Val(parent.GetPath()), ":", 2)
+		if len(splitPath) > 1 {
+			containerPath = splitPath[1]
+		}
+
+		m[fault.AddtlContainerPath] = containerPath
 	}
 
 	malware := item.GetMalware()

--- a/src/internal/connector/graph/errors_test.go
+++ b/src/internal/connector/graph/errors_test.go
@@ -261,16 +261,18 @@ func (suite *GraphErrorsUnitSuite) TestIsErrUnauthorized() {
 
 func (suite *GraphErrorsUnitSuite) TestMalwareInfo() {
 	var (
-		i       = models.DriveItem{}
-		cb      = models.User{}
-		cbID    = "created-by"
-		lm      = models.User{}
-		lmID    = "last-mod-by"
-		ref     = models.ItemReference{}
-		refCID  = "container-id"
-		refCN   = "container-name"
-		mal     = models.Malware{}
-		malDesc = "malware-description"
+		i        = models.DriveItem{}
+		cb       = models.User{}
+		cbID     = "created-by"
+		lm       = models.User{}
+		lmID     = "last-mod-by"
+		ref      = models.ItemReference{}
+		refCID   = "container-id"
+		refCN    = "container-name"
+		refCP    = "/drives/b!vF-sdsdsds-sdsdsa-sdsd/root:/Folder/container-name"
+		refCPexp = "/Folder/container-name"
+		mal      = models.Malware{}
+		malDesc  = "malware-description"
 	)
 
 	cb.SetId(&cbID)
@@ -281,6 +283,7 @@ func (suite *GraphErrorsUnitSuite) TestMalwareInfo() {
 
 	ref.SetId(&refCID)
 	ref.SetName(&refCN)
+	ref.SetPath(&refCP)
 	i.SetParentReference(&ref)
 
 	mal.SetDescription(&malDesc)
@@ -291,6 +294,7 @@ func (suite *GraphErrorsUnitSuite) TestMalwareInfo() {
 		fault.AddtlLastModBy:     lmID,
 		fault.AddtlContainerID:   refCID,
 		fault.AddtlContainerName: refCN,
+		fault.AddtlContainerPath: refCPexp,
 		fault.AddtlMalwareDesc:   malDesc,
 	}
 

--- a/src/pkg/fault/item.go
+++ b/src/pkg/fault/item.go
@@ -7,6 +7,7 @@ const (
 	AddtlLastModBy     = "last_modified_by"
 	AddtlContainerID   = "container_id"
 	AddtlContainerName = "container_name"
+	AddtlContainerPath = "container_path"
 	AddtlMalwareDesc   = "malware_description"
 )
 


### PR DESCRIPTION
This allows identifying the file location when an item is detected with malware

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #3112 

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
