### PR TITLE
Allow overriding the default username/hostname in kopia

### DIFF
--- a/src/internal/kopia/conn.go
+++ b/src/internal/kopia/conn.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kopia/kopia/snapshot/snapshotfs"
 	"github.com/pkg/errors"
 
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/storage"
 )
 
@@ -69,7 +70,7 @@ func NewConn(s storage.Storage) *conn {
 	}
 }
 
-func (w *conn) Initialize(ctx context.Context) error {
+func (w *conn) Initialize(ctx context.Context, opts control.Options) error {
 	bst, err := blobStoreByProvider(ctx, w.storage)
 	if err != nil {
 		return clues.Wrap(err, "initializing storage")
@@ -92,6 +93,7 @@ func (w *conn) Initialize(ctx context.Context) error {
 
 	err = w.commonConnect(
 		ctx,
+		opts,
 		cfg.KopiaCfgDir,
 		bst,
 		cfg.CorsoPassphrase,
@@ -108,7 +110,7 @@ func (w *conn) Initialize(ctx context.Context) error {
 	return nil
 }
 
-func (w *conn) Connect(ctx context.Context) error {
+func (w *conn) Connect(ctx context.Context, opts control.Options) error {
 	bst, err := blobStoreByProvider(ctx, w.storage)
 	if err != nil {
 		return clues.Wrap(err, "initializing storage")
@@ -122,6 +124,7 @@ func (w *conn) Connect(ctx context.Context) error {
 
 	return w.commonConnect(
 		ctx,
+		opts,
 		cfg.KopiaCfgDir,
 		bst,
 		cfg.CorsoPassphrase,
@@ -131,16 +134,21 @@ func (w *conn) Connect(ctx context.Context) error {
 
 func (w *conn) commonConnect(
 	ctx context.Context,
+	opts control.Options,
 	configDir string,
 	bst blob.Storage,
 	password, compressor string,
 ) error {
-	var opts *repo.ConnectOptions
+	kopiaOpts := &repo.ConnectOptions{
+		ClientOptions: repo.ClientOptions{
+			Username: opts.User,
+			Hostname: opts.Host,
+		},
+	}
+
 	if len(configDir) > 0 {
-		opts = &repo.ConnectOptions{
-			CachingOptions: content.CachingOptions{
-				CacheDirectory: configDir,
-			},
+		kopiaOpts.CachingOptions = content.CachingOptions{
+			CacheDirectory: configDir,
 		}
 	} else {
 		configDir = defaultKopiaConfigDir
@@ -154,7 +162,7 @@ func (w *conn) commonConnect(
 		cfgFile,
 		bst,
 		password,
-		opts,
+		kopiaOpts,
 	); err != nil {
 		return clues.Wrap(err, "connecting to repo").WithClues(ctx)
 	}

--- a/src/internal/kopia/conn.go
+++ b/src/internal/kopia/conn.go
@@ -70,7 +70,7 @@ func NewConn(s storage.Storage) *conn {
 	}
 }
 
-func (w *conn) Initialize(ctx context.Context, opts control.Options) error {
+func (w *conn) Initialize(ctx context.Context, opts control.RepoOptions) error {
 	bst, err := blobStoreByProvider(ctx, w.storage)
 	if err != nil {
 		return clues.Wrap(err, "initializing storage")
@@ -110,7 +110,7 @@ func (w *conn) Initialize(ctx context.Context, opts control.Options) error {
 	return nil
 }
 
-func (w *conn) Connect(ctx context.Context, opts control.Options) error {
+func (w *conn) Connect(ctx context.Context, opts control.RepoOptions) error {
 	bst, err := blobStoreByProvider(ctx, w.storage)
 	if err != nil {
 		return clues.Wrap(err, "initializing storage")
@@ -134,7 +134,7 @@ func (w *conn) Connect(ctx context.Context, opts control.Options) error {
 
 func (w *conn) commonConnect(
 	ctx context.Context,
-	opts control.Options,
+	opts control.RepoOptions,
 	configDir string,
 	bst blob.Storage,
 	password, compressor string,

--- a/src/internal/kopia/conn_test.go
+++ b/src/internal/kopia/conn_test.go
@@ -25,7 +25,7 @@ func openKopiaRepo(
 	st := tester.NewPrefixedS3Storage(t)
 
 	k := NewConn(st)
-	if err := k.Initialize(ctx, control.Defaults()); err != nil {
+	if err := k.Initialize(ctx, control.RepoOptions{}); err != nil {
 		return nil, err
 	}
 
@@ -79,13 +79,13 @@ func (suite *WrapperIntegrationSuite) TestRepoExistsError() {
 	st := tester.NewPrefixedS3Storage(t)
 	k := NewConn(st)
 
-	err := k.Initialize(ctx, control.Defaults())
+	err := k.Initialize(ctx, control.RepoOptions{})
 	require.NoError(t, err, clues.ToCore(err))
 
 	err = k.Close(ctx)
 	require.NoError(t, err, clues.ToCore(err))
 
-	err = k.Initialize(ctx, control.Defaults())
+	err = k.Initialize(ctx, control.RepoOptions{})
 	assert.Error(t, err, clues.ToCore(err))
 	assert.ErrorIs(t, err, ErrorRepoAlreadyExists)
 }
@@ -99,7 +99,7 @@ func (suite *WrapperIntegrationSuite) TestBadProviderErrors() {
 	st.Provider = storage.ProviderUnknown
 	k := NewConn(st)
 
-	err := k.Initialize(ctx, control.Defaults())
+	err := k.Initialize(ctx, control.RepoOptions{})
 	assert.Error(t, err, clues.ToCore(err))
 }
 
@@ -111,7 +111,7 @@ func (suite *WrapperIntegrationSuite) TestConnectWithoutInitErrors() {
 	st := tester.NewPrefixedS3Storage(t)
 	k := NewConn(st)
 
-	err := k.Connect(ctx, control.Defaults())
+	err := k.Connect(ctx, control.RepoOptions{})
 	assert.Error(t, err, clues.ToCore(err))
 }
 
@@ -358,7 +358,7 @@ func (suite *WrapperIntegrationSuite) TestConfigDefaultsSetOnInitAndNotOnConnect
 			err = k.Close(ctx)
 			require.NoError(t, err, clues.ToCore(err))
 
-			err = k.Connect(ctx, control.Defaults())
+			err = k.Connect(ctx, control.RepoOptions{})
 			require.NoError(t, err, clues.ToCore(err))
 
 			defer func() {
@@ -386,7 +386,7 @@ func (suite *WrapperIntegrationSuite) TestInitAndConnWithTempDirectory() {
 	require.NoError(t, err, clues.ToCore(err))
 
 	// Re-open with Connect.
-	err = k.Connect(ctx, control.Defaults())
+	err = k.Connect(ctx, control.RepoOptions{})
 	require.NoError(t, err, clues.ToCore(err))
 
 	err = k.Close(ctx)
@@ -397,9 +397,10 @@ func (suite *WrapperIntegrationSuite) TestSetUserAndHost() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 
-	opts := control.Defaults()
-	opts.User = "foo"
-	opts.Host = "bar"
+	opts := control.RepoOptions{
+		User: "foo",
+		Host: "bar",
+	}
 
 	t := suite.T()
 	st := tester.NewPrefixedS3Storage(t)
@@ -409,8 +410,8 @@ func (suite *WrapperIntegrationSuite) TestSetUserAndHost() {
 	require.NoError(t, err, clues.ToCore(err))
 
 	kopiaOpts := k.ClientOptions()
-	assert.Equal(t, opts.User, kopiaOpts.Username)
-	assert.Equal(t, opts.Host, kopiaOpts.Hostname)
+	require.Equal(t, opts.User, kopiaOpts.Username)
+	require.Equal(t, opts.Host, kopiaOpts.Hostname)
 
 	err = k.Close(ctx)
 	require.NoError(t, err, clues.ToCore(err))
@@ -423,11 +424,11 @@ func (suite *WrapperIntegrationSuite) TestSetUserAndHost() {
 	require.NoError(t, err, clues.ToCore(err))
 
 	kopiaOpts = k.ClientOptions()
-	assert.Equal(t, opts.User, kopiaOpts.Username)
-	assert.Equal(t, opts.Host, kopiaOpts.Hostname)
+	require.Equal(t, opts.User, kopiaOpts.Username)
+	require.Equal(t, opts.Host, kopiaOpts.Hostname)
 
 	err = k.Close(ctx)
-	assert.NoError(t, err, clues.ToCore(err))
+	require.NoError(t, err, clues.ToCore(err))
 
 	// Make sure not setting the values uses the kopia defaults.
 	opts.User = ""

--- a/src/internal/kopia/conn_test.go
+++ b/src/internal/kopia/conn_test.go
@@ -14,16 +14,18 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/storage"
 )
 
-//revive:disable:context-as-argument
-func openKopiaRepo(t *testing.T, ctx context.Context) (*conn, error) {
-	//revive:enable:context-as-argument
+func openKopiaRepo(
+	t *testing.T,
+	ctx context.Context, //revive:disable-line:context-as-argument
+) (*conn, error) {
 	st := tester.NewPrefixedS3Storage(t)
 
 	k := NewConn(st)
-	if err := k.Initialize(ctx); err != nil {
+	if err := k.Initialize(ctx, control.Defaults()); err != nil {
 		return nil, err
 	}
 
@@ -77,13 +79,13 @@ func (suite *WrapperIntegrationSuite) TestRepoExistsError() {
 	st := tester.NewPrefixedS3Storage(t)
 	k := NewConn(st)
 
-	err := k.Initialize(ctx)
+	err := k.Initialize(ctx, control.Defaults())
 	require.NoError(t, err, clues.ToCore(err))
 
 	err = k.Close(ctx)
 	require.NoError(t, err, clues.ToCore(err))
 
-	err = k.Initialize(ctx)
+	err = k.Initialize(ctx, control.Defaults())
 	assert.Error(t, err, clues.ToCore(err))
 	assert.ErrorIs(t, err, ErrorRepoAlreadyExists)
 }
@@ -97,7 +99,7 @@ func (suite *WrapperIntegrationSuite) TestBadProviderErrors() {
 	st.Provider = storage.ProviderUnknown
 	k := NewConn(st)
 
-	err := k.Initialize(ctx)
+	err := k.Initialize(ctx, control.Defaults())
 	assert.Error(t, err, clues.ToCore(err))
 }
 
@@ -109,7 +111,7 @@ func (suite *WrapperIntegrationSuite) TestConnectWithoutInitErrors() {
 	st := tester.NewPrefixedS3Storage(t)
 	k := NewConn(st)
 
-	err := k.Connect(ctx)
+	err := k.Connect(ctx, control.Defaults())
 	assert.Error(t, err, clues.ToCore(err))
 }
 
@@ -356,7 +358,7 @@ func (suite *WrapperIntegrationSuite) TestConfigDefaultsSetOnInitAndNotOnConnect
 			err = k.Close(ctx)
 			require.NoError(t, err, clues.ToCore(err))
 
-			err = k.Connect(ctx)
+			err = k.Connect(ctx, control.Defaults())
 			require.NoError(t, err, clues.ToCore(err))
 
 			defer func() {
@@ -384,7 +386,7 @@ func (suite *WrapperIntegrationSuite) TestInitAndConnWithTempDirectory() {
 	require.NoError(t, err, clues.ToCore(err))
 
 	// Re-open with Connect.
-	err = k.Connect(ctx)
+	err = k.Connect(ctx, control.Defaults())
 	require.NoError(t, err, clues.ToCore(err))
 
 	err = k.Close(ctx)

--- a/src/internal/kopia/model_store_test.go
+++ b/src/internal/kopia/model_store_test.go
@@ -804,7 +804,7 @@ func openConnAndModelStore(
 	st := tester.NewPrefixedS3Storage(t)
 	c := NewConn(st)
 
-	err := c.Initialize(ctx, control.Defaults())
+	err := c.Initialize(ctx, control.RepoOptions{})
 	require.NoError(t, err, clues.ToCore(err))
 
 	defer func() {
@@ -823,7 +823,7 @@ func reconnectToModelStore(
 	ctx context.Context, //revive:disable-line:context-as-argument
 	c *conn,
 ) *ModelStore {
-	err := c.Connect(ctx, control.Defaults())
+	err := c.Connect(ctx, control.RepoOptions{})
 	require.NoError(t, err, clues.ToCore(err))
 
 	defer func() {

--- a/src/internal/kopia/model_store_test.go
+++ b/src/internal/kopia/model_store_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/backup"
+	"github.com/alcionai/corso/src/pkg/control"
 )
 
 type fooModel struct {
@@ -803,7 +804,7 @@ func openConnAndModelStore(
 	st := tester.NewPrefixedS3Storage(t)
 	c := NewConn(st)
 
-	err := c.Initialize(ctx)
+	err := c.Initialize(ctx, control.Defaults())
 	require.NoError(t, err, clues.ToCore(err))
 
 	defer func() {
@@ -822,7 +823,7 @@ func reconnectToModelStore(
 	ctx context.Context, //revive:disable-line:context-as-argument
 	c *conn,
 ) *ModelStore {
-	err := c.Connect(ctx)
+	err := c.Connect(ctx, control.Defaults())
 	require.NoError(t, err, clues.ToCore(err))
 
 	defer func() {

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/alcionai/corso/src/internal/data/mock"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/alcionai/corso/src/internal/data/mock"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/backup/details"
-	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -83,7 +83,7 @@ func prepNewTestBackupOp(
 		k  = kopia.NewConn(st)
 	)
 
-	err := k.Initialize(ctx)
+	err := k.Initialize(ctx, control.Defaults())
 	require.NoError(t, err, clues.ToCore(err))
 
 	// kopiaRef comes with a count of 1 and Wrapper bumps it again so safe

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -83,7 +83,7 @@ func prepNewTestBackupOp(
 		k  = kopia.NewConn(st)
 	)
 
-	err := k.Initialize(ctx, control.Defaults())
+	err := k.Initialize(ctx, control.RepoOptions{})
 	require.NoError(t, err, clues.ToCore(err))
 
 	// kopiaRef comes with a count of 1 and Wrapper bumps it again so safe

--- a/src/internal/operations/restore_test.go
+++ b/src/internal/operations/restore_test.go
@@ -175,7 +175,7 @@ func (suite *RestoreOpIntegrationSuite) SetupSuite() {
 
 	suite.acct = tester.NewM365Account(t)
 
-	err := k.Initialize(ctx, control.Defaults())
+	err := k.Initialize(ctx, control.RepoOptions{})
 	require.NoError(t, err, clues.ToCore(err))
 
 	suite.kopiaCloser = func(ctx context.Context) {

--- a/src/internal/operations/restore_test.go
+++ b/src/internal/operations/restore_test.go
@@ -175,7 +175,7 @@ func (suite *RestoreOpIntegrationSuite) SetupSuite() {
 
 	suite.acct = tester.NewM365Account(t)
 
-	err := k.Initialize(ctx)
+	err := k.Initialize(ctx, control.Defaults())
 	require.NoError(t, err, clues.ToCore(err))
 
 	suite.kopiaCloser = func(ctx context.Context) {

--- a/src/internal/streamstore/collectables_test.go
+++ b/src/internal/streamstore/collectables_test.go
@@ -42,7 +42,7 @@ func (suite *StreamStoreIntgSuite) SetupSubTest() {
 	st := tester.NewPrefixedS3Storage(t)
 
 	k := kopia.NewConn(st)
-	require.NoError(t, k.Initialize(ctx, control.Defaults()))
+	require.NoError(t, k.Initialize(ctx, control.RepoOptions{}))
 
 	suite.kcloser = func() { k.Close(ctx) }
 

--- a/src/internal/streamstore/collectables_test.go
+++ b/src/internal/streamstore/collectables_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alcionai/corso/src/internal/kopia"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 )
@@ -41,7 +42,7 @@ func (suite *StreamStoreIntgSuite) SetupSubTest() {
 	st := tester.NewPrefixedS3Storage(t)
 
 	k := kopia.NewConn(st)
-	require.NoError(t, k.Initialize(ctx))
+	require.NoError(t, k.Initialize(ctx, control.Defaults()))
 
 	suite.kcloser = func() { k.Close(ctx) }
 

--- a/src/pkg/control/options.go
+++ b/src/pkg/control/options.go
@@ -13,8 +13,7 @@ type Options struct {
 	SkipReduce         bool            `json:"skipReduce"`
 	ToggleFeatures     Toggles         `json:"toggleFeatures"`
 	Parallelism        Parallelism     `json:"parallelism"`
-	User               string          `json:"user"`
-	Host               string          `json:"host"`
+	Repo               RepoOptions     `json:"repo"`
 }
 
 type FailureBehavior string
@@ -34,6 +33,12 @@ const (
 	// recovers whenever possible, does not report recovery as failure
 	BestEffort FailureBehavior = "best-effort"
 )
+
+// Repo represents options that are specific to the repo storing backed up data.
+type RepoOptions struct {
+	User string `json:"user"`
+	Host string `json:"host"`
+}
 
 // Defaults provides an Options with the default values set.
 func Defaults() Options {

--- a/src/pkg/control/options.go
+++ b/src/pkg/control/options.go
@@ -13,6 +13,8 @@ type Options struct {
 	SkipReduce         bool            `json:"skipReduce"`
 	ToggleFeatures     Toggles         `json:"toggleFeatures"`
 	Parallelism        Parallelism     `json:"parallelism"`
+	User               string          `json:"user"`
+	Host               string          `json:"host"`
 }
 
 type FailureBehavior string

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -120,7 +120,7 @@ func Initialize(
 	}()
 
 	kopiaRef := kopia.NewConn(s)
-	if err := kopiaRef.Initialize(ctx); err != nil {
+	if err := kopiaRef.Initialize(ctx, opts); err != nil {
 		// replace common internal errors so that sdk users can check results with errors.Is()
 		if errors.Is(err, kopia.ErrorRepoAlreadyExists) {
 			return nil, clues.Stack(ErrorRepoAlreadyExists, err).WithClues(ctx)
@@ -202,7 +202,7 @@ func Connect(
 	defer close(complete)
 
 	kopiaRef := kopia.NewConn(s)
-	if err := kopiaRef.Connect(ctx); err != nil {
+	if err := kopiaRef.Connect(ctx, opts); err != nil {
 		return nil, clues.Wrap(err, "connecting kopia client")
 	}
 	// kopiaRef comes with a count of 1 and NewWrapper/NewModelStore bumps it again so safe

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -120,7 +120,7 @@ func Initialize(
 	}()
 
 	kopiaRef := kopia.NewConn(s)
-	if err := kopiaRef.Initialize(ctx, opts); err != nil {
+	if err := kopiaRef.Initialize(ctx, opts.Repo); err != nil {
 		// replace common internal errors so that sdk users can check results with errors.Is()
 		if errors.Is(err, kopia.ErrorRepoAlreadyExists) {
 			return nil, clues.Stack(ErrorRepoAlreadyExists, err).WithClues(ctx)
@@ -202,7 +202,7 @@ func Connect(
 	defer close(complete)
 
 	kopiaRef := kopia.NewConn(s)
-	if err := kopiaRef.Connect(ctx, opts); err != nil {
+	if err := kopiaRef.Connect(ctx, opts.Repo); err != nil {
 		return nil, clues.Wrap(err, "connecting kopia client")
 	}
 	// kopiaRef comes with a count of 1 and NewWrapper/NewModelStore bumps it again so safe

--- a/src/pkg/repository/repository_unexported_test.go
+++ b/src/pkg/repository/repository_unexported_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
@@ -219,10 +220,10 @@ func (suite *RepositoryModelIntgSuite) SetupSuite() {
 
 	require.NotNil(t, k)
 
-	err = k.Initialize(ctx)
+	err = k.Initialize(ctx, control.Defaults())
 	require.NoError(t, err, clues.ToCore(err))
 
-	err = k.Connect(ctx)
+	err = k.Connect(ctx, control.Defaults())
 	require.NoError(t, err, clues.ToCore(err))
 
 	suite.kopiaCloser = func(ctx context.Context) {
@@ -269,8 +270,8 @@ func (suite *RepositoryModelIntgSuite) TestGetRepositoryModel() {
 		k = kopia.NewConn(s)
 	)
 
-	require.NoError(t, k.Initialize(ctx))
-	require.NoError(t, k.Connect(ctx))
+	require.NoError(t, k.Initialize(ctx, control.Defaults()))
+	require.NoError(t, k.Connect(ctx, control.Defaults()))
 
 	defer k.Close(ctx)
 

--- a/src/pkg/repository/repository_unexported_test.go
+++ b/src/pkg/repository/repository_unexported_test.go
@@ -220,10 +220,10 @@ func (suite *RepositoryModelIntgSuite) SetupSuite() {
 
 	require.NotNil(t, k)
 
-	err = k.Initialize(ctx, control.Defaults())
+	err = k.Initialize(ctx, control.RepoOptions{})
 	require.NoError(t, err, clues.ToCore(err))
 
-	err = k.Connect(ctx, control.Defaults())
+	err = k.Connect(ctx, control.RepoOptions{})
 	require.NoError(t, err, clues.ToCore(err))
 
 	suite.kopiaCloser = func(ctx context.Context) {
@@ -270,8 +270,8 @@ func (suite *RepositoryModelIntgSuite) TestGetRepositoryModel() {
 		k = kopia.NewConn(s)
 	)
 
-	require.NoError(t, k.Initialize(ctx, control.Defaults()))
-	require.NoError(t, k.Connect(ctx, control.Defaults()))
+	require.NoError(t, k.Initialize(ctx, control.RepoOptions{}))
+	require.NoError(t, k.Connect(ctx, control.RepoOptions{}))
 
 	defer k.Close(ctx)
 


### PR DESCRIPTION
This allows setting the username/hostname
kopia will use for maintenance. This
information is recorded in the kopia config
file during connect and reused during open

If no values are given, kopia pulls the
values from the OS

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3077

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
