### PR TITLE
Handle special case OD site name after recreating user

### DIFF
--- a/src/cmd/purge/scripts/exchangePurge.ps1
+++ b/src/cmd/purge/scripts/exchangePurge.ps1
@@ -615,9 +615,6 @@ function Purge-Items {
     }
 }
 
-#Somewhat hacky but user names may need to be sanitized in some cases resulting from re-creating CI user
-$User = [regex]::split($User, '\d*$')[0]
-
 Write-Host 'Authenticating with Exchange Web Services ...'
 $global:Token = Get-AccessToken | ConvertTo-SecureString -AsPlainText -Force 
 

--- a/src/cmd/purge/scripts/exchangePurge.ps1
+++ b/src/cmd/purge/scripts/exchangePurge.ps1
@@ -615,6 +615,9 @@ function Purge-Items {
     }
 }
 
+#Somewhat hacky but user names may need to be sanitized in some cases resulting from re-creating CI user
+$User = [regex]::split($User, '\d*$')[0]
+
 Write-Host 'Authenticating with Exchange Web Services ...'
 $global:Token = Get-AccessToken | ConvertTo-SecureString -AsPlainText -Force 
 

--- a/src/cmd/purge/scripts/onedrivePurge.ps1
+++ b/src/cmd/purge/scripts/onedrivePurge.ps1
@@ -73,7 +73,7 @@ function Purge-Library {
     Write-Host "`nPurging library: $LibraryName"
 
     $foldersToPurge = @()
-    $folders = Get-PnPFolderItem -FolderSiteRelativeUrl $LibraryName -ItemType Folder 
+    $folders = Get-PnPFolderItem -FolderSiteRelativeUrl $LibraryName -ItemType Folder -Recursive
 
     foreach ($f in $folders) {
         $folderName = $f.Name

--- a/src/cmd/purge/scripts/onedrivePurge.ps1
+++ b/src/cmd/purge/scripts/onedrivePurge.ps1
@@ -131,6 +131,12 @@ if (![string]::IsNullOrEmpty($User)) {
     # Works for dev domains where format is <user name>@<domain>.onmicrosoft.com
     $domain = $User.Split('@')[1].Split('.')[0]
     $userNameEscaped = $User.Replace('.', '_').Replace('@', '_')
+
+    # hacky special case because of recreated CI user
+    if ($userNameEscaped -ilike "lynner*") {
+        $userNameEscaped += '1'
+    }
+
     $siteUrl = "https://$domain-my.sharepoint.com/personal/$userNameEscaped/"
 
     if ($LibraryNameList.count -eq 0) {

--- a/src/cmd/purge/scripts/onedrivePurge.ps1
+++ b/src/cmd/purge/scripts/onedrivePurge.ps1
@@ -73,7 +73,7 @@ function Purge-Library {
     Write-Host "`nPurging library: $LibraryName"
 
     $foldersToPurge = @()
-    $folders = Get-PnPFolderItem -FolderSiteRelativeUrl $LibraryName -ItemType Folder -Recursive
+    $folders = Get-PnPFolderItem -FolderSiteRelativeUrl $LibraryName -ItemType Folder 
 
     foreach ($f in $folders) {
         $folderName = $f.Name


### PR DESCRIPTION
Special case Primary CI user LynneR for OneDrive CI cleanup

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
