### PR TITLE
logic change for sharepoint permission support

### DIFF
--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -167,7 +167,10 @@ jobs:
         id: new-data-creation-onedrive
         working-directory: ./src/cmd/factory
         run: |
+          set -euo pipefail
+
           suffix=$(date +"%Y-%m-%d_%H-%M-%S")
+          echo -e "\nGenerate OneDrive test data\n" >> ${CORSO_LOG_FILE}
 
           go run . onedrive files  \
             --user ${TEST_USER} \
@@ -192,6 +195,9 @@ jobs:
       - name: OneDrive - Create new data (for incremental)
         working-directory: ./src/cmd/factory
         run: |
+          set -euo pipefail
+          echo -e "\nGenerate more OneDrive test data\n" >> ${CORSO_LOG_FILE}
+
           go run . onedrive files  \
             --user ${TEST_USER} \
             --secondaryuser  ${SECONDARY_TEST_USER} \
@@ -218,6 +224,8 @@ jobs:
         id: new-data-creation-sharepoint
         working-directory: ./src/cmd/factory
         run: |
+          set -euo pipefail
+
           suffix=$(date +"%Y-%m-%d_%H-%M-%S")
           echo -e "\nGenerate SharePoint test data\n" >> ${CORSO_LOG_FILE}
 

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -167,10 +167,7 @@ jobs:
         id: new-data-creation-onedrive
         working-directory: ./src/cmd/factory
         run: |
-          set -euo pipefail
-
           suffix=$(date +"%Y-%m-%d_%H-%M-%S")
-          echo -e "\nGenerate OneDrive test data\n" >> ${CORSO_LOG_FILE}
 
           go run . onedrive files  \
             --user ${TEST_USER} \
@@ -195,9 +192,6 @@ jobs:
       - name: OneDrive - Create new data (for incremental)
         working-directory: ./src/cmd/factory
         run: |
-          set -euo pipefail
-          echo -e "\nGenerate more OneDrive test data\n" >> ${CORSO_LOG_FILE}
-
           go run . onedrive files  \
             --user ${TEST_USER} \
             --secondaryuser  ${SECONDARY_TEST_USER} \
@@ -224,10 +218,7 @@ jobs:
         id: new-data-creation-sharepoint
         working-directory: ./src/cmd/factory
         run: |
-          set -euo pipefail
-
           suffix=$(date +"%Y-%m-%d_%H-%M-%S")
-          echo -e "\nGenerate SharePoint test data\n" >> ${CORSO_LOG_FILE}
 
           go run . sharepoint files  \
             --site ${TEST_SITE} \

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -167,7 +167,7 @@ jobs:
         id: new-data-creation-onedrive
         working-directory: ./src/cmd/factory
         run: |
-          suffix=$(date +"%Y-%m-%d_%H-%M")
+          suffix=$(date +"%Y-%m-%d_%H-%M-%S")
 
           go run . onedrive files  \
             --user ${TEST_USER} \
@@ -176,7 +176,7 @@ jobs:
             --destination ${RESTORE_DEST_PFX}$suffix \
             --count 4
 
-          echo result="$suffix" >> $GITHUB_OUTPUT
+          echo result="${suffix}" >> $GITHUB_OUTPUT
 
       - name: OneDrive - Backup
         id: onedrive-backup
@@ -218,7 +218,7 @@ jobs:
         id: new-data-creation-sharepoint
         working-directory: ./src/cmd/factory
         run: |
-          suffix=$(date +"%Y-%m-%d_%H-%M")
+          suffix=$(date +"%Y-%m-%d_%H-%M-%S")
           echo -e "\nGenerate SharePoint test data\n" >> ${CORSO_LOG_FILE}
 
           go run . sharepoint files  \
@@ -229,7 +229,7 @@ jobs:
             --destination ${RESTORE_DEST_PFX}$suffix \
             --count 4
 
-          echo result="$suffix" >> $GITHUB_OUTPUT
+          echo result="${suffix}" >> $GITHUB_OUTPUT
 
       - name: SharePoint - Backup
         id: sharepoint-backup

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -216,8 +216,8 @@ jobs:
       # generate new entries for test
       - name: SharePoint - Create new data
         id: new-data-creation-sharepoint
-        working-directory: ./src/cmd/factory
         run: |
+          workdir=./src/cmd/factory
           suffix=$(date +"%Y-%m-%d_%H-%M-%S")
           echo -e "\nGenerate SharePoint test data\n" >> ${CORSO_LOG_FILE}
 

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -35,11 +35,12 @@ jobs:
       CORSO_BUCKET: ${{ secrets.CI_TESTS_S3_BUCKET }}
       CORSO_LOG_DIR: testlog
       CORSO_LOG_FILE: testlog/testlogging.log
+      CORSO_PASSPHRASE: ${{ secrets.INTEGRATION_TEST_CORSO_PASSPHRASE }}
+      RESTORE_DEST_PFX: Corso_Test_Sanity_
+      TEST_RESULT: test_results
       TEST_USER: ${{ github.event.inputs.user != '' && github.event.inputs.user || secrets.CORSO_M365_TEST_USER_ID }}
       TEST_SITE: ${{ secrets.CORSO_M365_TEST_SITE_URL }}
       SECONDARY_TEST_USER : ${{  secrets.CORSO_SECONDARY_M365_TEST_USER_ID }}
-      CORSO_PASSPHRASE: ${{ secrets.INTEGRATION_TEST_CORSO_PASSPHRASE }}
-      TEST_RESULT: test_results
       # The default working directory doesn't seem to apply to things without
       # the 'run' directive. https://stackoverflow.com/a/67845456
       WORKING_DIR: src
@@ -105,15 +106,11 @@ jobs:
       # only runs if the test was successful
       - name: Exchange - Create new data
         working-directory: ./src/cmd/factory
-        env:
-          AZURE_CLIENT_ID: ${{ secrets[needs.SetM365App.outputs.client_id_env] }}
-          AZURE_CLIENT_SECRET: ${{ secrets[needs.SetM365App.outputs.client_secret_env] }}
-          AZURE_TENANT_ID: ${{ secrets.TENANT_ID }}
         run: |
           go run . exchange emails \
           --user ${TEST_USER} \
-          --tenant ${{ env.AZURE_TENANT_ID }} \
-          --destination Corso_Test_Sanity_${{ steps.repo-init.outputs.result }} \
+          --tenant ${AZURE_TENANT_ID} \
+          --destination ${RESTORE_DEST_PFX}${{ steps.repo-init.outputs.result }} \
           --count 4
 
       - name: Exchange - Backup
@@ -123,8 +120,8 @@ jobs:
           service: exchange
           kind: backup
           backup-args: '--mailbox "${TEST_USER}" --data "email"'
-          restore-args: '--email-folder Corso_Test_Sanity_${{ steps.repo-init.outputs.result }}'
-          test-folder: 'Corso_Test_Sanity_${{ steps.repo-init.outputs.result }}'
+          restore-args: '--email-folder ${RESTORE_DEST_PFX}${{ steps.repo-init.outputs.result }}'
+          test-folder: '${RESTORE_DEST_PFX}${{ steps.repo-init.outputs.result }}'
 
       - name: Exchange - Incremental backup
         id: exchange-backup-incremental
@@ -133,8 +130,8 @@ jobs:
           service: exchange
           kind: backup-incremental
           backup-args: '--mailbox "${TEST_USER}" --data "email"'
-          restore-args: '--email-folder Corso_Test_Sanity_${{ steps.repo-init.outputs.result }}'
-          test-folder: 'Corso_Test_Sanity_${{ steps.repo-init.outputs.result }}'
+          restore-args: '--email-folder ${RESTORE_DEST_PFX}${{ steps.repo-init.outputs.result }}'
+          test-folder: '${RESTORE_DEST_PFX}${{ steps.repo-init.outputs.result }}'
           base-backup: ${{ steps.exchange-backup.outputs.backup-id }}
 
       - name: Exchange - Non delta backup
@@ -144,8 +141,8 @@ jobs:
           service: exchange
           kind: backup-non-delta
           backup-args: '--mailbox "${TEST_USER}" --data "email" --disable-delta'
-          restore-args: '--email-folder Corso_Test_Sanity_${{ steps.repo-init.outputs.result }}'
-          test-folder: 'Corso_Test_Sanity_${{ steps.repo-init.outputs.result }}'
+          restore-args: '--email-folder ${RESTORE_DEST_PFX}${{ steps.repo-init.outputs.result }}'
+          test-folder: '${RESTORE_DEST_PFX}${{ steps.repo-init.outputs.result }}'
           base-backup: ${{ steps.exchange-backup.outputs.backup-id }}
 
       - name: Exchange - Incremental backup after non-delta
@@ -155,8 +152,8 @@ jobs:
           service: exchange
           kind: backup-incremental-after-non-delta
           backup-args: '--mailbox "${TEST_USER}" --data "email"'
-          restore-args: '--email-folder Corso_Test_Sanity_${{ steps.repo-init.outputs.result }}'
-          test-folder: 'Corso_Test_Sanity_${{ steps.repo-init.outputs.result }}'
+          restore-args: '--email-folder ${RESTORE_DEST_PFX}${{ steps.repo-init.outputs.result }}'
+          test-folder: '${RESTORE_DEST_PFX}${{ steps.repo-init.outputs.result }}'
           base-backup: ${{ steps.exchange-backup.outputs.backup-id }}
 
 
@@ -168,18 +165,14 @@ jobs:
       - name: OneDrive - Create new data
         id: new-data-creation-onedrive
         working-directory: ./src/cmd/factory
-        env:
-          AZURE_CLIENT_ID: ${{ secrets[needs.SetM365App.outputs.client_id_env] }}
-          AZURE_CLIENT_SECRET: ${{ secrets[needs.SetM365App.outputs.client_secret_env] }}
-          AZURE_TENANT_ID: ${{ secrets.TENANT_ID }}
         run: |
           suffix=$(date +"%Y-%m-%d_%H-%M")
 
           go run . onedrive files  \
             --user ${TEST_USER} \
