### PR TITLE
expect standard dir/files from onedrive test users

### DIFF
--- a/src/cli/backup/onedrive_e2e_test.go
+++ b/src/cli/backup/onedrive_e2e_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/repository"
 	"github.com/alcionai/corso/src/pkg/selectors"
+	selTD "github.com/alcionai/corso/src/pkg/selectors/testdata"
 	"github.com/alcionai/corso/src/pkg/storage"
 )
 
@@ -176,7 +177,7 @@ func (suite *BackupDeleteOneDriveE2ESuite) SetupSuite() {
 
 	// some tests require an existing backup
 	sel := selectors.NewOneDriveBackup(users)
-	sel.Include(sel.Folders(selectors.Any()))
+	sel.Include(selTD.OneDriveBackupFolderScope(sel))
 
 	backupOp, err := suite.repo.NewBackupWithLookup(ctx, sel.Selector, ins)
 	require.NoError(t, err, clues.ToCore(err))

--- a/src/internal/connector/data_collections_test.go
+++ b/src/internal/connector/data_collections_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
-	"github.com/alcionai/corso/src/pkg/selectors/testdata"
+	selTD "github.com/alcionai/corso/src/pkg/selectors/testdata"
 )
 
 // ---------------------------------------------------------------------------
@@ -160,7 +160,7 @@ func (suite *DataCollectionIntgSuite) TestDataCollections_invalidResourceOwner()
 			name: "Invalid onedrive backup user",
 			getSelector: func(t *testing.T) selectors.Selector {
 				sel := selectors.NewOneDriveBackup(owners)
-				sel.Include(sel.Folders(selectors.Any()))
+				sel.Include(selTD.OneDriveBackupFolderScope(sel))
 				return sel.Selector
 			},
 		},
@@ -168,7 +168,7 @@ func (suite *DataCollectionIntgSuite) TestDataCollections_invalidResourceOwner()
 			name: "Invalid sharepoint backup site",
 			getSelector: func(t *testing.T) selectors.Selector {
 				sel := selectors.NewSharePointBackup(owners)
-				sel.Include(testdata.SharePointBackupFolderScope(sel))
+				sel.Include(selTD.SharePointBackupFolderScope(sel))
 				return sel.Selector
 			},
 		},
@@ -185,7 +185,7 @@ func (suite *DataCollectionIntgSuite) TestDataCollections_invalidResourceOwner()
 			name: "missing onedrive backup user",
 			getSelector: func(t *testing.T) selectors.Selector {
 				sel := selectors.NewOneDriveBackup(owners)
-				sel.Include(sel.Folders(selectors.Any()))
+				sel.Include(selTD.OneDriveBackupFolderScope(sel))
 				sel.DiscreteOwner = ""
 				return sel.Selector
 			},
@@ -194,7 +194,7 @@ func (suite *DataCollectionIntgSuite) TestDataCollections_invalidResourceOwner()
 			name: "missing sharepoint backup site",
 			getSelector: func(t *testing.T) selectors.Selector {
 				sel := selectors.NewSharePointBackup(owners)
-				sel.Include(testdata.SharePointBackupFolderScope(sel))
+				sel.Include(selTD.SharePointBackupFolderScope(sel))
 				sel.DiscreteOwner = ""
 				return sel.Selector
 			},
@@ -239,7 +239,7 @@ func (suite *DataCollectionIntgSuite) TestSharePointDataCollection() {
 			name: "Libraries",
 			getSelector: func() selectors.Selector {
 				sel := selectors.NewSharePointBackup(selSites)
-				sel.Include(testdata.SharePointBackupFolderScope(sel))
+				sel.Include(selTD.SharePointBackupFolderScope(sel))
 				return sel.Selector
 			},
 		},

--- a/src/internal/connector/graph_connector_disconnected_test.go
+++ b/src/internal/connector/graph_connector_disconnected_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alcionai/corso/src/internal/connector/support"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/selectors"
+	selTD "github.com/alcionai/corso/src/pkg/selectors/testdata"
 )
 
 // ---------------------------------------------------------------
@@ -82,19 +83,19 @@ func (suite *DisconnectedGraphConnectorSuite) TestVerifyBackupInputs_allServices
 			checkError: assert.NoError,
 			excludes: func(t *testing.T) selectors.Selector {
 				sel := selectors.NewOneDriveBackup([]string{"elliotReid@someHospital.org", "foo@SomeCompany.org"})
-				sel.Exclude(sel.Folders(selectors.Any()))
+				sel.Exclude(selTD.OneDriveBackupFolderScope(sel))
 				sel.DiscreteOwner = "elliotReid@someHospital.org"
 				return sel.Selector
 			},
 			filters: func(t *testing.T) selectors.Selector {
 				sel := selectors.NewOneDriveBackup([]string{"elliotReid@someHospital.org", "foo@SomeCompany.org"})
-				sel.Filter(sel.Folders(selectors.Any()))
+				sel.Filter(selTD.OneDriveBackupFolderScope(sel))
 				sel.DiscreteOwner = "elliotReid@someHospital.org"
 				return sel.Selector
 			},
 			includes: func(t *testing.T) selectors.Selector {
 				sel := selectors.NewOneDriveBackup([]string{"elliotReid@someHospital.org", "foo@SomeCompany.org"})
-				sel.Include(sel.Folders(selectors.Any()))
+				sel.Include(selTD.OneDriveBackupFolderScope(sel))
 				sel.DiscreteOwner = "elliotReid@someHospital.org"
 				return sel.Selector
 			},
