### PR TITLE
Convert PageLinker to DeltaPageLinker for NonDelta pagers

### DIFF
--- a/src/internal/connector/exchange/api/contacts.go
+++ b/src/internal/connector/exchange/api/contacts.go
@@ -222,13 +222,13 @@ func NewContactPager(
 	return &contactPager{gs, builder, options}, nil
 }
 
-func (p *contactPager) getPage(ctx context.Context) (api.PageLinker, error) {
+func (p *contactPager) getPage(ctx context.Context) (api.DeltaPageLinker, error) {
 	resp, err := p.builder.Get(ctx, p.options)
 	if err != nil {
 		return nil, graph.Stack(ctx, err)
 	}
 
-	return resp, nil
+	return api.EmptyDeltaLinker[models.Contactable](resp), nil
 }
 
 func (p *contactPager) setNext(nextLink string) {
@@ -301,7 +301,7 @@ func NewContactDeltaPager(
 	return &contactDeltaPager{gs, user, directoryID, builder, options}, nil
 }
 
-func (p *contactDeltaPager) getPage(ctx context.Context) (api.PageLinker, error) {
+func (p *contactDeltaPager) getPage(ctx context.Context) (api.DeltaPageLinker, error) {
 	resp, err := p.builder.Get(ctx, p.options)
 	if err != nil {
 		return nil, graph.Stack(ctx, err)

--- a/src/internal/connector/exchange/api/contacts.go
+++ b/src/internal/connector/exchange/api/contacts.go
@@ -228,7 +228,7 @@ func (p *contactPager) getPage(ctx context.Context) (api.DeltaPageLinker, error)
 		return nil, graph.Stack(ctx, err)
 	}
 
-	return api.EmptyDeltaLinker[models.Contactable](resp), nil
+	return api.EmptyDeltaLinker[models.Contactable]{PageLinkValuer: resp}, nil
 }
 
 func (p *contactPager) setNext(nextLink string) {

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -289,7 +289,7 @@ func (p *eventPager) getPage(ctx context.Context) (api.DeltaPageLinker, error) {
 		return nil, graph.Stack(ctx, err)
 	}
 
-	return api.EmptyDeltaLinker[models.Eventable](resp), nil
+	return api.EmptyDeltaLinker[models.Eventable]{PageLinkValuer: resp}, nil
 }
 
 func (p *eventPager) setNext(nextLink string) {

--- a/src/internal/connector/exchange/api/events.go
+++ b/src/internal/connector/exchange/api/events.go
@@ -283,13 +283,13 @@ func NewEventPager(
 	return &eventPager{gs, builder, options}, nil
 }
 
-func (p *eventPager) getPage(ctx context.Context) (api.PageLinker, error) {
+func (p *eventPager) getPage(ctx context.Context) (api.DeltaPageLinker, error) {
 	resp, err := p.builder.Get(ctx, p.options)
 	if err != nil {
 		return nil, graph.Stack(ctx, err)
 	}
 
-	return resp, nil
+	return api.EmptyDeltaLinker[models.Eventable](resp), nil
 }
 
 func (p *eventPager) setNext(nextLink string) {
@@ -359,7 +359,7 @@ func getEventDeltaBuilder(
 	return builder
 }
 
-func (p *eventDeltaPager) getPage(ctx context.Context) (api.PageLinker, error) {
+func (p *eventDeltaPager) getPage(ctx context.Context) (api.DeltaPageLinker, error) {
 	resp, err := p.builder.Get(ctx, p.options)
 	if err != nil {
 		return nil, graph.Stack(ctx, err)

--- a/src/internal/connector/exchange/api/mail.go
+++ b/src/internal/connector/exchange/api/mail.go
@@ -385,13 +385,13 @@ func NewMailPager(
 	return &mailPager{gs, builder, options}, nil
 }
 
-func (p *mailPager) getPage(ctx context.Context) (api.PageLinker, error) {
+func (p *mailPager) getPage(ctx context.Context) (api.DeltaPageLinker, error) {
 	page, err := p.builder.Get(ctx, p.options)
 	if err != nil {
 		return nil, graph.Stack(ctx, err)
 	}
 
-	return page, nil
+	return api.EmptyDeltaLinker[models.Messageable](page), nil
 }
 
 func (p *mailPager) setNext(nextLink string) {
@@ -465,7 +465,7 @@ func NewMailDeltaPager(
 	return &mailDeltaPager{gs, user, directoryID, builder, options}, nil
 }
 
-func (p *mailDeltaPager) getPage(ctx context.Context) (api.PageLinker, error) {
+func (p *mailDeltaPager) getPage(ctx context.Context) (api.DeltaPageLinker, error) {
 	page, err := p.builder.Get(ctx, p.options)
 	if err != nil {
 		return nil, graph.Stack(ctx, err)

--- a/src/internal/connector/exchange/api/mail.go
+++ b/src/internal/connector/exchange/api/mail.go
@@ -391,7 +391,7 @@ func (p *mailPager) getPage(ctx context.Context) (api.DeltaPageLinker, error) {
 		return nil, graph.Stack(ctx, err)
 	}
 
-	return api.EmptyDeltaLinker[models.Messageable](page), nil
+	return api.EmptyDeltaLinker[models.Messageable]{PageLinkValuer: page}, nil
 }
 
 func (p *mailPager) setNext(nextLink string) {

--- a/src/internal/connector/exchange/api/shared.go
+++ b/src/internal/connector/exchange/api/shared.go
@@ -18,7 +18,7 @@ import (
 
 type itemPager interface {
 	// getPage get a page with the specified options from graph
-	getPage(context.Context) (api.PageLinker, error)
+	getPage(context.Context) (api.DeltaPageLinker, error)
 	// setNext is used to pass in the next url got from graph
 	setNext(string)
 	// reset is used to clear delta url in delta pagers. When
@@ -119,8 +119,6 @@ func getItemsAddedAndRemovedFromContainer(
 		addedIDs   = []string{}
 		removedIDs = []string{}
 		deltaURL   string
-		nextLink   string
-		deltaLink  string
 	)
 
 	itemCount := 0
@@ -160,13 +158,7 @@ func getItemsAddedAndRemovedFromContainer(
 			}
 		}
 
-		dresp, ok := resp.(api.DeltaPageLinker)
-		if ok {
-			nextLink, deltaLink = api.NextAndDeltaLink(dresp)
-		} else {
-			nextLink = api.NextLink(resp)
-			deltaLink = "" // to make sure we don't use an old value
-		}
+		nextLink, deltaLink := api.NextAndDeltaLink(resp)
 
 		// the deltaLink is kind of like a cursor for overall data state.
 		// once we run through pages of nextLinks, the last query will

--- a/src/internal/connector/exchange/api/shared_test.go
+++ b/src/internal/connector/exchange/api/shared_test.go
@@ -35,6 +35,11 @@ func (p testPage) GetOdataNextLink() *string {
 	return &next
 }
 
+func (p testPage) GetOdataDeltaLink() *string {
+	delta := "" // delta is not tested here
+	return &delta
+}
+
 var _ itemPager = &testPager{}
 
 type testPager struct {
@@ -45,7 +50,7 @@ type testPager struct {
 	needsReset bool
 }
 
-func (p *testPager) getPage(ctx context.Context) (api.PageLinker, error) {
+func (p *testPager) getPage(ctx context.Context) (api.DeltaPageLinker, error) {
 	if p.errorCode != "" {
 		ierr := odataerrors.NewMainError()
 		ierr.SetCode(&p.errorCode)

--- a/src/internal/connector/exchange/api/shared_test.go
+++ b/src/internal/connector/exchange/api/shared_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/graph/api"
 	"github.com/alcionai/corso/src/internal/tester"
@@ -31,13 +32,13 @@ func (v testPagerValue) GetAdditionalData() map[string]any {
 type testPage struct{}
 
 func (p testPage) GetOdataNextLink() *string {
-	next := "" // no next, just one page
-	return &next
+	// no next, just one page
+	return ptr.To("")
 }
 
 func (p testPage) GetOdataDeltaLink() *string {
-	delta := "" // delta is not tested here
-	return &delta
+	// delta is not tested here
+	return ptr.To("")
 }
 
 var _ itemPager = &testPager{}

--- a/src/internal/connector/graph/api/api.go
+++ b/src/internal/connector/graph/api/api.go
@@ -37,20 +37,15 @@ type PageLinkValuer[T any] interface {
 	Valuer[T]
 }
 
-// emptyDeltaLinker is used to convert PageLinker to DeltaPageLinker
-type emptyDeltaLinker[T any] struct {
+// EmptyDeltaLinker is used to convert PageLinker to DeltaPageLinker
+type EmptyDeltaLinker[T any] struct {
 	PageLinkValuer[T]
 }
 
-func (emptyDeltaLinker[T]) GetOdataDeltaLink() *string {
-	empty := ""
-	return &empty
+func (EmptyDeltaLinker[T]) GetOdataDeltaLink() *string {
+	return ptr.To("")
 }
 
-func EmptyDeltaLinker[T any](e PageLinkValuer[T]) emptyDeltaLinker[T] {
-	return emptyDeltaLinker[T]{e}
-}
-
-func (e emptyDeltaLinker[T]) GetValue() []T {
+func (e EmptyDeltaLinker[T]) GetValue() []T {
 	return e.PageLinkValuer.GetValue()
 }

--- a/src/internal/connector/graph/api/api.go
+++ b/src/internal/connector/graph/api/api.go
@@ -27,3 +27,30 @@ func NextLink(pl PageLinker) string {
 func NextAndDeltaLink(pl DeltaPageLinker) (string, string) {
 	return NextLink(pl), ptr.Val(pl.GetOdataDeltaLink())
 }
+
+type Valuer[T any] interface {
+	GetValue() []T
+}
+
+type PageLinkValuer[T any] interface {
+	PageLinker
+	Valuer[T]
+}
+
+// emptyDeltaLinker is used to convert PageLinker to DeltaPageLinker
+type emptyDeltaLinker[T any] struct {
+	PageLinkValuer[T]
+}
+
+func (emptyDeltaLinker[T]) GetOdataDeltaLink() *string {
+	empty := ""
+	return &empty
+}
+
+func EmptyDeltaLinker[T any](e PageLinkValuer[T]) emptyDeltaLinker[T] {
+	return emptyDeltaLinker[T]{e}
+}
+
+func (e emptyDeltaLinker[T]) GetValue() []T {
+	return e.PageLinkValuer.GetValue()
+}


### PR DESCRIPTION
This ensures that the interface for both Delta and NonDelta requests are the same and we don't have to cast the type before getting delta url from the returned object.

Follow up to https://github.com/alcionai/corso/pull/3212#discussion_r1191511216

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
