### PR TITLE
Fix NPE in SharePoint incremental backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] (beta)
 
+### Fixed
+- Fix nil pointer exception when running an incremental backup on SharePoint where the base backup used an older index data format.
+
 ## [v0.7.0] (beta) - 2023-05-02
 
 ### Added

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -628,15 +628,20 @@ func UpdateItem(item *ItemInfo, newLocPath *path.Builder) {
 	// contained in them.
 	var updatePath func(newLocPath *path.Builder)
 
-	switch item.infoType() {
-	case ExchangeContact, ExchangeEvent, ExchangeMail:
+	// Can't switch based on infoType because that's been unstable.
+	if item.Exchange != nil {
 		updatePath = item.Exchange.UpdateParentPath
-	case SharePointLibrary:
+	} else if item.SharePoint != nil {
+		// SharePoint used to store library items with the OneDriveItem ItemType.
+		// Start switching them over as we see them since there's no point in
+		// keeping the old format.
+		if item.SharePoint.ItemType == OneDriveItem {
+			item.SharePoint.ItemType = SharePointLibrary
+		}
+
 		updatePath = item.SharePoint.UpdateParentPath
-	case OneDriveItem:
+	} else if item.OneDrive != nil {
 		updatePath = item.OneDrive.UpdateParentPath
-	default:
-		return
 	}
 
 	updatePath(newLocPath)

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -642,6 +642,8 @@ func UpdateItem(item *ItemInfo, newLocPath *path.Builder) {
 		updatePath = item.SharePoint.UpdateParentPath
 	} else if item.OneDrive != nil {
 		updatePath = item.OneDrive.UpdateParentPath
+	} else {
+		return
 	}
 
 	updatePath(newLocPath)

--- a/src/pkg/backup/details/details_test.go
+++ b/src/pkg/backup/details/details_test.go
@@ -1164,6 +1164,12 @@ func (suite *DetailsUnitSuite) TestUpdateItem() {
 				},
 			},
 		},
+		{
+			name:         "Empty Item Doesn't Fail",
+			input:        ItemInfo{},
+			locPath:      newOneDrivePB,
+			expectedItem: ItemInfo{},
+		},
 	}
 
 	for _, test := range table {

--- a/src/pkg/backup/details/details_test.go
+++ b/src/pkg/backup/details/details_test.go
@@ -1148,6 +1148,22 @@ func (suite *DetailsUnitSuite) TestUpdateItem() {
 				},
 			},
 		},
+		{
+			name: "SharePoint Old Format",
+			input: ItemInfo{
+				SharePoint: &SharePointInfo{
+					ItemType:   OneDriveItem,
+					ParentPath: folder1,
+				},
+			},
+			locPath: newOneDrivePB,
+			expectedItem: ItemInfo{
+				SharePoint: &SharePointInfo{
+					ItemType:   SharePointLibrary,
+					ParentPath: folder2,
+				},
+			},
+		},
 	}
 
 	for _, test := range table {


### PR DESCRIPTION
Original code was switching based on the ItemType, but SharePoint historically used the OneDriveItem ItemType, making the system think it should be updating a OneDriveItemInfo struct instead of a SharePointItemInfo struct.

Also add a regression test for older backup formats.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* closes #3306

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
