### PR TITLE
Force full item enumeration if a backup that used file names is the base

### DIFF
--- a/src/internal/connector/data_collections.go
+++ b/src/internal/connector/data_collections.go
@@ -114,6 +114,7 @@ func (gc *GraphConnector) ProduceBackupCollections(
 			sels,
 			owner,
 			metadata,
+			lastBackupVersion,
 			gc.credentials,
 			gc.Service,
 			gc,

--- a/src/internal/connector/data_collections_test.go
+++ b/src/internal/connector/data_collections_test.go
@@ -265,6 +265,7 @@ func (suite *DataCollectionIntgSuite) TestSharePointDataCollection() {
 				sel,
 				sel,
 				nil,
+				version.NoBackup,
 				connector.credentials,
 				connector.Service,
 				connector,

--- a/src/internal/connector/graph/collections.go
+++ b/src/internal/connector/graph/collections.go
@@ -175,3 +175,35 @@ func NewPrefixCollection(prev, full path.Path, su support.StatusUpdater) (*prefi
 
 	return pc, nil
 }
+
+// NewDeletedPrefixCollection creates a new collection that only handles
+// deleting the prefix path.
+func NewDeletedPrefixCollection(
+	prev path.Path,
+	su support.StatusUpdater,
+) (*prefixCollection, error) {
+	if prev == nil {
+		return nil, clues.New("nil prefix path")
+	}
+
+	if len(prev.Item()) > 0 {
+		return nil, clues.New("prefix collection previous path contains an item")
+	}
+
+	if len(prev.Folders()) > 0 {
+		return nil, clues.New("prefix collection previous path contains folders")
+	}
+
+	pc := &prefixCollection{
+		prev:  prev,
+		full:  nil,
+		su:    su,
+		state: data.StateOf(prev, nil),
+	}
+
+	if pc.state != data.DeletedState {
+		return nil, clues.New("collection didn't attempt to delete prefix")
+	}
+
+	return pc, nil
+}

--- a/src/internal/connector/graph/collections_test.go
+++ b/src/internal/connector/graph/collections_test.go
@@ -98,3 +98,51 @@ func (suite *CollectionsUnitSuite) TestNewPrefixCollection() {
 		})
 	}
 }
+
+func (suite *CollectionsUnitSuite) TestNewDeletedPrefixCollection() {
+	t := suite.T()
+	serv := path.OneDriveService
+	cat := path.FilesCategory
+
+	p1, err := path.ServicePrefix("t", "ro1", serv, cat)
+	require.NoError(t, err, clues.ToCore(err))
+
+	items, err := path.Build("t", "ro", serv, cat, true, "fld", "itm")
+	require.NoError(t, err, clues.ToCore(err))
+
+	folders, err := path.Build("t", "ro", serv, cat, false, "fld")
+	require.NoError(t, err, clues.ToCore(err))
+
+	table := []struct {
+		name      string
+		prev      path.Path
+		expectErr require.ErrorAssertionFunc
+	}{
+		{
+			name:      "nil",
+			prev:      nil,
+			expectErr: require.Error,
+		},
+		{
+			name:      "deleted",
+			prev:      p1,
+			expectErr: require.NoError,
+		},
+		{
+			name:      "prev has items",
+			prev:      items,
+			expectErr: require.Error,
+		},
+		{
+			name:      "prev has folders",
+			prev:      folders,
+			expectErr: require.Error,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			_, err := NewDeletedPrefixCollection(test.prev, nil)
+			test.expectErr(suite.T(), err, clues.ToCore(err))
+		})
+	}
+}

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -1013,9 +1013,13 @@ func inflateBaseTree(
 
 		// This ensures that a migration on the directory prefix can complete.
 		// The prefix is the tenant/service/owner/category set, which remains
-		// otherwise unchecked in tree inflation below this point.
+		// otherwise unchecked in tree inflation below this point. If p is nil then
+		// the prefix was deleted. The call to traverseBaseDir will handle that
+		// properly, we just need to avoid an NPE here. Since we're still calling
+		// traverseBaseDir instead of just continuing with the loop the usual
+		// merging rules for subfolders still applies.
 		newSubtreePath := subtreePath
-		if p, ok := updatedPaths[subtreePath.String()]; ok {
+		if p, ok := updatedPaths[subtreePath.String()]; ok && p != nil {
 			newSubtreePath = p.ToBuilder()
 		}
 


### PR DESCRIPTION
At some point we switched from using file names
to file IDs in kopia as IDs were required for
incremental backups. However, before that change
went through we started persisting metadata for
incrementals. This means it was possible to get
delta changes when the base used file names which
would make it impossible to remove moved/deleted
files from the base as we wouldn't know the old
name

This PR forces full enumeration if the base
backup uses file names. It stops hierarchy merging
in kopia by deleting the old prefix and everything
under it and then passing in no metadata to the
get collections operation

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3139

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
