### PR TITLE
Only select a test file if it's not empty

### DIFF
--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -68,7 +68,8 @@ func (suite *ItemIntegrationSuite) TestItemReader_oneDrive() {
 	defer flush()
 
 	var driveItem models.DriveItemable
-	// This item collector tries to find "a" drive item that is a file to test the reader function
+	// This item collector tries to find "a" drive item that is a non-empty
+	// file to test the reader function
 	itemCollector := func(
 		_ context.Context,
 		_, _ string,
@@ -81,7 +82,7 @@ func (suite *ItemIntegrationSuite) TestItemReader_oneDrive() {
 		_ *fault.Bus,
 	) error {
 		for _, item := range items {
-			if item.GetFile() != nil {
+			if item.GetFile() != nil && ptr.Val(item.GetSize()) > 0 {
 				driveItem = item
 				break
 			}


### PR DESCRIPTION
This is to protect against accidentally selecting a zero sized file for item read tests. This may happen if another CI test is running in parallel which creates a bunch of empty files in the same drive.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
