### PR TITLE
Switch to folder IDs in Exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OneDrive backups no longer include a user's non-default drives.
 - OneDrive and SharePoint file downloads will properly redirect from 3xx responses.
 - Refined oneDrive rate limiter controls to reduce throttling errors.
+- Fix handling of duplicate folders at the same hierarchy level in Exchange. Duplicate folders will be merged during restore operations.
+
+### Known Issues
+- Restore operations will merge duplicate Exchange folders at the same hierarchy level into a single folder.
 
 ## [v0.7.0] (beta) - 2023-05-02
 

--- a/src/internal/connector/exchange/data_collections_test.go
+++ b/src/internal/connector/exchange/data_collections_test.go
@@ -282,9 +282,18 @@ func (suite *DataCollectionsIntegrationSuite) TestMailFetch() {
 				}
 
 				require.NotEmpty(t, c.FullPath().Folder(false))
-				folder := c.FullPath().Folder(false)
 
-				delete(test.folderNames, folder)
+				// TODO(ashmrtn): Remove when LocationPath is made part of BackupCollection
+				// interface.
+				if !assert.Implements(t, (*data.LocationPather)(nil), c) {
+					continue
+				}
+
+				loc := c.(data.LocationPather).LocationPath().String()
+
+				require.NotEmpty(t, loc)
+
+				delete(test.folderNames, loc)
 			}
 
 			assert.Empty(t, test.folderNames)
@@ -525,7 +534,16 @@ func (suite *DataCollectionsIntegrationSuite) TestContactSerializationRegression
 					continue
 				}
 
-				assert.Equal(t, edc.FullPath().Folder(false), DefaultContactFolder)
+				// TODO(ashmrtn): Remove when LocationPath is made part of BackupCollection
+				// interface.
+				if !assert.Implements(t, (*data.LocationPather)(nil), edc) {
+					continue
+				}
+
+				assert.Equal(
+					t,
+					edc.(data.LocationPather).LocationPath().String(),
+					DefaultContactFolder)
 				assert.NotZero(t, count)
 			}
 

--- a/src/internal/connector/exchange/service_functions.go
+++ b/src/internal/connector/exchange/service_functions.go
@@ -137,21 +137,15 @@ func includeContainer(
 		directory = locPath.Folder(false)
 	}
 
-	var (
-		ok      bool
-		pathRes path.Path
-	)
+	var ok bool
 
 	switch category {
 	case path.EmailCategory:
 		ok = scope.Matches(selectors.ExchangeMailFolder, directory)
-		pathRes = locPath
 	case path.ContactsCategory:
 		ok = scope.Matches(selectors.ExchangeContactFolder, directory)
-		pathRes = locPath
 	case path.EventsCategory:
 		ok = scope.Matches(selectors.ExchangeEventCalendar, directory)
-		pathRes = dirPath
 	default:
 		return nil, nil, false
 	}
@@ -162,5 +156,5 @@ func includeContainer(
 		"matches_input", directory,
 	).Debug("backup folder selection filter")
 
-	return pathRes, loc, ok
+	return dirPath, loc, ok
 }

--- a/src/internal/connector/exchange/service_iterators.go
+++ b/src/internal/connector/exchange/service_iterators.go
@@ -56,10 +56,6 @@ func filterContainersAndFillCollections(
 		// deleted from this map, leaving only the deleted folders behind
 		tombstones = makeTombstones(dps)
 		category   = qp.Category
-
-		// Stop-gap: Track folders by LocationPath and if there's duplicates pick
-		// the one with the lexicographically larger ID.
-		dupPaths = map[string]string{}
 	)
 
 	logger.Ctx(ctx).Infow("filling collections", "len_deltapaths", len(dps))
@@ -107,53 +103,6 @@ func filterContainersAndFillCollections(
 		if !ok {
 			continue
 		}
-
-		// This is a duplicate collection. Either the collection we're examining now
-		// should be skipped or the collection we previously added should be
-		// skipped.
-		//
-		// Calendars is already using folder IDs so we don't need to pick the
-		// "newest" folder for that.
-		if oldCID := dupPaths[locPath.String()]; category != path.EventsCategory && len(oldCID) > 0 {
-			if cID < oldCID {
-				logger.Ctx(ictx).Infow(
-					"skipping duplicate folder with lesser ID",
-					"previous_folder_id", clues.Hide(oldCID),
-					"current_folder_id", clues.Hide(cID),
-					"duplicate_path", locPath)
-
-				// Readd this entry to the tombstone map because we remove it first off.
-				if oldDP, ok := dps[cID]; ok {
-					tombstones[cID] = oldDP.path
-				}
-
-				// Continuing here ensures we don't add anything to the paths map or the
-				// delta map which is the behavior we want.
-				continue
-			}
-
-			logger.Ctx(ictx).Infow(
-				"switching duplicate folders as newer folder found",
-				"previous_folder_id", clues.Hide(oldCID),
-				"current_folder_id", clues.Hide(cID),
-				"duplicate_path", locPath)
-
-			// Remove the previous collection from the maps. This will make us think
-			// it's a new item and properly populate it if it ever:
-			//   * moves
-			//   * replaces the current entry (current entry moves/is deleted)
-			delete(collections, oldCID)
-			delete(deltaURLs, oldCID)
-			delete(currPaths, oldCID)
-
-			// Re-add the tombstone entry for the old folder so that it can be marked
-			// as deleted if need.
-			if oldDP, ok := dps[oldCID]; ok {
-				tombstones[oldCID] = oldDP.path
-			}
-		}
-
-		dupPaths[locPath.String()] = cID
 
 		if len(prevPathStr) > 0 {
 			if prevPath, err = pathFromPrevString(prevPathStr); err != nil {

--- a/src/internal/connector/exchange/service_iterators_test.go
+++ b/src/internal/connector/exchange/service_iterators_test.go
@@ -384,6 +384,7 @@ func (suite *ServiceIteratorsSuite) TestFilterContainersAndFillCollections_Dupli
 			ResourceOwner: inMock.NewProvider("user_id", "user_name"),
 			Credentials:   suite.creds,
 		}
+
 		statusUpdater = func(*support.ConnectorOperationStatus) {}
 
 		dataTypes = []scopeCat{

--- a/src/internal/connector/graph_connector_helper_test.go
+++ b/src/internal/connector/graph_connector_helper_test.go
@@ -934,7 +934,7 @@ func checkHasCollections(
 				continue
 			}
 
-			loc = path.FormatDriveFolders(dp.DriveID, loc.Elements()...)
+			loc = path.BuildDriveLocation(dp.DriveID, loc.Elements()...)
 		}
 
 		p, err := loc.ToDataLayerPath(

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -1110,8 +1110,10 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_incrementalExchange() {
 					}
 				}
 			},
-			itemsRead:    0, // containers are not counted as reads
-			itemsWritten: 4, // two items per category
+			itemsRead: 0, // containers are not counted as reads
+			// Renaming a folder doesn't cause kopia changes as the folder ID doesn't
+			// change.
+			itemsWritten: 0,
 		},
 		{
 			name: "add a new item",


### PR DESCRIPTION
Store all folders from Exchange by folder ID
in kopia. Remove the old duplicate folder
name stop-gap measure as well since it's no
longer required

Update tests to check LocationPath instead
of FullPath since LocationPath still has
display name info

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* closes #3197

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
