### PR TITLE
Smarter item load ordering during ProduceRestoreCollections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - POST Retries following certain status codes (500, 502, 504) will re-use the post body instead of retrying with a no-content request.
 - Fix nil pointer exception when running an incremental backup on SharePoint where the base backup used an older index data format.
 - --user and --mailbox flags (already not supported) have been removed from CLI examples for details and restore commands.
+- Improve restore time on large restores by optimizing how items are loaded from the remote repository.
 
 ## [v0.7.0] (beta) - 2023-05-02
 

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -370,6 +370,12 @@ type dirAndItems struct {
 	items []string
 }
 
+// loadDirsAndItems takes a set of ShortRef -> (directory path, []item names)
+// and creates a collection for each tuple in the set. Non-fatal errors are
+// accumulated into bus. Any fatal errors will stop processing and return the
+// error directly.
+//
+// All data is loaded from the given snapshot.
 func loadDirsAndItems(
 	ctx context.Context,
 	snapshotRoot fs.Entry,

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -2,6 +2,7 @@ package kopia
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/alcionai/clues"
@@ -525,6 +526,12 @@ func (w Wrapper) FetchPrevSnapshotManifests(
 }
 
 func isErrEntryNotFound(err error) bool {
+	// Calling Child on a directory may return this.
+	if errors.Is(err, fs.ErrEntryNotFound) {
+		return true
+	}
+
+	// This is returned when walking the hierarchy of a backup.
 	return strings.Contains(err.Error(), "entry not found") &&
 		!strings.Contains(err.Error(), "parent is not a directory")
 }


### PR DESCRIPTION
Optimize loading items for restore a little bit by first grouping items
by directory, loading the directory once, and then loading all items
from the loaded directory. This brings item loading on my local machine
(communicating with remote S3) down to ~1.5min/1k items

Future improvements could lazily load items as they're returned in the
Items() call of each collection but doing so would change the semantics
of ProduceRestoreCollections() (specifically item not found errors would
be returned during Items() instead of during
ProduceRestoreCollections())

The kopia data collection has also been updated to hold onto a
reference to the folder it corresponds to. This folder reference is
used to service Fetch() calls

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3293

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
