### PR TITLE
get all the gotchas to restore sp permissions

### DIFF
--- a/src/internal/connector/data_collections.go
+++ b/src/internal/connector/data_collections.go
@@ -218,7 +218,7 @@ func (gc *GraphConnector) ConsumeRestoreCollections(
 	case selectors.ServiceOneDrive:
 		status, err = onedrive.RestoreCollections(ctx, creds, backupVersion, gc.Service, dest, opts, dcs, deets, errs)
 	case selectors.ServiceSharePoint:
-		status, err = sharepoint.RestoreCollections(ctx, backupVersion, creds, gc.Service, dest, dcs, deets, errs)
+		status, err = sharepoint.RestoreCollections(ctx, backupVersion, creds, gc.Service, dest, opts, dcs, deets, errs)
 	default:
 		err = clues.Wrap(clues.New(selector.Service.String()), "service not supported")
 	}

--- a/src/internal/connector/onedrive/api/drive.go
+++ b/src/internal/connector/onedrive/api/drive.go
@@ -372,3 +372,21 @@ func GetFolderByName(
 
 	return foundItem, nil
 }
+
+func PostItemPermissionUpdate(
+	ctx context.Context,
+	service graph.Servicer,
+	driveID, itemID string,
+	body *drive.ItemsItemInvitePostRequestBody,
+) (drives.ItemItemsItemInviteResponseable, error) {
+	itm, err := service.Client().
+		DrivesById(driveID).
+		ItemsById(itemID).
+		Invite().
+		Post(ctx, body, nil)
+	if err != nil {
+		return nil, graph.Wrap(ctx, err, "posting permissions")
+	}
+
+	return itm, nil
+}

--- a/src/internal/connector/onedrive/drive_test.go
+++ b/src/internal/connector/onedrive/drive_test.go
@@ -351,18 +351,18 @@ func (suite *OneDriveSuite) TestCreateGetDeleteFolder() {
 		Folders: folderElements,
 	}
 
