### PR TITLE
move nested test folder creation to top level

### DIFF
--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -154,10 +154,6 @@ func (suite *ItemIntegrationSuite) TestItemWriter() {
 			root, err := srv.Client().DrivesById(test.driveID).Root().Get(ctx, nil)
 			require.NoError(t, err, clues.ToCore(err))
 
-			// Test Requirement 2: "Test Folder" should exist
-			folder, err := api.GetFolderByName(ctx, srv, test.driveID, ptr.Val(root.GetId()), "Test Folder")
-			require.NoError(t, err, clues.ToCore(err))
-
 			newFolderName := tester.DefaultTestRestoreDestination("folder").ContainerName
 			t.Logf("creating folder %s", newFolderName)
 
@@ -165,7 +161,7 @@ func (suite *ItemIntegrationSuite) TestItemWriter() {
 				ctx,
 				srv,
 				test.driveID,
-				ptr.Val(folder.GetId()),
+				ptr.Val(root.GetId()),
 				newItem(newFolderName, true))
 			require.NoError(t, err, clues.ToCore(err))
 			require.NotNil(t, newFolder.GetId())


### PR DESCRIPTION
tests that create items which require automatic cleanup should always create those items at the root directory. We have one bad citizen test which creates them in a subdirectory.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Supportability/Tests

#### Test Plan

- [x] :green_heart: E2E
