### PR TITLE
customize tcp handshake timeouts

### DIFF
--- a/src/internal/connector/graph/http_wrapper.go
+++ b/src/internal/connector/graph/http_wrapper.go
@@ -37,7 +37,7 @@ func NewHTTPWrapper(opts ...Option) *httpWrapper {
 		rt = customTransport{
 			n: pipeline{
 				middlewares: internalMiddleware(cc),
-				transport:   defaultTransport(),
+				transport:   defaultHttpTransport(),
 			},
 		}
 		redirect = func(req *http.Request, via []*http.Request) error {
@@ -130,13 +130,6 @@ func (pl pipeline) Next(req *http.Request, idx int) (*http.Response, error) {
 	}
 
 	return pl.transport.RoundTrip(req)
-}
-
-func defaultTransport() http.RoundTripper {
-	defaultTransport := http.DefaultTransport.(*http.Transport).Clone()
-	defaultTransport.ForceAttemptHTTP2 = true
-
-	return defaultTransport
 }
 
 func internalMiddleware(cc *clientConfig) []khttp.Middleware {


### PR DESCRIPTION
shot in the dark at avoiding tcp read timeouts by
extending the tcp dialer and tls handshake timeouts in the graph client transport.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
