### PR TITLE
Create a collection to merge other collection data

### DIFF
--- a/src/internal/kopia/merge_collection.go
+++ b/src/internal/kopia/merge_collection.go
@@ -1,0 +1,110 @@
+package kopia
+
+import (
+	"context"
+	"errors"
+
+	"github.com/alcionai/clues"
+	"golang.org/x/exp/slices"
+
+	"github.com/alcionai/corso/src/internal/data"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/logger"
+	"github.com/alcionai/corso/src/pkg/path"
+)
+
+type col struct {
+	storagePath string
+	data.RestoreCollection
+}
+
+type mergeCollection struct {
+	cols []col
+	// Technically don't need to track this but it can help detect errors.
+	fullPath path.Path
+}
+
+func (mc *mergeCollection) addCollection(
+	storagePath string,
+	c data.RestoreCollection,
+) error {
+	if c == nil {
+		return clues.New("adding nil collection").
+			With("current_path", mc.FullPath())
+	} else if mc.FullPath().String() != c.FullPath().String() {
+		return clues.New("attempting to merge collection with different path").
+			With("current_path", mc.FullPath(), "new_path", c.FullPath())
+	}
+
+	mc.cols = append(mc.cols, col{storagePath: storagePath, RestoreCollection: c})
+
+	// Keep a stable sorting of this merged collection set so we can say there's
+	// some deterministic behavior when Fetch is called. We don't expect to have
+	// to merge many collections.
+	slices.SortStableFunc(mc.cols, func(a, b col) bool {
+		return a.storagePath < b.storagePath
+	})
+
+	return nil
+}
+
+func (mc mergeCollection) FullPath() path.Path {
+	return mc.fullPath
+}
+
+func (mc *mergeCollection) Items(
+	ctx context.Context,
+	errs *fault.Bus,
+) <-chan data.Stream {
+	res := make(chan data.Stream)
+
+	go func() {
+		defer close(res)
+
+		logger.Ctx(ctx).Infow(
+			"getting items for merged collection",
+			"merged_collection_count", len(mc.cols))
+
+		for _, c := range mc.cols {
+			// Unfortunately doesn't seem to be a way right now to see if the
+			// iteration failed and we should be exiting early.
+			ictx := clues.Add(ctx, "merged_collection_storage_path", c.storagePath)
+			logger.Ctx(ictx).Infow("sending items from merged collection")
+
+			for item := range c.Items(ictx, errs) {
+				res <- item
+			}
+		}
+	}()
+
+	return res
+}
+
+// Fetch goes through all the collections in this one and returns the first
+// match found or the first error that is not data.ErrNotFound. If multiple
+// collections have the requested item, the instance in the collection with the
+// lexicographically smallest storage path is returned.
+func (mc *mergeCollection) Fetch(
+	ctx context.Context,
+	name string,
+) (data.Stream, error) {
+	logger.Ctx(ctx).Infow(
+		"fetching item in merged collection",
+		"merged_collection_count", len(mc.cols))
+
+	for _, c := range mc.cols {
+		ictx := clues.Add(ctx, "merged_collection_storage_path", c.storagePath)
+
+		logger.Ctx(ictx).Infow("looking for item in merged collection")
+
+		s, err := c.Fetch(ictx, name)
+		if err == nil {
+			return s, nil
+		} else if err != nil && !errors.Is(err, data.ErrNotFound) {
+			return nil, clues.Wrap(err, "fetching from merged collection").
+				WithClues(ictx)
+		}
+	}
+
+	return nil, clues.Wrap(data.ErrNotFound, "merged collection fetch")
+}

