### PR TITLE
use graph client for large data set

### DIFF
--- a/src/internal/connector/exchange/attachment.go
+++ b/src/internal/connector/exchange/attachment.go
@@ -11,7 +11,6 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/support"
-	"github.com/alcionai/corso/src/internal/connector/uploadsession"
 	"github.com/alcionai/corso/src/pkg/logger"
 )
 
@@ -106,7 +105,7 @@ func uploadLargeAttachment(
 	}
 
 	url := ptr.Val(session.GetUploadUrl())
-	aw := uploadsession.NewWriter(uploader.getItemID(), url, size)
+	aw := graph.NewWriter(uploader.getItemID(), url, size)
 	logger.Ctx(ctx).Debugw("uploading large attachment", "attachment_url", graph.LoggableURL(url))
 
 	// Upload the stream data

--- a/src/internal/connector/exchange/attachment.go
+++ b/src/internal/connector/exchange/attachment.go
@@ -105,7 +105,7 @@ func uploadLargeAttachment(
 	}
 
 	url := ptr.Val(session.GetUploadUrl())
-	aw := graph.NewWriter(uploader.getItemID(), url, size)
+	aw := graph.NewLargeItemWriter(uploader.getItemID(), url, size)
 	logger.Ctx(ctx).Debugw("uploading large attachment", "attachment_url", graph.LoggableURL(url))
 
 	// Upload the stream data

--- a/src/internal/connector/graph/uploadsession.go
+++ b/src/internal/connector/graph/uploadsession.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/alcionai/clues"
 
@@ -57,7 +58,12 @@ func (iw *largeItemWriter) Write(p []byte) (int, error) {
 		iw.contentLength)
 	headers[contentLengthHeaderKey] = fmt.Sprintf("%d", rangeLength)
 
-	_, err := iw.client.Request(ctx, "PUT", iw.url, bytes.NewReader(p), headers)
+	_, err := iw.client.Request(
+		ctx,
+		http.MethodPut,
+		iw.url,
+		bytes.NewReader(p),
+		headers)
 	if err != nil {
 		return 0, clues.Wrap(err, "uploading item").With(
 			"upload_id", iw.id,

--- a/src/internal/connector/graph/uploadsession.go
+++ b/src/internal/connector/graph/uploadsession.go
@@ -1,12 +1,12 @@
-package uploadsession
+package graph
 
 import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/alcionai/clues"
-	"gopkg.in/resty.v1"
 
 	"github.com/alcionai/corso/src/pkg/logger"
 )
@@ -29,11 +29,11 @@ type writer struct {
 	contentLength int64
 	// Last item offset that was written to
 	lastWrittenOffset int64
-	client            *resty.Client
+	client            httpWrapper
 }
 
 func NewWriter(id, url string, size int64) *writer {
-	return &writer{id: id, url: url, contentLength: size, client: resty.New()}
+	return &writer{id: id, url: url, contentLength: size, client: *NewNoTimeoutHTTPWrapper()}
 }
 
 // Write will upload the provided data to M365. It sets the `Content-Length` and `Content-Range` headers based on
@@ -48,17 +48,25 @@ func (iw *writer) Write(p []byte) (int, error) {
 
 	// PUT the request - set headers `Content-Range`to describe total size and `Content-Length` to describe size of
 	// data in the current request
-	_, err := iw.client.R().
-		SetHeaders(map[string]string{
-			contentRangeHeaderKey: fmt.Sprintf(
-				contentRangeHeaderValueFmt,
-				iw.lastWrittenOffset,
-				endOffset-1,
-				iw.contentLength),
-			contentLengthHeaderKey: fmt.Sprintf("%d", rangeLength),
-		}).
-		SetBody(bytes.NewReader(p)).
-		Put(iw.url)
+	req, err := http.NewRequest("PUT", iw.url, bytes.NewReader(p))
+	if err != nil {
+		return 0, clues.Wrap(err, "uploading item").With(
+			"upload_id", iw.id,
+			"upload_chunk_size", rangeLength,
+			"upload_offset", iw.lastWrittenOffset,
+			"upload_size", iw.contentLength)
+	}
+
+	req.Header = http.Header{
+		contentRangeHeaderKey: {fmt.Sprintf(
+			contentRangeHeaderValueFmt,
+			iw.lastWrittenOffset,
+			endOffset-1,
+			iw.contentLength)},
+		contentLengthHeaderKey: {fmt.Sprintf("%d", rangeLength)},
+	}
+	_, err = iw.client.client.Do(req)
+
 	if err != nil {
 		return 0, clues.Wrap(err, "uploading item").With(
 			"upload_id", iw.id,

--- a/src/internal/connector/graph/uploadsession_test.go
+++ b/src/internal/connector/graph/uploadsession_test.go
@@ -1,4 +1,4 @@
-package uploadsession
+package graph
 
 import (
 	"bytes"

--- a/src/internal/connector/graph/uploadsession_test.go
+++ b/src/internal/connector/graph/uploadsession_test.go
@@ -69,7 +69,7 @@ func (suite *UploadSessionSuite) TestWriter() {
 
 	defer ts.Close()
 
-	writer := NewWriter("item", ts.URL, writeSize)
+	writer := NewLargeItemWriter("item", ts.URL, writeSize)
 
 	// Using a 32 KB buffer for the copy allows us to validate the
 	// multi-part upload. `io.CopyBuffer` will only write 32 KB at

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -16,7 +16,6 @@ import (
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/onedrive/api"
 	"github.com/alcionai/corso/src/internal/connector/onedrive/metadata"
-	"github.com/alcionai/corso/src/internal/connector/uploadsession"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/logger"
 )
@@ -360,7 +359,7 @@ func driveItemWriter(
 
 	url := ptr.Val(r.GetUploadUrl())
 
-	return uploadsession.NewWriter(itemID, url, itemSize), nil
+	return graph.NewWriter(itemID, url, itemSize), nil
 }
 
 // constructWebURL helper function for recreating the webURL

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -359,7 +359,7 @@ func driveItemWriter(
 
 	url := ptr.Val(r.GetUploadUrl())
 
-	return graph.NewWriter(itemID, url, itemSize), nil
+	return graph.NewLargeItemWriter(itemID, url, itemSize), nil
 }
 
 // constructWebURL helper function for recreating the webURL


### PR DESCRIPTION
<!-- PR description-->
- Use graph client instead of Resty client. This brings uniformity and will help in utilising other features like Middlewares from graph client wrapper
- Moved the upload session to graph package to use Graph http-client wrapper

#### Does this PR need a docs update or release note?
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* https://github.com/alcionai/corso/issues/2300

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
