### PR TITLE
Explicitly mention it is id of email and not email id for --email

### DIFF
--- a/src/cli/utils/exchange.go
+++ b/src/cli/utils/exchange.go
@@ -113,7 +113,7 @@ func AddExchangeDetailsAndRestoreFlags(cmd *cobra.Command) {
 	fs.StringSliceVar(
 		&EmailFV,
 		EmailFN, nil,
-		"Select emails by email ID; accepts '"+Wildcard+"' to select all emails.")
+		"Select email messages by ID; accepts '"+Wildcard+"' to select all emails.")
 	fs.StringSliceVar(
 		&EmailFolderFV,
 		EmailFolderFN, nil,

--- a/website/docs/quickstart.md
+++ b/website/docs/quickstart.md
@@ -250,7 +250,7 @@ To restore the selected email, use the following command.
 
   ```powershell
   # Restore a selected email
-  .\corso restore exchange --backup <id of your selected backup> --email <email ID>
+  .\corso restore exchange --backup <id of your selected backup> --email <email message ID>
   ```
 
 </TabItem>
@@ -258,7 +258,7 @@ To restore the selected email, use the following command.
 
   ```bash
   # Restore a selected email
-  ./corso restore exchange --backup <id of your selected backup> --email <email ID>
+  ./corso restore exchange --backup <id of your selected backup> --email <email message ID>
   ```
 
 </TabItem>
@@ -268,7 +268,7 @@ To restore the selected email, use the following command.
 `# Restore a selected email
 docker run --env-file $HOME/.corso/corso.env \\
   --volume $HOME/.corso:/app/corso ghcr.io/alcionai/corso:${Version()} \\
-  restore exchange --backup <id of your selected backup> --email <email ID>`
+  restore exchange --backup <id of your selected backup> --email <email message ID>`
 }</CodeBlock>
 
 </TabItem>


### PR DESCRIPTION
It was easier to confuse `email ID` with `email id` and think it is the email address.  This commit makes it clear that it is the id of the email message.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [x] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