--- a/src/internal/kopia/merge_collection.go
+++ b/src/internal/kopia/merge_collection.go
@@ -13,6 +13,8 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
+var _ data.RestoreCollection = &mergeCollection{}
+
 type col struct {
 	storagePath string
 	data.RestoreCollection
@@ -69,7 +71,7 @@ func (mc *mergeCollection) Items(
 			// Unfortunately doesn't seem to be a way right now to see if the
 			// iteration failed and we should be exiting early.
 			ictx := clues.Add(ctx, "merged_collection_storage_path", c.storagePath)
-			logger.Ctx(ictx).Infow("sending items from merged collection")
+			logger.Ctx(ictx).Debug("sending items from merged collection")
 
 			for item := range c.Items(ictx, errs) {
 				res <- item
@@ -95,7 +97,7 @@ func (mc *mergeCollection) Fetch(
 	for _, c := range mc.cols {
 		ictx := clues.Add(ctx, "merged_collection_storage_path", c.storagePath)
 
-		logger.Ctx(ictx).Infow("looking for item in merged collection")
+		logger.Ctx(ictx).Debug("looking for item in merged collection")
 
 		s, err := c.Fetch(ictx, name)
 		if err == nil {

--- a/src/internal/kopia/merge_collection_test.go
+++ b/src/internal/kopia/merge_collection_test.go
@@ -1,0 +1,297 @@
+package kopia
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/alcionai/clues"
+	"github.com/kopia/kopia/fs"
+	"github.com/kopia/kopia/fs/virtualfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/connector/exchange/mock"
+	"github.com/alcionai/corso/src/internal/data"
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/path"
+)
+
+type MergeCollectionUnitSuite struct {
+	tester.Suite
+}
+
+func TestMergeCollectionUnitSuite(t *testing.T) {
+	suite.Run(t, &MergeCollectionUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *MergeCollectionUnitSuite) TestReturnsPath() {
+	t := suite.T()
+
+	pth, err := path.Build(
+		"a-tenant",
+		"a-user",
+		path.ExchangeService,
+		path.EmailCategory,
+		false,
+		"some", "path", "for", "data")
+	require.NoError(t, err, clues.ToCore(err))
+
+	c := mergeCollection{
+		fullPath: pth,
+	}
+
+	assert.Equal(t, pth, c.FullPath())
+}
+
+func (suite *MergeCollectionUnitSuite) TestItems() {
+	ctx, flush := tester.NewContext()
+	defer flush()
+
+	t := suite.T()
+	storagePaths := []string{
+		"tenant-id/exchange/user-id/mail/some/folder/path1",
+		"tenant-id/exchange/user-id/mail/some/folder/path2",
+	}
+
+	expectedItemNames := []string{"1", "2"}
+
+	pth, err := path.Build(
+		"a-tenant",
+		"a-user",
+		path.ExchangeService,
+		path.EmailCategory,
+		false,
+		"some", "path", "for", "data")
+	require.NoError(t, err, clues.ToCore(err))
+
+	c1 := mock.NewCollection(pth, nil, 1)
+	c1.Names[0] = expectedItemNames[0]
+
+	c2 := mock.NewCollection(pth, nil, 1)
+	c2.Names[0] = expectedItemNames[1]
+
+	// Not testing fetch here so safe to use this wrapper.
+	cols := []data.RestoreCollection{
+		data.NotFoundRestoreCollection{Collection: c1},
+		data.NotFoundRestoreCollection{Collection: c2},
+	}
+
+	dc := &mergeCollection{fullPath: pth}
+
+	for i, c := range cols {
+		err := dc.addCollection(storagePaths[i], c)
+		require.NoError(t, err, "adding collection", clues.ToCore(err))
+	}
+
+	gotItemNames := []string{}
+
+	for item := range dc.Items(ctx, fault.New(true)) {
+		gotItemNames = append(gotItemNames, item.UUID())
+	}
+
+	assert.ElementsMatch(t, expectedItemNames, gotItemNames)
+}
+
+func (suite *MergeCollectionUnitSuite) TestAddCollection_DifferentPathFails() {
+	t := suite.T()
+
+	pth1, err := path.Build(
+		"a-tenant",
+		"a-user",
+		path.ExchangeService,
+		path.EmailCategory,
+		false,
+		"some", "path", "for", "data")
+	require.NoError(t, err, clues.ToCore(err))
+
+	pth2, err := path.Build(
+		"a-tenant",
+		"a-user",
+		path.ExchangeService,
+		path.EmailCategory,
+		false,
+		"some", "path", "for", "data2")
+	require.NoError(t, err, clues.ToCore(err))
+
+	dc := mergeCollection{fullPath: pth1}
+
+	err = dc.addCollection("some/path", &kopiaDataCollection{path: pth2})
+	assert.Error(t, err, clues.ToCore(err))
+}
+
+func (suite *MergeCollectionUnitSuite) TestFetch() {
+	var (
+		fileData1 = []byte("abcdefghijklmnopqrstuvwxyz")
+		fileData2 = []byte("zyxwvutsrqponmlkjihgfedcba")
+		fileData3 = []byte("foo bar baz")
+
+		fileName1         = "file1"
+		fileName2         = "file2"
+		fileLookupErrName = "errLookup"
+		fileOpenErrName   = "errOpen"
+
+		colPaths = []string{
+			"tenant-id/exchange/user-id/mail/some/data/directory1",
+			"tenant-id/exchange/user-id/mail/some/data/directory2",
+		}
+	)
+
+	pth, err := path.Build(
+		"a-tenant",
+		"a-user",
+		path.ExchangeService,
+		path.EmailCategory,
+		false,
+		"some", "path", "for", "data")
+	require.NoError(suite.T(), err, clues.ToCore(err))
+
+	// Needs to be a function so the readers get refreshed each time.
+	layouts := []func() fs.Directory{
+		// Has the following;
+		//   - file1: data[0]
+		//   - errOpen: (error opening file)
+		func() fs.Directory {
+			return virtualfs.NewStaticDirectory(encodeAsPath(colPaths[0]), []fs.Entry{
+				&mockFile{
+					StreamingFile: virtualfs.StreamingFileFromReader(
+						encodeAsPath(fileName1),
+						nil,
+					),
+					r: newBackupStreamReader(
+						serializationVersion,
+						io.NopCloser(bytes.NewReader(fileData1)),
+					),
+					size: int64(len(fileData1) + versionSize),
+				},
+				&mockFile{
+					StreamingFile: virtualfs.StreamingFileFromReader(
+						encodeAsPath(fileOpenErrName),
+						nil,
+					),
+					openErr: assert.AnError,
+				},
+			})
+		},
+
+		// Has the following;
+		//   - file1: data[1]
+		//   - file2: data[0]
+		//   - errOpen: data[2]
+		func() fs.Directory {
+			return virtualfs.NewStaticDirectory(encodeAsPath(colPaths[1]), []fs.Entry{
+				&mockFile{
+					StreamingFile: virtualfs.StreamingFileFromReader(
+						encodeAsPath(fileName1),
+						nil,
+					),
+					r: newBackupStreamReader(
+						serializationVersion,
+						io.NopCloser(bytes.NewReader(fileData2)),
+					),
+					size: int64(len(fileData2) + versionSize),
+				},
+				&mockFile{
+					StreamingFile: virtualfs.StreamingFileFromReader(
+						encodeAsPath(fileName2),
+						nil,
+					),
+					r: newBackupStreamReader(
+						serializationVersion,
+						io.NopCloser(bytes.NewReader(fileData1)),
+					),
+					size: int64(len(fileData1) + versionSize),
+				},
+				&mockFile{
+					StreamingFile: virtualfs.StreamingFileFromReader(
+						encodeAsPath(fileOpenErrName),
+						nil,
+					),
+					r: newBackupStreamReader(
+						serializationVersion,
+						io.NopCloser(bytes.NewReader(fileData3)),
+					),
+					size: int64(len(fileData3) + versionSize),
+				},
+			})
+		},
+	}
+
+	table := []struct {
+		name        string
+		fileName    string
+		expectError assert.ErrorAssertionFunc
+		expectData  []byte
+		notFoundErr bool
+	}{
+		{
+			name:        "Duplicate File, first collection",
+			fileName:    fileName1,
+			expectError: assert.NoError,
+			expectData:  fileData1,
+		},
+		{
+			name:        "Distinct File, second collection",
+			fileName:    fileName2,
+			expectError: assert.NoError,
+			expectData:  fileData1,
+		},
+		{
+			name:        "Error opening file",
+			fileName:    fileOpenErrName,
+			expectError: assert.Error,
+		},
+		{
+			name:        "File not found",
+			fileName:    fileLookupErrName,
+			expectError: assert.Error,
+			notFoundErr: true,
+		},
+	}
+
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			ctx, flush := tester.NewContext()
+			defer flush()
+
+			t := suite.T()
+			c := &i64counter{}
+
+			dc := mergeCollection{fullPath: pth}
+
+			for i, layout := range layouts {
+				col := &kopiaDataCollection{
+					path:            pth,
+					dir:             layout(),
+					counter:         c,
+					expectedVersion: serializationVersion,
+				}
+
+				err := dc.addCollection(colPaths[i], col)
+				require.NoError(t, err, "adding collection", clues.ToCore(err))
+			}
+
+			s, err := dc.Fetch(ctx, test.fileName)
+			test.expectError(t, err, clues.ToCore(err))
+
+			if err != nil {
+				if test.notFoundErr {
+					assert.ErrorIs(t, err, data.ErrNotFound, clues.ToCore(err))
+				}
+
+				return
+			}
+
+			fileData, err := io.ReadAll(s.ToReader())
+			require.NoError(t, err, "reading file data", clues.ToCore(err))
+
+			if err != nil {
+				return
+			}
+
+			assert.Equal(t, test.expectData, fileData)
+		})
+	}
+}

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -399,12 +399,9 @@ func loadDirsAndItems(
 			return nil, el.Failure()
 		}
 
-		var (
-			mergeCol *mergeCollection
-			ictx     = clues.Add(ctx, "restore_path", col.restorePath)
-		)
+		ictx := clues.Add(ctx, "restore_path", col.restorePath)
 
-		mergeCol = &mergeCollection{fullPath: col.restorePath}
+		mergeCol := &mergeCollection{fullPath: col.restorePath}
 		res = append(res, mergeCol)
 
 		for _, dirItems := range col.storageDirs {

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -406,7 +406,7 @@ func loadDirsAndItems(
 				return nil, el.Failure()
 			}
 
-			ictx = clues.Add(ctx, "storage_directory_path", dirItems.dir)
+			ictx = clues.Add(ictx, "storage_directory_path", dirItems.dir)
 
 			dir, err := getDir(ictx, dirItems.dir, snapshotRoot)
 			if err != nil {
@@ -509,7 +509,6 @@ func (w Wrapper) ProduceRestoreCollections(
 			"restore_path", itemPaths.RestorePath.String())
 
 		parentStoragePath, err := itemPaths.StoragePath.Dir()
-
 		if err != nil {
 			el.AddRecoverable(clues.Wrap(err, "getting storage directory path").
 				WithClues(ictx).
@@ -523,6 +522,7 @@ func (w Wrapper) ProduceRestoreCollections(
 		if rc == nil {
 			dirsToItems[itemPaths.RestorePath.ShortRef()] = &restoreCollection{
 				restorePath: itemPaths.RestorePath,
+				storageDirs: map[string]*dirAndItems{},
 			}
 			rc = dirsToItems[itemPaths.RestorePath.ShortRef()]
 		}

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -400,15 +400,12 @@ func loadDirsAndItems(
 		}
 
 		var (
-			mergeDC *mergeCollection
-			ictx    = clues.Add(ctx, "restore_path", col.restorePath)
-			merge   = len(col.storageDirs) > 0
+			mergeCol *mergeCollection
+			ictx     = clues.Add(ctx, "restore_path", col.restorePath)
 		)
 
-		if merge {
-			mergeDC = &mergeCollection{fullPath: col.restorePath}
-			res = append(res, mergeDC)
-		}
+		mergeCol = &mergeCollection{fullPath: col.restorePath}
+		res = append(res, mergeCol)
 
 		for _, dirItems := range col.storageDirs {
 			if el.Failure() != nil {
@@ -433,16 +430,12 @@ func loadDirsAndItems(
 				expectedVersion: serializationVersion,
 			}
 
-			if merge {
-				if err := mergeDC.addCollection(dirItems.dir.String(), dc); err != nil {
-					el.AddRecoverable(clues.Wrap(err, "adding collection to merge collection").
-						WithClues(ctx).
-						Label(fault.LabelForceNoBackupCreation))
+			if err := mergeCol.addCollection(dirItems.dir.String(), dc); err != nil {
+				el.AddRecoverable(clues.Wrap(err, "adding collection to merge collection").
+					WithClues(ctx).
+					Label(fault.LabelForceNoBackupCreation))
 
-					continue
-				}
-			} else {
-				res = append(res, dc)
+				continue
 			}
 
 			for _, item := range dirItems.items {

--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -381,7 +381,7 @@ func formatDetailsForRestoration(
 		if err != nil {
 			el.AddRecoverable(clues.
 				Wrap(err, "getting restore directory after reduction").
-				WithMap(clues.In(ctx)).
+				WithClues(ctx).
 				With("path", fdsPaths[i]))
 
 			continue


### PR DESCRIPTION
Now that Corso changed how it loads data from
kopia during restore create some code to merge
results from several underlying collections.
This will come in handy when we have multiple
external service folders with distinct IDs but
which have the same display name and path
(LocationRef)

This code also defines the behavior when
multiple collections in the merge set have the
same item and `Fetch` is called

This should be merged into #3337 prior to it
merging to main

This is not expected to change system
functionality

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3197

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