+	caches := NewRestoreCaches()
+	caches.DriveIDToRootFolderID[driveID] = ptr.Val(rootFolder.GetId())
+
 	folderID, err := CreateRestoreFolders(
 		ctx,
 		suite.creds,
 		gs,
 		&drivePath,
-		ptr.Val(rootFolder.GetId()),
 		restoreDir,
 		nil, // only needed for permissions
 		metadata.Metadata{},
-		map[string]metadata.Metadata{},
-		NewFolderCache(),
-		map[string]string{},
+		caches,
 		false)
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -376,13 +376,10 @@ func (suite *OneDriveSuite) TestCreateGetDeleteFolder() {
 		suite.creds,
 		gs,
 		&drivePath,
-		ptr.Val(rootFolder.GetId()),
 		restoreDir,
 		nil, // only needed for permissions
 		metadata.Metadata{},
-		map[string]metadata.Metadata{},
-		NewFolderCache(),
-		map[string]string{},
+		caches,
 		false)
 	require.NoError(t, err, clues.ToCore(err))
 

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -242,24 +242,23 @@ func filterUserPermissions(ctx context.Context, perms []models.Permissionable) [
 		// read  - Read
 		// empty - Restricted View
 		roles := p.GetRoles()
-
 		entityID := ""
-		if gv2.GetUser() != nil {
-			entityID = ptr.Val(gv2.GetUser().GetId())
-		} else if gv2.GetGroup() != nil {
-			entityID = ptr.Val(gv2.GetGroup().GetId())
-		} else {
-			logm := logger.Ctx(ctx)
 
-			if gv2.GetApplication() != nil {
-				entityID = ptr.Val(gv2.GetApplication().GetId())
-			} else if gv2.GetDevice() != nil {
-				entityID = ptr.Val(gv2.GetDevice().GetId())
-			}
-			if gv2.GetDevice() != nil {
-				logm.With("device_id", ptr.Val(gv2.GetDevice().GetId()))
-			}
-			logm.Info("untracked permission")
+		switch true {
+		case gv2.GetUser() != nil:
+			entityID = ptr.Val(gv2.GetUser().GetId())
+		case gv2.GetGroup() != nil:
+			entityID = ptr.Val(gv2.GetGroup().GetId())
+		case gv2.GetApplication() != nil:
+			entityID = ptr.Val(gv2.GetApplication().GetId())
+		case gv2.GetDevice() != nil:
+			entityID = ptr.Val(gv2.GetDevice().GetId())
+		default:
+			logger.Ctx(ctx).Info("untracked permission")
+		}
+
+		if gv2.GetDevice() != nil {
+			logger.Ctx(ctx).With("device_id", ptr.Val(gv2.GetDevice().GetId()))
 		}
 
 		// Technically GrantedToV2 can also contain devices, but the

--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -288,7 +288,7 @@ func TestItemUnitTestSuite(t *testing.T) {
 	suite.Run(t, &ItemUnitTestSuite{Suite: tester.NewUnitSuite(t)})
 }
 
-func (suite *ItemUnitTestSuite) TestOneDrivePermissionsFilter() {
+func (suite *ItemUnitTestSuite) TestDrivePermissionsFilter() {
 	permID := "fakePermId"
 	userID := "fakeuser@provider.com"
 	userID2 := "fakeuser2@provider.com"

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -182,9 +182,7 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 		op.Results.BackupID)
 	if err != nil {
 		// No return here!  We continue down to persistResults, even in case of failure.
-		logger.Ctx(ctx).
-			With("err", err).
-			Errorw("running backup", clues.InErr(err).Slice()...)
+		logger.CtxErr(ctx, err).Error("running backup")
 		op.Errors.Fail(clues.Wrap(err, "running backup"))
 	}
 

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -1336,7 +1336,6 @@ func runDriveIncrementalTest(
 		updateFiles  func(t *testing.T)
 		itemsRead    int
 		itemsWritten int
-		skip         bool
 	}{
 		{
 			name:         "clean incremental, no changes",
@@ -1364,7 +1363,6 @@ func runDriveIncrementalTest(
 		},
 		{
 			name: "add permission to new file",
-			skip: skipPermissionsTests,
 			updateFiles: func(t *testing.T) {
 				driveItem := models.NewDriveItem()
 				driveItem.SetName(&newFileName)
@@ -1385,7 +1383,6 @@ func runDriveIncrementalTest(
 		},
 		{
 			name: "remove permission from new file",
-			skip: skipPermissionsTests,
 			updateFiles: func(t *testing.T) {
 				driveItem := models.NewDriveItem()
 				driveItem.SetName(&newFileName)
@@ -1399,14 +1396,13 @@ func runDriveIncrementalTest(
 					[]metadata.Permission{},
 					[]metadata.Permission{writePerm},
 					permissionIDMappings)
-				require.NoErrorf(t, err, "adding permission to file %v", clues.ToCore(err))
+				require.NoErrorf(t, err, "removing permission from file %v", clues.ToCore(err))
 			},
 			itemsRead:    1, // .data file for newitem
 			itemsWritten: 2, // .meta for newitem, .dirmeta for parent (.data is not written as it is not updated)
 		},
 		{
 			name: "add permission to container",
-			skip: skipPermissionsTests,
 			updateFiles: func(t *testing.T) {
 				targetContainer := containerIDs[container1]
 				driveItem := models.NewDriveItem()
@@ -1421,14 +1417,13 @@ func runDriveIncrementalTest(
 					[]metadata.Permission{writePerm},
 					[]metadata.Permission{},
 					permissionIDMappings)
-				require.NoErrorf(t, err, "adding permission to file %v", clues.ToCore(err))
+				require.NoErrorf(t, err, "adding permission to container %v", clues.ToCore(err))
 			},
 			itemsRead:    0,
 			itemsWritten: 1, // .dirmeta for collection
 		},
 		{
 			name: "remove permission from container",
-			skip: skipPermissionsTests,
 			updateFiles: func(t *testing.T) {
 				targetContainer := containerIDs[container1]
 				driveItem := models.NewDriveItem()
@@ -1443,7 +1438,7 @@ func runDriveIncrementalTest(
 					[]metadata.Permission{},
 					[]metadata.Permission{writePerm},
 					permissionIDMappings)
-				require.NoErrorf(t, err, "adding permission to file %v", clues.ToCore(err))
+				require.NoErrorf(t, err, "removing permission from container %v", clues.ToCore(err))
 			},
 			itemsRead:    0,
 			itemsWritten: 1, // .dirmeta for collection
@@ -1614,10 +1609,6 @@ func runDriveIncrementalTest(
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			if test.skip {
-				suite.T().Skip("flagged to skip")
-			}
-
 			cleanGC, err := connector.NewGraphConnector(ctx, acct, resource)
 			require.NoError(t, err, clues.ToCore(err))
 

--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -146,9 +146,7 @@ func (op *RestoreOperation) Run(ctx context.Context) (restoreDetails *details.De
 	deets, err := op.do(ctx, &opStats, sstore, start)
 	if err != nil {
 		// No return here!  We continue down to persistResults, even in case of failure.
-		logger.Ctx(ctx).
-			With("err", err).
-			Errorw("running restore", clues.InErr(err).Slice()...)
+		logger.CtxErr(ctx, err).Error("running restore")
 		op.Errors.Fail(clues.Wrap(err, "running restore"))
 	}
 


### PR DESCRIPTION
Aggregate changes from manual testing of sharepoint permission restores.  Largely a bunch of code centralization and smoothing/catching gotchas that were either not evident or not quickly toggleable in order to suceed at permission restoration.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #3135

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