-            --secondaryuser  ${{ env.SECONDARY_TEST_USER }} \
-            --tenant ${{ env.AZURE_TENANT_ID }} \
-            --destination Corso_Test_Sanity_$suffix \
+            --secondaryuser  ${SECONDARY_TEST_USER} \
+            --tenant ${AZURE_TENANT_ID} \
+            --destination ${RESTORE_DEST_PFX}$suffix \
             --count 4
 
           echo result="$suffix" >> $GITHUB_OUTPUT
@@ -191,22 +184,18 @@ jobs:
           service: onedrive
           kind: backup
           backup-args: '--user "${TEST_USER}"'
-          restore-args: '--folder Corso_Test_Sanity_${{ steps.new-data-creation-onedrive.outputs.result }} --restore-permissions'
-          test-folder: 'Corso_Test_Sanity_${{ steps.new-data-creation-onedrive.outputs.result }}'
+          restore-args: '--folder ${RESTORE_DEST_PFX}${{ steps.new-data-creation-onedrive.outputs.result }} --restore-permissions'
+          test-folder: '${RESTORE_DEST_PFX}${{ steps.new-data-creation-onedrive.outputs.result }}'
 
       # generate some more enteries for incremental check
       - name: OneDrive - Create new data (for incremental)
         working-directory: ./src/cmd/factory
-        env:
-          AZURE_CLIENT_ID: ${{ secrets[needs.SetM365App.outputs.client_id_env] }}
-          AZURE_CLIENT_SECRET: ${{ secrets[needs.SetM365App.outputs.client_secret_env] }}
-          AZURE_TENANT_ID: ${{ secrets.TENANT_ID }}
         run: |
           go run . onedrive files  \
             --user ${TEST_USER} \
-            --secondaryuser  ${{ env.SECONDARY_TEST_USER }} \
-            --tenant ${{ env.AZURE_TENANT_ID }} \
-            --destination Corso_Test_Sanity_${{ steps.new-data-creation-onedrive.outputs.result }} \
+            --secondaryuser  ${SECONDARY_TEST_USER} \
+            --tenant ${AZURE_TENANT_ID} \
+            --destination ${RESTORE_DEST_PFX}${{ steps.new-data-creation-onedrive.outputs.result }} \
             --count 4
 
       - name: OneDrive - Incremental backup
@@ -216,15 +205,29 @@ jobs:
           service: onedrive
           kind: incremental
           backup-args: '--user "${TEST_USER}"'
-          restore-args: '--folder Corso_Test_Sanity_${{ steps.new-data-creation-onedrive.outputs.result }} --restore-permissions'
-          test-folder: 'Corso_Test_Sanity_${{ steps.new-data-creation-onedrive.outputs.result }}'
+          restore-args: '--folder ${RESTORE_DEST_PFX}${{ steps.new-data-creation-onedrive.outputs.result }} --restore-permissions'
+          test-folder: '${RESTORE_DEST_PFX}${{ steps.new-data-creation-onedrive.outputs.result }}'
 
 ##########################################################################################################################################
 
 # Sharepoint
 
-      # TODO(keepers): generate new entries for test
-      # TODO: Add '--restore-permissions' when supported
+      # generate new entries for test
+      - name: SharePoint - Create new data
+        id: new-data-creation-sharepoint
+        working-directory: ./src/cmd/factory
+        run: |
+          suffix=$(date +"%Y-%m-%d_%H-%M")
+
+          go run . sharepoint files  \
+            --site ${TEST_SITE} \
+            --user ${TEST_USER} \
+            --secondaryuser  ${SECONDARY_TEST_USER} \
+            --tenant ${AZURE_TENANT_ID} \
+            --destination ${RESTORE_DEST_PFX}$suffix \
+            --count 4
+
+          echo result="$suffix" >> $GITHUB_OUTPUT
 
       - name: SharePoint - Backup
         id: sharepoint-backup
@@ -233,10 +236,20 @@ jobs:
           service: sharepoint
           kind: backup
           backup-args: '--site "${TEST_SITE}"'
-          restore-args: ''
-          test-folder: ''
+          restore-args: '--folder ${RESTORE_DEST_PFX}${{ steps.new-data-creation-sharepoint.outputs.result }} --restore-permissions'
+          test-folder: '${RESTORE_DEST_PFX}${{ steps.new-data-creation-sharepoint.outputs.result }}'
 
-      # TODO(rkeepers): generate some more entries for incremental check
+      # generate some more enteries for incremental check
+      - name: SharePoint - Create new data (for incremental)
+        working-directory: ./src/cmd/factory
+        run: |
+          go run . sharepoint files  \
+            --site ${TEST_SITE} \
+            --user ${TEST_USER} \
+            --secondaryuser  ${SECONDARY_TEST_USER} \
+            --tenant ${AZURE_TENANT_ID} \
+            --destination ${RESTORE_DEST_PFX}${{ steps.new-data-creation-sharepoint.outputs.result }} \
+            --count 4
 
       - name: SharePoint - Incremental backup
         id: sharepoint-incremental
@@ -245,8 +258,8 @@ jobs:
           service: sharepoint
           kind: incremental
           backup-args: '--site "${TEST_SITE}"'
-          restore-args: ''
-          test-folder: ''
+          restore-args: '--folder ${RESTORE_DEST_PFX}${{ steps.new-data-creation-sharepoint.outputs.result }} --restore-permissions'
+          test-folder: '${RESTORE_DEST_PFX}${{ steps.new-data-creation-sharepoint.outputs.result }}'
 
 ##########################################################################################################################################
 

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -216,8 +216,8 @@ jobs:
       # generate new entries for test
       - name: SharePoint - Create new data
         id: new-data-creation-sharepoint
+        working-directory: ./src/cmd/factory
         run: |
-          workdir=./src/cmd/factory
           suffix=$(date +"%Y-%m-%d_%H-%M-%S")
           echo -e "\nGenerate SharePoint test data\n" >> ${CORSO_LOG_FILE}
 

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -42,7 +42,6 @@ jobs:
       TEST_USER: ${{ github.event.inputs.user != '' && github.event.inputs.user || secrets.CORSO_M365_TEST_USER_ID }}
       TEST_SITE: ${{ secrets.CORSO_M365_TEST_SITE_URL }}
       SECONDARY_TEST_USER : ${{  secrets.CORSO_SECONDARY_M365_TEST_USER_ID }}
-      RUNTEST: false
       # The default working directory doesn't seem to apply to things without
       # the 'run' directive. https://stackoverflow.com/a/67845456
       WORKING_DIR: src

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -219,6 +219,7 @@ jobs:
         working-directory: ./src/cmd/factory
         run: |
           suffix=$(date +"%Y-%m-%d_%H-%M")
+          echo -e "\nGenerate SharePoint test data\n" >> ${CORSO_LOG_FILE}
 
           go run . sharepoint files  \
             --site ${TEST_SITE} \

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 3135-logic
   workflow_dispatch:
     inputs:
       user:

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -42,6 +42,7 @@ jobs:
       TEST_USER: ${{ github.event.inputs.user != '' && github.event.inputs.user || secrets.CORSO_M365_TEST_USER_ID }}
       TEST_SITE: ${{ secrets.CORSO_M365_TEST_SITE_URL }}
       SECONDARY_TEST_USER : ${{  secrets.CORSO_SECONDARY_M365_TEST_USER_ID }}
+      RUNTEST: false
       # The default working directory doesn't seem to apply to things without
       # the 'run' directive. https://stackoverflow.com/a/67845456
       WORKING_DIR: src

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Released the --mask-sensitive-data flag, which will automatically obscure private data in logs.
 - Added `--disable-delta` flag to disable delta based backups for Exchange
+- Permission support for SharePoint libraries.
 
 ### Fixed
 - Graph requests now automatically retry in case of a Bad Gateway or Gateway Timeout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Known Issues
 - Restore operations will merge duplicate Exchange folders at the same hierarchy level into a single folder.
+- Sharepoint SiteGroup permissions are not restored.
 
  ### Known Issues
  - SharePoint document library data can't be restored after the library has been deleted.

--- a/src/cli/restore/sharepoint.go
+++ b/src/cli/restore/sharepoint.go
@@ -33,6 +33,8 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 
 		utils.AddBackupIDFlag(c, true)
 		utils.AddSharePointDetailsAndRestoreFlags(c)
+
+		options.AddRestorePermissionsFlag(c)
 		options.AddFailFastFlag(c)
 	}
 
