### PR TITLE
aggregate onedrive maps into caches

### DIFF
--- a/src/internal/connector/onedrive/drive_test.go
+++ b/src/internal/connector/onedrive/drive_test.go
@@ -335,8 +335,16 @@ func (suite *OneDriveSuite) TestCreateGetDeleteFolder() {
 	require.NoError(t, err, clues.ToCore(err))
 
 	restoreFolders := path.Builder{}.Append(folderElements...)
+	drivePath := path.DrivePath{
+		DriveID: driveID,
+		Root:    "root:",
+		Folders: folderElements,
+	}
 
-	folderID, err := CreateRestoreFolders(ctx, gs, driveID, ptr.Val(rootFolder.GetId()), restoreFolders, NewFolderCache())
+	caches := NewRestoreCaches()
+	caches.DriveIDToRootFolderID[driveID] = ptr.Val(rootFolder.GetId())
+
+	folderID, err := CreateRestoreFolders(ctx, gs, &drivePath, restoreFolders, caches)
 	require.NoError(t, err, clues.ToCore(err))
 
 	folderIDs = append(folderIDs, folderID)
@@ -344,7 +352,7 @@ func (suite *OneDriveSuite) TestCreateGetDeleteFolder() {
 	folderName2 := "Corso_Folder_Test_" + dttm.FormatNow(dttm.SafeForTesting)
 	restoreFolders = restoreFolders.Append(folderName2)
 
-	folderID, err = CreateRestoreFolders(ctx, gs, driveID, ptr.Val(rootFolder.GetId()), restoreFolders, NewFolderCache())
+	folderID, err = CreateRestoreFolders(ctx, gs, &drivePath, restoreFolders, caches)
 	require.NoError(t, err, clues.ToCore(err))
 
 	folderIDs = append(folderIDs, folderID)

--- a/src/internal/connector/onedrive/permission.go
+++ b/src/internal/connector/onedrive/permission.go
@@ -42,7 +42,7 @@ func getCollectionMetadata(
 	ctx context.Context,
 	drivePath *path.DrivePath,
 	dc data.RestoreCollection,
-	metas map[string]metadata.Metadata,
+	caches *restoreCaches,
 	backupVersion int,
 	restorePerms bool,
 ) (metadata.Metadata, error) {
@@ -61,7 +61,7 @@ func getCollectionMetadata(
 	}
 
 	if backupVersion < version.OneDrive4DirIncludesPermissions {
-		colMeta, err := getParentMetadata(collectionPath, metas)
+		colMeta, err := getParentMetadata(collectionPath, caches.ParentDirToMeta)
 		if err != nil {
 			return metadata.Metadata{}, clues.Wrap(err, "collection metadata")
 		}
@@ -232,9 +232,7 @@ func RestorePermissions(
 	itemID string,
 	itemPath path.Path,
 	current metadata.Metadata,
-	// map parent dir -> parent's metadata
-	parentMetas map[string]metadata.Metadata,
-	oldPermIDToNewID map[string]string,
+	caches *restoreCaches,
 ) error {
 	if current.SharingMode == metadata.SharingModeInherited {
 		return nil
@@ -242,7 +240,7 @@ func RestorePermissions(
 
 	ctx = clues.Add(ctx, "permission_item_id", itemID)
 
-	parents, err := computeParentPermissions(itemPath, parentMetas)
+	parents, err := computeParentPermissions(itemPath, caches.ParentDirToMeta)
 	if err != nil {
 		return clues.Wrap(err, "parent permissions").WithClues(ctx)
 	}
@@ -257,5 +255,5 @@ func RestorePermissions(
 		itemID,
 		permAdded,
 		permRemoved,
-		oldPermIDToNewID)
+		caches.OldPermIDToNewID)
 }

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -33,6 +33,22 @@ import (
 // https://docs.microsoft.com/en-us/graph/api/driveitem-createuploadsession?view=graph-rest-1.0#best-practices
 const copyBufferSize = 5 * 1024 * 1024
 
+type restoreCaches struct {
+	Folders               *folderCache
+	ParentDirToMeta       map[string]metadata.Metadata
+	OldPermIDToNewID      map[string]string
+	DriveIDToRootFolderID map[string]string
+}
+
+func NewRestoreCaches() *restoreCaches {
+	return &restoreCaches{
+		Folders:               NewFolderCache(),
+		ParentDirToMeta:       map[string]metadata.Metadata{},
+		OldPermIDToNewID:      map[string]string{},
+		DriveIDToRootFolderID: map[string]string{},
+	}
+}
+
 // RestoreCollections will restore the specified data collections into OneDrive
 func RestoreCollections(
 	ctx context.Context,
@@ -46,15 +62,9 @@ func RestoreCollections(
 	errs *fault.Bus,
 ) (*support.ConnectorOperationStatus, error) {
 	var (
-		restoreMetrics  support.CollectionMetrics
-		metrics         support.CollectionMetrics
-		parentDirToMeta = map[string]metadata.Metadata{}
-
-		// oldPermIDToNewID is used to map between old and new id
-		// of permissions as we restore them
-		oldPermIDToNewID  = map[string]string{}
-		fc                = NewFolderCache()
-		rootFolderIDCache = map[string]string{}
+		restoreMetrics support.CollectionMetrics
+		caches         = NewRestoreCaches()
+		el             = errs.Local()
 	)
 
 	ctx = clues.Add(
@@ -68,8 +78,6 @@ func RestoreCollections(
 		return dcs[i].FullPath().String() < dcs[j].FullPath().String()
 	})
 
-	el := errs.Local()
-
 	// Iterate through the data collections and restore the contents of each
 	for _, dc := range dcs {
 		if el.Failure() != nil {
@@ -77,8 +85,9 @@ func RestoreCollections(
 		}
 
 		var (
-			err  error
-			ictx = clues.Add(
+			err     error
+			metrics support.CollectionMetrics
+			ictx    = clues.Add(
 				ctx,
 				"resource_owner", clues.Hide(dc.FullPath().ResourceOwner()),
 				"category", dc.FullPath().Category(),
@@ -91,10 +100,7 @@ func RestoreCollections(
 			backupVersion,
 			service,
 			dc,
-			parentDirToMeta,
-			oldPermIDToNewID,
-			fc,
-			rootFolderIDCache,
+			caches,
 			OneDriveSource,
 			dest.ContainerName,
 			deets,
@@ -132,10 +138,7 @@ func RestoreCollection(
 	backupVersion int,
 	service graph.Servicer,
 	dc data.RestoreCollection,
-	parentDirToMeta map[string]metadata.Metadata,
-	oldPermIDToNewID map[string]string,
-	fc *folderCache,
-	rootFolderIDCache map[string]string, // map of drive id -> root folder ID
+	caches *restoreCaches,
 	source driveSource,
 	restoreContainerName string,
 	deets *details.Builder,
@@ -157,17 +160,13 @@ func RestoreCollection(
 		return metrics, clues.Wrap(err, "creating drive path").WithClues(ctx)
 	}
 
-	if rootFolderIDCache == nil {
-		rootFolderIDCache = map[string]string{}
-	}
-
-	if _, ok := rootFolderIDCache[drivePath.DriveID]; !ok {
+	if _, ok := caches.DriveIDToRootFolderID[drivePath.DriveID]; !ok {
 		root, err := api.GetDriveRoot(ctx, service, drivePath.DriveID)
 		if err != nil {
 			return metrics, clues.Wrap(err, "getting drive root id")
 		}
 
-		rootFolderIDCache[drivePath.DriveID] = ptr.Val(root.GetId())
+		caches.DriveIDToRootFolderID[drivePath.DriveID] = ptr.Val(root.GetId())
 	}
 
 	// Assemble folder hierarchy we're going to restore into (we recreate the folder hierarchy
@@ -189,7 +188,7 @@ func RestoreCollection(
 		ctx,
 		drivePath,
 		dc,
-		parentDirToMeta,
+		caches,
 		backupVersion,
 		restorePerms)
 	if err != nil {
@@ -202,19 +201,16 @@ func RestoreCollection(
 		creds,
 		service,
 		drivePath,
-		rootFolderIDCache[drivePath.DriveID],
 		restoreFolderElements,
 		dc.FullPath(),
 		colMeta,
-		parentDirToMeta,
-		fc,
-		oldPermIDToNewID,
+		caches,
 		restorePerms)
 	if err != nil {
 		return metrics, clues.Wrap(err, "creating folders for restore")
 	}
 
-	parentDirToMeta[dc.FullPath().String()] = colMeta
+	caches.ParentDirToMeta[dc.FullPath().String()] = colMeta
 	items := dc.Items(ctx, errs)
 
 	for {
@@ -247,8 +243,7 @@ func RestoreCollection(
 				drivePath,
 				restoreFolderID,
 				copyBuffer,
-				parentDirToMeta,
-				oldPermIDToNewID,
+				caches,
 				restorePerms,
 				itemData,
 				itemPath)
@@ -298,8 +293,7 @@ func restoreItem(
 	drivePath *path.DrivePath,
 	restoreFolderID string,
 	copyBuffer []byte,
-	parentDirToMeta map[string]metadata.Metadata,
-	oldPermIDToNewID map[string]string,
+	caches *restoreCaches,
 	restorePerms bool,
 	itemData data.Stream,
 	itemPath path.Path,
@@ -348,7 +342,7 @@ func restoreItem(
 		}
 
 		trimmedPath := strings.TrimSuffix(itemPath.String(), metadata.DirMetaFileSuffix)
-		parentDirToMeta[trimmedPath] = meta
+		caches.ParentDirToMeta[trimmedPath] = meta
 
 		return details.ItemInfo{}, true, nil
 	}
@@ -366,8 +360,7 @@ func restoreItem(
 			restoreFolderID,
 			copyBuffer,
 			restorePerms,
-			parentDirToMeta,
-			oldPermIDToNewID,
+			caches,
 			itemPath,
 			itemData)
 		if err != nil {
@@ -389,8 +382,7 @@ func restoreItem(
 		restoreFolderID,
 		copyBuffer,
 		restorePerms,
-		parentDirToMeta,
-		oldPermIDToNewID,
+		caches,
 		itemPath,
 		itemData)
 	if err != nil {
@@ -439,8 +431,7 @@ func restoreV1File(
 	restoreFolderID string,
 	copyBuffer []byte,
 	restorePerms bool,
-	parentDirToMeta map[string]metadata.Metadata,
-	oldPermIDToNewID map[string]string,
+	caches *restoreCaches,
 	itemPath path.Path,
 	itemData data.Stream,
 ) (details.ItemInfo, error) {
@@ -481,8 +472,7 @@ func restoreV1File(
 		itemID,
 		itemPath,
 		meta,
-		parentDirToMeta,
-		oldPermIDToNewID)
+		caches)
 	if err != nil {
 		return details.ItemInfo{}, clues.Wrap(err, "restoring item permissions")
 	}
@@ -500,8 +490,7 @@ func restoreV6File(
 	restoreFolderID string,
 	copyBuffer []byte,
 	restorePerms bool,
-	parentDirToMeta map[string]metadata.Metadata,
-	oldPermIDToNewID map[string]string,
+	caches *restoreCaches,
 	itemPath path.Path,
 	itemData data.Stream,
 ) (details.ItemInfo, error) {
@@ -553,8 +542,7 @@ func restoreV6File(
 		itemID,
 		itemPath,
 		meta,
-		parentDirToMeta,
-		oldPermIDToNewID)
+		caches)
 	if err != nil {
 		return details.ItemInfo{}, clues.Wrap(err, "restoring item permissions")
 	}
@@ -572,22 +560,18 @@ func createRestoreFoldersWithPermissions(
 	creds account.M365Config,
 	service graph.Servicer,
 	drivePath *path.DrivePath,
-	driveRootID string,
 	restoreFolders *path.Builder,
 	folderPath path.Path,
 	folderMetadata metadata.Metadata,
-	folderMetas map[string]metadata.Metadata,
-	fc *folderCache,
-	permissionIDMappings map[string]string,
+	caches *restoreCaches,
 	restorePerms bool,
 ) (string, error) {
 	id, err := CreateRestoreFolders(
 		ctx,
 		service,
-		drivePath.DriveID,
-		driveRootID,
+		drivePath,
 		restoreFolders,
-		fc)
+		caches)
 	if err != nil {
 		return "", err
 	}
@@ -609,8 +593,7 @@ func createRestoreFoldersWithPermissions(
 		id,
 		folderPath,
 		folderMetadata,
-		folderMetas,
-		permissionIDMappings)
+		caches)
 
 	return id, err
 }
@@ -621,15 +604,21 @@ func createRestoreFoldersWithPermissions(
 func CreateRestoreFolders(
 	ctx context.Context,
 	service graph.Servicer,
-	driveID, driveRootID string,
+	drivePath *path.DrivePath,
 	restoreDir *path.Builder,
-	fc *folderCache,
+	caches *restoreCaches,
 ) (string, error) {
 	var (
 		location       = &path.Builder{}
-		parentFolderID = driveRootID
 		folders        = restoreDir.Elements()
+		driveID        = drivePath.DriveID
+		parentFolderID = caches.DriveIDToRootFolderID[drivePath.DriveID]
 	)
+
+	ctx = clues.Add(
+		ctx,
+		"drive_id", drivePath.DriveID,
+		"root_folder_id", parentFolderID)
 
 	for _, folder := range folders {
 		location = location.Append(folder)
@@ -639,7 +628,7 @@ func CreateRestoreFolders(
 			"restore_folder_location", location,
 			"parent_of_restore_folder", parentFolderID)
 
-		if fl, ok := fc.get(location); ok {
+		if fl, ok := caches.Folders.get(location); ok {
 			parentFolderID = ptr.Val(fl.GetId())
 			// folder was already created, move on to the child
 			continue
@@ -653,7 +642,7 @@ func CreateRestoreFolders(
 		// folder found, moving to next child
 		if err == nil {
 			parentFolderID = ptr.Val(folderItem.GetId())
-			fc.set(location, folderItem)
+			caches.Folders.set(location, folderItem)
 
 			continue
 		}
@@ -665,7 +654,7 @@ func CreateRestoreFolders(
 		}
 
 		parentFolderID = ptr.Val(folderItem.GetId())
-		fc.set(location, folderItem)
+		caches.Folders.set(location, folderItem)
 
 		logger.Ctx(ictx).Debug("resolved restore destination")
 	}

--- a/src/internal/connector/sharepoint/restore.go
+++ b/src/internal/connector/sharepoint/restore.go
@@ -2,6 +2,7 @@ package sharepoint
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"runtime/trace"
@@ -12,7 +13,6 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/onedrive"
-	"github.com/alcionai/corso/src/internal/connector/onedrive/metadata"
 	"github.com/alcionai/corso/src/internal/connector/sharepoint/api"
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/data"
@@ -51,20 +51,25 @@ func RestoreCollections(
 	errs *fault.Bus,
 ) (*support.ConnectorOperationStatus, error) {
 	var (
-		err            error
 		restoreMetrics support.CollectionMetrics
+		caches         = onedrive.NewRestoreCaches()
+		el             = errs.Local()
 	)
 
 	// Iterate through the data collections and restore the contents of each
 	for _, dc := range dcs {
+		if el.Failure() != nil {
+			break
+		}
+
 		var (
+			err      error
 			category = dc.FullPath().Category()
 			metrics  support.CollectionMetrics
 			ictx     = clues.Add(ctx,
 				"category", category,
 				"destination", clues.Hide(dest.ContainerName),
 				"resource_owner", clues.Hide(dc.FullPath().ResourceOwner()))
-			driveFolderCache = onedrive.NewFolderCache()
 		)
 
 		switch dc.FullPath().Category() {
@@ -75,10 +80,7 @@ func RestoreCollections(
 				backupVersion,
 				service,
 				dc,
-				map[string]metadata.Metadata{}, // Currently permission data is not stored for sharepoint
-				map[string]string{},
-				driveFolderCache,
-				nil,
+				caches,
 				onedrive.SharePointSource,
 				dest.ContainerName,
 				deets,
@@ -110,6 +112,10 @@ func RestoreCollections(
 		restoreMetrics = support.CombineMetrics(restoreMetrics, metrics)
 
 		if err != nil {
+			el.AddRecoverable(err)
+		}
+
+		if errors.Is(err, context.Canceled) {
 			break
 		}
 	}
@@ -121,7 +127,7 @@ func RestoreCollections(
 		restoreMetrics,
 		dest.ContainerName)
 
-	return status, err
+	return status, el.Failure()
 }
 
 // restoreListItem utility function restores a List to the siteID.


### PR DESCRIPTION
onedrive restore has too many loose maps being used as local caches, which follow different patterns of creation and validation.  This move should centralize them all so that hooking into a drive restore is more foolproof and safely coordinated.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3135

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
