### PR TITLE
Handle ErrorFolderExists for contact restore folders

### DIFF
--- a/src/internal/connector/exchange/api/contacts.go
+++ b/src/internal/connector/exchange/api/contacts.go
@@ -55,6 +55,22 @@ func (c Contacts) CreateContactFolder(
 	return mdl, nil
 }
 
+// CreateContactFolder makes a contact folder with the displayName of folderName.
+// If successful, returns the created folder object.
+func (c Contacts) GetContactFolders(
+	ctx context.Context,
+	user string,
+) (models.ContactFolderCollectionResponseable, error) {
+	// TODO: Add pagination or just reuse EnumerateContainer logic
+	// with base id at root
+	mdl, err := c.Stable.Client().UsersById(user).ContactFolders().Get(ctx, nil)
+	if err != nil {
+		return nil, graph.Wrap(ctx, err, "creating contact folder")
+	}
+
+	return mdl, nil
+}
+
 // DeleteContainer deletes the ContactFolder associated with the M365 ID if permissions are valid.
 func (c Contacts) DeleteContainer(
 	ctx context.Context,

--- a/src/internal/connector/exchange/api/contacts.go
+++ b/src/internal/connector/exchange/api/contacts.go
@@ -55,14 +55,12 @@ func (c Contacts) CreateContactFolder(
 	return mdl, nil
 }
 
-// CreateContactFolder makes a contact folder with the displayName of folderName.
-// If successful, returns the created folder object.
+// TODO: Add pagination or just reuse EnumerateContainer logic
+// with base id at root
 func (c Contacts) GetContactFolders(
 	ctx context.Context,
 	user string,
 ) (models.ContactFolderCollectionResponseable, error) {
-	// TODO: Add pagination or just reuse EnumerateContainer logic
-	// with base id at root
 	mdl, err := c.Stable.Client().UsersById(user).ContactFolders().Get(ctx, nil)
 	if err != nil {
 		return nil, graph.Wrap(ctx, err, "creating contact folder")

--- a/src/internal/connector/exchange/service_restore.go
+++ b/src/internal/connector/exchange/service_restore.go
@@ -649,10 +649,18 @@ func establishContactsRestoreLocation(
 		return cached, nil
 	}
 
+	folders[0] = "Corso_Restore_02-May-2023_00:06:19"
 	ctx = clues.Add(ctx, "is_new_cache", isNewCache)
 
+	// This is where destination folder gets created by corso in graph
+	// This is the POST operation which may fail if the folder exists
 	temp, err := ac.Contacts().CreateContactFolder(ctx, user, folders[0])
 	if err != nil {
+		// TODO:: Add status code check too
+		if graph.IsErrFolderExists(err) {
+			result, _ := ac.Contacts().GetContactFolders(ctx, user)
+			//fmt.Println(result.GetValue())
+		}
 		return "", err
 	}
 

--- a/src/internal/connector/exchange/service_restore.go
+++ b/src/internal/connector/exchange/service_restore.go
@@ -659,7 +659,6 @@ func establishContactsRestoreLocation(
 		// TODO:: Add status code check too
 		if graph.IsErrFolderExists(err) {
 			result, _ := ac.Contacts().GetContactFolders(ctx, user)
-			//fmt.Println(result.GetValue())
 		}
 		return "", err
 	}

--- a/src/internal/connector/graph/errors.go
+++ b/src/internal/connector/graph/errors.go
@@ -41,6 +41,7 @@ const (
 	syncFolderNotFound          errorCode = "ErrorSyncFolderNotFound"
 	syncStateInvalid            errorCode = "SyncStateInvalid"
 	syncStateNotFound           errorCode = "SyncStateNotFound"
+	folderExists                errorCode = "ErrorFolderExists"
 )
 
 const (
@@ -170,6 +171,10 @@ func IsMalwareResp(ctx context.Context, resp *http.Response) bool {
 	}
 
 	return false
+}
+
+func IsErrFolderExists(err error) bool {
+	return hasErrorCode(err, folderExists)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Handle 409, `ErrorFolderExists` error in restore path while creating destination contact folder. We need to fix this for all m365 services. Starting with contacts to get a buy in on the fix. Will add integration tests + similar fixes for rest of exchange, onedrive, etc. in later PRs. 

Context:
`CreateContactFolder()` may fail with `ErrorFolderExists` under certain error conditions. For e.g. consider below scenario. 
1. `CreateContactFolder()` does a `POST` to graph to create restore destination folder but this fails with 5xx. 
2. It's possible that step 1 may have left some dirty state in graph. For e.g. it's possible that the destination folder in step 1 was actually created, but 5xx was returned due to other reasons. 
3. So when we reattempt `POST` in such a scenario, we sometimes observe `ErrorFolderExists` error .
4. Corso should be resilient to such errors. To fix this, when we encounter such an error, we will do a `GET` to fetch the restore destination folder and add it to folder cache.



---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E


