### PR TITLE
insert restoreEnd event into deferred func

### DIFF
--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -140,6 +140,25 @@ func (op *RestoreOperation) Run(ctx context.Context) (restoreDetails *details.De
 		"service", op.Selectors.Service,
 		"destination_container", clues.Hide(op.Destination.ContainerName))
 
+	defer func() {
+		op.bus.Event(
+			ctx,
+			events.RestoreEnd,
+			map[string]any{
+				events.BackupID:      op.BackupID,
+				events.DataRetrieved: op.Results.BytesRead,
+				events.Duration:      op.Results.CompletedAt.Sub(op.Results.StartedAt),
+				events.EndTime:       dttm.Format(op.Results.CompletedAt),
+				events.ItemsRead:     op.Results.ItemsRead,
+				events.ItemsWritten:  op.Results.ItemsWritten,
+				events.Resources:     op.Results.ResourceOwners,
+				events.RestoreID:     opStats.restoreID,
+				events.Service:       op.Selectors.Service.String(),
+				events.StartTime:     dttm.Format(op.Results.StartedAt),
+				events.Status:        op.Status.String(),
+			})
+	}()
+
 	// -----
 	// Execution
 	// -----
@@ -282,24 +301,6 @@ func (op *RestoreOperation) persistResults(
 	}
 
 	op.Results.ItemsWritten = opStats.gc.Successes
-
-	op.bus.Event(
-		ctx,
-		events.RestoreEnd,
-		map[string]any{
-			events.BackupID:      op.BackupID,
-			events.DataRetrieved: op.Results.BytesRead,
-			events.Duration:      op.Results.CompletedAt.Sub(op.Results.StartedAt),
-			events.EndTime:       dttm.Format(op.Results.CompletedAt),
-			events.ItemsRead:     op.Results.ItemsRead,
-			events.ItemsWritten:  op.Results.ItemsWritten,
-			events.Resources:     op.Results.ResourceOwners,
-			events.RestoreID:     opStats.restoreID,
-			events.Service:       op.Selectors.Service.String(),
-			events.StartTime:     dttm.Format(op.Results.StartedAt),
-			events.Status:        op.Status.String(),
-		},
-	)
 
 	return op.Errors.Failure()
 }

--- a/src/internal/operations/restore_test.go
+++ b/src/internal/operations/restore_test.go
@@ -458,7 +458,7 @@ func (suite *RestoreOpIntegrationSuite) TestRestore_Run() {
 	}
 }
 
-func (suite *RestoreOpIntegrationSuite) TestRestore_Run_errorNoResults() {
+func (suite *RestoreOpIntegrationSuite) TestRestore_Run_errorNoBackup() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 
@@ -495,6 +495,7 @@ func (suite *RestoreOpIntegrationSuite) TestRestore_Run_errorNoResults() {
 	require.Nil(t, ds, "restoreOp.Run() should not produce details")
 	assert.Zero(t, ro.Results.ResourceOwners, "resource owners")
 	assert.Zero(t, ro.Results.BytesRead, "bytes read")
-	assert.Zero(t, mb.TimesCalled[events.RestoreStart], "restore-start events")
-	assert.Zero(t, mb.TimesCalled[events.RestoreEnd], "restore-end events")
+	// no restore start, because we'd need to find the backup first.
+	assert.Equal(t, 0, mb.TimesCalled[events.RestoreStart], "restore-start events")
+	assert.Equal(t, 1, mb.TimesCalled[events.RestoreEnd], "restore-end events")
 }


### PR DESCRIPTION
move the end-of-op notification event to a defer within backup/restore.Do(). This ensures we'll get the end event data even in case of failure.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix
- [x] :robot: Supportability/Tests

#### Issue(s)

* #3388

#### Test Plan
