### PR TITLE
Don't try to fetch backup version if no compete backups available

### DIFF
--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -243,7 +243,7 @@ func (op *BackupOperation) do(
 	var (
 		reasons           = selectorToReasons(op.Selectors, false)
 		fallbackReasons   = makeFallbackReasons(op.Selectors)
-		lastBackupVersion = -1
+		lastBackupVersion = version.NoBackup
 	)
 
 	logger.Ctx(ctx).With(

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -241,8 +241,9 @@ func (op *BackupOperation) do(
 	backupID model.StableID,
 ) (*details.Builder, error) {
 	var (
-		reasons         = selectorToReasons(op.Selectors, false)
-		fallbackReasons = makeFallbackReasons(op.Selectors)
+		reasons           = selectorToReasons(op.Selectors, false)
+		fallbackReasons   = makeFallbackReasons(op.Selectors)
+		lastBackupVersion = -1
 	)
 
 	logger.Ctx(ctx).With(
@@ -264,9 +265,11 @@ func (op *BackupOperation) do(
 		return nil, clues.Wrap(err, "producing manifests and metadata")
 	}
 
-	_, lastBackupVersion, err := lastCompleteBackups(ctx, op.store, mans)
-	if err != nil {
-		return nil, clues.Wrap(err, "retrieving prior backups")
+	if canUseMetaData {
+		_, lastBackupVersion, err = lastCompleteBackups(ctx, op.store, mans)
+		if err != nil {
+			return nil, clues.Wrap(err, "retrieving prior backups")
+		}
 	}
 
 	cs, excludes, err := produceBackupDataCollections(


### PR DESCRIPTION
Regression from https://github.com/alcionai/corso/commit/62daf10213ce29782752924bc1c53a44a65dfe01#diff-f088d3a5f56348ddaf6fbf485c2aeaa6d8b40a860de014f7084db6daf0753829R267


---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
