### PR TITLE
Fetch calendar by name on 409 ErrorFolderExist

### DIFF
--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -117,15 +117,16 @@ func (c Events) GetContainerByName(
 
 	resp, err := c.Stable.Client().UsersById(userID).Calendars().Get(ctx, options)
 	if err != nil {
-		return nil, graph.Wrap(ctx, err, "searching calendar by name")
+		return nil, graph.Stack(ctx, err).WithClues(ctx)
 	}
 
 	// We only allow the api to match one calendar with provided name.
 	// Return an error if multiple calendars exist(unlikely) or if no calendar
 	// is found.
 	if len(resp.GetValue()) != 1 {
-		return nil, graph.Wrap(ctx, err, "unexpected number of calendars").
+		err = clues.New("unexpected number of calendars returned").
 			With("returned_calendar_count", len(resp.GetValue()))
+		return nil, err
 	}
 
 	// Sanity check ID and name

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -106,20 +106,16 @@ func (c Events) GetContainerByName(
 	ctx context.Context,
 	userID, name string,
 ) (models.Calendarable, error) {
-	service, err := c.service()
-	if err != nil {
-		return nil, graph.Stack(ctx, err)
-	}
-
 	filter := fmt.Sprintf("name eq '%s'", name)
 	options := &users.ItemCalendarsRequestBuilderGetRequestConfiguration{
 		QueryParameters: &users.ItemCalendarsRequestBuilderGetQueryParameters{
 			Filter: &filter,
 		},
 	}
+
 	ctx = clues.Add(ctx, "calendar_name", name)
 
-	resp, err := service.Client().UsersById(userID).Calendars().Get(ctx, options)
+	resp, err := c.Stable.Client().UsersById(userID).Calendars().Get(ctx, options)
 	if err != nil {
 		return nil, graph.Wrap(ctx, err, "searching calendar by name")
 	}

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -129,7 +129,7 @@ func (c Events) GetContainerByName(
 	// is found.
 	if len(resp.GetValue()) != 1 {
 		return nil, graph.Wrap(ctx, err, "unexpected number of calendars").
-			With("calendar_count", len(resp.GetValue()))
+			With("returned_calendar_count", len(resp.GetValue()))
 	}
 
 	// Sanity check ID and name

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -99,9 +99,7 @@ func (c Events) GetContainerByID(
 	return graph.CalendarDisplayable{Calendarable: cal}, nil
 }
 
-// GetContainerByName fetches calendar by name.
-// Note: At the moment, we only support lookups for calendars which belong to
-// the default calendar group.
+// GetContainerByName fetches a calendar by name
 func (c Events) GetContainerByName(
 	ctx context.Context,
 	userID, name string,
@@ -121,7 +119,7 @@ func (c Events) GetContainerByName(
 	}
 
 	// We only allow the api to match one calendar with provided name.
-	// Return an error if multiple calendars exist(unlikely) or if no calendar
+	// Return an error if multiple calendars exist (unlikely) or if no calendar
 	// is found.
 	if len(resp.GetValue()) != 1 {
 		err = clues.New("unexpected number of calendars returned").

--- a/src/internal/connector/exchange/restore_test.go
+++ b/src/internal/connector/exchange/restore_test.go
@@ -2,7 +2,6 @@ package exchange
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -383,55 +382,6 @@ func (suite *ExchangeRestoreSuite) TestRestoreExchangeObject() {
 
 			err = deleters[test.category].DeleteContainer(ctx, userID, destination)
 			assert.NoError(t, err, clues.ToCore(err))
-		})
-	}
-}
-
-// TestRestoreExchangeObject verifies path.Category usage for restored objects
-func (suite *ExchangeRestoreSuite) TestGetContainerByName() {
-	// deleters := map[path.CategoryType]containerDeleter{
-	// 	path.EventsCategory: suite.ac.Events(),
-	// }
-
-	userID := tester.M365UserID(suite.T())
-	folderName := tester.DefaultTestRestoreDestination().ContainerName
-	fmt.Println(folderName)
-
-	tests := []struct {
-		name        string
-		category    path.CategoryType
-		destination func(*testing.T, context.Context, string) string
-	}{
-		{
-			name:     "Test Events",
-			category: path.EventsCategory,
-			// destination: func(t *testing.T, ctx context.Context, calName string) string {
-			// 	calendar, err := suite.ac.Events().CreateCalendar(ctx, userID, calName)
-			// 	require.NoError(t, err, clues.ToCore(err))
-
-			// 	return ptr.Val(calendar.GetId())
-			// },
-		},
-	}
-
-	for _, test := range tests {
-		suite.Run(test.name, func() {
-			t := suite.T()
-
-			ctx, flush := tester.NewContext()
-			defer flush()
-
-			//id := test.destination(t, ctx, folderName)
-			folder := "Corso_Restore_05-May-2023_09-38-09.814424"
-			_, err := suite.ac.Events().CreateCalendar(ctx, userID, folder)
-			require.NoError(t, err, clues.ToCore(err))
-
-			fmt.Print("here after dest")
-			_, err = suite.ac.Events().GetContainerByName(ctx, userID, folder) //ptr.Val("calendar.GetName())")
-			assert.NoError(t, err, clues.ToCore(err))
-			//fmt.Print(id)
-			// err = deleters[test.category].DeleteContainer(ctx, userID, id)
-			// assert.NoError(t, err, clues.ToCore(err))
 		})
 	}
 }

--- a/src/internal/connector/exchange/restore_test.go
+++ b/src/internal/connector/exchange/restore_test.go
@@ -393,7 +393,7 @@ func (suite *ExchangeRestoreSuite) TestGetContainerByName() {
 	// 	path.EventsCategory: suite.ac.Events(),
 	// }
 
-	userID := "Dustin.Corners@10rqc2.onmicrosoft.com" //tester.M365UserID(suite.T())
+	userID := tester.M365UserID(suite.T())
 	folderName := tester.DefaultTestRestoreDestination().ContainerName
 	fmt.Println(folderName)
 

--- a/src/internal/connector/exchange/restore_test.go
+++ b/src/internal/connector/exchange/restore_test.go
@@ -2,6 +2,7 @@ package exchange
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -382,6 +383,55 @@ func (suite *ExchangeRestoreSuite) TestRestoreExchangeObject() {
 
 			err = deleters[test.category].DeleteContainer(ctx, userID, destination)
 			assert.NoError(t, err, clues.ToCore(err))
+		})
+	}
+}
+
+// TestRestoreExchangeObject verifies path.Category usage for restored objects
+func (suite *ExchangeRestoreSuite) TestGetContainerByName() {
+	// deleters := map[path.CategoryType]containerDeleter{
+	// 	path.EventsCategory: suite.ac.Events(),
+	// }
+
+	userID := "Dustin.Corners@10rqc2.onmicrosoft.com" //tester.M365UserID(suite.T())
+	folderName := tester.DefaultTestRestoreDestination().ContainerName
+	fmt.Println(folderName)
+
+	tests := []struct {
+		name        string
+		category    path.CategoryType
+		destination func(*testing.T, context.Context, string) string
+	}{
+		{
+			name:     "Test Events",
+			category: path.EventsCategory,
+			// destination: func(t *testing.T, ctx context.Context, calName string) string {
+			// 	calendar, err := suite.ac.Events().CreateCalendar(ctx, userID, calName)
+			// 	require.NoError(t, err, clues.ToCore(err))
+
+			// 	return ptr.Val(calendar.GetId())
+			// },
+		},
+	}
+
+	for _, test := range tests {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext()
+			defer flush()
+
+			//id := test.destination(t, ctx, folderName)
+			folder := "Corso_Restore_05-May-2023_09-38-09.814424"
+			_, err := suite.ac.Events().CreateCalendar(ctx, userID, folder)
+			require.NoError(t, err, clues.ToCore(err))
+
+			fmt.Print("here after dest")
+			_, err = suite.ac.Events().GetContainerByName(ctx, userID, folder) //ptr.Val("calendar.GetName())")
+			assert.NoError(t, err, clues.ToCore(err))
+			//fmt.Print(id)
+			// err = deleters[test.category].DeleteContainer(ctx, userID, id)
+			// assert.NoError(t, err, clues.ToCore(err))
 		})
 	}
 }

