### PR TITLE
Don't use RepoRef in selector reduction

### DIFF
--- a/src/cli/utils/testdata/opts.go
+++ b/src/cli/utils/testdata/opts.go
@@ -138,14 +138,14 @@ var (
 			Name:     "EmailsFolderPrefixMatch",
 			Expected: testdata.ExchangeEmailItems,
 			Opts: utils.ExchangeOpts{
-				EmailFolder: []string{testdata.ExchangeEmailInboxPath.Folder(false)},
+				EmailFolder: []string{testdata.ExchangeEmailInboxPath.FolderLocation()},
 			},
 		},
 		{
 			Name:     "EmailsFolderPrefixMatchTrailingSlash",
 			Expected: testdata.ExchangeEmailItems,
 			Opts: utils.ExchangeOpts{
-				EmailFolder: []string{testdata.ExchangeEmailInboxPath.Folder(false) + "/"},
+				EmailFolder: []string{testdata.ExchangeEmailInboxPath.FolderLocation() + "/"},
 			},
 		},
 		{
@@ -155,7 +155,7 @@ var (
 				testdata.ExchangeEmailItems[2],
 			},
 			Opts: utils.ExchangeOpts{
-				EmailFolder: []string{testdata.ExchangeEmailBasePath2.Folder(false)},
+				EmailFolder: []string{testdata.ExchangeEmailBasePath2.FolderLocation()},
 			},
 		},
 		{
@@ -165,7 +165,7 @@ var (
 				testdata.ExchangeEmailItems[2],
 			},
 			Opts: utils.ExchangeOpts{
-				EmailFolder: []string{testdata.ExchangeEmailBasePath2.Folder(false) + "/"},
+				EmailFolder: []string{testdata.ExchangeEmailBasePath2.FolderLocation() + "/"},
 			},
 		},
 		{
@@ -209,7 +209,7 @@ var (
 			Name:     "MailShortRef",
 			Expected: []details.DetailsEntry{testdata.ExchangeEmailItems[0]},
 			Opts: utils.ExchangeOpts{
-				Email: []string{testdata.ExchangeEmailItemPath1.ShortRef()},
+				Email: []string{testdata.ExchangeEmailItemPath1.RR.ShortRef()},
 			},
 		},
 		{
@@ -220,8 +220,8 @@ var (
 			},
 			Opts: utils.ExchangeOpts{
 				Email: []string{
-					testdata.ExchangeEmailItemPath1.ShortRef(),
-					testdata.ExchangeEmailItemPath2.ShortRef(),
+					testdata.ExchangeEmailItemPath1.RR.ShortRef(),
+					testdata.ExchangeEmailItemPath2.RR.ShortRef(),
 				},
 			},
 		},
@@ -248,8 +248,8 @@ var (
 				testdata.ExchangeEventsItems[0],
 			},
 			Opts: utils.ExchangeOpts{
-				Email: []string{testdata.ExchangeEmailItemPath1.ShortRef()},
-				Event: []string{testdata.ExchangeEventsItemPath1.ShortRef()},
+				Email: []string{testdata.ExchangeEmailItemPath1.RR.ShortRef()},
+				Event: []string{testdata.ExchangeEventsItemPath1.RR.ShortRef()},
 			},
 		},
 	}
