### PR TITLE
Create defensive copies of data being backed up

### DIFF
--- a/src/internal/connector/exchange/mock/mail.go
+++ b/src/internal/connector/exchange/mock/mail.go
@@ -10,6 +10,7 @@ import (
 	kjson "github.com/microsoft/kiota-serialization-json-go"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 
 	"github.com/alcionai/corso/src/internal/common/dttm"
 )
@@ -735,13 +736,15 @@ func MessageWithNestedItemAttachmentContact(t *testing.T, nested []byte, subject
 
 func serialize(t *testing.T, item serialization.Parsable) []byte {
 	wtr := kjson.NewJsonSerializationWriter()
+	defer wtr.Close()
+
 	err := wtr.WriteObjectValue("", item)
 	require.NoError(t, err, clues.ToCore(err))
 
 	byteArray, err := wtr.GetSerializedContent()
 	require.NoError(t, err, clues.ToCore(err))
 
-	return byteArray
+	return slices.Clone(byteArray)
 }
 
 func hydrateMessage(byteArray []byte) (models.Messageable, error) {

--- a/src/internal/connector/sharepoint/collection.go
+++ b/src/internal/connector/sharepoint/collection.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alcionai/clues"
 	"github.com/microsoft/kiota-abstractions-go/serialization"
 	kjson "github.com/microsoft/kiota-serialization-json-go"
+	"golang.org/x/exp/slices"
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/connector/graph"
@@ -182,6 +183,8 @@ func (sc *Collection) runPopulate(ctx context.Context, errs *fault.Bus) (support
 		writer  = kjson.NewJsonSerializationWriter()
 	)
 
+	defer writer.Close()
+
 	// TODO: Insert correct ID for CollectionProgress
 	colProgress, closer := observe.CollectionProgress(
 		ctx,
@@ -340,5 +343,5 @@ func serializeContent(
 		return nil, graph.Wrap(ctx, err, "getting content from writer")
 	}
 
-	return byteArray, nil
+	return slices.Clone(byteArray), nil
 }

--- a/src/internal/connector/sharepoint/collection_test.go
+++ b/src/internal/connector/sharepoint/collection_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/exp/slices"
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/connector/sharepoint/api"
@@ -95,6 +96,8 @@ func (suite *SharePointCollectionSuite) TestCollection_Items() {
 			},
 			getItem: func(t *testing.T, name string) *Item {
 				ow := kioser.NewJsonSerializationWriter()
+				defer ow.Close()
+
 				listing := spMock.ListDefault(name)
 				listing.SetDisplayName(&name)
 
@@ -106,7 +109,7 @@ func (suite *SharePointCollectionSuite) TestCollection_Items() {
 
 				data := &Item{
 					id:   name,
-					data: io.NopCloser(bytes.NewReader(byteArray)),
+					data: io.NopCloser(bytes.NewReader(slices.Clone(byteArray))),
 					info: sharePointListInfo(listing, int64(len(byteArray))),
 				}
 

--- a/src/internal/connector/sharepoint/mock/list.go
+++ b/src/internal/connector/sharepoint/mock/list.go
@@ -10,6 +10,7 @@ import (
 	kjson "github.com/microsoft/kiota-serialization-json-go"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -153,7 +154,12 @@ func ListBytes(title string) ([]byte, error) {
 		return nil, err
 	}
 
-	return objectWriter.GetSerializedContent()
+	bs, err := objectWriter.GetSerializedContent()
+	if err != nil {
+		return nil, clues.Stack(err)
+	}
+
+	return slices.Clone(bs), nil
 }
 
 // ListStream returns the data.Stream representation

--- a/src/internal/connector/sharepoint/mock/mock_test.go
+++ b/src/internal/connector/sharepoint/mock/mock_test.go
@@ -32,7 +32,10 @@ func (suite *MockSuite) TestMockByteHydration() {
 			transformation: func(t *testing.T) error {
 				emptyMap := make(map[string]string)
 				temp := List(subject, "Artist", emptyMap)
+
 				writer := kioser.NewJsonSerializationWriter()
+				defer writer.Close()
+
 				err := writer.WriteObjectValue("", temp)
 				require.NoError(t, err, clues.ToCore(err))
 

--- a/src/internal/connector/support/m365Support_test.go
+++ b/src/internal/connector/support/m365Support_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/exp/slices"
 
 	exchMock "github.com/alcionai/corso/src/internal/connector/exchange/mock"
 	bmodels "github.com/alcionai/corso/src/internal/connector/graph/betasdk/models"
@@ -213,13 +214,15 @@ func (suite *DataSupportSuite) TestCreatePageFromBytes() {
 				pg.SetWebUrl(&title)
 
 				writer := kioser.NewJsonSerializationWriter()
+				defer writer.Close()
+
 				err := writer.WriteObjectValue("", pg)
 				require.NoError(t, err, clues.ToCore(err))
 
 				byteArray, err := writer.GetSerializedContent()
 				require.NoError(t, err, clues.ToCore(err))
 
-				return byteArray
+				return slices.Clone(byteArray)
 			},
 		},
 	}

--- a/src/pkg/services/m365/api/contacts.go
+++ b/src/pkg/services/m365/api/contacts.go
@@ -9,6 +9,7 @@ import (
 	kjson "github.com/microsoft/kiota-serialization-json-go"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
+	"golang.org/x/exp/slices"
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/connector/graph"
@@ -366,7 +367,10 @@ func (c Contacts) Serialize(
 		return nil, graph.Wrap(ctx, err, "serializing contact")
 	}
 
-	return bs, nil
+	// Return a defensive copy here since the kiota library gives us an alias to
+	// the underlying byte buffer they're using and that could change while we're
+	// uploading data.
+	return slices.Clone(bs), nil
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/services/m365/api/events.go
+++ b/src/pkg/services/m365/api/events.go
@@ -10,6 +10,7 @@ import (
 	kjson "github.com/microsoft/kiota-serialization-json-go"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
+	"golang.org/x/exp/slices"
 
 	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/common/ptr"
@@ -457,7 +458,10 @@ func (c Events) Serialize(
 		return nil, graph.Wrap(ctx, err, "serializing event")
 	}
 
-	return bs, nil
+	// Return a defensive copy here since the kiota library gives us an alias to
+	// the underlying byte buffer they're using and that could change while we're
+	// uploading data.
+	return slices.Clone(bs), nil
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/services/m365/api/item_serialization_test.go
+++ b/src/pkg/services/m365/api/item_serialization_test.go
@@ -1,0 +1,144 @@
+package api_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/alcionai/clues"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/internal/connector/support"
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+)
+
+type ItemSerializationUnitSuite struct {
+	tester.Suite
+}
+
+func TestItemSerializationUnitSuite(t *testing.T) {
+	suite.Run(t, &ItemSerializationUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *ItemSerializationUnitSuite) TestStableSerializedData() {
+	var (
+		user      = "a-user"
+		instances = 100
+	)
+
+	table := []struct {
+		name                   string
+		serializer             func(t *testing.T, ctx context.Context, idx int) []byte
+		deserializeAndGetField func(t *testing.T, bs []byte) string
+	}{
+		{
+			name: "Exchange Mail",
+			serializer: func(t *testing.T, ctx context.Context, idx int) []byte {
+				subject := fmt.Sprintf("%d", idx)
+
+				item := models.NewMessage()
+				item.SetSubject(&subject)
+
+				bs, err := api.Mail{}.Serialize(ctx, item, user, subject)
+				require.NoError(t, err, clues.ToCore(err))
+
+				return bs
+			},
+			deserializeAndGetField: func(t *testing.T, bs []byte) string {
+				item, err := support.CreateMessageFromBytes(bs)
+				require.NoError(
+					t,
+					err,
+					"deserializing message of %q: %v",
+					string(bs),
+					clues.ToCore(err))
+
+				return ptr.Val(item.GetSubject())
+			},
+		},
+		{
+			name: "Exchange Event",
+			serializer: func(t *testing.T, ctx context.Context, idx int) []byte {
+				subject := fmt.Sprintf("%d", idx)
+
+				item := models.NewEvent()
+				item.SetSubject(&subject)
+
+				bs, err := api.Events{}.Serialize(ctx, item, user, subject)
+				require.NoError(t, err, clues.ToCore(err))
+
+				return bs
+			},
+			deserializeAndGetField: func(t *testing.T, bs []byte) string {
+				item, err := support.CreateEventFromBytes(bs)
+				require.NoError(
+					t,
+					err,
+					"deserializing event of %q: %v",
+					string(bs),
+					clues.ToCore(err))
+
+				return ptr.Val(item.GetSubject())
+			},
+		},
+		{
+			name: "Exchange Contact",
+			serializer: func(t *testing.T, ctx context.Context, idx int) []byte {
+				name := fmt.Sprintf("%d", idx)
+
+				item := models.NewContact()
+				item.SetGivenName(&name)
+
+				bs, err := api.Contacts{}.Serialize(ctx, item, user, name)
+				require.NoError(t, err, clues.ToCore(err))
+
+				return bs
+			},
+			deserializeAndGetField: func(t *testing.T, bs []byte) string {
+				item, err := support.CreateContactFromBytes(bs)
+				require.NoError(
+					t,
+					err,
+					"deserializing contact of %q: %v",
+					string(bs),
+					clues.ToCore(err))
+
+				return ptr.Val(item.GetGivenName())
+			},
+		},
+	}
+
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			ctx, flusher := tester.NewContext()
+			defer flusher()
+
+			t := suite.T()
+			output := make([][]byte, instances)
+			wg := sync.WaitGroup{}
+			wg.Add(instances)
+
+			for i := 0; i < instances; i++ {
+				go func(idx int) {
+					defer wg.Done()
+
+					output[idx] = test.serializer(t, ctx, idx)
+				}(i)
+			}
+
+			wg.Wait()
+
+			for i := 0; i < instances; i++ {
+				got := test.deserializeAndGetField(t, output[i])
+				// I'm lazy and don't want to deal with the error from atoi functions.
+				assert.Equal(t, fmt.Sprintf("%d", i), got, "item output")
+			}
+		})
+	}
+}

--- a/src/pkg/services/m365/api/mail.go
+++ b/src/pkg/services/m365/api/mail.go
@@ -9,6 +9,7 @@ import (
 	kjson "github.com/microsoft/kiota-serialization-json-go"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
+	"golang.org/x/exp/slices"
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/connector/graph"
@@ -563,7 +564,10 @@ func (c Mail) Serialize(
 		return nil, graph.Wrap(ctx, err, "serializing email")
 	}
 
-	return bs, nil
+	// Return a defensive copy here since the kiota library gives us an alias to
+	// the underlying byte buffer they're using and that could change while we're
+	// uploading data.
+	return slices.Clone(bs), nil
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/services/m365/api/mail_test.go
+++ b/src/pkg/services/m365/api/mail_test.go
@@ -191,6 +191,7 @@ func (suite *MailAPIIntgSuite) SetupSuite() {
 
 func getJSONObject(t *testing.T, thing serialization.Parsable) map[string]interface{} {
 	sw := kjson.NewJsonSerializationWriter()
+	defer sw.Close()
 
 	err := sw.WriteObjectValue("", thing)
 	require.NoError(t, err, "serialize")


### PR DESCRIPTION
Currently the kiota serialization code is returning
shallow copies of the data in the serialization
writer. This could lead to errors if there's reuse
of the writer prior to the returned data being
completely consumed

This PR works around the issue in the backup
path by returning defensive copies of the data in
the serialization writer. It also adds a set of
tests for Exchange objects to try to catch buffer
reuse errors

This does not address any outstanding issues that
may be in the graph SDK package for posting items
---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