--- a/src/internal/connector/graph/errors.go
+++ b/src/internal/connector/graph/errors.go
@@ -41,6 +41,10 @@ const (
 	syncFolderNotFound          errorCode = "ErrorSyncFolderNotFound"
 	syncStateInvalid            errorCode = "SyncStateInvalid"
 	syncStateNotFound           errorCode = "SyncStateNotFound"
+	// This error occurs when an attempt is made to create a folder that has
+	// the same name as another folder in the same parent. Such duplicate folder
+	// names are not allowed by graph.
+	folderExists errorCode = "ErrorFolderExists"
 )
 
 type errorMessage string
@@ -176,6 +180,10 @@ func IsMalwareResp(ctx context.Context, resp *http.Response) bool {
 	}
 
 	return false
+}
+
+func IsErrFolderExists(err error) bool {
+	return hasErrorCode(err, folderExists)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/internal/connector/graph/errors_test.go
+++ b/src/internal/connector/graph/errors_test.go
@@ -300,3 +300,48 @@ func (suite *GraphErrorsUnitSuite) TestMalwareInfo() {
 
 	assert.Equal(suite.T(), expect, ItemInfo(&i))
 }
+
+func (suite *GraphErrorsUnitSuite) TestIsErrFolderExists() {
+	table := []struct {
+		name   string
+		err    error
+		expect assert.BoolAssertionFunc
+	}{
+		{
+			name:   "nil",
+			err:    nil,
+			expect: assert.False,
+		},
+		{
+			name:   "non-matching",
+			err:    assert.AnError,
+			expect: assert.False,
+		},
+		{
+			name:   "non-matching oDataErr",
+			err:    odErr("folder doesn't exist"),
+			expect: assert.False,
+		},
+		{
+			name:   "matching oDataErr",
+			err:    odErr(string(folderExists)),
+			expect: assert.True,
+		},
+		// next two tests are to make sure the checks are case insensitive
+		{
+			name:   "oDataErr camelcase",
+			err:    odErr("ErrorFolderExists"),
+			expect: assert.True,
+		},
+		{
+			name:   "oDataErr lowercase",
+			err:    odErr("errorfolderexists"),
+			expect: assert.True,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			test.expect(suite.T(), IsErrFolderExists(test.err))
+		})
+	}
+}


### PR DESCRIPTION
Handle 409, `ErrorFolderExists` error in restore path while creating destination calendar. We need to fix this for all m365 services. This PR is focused on calendar only.

Context:
`CreateCalendar()` may fail with ErrorFolderExists under certain error conditions. For e.g. consider below scenario.

1. `CreateCalendar()` does a POST to graph to create restore destination calendar but this fails with 5xx.
2. It's possible that step 1 may have left some dirty state in graph. For e.g. it's possible that the destination folder in step 1 was actually created, but 5xx was returned due to other reasons.
3. So when we reattempt POST in such a scenario, we sometimes observe ErrorFolderExists error .
4. Corso should be resilient to such errors. To fix this, when we encounter such an error, we will do a GET to fetch the restore destination folder and add it to folder cache.


---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
Integration tests and mock tests will be added in a follow up PR. 
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
