### PR TITLE
More robust folder fetching for container cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Fixed
+- Fix Exchange folder cache population error when parent folder isn't found.
+
 ### Known Issues
 
 ## [v0.8.0] (beta) - 2023-05-15

--- a/src/internal/connector/exchange/contact_folder_cache.go
+++ b/src/internal/connector/exchange/contact_folder_cache.go
@@ -34,7 +34,7 @@ func (cfc *contactFolderCache) populateContactRoot(
 		f,
 		path.Builder{}.Append(ptr.Val(f.GetId())),   // path of IDs
 		path.Builder{}.Append(baseContainerPath...)) // display location
-	if err := cfc.addFolder(temp); err != nil {
+	if err := cfc.addFolder(&temp); err != nil {
 		return clues.Wrap(err, "adding resolver dir").WithClues(ctx)
 	}
 

--- a/src/internal/connector/exchange/contact_folder_cache.go
+++ b/src/internal/connector/exchange/contact_folder_cache.go
@@ -99,7 +99,10 @@ func (cfc *contactFolderCache) init(
 	}
 
 	if cfc.containerResolver == nil {
-		cfc.containerResolver = newContainerResolver()
+		cfc.containerResolver = newContainerResolver(&contactRefresher{
+			userID: cfc.userID,
+			getter: cfc.getter,
+		})
 	}
 
 	return cfc.populateContactRoot(ctx, baseNode, baseContainerPath)

--- a/src/internal/connector/exchange/contact_folder_cache.go
+++ b/src/internal/connector/exchange/contact_folder_cache.go
@@ -11,7 +11,29 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
-var _ graph.ContainerResolver = &contactFolderCache{}
+var (
+	_ graph.ContainerResolver = &contactFolderCache{}
+	_ containerRefresher      = &contactRefresher{}
+)
+
+type contactRefresher struct {
+	getter containerGetter
+	userID string
+}
+
+func (r *contactRefresher) refreshContainer(
+	ctx context.Context,
+	id string,
+) (graph.CachedContainer, error) {
+	c, err := r.getter.GetContainerByID(ctx, r.userID, id)
+	if err != nil {
+		return nil, clues.Stack(err)
+	}
+
+	f := graph.NewCacheFolder(c, nil, nil)
+
+	return &f, nil
+}
 
 type contactFolderCache struct {
 	*containerResolver

--- a/src/internal/connector/exchange/container_resolver.go
+++ b/src/internal/connector/exchange/container_resolver.go
@@ -31,6 +31,13 @@ type containersEnumerator interface {
 	) error
 }
 
+type containerRefresher interface {
+	refreshContainer(
+		ctx context.Context,
+		dirID string,
+	) (graph.CachedContainer, error)
+}
+
 // ---------------------------------------------------------------------------
 // controller
 // ---------------------------------------------------------------------------

--- a/src/internal/connector/exchange/container_resolver.go
+++ b/src/internal/connector/exchange/container_resolver.go
@@ -68,12 +68,12 @@ func (cr *containerResolver) IDToPath(
 
 	c, ok := cr.cache[folderID]
 	if !ok {
-		return nil, nil, clues.New("folder not cached").WithClues(ctx)
+		return nil, nil, clues.New("container not cached").WithClues(ctx)
 	}
 
 	p := c.Path()
 	if p == nil {
-		return nil, nil, clues.New("folder has no path").WithClues(ctx)
+		return nil, nil, clues.New("cached container has no path").WithClues(ctx)
 	}
 
 	return p, c.Location(), nil
@@ -87,7 +87,7 @@ func (cr *containerResolver) refreshContainer(
 	logger.Ctx(ctx).Debug("refreshing container")
 
 	if cr.refresher == nil {
-		return nil, false, clues.New("nil refresher")
+		return nil, false, clues.New("nil refresher").WithClues(ctx)
 	}
 
 	c, err := cr.refresher.refreshContainer(ctx, id)
@@ -154,7 +154,7 @@ func (cr *containerResolver) idToPath(
 	}
 
 	if !parentCached {
-		logger.Ctx(ctx).Debug("parent folder was refreshed")
+		logger.Ctx(ctx).Debug("parent container was refreshed")
 
 		newContainer, currentShouldDelete, err := cr.refreshContainer(ctx, folderID)
 		if err != nil {
@@ -162,7 +162,7 @@ func (cr *containerResolver) idToPath(
 		}
 
 		if currentShouldDelete {
-			logger.Ctx(ctx).Debug("refreshing folder showed it was deleted")
+			logger.Ctx(ctx).Debug("refreshing container showed it was deleted")
 			delete(cr.cache, folderID)
 
 			return nil, nil, true, true, nil
@@ -185,7 +185,7 @@ func (cr *containerResolver) idToPath(
 	// If the parent wasn't found and refreshing the folder itself showed it
 	// hadn't changed then just delete it.
 	if shouldDelete {
-		logger.Ctx(ctx).Debug("deleting folder since parent was deleted")
+		logger.Ctx(ctx).Debug("deleting container since parent was deleted")
 		delete(cr.cache, folderID)
 
 		return nil, nil, true, true, nil

--- a/src/internal/connector/exchange/container_resolver.go
+++ b/src/internal/connector/exchange/container_resolver.go
@@ -26,7 +26,7 @@ type containersEnumerator interface {
 	EnumerateContainers(
 		ctx context.Context,
 		userID, baseDirID string,
-		fn func(graph.CacheFolder) error,
+		fn func(graph.CachedContainer) error,
 		errs *fault.Bus,
 	) error
 }
@@ -139,14 +139,14 @@ func (cr *containerResolver) LocationInCache(pathString string) (string, bool) {
 
 // addFolder adds a folder to the cache with the given ID. If the item is
 // already in the cache does nothing. The path for the item is not modified.
-func (cr *containerResolver) addFolder(cf graph.CacheFolder) error {
+func (cr *containerResolver) addFolder(cf graph.CachedContainer) error {
 	// Only require a non-nil non-empty parent if the path isn't already populated.
 	if cf.Path() != nil {
-		if err := checkIDAndName(cf.Container); err != nil {
+		if err := checkIDAndName(cf); err != nil {
 			return clues.Wrap(err, "adding item to cache")
 		}
 	} else {
-		if err := checkRequiredValues(cf.Container); err != nil {
+		if err := checkRequiredValues(cf); err != nil {
 			return clues.Wrap(err, "adding item to cache")
 		}
 	}
@@ -155,7 +155,7 @@ func (cr *containerResolver) addFolder(cf graph.CacheFolder) error {
 		return nil
 	}
 
-	cr.cache[ptr.Val(cf.GetId())] = &cf
+	cr.cache[ptr.Val(cf.GetId())] = cf
 
 	return nil
 }
@@ -176,7 +176,7 @@ func (cr *containerResolver) AddToCache(
 	ctx context.Context,
 	f graph.Container,
 ) error {
-	temp := graph.CacheFolder{
+	temp := &graph.CacheFolder{
 		Container: f,
 	}
 	if err := cr.addFolder(temp); err != nil {

--- a/src/internal/connector/exchange/container_resolver_test.go
+++ b/src/internal/connector/exchange/container_resolver_test.go
@@ -536,7 +536,7 @@ func (suite *ConfiguredFolderCacheUnitSuite) TestDepthLimit() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			resolver, containers := resolverWithContainers(test.numContainers, false)
-			_, _, _, _, err := resolver.idToPath(ctx, containers[len(containers)-1].id, 0)
+			_, err := resolver.idToPath(ctx, containers[len(containers)-1].id, 0)
 			test.check(suite.T(), err, clues.ToCore(err))
 		})
 	}

--- a/src/internal/connector/exchange/container_resolver_test.go
+++ b/src/internal/connector/exchange/container_resolver_test.go
@@ -458,14 +458,14 @@ func (suite *ConfiguredFolderCacheUnitSuite) TestRefreshContainer_RefreshAncesto
 	gone := containers[len(containers)-2]
 	last := containers[len(containers)-1]
 
-	expected := &(*last)
+	expected := *last
 	expected.parentID = other.id
 	expected.expectedPath = stdpath.Join(other.expectedPath, expected.id)
 	expected.expectedLocation = stdpath.Join(other.expectedLocation, expected.displayName)
 
 	refresher := mockContainerRefresher{
 		entries: map[string]refreshResult{
-			last.id: {c: expected},
+			last.id: {c: &expected},
 		},
 	}
 

--- a/src/internal/connector/exchange/container_resolver_test.go
+++ b/src/internal/connector/exchange/container_resolver_test.go
@@ -233,7 +233,7 @@ func (suite *FolderCacheUnitSuite) TestAddFolder() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			fc := newContainerResolver()
-			err := fc.addFolder(test.cf)
+			err := fc.addFolder(&test.cf)
 			test.check(suite.T(), err, clues.ToCore(err))
 		})
 	}

--- a/src/internal/connector/exchange/data_collections_test.go
+++ b/src/internal/connector/exchange/data_collections_test.go
@@ -597,7 +597,7 @@ func (suite *DataCollectionsIntegrationSuite) TestEventsSerializationRegression(
 		bdayID string
 	)
 
-	fn := func(gcf graph.CacheFolder) error {
+	fn := func(gcf graph.CachedContainer) error {
 		if ptr.Val(gcf.GetDisplayName()) == DefaultCalendar {
 			calID = ptr.Val(gcf.GetId())
 		}

--- a/src/internal/connector/exchange/event_calendar_cache.go
+++ b/src/internal/connector/exchange/event_calendar_cache.go
@@ -27,7 +27,7 @@ func (ecc *eventCalendarCache) init(
 	ctx context.Context,
 ) error {
 	if ecc.containerResolver == nil {
-		ecc.containerResolver = newContainerResolver()
+		ecc.containerResolver = newContainerResolver(nil)
 	}
 
 	return ecc.populateEventRoot(ctx)

--- a/src/internal/connector/exchange/event_calendar_cache.go
+++ b/src/internal/connector/exchange/event_calendar_cache.go
@@ -49,7 +49,7 @@ func (ecc *eventCalendarCache) populateEventRoot(ctx context.Context) error {
 		f,
 		path.Builder{}.Append(ptr.Val(f.GetId())),          // storage path
 		path.Builder{}.Append(ptr.Val(f.GetDisplayName()))) // display location
-	if err := ecc.addFolder(temp); err != nil {
+	if err := ecc.addFolder(&temp); err != nil {
 		return clues.Wrap(err, "initializing calendar resolver").WithClues(ctx)
 	}
 
@@ -98,7 +98,7 @@ func (ecc *eventCalendarCache) AddToCache(ctx context.Context, f graph.Container
 		path.Builder{}.Append(ptr.Val(f.GetId())),          // storage path
 		path.Builder{}.Append(ptr.Val(f.GetDisplayName()))) // display location
 
-	if err := ecc.addFolder(temp); err != nil {
+	if err := ecc.addFolder(&temp); err != nil {
 		return clues.Wrap(err, "adding container").WithClues(ctx)
 	}
 

--- a/src/internal/connector/exchange/mail_folder_cache.go
+++ b/src/internal/connector/exchange/mail_folder_cache.go
@@ -10,7 +10,29 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
-var _ graph.ContainerResolver = &mailFolderCache{}
+var (
+	_ graph.ContainerResolver = &mailFolderCache{}
+	_ containerRefresher      = &mailRefresher{}
+)
+
+type mailRefresher struct {
+	getter containerGetter
+	userID string
+}
+
+func (r *mailRefresher) refreshContainer(
+	ctx context.Context,
+	id string,
+) (graph.CachedContainer, error) {
+	c, err := r.getter.GetContainerByID(ctx, r.userID, id)
+	if err != nil {
+		return nil, clues.Stack(err)
+	}
+
+	f := graph.NewCacheFolder(c, nil, nil)
+
+	return &f, nil
+}
 
 // mailFolderCache struct used to improve lookup of directories within exchange.Mail
 // cache map of cachedContainers where the  key =  M365ID

--- a/src/internal/connector/exchange/mail_folder_cache.go
+++ b/src/internal/connector/exchange/mail_folder_cache.go
@@ -52,7 +52,7 @@ func (mc *mailFolderCache) populateMailRoot(ctx context.Context) error {
 		// the user doesn't see in the regular UI for Exchange.
 		path.Builder{}.Append(), // path of IDs
 		path.Builder{}.Append()) // display location
-	if err := mc.addFolder(temp); err != nil {
+	if err := mc.addFolder(&temp); err != nil {
 		return clues.Wrap(err, "adding resolver dir").WithClues(ctx)
 	}
 

--- a/src/internal/connector/exchange/mail_folder_cache.go
+++ b/src/internal/connector/exchange/mail_folder_cache.go
@@ -51,7 +51,10 @@ func (mc *mailFolderCache) init(
 	ctx context.Context,
 ) error {
 	if mc.containerResolver == nil {
-		mc.containerResolver = newContainerResolver()
+		mc.containerResolver = newContainerResolver(&mailRefresher{
+			userID: mc.userID,
+			getter: mc.getter,
+		})
 	}
 
 	return mc.populateMailRoot(ctx)

--- a/src/internal/connector/exchange/mail_folder_cache_test.go
+++ b/src/internal/connector/exchange/mail_folder_cache_test.go
@@ -1,11 +1,11 @@
 package exchange
 
 import (
-	//stdpath "path"
+	stdpath "path"
 	"testing"
 
 	"github.com/alcionai/clues"
-	//"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -52,7 +52,7 @@ func (suite *MailFolderCacheIntegrationSuite) SetupSuite() {
 }
 
 func (suite *MailFolderCacheIntegrationSuite) TestDeltaFetch() {
-	//suite.T().Skipf("Test depends on hardcoded folder names. Skipping till that is fixed")
+	suite.T().Skipf("Test depends on hardcoded folder names. Skipping till that is fixed")
 
 	ctx, flush := tester.NewContext()
 	defer flush()
@@ -66,15 +66,15 @@ func (suite *MailFolderCacheIntegrationSuite) TestDeltaFetch() {
 			name: "Default Root",
 			root: rootFolderAlias,
 		},
-		//{
-		//	name: "Node Root",
-		//	root: topFolderID,
-		//},
-		//{
-		//	name: "Node Root Non-empty Path",
-		//	root: topFolderID,
-		//	path: []string{"some", "leading", "path"},
-		//},
+		{
+			name: "Node Root",
+			root: topFolderID,
+		},
+		{
+			name: "Node Root Non-empty Path",
+			root: topFolderID,
+			path: []string{"some", "leading", "path"},
+		},
 	}
 	userID := tester.M365UserID(suite.T())
 
@@ -96,16 +96,16 @@ func (suite *MailFolderCacheIntegrationSuite) TestDeltaFetch() {
 			err = mfc.Populate(ctx, fault.New(true), test.root, test.path...)
 			require.NoError(t, err, clues.ToCore(err))
 
-			//p, l, err := mfc.IDToPath(ctx, testFolderID)
-			//require.NoError(t, err, clues.ToCore(err))
-			//t.Logf("Path: %s\n", p.String())
-			//t.Logf("Location: %s\n", l.String())
+			p, l, err := mfc.IDToPath(ctx, testFolderID)
+			require.NoError(t, err, clues.ToCore(err))
+			t.Logf("Path: %s\n", p.String())
+			t.Logf("Location: %s\n", l.String())
 
-			//expectedPath := stdpath.Join(append(test.path, expectedFolderPath)...)
-			//assert.Equal(t, expectedPath, p.String())
-			//identifier, ok := mfc.LocationInCache(p.String())
-			//assert.True(t, ok)
-			//assert.NotEmpty(t, identifier)
+			expectedPath := stdpath.Join(append(test.path, expectedFolderPath)...)
+			assert.Equal(t, expectedPath, p.String())
+			identifier, ok := mfc.LocationInCache(p.String())
+			assert.True(t, ok)
+			assert.NotEmpty(t, identifier)
 		})
 	}
 }

--- a/src/internal/connector/exchange/mail_folder_cache_test.go
+++ b/src/internal/connector/exchange/mail_folder_cache_test.go
@@ -1,11 +1,11 @@
 package exchange
 
 import (
-	stdpath "path"
+	//stdpath "path"
 	"testing"
 
 	"github.com/alcionai/clues"
-	"github.com/stretchr/testify/assert"
+	//"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -52,7 +52,7 @@ func (suite *MailFolderCacheIntegrationSuite) SetupSuite() {
 }
 
 func (suite *MailFolderCacheIntegrationSuite) TestDeltaFetch() {
-	suite.T().Skipf("Test depends on hardcoded folder names. Skipping till that is fixed")
+	//suite.T().Skipf("Test depends on hardcoded folder names. Skipping till that is fixed")
 
 	ctx, flush := tester.NewContext()
 	defer flush()
@@ -66,15 +66,15 @@ func (suite *MailFolderCacheIntegrationSuite) TestDeltaFetch() {
 			name: "Default Root",
 			root: rootFolderAlias,
 		},
-		{
-			name: "Node Root",
-			root: topFolderID,
-		},
-		{
-			name: "Node Root Non-empty Path",
-			root: topFolderID,
-			path: []string{"some", "leading", "path"},
-		},
+		//{
+		//	name: "Node Root",
+		//	root: topFolderID,
+		//},
+		//{
+		//	name: "Node Root Non-empty Path",
+		//	root: topFolderID,
+		//	path: []string{"some", "leading", "path"},
+		//},
 	}
 	userID := tester.M365UserID(suite.T())
 
@@ -96,16 +96,16 @@ func (suite *MailFolderCacheIntegrationSuite) TestDeltaFetch() {
 			err = mfc.Populate(ctx, fault.New(true), test.root, test.path...)
 			require.NoError(t, err, clues.ToCore(err))
 
-			p, l, err := mfc.IDToPath(ctx, testFolderID)
-			require.NoError(t, err, clues.ToCore(err))
-			t.Logf("Path: %s\n", p.String())
-			t.Logf("Location: %s\n", l.String())
+			//p, l, err := mfc.IDToPath(ctx, testFolderID)
+			//require.NoError(t, err, clues.ToCore(err))
+			//t.Logf("Path: %s\n", p.String())
+			//t.Logf("Location: %s\n", l.String())
 
-			expectedPath := stdpath.Join(append(test.path, expectedFolderPath)...)
-			assert.Equal(t, expectedPath, p.String())
-			identifier, ok := mfc.LocationInCache(p.String())
-			assert.True(t, ok)
-			assert.NotEmpty(t, identifier)
+			//expectedPath := stdpath.Join(append(test.path, expectedFolderPath)...)
+			//assert.Equal(t, expectedPath, p.String())
+			//identifier, ok := mfc.LocationInCache(p.String())
+			//assert.True(t, ok)
+			//assert.NotEmpty(t, identifier)
 		})
 	}
 }

--- a/src/pkg/services/m365/api/contacts.go
+++ b/src/pkg/services/m365/api/contacts.go
@@ -118,7 +118,7 @@ func (c Contacts) GetContainerByID(
 func (c Contacts) EnumerateContainers(
 	ctx context.Context,
 	userID, baseDirID string,
-	fn func(graph.CacheFolder) error,
+	fn func(graph.CachedContainer) error,
 	errs *fault.Bus,
 ) error {
 	service, err := c.Service()
@@ -166,7 +166,7 @@ func (c Contacts) EnumerateContainers(
 				"container_display_name", ptr.Val(fold.GetDisplayName()))
 
 			temp := graph.NewCacheFolder(fold, nil, nil)
-			if err := fn(temp); err != nil {
+			if err := fn(&temp); err != nil {
 				errs.AddRecoverable(graph.Stack(fctx, err).Label(fault.LabelForceNoBackupCreation))
 				continue
 			}

--- a/src/pkg/services/m365/api/events.go
+++ b/src/pkg/services/m365/api/events.go
@@ -192,7 +192,7 @@ func (c Events) GetItem(
 func (c Events) EnumerateContainers(
 	ctx context.Context,
 	userID, baseDirID string,
-	fn func(graph.CacheFolder) error,
+	fn func(graph.CachedContainer) error,
 	errs *fault.Bus,
 ) error {
 	service, err := c.Service()
@@ -239,7 +239,7 @@ func (c Events) EnumerateContainers(
 				cd,
 				path.Builder{}.Append(ptr.Val(cd.GetId())),          // storage path
 				path.Builder{}.Append(ptr.Val(cd.GetDisplayName()))) // display location
-			if err := fn(temp); err != nil {
+			if err := fn(&temp); err != nil {
 				errs.AddRecoverable(graph.Stack(fctx, err).Label(fault.LabelForceNoBackupCreation))
 				continue
 			}

--- a/src/pkg/services/m365/api/mail.go
+++ b/src/pkg/services/m365/api/mail.go
@@ -309,7 +309,7 @@ func (p *mailFolderPager) valuesIn(pl api.PageLinker) ([]models.MailFolderable, 
 func (c Mail) EnumerateContainers(
 	ctx context.Context,
 	userID, baseDirID string,
-	fn func(graph.CacheFolder) error,
+	fn func(graph.CachedContainer) error,
 	errs *fault.Bus,
 ) error {
 	service, err := c.Service()
@@ -347,7 +347,7 @@ func (c Mail) EnumerateContainers(
 				"container_name", ptr.Val(v.GetDisplayName()))
 
 			temp := graph.NewCacheFolder(v, nil, nil)
-			if err := fn(temp); err != nil {
+			if err := fn(&temp); err != nil {
 				errs.AddRecoverable(graph.Stack(fctx, err).Label(fault.LabelForceNoBackupCreation))
 				continue
 			}


### PR DESCRIPTION
Update folder cache population
* try to fetch missing parent folders
* refresh current folder if parent wasn't cached
* only populate paths during populatePaths not during IDToFolder

Manually tested email folder resolver population with
stable reproducer and succeeded

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
