### PR TITLE
Helper method to expose internal errors associated with a public error category

### DIFF
--- a/src/pkg/errs/err.go
+++ b/src/pkg/errs/err.go
@@ -1,7 +1,7 @@
 package errs
 
 import (
-	"strings"
+	"errors"
 
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/pkg/repository"
@@ -29,20 +29,24 @@ var internalToExternal = map[errEnum][]error{
 	ResourceOwnerNotFound: {graph.ErrResourceOwnerNotFound},
 }
 
+func Get(enum errEnum) []error {
+	esl, ok := internalToExternal[enum]
+	if !ok {
+		return nil
+	}
+	return esl
+}
+
 // Is checks if the provided error contains an internal error that matches
 // the public error category.
 func Is(err error, enum errEnum) bool {
-	if err == nil {
-		return false
-	}
-
 	esl, ok := internalToExternal[enum]
 	if !ok {
 		return false
 	}
 
 	for _, e := range esl {
-		if strings.Contains(err.Error(), e.Error()) {
+		if errors.Is(err, e) {
 			return true
 		}
 	}

--- a/src/pkg/errs/err.go
+++ b/src/pkg/errs/err.go
@@ -1,7 +1,7 @@
 package errs
 
 import (
-	"errors"
+	"strings"
 
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/pkg/repository"
@@ -32,13 +32,17 @@ var internalToExternal = map[errEnum][]error{
 // Is checks if the provided error contains an internal error that matches
 // the public error category.
 func Is(err error, enum errEnum) bool {
+	if err == nil {
+		return false
+	}
+
 	esl, ok := internalToExternal[enum]
 	if !ok {
 		return false
 	}
 
 	for _, e := range esl {
-		if errors.Is(err, e) {
+		if strings.Contains(err.Error(), e.Error()) {
 			return true
 		}
 	}

--- a/src/pkg/errs/err.go
+++ b/src/pkg/errs/err.go
@@ -29,8 +29,8 @@ var internalToExternal = map[errEnum][]error{
 	ResourceOwnerNotFound: {graph.ErrResourceOwnerNotFound},
 }
 
-// Get returns the internal errors which match to the public error category.
-func Get(enum errEnum) []error {
+// Internal returns the internal errors which match to the public error category.
+func Internal(enum errEnum) []error {
 	return internalToExternal[enum]
 }
 

--- a/src/pkg/errs/err.go
+++ b/src/pkg/errs/err.go
@@ -29,12 +29,9 @@ var internalToExternal = map[errEnum][]error{
 	ResourceOwnerNotFound: {graph.ErrResourceOwnerNotFound},
 }
 
+// Get returns the internal errors which match to the public error category.
 func Get(enum errEnum) []error {
-	esl, ok := internalToExternal[enum]
-	if !ok {
-		return nil
-	}
-	return esl
+	return internalToExternal[enum]
 }
 
 // Is checks if the provided error contains an internal error that matches

--- a/src/pkg/errs/errs_test.go
+++ b/src/pkg/errs/errs_test.go
@@ -7,8 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/alcionai/clues"
+	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/repository"
 )
 
 type ErrUnitSuite struct {
@@ -19,16 +20,33 @@ func TestErrUnitSuite(t *testing.T) {
 	suite.Run(t, &ErrUnitSuite{Suite: tester.NewUnitSuite(t)})
 }
 
+func (suite *ErrUnitSuite) TestGet() {
+	table := []struct {
+		get  errEnum
+		errs []error
+	}{
+		{RepoAlreadyExists, []error{repository.ErrorRepoAlreadyExists}},
+		{BackupNotFound, []error{repository.ErrorBackupNotFound}},
+		{ServiceNotEnabled, []error{graph.ErrServiceNotEnabled}},
+		{ResourceOwnerNotFound, []error{graph.ErrResourceOwnerNotFound}},
+	}
+	for _, test := range table {
+		suite.Run(string(test.get), func() {
+			assert.Equal(suite.T(), test.errs, Get(test.get))
+		})
+	}
+}
+
 func (suite *ErrUnitSuite) TestIs() {
 	table := []struct {
 		is    errEnum
 		input error
 	}{
-		{RepoAlreadyExists, clues.New("a repository was already initialized with that configuration")},
-		{RepoAlreadyExists, errors.Wrapf(clues.New("a repository was already initialized with that configuration"), "error identifying resource owner")},
-		{BackupNotFound, clues.New("no backup exists with that id")},
-		{ServiceNotEnabled, clues.New("service is not enabled for that resource owner")},
-		{ResourceOwnerNotFound, clues.New("resource owner not found in tenant")},
+		{RepoAlreadyExists, repository.ErrorRepoAlreadyExists},
+		{BackupNotFound, repository.ErrorBackupNotFound},
+		{ServiceNotEnabled, graph.ErrServiceNotEnabled},
+		{ResourceOwnerNotFound, graph.ErrResourceOwnerNotFound},
+		{ResourceOwnerNotFound, errors.Wrapf(graph.ErrResourceOwnerNotFound, "error identifying resource owner")},
 	}
 	for _, test := range table {
 		suite.Run(string(test.is), func() {

--- a/src/pkg/errs/errs_test.go
+++ b/src/pkg/errs/errs_test.go
@@ -3,12 +3,12 @@ package errs
 import (
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/alcionai/corso/src/internal/connector/graph"
+	"github.com/alcionai/clues"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/pkg/repository"
 )
 
 type ErrUnitSuite struct {
@@ -24,10 +24,11 @@ func (suite *ErrUnitSuite) TestIs() {
 		is    errEnum
 		input error
 	}{
-		{RepoAlreadyExists, repository.ErrorRepoAlreadyExists},
-		{BackupNotFound, repository.ErrorBackupNotFound},
-		{ServiceNotEnabled, graph.ErrServiceNotEnabled},
-		{ResourceOwnerNotFound, graph.ErrResourceOwnerNotFound},
+		{RepoAlreadyExists, clues.New("a repository was already initialized with that configuration")},
+		{RepoAlreadyExists, errors.Wrapf(clues.New("a repository was already initialized with that configuration"), "error identifying resource owner")},
+		{BackupNotFound, clues.New("no backup exists with that id")},
+		{ServiceNotEnabled, clues.New("service is not enabled for that resource owner")},
+		{ResourceOwnerNotFound, clues.New("resource owner not found in tenant")},
 	}
 	for _, test := range table {
 		suite.Run(string(test.is), func() {

--- a/src/pkg/errs/errs_test.go
+++ b/src/pkg/errs/errs_test.go
@@ -20,7 +20,7 @@ func TestErrUnitSuite(t *testing.T) {
 	suite.Run(t, &ErrUnitSuite{Suite: tester.NewUnitSuite(t)})
 }
 
-func (suite *ErrUnitSuite) TestGet() {
+func (suite *ErrUnitSuite) TestInternal() {
 	table := []struct {
 		get  errEnum
 		errs []error
@@ -32,7 +32,7 @@ func (suite *ErrUnitSuite) TestGet() {
 	}
 	for _, test := range table {
 		suite.Run(string(test.get), func() {
-			assert.Equal(suite.T(), test.errs, Get(test.get))
+			assert.Equal(suite.T(), test.errs, Internal(test.get))
 		})
 	}
 }

--- a/src/pkg/errs/errs_test.go
+++ b/src/pkg/errs/errs_test.go
@@ -3,7 +3,6 @@ package errs
 import (
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
@@ -22,8 +21,8 @@ func TestErrUnitSuite(t *testing.T) {
 
 func (suite *ErrUnitSuite) TestInternal() {
 	table := []struct {
-		get  errEnum
-		errs []error
+		get    errEnum
+		expect []error
 	}{
 		{RepoAlreadyExists, []error{repository.ErrorRepoAlreadyExists}},
 		{BackupNotFound, []error{repository.ErrorBackupNotFound}},
@@ -32,7 +31,7 @@ func (suite *ErrUnitSuite) TestInternal() {
 	}
 	for _, test := range table {
 		suite.Run(string(test.get), func() {
-			assert.Equal(suite.T(), test.errs, Internal(test.get))
+			assert.ElementsMatch(suite.T(), test.expect, Internal(test.get))
 		})
 	}
 }
@@ -46,7 +45,6 @@ func (suite *ErrUnitSuite) TestIs() {
 		{BackupNotFound, repository.ErrorBackupNotFound},
 		{ServiceNotEnabled, graph.ErrServiceNotEnabled},
 		{ResourceOwnerNotFound, graph.ErrResourceOwnerNotFound},
-		{ResourceOwnerNotFound, errors.Wrapf(graph.ErrResourceOwnerNotFound, "error identifying resource owner")},
 	}
 	for _, test := range table {
 		suite.Run(string(test.is), func() {


### PR DESCRIPTION
<!-- PR description-->

Helper method to expose internal errors associated with a public error category, useful for testing `errs.Is` scenarios. The internal error needs to be used because `errs.Is` checks if the error chain contains a ref to the internal error.

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #COR-77

#### Test Plan

<!-- How will this be tested prior to merging.-->
-  [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
