### PR TITLE
Fallback to RepoRef is LocationRef is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Drives with a directory containing a folder named 'folder' will now restore without error.
 - The CORSO_LOG_FILE env is appropriately utilized if no --log-file flag is provided.
 - Fixed Exchange events progress output to show calendar names instead of IDs.
+- Fixed reporting no items match if restoring or listing details on an older Exchange backup and filtering by folder.
 
 ### Known Issues
 - Restoring a OneDrive or SharePoint file with the same name as a file with that name as its M365 ID may restore both items.

--- a/src/pkg/selectors/exchange.go
+++ b/src/pkg/selectors/exchange.go
@@ -617,8 +617,15 @@ func (ec exchangeCategory) pathValues(
 		item = repo.Item()
 	}
 
+	// Will hit the if-condition when we're at a top-level folder, but we'll get
+	// the same result when we extract from the RepoRef.
+	folder := ent.LocationRef
+	if len(folder) == 0 {
+		folder = repo.Folder(true)
+	}
+
 	result := map[categorizer][]string{
-		folderCat: {ent.LocationRef},
+		folderCat: {folder},
 		itemCat:   {item, ent.ShortRef},
 	}
 


### PR DESCRIPTION
Fixes issue where doing backup detail or a restore
on an older backup and selecting by folder in
exchange wouldn't return any results. Root cause
is that older backup versions didn't populate
LocationRef in backup details which is what we
compare against

Manually tested on an older Corso backup. Will
write automated unit tests in a bit, wanted to
get this in prior to release

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* closes #3269

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