@@ -104,17 +105,17 @@ func (suite *DisconnectedGraphConnectorSuite) TestVerifyBackupInputs_allServices
 			checkError: assert.NoError,
 			excludes: func(t *testing.T) selectors.Selector {
 				sel := selectors.NewOneDriveBackup([]string{"foo@SomeCompany.org"})
-				sel.Exclude(sel.Folders(selectors.Any()))
+				sel.Exclude(selTD.OneDriveBackupFolderScope(sel))
 				return sel.Selector
 			},
 			filters: func(t *testing.T) selectors.Selector {
 				sel := selectors.NewOneDriveBackup([]string{"foo@SomeCompany.org"})
-				sel.Filter(sel.Folders(selectors.Any()))
+				sel.Filter(selTD.OneDriveBackupFolderScope(sel))
 				return sel.Selector
 			},
 			includes: func(t *testing.T) selectors.Selector {
 				sel := selectors.NewOneDriveBackup([]string{"foo@SomeCompany.org"})
-				sel.Include(sel.Folders(selectors.Any()))
+				sel.Include(selTD.OneDriveBackupFolderScope(sel))
 				return sel.Selector
 			},
 		},

--- a/src/internal/connector/graph_connector_helper_test.go
+++ b/src/internal/connector/graph_connector_helper_test.go
@@ -1099,7 +1099,7 @@ func makeSharePointBackupSel(
 }
 
 // backupSelectorForExpected creates a selector that can be used to backup the