@@ -47,7 +49,11 @@ const (
 	sharePointServiceCommandRestoreExamples = `# Restore file with ID 98765abcdef in Bob's latest backup (1234abcd...)
 corso restore sharepoint --backup 1234abcd-12ab-cd34-56de-1234abcd --file 98765abcdef
 
-# Restore files named "ServerRenderTemplate.xsl in the folder "Display Templates/Style Sheets".
+# Restore the file with ID 98765abcdef along with its associated permissions
+corso restore sharepoint --backup 1234abcd-12ab-cd34-56de-1234abcd \
+	--file 98765abcdef --restore-permissions
+
+# Restore files named "ServerRenderTemplate.xsl" in the folder "Display Templates/Style Sheets".
 corso restore sharepoint --backup 1234abcd-12ab-cd34-56de-1234abcd \
     --file "ServerRenderTemplate.xsl" --folder "Display Templates/Style Sheets"
 

--- a/src/cli/restore/sharepoint.go
+++ b/src/cli/restore/sharepoint.go
@@ -51,7 +51,7 @@ corso restore sharepoint --backup 1234abcd-12ab-cd34-56de-1234abcd --file 98765a
 
 # Restore the file with ID 98765abcdef along with its associated permissions
 corso restore sharepoint --backup 1234abcd-12ab-cd34-56de-1234abcd \
-	--file 98765abcdef --restore-permissions
+    --file 98765abcdef --restore-permissions
 
 # Restore files named "ServerRenderTemplate.xsl" in the folder "Display Templates/Style Sheets".
 corso restore sharepoint --backup 1234abcd-12ab-cd34-56de-1234abcd \

--- a/src/cli/utils/testdata/flags.go
+++ b/src/cli/utils/testdata/flags.go
@@ -43,4 +43,6 @@ var (
 
 	PageFolderInput = []string{"pageFolder1", "pageFolder2"}
 	PageInput       = []string{"page1", "page2"}
+
+	RestorePermissions = true
 )

--- a/src/cmd/factory/factory.go
+++ b/src/cmd/factory/factory.go
@@ -29,6 +29,12 @@ var oneDriveCmd = &cobra.Command{
 	RunE:  handleOneDriveFactory,
 }
 
+var sharePointCmd = &cobra.Command{
+	Use:   "sharepoint",
+	Short: "Generate shareopint data",
+	RunE:  handleSharePointFactory,
+}
+
 // ------------------------------------------------------------------------------------------
 // CLI command handlers
 // ------------------------------------------------------------------------------------------
@@ -42,8 +48,8 @@ func main() {
 	// persistent flags that are common to all use cases
 	fs := factoryCmd.PersistentFlags()
 	fs.StringVar(&impl.Tenant, "tenant", "", "m365 tenant containing the user")
+	fs.StringVar(&impl.Site, "site", "", "sharepoint site owning the new data")
 	fs.StringVar(&impl.User, "user", "", "m365 user owning the new data")
-	cobra.CheckErr(factoryCmd.MarkPersistentFlagRequired("user"))
 	fs.StringVar(&impl.SecondaryUser, "secondaryuser", "", "m365 secondary user owning the new data")
 	fs.IntVar(&impl.Count, "count", 0, "count of items to produce")
 	cobra.CheckErr(factoryCmd.MarkPersistentFlagRequired("count"))
@@ -54,6 +60,8 @@ func main() {
 	impl.AddExchangeCommands(exchangeCmd)
 	factoryCmd.AddCommand(oneDriveCmd)
 	impl.AddOneDriveCommands(oneDriveCmd)
+	factoryCmd.AddCommand(sharePointCmd)
+	impl.AddSharePointCommands(sharePointCmd)
 
 	if err := factoryCmd.ExecuteContext(ctx); err != nil {
 		logger.Flush(ctx)
@@ -72,6 +80,11 @@ func handleExchangeFactory(cmd *cobra.Command, args []string) error {
 }
 
 func handleOneDriveFactory(cmd *cobra.Command, args []string) error {
+	Err(cmd.Context(), impl.ErrNotYetImplemented)
+	return cmd.Help()
+}
+
+func handleSharePointFactory(cmd *cobra.Command, args []string) error {
 	Err(cmd.Context(), impl.ErrNotYetImplemented)
 	return cmd.Help()
 }

--- a/src/cmd/factory/factory.go
+++ b/src/cmd/factory/factory.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 
 	. "github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/cmd/factory/impl"
+	"github.com/alcionai/corso/src/internal/common/crash"
 	"github.com/alcionai/corso/src/pkg/logger"
 )
 
@@ -40,10 +42,15 @@ var sharePointCmd = &cobra.Command{
 // ------------------------------------------------------------------------------------------
 
 func main() {
+	fmt.Printf("\n-----\nfactory main\n-----\n")
+
 	ctx, _ := logger.SeedLevel(context.Background(), logger.Development)
 	ctx = SetRootCmd(ctx, factoryCmd)
 
-	defer logger.Flush(ctx)
+	defer func() {
+		crash.Recovery(ctx, recover(), "backup")
+		logger.Flush(ctx)
+	}()
 
 	// persistent flags that are common to all use cases
 	fs := factoryCmd.PersistentFlags()

--- a/src/cmd/factory/factory.go
+++ b/src/cmd/factory/factory.go
@@ -45,7 +45,10 @@ func main() {
 	ctx = SetRootCmd(ctx, factoryCmd)
 
 	defer func() {
-		crash.Recovery(ctx, recover(), "backup")
+		if err := crash.Recovery(ctx, recover(), "backup"); err != nil {
+			logger.CtxErr(ctx, err).Error("panic in factory")
+		}
+
 		logger.Flush(ctx)
 	}()
 

--- a/src/cmd/factory/factory.go
+++ b/src/cmd/factory/factory.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -42,8 +41,6 @@ var sharePointCmd = &cobra.Command{
 // ------------------------------------------------------------------------------------------
 
 func main() {
-	fmt.Printf("\n-----\nfactory main\n-----\n")
-
 	ctx, _ := logger.SeedLevel(context.Background(), logger.Development)
 	ctx = SetRootCmd(ctx, factoryCmd)
 

--- a/src/cmd/factory/impl/exchange.go
+++ b/src/cmd/factory/impl/exchange.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/cli/utils"
+	"github.com/alcionai/corso/src/internal/connector"
 	exchMock "github.com/alcionai/corso/src/internal/connector/exchange/mock"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -51,7 +52,7 @@ func handleExchangeEmailFactory(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	gc, acct, _, err := getGCAndVerifyUser(ctx, User)
+	gc, acct, _, err := getGCAndVerifyResourceOwner(ctx, connector.Users, User)
 	if err != nil {
 		return Only(ctx, err)
 	}
@@ -98,7 +99,7 @@ func handleExchangeCalendarEventFactory(cmd *cobra.Command, args []string) error
 		return nil
 	}
 
-	gc, acct, _, err := getGCAndVerifyUser(ctx, User)
+	gc, acct, _, err := getGCAndVerifyResourceOwner(ctx, connector.Users, User)
 	if err != nil {
 		return Only(ctx, err)
 	}
@@ -144,7 +145,7 @@ func handleExchangeContactFactory(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	gc, acct, _, err := getGCAndVerifyUser(ctx, User)
+	gc, acct, _, err := getGCAndVerifyResourceOwner(ctx, connector.Users, User)
 	if err != nil {
 		return Only(ctx, err)
 	}

--- a/src/cmd/factory/impl/sharepoint.go
+++ b/src/cmd/factory/impl/sharepoint.go
@@ -14,21 +14,21 @@ import (
 	"github.com/alcionai/corso/src/pkg/selectors"
 )
 
-var odFilesCmd = &cobra.Command{
+var spFilesCmd = &cobra.Command{
 	Use:   "files",
 	Short: "Generate OneDrive files",
-	RunE:  handleOneDriveFileFactory,
+	RunE:  handleSharePointLibraryFileFactory,
 }
 
-func AddOneDriveCommands(cmd *cobra.Command) {
-	cmd.AddCommand(odFilesCmd)
+func AddSharePointCommands(cmd *cobra.Command) {
+	cmd.AddCommand(spFilesCmd)
 }
 
-func handleOneDriveFileFactory(cmd *cobra.Command, args []string) error {
+func handleSharePointLibraryFileFactory(cmd *cobra.Command, args []string) error {
 	var (
 		ctx      = cmd.Context()
-		service  = path.OneDriveService
-		category = path.FilesCategory
+		service  = path.SharePointService
+		category = path.LibrariesCategory
 		errs     = fault.New(false)
 	)
 
@@ -36,12 +36,12 @@ func handleOneDriveFileFactory(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	gc, acct, inp, err := getGCAndVerifyResourceOwner(ctx, connector.Users, User)
+	gc, acct, inp, err := getGCAndVerifyResourceOwner(ctx, connector.Sites, Site)
 	if err != nil {
 		return Only(ctx, err)
 	}
 
-	sel := selectors.NewOneDriveBackup([]string{User}).Selector
+	sel := selectors.NewSharePointBackup([]string{Site}).Selector
 	sel.SetDiscreteOwnerIDName(inp.ID(), inp.Name())
 
 	deets, err := generateAndRestoreDriveItems(

--- a/src/cmd/factory/impl/sharepoint.go
+++ b/src/cmd/factory/impl/sharepoint.go
@@ -1,7 +1,6 @@
 package impl
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -26,8 +25,6 @@ func AddSharePointCommands(cmd *cobra.Command) {
 }
 
 func handleSharePointLibraryFileFactory(cmd *cobra.Command, args []string) error {
-	fmt.Printf("\n-----\nbeginning sharepoint factory %+v\n-----\n", args)
-
 	var (
 		ctx      = cmd.Context()
 		service  = path.SharePointService

--- a/src/cmd/factory/impl/sharepoint.go
+++ b/src/cmd/factory/impl/sharepoint.go
@@ -1,6 +1,7 @@
 package impl
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -25,6 +26,8 @@ func AddSharePointCommands(cmd *cobra.Command) {
 }
 
 func handleSharePointLibraryFileFactory(cmd *cobra.Command, args []string) error {
+	fmt.Printf("\n-----\nbeginning sharepoint factory %+v\n-----\n", args)
+
 	var (
 		ctx      = cmd.Context()
 		service  = path.SharePointService

--- a/src/cmd/factory/impl/sharepoint.go
+++ b/src/cmd/factory/impl/sharepoint.go
@@ -17,7 +17,7 @@ import (
 
 var spFilesCmd = &cobra.Command{
 	Use:   "files",
-	Short: "Generate OneDrive files",
+	Short: "Generate SharePoint files",
 	RunE:  handleSharePointLibraryFileFactory,
 }
 

--- a/src/cmd/sanity_test/sanity_tests.go
+++ b/src/cmd/sanity_test/sanity_tests.go
@@ -87,7 +87,7 @@ func main() {
 	case "onedrive":
 		checkOneDriveRestoration(ctx, client, testUser, folder, dataFolder, startTime)
 	case "sharepoint":
-		checkSharePointRestoration(ctx, client, testSite, folder, dataFolder, startTime)
+		checkSharePointRestoration(ctx, client, testSite, testUser, folder, dataFolder, startTime)
 	default:
 		fatal(ctx, "no service specified", nil)
 	}
@@ -314,7 +314,6 @@ func checkOneDriveRestoration(
 		ctx,
 		client,
 		path.OneDriveService,
-		userID,
 		folderName,
 		ptr.Val(drive.GetId()),
 		ptr.Val(drive.GetName()),
@@ -330,7 +329,7 @@ func checkOneDriveRestoration(
 func checkSharePointRestoration(
 	ctx context.Context,
 	client *msgraphsdk.GraphServiceClient,
-	siteID, folderName, dataFolder string,
+	siteID, userID, folderName, dataFolder string,
 	startTime time.Time,
 ) {
 	drive, err := client.
@@ -345,7 +344,6 @@ func checkSharePointRestoration(
 		ctx,
 		client,
 		path.SharePointService,
-		siteID,
 		folderName,
 		ptr.Val(drive.GetId()),
 		ptr.Val(drive.GetName()),
@@ -362,7 +360,6 @@ func checkDriveRestoration(
 	ctx context.Context,
 	client *msgraphsdk.GraphServiceClient,
 	service path.ServiceType,
-	resourceOwner,
 	folderName,
 	driveID,
 	driveName,

--- a/src/cmd/sanity_test/sanity_tests.go
+++ b/src/cmd/sanity_test/sanity_tests.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
+	stdpath "path"
 	"strings"
 	"time"
 
@@ -21,6 +21,7 @@ import (
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/filters"
 	"github.com/alcionai/corso/src/pkg/logger"
+	"github.com/alcionai/corso/src/pkg/path"
 )
 
 // ---------------------------------------------------------------------------
@@ -225,7 +226,7 @@ func getAllMailSubFolders(
 			childDisplayName = ptr.Val(child.GetDisplayName())
 			childFolderCount = ptr.Val(child.GetChildFolderCount())
 			//nolint:forbidigo
-			fullFolderName = path.Join(parentFolder, childDisplayName)
+			fullFolderName = stdpath.Join(parentFolder, childDisplayName)
 		)
 
 		if filters.PathContains([]string{dataFolder}).Compare(fullFolderName) {
@@ -274,7 +275,7 @@ func checkAllSubFolder(
 		var (
 			childDisplayName = ptr.Val(child.GetDisplayName())
 			//nolint:forbidigo
-			fullFolderName = path.Join(parentFolder, childDisplayName)
+			fullFolderName = stdpath.Join(parentFolder, childDisplayName)
 		)
 
 		if filters.PathContains([]string{dataFolder}).Compare(fullFolderName) {
@@ -312,6 +313,7 @@ func checkOneDriveRestoration(
 	checkDriveRestoration(
 		ctx,
 		client,
+		path.OneDriveService,
 		userID,
 		folderName,
 		ptr.Val(drive.GetId()),
@@ -342,6 +344,7 @@ func checkSharePointRestoration(
 	checkDriveRestoration(
 		ctx,
 		client,
+		path.SharePointService,
 		siteID,
 		folderName,
 		ptr.Val(drive.GetId()),
@@ -358,6 +361,7 @@ func checkSharePointRestoration(
 func checkDriveRestoration(
 	ctx context.Context,
 	client *msgraphsdk.GraphServiceClient,
+	service path.ServiceType,
 	resourceOwner,
 	folderName,
 	driveID,
@@ -428,6 +432,7 @@ func checkDriveRestoration(
 
 	checkRestoredDriveItemPermissions(
 		ctx,
+		service,
 		skipPermissionTest,
 		folderPermissions,
 		restoredFolderPermissions)
@@ -450,6 +455,7 @@ func checkDriveRestoration(
 
 func checkRestoredDriveItemPermissions(
 	ctx context.Context,
+	service path.ServiceType,
 	skip bool,
 	folderPermissions map[string][]permissionInfo,
 	restoredFolderPermissions map[string][]permissionInfo,
@@ -457,6 +463,11 @@ func checkRestoredDriveItemPermissions(
 	if skip {
 		return
 	}
+
+	/**
+		TODO: replace this check with testElementsMatch
+		from internal/connecter/graph_connector_helper_test.go
+	**/
 
 	for folderName, permissions := range folderPermissions {
 		logAndPrint(ctx, "checking for folder: %s", folderName)
@@ -468,23 +479,32 @@ func checkRestoredDriveItemPermissions(
 			continue
 		}
 
+		permCheck := func() bool { return len(permissions) == len(restoreFolderPerm) }
+
+		if service == path.SharePointService {
+			permCheck = func() bool { return len(permissions) <= len(restoreFolderPerm) }
+		}
+
 		assert(
 			ctx,
-			func() bool { return len(permissions) == len(restoreFolderPerm) },
+			permCheck,
 			fmt.Sprintf("wrong number of restored permissions: %s", folderName),
 			permissions,
 			restoreFolderPerm)
 
-		for i, perm := range permissions {
-			// permissions should be sorted, so a by-index comparison works
-			restored := restoreFolderPerm[i]
+		for _, perm := range permissions {
+			eqID := func(pi permissionInfo) bool { return strings.EqualFold(pi.entityID, perm.entityID) }
+			i := slices.IndexFunc(restoreFolderPerm, eqID)
 
 			assert(
 				ctx,
-				func() bool { return strings.EqualFold(perm.entityID, restored.entityID) },
-				fmt.Sprintf("non-matching entity id: %s", folderName),
+				func() bool { return i >= 0 },
+				fmt.Sprintf("permission was restored in: %s", folderName),
 				perm.entityID,
-				restored.entityID)
+				restoreFolderPerm)
+
+			// permissions should be sorted, so a by-index comparison works
+			restored := restoreFolderPerm[i]
 
 			assert(
 				ctx,
@@ -612,6 +632,7 @@ func permissionIn(
 			entityID string
 		)
 
+		// TODO: replace with filterUserPermissions in onedrive item.go
 		if gv2.GetUser() != nil {
 			entityID = ptr.Val(gv2.GetUser().GetId())
 		} else if gv2.GetGroup() != nil {

--- a/src/internal/connector/data_collections.go
+++ b/src/internal/connector/data_collections.go
@@ -237,7 +237,7 @@ func (gc *GraphConnector) ConsumeRestoreCollections(
 	case selectors.ServiceOneDrive:
 		status, err = onedrive.RestoreCollections(ctx, creds, backupVersion, gc.Service, dest, opts, dcs, deets, errs)
 	case selectors.ServiceSharePoint:
-		status, err = sharepoint.RestoreCollections(ctx, backupVersion, creds, gc.Service, dest, dcs, deets, errs)
+		status, err = sharepoint.RestoreCollections(ctx, backupVersion, creds, gc.Service, dest, opts, dcs, deets, errs)
 	default:
 		err = clues.Wrap(clues.New(sels.Service.String()), "service not supported")
 	}

--- a/src/internal/connector/graph_connector_helper_test.go
+++ b/src/internal/connector/graph_connector_helper_test.go
@@ -48,13 +48,15 @@ func testElementsMatch[T any](
 	t *testing.T,
 	expected []T,
 	got []T,
+	subset bool,
 	equalityCheck func(expectedItem, gotItem T) bool,
 ) {
 	t.Helper()
 
 	pending := make([]*T, len(expected))
-	for i := 0; i < len(expected); i++ {
-		pending[i] = &expected[i]
+	for i := range expected {
+		ei := expected[i]
+		pending[i] = &ei
 	}
 
 	unexpected := []T{}
@@ -97,15 +99,20 @@ func testElementsMatch[T any](
 		return
 	}
 
+	if subset && len(missing) == 0 && len(unexpected) > 0 {
+		return
+	}
+
 	assert.Failf(
 		t,
-		"contain different elements",
-		"missing items: (%T)%v\nunexpected items: (%T)%v\n",
+		"elements differ",
+		"expected: (%T)%+v\ngot: (%T)%+v\nmissing: %+v\nextra: %+v\n",
 		expected,
-		missing,
+		expected,
 		got,
-		unexpected,
-	)
+		got,
+		missing,
+		unexpected)
 }
 
 type configInfo struct {
@@ -211,7 +218,7 @@ func checkMessage(
 	expected models.Messageable,
 	got models.Messageable,
 ) {
-	testElementsMatch(t, expected.GetAttachments(), got.GetAttachments(), attachmentEqual)
+	testElementsMatch(t, expected.GetAttachments(), got.GetAttachments(), false, attachmentEqual)
 
 	assert.Equal(t, expected.GetBccRecipients(), got.GetBccRecipients(), "BccRecipients")
 
@@ -289,7 +296,7 @@ func checkMessage(
 
 	assert.Equal(t, ptr.Val(expected.GetSubject()), ptr.Val(got.GetSubject()), "Subject")
 
-	testElementsMatch(t, expected.GetToRecipients(), got.GetToRecipients(), recipientEqual)
+	testElementsMatch(t, expected.GetToRecipients(), got.GetToRecipients(), false, recipientEqual)
 
 	// Skip WebLink as it's tied to this specific instance of the item.
 
@@ -535,10 +542,10 @@ func checkEvent(
 		t,
 		[]models.Locationable{expected.GetLocation()},
 		[]models.Locationable{got.GetLocation()},
-		locationEqual,
-	)
+		false,
+		locationEqual)
 
-	testElementsMatch(t, expected.GetLocations(), got.GetLocations(), locationEqual)
+	testElementsMatch(t, expected.GetLocations(), got.GetLocations(), false, locationEqual)
 
 	assert.Equal(t, expected.GetOnlineMeeting(), got.GetOnlineMeeting(), "OnlineMeeting")
 
@@ -726,7 +733,7 @@ func compareDriveItem(
 	t *testing.T,
 	expected map[string][]byte,
 	item data.Stream,
-	restorePermissions bool,
+	config configInfo,
 	rootDir bool,
 ) bool {
 	// Skip Drive permissions in the folder that used to be the root. We don't
@@ -746,19 +753,15 @@ func compareDriveItem(
 		isMeta      = metadata.HasMetaSuffix(name)
 	)
 
-	if isMeta {
-		var itemType *metadata.Item
-
-		assert.IsType(t, itemType, item)
-	} else {
+	if !isMeta {
 		oitem := item.(*onedrive.Item)
 		info := oitem.Info()
 
-		// Don't need to check SharePoint because it was added after we stopped
-		// adding meta files to backup details.
 		if info.OneDrive != nil {
 			displayName = oitem.Info().OneDrive.ItemName
 
+			// Don't need to check SharePoint because it was added after we stopped
+			// adding meta files to backup details.
 			assert.False(t, oitem.Info().OneDrive.IsMeta, "meta marker for non meta item %s", name)
 		} else if info.SharePoint != nil {
 			displayName = oitem.Info().SharePoint.ItemName
@@ -768,6 +771,9 @@ func compareDriveItem(
 	}
 
 	if isMeta {
+		var itemType *metadata.Item
+		assert.IsType(t, itemType, item)
+
 		var (
 			itemMeta     metadata.Metadata
 			expectedMeta metadata.Metadata
@@ -806,7 +812,7 @@ func compareDriveItem(
 			assert.Equal(t, expectedMeta.FileName, itemMeta.FileName)
 		}
 
-		if !restorePermissions {
+		if !config.opts.RestorePermissions {
 			assert.Equal(t, 0, len(itemMeta.Permissions))
 			return true
 		}
@@ -824,6 +830,10 @@ func compareDriveItem(
 			t,
 			expectedMeta.Permissions,
 			itemPerms,
+			// sharepoint retrieves a superset of permissions
+			// (all site admins, site groups, built in by default)
+			// relative to the permissions changed by the test.
+			config.service == path.SharePointService,
 			permissionEqual)
 
 		return true
@@ -865,7 +875,7 @@ func compareItem(
 	service path.ServiceType,
 	category path.CategoryType,
 	item data.Stream,
-	restorePermissions bool,
+	config configInfo,
 	rootDir bool,
 ) bool {
 	if mt, ok := item.(data.StreamModTime); ok {
@@ -886,7 +896,7 @@ func compareItem(
 		}
 
 	case path.OneDriveService:
-		return compareDriveItem(t, expected, item, restorePermissions, rootDir)
+		return compareDriveItem(t, expected, item, config, rootDir)
 
 	case path.SharePointService:
 		if category != path.LibrariesCategory {
@@ -894,7 +904,7 @@ func compareItem(
 		}
 
 		// SharePoint libraries reuses OneDrive code.
-		return compareDriveItem(t, expected, item, restorePermissions, rootDir)
+		return compareDriveItem(t, expected, item, config, rootDir)
 
 	default:
 		assert.FailNowf(t, "unexpected service: %s", service.String())
@@ -959,8 +969,7 @@ func checkCollections(
 	expectedItems int,
 	expected map[string]map[string][]byte,
 	got []data.BackupCollection,
-	dest control.RestoreDestination,
-	restorePermissions bool,
+	config configInfo,
 ) int {
 	collectionsWithItems := []data.BackupCollection{}
 
@@ -974,7 +983,7 @@ func checkCollections(
 			category        = returned.FullPath().Category()
 			expectedColData = expected[returned.FullPath().String()]
 			folders         = returned.FullPath().Elements()
-			rootDir         = folders[len(folders)-1] == dest.ContainerName
+			rootDir         = folders[len(folders)-1] == config.dest.ContainerName
 		)
 
 		// Need to iterate through all items even if we don't expect to find a match
@@ -1007,7 +1016,7 @@ func checkCollections(
 				service,
 				category,
 				item,
-				restorePermissions,
+				config,
 				rootDir) {
 				gotItems--
 			}
@@ -1239,7 +1248,7 @@ func collectionsForInfo(
 		baseDestPath := backupOutputPathFromRestore(t, dest, pth)
 
 		baseExpected := expectedData[baseDestPath.String()]
-		if baseExpected == nil {
+		if len(baseExpected) == 0 {
 			expectedData[baseDestPath.String()] = make(map[string][]byte, len(info.items))
 			baseExpected = expectedData[baseDestPath.String()]
 		}

--- a/src/internal/connector/graph_connector_helper_test.go
+++ b/src/internal/connector/graph_connector_helper_test.go
@@ -54,6 +54,7 @@ func testElementsMatch[T any](
 	t.Helper()
 
 	pending := make([]*T, len(expected))
+
 	for i := range expected {
 		ei := expected[i]
 		pending[i] = &ei
@@ -772,6 +773,7 @@ func compareDriveItem(
 
 	if isMeta {
 		var itemType *metadata.Item
+
 		assert.IsType(t, itemType, item)
 
 		var (

--- a/src/internal/connector/graph_connector_onedrive_test.go
+++ b/src/internal/connector/graph_connector_onedrive_test.go
@@ -286,7 +286,7 @@ type itemData struct {
 	perms permData
 }
 
-type onedriveColInfo struct {
+type driveColInfo struct {
 	pathElements []string
 	perms        permData
 	files        []itemData
@@ -296,7 +296,7 @@ type onedriveColInfo struct {
 func testDataForInfo(
 	t *testing.T,
 	service path.ServiceType,
-	cols []onedriveColInfo,
+	cols []driveColInfo,
 	backupVersion int,
 ) []colInfo {
 	var res []colInfo
@@ -493,6 +493,11 @@ func (suite *GraphConnectorSharePointIntegrationSuite) TestPermissionsInheritanc
 	testPermissionsInheritanceRestoreAndBackup(suite, version.Backup)
 }
 
+func (suite *GraphConnectorSharePointIntegrationSuite) TestRestoreFolderNamedFolderRegression() {
+	// No reason why it couldn't work with previous versions, but this is when it got introduced.
+	testRestoreFolderNamedFolderRegression(suite, version.All8MigrateUserPNToID)
+}
+
 // ---------------------------------------------------------------------------
 // OneDrive most recent backup version
 // ---------------------------------------------------------------------------
@@ -670,7 +675,7 @@ func testRestoreAndBackupMultipleFilesAndFoldersNoPermissions(
 		folderBName,
 	}
 
-	cols := []onedriveColInfo{
+	cols := []driveColInfo{
 		{
 			pathElements: rootPath,
 			files: []itemData{
@@ -814,7 +819,7 @@ func testPermissionsRestoreAndBackup(suite oneDriveSuite, startVersion int) {
 		folderCName,
 	}
 
-	cols := []onedriveColInfo{
+	cols := []driveColInfo{
 		{
 			pathElements: rootPath,
 			files: []itemData{
@@ -946,9 +951,10 @@ func testPermissionsRestoreAndBackup(suite oneDriveSuite, startVersion int) {
 	}
 
 	expected := testDataForInfo(suite.T(), suite.BackupService(), cols, version.Backup)
+	bss := suite.BackupService().String()
 
 	for vn := startVersion; vn <= version.Backup; vn++ {
-		suite.Run(fmt.Sprintf("Version%d", vn), func() {
+		suite.Run(fmt.Sprintf("%s-Version%d", bss, vn), func() {
 			t := suite.T()
 			// Ideally this can always be true or false and still
 			// work, but limiting older versions to use emails so as
@@ -991,7 +997,7 @@ func testPermissionsBackupAndNoRestore(suite oneDriveSuite, startVersion int) {
 		suite.Service(),
 		suite.BackupResourceOwner())
 
-	inputCols := []onedriveColInfo{
+	inputCols := []driveColInfo{
 		{
 			pathElements: []string{
 				odConsts.DrivesPathDir,
@@ -1012,7 +1018,7 @@ func testPermissionsBackupAndNoRestore(suite oneDriveSuite, startVersion int) {
 		},
 	}
 
-	expectedCols := []onedriveColInfo{
+	expectedCols := []driveColInfo{
 		{
 			pathElements: []string{
 				odConsts.DrivesPathDir,
@@ -1030,9 +1036,10 @@ func testPermissionsBackupAndNoRestore(suite oneDriveSuite, startVersion int) {
 	}
 
 	expected := testDataForInfo(suite.T(), suite.BackupService(), expectedCols, version.Backup)
+	bss := suite.BackupService().String()
 
 	for vn := startVersion; vn <= version.Backup; vn++ {
-		suite.Run(fmt.Sprintf("Version%d", vn), func() {
+		suite.Run(fmt.Sprintf("%s-Version%d", bss, vn), func() {
 			t := suite.T()
 			input := testDataForInfo(t, suite.BackupService(), inputCols, vn)
 
@@ -1157,7 +1164,7 @@ func testPermissionsInheritanceRestoreAndBackup(suite oneDriveSuite, startVersio
 	// 	   - inherted-permission-file
 	//     - empty-permission-file (empty/empty might have interesting behavior)
 
-	cols := []onedriveColInfo{
+	cols := []driveColInfo{
 		{
 			pathElements: rootPath,
 			files:        []itemData{},
@@ -1206,9 +1213,10 @@ func testPermissionsInheritanceRestoreAndBackup(suite oneDriveSuite, startVersio
 	}
 
 	expected := testDataForInfo(suite.T(), suite.BackupService(), cols, version.Backup)
+	bss := suite.BackupService().String()
 
 	for vn := startVersion; vn <= version.Backup; vn++ {
-		suite.Run(fmt.Sprintf("Version%d", vn), func() {
+		suite.Run(fmt.Sprintf("%s-Version%d", bss, vn), func() {
 			t := suite.T()
 			// Ideally this can always be true or false and still
 			// work, but limiting older versions to use emails so as
@@ -1271,7 +1279,7 @@ func testRestoreFolderNamedFolderRegression(
 		folderBName,
 	}
 
-	cols := []onedriveColInfo{
+	cols := []driveColInfo{
 		{
 			pathElements: rootPath,
 			files: []itemData{
@@ -1320,9 +1328,10 @@ func testRestoreFolderNamedFolderRegression(
 	}
 
 	expected := testDataForInfo(suite.T(), suite.BackupService(), cols, version.Backup)
+	bss := suite.BackupService().String()
 
 	for vn := startVersion; vn <= version.Backup; vn++ {
-		suite.Run(fmt.Sprintf("Version%d", vn), func() {
+		suite.Run(fmt.Sprintf("%s-Version%d", bss, vn), func() {
 			t := suite.T()
 			input := testDataForInfo(t, suite.BackupService(), cols, vn)
 

--- a/src/internal/connector/graph_connector_onedrive_test.go
+++ b/src/internal/connector/graph_connector_onedrive_test.go
@@ -431,11 +431,6 @@ func (si suiteInfoImpl) Resource() Resource {
 // SharePoint shares most of its libraries implementation with OneDrive so we
 // only test simple things here and leave the more extensive testing to
 // OneDrive.
-//
-// TODO(ashmrtn): SharePoint doesn't have permissions backup/restore enabled
-// right now. Adjust the tests here when that is enabled so we have at least
-// basic assurances that it's doing the right thing. We can leave the more
-// extensive permissions tests to OneDrive as well.
 
 type GraphConnectorSharePointIntegrationSuite struct {
 	tester.Suite
@@ -484,6 +479,18 @@ func (suite *GraphConnectorSharePointIntegrationSuite) SetupSuite() {
 
 func (suite *GraphConnectorSharePointIntegrationSuite) TestRestoreAndBackup_MultipleFilesAndFolders_NoPermissions() {
 	testRestoreAndBackupMultipleFilesAndFoldersNoPermissions(suite, version.Backup)
+}
+
+func (suite *GraphConnectorSharePointIntegrationSuite) TestPermissionsRestoreAndBackup() {
+	testPermissionsRestoreAndBackup(suite, version.Backup)
+}
+
+func (suite *GraphConnectorSharePointIntegrationSuite) TestPermissionsBackupAndNoRestore() {
+	testPermissionsBackupAndNoRestore(suite, version.Backup)
+}
+
+func (suite *GraphConnectorSharePointIntegrationSuite) TestPermissionsInheritanceRestoreAndBackup() {
+	testPermissionsInheritanceRestoreAndBackup(suite, version.Backup)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/internal/connector/graph_connector_test.go
+++ b/src/internal/connector/graph_connector_test.go
@@ -430,8 +430,7 @@ func getCollectionsAndExpected(
 			owner,
 			config.dest,
 			testCollections,
-			backupVersion,
-		)
+			backupVersion)
 
 		collections = append(collections, ownerCollections...)
 		totalItems += numItems
@@ -550,8 +549,7 @@ func runBackupAndCompare(
 		totalKopiaItems,
 		expectedData,
 		dcs,
-		config.dest,
-		config.opts.RestorePermissions)
+		config)
 
 	status := backupGC.Wait()
 
@@ -1125,17 +1123,15 @@ func (suite *GraphConnectorIntegrationSuite) TestMultiFolderBackupDifferentNames
 
 			t.Log("Backup enumeration complete")
 
+			ci := configInfo{
+				opts: control.Options{RestorePermissions: true},
+				// Alright to be empty, needed for OneDrive.
+				dest: control.RestoreDestination{},
+			}
+
 			// Pull the data prior to waiting for the status as otherwise it will
 			// deadlock.
-			skipped := checkCollections(
-				t,
-				ctx,
-				allItems,
-				allExpectedData,
-				dcs,
-				// Alright to be empty, needed for OneDrive.
-				control.RestoreDestination{},
-				true)
+			skipped := checkCollections(t, ctx, allItems, allExpectedData, dcs, ci)
 
 			status := backupGC.Wait()
 			assert.Equal(t, allItems+skipped, status.Objects, "status.Objects")

--- a/src/internal/connector/onedrive/drive_test.go
+++ b/src/internal/connector/onedrive/drive_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/alcionai/corso/src/internal/connector/onedrive/api"
 	"github.com/alcionai/corso/src/internal/connector/onedrive/api/mock"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
@@ -282,6 +283,7 @@ func (suite *OneDriveUnitSuite) TestDrives() {
 type OneDriveIntgSuite struct {
 	tester.Suite
 	userID string
+	creds  account.M365Config
 }
 
 func TestOneDriveSuite(t *testing.T) {
@@ -293,7 +295,15 @@ func TestOneDriveSuite(t *testing.T) {
 }
 
 func (suite *OneDriveIntgSuite) SetupSuite() {
-	suite.userID = tester.SecondaryM365UserID(suite.T())
+	t := suite.T()
+
+	suite.userID = tester.SecondaryM365UserID(t)
+
+	acct := tester.NewM365Account(t)
+	creds, err := acct.M365Config()
+	require.NoError(t, err)
+
+	suite.creds = creds
 }
 
 func (suite *OneDriveIntgSuite) TestCreateGetDeleteFolder() {
@@ -334,7 +344,7 @@ func (suite *OneDriveIntgSuite) TestCreateGetDeleteFolder() {
 	rootFolder, err := api.GetDriveRoot(ctx, gs, driveID)
 	require.NoError(t, err, clues.ToCore(err))
 
-	restoreFolders := path.Builder{}.Append(folderElements...)
+	restoreDir := path.Builder{}.Append(folderElements...)
 	drivePath := path.DrivePath{
 		DriveID: driveID,
 		Root:    "root:",
@@ -344,15 +354,15 @@ func (suite *OneDriveIntgSuite) TestCreateGetDeleteFolder() {
 	caches := NewRestoreCaches()
 	caches.DriveIDToRootFolderID[driveID] = ptr.Val(rootFolder.GetId())
 
-	folderID, err := CreateRestoreFolders(ctx, gs, &drivePath, restoreFolders, caches)
+	folderID, err := createRestoreFolders(ctx, gs, &drivePath, restoreDir, caches)
 	require.NoError(t, err, clues.ToCore(err))
 
 	folderIDs = append(folderIDs, folderID)
 
 	folderName2 := "Corso_Folder_Test_" + dttm.FormatNow(dttm.SafeForTesting)
-	restoreFolders = restoreFolders.Append(folderName2)
+	restoreDir = restoreDir.Append(folderName2)
 
-	folderID, err = CreateRestoreFolders(ctx, gs, &drivePath, restoreFolders, caches)
+	folderID, err = createRestoreFolders(ctx, gs, &drivePath, restoreDir, caches)
 	require.NoError(t, err, clues.ToCore(err))
 
 	folderIDs = append(folderIDs, folderID)

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -251,8 +251,12 @@ func filterUserPermissions(ctx context.Context, perms []models.Permissionable) [
 		switch true {
 		case gv2.GetUser() != nil:
 			entityID = ptr.Val(gv2.GetUser().GetId())
+		case gv2.GetSiteUser() != nil:
+			entityID = ptr.Val(gv2.GetSiteUser().GetId())
 		case gv2.GetGroup() != nil:
 			entityID = ptr.Val(gv2.GetGroup().GetId())
+		case gv2.GetSiteGroup() != nil:
+			entityID = ptr.Val(gv2.GetSiteGroup().GetId())
 		case gv2.GetApplication() != nil:
 			entityID = ptr.Val(gv2.GetApplication().GetId())
 		case gv2.GetDevice() != nil:

--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -243,50 +243,39 @@ func (suite *ItemIntegrationSuite) TestDriveGetFolder() {
 	}
 }
 
-type identityType string
-
-const (
-	itApp       identityType = "application"
-	itDevice    identityType = "device"
-	itGroup     identityType = "group"
-	itSiteUser  identityType = "site_user"
-	itSiteGroup identityType = "site_group"
-	itUser      identityType = "user"
-)
-
 func getPermsAndResourceOwnerPerms(
 	permID, resourceOwner string,
-	it identityType,
+	gv2t metadata.GV2Type,
 	scopes []string,
 ) (models.Permissionable, metadata.Permission) {
 	sharepointIdentitySet := models.NewSharePointIdentitySet()
 
-	switch it {
-	case itApp, itDevice, itGroup, itUser:
+	switch gv2t {
+	case metadata.GV2App, metadata.GV2Device, metadata.GV2Group, metadata.GV2User:
 		identity := models.NewIdentity()
 		identity.SetId(&resourceOwner)
 		identity.SetAdditionalData(map[string]any{"email": &resourceOwner})
 
-		switch it {
-		case itUser:
+		switch gv2t {
+		case metadata.GV2User:
 			sharepointIdentitySet.SetUser(identity)
-		case itGroup:
+		case metadata.GV2Group:
 			sharepointIdentitySet.SetGroup(identity)
-		case itApp:
+		case metadata.GV2App:
 			sharepointIdentitySet.SetApplication(identity)
-		case itDevice:
+		case metadata.GV2Device:
 			sharepointIdentitySet.SetDevice(identity)
 		}
 
-	case itSiteUser, itSiteGroup:
+	case metadata.GV2SiteUser, metadata.GV2SiteGroup:
 		spIdentity := models.NewSharePointIdentity()
 		spIdentity.SetId(&resourceOwner)
 		spIdentity.SetAdditionalData(map[string]any{"email": &resourceOwner})
 
-		switch it {
-		case itSiteUser:
+		switch gv2t {
+		case metadata.GV2SiteUser:
 			sharepointIdentitySet.SetSiteUser(spIdentity)
-		case itSiteGroup:
+		case metadata.GV2SiteGroup:
 			sharepointIdentitySet.SetSiteGroup(spIdentity)
 		}
 	}
@@ -297,9 +286,10 @@ func getPermsAndResourceOwnerPerms(
 	perm.SetGrantedToV2(sharepointIdentitySet)
 
 	ownersPerm := metadata.Permission{
-		ID:       permID,
-		Roles:    []string{"read"},
-		EntityID: resourceOwner,
+		ID:         permID,
+		Roles:      []string{"read"},
+		EntityID:   resourceOwner,
+		EntityType: gv2t,
 	}
 
 	return perm, ownersPerm
@@ -323,17 +313,17 @@ func (suite *ItemUnitTestSuite) TestDrivePermissionsFilter() {
 		rw   = []string{"read", "write"}
 	)
 
-	userOwnerPerm, userOwnerROperm := getPermsAndResourceOwnerPerms(pID, uID, itUser, own)
-	userReadPerm, userReadROperm := getPermsAndResourceOwnerPerms(pID, uID, itUser, r)
-	userReadWritePerm, userReadWriteROperm := getPermsAndResourceOwnerPerms(pID, uID2, itUser, rw)
-	siteUserOwnerPerm, siteUserOwnerROperm := getPermsAndResourceOwnerPerms(pID, uID, itSiteUser, own)
-	siteUserReadPerm, siteUserReadROperm := getPermsAndResourceOwnerPerms(pID, uID, itSiteUser, r)
-	siteUserReadWritePerm, siteUserReadWriteROperm := getPermsAndResourceOwnerPerms(pID, uID2, itSiteUser, rw)
+	userOwnerPerm, userOwnerROperm := getPermsAndResourceOwnerPerms(pID, uID, metadata.GV2User, own)
+	userReadPerm, userReadROperm := getPermsAndResourceOwnerPerms(pID, uID, metadata.GV2User, r)
+	userReadWritePerm, userReadWriteROperm := getPermsAndResourceOwnerPerms(pID, uID2, metadata.GV2User, rw)
+	siteUserOwnerPerm, siteUserOwnerROperm := getPermsAndResourceOwnerPerms(pID, uID, metadata.GV2SiteUser, own)
+	siteUserReadPerm, siteUserReadROperm := getPermsAndResourceOwnerPerms(pID, uID, metadata.GV2SiteUser, r)
+	siteUserReadWritePerm, siteUserReadWriteROperm := getPermsAndResourceOwnerPerms(pID, uID2, metadata.GV2SiteUser, rw)
 
-	groupReadPerm, groupReadROperm := getPermsAndResourceOwnerPerms(pID, uID, itGroup, r)
-	groupReadWritePerm, groupReadWriteROperm := getPermsAndResourceOwnerPerms(pID, uID2, itGroup, rw)
-	siteGroupReadPerm, siteGroupReadROperm := getPermsAndResourceOwnerPerms(pID, uID, itSiteGroup, r)
-	siteGroupReadWritePerm, siteGroupReadWriteROperm := getPermsAndResourceOwnerPerms(pID, uID2, itSiteGroup, rw)
+	groupReadPerm, groupReadROperm := getPermsAndResourceOwnerPerms(pID, uID, metadata.GV2Group, r)
+	groupReadWritePerm, groupReadWriteROperm := getPermsAndResourceOwnerPerms(pID, uID2, metadata.GV2Group, rw)
+	siteGroupReadPerm, siteGroupReadROperm := getPermsAndResourceOwnerPerms(pID, uID, metadata.GV2SiteGroup, r)
+	siteGroupReadWritePerm, siteGroupReadWriteROperm := getPermsAndResourceOwnerPerms(pID, uID2, metadata.GV2SiteGroup, rw)
 
 	noPerm, _ := getPermsAndResourceOwnerPerms(pID, uID, "user", []string{"read"})
 	noPerm.SetGrantedToV2(nil) // eg: link shares

--- a/src/internal/connector/onedrive/metadata/permissions.go
+++ b/src/internal/connector/onedrive/metadata/permissions.go
@@ -13,6 +13,17 @@ const (
 	SharingModeInherited
 )
 
+type GV2Type string
+
+const (
+	GV2App       GV2Type = "application"
+	GV2Device    GV2Type = "device"
+	GV2Group     GV2Type = "group"
+	GV2SiteUser  GV2Type = "site_user"
+	GV2SiteGroup GV2Type = "site_group"
+	GV2User      GV2Type = "user"
+)
+
 // FilePermission is used to store permissions of a specific resource owner
 // to a drive item.
 type Permission struct {
@@ -20,6 +31,7 @@ type Permission struct {
 	Roles      []string   `json:"role,omitempty"`
 	Email      string     `json:"email,omitempty"`    // DEPRECATED: Replaced with EntityID in newer backups
 	EntityID   string     `json:"entityId,omitempty"` // this is the resource owner's ID
+	EntityType GV2Type    `json:"entityType,omitempty"`
 	Expiration *time.Time `json:"expiration,omitempty"`
 }
 

--- a/src/internal/connector/onedrive/permission.go
+++ b/src/internal/connector/onedrive/permission.go
@@ -118,6 +118,8 @@ func computeParentPermissions(
 			return metadata.Metadata{}, clues.New("getting parent").WithClues(ctx)
 		}
 
+		fmt.Println("parent_dir", parent)
+
 		ictx := clues.Add(ctx, "parent_dir", parent)
 
 		drivePath, err := path.ToDrivePath(parent)

--- a/src/internal/connector/onedrive/permission.go
+++ b/src/internal/connector/onedrive/permission.go
@@ -104,11 +104,10 @@ func computeParentPermissions(
 		ok  bool
 	)
 
-	fmt.Printf("\n-----\nparent %+v\n-----\n", originDir)
+	fmt.Printf("\n-----\nparent metas\n-----\n")
 	for k := range parentMetas {
-		fmt.Println(k)
+		fmt.Println("pm", k)
 	}
-	fmt.Printf("\n-----\nwrap\n-----\n")
 
 	parent = originDir
 
@@ -118,7 +117,7 @@ func computeParentPermissions(
 			return metadata.Metadata{}, clues.New("getting parent").WithClues(ctx)
 		}
 
-		fmt.Println("parent_dir", parent)
+		fmt.Println("pd", parent)
 
 		ictx := clues.Add(ctx, "parent_dir", parent)
 
@@ -133,7 +132,7 @@ func computeParentPermissions(
 
 		meta, ok = parentMetas[parent.String()]
 		if !ok {
-			return metadata.Metadata{}, clues.New("no parent meta").WithClues(ictx)
+			return metadata.Metadata{}, clues.New("no metadata found for parent folder: " + parent.String()).WithClues(ictx)
 		}
 
 		if meta.SharingMode == metadata.SharingModeCustom {

--- a/src/internal/connector/onedrive/permission.go
+++ b/src/internal/connector/onedrive/permission.go
@@ -190,7 +190,9 @@ func UpdatePermissions(
 			}
 		}
 
-		if len(roles) == 0 {
+		// TODO: sitegroup support.  Currently errors with "One or more users could not be resolved",
+		// likely due to the site group entityID consisting of a single integer (ex: 4)
+		if len(roles) == 0 || p.EntityType == metadata.GV2SiteGroup {
 			continue
 		}
 

--- a/src/internal/connector/onedrive/permission.go
+++ b/src/internal/connector/onedrive/permission.go
@@ -52,8 +52,8 @@ func getCollectionMetadata(
 	}
 
 	var (
-		err            error
-		collectionPath = dc.FullPath()
+		err      error
+		fullPath = dc.FullPath()
 	)
 
 	if len(drivePath.Folders) == 0 {
@@ -62,7 +62,7 @@ func getCollectionMetadata(
 	}
 
 	if backupVersion < version.OneDrive4DirIncludesPermissions {
-		colMeta, err := getParentMetadata(collectionPath, caches.ParentDirToMeta)
+		colMeta, err := getParentMetadata(fullPath, caches.ParentDirToMeta)
 		if err != nil {
 			return metadata.Metadata{}, clues.Wrap(err, "collection metadata")
 		}
@@ -70,8 +70,7 @@ func getCollectionMetadata(
 		return colMeta, nil
 	}
 
-	// Root folder doesn't have a metadata file associated with it.
-	folders := collectionPath.Folders()
+	folders := fullPath.Folders()
 	metaName := folders[len(folders)-1] + metadata.DirMetaFileSuffix
 
 	if backupVersion >= version.OneDrive5DirMetaNoName {
@@ -103,12 +102,6 @@ func computeParentPermissions(
 		err error
 		ok  bool
 	)
-
-	fmt.Printf("\n-----\nparent metas\n-----\n")
-	for k, v := range parentMetas {
-		fmt.Println("pm", k)
-		fmt.Printf("%+v\n", v)
-	}
 
 	parent = originDir
 

--- a/src/internal/connector/onedrive/permission.go
+++ b/src/internal/connector/onedrive/permission.go
@@ -105,8 +105,9 @@ func computeParentPermissions(
 	)
 
 	fmt.Printf("\n-----\nparent metas\n-----\n")
-	for k := range parentMetas {
+	for k, v := range parentMetas {
 		fmt.Println("pm", k)
+		fmt.Printf("%+v\n", v)
 	}
 
 	parent = originDir

--- a/src/internal/connector/onedrive/permission_test.go
+++ b/src/internal/connector/onedrive/permission_test.go
@@ -151,12 +151,12 @@ func runComputeParentPermissionsTest(
 
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			_, flush := tester.NewContext()
+			ctx, flush := tester.NewContext()
 			defer flush()
 
 			t := suite.T()
 
-			m, err := computeParentPermissions(test.item, test.parentPerms)
+			m, err := computeParentPermissions(ctx, test.item, test.parentPerms)
 			require.NoError(t, err, "compute permissions")
 
 			assert.Equal(t, m, test.meta)

--- a/src/internal/connector/onedrive/permission_test.go
+++ b/src/internal/connector/onedrive/permission_test.go
@@ -22,8 +22,12 @@ func TestPermissionsUnitTestSuite(t *testing.T) {
 	suite.Run(t, &PermissionsUnitTestSuite{Suite: tester.NewUnitSuite(t)})
 }
 
-func (suite *PermissionsUnitTestSuite) TestComputeParentPermissions() {
+func (suite *PermissionsUnitTestSuite) TestComputeParentPermissions_oneDrive() {
 	runComputeParentPermissionsTest(suite, path.OneDriveService, path.FilesCategory, "user")
+}
+
+func (suite *PermissionsUnitTestSuite) TestComputeParentPermissions_sharePoint() {
+	runComputeParentPermissionsTest(suite, path.SharePointService, path.LibrariesCategory, "site")
 }
 
 func runComputeParentPermissionsTest(

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -326,6 +326,8 @@ func restoreItem(
 
 	// only v1+ backups from this point on
 
+	fmt.Printf("\n-----\n%+v\n-----\n", itemUUID)
+
 	if strings.HasSuffix(itemUUID, metadata.MetaFileSuffix) {
 		// Just skip this for the moment since we moved the code to the above
 		// item restore path. We haven't yet stopped fetching these items in
@@ -338,6 +340,7 @@ func restoreItem(
 		// permission for child folders here. Later versions can request
 		// permissions inline when processing the collection.
 		if !restorePerms || backupVersion >= version.OneDrive4DirIncludesPermissions {
+			fmt.Printf("\n-----\n>>> %v || %v\n-----\n", !restorePerms, backupVersion >= version.OneDrive4DirIncludesPermissions)
 			return details.ItemInfo{}, true, nil
 		}
 
@@ -346,6 +349,7 @@ func restoreItem(
 
 		meta, err := getMetadata(metaReader)
 		if err != nil {
+			fmt.Printf("\n-----\n>>> %v\n-----\n", err)
 			return details.ItemInfo{}, true, clues.Wrap(err, "getting directory metadata").WithClues(ctx)
 		}
 

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -91,9 +91,10 @@ func RestoreCollections(
 			metrics support.CollectionMetrics
 			ictx    = clues.Add(
 				ctx,
-				"resource_owner", clues.Hide(dc.FullPath().ResourceOwner()),
 				"category", dc.FullPath().Category(),
-				"path", dc.FullPath())
+				"destination", clues.Hide(dest.ContainerName),
+				"resource_owner", clues.Hide(dc.FullPath().ResourceOwner()),
+				"full_path", dc.FullPath())
 		)
 
 		metrics, err = RestoreCollection(
@@ -154,7 +155,7 @@ func RestoreCollection(
 		el         = errs.Local()
 	)
 
-	ctx, end := diagnostics.Span(ctx, "gc:oneDrive:restoreCollection", diagnostics.Label("path", directory))
+	ctx, end := diagnostics.Span(ctx, "gc:drive:restoreCollection", diagnostics.Label("path", directory))
 	defer end()
 
 	drivePath, err := path.ToDrivePath(directory)

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -3,6 +3,7 @@ package onedrive
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"runtime/trace"
 	"sort"
@@ -213,6 +214,7 @@ func RestoreCollection(
 		return metrics, clues.Wrap(err, "creating folders for restore")
 	}
 
+	fmt.Printf("\n-----\nadding fp %+v\n-----\n", dc.FullPath().String())
 	caches.ParentDirToMeta[dc.FullPath().String()] = colMeta
 	items := dc.Items(ctx, errs)
 
@@ -346,6 +348,8 @@ func restoreItem(
 		if err != nil {
 			return details.ItemInfo{}, true, clues.Wrap(err, "getting directory metadata").WithClues(ctx)
 		}
+
+		fmt.Printf("\n-----\nadding %+v\n-----\n", itemPath.String())
 
 		trimmedPath := strings.TrimSuffix(itemPath.String(), metadata.DirMetaFileSuffix)
 		caches.ParentDirToMeta[trimmedPath] = meta

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -180,7 +180,7 @@ func RestoreCollection(
 	ctx = clues.Add(
 		ctx,
 		"directory", dc.FullPath().Folder(false),
-		"destination_elements", restoreDir,
+		"restore_destination", restoreDir,
 		"drive_id", drivePath.DriveID)
 
 	trace.Log(ctx, "gc:oneDrive:restoreCollection", directory.String())
@@ -303,6 +303,7 @@ func restoreItem(
 	itemPath path.Path,
 ) (details.ItemInfo, bool, error) {
 	itemUUID := itemData.UUID()
+	ctx = clues.Add(ctx, "item_id", itemUUID)
 
 	if backupVersion < version.OneDrive1DataAndMetaFiles {
 		itemInfo, err := restoreV0File(

--- a/src/internal/connector/sharepoint/restore.go
+++ b/src/internal/connector/sharepoint/restore.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"runtime/trace"
-	"sort"
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -58,13 +57,9 @@ func RestoreCollections(
 		el             = errs.Local()
 	)
 
-	// TODO: this is a gotcha/smell and should be centralized within the
-	// restore process.
 	// Reorder collections so that the parents directories are created
 	// before the child directories; a requirement for permissions.
-	sort.Slice(dcs, func(i, j int) bool {
-		return dcs[i].FullPath().String() < dcs[j].FullPath().String()
-	})
+	data.SortRestoreCollections(dcs)
 
 	// Iterate through the data collections and restore the contents of each
 	for _, dc := range dcs {

--- a/src/internal/connector/sharepoint/restore.go
+++ b/src/internal/connector/sharepoint/restore.go
@@ -79,7 +79,8 @@ func RestoreCollections(
 			ictx     = clues.Add(ctx,
 				"category", category,
 				"destination", clues.Hide(dest.ContainerName),
-				"resource_owner", clues.Hide(dc.FullPath().ResourceOwner()))
+				"resource_owner", clues.Hide(dc.FullPath().ResourceOwner()),
+				"full_path", dc.FullPath())
 		)
 
 		switch dc.FullPath().Category() {

--- a/src/internal/connector/sharepoint/restore.go
+++ b/src/internal/connector/sharepoint/restore.go
@@ -58,6 +58,14 @@ func RestoreCollections(
 		el             = errs.Local()
 	)
 
+	// TODO: this is a gotcha/smell and should be centralized within the
+	// restore process.
+	// Reorder collections so that the parents directories are created
+	// before the child directories; a requirement for permissions.
+	sort.Slice(dcs, func(i, j int) bool {
+		return dcs[i].FullPath().String() < dcs[j].FullPath().String()
+	})
+
 	// Iterate through the data collections and restore the contents of each
 	for _, dc := range dcs {
 		if el.Failure() != nil {
@@ -73,14 +81,6 @@ func RestoreCollections(
 				"destination", clues.Hide(dest.ContainerName),
 				"resource_owner", clues.Hide(dc.FullPath().ResourceOwner()))
 		)
-
-		// TODO: this is a gotcha/smell and should be centralized within the
-		// restore process.
-		// Reorder collections so that the parents directories are created
-		// before the child directories; a requirement for permissions.
-		sort.Slice(dcs, func(i, j int) bool {
-			return dcs[i].FullPath().String() < dcs[j].FullPath().String()
-		})
 
 		switch dc.FullPath().Category() {
 		case path.LibrariesCategory:

--- a/src/internal/data/helpers.go
+++ b/src/internal/data/helpers.go
@@ -1,0 +1,10 @@
+package data
+
+import "sort"
+
+// SortRestoreCollections performs an in-place sort on the provided collection.
+func SortRestoreCollections(rcs []RestoreCollection) {
+	sort.Slice(rcs, func(i, j int) bool {
+		return rcs[i].FullPath().String() < rcs[j].FullPath().String()
+	})
+}

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -1540,7 +1540,6 @@ func runDriveIncrementalTest(
 		updateFiles  func(t *testing.T)
 		itemsRead    int
 		itemsWritten int
-		skip         bool
 	}{
 		{
 			name:         "clean incremental, no changes",
@@ -1572,7 +1571,6 @@ func runDriveIncrementalTest(
 		},
 		{
 			name: "add permission to new file",
-			skip: skipPermissionsTests,
 			updateFiles: func(t *testing.T) {
 				driveItem := models.NewDriveItem()
 				driveItem.SetName(&newFileName)
@@ -1595,7 +1593,6 @@ func runDriveIncrementalTest(
 		},
 		{
 			name: "remove permission from new file",
-			skip: skipPermissionsTests,
 			updateFiles: func(t *testing.T) {
 				driveItem := models.NewDriveItem()
 				driveItem.SetName(&newFileName)
@@ -1617,7 +1614,6 @@ func runDriveIncrementalTest(
 		},
 		{
 			name: "add permission to container",
-			skip: skipPermissionsTests,
 			updateFiles: func(t *testing.T) {
 				targetContainer := containerIDs[container1]
 				driveItem := models.NewDriveItem()
@@ -1640,7 +1636,6 @@ func runDriveIncrementalTest(
 		},
 		{
 			name: "remove permission from container",
-			skip: skipPermissionsTests,
 			updateFiles: func(t *testing.T) {
 				targetContainer := containerIDs[container1]
 				driveItem := models.NewDriveItem()
@@ -1852,10 +1847,6 @@ func runDriveIncrementalTest(
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			if test.skip {
-				suite.T().Skip("flagged to skip")
-			}
-
 			cleanGC, err := connector.NewGraphConnector(ctx, acct, resource)
 			require.NoError(t, err, clues.ToCore(err))
 

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -389,13 +389,16 @@ func generateContainerOfItems(
 		dest,
 		collections)
 
+	opts := control.Defaults()
+	opts.RestorePermissions = true
+
 	deets, err := gc.ConsumeRestoreCollections(
 		ctx,
 		backupVersion,
 		acct,
 		sel,
 		dest,
-		control.Options{RestorePermissions: true},
+		opts,
 		dataColls,
 		fault.New(true))
 	require.NoError(t, err, clues.ToCore(err))

--- a/src/internal/operations/helpers.go
+++ b/src/internal/operations/helpers.go
@@ -59,18 +59,18 @@ func LogFaultErrors(ctx context.Context, fe *fault.Errors, prefix string) {
 	}
 
 	if fe.Failure != nil {
-		log.With("error", fe.Failure).Error(pfxMsg + " primary failure")
+		log.With("error", fe.Failure).Errorf("%s primary failure: %s", pfxMsg, fe.Failure.Msg)
 	}
 
 	for i, item := range fe.Items {
-		log.With("failed_item", item).Errorf("%s item failure %d of %d", pfxMsg, i+1, li)
+		log.With("failed_item", item).Errorf("%s item failure %d of %d: %s", pfxMsg, i+1, li, item.Cause)
 	}
 
 	for i, item := range fe.Skipped {
-		log.With("skipped_item", item).Errorf("%s skipped item %d of %d", pfxMsg, i+1, ls)
+		log.With("skipped_item", item).Errorf("%s skipped item %d of %d: %s", pfxMsg, i+1, ls, item.Item.Cause)
 	}
 
 	for i, err := range fe.Recovered {
-		log.With("recovered_error", err).Errorf("%s recoverable error %d of %d", pfxMsg, i+1, lr)
+		log.With("recovered_error", err).Errorf("%s recoverable error %d of %d: %s", pfxMsg, i+1, lr, err.Msg)
 	}
 }

--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -360,7 +360,7 @@ func formatDetailsForRestoration(
 		return nil, clues.Wrap(err, "getting restore paths")
 	}
 
-	if sel.Service == selectors.ServiceOneDrive {
+	if sel.Service == selectors.ServiceOneDrive || sel.Service == selectors.ServiceSharePoint {
 		paths, err = onedrive.AugmentRestorePaths(backupVersion, paths)
 		if err != nil {
 			return nil, clues.Wrap(err, "augmenting paths")

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -226,11 +226,11 @@ func (dm DetailsModel) FilterMetaFiles() DetailsModel {
 }
 
 // Check if a file is a metadata file. These are used to store
-// additional data like permissions in case of OneDrive and are not to
-// be treated as regular files.
+// additional data like permissions (in case of Drive items) and are
+// not to be treated as regular files.
 func (de Entry) isMetaFile() bool {
-	// TODO: Add meta file filtering to SharePoint as well once we add
-	// meta files for SharePoint.
+	// sharepoint types not needed, since sharepoint permissions were
+	// added after IsMeta was deprecated.
 	return de.ItemInfo.OneDrive != nil && de.ItemInfo.OneDrive.IsMeta
 }
 


### PR DESCRIPTION
adds logical changes required for sharepoint permission handling, both backup and restore.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #3135

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
