### PR TITLE
Return SharePoint exclude information

### DIFF
--- a/src/internal/connector/sharepoint/data_collections.go
+++ b/src/internal/connector/sharepoint/data_collections.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/alcionai/clues"
+	"golang.org/x/exp/maps"
 
 	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/connector/graph"
@@ -50,6 +51,7 @@ func DataCollections(
 		"site_url", clues.Hide(site.Name()))
 
 	var (
+		excluded    map[string]map[string]struct{}
 		el          = errs.Local()
 		collections = []data.BackupCollection{}
 		categories  = map[path.CategoryType]struct{}{}
@@ -84,7 +86,9 @@ func DataCollections(
 			}
 
 		case path.LibrariesCategory:
-			spcs, _, err = collectLibraries(
+			var excludes map[string]map[string]struct{}
+
+			spcs, excludes, err = collectLibraries(
 				ctx,
 				itemClient,
 				serv,
@@ -98,6 +102,14 @@ func DataCollections(
 			if err != nil {
 				el.AddRecoverable(err)
 				continue
+			}
+
+			for prefix, excludes := range excludes {
+				if _, ok := excluded[prefix]; !ok {
+					excluded[prefix] = map[string]struct{}{}
+				}
+
+				maps.Copy(excluded[prefix], excludes)
 			}
 
 		case path.PagesCategory:
@@ -138,7 +150,7 @@ func DataCollections(
 		collections = append(collections, baseCols...)
 	}
 
-	return collections, nil, el.Failure()
+	return collections, excluded, el.Failure()
 }
 
 func collectLists(
@@ -216,8 +228,6 @@ func collectLibraries(
 			ctrlOpts)
 	)
 
-	// TODO(ashmrtn): Pass previous backup metadata when SharePoint supports delta
-	// token-based incrementals.
 	odcs, excludes, err := colls.Get(ctx, metadata, errs)
 	if err != nil {
 		return nil, nil, graph.Wrap(ctx, err, "getting library")

--- a/src/internal/connector/sharepoint/data_collections.go
+++ b/src/internal/connector/sharepoint/data_collections.go
@@ -51,10 +51,10 @@ func DataCollections(
 		"site_url", clues.Hide(site.Name()))
 
 	var (
-		excluded    map[string]map[string]struct{}
 		el          = errs.Local()
 		collections = []data.BackupCollection{}
 		categories  = map[path.CategoryType]struct{}{}
+		excluded    = map[string]map[string]struct{}{}
 	)
 
 	for _, scope := range b.Scopes() {


### PR DESCRIPTION
Allows proper deletion of files and also fixes file moves.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3240

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
