### PR TITLE
Correct help for exchange backup details

### DIFF
--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -49,20 +49,20 @@ corso backup create exchange --mailbox '*'`
 	exchangeServiceCommandDeleteExamples = `# Delete Exchange backup with ID 1234abcd-12ab-cd34-56de-1234abcd
 corso backup delete exchange --backup 1234abcd-12ab-cd34-56de-1234abcd`
 
-	exchangeServiceCommandDetailsExamples = `# Explore Alice's items in backup 1234abcd-12ab-cd34-56de-1234abcd 
+	exchangeServiceCommandDetailsExamples = `# Explore items in backup 1234abcd-12ab-cd34-56de-1234abcd (Alice's backup)
 corso backup details exchange --backup 1234abcd-12ab-cd34-56de-1234abcd --mailbox alice@example.com
 
 # Explore Alice's emails with subject containing "Hello world" in folder "Inbox" from a specific backup 
 corso backup details exchange --backup 1234abcd-12ab-cd34-56de-1234abcd \
-    --mailbox alice@example.com --email-subject "Hello world" --email-folder Inbox
+    --email-subject "Hello world" --email-folder Inbox
 
 # Explore Bobs's events occurring after start of 2022 from a specific backup
 corso backup details exchange --backup 1234abcd-12ab-cd34-56de-1234abcd \
-    --mailbox bob@example.com --event-starts-after 2022-01-01T00:00:00
+    --event-starts-after 2022-01-01T00:00:00
 
 # Explore Alice's contacts with name containing Andy from a specific backup
 corso backup details exchange --backup 1234abcd-12ab-cd34-56de-1234abcd \
-    --mailbox alice@example.com --contact-name Andy`
+    --contact-name Andy`
 )
 
 // called by backup.go to map subcommands to provider-specific handling.


### PR DESCRIPTION
Incorrectly incudes `--mailbox` as a flag in examples when backups are already per mailbox.
---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
