### PR TITLE
move ad-hoc exchange graph calls to api, first pass

### DIFF
--- a/src/internal/connector/data_collections.go
+++ b/src/internal/connector/data_collections.go
@@ -233,7 +233,7 @@ func (gc *GraphConnector) ConsumeRestoreCollections(
 
 	switch sels.Service {
 	case selectors.ServiceExchange:
-		status, err = exchange.RestoreExchangeDataCollections(ctx, creds, gc.Service, dest, dcs, deets, errs)
+		status, err = exchange.RestoreCollections(ctx, creds, gc.Discovery, gc.Service, dest, dcs, deets, errs)
 	case selectors.ServiceOneDrive:
 		status, err = onedrive.RestoreCollections(ctx, creds, backupVersion, gc.Service, dest, opts, dcs, deets, errs)
 	case selectors.ServiceSharePoint:

--- a/src/internal/connector/exchange/restore_test.go
+++ b/src/internal/connector/exchange/restore_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
-type ExchangeRestoreSuite struct {
+type ExchangeRestoreIntgSuite struct {
 	tester.Suite
 	gs          graph.Servicer
 	credentials account.M365Config
@@ -28,7 +28,7 @@ type ExchangeRestoreSuite struct {
 }
 
 func TestExchangeRestoreSuite(t *testing.T) {
-	suite.Run(t, &ExchangeRestoreSuite{
+	suite.Run(t, &ExchangeRestoreIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
 			[][]string{tester.M365AcctCredEnvs},
@@ -36,7 +36,7 @@ func TestExchangeRestoreSuite(t *testing.T) {
 	})
 }
 
-func (suite *ExchangeRestoreSuite) SetupSuite() {
+func (suite *ExchangeRestoreIntgSuite) SetupSuite() {
 	t := suite.T()
 
 	a := tester.NewM365Account(t)
@@ -58,7 +58,7 @@ func (suite *ExchangeRestoreSuite) SetupSuite() {
 
 // TestRestoreContact ensures contact object can be created, placed into
 // the Corso Folder. The function handles test clean-up.
-func (suite *ExchangeRestoreSuite) TestRestoreContact() {
+func (suite *ExchangeRestoreIntgSuite) TestRestoreContact() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 
@@ -79,10 +79,10 @@ func (suite *ExchangeRestoreSuite) TestRestoreContact() {
 		assert.NoError(t, err, clues.ToCore(err))
 	}()
 
-	info, err := RestoreExchangeContact(
+	info, err := RestoreContact(
 		ctx,
 		exchMock.ContactBytes("Corso TestContact"),
-		suite.gs,
+		suite.ac.Contacts(),
 		control.Copy,
 		folderID,
 		userID)
@@ -92,7 +92,7 @@ func (suite *ExchangeRestoreSuite) TestRestoreContact() {
 
 // TestRestoreEvent verifies that event object is able to created
 // and sent into the test account of the Corso user in the newly created Corso Calendar
-func (suite *ExchangeRestoreSuite) TestRestoreEvent() {
+func (suite *ExchangeRestoreIntgSuite) TestRestoreEvent() {
 	ctx, flush := tester.NewContext()
 	defer flush()
 
@@ -134,9 +134,10 @@ func (suite *ExchangeRestoreSuite) TestRestoreEvent() {
 			ctx, flush := tester.NewContext()
 			defer flush()
 
-			info, err := RestoreExchangeEvent(
+			info, err := RestoreEvent(
 				ctx,
 				test.bytes,
+				suite.ac.Events(),
 				suite.gs,
 				control.Copy,
 				calendarID,
@@ -153,7 +154,7 @@ type containerDeleter interface {
 }
 
 // TestRestoreExchangeObject verifies path.Category usage for restored objects
-func (suite *ExchangeRestoreSuite) TestRestoreExchangeObject() {
+func (suite *ExchangeRestoreIntgSuite) TestRestoreExchangeObject() {
 	t := suite.T()
 	a := tester.NewM365Account(t)
 	m365, err := a.M365Config()
@@ -364,11 +365,12 @@ func (suite *ExchangeRestoreSuite) TestRestoreExchangeObject() {
 			defer flush()
 
 			destination := test.destination(t, ctx)
-			info, err := RestoreExchangeObject(
+			info, err := RestoreItem(
 				ctx,
 				test.bytes,
 				test.category,
 				control.Copy,
+				suite.ac,
 				service,
 				destination,
 				userID,

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -979,14 +979,7 @@ func testExchangeContinuousBackups(suite *BackupOpIntegrationSuite, toggles cont
 				body := users.NewItemMailFoldersItemMovePostRequestBody()
 				body.SetDestinationId(ptr.To(to.containerID))
 
-				_, err := gc.Service.
-					Client().
-					Users().
-					ByUserId(uidn.ID()).
-					MailFolders().
-					ByMailFolderId(from.containerID).
-					Move().
-					Post(ctx, body, nil)
+				err := ac.Mail().MoveContainer(ctx, uidn.ID(), from.containerID, body)
 				require.NoError(t, err, clues.ToCore(err))
 
 				newLoc := expectDeets.MoveLocation(cat.String(), from.locRef, to.locRef)
@@ -1079,7 +1072,6 @@ func testExchangeContinuousBackups(suite *BackupOpIntegrationSuite, toggles cont
 			name: "rename a folder",
 			updateUserData: func(t *testing.T) {
 				for category, d := range dataset {
-					cli := gc.Service.Client().Users().ByUserId(uidn.ID())
 					containerID := d.dests[container3].containerID
 					newLoc := containerRename
 
@@ -1099,34 +1091,28 @@ func testExchangeContinuousBackups(suite *BackupOpIntegrationSuite, toggles cont
 
 					switch category {
 					case path.EmailCategory:
-						cmf := cli.MailFolders().ByMailFolderId(containerID)
-
-						body, err := cmf.Get(ctx, nil)
-						require.NoError(t, err, "getting mail folder", clues.ToCore(err))
+						body, err := ac.Mail().GetFolder(ctx, uidn.ID(), containerID)
+						require.NoError(t, err, clues.ToCore(err))
 
 						body.SetDisplayName(&containerRename)
-						_, err = cmf.Patch(ctx, body, nil)
-						require.NoError(t, err, "updating mail folder name", clues.ToCore(err))
+						err = ac.Mail().PatchFolder(ctx, uidn.ID(), containerID, body)
+						require.NoError(t, err, clues.ToCore(err))
 
 					case path.ContactsCategory:
-						ccf := cli.ContactFolders().ByContactFolderId(containerID)
-
-						body, err := ccf.Get(ctx, nil)
-						require.NoError(t, err, "getting contact folder", clues.ToCore(err))
+						body, err := ac.Contacts().GetFolder(ctx, uidn.ID(), containerID)
+						require.NoError(t, err, clues.ToCore(err))
 
 						body.SetDisplayName(&containerRename)
-						_, err = ccf.Patch(ctx, body, nil)
-						require.NoError(t, err, "updating contact folder name", clues.ToCore(err))
+						err = ac.Contacts().PatchFolder(ctx, uidn.ID(), containerID, body)
+						require.NoError(t, err, clues.ToCore(err))
 
 					case path.EventsCategory:
-						cbi := cli.Calendars().ByCalendarId(containerID)
-
-						body, err := cbi.Get(ctx, nil)
-						require.NoError(t, err, "getting calendar", clues.ToCore(err))
+						body, err := ac.Events().GetCalendar(ctx, uidn.ID(), containerID)
+						require.NoError(t, err, clues.ToCore(err))
 
 						body.SetName(&containerRename)
-						_, err = cbi.Patch(ctx, body, nil)
-						require.NoError(t, err, "updating calendar name", clues.ToCore(err))
+						err = ac.Events().PatchCalendar(ctx, uidn.ID(), containerID, body)
+						require.NoError(t, err, clues.ToCore(err))
 					}
 				}
 			},
@@ -1142,16 +1128,15 @@ func testExchangeContinuousBackups(suite *BackupOpIntegrationSuite, toggles cont
 			updateUserData: func(t *testing.T) {
 				for category, d := range dataset {
 					containerID := d.dests[container1].containerID
-					cli := gc.Service.Client().Users().ByUserId(uidn.ID())
 
 					switch category {
 					case path.EmailCategory:
 						_, itemData := generateItemData(t, category, uidn.ID(), mailDBF)
 						body, err := support.CreateMessageFromBytes(itemData)
-						require.NoError(t, err, "transforming mail bytes to messageable", clues.ToCore(err))
+						require.NoErrorf(t, err, "transforming mail bytes to messageable: %+v", clues.ToCore(err))
 
-						itm, err := cli.MailFolders().ByMailFolderId(containerID).Messages().Post(ctx, body, nil)
-						require.NoError(t, err, "posting email item", clues.ToCore(err))
+						itm, err := ac.Mail().PostItem(ctx, uidn.ID(), containerID, body)
+						require.NoError(t, err, clues.ToCore(err))
 
 						expectDeets.AddItem(
 							category.String(),
@@ -1161,10 +1146,10 @@ func testExchangeContinuousBackups(suite *BackupOpIntegrationSuite, toggles cont
 					case path.ContactsCategory:
 						_, itemData := generateItemData(t, category, uidn.ID(), contactDBF)
 						body, err := support.CreateContactFromBytes(itemData)
-						require.NoError(t, err, "transforming contact bytes to contactable", clues.ToCore(err))
+						require.NoErrorf(t, err, "transforming contact bytes to contactable: %+v", clues.ToCore(err))
 
-						itm, err := cli.ContactFolders().ByContactFolderId(containerID).Contacts().Post(ctx, body, nil)
-						require.NoError(t, err, "posting contact item", clues.ToCore(err))
+						itm, err := ac.Contacts().PostItem(ctx, uidn.ID(), containerID, body)
+						require.NoError(t, err, clues.ToCore(err))
 
 						expectDeets.AddItem(
 							category.String(),
@@ -1174,10 +1159,10 @@ func testExchangeContinuousBackups(suite *BackupOpIntegrationSuite, toggles cont
 					case path.EventsCategory:
 						_, itemData := generateItemData(t, category, uidn.ID(), eventDBF)
 						body, err := support.CreateEventFromBytes(itemData)
-						require.NoError(t, err, "transforming event bytes to eventable", clues.ToCore(err))
+						require.NoErrorf(t, err, "transforming event bytes to eventable: %+v", clues.ToCore(err))
 
-						itm, err := cli.Calendars().ByCalendarId(containerID).Events().Post(ctx, body, nil)
-						require.NoError(t, err, "posting events item", clues.ToCore(err))
+						itm, err := ac.Events().PostItem(ctx, uidn.ID(), containerID, body)
+						require.NoError(t, err, clues.ToCore(err))
 
 						expectDeets.AddItem(
 							category.String(),
@@ -1196,7 +1181,6 @@ func testExchangeContinuousBackups(suite *BackupOpIntegrationSuite, toggles cont
 			updateUserData: func(t *testing.T) {
 				for category, d := range dataset {
 					containerID := d.dests[container1].containerID
-					cli := gc.Service.Client().Users().ByUserId(uidn.ID())
 
 					switch category {
 					case path.EmailCategory:
@@ -1204,7 +1188,7 @@ func testExchangeContinuousBackups(suite *BackupOpIntegrationSuite, toggles cont
 						require.NoError(t, err, "getting message ids", clues.ToCore(err))
 						require.NotEmpty(t, ids, "message ids in folder")
 
-						err = cli.Messages().ByMessageId(ids[0]).Delete(ctx, nil)
+						err = ac.Mail().DeleteItem(ctx, uidn.ID(), ids[0])
 						require.NoError(t, err, "deleting email item", clues.ToCore(err))
 
 						expectDeets.RemoveItem(
@@ -1217,7 +1201,7 @@ func testExchangeContinuousBackups(suite *BackupOpIntegrationSuite, toggles cont
 						require.NoError(t, err, "getting contact ids", clues.ToCore(err))
 						require.NotEmpty(t, ids, "contact ids in folder")
 
-						err = cli.Contacts().ByContactId(ids[0]).Delete(ctx, nil)
+						err = ac.Contacts().DeleteItem(ctx, uidn.ID(), ids[0])
 						require.NoError(t, err, "deleting contact item", clues.ToCore(err))
 
 						expectDeets.RemoveItem(
@@ -1230,7 +1214,7 @@ func testExchangeContinuousBackups(suite *BackupOpIntegrationSuite, toggles cont
 						require.NoError(t, err, "getting event ids", clues.ToCore(err))
 						require.NotEmpty(t, ids, "event ids in folder")
 
-						err = cli.Calendars().ByCalendarId(ids[0]).Delete(ctx, nil)
+						err = ac.Events().DeleteItem(ctx, uidn.ID(), ids[0])
 						require.NoError(t, err, "deleting calendar", clues.ToCore(err))
 
 						expectDeets.RemoveItem(

--- a/src/pkg/services/m365/api/events.go
+++ b/src/pkg/services/m365/api/events.go
@@ -33,7 +33,7 @@ type Events struct {
 }
 
 // ---------------------------------------------------------------------------
-// methods
+// containers
 // ---------------------------------------------------------------------------
 
 // CreateCalendar makes an event Calendar with the name in the user's M365 exchange account
@@ -74,10 +74,13 @@ func (c Events) DeleteContainer(
 	return nil
 }
 
-func (c Events) GetContainerByID(
+// prefer GetContainerByID where possible.
+// use this only in cases where the models.Calendarable
+// is required.
+func (c Events) GetCalendar(
 	ctx context.Context,
 	userID, containerID string,
-) (graph.Container, error) {
+) (models.Calendarable, error) {
 	service, err := c.Service()
 	if err != nil {
 		return nil, graph.Stack(ctx, err)
@@ -89,14 +92,27 @@ func (c Events) GetContainerByID(
 		},
 	}
 
-	cal, err := service.Client().
+	resp, err := service.Client().
 		Users().
 		ByUserId(userID).
 		Calendars().
 		ByCalendarId(containerID).
 		Get(ctx, config)
 	if err != nil {
-		return nil, graph.Stack(ctx, err).WithClues(ctx)
+		return nil, graph.Stack(ctx, err)
+	}
+
+	return resp, nil
+}
+
+// interface-compliant wrapper of GetCalendar
+func (c Events) GetContainerByID(
+	ctx context.Context,
+	userID, dirID string,
+) (graph.Container, error) {
+	cal, err := c.GetCalendar(ctx, userID, dirID)
+	if err != nil {
+		return nil, err
 	}
 
 	return graph.CalendarDisplayable{Calendarable: cal}, nil
@@ -141,56 +157,32 @@ func (c Events) GetContainerByName(
 	return cal, nil
 }
 
-// GetItem retrieves an Eventable item.
-func (c Events) GetItem(
+func (c Events) PatchCalendar(
 	ctx context.Context,
-	user, itemID string,
-	immutableIDs bool,
-	errs *fault.Bus,
-) (serialization.Parsable, *details.ExchangeInfo, error) {
-	var (
-		err    error
-		event  models.Eventable
-		config = &users.ItemEventsEventItemRequestBuilderGetRequestConfiguration{
-			Headers: newPreferHeaders(preferImmutableIDs(immutableIDs)),
-		}
-	)
-
-	event, err = c.Stable.Client().
-		Users().
-		ByUserId(user).
-		Events().
-		ByEventId(itemID).
-		Get(ctx, config)
+	userID, containerID string,
+	body models.Calendarable,
+) error {
+	service, err := c.Service()
 	if err != nil {
-		return nil, nil, graph.Stack(ctx, err)
+		return graph.Stack(ctx, err)
 	}
 
-	if ptr.Val(event.GetHasAttachments()) || HasAttachments(event.GetBody()) {
-		config := &users.ItemEventsItemAttachmentsRequestBuilderGetRequestConfiguration{
-			QueryParameters: &users.ItemEventsItemAttachmentsRequestBuilderGetQueryParameters{
-				Expand: []string{"microsoft.graph.itemattachment/item"},
-			},
-			Headers: newPreferHeaders(preferPageSize(maxNonDeltaPageSize), preferImmutableIDs(immutableIDs)),
-		}
-
-		attached, err := c.LargeItem.
-			Client().
-			Users().
-			ByUserId(user).
-			Events().
-			ByEventId(itemID).
-			Attachments().
-			Get(ctx, config)
-		if err != nil {
-			return nil, nil, graph.Wrap(ctx, err, "event attachment download")
-		}
-
-		event.SetAttachments(attached.GetValue())
+	_, err = service.Client().
+		Users().
+		ByUserId(userID).
+		Calendars().
+		ByCalendarId(containerID).
+		Patch(ctx, body, nil)
+	if err != nil {
+		return graph.Wrap(ctx, err, "patching event calendar")
 	}
 
-	return event, EventInfo(event), nil
+	return nil
 }
+
+// ---------------------------------------------------------------------------
+// container pager
+// ---------------------------------------------------------------------------
 
 // EnumerateContainers iterates through all of the users current
 // calendars, converting each to a graph.CacheFolder, and
@@ -271,6 +263,109 @@ func (c Events) EnumerateContainers(
 const (
 	eventBetaDeltaURLTemplate = "https://graph.microsoft.com/beta/users/%s/calendars/%s/events/delta"
 )
+
+// ---------------------------------------------------------------------------
+// items
+// ---------------------------------------------------------------------------
+
+// GetItem retrieves an Eventable item.
+func (c Events) GetItem(
+	ctx context.Context,
+	user, itemID string,
+	immutableIDs bool,
+	errs *fault.Bus,
+) (serialization.Parsable, *details.ExchangeInfo, error) {
+	var (
+		err    error
+		event  models.Eventable
+		config = &users.ItemEventsEventItemRequestBuilderGetRequestConfiguration{
+			Headers: newPreferHeaders(preferImmutableIDs(immutableIDs)),
+		}
+	)
+
+	event, err = c.Stable.Client().
+		Users().
+		ByUserId(user).
+		Events().
+		ByEventId(itemID).
+		Get(ctx, config)
+	if err != nil {
+		return nil, nil, graph.Stack(ctx, err)
+	}
+
+	if ptr.Val(event.GetHasAttachments()) || HasAttachments(event.GetBody()) {
+		config := &users.ItemEventsItemAttachmentsRequestBuilderGetRequestConfiguration{
+			QueryParameters: &users.ItemEventsItemAttachmentsRequestBuilderGetQueryParameters{
+				Expand: []string{"microsoft.graph.itemattachment/item"},
+			},
+			Headers: newPreferHeaders(preferPageSize(maxNonDeltaPageSize), preferImmutableIDs(immutableIDs)),
+		}
+
+		attached, err := c.LargeItem.
+			Client().
+			Users().
+			ByUserId(user).
+			Events().
+			ByEventId(itemID).
+			Attachments().
+			Get(ctx, config)
+		if err != nil {
+			return nil, nil, graph.Wrap(ctx, err, "event attachment download")
+		}
+
+		event.SetAttachments(attached.GetValue())
+	}
+
+	return event, EventInfo(event), nil
+}
+
+func (c Events) PostItem(
+	ctx context.Context,
+	userID, containerID string,
+	body models.Eventable,
+) (models.Eventable, error) {
+	service, err := c.Service()
+	if err != nil {
+		return nil, graph.Stack(ctx, err)
+	}
+
+	itm, err := service.Client().
+		Users().
+		ByUserId(userID).
+		Calendars().
+		ByCalendarId(containerID).
+		Events().
+		Post(ctx, body, nil)
+	if err != nil {
+		return nil, graph.Wrap(ctx, err, "creating calendar event")
+	}
+
+	return itm, nil
+}
+
+func (c Events) DeleteItem(
+	ctx context.Context,
+	userID, itemID string,
+) error {
+	// deletes require unique http clients
+	// https://github.com/alcionai/corso/issues/2707
+	service, err := c.Service()
+	if err != nil {
+		return graph.Stack(ctx, err)
+	}
+
+	err = service.Client().
+		Users().
+		ByUserId(userID).
+		Events().
+		ByEventId(itemID).
+		Delete(ctx, nil)
+	if err != nil {
+		return graph.Wrap(ctx, err, "deleting calendar event")
+	}
+
+	return nil
+}
 
 // ---------------------------------------------------------------------------
 // item pager


### PR DESCRIPTION
moves most ad-hoc graph api client usage for exchange behaviors into the m365/api package.  Attachment calls haven't been moved yet, and transition over in the next PR.

Logical changes are kept to a strict minimum, only what is required to move the code between packages.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #1996

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