-// given items in expected based on the item paths. Fails the test if items from
+// given dests based on the item paths. Fails the test if items from
 // multiple services are in expected.
 func backupSelectorForExpected(
 	t *testing.T,

--- a/src/internal/connector/graph_connector_test.go
+++ b/src/internal/connector/graph_connector_test.go
@@ -1214,9 +1214,7 @@ func (suite *GraphConnectorIntegrationSuite) TestBackup_CreatesPrefixCollections
 			resource: Users,
 			selectorFunc: func(t *testing.T) selectors.Selector {
 				sel := selectors.NewOneDriveBackup([]string{suite.user})
-				sel.Include(
-					sel.Folders([]string{selectors.NoneTgt}),
-				)
+				sel.Include(sel.Folders([]string{selectors.NoneTgt}))
 
 				return sel.Selector
 			},

--- a/src/internal/connector/onedrive/drive_test.go
+++ b/src/internal/connector/onedrive/drive_test.go
@@ -279,24 +279,24 @@ func (suite *OneDriveUnitSuite) TestDrives() {
 
 // Integration tests
 
-type OneDriveSuite struct {
+type OneDriveIntgSuite struct {
 	tester.Suite
 	userID string
 }
 
 func TestOneDriveSuite(t *testing.T) {
-	suite.Run(t, &OneDriveSuite{
+	suite.Run(t, &OneDriveIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
 			[][]string{tester.M365AcctCredEnvs}),
 	})
 }
 
-func (suite *OneDriveSuite) SetupSuite() {
+func (suite *OneDriveIntgSuite) SetupSuite() {
 	suite.userID = tester.SecondaryM365UserID(suite.T())
 }
 
-func (suite *OneDriveSuite) TestCreateGetDeleteFolder() {
+func (suite *OneDriveIntgSuite) TestCreateGetDeleteFolder() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 
@@ -401,7 +401,7 @@ func (fm testFolderMatcher) Matches(p string) bool {
 	return fm.scope.Matches(selectors.OneDriveFolder, p)
 }
 
-func (suite *OneDriveSuite) TestOneDriveNewCollections() {
+func (suite *OneDriveIntgSuite) TestOneDriveNewCollections() {
 	creds, err := tester.NewM365Account(suite.T()).M365Config()
 	require.NoError(suite.T(), err, clues.ToCore(err))
 

--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -154,10 +154,6 @@ func (suite *ItemIntegrationSuite) TestItemWriter() {
 			root, err := srv.Client().DrivesById(test.driveID).Root().Get(ctx, nil)
 			require.NoError(t, err, clues.ToCore(err))
 
-			// Test Requirement 2: "Test Folder" should exist
-			folder, err := api.GetFolderByName(ctx, srv, test.driveID, ptr.Val(root.GetId()), "Test Folder")
-			require.NoError(t, err, clues.ToCore(err))
-
 			newFolderName := tester.DefaultTestRestoreDestination("folder").ContainerName
 			t.Logf("creating folder %s", newFolderName)
 
@@ -165,7 +161,7 @@ func (suite *ItemIntegrationSuite) TestItemWriter() {
 				ctx,
 				srv,
 				test.driveID,
-				ptr.Val(folder.GetId()),
+				ptr.Val(root.GetId()),
 				newItem(newFolderName, true))
 			require.NoError(t, err, clues.ToCore(err))
 			require.NotNil(t, newFolder.GetId())

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -46,7 +46,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
-	"github.com/alcionai/corso/src/pkg/selectors/testdata"
+	selTD "github.com/alcionai/corso/src/pkg/selectors/testdata"
 	"github.com/alcionai/corso/src/pkg/store"
 )
 
@@ -1134,7 +1134,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDrive() {
 		osel       = selectors.NewOneDriveBackup([]string{m365UserID})
 	)
 
-	osel.Include(osel.AllData())
+	osel.Include(selTD.OneDriveBackupFolderScope(osel))
 
 	bo, _, _, _, _, _, closer := prepNewTestBackupOp(t, ctx, mb, osel.Selector, control.Toggles{}, version.Backup)
 	defer closer()
@@ -1692,7 +1692,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveOwnerMigration() {
 	uname := ptr.Val(userable.GetUserPrincipalName())
 
 	oldsel := selectors.NewOneDriveBackup([]string{uname})
-	oldsel.Include(oldsel.Folders([]string{"test"}, selectors.ExactMatch()))
+	oldsel.Include(selTD.OneDriveBackupFolderScope(oldsel))
 
 	bo, _, kw, ms, gc, sel, closer := prepNewTestBackupOp(t, ctx, mb, oldsel.Selector, ffs, 0)
 	defer closer()
@@ -1714,7 +1714,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveOwnerMigration() {
 	runAndCheckBackup(t, ctx, &bo, mb, false)
 
 	newsel := selectors.NewOneDriveBackup([]string{uid})
-	newsel.Include(newsel.Folders([]string{"test"}, selectors.ExactMatch()))
+	newsel.Include(selTD.OneDriveBackupFolderScope(newsel))
 	sel = newsel.SetDiscreteOwnerIDName(uid, uname)
 
 	var (
@@ -1793,7 +1793,7 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_sharePoint() {
 		sel = selectors.NewSharePointBackup([]string{suite.site})
 	)
 
-	sel.Include(testdata.SharePointBackupFolderScope(sel))
+	sel.Include(selTD.SharePointBackupFolderScope(sel))
 
 	bo, _, kw, _, _, sels, closer := prepNewTestBackupOp(t, ctx, mb, sel.Selector, control.Toggles{}, version.Backup)
 	defer closer()

--- a/src/pkg/repository/loadtest/repository_load_test.go
+++ b/src/pkg/repository/loadtest/repository_load_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/repository"
 	"github.com/alcionai/corso/src/pkg/selectors"
+	selTD "github.com/alcionai/corso/src/pkg/selectors/testdata"
 	"github.com/alcionai/corso/src/pkg/storage"
 )
 
@@ -541,7 +542,7 @@ func (suite *LoadOneDriveSuite) TestOneDrive() {
 	defer flush()
 
 	bsel := selectors.NewOneDriveBackup(suite.usersUnderTest)
-	bsel.Include(bsel.AllData())
+	bsel.Include(selTD.OneDriveBackupFolderScope(bsel))
 	sel := bsel.Selector
 
 	runLoadTest(
@@ -588,7 +589,7 @@ func (suite *IndividualLoadOneDriveSuite) TestOneDrive() {
 	defer flush()
 
 	bsel := selectors.NewOneDriveBackup(suite.usersUnderTest)
-	bsel.Include(bsel.AllData())
+	bsel.Include(selTD.OneDriveBackupFolderScope(bsel))
 	sel := bsel.Selector
 
 	runLoadTest(

--- a/src/pkg/selectors/testdata/onedrive.go
+++ b/src/pkg/selectors/testdata/onedrive.go
@@ -1,0 +1,9 @@
+package testdata
+
+import "github.com/alcionai/corso/src/pkg/selectors"
+
+// OneDriveBackupFolderScope is the standard folder scope that should be used
+// in integration backups with onedrive.
+func OneDriveBackupFolderScope(sel *selectors.OneDriveBackup) []selectors.OneDriveScope {
+	return sel.Folders([]string{"test"}, selectors.PrefixMatch())
+}


### PR DESCRIPTION
Updates onedrive backup selectors to look for a specifc folder (named "test") within the onedrive user's root drive.  All onedrive tests which back up data should utilize this constraint in order to minimize data production.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Supportability/Tests

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
