### PR TITLE
Fix font-override in blog and docs

### DIFF
--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -6,8 +6,8 @@ CUSTOM TO THE NEW HOME PAGE
 @import "icons.scss";
 @import url('https://fonts.googleapis.com/css2?family=Nunito&display=swap');
 
-* {
-  font-family: 'Nunito', sans-serif !important;
+:root {
+  --ifm-font-family-base: 'Nunito', sans-serif;
 }
 
 html {


### PR DESCRIPTION
This prevents it from overriding font for code blocks and helps retain monosapce font for them.

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
