### PR TITLE
Add workflow to manually publish image via CI

### DIFF
--- a/.github/actions/publish-binary/action.yml
+++ b/.github/actions/publish-binary/action.yml
@@ -1,0 +1,75 @@
+name: Publish Binary
+
+inputs:
+  version:
+    description: Corso version to use for publishing
+    required: true
+  github_token:
+    description: GitHub token for publishing
+    required: true
+  rudderstack_write_key:
+    description: Write key for RudderStack
+    required: true
+  rudderstack_data_plane_url:
+    description: Data plane URL for RudderStack
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 # needed to pull changelog
+
+    - name: Setup Golang with cache
+      uses: magnetikonline/action-golang-cache@v4
+      with:
+        go-version-file: src/go.mod
+
+    - name: Mark snapshot release
+      shell: bash
+      if: ${{ !startsWith(github.ref , 'refs/tags/') }}
+      run: |
+        echo "grflags=--snapshot" >> $GITHUB_ENV
+
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v4
+      with:
+        version: latest
+        args: release --rm-dist --timeout 500m --parallelism 1 ${{ env.grflags }}
+        workdir: src
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        RUDDERSTACK_CORSO_WRITE_KEY: ${{ inputs.rudderstack_write_key }}
+        RUDDERSTACK_CORSO_DATA_PLANE_URL: ${{ inputs.rudderstack_data_plane_url }}
+        CORSO_VERSION: ${{ inputs.version }}
+
+    - name: Upload darwin arm64
+      uses: actions/upload-artifact@v3
+      with:
+        name: corso_Darwin_arm64
+        path: src/dist/corso_darwin_arm64/corso
+
+    - name: Upload linux arm64
+      uses: actions/upload-artifact@v3
+      with:
+        name: corso_Linux_arm64
+        path: src/dist/corso_linux_arm64/corso
+
+    - name: Upload darwin amd64
+      uses: actions/upload-artifact@v3
+      with:
+        name: corso_Darwin_amd64
+        path: src/dist/corso_darwin_amd64_v1/corso
+
+    - name: Upload linux amd64
+      uses: actions/upload-artifact@v3
+      with:
+        name: corso_Linux_amd64
+        path: src/dist/corso_linux_amd64_v1/corso
+
+    - name: Upload windows amd64
+      uses: actions/upload-artifact@v3
+      with:
+        name: corso_Windows_amd64
+        path: src/dist/corso_windows_amd64_v1/corso.exe

--- a/.github/workflows/binary-publish.yml
+++ b/.github/workflows/binary-publish.yml
@@ -1,0 +1,37 @@
+name: Publish binary
+on:
+  workflow_dispatch:
+
+jobs:
+  SetEnv:
+    environment: Testing
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get version string
+        id: version
+        run: |
+          if ${{ startsWith(github.ref, 'refs/tags/') }}; then
+            echo "version=$(git describe --exact-match --tags $(git rev-parse HEAD))" | tee -a $GITHUB_OUTPUT
+          else
+            echo "version=$(echo unreleased-$(git rev-parse --short HEAD))" | tee -a $GITHUB_OUTPUT
+          fi
+
+  Publish-Binary:
+    needs: [SetEnv]
+    environment: Testing
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Publish Binary
+        uses: ./.github/actions/publish-binary
+        with:
+          version: ${{ needs.SetEnv.outputs.version }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          rudderstack_write_key: ${{ secrets.RUDDERSTACK_CORSO_WRITE_KEY }}
+          rudderstack_data_plane_url: ${{ secrets.RUDDERSTACK_CORSO_DATA_PLANE_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,70 +444,17 @@ jobs:
     environment: ${{ needs.SetEnv.outputs.environment }}
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
-    defaults:
-      run:
-        working-directory: src
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 # needed to pull changelog
 
-      - name: Setup Golang with cache
-        uses: magnetikonline/action-golang-cache@v4
+      - name: Publish Binary
+        uses: ./.github/actions/publish-binary
         with:
-          go-version-file: src/go.mod
-
-      - name: Decide goreleaser release mode
-        shell: bash
-        run: |
-          if test '${{ github.ref }}' = "refs/heads/main"; then
-            echo "grflags=--snapshot" >> $GITHUB_ENV
-          else
-            echo "grflags=" >> $GITHUB_ENV
-          fi
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
-        with:
-          version: latest
-          args: release --rm-dist --timeout 500m --parallelism 1 ${{ env.grflags }}
-          workdir: src
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUDDERSTACK_CORSO_WRITE_KEY: ${{ secrets.RUDDERSTACK_CORSO_WRITE_KEY }}
-          RUDDERSTACK_CORSO_DATA_PLANE_URL: ${{ secrets.RUDDERSTACK_CORSO_DATA_PLANE_URL }}
-          CORSO_VERSION: ${{ needs.SetEnv.outputs.version }}
-
-      - name: Upload darwin arm64
-        uses: actions/upload-artifact@v3
-        with:
-          name: corso_Darwin_arm64
-          path: src/dist/corso_darwin_arm64/corso
-
-      - name: Upload linux arm64
-        uses: actions/upload-artifact@v3
-        with:
-          name: corso_Linux_arm64
-          path: src/dist/corso_linux_arm64/corso
-
-      - name: Upload darwin amd64
-        uses: actions/upload-artifact@v3
-        with:
-          name: corso_Darwin_amd64
-          path: src/dist/corso_darwin_amd64_v1/corso
-
-      - name: Upload linux amd64
-        uses: actions/upload-artifact@v3
-        with:
-          name: corso_Linux_amd64
-          path: src/dist/corso_linux_amd64_v1/corso
-
-      - name: Upload windows amd64
-        uses: actions/upload-artifact@v3
-        with:
-          name: corso_Windows_amd64
-          path: src/dist/corso_windows_amd64_v1/corso.exe
+          version: ${{ needs.SetEnv.outputs.version }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          rudderstack_write_key: ${{ secrets.RUDDERSTACK_CORSO_WRITE_KEY }}
+          rudderstack_data_plane_url: ${{ secrets.RUDDERSTACK_CORSO_DATA_PLANE_URL }}
 
   Publish-Image:
     needs: [Test-Suite-Trusted, Linting, Website-Linting, SetEnv]


### PR DESCRIPTION
Option to manually publish a binary from a specific branch. This is useful when  we want to share test builds without having to merge to main. Once merged, this will let us release binaries for any branch just like publish website.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [x] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
