### PR TITLE
Combine collection structs

### DIFF
--- a/src/internal/connector/graph/collections.go
+++ b/src/internal/connector/graph/collections.go
@@ -13,9 +13,14 @@ import (
 
 var _ data.BackupCollection = emptyCollection{}
 
+// TODO: move this out of graph.  /data would be a much better owner
+// for a generic struct like this.  However, support.StatusUpdater makes
+// it difficult to extract from this package in a generic way.
 type emptyCollection struct {
-	p  path.Path
-	su support.StatusUpdater
+	full  path.Path
+	prev  path.Path
+	su    support.StatusUpdater
+	state data.CollectionState
 }
 
 func (c emptyCollection) Items(ctx context.Context, _ *fault.Bus) <-chan data.Stream {
@@ -29,17 +34,15 @@ func (c emptyCollection) Items(ctx context.Context, _ *fault.Bus) <-chan data.St
 }
 
 func (c emptyCollection) FullPath() path.Path {
-	return c.p
+	return c.full
 }
 
 func (c emptyCollection) PreviousPath() path.Path {
-	return c.p
+	return c.prev
 }
 
 func (c emptyCollection) State() data.CollectionState {
-	// This assumes we won't change the prefix path. Could probably use MovedState
-	// as well if we do need to change things around.
-	return data.NotMovedState
+	return c.state
 }
 
 func (c emptyCollection) DoNotMergeItems() bool {
@@ -76,7 +79,7 @@ func BaseCollections(
 	for cat := range categories {
 		ictx := clues.Add(ctx, "base_service", service, "base_category", cat)
 
-		p, err := path.ServicePrefix(tenant, rOwner, service, cat)
+		full, err := path.ServicePrefix(tenant, rOwner, service, cat)
 		if err != nil {
 			// Shouldn't happen.
 			err = clues.Wrap(err, "making path").WithClues(ictx)
@@ -87,8 +90,13 @@ func BaseCollections(
 		}
 
 		// only add this collection if it doesn't already exist in the set.
-		if _, ok := collKeys[p.String()]; !ok {
-			res = append(res, emptyCollection{p: p, su: su})
+		if _, ok := collKeys[full.String()]; !ok {
+			res = append(res, &emptyCollection{
+				prev:  full,
+				full:  full,
+				su:    su,
+				state: data.StateOf(full, full),
+			})
 		}
 	}
 
@@ -99,45 +107,8 @@ func BaseCollections(
 // prefix migration
 // ---------------------------------------------------------------------------
 
-var _ data.BackupCollection = prefixCollection{}
-
-// TODO: move this out of graph.  /data would be a much better owner
-// for a generic struct like this.  However, support.StatusUpdater makes
-// it difficult to extract from this package in a generic way.
-type prefixCollection struct {
-	full, prev path.Path
-	su         support.StatusUpdater
-	state      data.CollectionState
-}
-
-func (c prefixCollection) Items(ctx context.Context, _ *fault.Bus) <-chan data.Stream {
-	res := make(chan data.Stream)
-	close(res)
-
-	s := support.CreateStatus(ctx, support.Backup, 0, support.CollectionMetrics{}, "")
-	c.su(s)
-
-	return res
-}
-
-func (c prefixCollection) FullPath() path.Path {
-	return c.full
-}
-
-func (c prefixCollection) PreviousPath() path.Path {
-	return c.prev
-}
-
-func (c prefixCollection) State() data.CollectionState {
-	return c.state
-}
-
-func (c prefixCollection) DoNotMergeItems() bool {
-	return false
-}
-
 // Creates a new collection that only handles prefix pathing.
-func NewPrefixCollection(prev, full path.Path, su support.StatusUpdater) (*prefixCollection, error) {
+func NewPrefixCollection(prev, full path.Path, su support.StatusUpdater) (*emptyCollection, error) {
 	if prev != nil {
 		if len(prev.Item()) > 0 {
 			return nil, clues.New("prefix collection previous path contains an item")
@@ -158,7 +129,7 @@ func NewPrefixCollection(prev, full path.Path, su support.StatusUpdater) (*prefi
 		}
 	}
 
-	pc := &prefixCollection{
+	pc := &emptyCollection{
 		prev:  prev,
 		full:  full,
 		su:    su,


### PR DESCRIPTION
They both implement the same underlying functionality, just in slightly different ways. Combine them so there's less code duplication.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
