### PR TITLE
remove cli support for exchange item msoft id lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Graph requests now automatically retry in case of a Bad Gateway or Gateway Timeout.
 - POST Retries following certain status codes (500, 502, 504) will re-use the post body instead of retrying with a no-content request.
 - Fix nil pointer exception when running an incremental backup on SharePoint where the base backup used an older index data format.
-- --user and --mailbox flags (already not supported) have been removed from CLI examples for details and restore commands.
+- --user and --mailbox flags have been removed from CLI examples for details and restore commands (they were already not supported, this only updates the docs).
 - Improve restore time on large restores by optimizing how items are loaded from the remote repository.
+- Remove exchange item filtering based on m365 item ID via the CLI.
 
 ## [v0.7.0] (beta) - 2023-05-02
 

--- a/src/cli/utils/testdata/opts.go
+++ b/src/cli/utils/testdata/opts.go
@@ -199,17 +199,19 @@ var (
 			},
 		},
 		{
-			Name:     "MailItemRef",
-			Expected: []details.Entry{testdata.ExchangeEmailItems[0]},
-			Opts: utils.ExchangeOpts{
-				Email: []string{testdata.ExchangeEmailItems[0].ItemRef},
-			},
-		},
-		{
 			Name:     "MailShortRef",
 			Expected: []details.Entry{testdata.ExchangeEmailItems[0]},
 			Opts: utils.ExchangeOpts{
 				Email: []string{testdata.ExchangeEmailItemPath1.RR.ShortRef()},
+			},
+		},
+		{
+			Name: "BadMailItemRef",
+			// no matches are expected, since exchange ItemRefs
+			// are not matched when using the CLI's selectors.
+			Expected: []details.Entry{},
+			Opts: utils.ExchangeOpts{
+				Email: []string{testdata.ExchangeEmailItems[0].ItemRef},
 			},
 		},
 		{

--- a/src/pkg/selectors/exchange.go
+++ b/src/pkg/selectors/exchange.go
@@ -617,6 +617,15 @@ func (ec exchangeCategory) pathValues(
 		item = repo.Item()
 	}
 
+	items := []string{ent.ShortRef, item}
+
+	// only include the item ID when the user is NOT matching
+	// item names. Exchange data does not contain an item name,
+	// only an ID, and we don't want to mix up the two.
+	if cfg.OnlyMatchItemNames {
+		items = []string{ent.ShortRef}
+	}
+
 	// Will hit the if-condition when we're at a top-level folder, but we'll get
 	// the same result when we extract from the RepoRef.
 	folder := ent.LocationRef
@@ -626,7 +635,7 @@ func (ec exchangeCategory) pathValues(
 
 	result := map[categorizer][]string{
 		folderCat: {folder},
-		itemCat:   {item, ent.ShortRef},
+		itemCat:   items,
 	}
 
 	return result, nil


### PR DESCRIPTION
removes the microsoft item ID from the exchange pathValues set when using only-name selector configuration.  This is the standard config for the cli, thus this removes the ability to filter exchange items from the cli by using their m365 id.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3313

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
