### PR TITLE
lookup user default drive for onedrive

### DIFF
--- a/src/cmd/getM365/onedrive/get_item.go
+++ b/src/cmd/getM365/onedrive/get_item.go
@@ -112,7 +112,7 @@ func runDisplayM365JSON(
 	creds account.M365Config,
 	user, itemID string,
 ) error {
-	drive, err := api.GetDriveByID(ctx, srv, user)
+	drive, err := api.GetUsersDefaultDrive(ctx, srv, user)
 	if err != nil {
 		return err
 	}

--- a/src/cmd/purge/purge.go
+++ b/src/cmd/purge/purge.go
@@ -166,7 +166,7 @@ func purgeOneDriveFolders(
 			return nil, err
 		}
 
-		cfs, err := onedrive.GetAllFolders(ctx, gs, pager, prefix, fault.New(true))
+		cfs, err := onedrive.GetAllFolders(ctx, gs, "", onedrive.OneDriveSource, pager, prefix, fault.New(true))
 		if err != nil {
 			return nil, err
 		}

--- a/src/internal/connector/onedrive/collections_test.go
+++ b/src/internal/connector/onedrive/collections_test.go
@@ -2242,7 +2242,7 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 				func(*support.ConnectorOperationStatus) {},
 				control.Options{ToggleFeatures: control.Toggles{}},
 			)
-			c.drivePagerFunc = drivePagerFunc
+			c.dpf = drivePagerFunc
 			c.itemPagerFunc = itemPagerFunc
 
 			prevDelta := "prev-delta"

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -234,19 +234,21 @@ func (op *Displayable) GetDisplayName() *string {
 	return op.GetName()
 }
 
-// GetAllFolders returns all folders in all drives for the given user. If a
+// GetAllFolders returns all folders in tracked drives for the given user. If a
 // prefix is given, returns all folders with that prefix, regardless of if they
 // are a subfolder or top-level folder in the hierarchy.
 func GetAllFolders(
 	ctx context.Context,
 	gs graph.Servicer,
+	resourceOwner string,
+	source driveSource,
 	pager api.DrivePager,
 	prefix string,
 	errs *fault.Bus,
 ) ([]*Displayable, error) {
-	drives, err := api.GetAllDrives(ctx, pager, true, maxDrivesRetries)
+	drives, err := getDrivesBySource(ctx, gs, resourceOwner, source, pager)
 	if err != nil {
-		return nil, clues.Wrap(err, "getting OneDrive folders")
+		return nil, clues.Wrap(err, "getting folders across all drives")
 	}
 
 	var (

--- a/src/internal/connector/onedrive/drive_test.go
+++ b/src/internal/connector/onedrive/drive_test.go
@@ -308,10 +308,7 @@ func (suite *OneDriveSuite) TestCreateGetDeleteFolder() {
 		gs             = loadTestService(t)
 	)
 
-	pager, err := PagerForSource(OneDriveSource, gs, suite.userID, nil)
-	require.NoError(t, err, clues.ToCore(err))
-
-	drives, err := api.GetAllDrives(ctx, pager, true, maxDrivesRetries)
+	drives, err := getDrivesBySource(ctx, gs, suite.userID, OneDriveSource, nil)
 	require.NoError(t, err, clues.ToCore(err))
 	require.NotEmpty(t, drives)
 
@@ -367,10 +364,14 @@ func (suite *OneDriveSuite) TestCreateGetDeleteFolder() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			pager, err := PagerForSource(OneDriveSource, gs, suite.userID, nil)
-			require.NoError(t, err, clues.ToCore(err))
-
-			allFolders, err := GetAllFolders(ctx, gs, pager, test.prefix, fault.New(true))
+			allFolders, err := GetAllFolders(
+				ctx,
+				gs,
+				suite.userID,
+				OneDriveSource,
+				nil,
+				test.prefix,
+				fault.New(true))
 			require.NoError(t, err, clues.ToCore(err))
 
 			foundFolderIDs := []string{}

--- a/src/internal/connector/onedrive/service_test.go
+++ b/src/internal/connector/onedrive/service_test.go
@@ -8,15 +8,29 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/alcionai/corso/src/internal/connector/graph"
+	"github.com/alcionai/corso/src/internal/connector/graph/mock"
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/account"
+	"github.com/alcionai/corso/src/pkg/logger"
 )
 
-type MockGraphService struct{}
+type MockGraphService struct {
+	useMockClient bool
+	creds         account.M365Config // only required if useMockClient=true
+}
 
 func (ms *MockGraphService) Client() *msgraphsdk.GraphServiceClient {
-	return nil
+	if !ms.useMockClient {
+		return nil
+	}
+
+	s, err := mock.NewService(ms.creds)
+	if err != nil {
+		logger.Ctx(nil).Error("mocking client", err)
+	}
+
+	return s.Client()
 }
 
 func (ms *MockGraphService) Adapter() *msgraphsdk.GraphRequestAdapter {


### PR DESCRIPTION
instead of enumerating all drives during backup, if we're processing a onedrive source, opt to look up only the default drive instead of enumerating all drives.

---

#### Does this PR need a docs update or release note?

- [x] :clock1: Yes, but in a later PR

#### Type of change

- [x] :bug: Bugfix

#### Issue(s)

* #3335

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