@@ -376,6 +376,13 @@ var (
 			},
 		},
 		{
+			Name:     "FolderRepoRefMatchesNothing",
+			Expected: []details.DetailsEntry{},
+			Opts: utils.OneDriveOpts{
+				FolderPath: []string{testdata.OneDriveFolderPath.RR.Folder(true)},
+			},
+		},
+		{
 			Name: "ShortRef",
 			Expected: []details.DetailsEntry{
 				testdata.OneDriveItems[0],
@@ -492,6 +499,13 @@ var (
 			Expected: testdata.SharePointLibraryItems,
 			Opts: utils.SharePointOpts{
 				FolderPath: []string{testdata.SharePointLibraryFolder + "/"},
+			},
+		},
+		{
+			Name:     "FolderRepoRefMatchesNothing",
+			Expected: []details.DetailsEntry{},
+			Opts: utils.SharePointOpts{
+				FolderPath: []string{testdata.SharePointLibraryPath.RR.Folder(true)},
 			},
 		},
 		{

--- a/src/pkg/selectors/example_selectors_test.go
+++ b/src/pkg/selectors/example_selectors_test.go
@@ -123,9 +123,10 @@ var (
 		DetailsModel: details.DetailsModel{
 			Entries: []details.DetailsEntry{
 				{
-					RepoRef:  "tID/exchange/your-user-id/email/example/itemID",
-					ShortRef: "xyz",
-					ItemRef:  "123",
+					RepoRef:     "tID/exchange/your-user-id/email/example/itemID",
+					LocationRef: "example",
+					ShortRef:    "xyz",
+					ItemRef:     "123",
 					ItemInfo: details.ItemInfo{
 						Exchange: &details.ExchangeInfo{
 							ItemType: details.ExchangeMail,

--- a/src/pkg/selectors/exchange.go
+++ b/src/pkg/selectors/exchange.go
@@ -618,12 +618,8 @@ func (ec exchangeCategory) pathValues(
 	}
 
 	result := map[categorizer][]string{
-		folderCat: {repo.Folder(false)},
+		folderCat: {ent.LocationRef},
 		itemCat:   {item, ent.ShortRef},
-	}
-
-	if len(ent.LocationRef) > 0 {
-		result[folderCat] = append(result[folderCat], ent.LocationRef)
 	}
 
 	return result, nil

--- a/src/pkg/selectors/exchange_test.go
+++ b/src/pkg/selectors/exchange_test.go
@@ -713,15 +713,15 @@ func (suite *ExchangeSelectorSuite) TestExchangeScope_MatchesInfo() {
 func (suite *ExchangeSelectorSuite) TestExchangeScope_MatchesPath() {
 	const (
 		usr  = "userID"
-		fID1 = "mf_id_1"
+		fID1 = "mf_id_1.d"
 		fld1 = "mailFolder"
-		fID2 = "mf_id_2"
+		fID2 = "mf_id_2.d"
 		fld2 = "subFolder"
 		mail = "mailID"
 	)
 
 	var (
-		repo  = stubPath(suite.T(), usr, []string{fID1 + ".d", fID2 + ".d", mail}, path.EmailCategory)
+		repo  = stubPath(suite.T(), usr, []string{fID1, fID2, mail}, path.EmailCategory)
 		loc   = strings.Join([]string{fld1, fld2, mail}, "/")
 		short = "thisisahashofsomekind"
 		es    = NewExchangeRestore(Any())

--- a/src/pkg/selectors/onedrive.go
+++ b/src/pkg/selectors/onedrive.go
@@ -399,7 +399,7 @@ func (c oneDriveCategory) pathValues(
 	}
 
 	// Ignore `drives/<driveID>/root:` for folder comparison
-	rFld := path.Builder{}.Append(repo.Folders()...).PopFront().PopFront().PopFront().String()
+	rFld := ent.OneDrive.ParentPath
 
 	item := ent.ItemRef
 	if len(item) == 0 {

--- a/src/pkg/selectors/selectors_reduce_test.go
+++ b/src/pkg/selectors/selectors_reduce_test.go
@@ -48,7 +48,7 @@ func (suite *SelectorReduceSuite) TestReduce() {
 			selFunc: func() selectors.Reducer {
 				sel := selectors.NewExchangeRestore(selectors.Any())
 				sel.Include(sel.MailFolders(
-					[]string{testdata.ExchangeEmailInboxPath.Folder(false)},
+					[]string{testdata.ExchangeEmailInboxPath.FolderLocation()},
 				))
 
 				return sel
@@ -72,7 +72,7 @@ func (suite *SelectorReduceSuite) TestReduce() {
 				sel.Filter(sel.MailSender("a-person"))
 				sel.Exclude(sel.Mails(
 					selectors.Any(),
-					[]string{testdata.ExchangeEmailItemPath2.ShortRef()},
+					[]string{testdata.ExchangeEmailItemPath2.RR.ShortRef()},
 				))
 
 				return sel
@@ -110,7 +110,7 @@ func (suite *SelectorReduceSuite) TestReduce() {
 				sel := selectors.NewExchangeRestore(selectors.Any())
 				sel.Include(sel.Mails(
 					selectors.Any(),
-					[]string{testdata.ExchangeEmailItemPath1.Item()},
+					[]string{testdata.ExchangeEmailItemPath1.ItemLocation()},
 				))
 
 				return sel
@@ -123,7 +123,7 @@ func (suite *SelectorReduceSuite) TestReduce() {
 				sel := selectors.NewExchangeRestore(selectors.Any())
 				sel.Include(sel.Mails(
 					selectors.Any(),
-					[]string{testdata.ExchangeEmailItemPath1.ShortRef()},
+					[]string{testdata.ExchangeEmailItemPath1.RR.ShortRef()},
 				))
 
 				return sel
@@ -177,7 +177,7 @@ func (suite *SelectorReduceSuite) TestReduce() {
 			selFunc: func() selectors.Reducer {
 				sel := selectors.NewExchangeRestore(selectors.Any())
 				sel.Include(sel.MailFolders(
-					[]string{testdata.ExchangeEmailBasePath.Folder(false)},
+					[]string{testdata.ExchangeEmailBasePath.FolderLocation()},
 				))
 
 				return sel
@@ -192,7 +192,7 @@ func (suite *SelectorReduceSuite) TestReduce() {
 			selFunc: func() selectors.Reducer {
 				sel := selectors.NewExchangeRestore(selectors.Any())
 				sel.Include(sel.MailFolders(
-					[]string{testdata.ExchangeEmailBasePath.Folder(false)},
+					[]string{testdata.ExchangeEmailBasePath.FolderLocation()},
 					selectors.PrefixMatch(), // force prefix matching
 				))
 
@@ -205,7 +205,7 @@ func (suite *SelectorReduceSuite) TestReduce() {
 			selFunc: func() selectors.Reducer {
 				sel := selectors.NewExchangeRestore(selectors.Any())
 				sel.Include(sel.MailFolders(
-					[]string{testdata.ExchangeEmailInboxPath.Folder(false)},
+					[]string{testdata.ExchangeEmailInboxPath.FolderLocation()},
 				))
 
 				return sel
@@ -217,7 +217,7 @@ func (suite *SelectorReduceSuite) TestReduce() {
 			selFunc: func() selectors.Reducer {
 				sel := selectors.NewExchangeRestore(selectors.Any())
 				sel.Include(sel.ContactFolders(
-					[]string{testdata.ExchangeContactsBasePath.Folder(false)},
+					[]string{testdata.ExchangeContactsBasePath.FolderLocation()},
 				))
 
 				return sel
@@ -229,7 +229,7 @@ func (suite *SelectorReduceSuite) TestReduce() {
 			selFunc: func() selectors.Reducer {
 				sel := selectors.NewExchangeRestore(selectors.Any())
 				sel.Include(sel.ContactFolders(
-					[]string{testdata.ExchangeContactsRootPath.Folder(false)},
+					[]string{testdata.ExchangeContactsRootPath.FolderLocation()},
 				))
 
 				return sel
@@ -242,7 +242,7 @@ func (suite *SelectorReduceSuite) TestReduce() {
 			selFunc: func() selectors.Reducer {
 				sel := selectors.NewExchangeRestore(selectors.Any())
 				sel.Include(sel.EventCalendars(
-					[]string{testdata.ExchangeEventsBasePath.Folder(false)},
+					[]string{testdata.ExchangeEventsBasePath.FolderLocation()},
 				))
 
 				return sel
@@ -254,7 +254,7 @@ func (suite *SelectorReduceSuite) TestReduce() {
 			selFunc: func() selectors.Reducer {
 				sel := selectors.NewExchangeRestore(selectors.Any())
 				sel.Include(sel.EventCalendars(
-					[]string{testdata.ExchangeEventsRootPath.Folder(false)},
+					[]string{testdata.ExchangeEventsRootPath.FolderLocation()},
 				))
 
 				return sel

--- a/src/pkg/selectors/sharepoint.go
+++ b/src/pkg/selectors/sharepoint.go
@@ -520,9 +520,9 @@ func (c sharePointCategory) pathValues(
 	cfg Config,
 ) (map[categorizer][]string, error) {
 	var (
-		folderCat, itemCat    categorizer
-		dropDriveFolderPrefix bool
-		itemID                string
+		folderCat, itemCat categorizer
+		itemID             string
+		rFld               string
 	)
 
 	switch c {
@@ -531,23 +531,19 @@ func (c sharePointCategory) pathValues(
 			return nil, clues.New("no SharePoint ItemInfo in details")
 		}
 
-		dropDriveFolderPrefix = true
 		folderCat, itemCat = SharePointLibraryFolder, SharePointLibraryItem
+		rFld = ent.SharePoint.ParentPath
 
 	case SharePointList, SharePointListItem:
 		folderCat, itemCat = SharePointList, SharePointListItem
+		rFld = ent.LocationRef
 
 	case SharePointPage, SharePointPageFolder:
 		folderCat, itemCat = SharePointPageFolder, SharePointPage
+		rFld = ent.LocationRef
 
 	default:
 		return nil, clues.New("unrecognized sharePointCategory").With("category", c)
-	}
-
-	rFld := repo.Folder(false)
-	if dropDriveFolderPrefix {
-		// like onedrive, ignore `drives/<driveID>/root:` for library folder comparison
-		rFld = path.Builder{}.Append(repo.Folders()...).PopFront().PopFront().PopFront().String()
 	}
 
 	item := ent.ItemRef
@@ -566,10 +562,6 @@ func (c sharePointCategory) pathValues(
 
 	if len(itemID) > 0 {
 		result[itemCat] = append(result[itemCat], itemID)
-	}
-
-	if len(ent.LocationRef) > 0 {
-		result[folderCat] = append(result[folderCat], ent.LocationRef)
 	}
 
 	return result, nil

--- a/src/pkg/selectors/sharepoint_test.go
+++ b/src/pkg/selectors/sharepoint_test.go
@@ -1,6 +1,7 @@
 package selectors
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -204,67 +205,123 @@ func (suite *SharePointSelectorSuite) TestToSharePointRestore() {
 }
 
 func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
+	toRR := func(cat path.CategoryType, siteID string, folders []string, item string) string {
+		folderElems := make([]string, 0, len(folders))
+
+		for _, f := range folders {
+			folderElems = append(folderElems, f+".d")
+		}
+
+		return stubRepoRef(
+			path.SharePointService,
+			cat,
+			siteID,
+			strings.Join(folderElems, "/"),
+			item)
+	}
+
 	var (
-		drivePfx = "drive/drive!id/root:/"
-		pairAC   = "folderA/folderC"
-		pairGH   = "folderG/folderH"
-		item     = stubRepoRef(path.SharePointService, path.LibrariesCategory, "sid", drivePfx+"folderA/folderB", "item")
-		item2    = stubRepoRef(path.SharePointService, path.LibrariesCategory, "sid", drivePfx+pairAC, "item2")
-		item3    = stubRepoRef(path.SharePointService, path.LibrariesCategory, "sid", drivePfx+"folderD/folderE", "item3")
-		item4    = stubRepoRef(path.SharePointService, path.PagesCategory, "sid", pairGH, "item4")
-		item5    = stubRepoRef(path.SharePointService, path.PagesCategory, "sid", pairGH, "item5")
+		prefixElems = []string{
+			"drive",
+			"drive!id",
+			"root:",
+		}
+		itemElems1 = []string{"folderA", "folderB"}
+		itemElems2 = []string{"folderA", "folderC"}
+		itemElems3 = []string{"folderD", "folderE"}
+		pairAC     = "folderA/folderC"
+		pairGH     = "folderG/folderH"
+		item       = toRR(
+			path.LibrariesCategory,
+			"sid",
+			append(
+				append(
+					[]string{},
+					prefixElems...),
+				itemElems1...),
+			"item")
+		item2 = toRR(
+			path.LibrariesCategory,
+			"sid",
+			append(
+				append(
+					[]string{},
+					prefixElems...),
+				itemElems2...),
+			"item2")
+		item3 = toRR(
+			path.LibrariesCategory,
+			"sid",
+			append(
+				append(
+					[]string{},
+					prefixElems...),
+				itemElems3...),
+			"item3")
+		item4 = stubRepoRef(path.SharePointService, path.PagesCategory, "sid", pairGH, "item4")
+		item5 = stubRepoRef(path.SharePointService, path.PagesCategory, "sid", pairGH, "item5")
 	)
 
 	deets := &details.Details{
 		DetailsModel: details.DetailsModel{
 			Entries: []details.DetailsEntry{
 				{
-					RepoRef: item,
-					ItemRef: "item",
+					RepoRef:     item,
+					ItemRef:     "item",
+					LocationRef: strings.Join(append([]string{"root:"}, itemElems1...), "/"),
 					ItemInfo: details.ItemInfo{
 						SharePoint: &details.SharePointInfo{
-							ItemType: details.SharePointLibrary,
-							ItemName: "itemName",
+							ItemType:   details.SharePointLibrary,
+							ItemName:   "itemName",
+							ParentPath: strings.Join(itemElems1, "/"),
 						},
 					},
 				},
 				{
-					RepoRef: item2,
+					RepoRef:     item2,
+					LocationRef: strings.Join(append([]string{"root:"}, itemElems2...), "/"),
 					// ItemRef intentionally blank to test fallback case
 					ItemInfo: details.ItemInfo{
 						SharePoint: &details.SharePointInfo{
-							ItemType: details.SharePointLibrary,
-							ItemName: "itemName2",
+							ItemType:   details.SharePointLibrary,
+							ItemName:   "itemName2",
+							ParentPath: strings.Join(itemElems2, "/"),
 						},
 					},
 				},
 				{
-					RepoRef: item3,
-					ItemRef: "item3",
+					RepoRef:     item3,
+					ItemRef:     "item3",
+					LocationRef: strings.Join(append([]string{"root:"}, itemElems3...), "/"),
 					ItemInfo: details.ItemInfo{
 						SharePoint: &details.SharePointInfo{
-							ItemType: details.SharePointLibrary,
-							ItemName: "itemName3",
+							ItemType:   details.SharePointLibrary,
+							ItemName:   "itemName3",
+							ParentPath: strings.Join(itemElems3, "/"),
 						},
 					},
 				},
 				{
-					RepoRef: item4,
-					ItemRef: "item4",
+					RepoRef:     item4,
+					LocationRef: pairGH,
+					ItemRef:     "item4",
 					ItemInfo: details.ItemInfo{
 						SharePoint: &details.SharePointInfo{
-							ItemType: details.SharePointPage,
-							ItemName: "itemName4",
+							ItemType:   details.SharePointPage,
+							ItemName:   "itemName4",
+							ParentPath: pairGH,
 						},
 					},
 				},
 				{
-					RepoRef: item5,
+					RepoRef:     item5,
+					LocationRef: pairGH,
 					// ItemRef intentionally blank to test fallback case
 					ItemInfo: details.ItemInfo{
 						SharePoint: &details.SharePointInfo{
-							ItemType: details.SharePointPage,
-							ItemName: "itemName5",
+							ItemType:   details.SharePointPage,
+							ItemName:   "itemName5",
+							ParentPath: pairGH,
 						},
 					},
 				},
@@ -278,14 +335,12 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 
 	table := []struct {
 		name         string
-		deets        *details.Details
 		makeSelector func() *SharePointRestore
 		expect       []string
 		cfg          Config
 	}{
 		{
-			name:  "all",
-			deets: deets,
+			name: "all",
 			makeSelector: func() *SharePointRestore {
 				odr := NewSharePointRestore(Any())
 				odr.Include(odr.AllData())
@@ -294,8 +349,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 			expect: arr(item, item2, item3, item4, item5),
 		},
 		{
-			name:  "only match item",
-			deets: deets,
+			name: "only match item",
 			makeSelector: func() *SharePointRestore {
 				odr := NewSharePointRestore(Any())
 				odr.Include(odr.LibraryItems(Any(), []string{"item2"}))
@@ -304,8 +358,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 			expect: arr(item2),
 		},
 		{
-			name:  "id doesn't match name",
-			deets: deets,
+			name: "id doesn't match name",
 			makeSelector: func() *SharePointRestore {
 				odr := NewSharePointRestore(Any())
 				odr.Include(odr.LibraryItems(Any(), []string{"item2"}))
@@ -315,8 +368,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 			cfg:    Config{OnlyMatchItemNames: true},
 		},
 		{
-			name:  "only match item name",
-			deets: deets,
+			name: "only match item name",
 			makeSelector: func() *SharePointRestore {
 				odr := NewSharePointRestore(Any())
 				odr.Include(odr.LibraryItems(Any(), []string{"itemName2"}))
@@ -326,8 +378,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 			cfg:    Config{OnlyMatchItemNames: true},
 		},
 		{
-			name:  "name doesn't match",
-			deets: deets,
+			name: "name doesn't match",
 			makeSelector: func() *SharePointRestore {
 				odr := NewSharePointRestore(Any())
 				odr.Include(odr.LibraryItems(Any(), []string{"itemName2"}))
@@ -336,8 +387,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 			expect: []string{},
 		},
 		{
-			name:  "only match folder",
-			deets: deets,
+			name: "only match folder",
 			makeSelector: func() *SharePointRestore {
 				odr := NewSharePointRestore([]string{"sid"})
 				odr.Include(odr.LibraryFolders([]string{"folderA/folderB", pairAC}))
@@ -346,8 +396,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 			expect: arr(item, item2),
 		},
 		{
-			name:  "pages match folder",
-			deets: deets,
+			name: "pages match folder",
 			makeSelector: func() *SharePointRestore {
 				odr := NewSharePointRestore([]string{"sid"})
 				odr.Include(odr.Pages([]string{pairGH, pairAC}))
@@ -365,7 +414,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 
 			sel := test.makeSelector()
 			sel.Configure(test.cfg)
-			results := sel.Reduce(ctx, test.deets, fault.New(true))
+			results := sel.Reduce(ctx, deets, fault.New(true))
 			paths := results.Paths()
 			assert.Equal(t, test.expect, paths)
 		})
@@ -377,21 +426,25 @@ func (suite *SharePointSelectorSuite) TestSharePointCategory_PathValues() {
 		itemName   = "item"
 		itemID     = "item-id"
 		shortRef   = "short"
-		driveElems = []string{"drive", "drive!id", "root:", "dir1", "dir2", itemID}
+		driveElems = []string{"drive", "drive!id", "root:.d", "dir1.d", "dir2.d", itemID}
 		elems      = []string{"dir1", "dir2", itemID}
 	)
 
 	table := []struct {
-		name      string
-		sc        sharePointCategory
-		pathElems []string
-		expected  map[categorizer][]string
-		cfg       Config
+		name       string
+		sc         sharePointCategory
+		pathElems  []string
+		locRef     string
+		parentPath string
+		expected   map[categorizer][]string
+		cfg        Config
 	}{
 		{
-			name:      "SharePoint Libraries",
-			sc:        SharePointLibraryItem,
-			pathElems: driveElems,
+			name:       "SharePoint Libraries",
+			sc:         SharePointLibraryItem,
+			pathElems:  driveElems,
+			locRef:     "root:/dir1/dir2",
+			parentPath: "dir1/dir2",
 			expected: map[categorizer][]string{
 				SharePointLibraryFolder: {"dir1/dir2"},
 				SharePointLibraryItem:   {itemID, shortRef},
@@ -399,9 +452,11 @@ func (suite *SharePointSelectorSuite) TestSharePointCategory_PathValues() {
 			cfg: Config{},
 		},
 		{
-			name:      "SharePoint Libraries w/ name",
-			sc:        SharePointLibraryItem,
-			pathElems: driveElems,
+			name:       "SharePoint Libraries w/ name",
+			sc:         SharePointLibraryItem,
+			pathElems:  driveElems,
+			locRef:     "root:/dir1/dir2",
+			parentPath: "dir1/dir2",
 			expected: map[categorizer][]string{
 				SharePointLibraryFolder: {"dir1/dir2"},
 				SharePointLibraryItem:   {itemName, shortRef},
@@ -412,6 +467,7 @@ func (suite *SharePointSelectorSuite) TestSharePointCategory_PathValues() {
 			name:      "SharePoint Lists",
 			sc:        SharePointListItem,
 			pathElems: elems,
+			locRef:    "dir1/dir2",
 			expected: map[categorizer][]string{
 				SharePointList:     {"dir1/dir2"},
 				SharePointListItem: {itemID, shortRef},
@@ -434,12 +490,14 @@ func (suite *SharePointSelectorSuite) TestSharePointCategory_PathValues() {
 			require.NoError(t, err, clues.ToCore(err))
 
 			ent := details.DetailsEntry{
-				RepoRef:  itemPath.String(),
-				ShortRef: shortRef,
-				ItemRef:  itemPath.Item(),
+				RepoRef:     itemPath.String(),
+				ShortRef:    shortRef,
+				ItemRef:     itemPath.Item(),
+				LocationRef: test.locRef,
 				ItemInfo: details.ItemInfo{
 					SharePoint: &details.SharePointInfo{
-						ItemName: itemName,
+						ItemName:   itemName,
+						ParentPath: test.parentPath,
 					},
 				},
 			}

--- a/src/pkg/selectors/sharepoint_test.go
+++ b/src/pkg/selectors/sharepoint_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/exp/slices"
 
 	"github.com/alcionai/corso/src/internal/common"
 	"github.com/alcionai/corso/src/internal/tester"
@@ -234,29 +235,17 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 		item       = toRR(
 			path.LibrariesCategory,
 			"sid",
-			append(
-				append(
-					[]string{},
-					prefixElems...),
-				itemElems1...),
+			append(slices.Clone(prefixElems), itemElems1...),
 			"item")
 		item2 = toRR(
 			path.LibrariesCategory,
 			"sid",
-			append(
-				append(
-					[]string{},
-					prefixElems...),
-				itemElems2...),
+			append(slices.Clone(prefixElems), itemElems2...),
 			"item2")
 		item3 = toRR(
 			path.LibrariesCategory,
 			"sid",
-			append(
-				append(
-					[]string{},
-					prefixElems...),
-				itemElems3...),
+			append(slices.Clone(prefixElems), itemElems3...),
 			"item3")
 		item4 = stubRepoRef(path.SharePointService, path.PagesCategory, "sid", pairGH, "item4")
 		item5 = stubRepoRef(path.SharePointService, path.PagesCategory, "sid", pairGH, "item5")


### PR DESCRIPTION
A few high-level things of note:
* things will no longer match on folder ID. Folder IDs weren't displayed
  to the user via CLI and SDK consumers have no insight into folder IDs
  so this shouldn't be an issue
* OneDrive and SharePoint match on ParentPath (derived from
  LocationRef). ParentPath *does not* include root: in the path

Not matching on folder ID should be the only user-visible change in
this PR

First commit contains the required logic changes. All other changes
are test updates

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* closes #3194

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
