### PR TITLE
Return map instead of using in-out param

### DIFF
--- a/src/internal/connector/exchange/data_collections.go
+++ b/src/internal/connector/exchange/data_collections.go
@@ -276,9 +276,6 @@ func createCollections(
 		return nil, clues.Stack(err).WithClues(ctx)
 	}
 
-	// Create collection of ExchangeDataCollection
-	collections := make(map[string]data.BackupCollection)
-
 	qp := graph.QueryParams{
 		Category:      category,
 		ResourceOwner: user,
@@ -296,11 +293,10 @@ func createCollections(
 		return nil, clues.Wrap(err, "populating container cache")
 	}
 
-	err = filterContainersAndFillCollections(
+	collections, err := filterContainersAndFillCollections(
 		ctx,
 		qp,
 		getter,
-		collections,
 		su,
 		resolver,
 		scope,

--- a/src/internal/connector/exchange/service_iterators_test.go
+++ b/src/internal/connector/exchange/service_iterators_test.go
@@ -287,13 +287,10 @@ func (suite *ServiceIteratorsSuite) TestFilterContainersAndFillCollections() {
 			ctx, flush := tester.NewContext()
 			defer flush()
 
-			collections := map[string]data.BackupCollection{}
-
-			err := filterContainersAndFillCollections(
+			collections, err := filterContainersAndFillCollections(
 				ctx,
 				qp,
 				test.getter,
-				collections,
 				statusUpdater,
 				test.resolver,
 				test.scope,
@@ -629,13 +626,10 @@ func (suite *ServiceIteratorsSuite) TestFilterContainersAndFillCollections_Dupli
 					ctx, flush := tester.NewContext()
 					defer flush()
 
-					collections := map[string]data.BackupCollection{}
-
-					err := filterContainersAndFillCollections(
+					collections, err := filterContainersAndFillCollections(
 						ctx,
 						qp,
 						test.getter,
-						collections,
 						statusUpdater,
 						test.resolver,
 						sc.scope,
@@ -878,13 +872,10 @@ func (suite *ServiceIteratorsSuite) TestFilterContainersAndFillCollections_Dupli
 			ctx, flush := tester.NewContext()
 			defer flush()
 
-			collections := map[string]data.BackupCollection{}
-
-			err := filterContainersAndFillCollections(
+			collections, err := filterContainersAndFillCollections(
 				ctx,
 				qp,
 				test.getter,
-				collections,
 				statusUpdater,
 				test.resolver,
 				scope,
@@ -1033,13 +1024,10 @@ func (suite *ServiceIteratorsSuite) TestFilterContainersAndFillCollections_repea
 			require.Equal(t, "user_id", qp.ResourceOwner.ID(), qp.ResourceOwner)
 			require.Equal(t, "user_name", qp.ResourceOwner.Name(), qp.ResourceOwner)
 
-			collections := map[string]data.BackupCollection{}
-
-			err := filterContainersAndFillCollections(
+			collections, err := filterContainersAndFillCollections(
 				ctx,
 				qp,
 				test.getter,
-				collections,
 				statusUpdater,
 				resolver,
 				allScope,
@@ -1398,13 +1386,10 @@ func (suite *ServiceIteratorsSuite) TestFilterContainersAndFillCollections_incre
 			ctx, flush := tester.NewContext()
 			defer flush()
 
-			collections := map[string]data.BackupCollection{}
-
-			err := filterContainersAndFillCollections(
+			collections, err := filterContainersAndFillCollections(
 				ctx,
 				qp,
 				test.getter,
-				collections,
 				statusUpdater,
 				test.resolver,
 				allScope,


### PR DESCRIPTION
Return type should really be switched to []data.BackupCollection but that's a non-trivial change to make since tests rely on being able to lookup things by folder ID.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
