### PR TITLE
add test name to test context

### DIFF
--- a/src/cli/backup/exchange_e2e_test.go
+++ b/src/cli/backup/exchange_e2e_test.go
@@ -58,10 +58,11 @@ func TestNoBackupExchangeE2ESuite(t *testing.T) {
 }
 
 func (suite *NoBackupExchangeE2ESuite) SetupSuite() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	t := suite.T()
 	acct, st, repo, vpr, recorder, cfgFilePath := prepM365Test(t, ctx)
 
 	suite.acct = acct
@@ -75,7 +76,7 @@ func (suite *NoBackupExchangeE2ESuite) SetupSuite() {
 
 func (suite *NoBackupExchangeE2ESuite) TestExchangeBackupListCmd_empty() {
 	t := suite.T()
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 	ctx = config.SetViper(ctx, suite.vpr)
 
 	defer flush()
@@ -123,10 +124,11 @@ func TestBackupExchangeE2ESuite(t *testing.T) {
 }
 
 func (suite *BackupExchangeE2ESuite) SetupSuite() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	t := suite.T()
 	acct, st, repo, vpr, _, cfgFilePath := prepM365Test(t, ctx)
 
 	suite.acct = acct
@@ -155,7 +157,7 @@ func runExchangeBackupCategoryTest(suite *BackupExchangeE2ESuite, category strin
 
 	t := suite.T()
 
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 	ctx = config.SetViper(ctx, suite.vpr)
 
 	defer flush()
@@ -191,7 +193,7 @@ func runExchangeBackupUserNotFoundTest(suite *BackupExchangeE2ESuite, category s
 
 	t := suite.T()
 
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 	ctx = config.SetViper(ctx, suite.vpr)
 
 	defer flush()
@@ -237,10 +239,11 @@ func TestPreparedBackupExchangeE2ESuite(t *testing.T) {
 }
 
 func (suite *PreparedBackupExchangeE2ESuite) SetupSuite() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	t := suite.T()
 	acct, st, repo, vpr, recorder, cfgFilePath := prepM365Test(t, ctx)
 
 	suite.acct = acct
@@ -315,7 +318,7 @@ func runExchangeListCmdTest(suite *PreparedBackupExchangeE2ESuite, category path
 
 	t := suite.T()
 
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 	ctx = config.SetViper(ctx, suite.vpr)
 
 	defer flush()
@@ -354,7 +357,7 @@ func runExchangeListSingleCmdTest(suite *PreparedBackupExchangeE2ESuite, categor
 
 	t := suite.T()
 
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 	ctx = config.SetViper(ctx, suite.vpr)
 
 	defer flush()
@@ -383,7 +386,7 @@ func runExchangeListSingleCmdTest(suite *PreparedBackupExchangeE2ESuite, categor
 func (suite *PreparedBackupExchangeE2ESuite) TestExchangeListCmd_badID() {
 	t := suite.T()
 
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 	ctx = config.SetViper(ctx, suite.vpr)
 
 	defer flush()
@@ -418,7 +421,7 @@ func runExchangeDetailsCmdTest(suite *PreparedBackupExchangeE2ESuite, category p
 
 	t := suite.T()
 
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 	ctx = config.SetViper(ctx, suite.vpr)
 
 	defer flush()
@@ -492,10 +495,11 @@ func TestBackupDeleteExchangeE2ESuite(t *testing.T) {
 }
 
 func (suite *BackupDeleteExchangeE2ESuite) SetupSuite() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	t := suite.T()
 	acct, st, repo, vpr, _, cfgFilePath := prepM365Test(t, ctx)
 
 	suite.acct = acct
@@ -522,7 +526,8 @@ func (suite *BackupDeleteExchangeE2ESuite) SetupSuite() {
 
 func (suite *BackupDeleteExchangeE2ESuite) TestExchangeBackupDeleteCmd() {
 	t := suite.T()
-	ctx, flush := tester.NewContext()
+
+	ctx, flush := tester.NewContext(t)
 	ctx = config.SetViper(ctx, suite.vpr)
 
 	defer flush()
@@ -550,7 +555,8 @@ func (suite *BackupDeleteExchangeE2ESuite) TestExchangeBackupDeleteCmd() {
 
 func (suite *BackupDeleteExchangeE2ESuite) TestExchangeBackupDeleteCmd_UnknownID() {
 	t := suite.T()
-	ctx, flush := tester.NewContext()
+
+	ctx, flush := tester.NewContext(t)
 	ctx = config.SetViper(ctx, suite.vpr)
 
 	defer flush()

--- a/src/cli/backup/exchange_test.go
+++ b/src/cli/backup/exchange_test.go
@@ -275,14 +275,14 @@ func (suite *ExchangeUnitSuite) TestExchangeBackupCreateSelectors() {
 }
 
 func (suite *ExchangeUnitSuite) TestExchangeBackupDetailsSelectors() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	for v := 0; v <= version.Backup; v++ {
 		suite.Run(fmt.Sprintf("version%d", v), func() {
 			for _, test := range testdata.ExchangeOptionDetailLookups {
 				suite.Run(test.Name, func() {
 					t := suite.T()
+
+					ctx, flush := tester.NewContext(t)
+					defer flush()
 
 					bg := testdata.VersionedBackupGetter{
 						Details: dtd.GetDetailsSetForVersion(t, v),
@@ -303,12 +303,12 @@ func (suite *ExchangeUnitSuite) TestExchangeBackupDetailsSelectors() {
 }
 
 func (suite *ExchangeUnitSuite) TestExchangeBackupDetailsSelectorsBadFormats() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	for _, test := range testdata.BadExchangeOptionsFormats {
 		suite.Run(test.Name, func() {
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			output, err := runDetailsExchangeCmd(
 				ctx,

--- a/src/cli/backup/onedrive_e2e_test.go
+++ b/src/cli/backup/onedrive_e2e_test.go
@@ -50,10 +50,11 @@ func TestNoBackupOneDriveE2ESuite(t *testing.T) {
 }
 
 func (suite *NoBackupOneDriveE2ESuite) SetupSuite() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	t := suite.T()
 	acct, st, repo, vpr, recorder, cfgFilePath := prepM365Test(t, ctx)
 
 	suite.acct = acct
@@ -67,7 +68,8 @@ func (suite *NoBackupOneDriveE2ESuite) SetupSuite() {
 
 func (suite *NoBackupOneDriveE2ESuite) TestOneDriveBackupListCmd_empty() {
 	t := suite.T()
-	ctx, flush := tester.NewContext()
+
+	ctx, flush := tester.NewContext(t)
 	ctx = config.SetViper(ctx, suite.vpr)
 
 	defer flush()
@@ -98,7 +100,7 @@ func (suite *NoBackupOneDriveE2ESuite) TestOneDriveBackupCmd_UserNotInTenant() {
 
 	t := suite.T()
 
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	ctx = config.SetViper(ctx, suite.vpr)
@@ -152,10 +154,11 @@ func TestBackupDeleteOneDriveE2ESuite(t *testing.T) {
 }
 
 func (suite *BackupDeleteOneDriveE2ESuite) SetupSuite() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	t := suite.T()
 	acct, st, repo, vpr, recorder, cfgFilePath := prepM365Test(t, ctx)
 
 	suite.acct = acct
@@ -186,7 +189,8 @@ func (suite *BackupDeleteOneDriveE2ESuite) SetupSuite() {
 
 func (suite *BackupDeleteOneDriveE2ESuite) TestOneDriveBackupDeleteCmd() {
 	t := suite.T()
-	ctx, flush := tester.NewContext()
+
+	ctx, flush := tester.NewContext(t)
 	ctx = config.SetViper(ctx, suite.vpr)
 
 	defer flush()
@@ -223,7 +227,8 @@ func (suite *BackupDeleteOneDriveE2ESuite) TestOneDriveBackupDeleteCmd() {
 
 func (suite *BackupDeleteOneDriveE2ESuite) TestOneDriveBackupDeleteCmd_unknownID() {
 	t := suite.T()
-	ctx, flush := tester.NewContext()
+
+	ctx, flush := tester.NewContext(t)
 	ctx = config.SetViper(ctx, suite.vpr)
 
 	defer flush()

--- a/src/cli/backup/onedrive_test.go
+++ b/src/cli/backup/onedrive_test.go
@@ -137,14 +137,14 @@ func (suite *OneDriveUnitSuite) TestValidateOneDriveBackupCreateFlags() {
 }
 
 func (suite *OneDriveUnitSuite) TestOneDriveBackupDetailsSelectors() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	for v := 0; v <= version.Backup; v++ {
 		suite.Run(fmt.Sprintf("version%d", v), func() {
 			for _, test := range testdata.OneDriveOptionDetailLookups {
 				suite.Run(test.Name, func() {
 					t := suite.T()
+
+					ctx, flush := tester.NewContext(t)
+					defer flush()
 
 					bg := testdata.VersionedBackupGetter{
 						Details: dtd.GetDetailsSetForVersion(t, v),
@@ -165,12 +165,12 @@ func (suite *OneDriveUnitSuite) TestOneDriveBackupDetailsSelectors() {
 }
 
 func (suite *OneDriveUnitSuite) TestOneDriveBackupDetailsSelectorsBadFormats() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	for _, test := range testdata.BadOneDriveOptionsFormats {
 		suite.Run(test.Name, func() {
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			output, err := runDetailsOneDriveCmd(
 				ctx,

--- a/src/cli/backup/sharepoint_e2e_test.go
+++ b/src/cli/backup/sharepoint_e2e_test.go
@@ -49,10 +49,11 @@ func TestNoBackupSharePointE2ESuite(t *testing.T) {
 }
 
 func (suite *NoBackupSharePointE2ESuite) SetupSuite() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	t := suite.T()
 	acct, st, repo, vpr, recorder, cfgFilePath := prepM365Test(t, ctx)
 
 	suite.acct = acct
@@ -66,7 +67,8 @@ func (suite *NoBackupSharePointE2ESuite) SetupSuite() {
 
 func (suite *NoBackupSharePointE2ESuite) TestSharePointBackupListCmd_empty() {
 	t := suite.T()
-	ctx, flush := tester.NewContext()
+
+	ctx, flush := tester.NewContext(t)
 	ctx = config.SetViper(ctx, suite.vpr)
 
 	defer flush()
@@ -116,10 +118,11 @@ func TestBackupDeleteSharePointE2ESuite(t *testing.T) {
 }
 
 func (suite *BackupDeleteSharePointE2ESuite) SetupSuite() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	t := suite.T()
 	acct, st, repo, vpr, recorder, cfgFilePath := prepM365Test(t, ctx)
 
 	suite.acct = acct
@@ -150,7 +153,8 @@ func (suite *BackupDeleteSharePointE2ESuite) SetupSuite() {
 
 func (suite *BackupDeleteSharePointE2ESuite) TestSharePointBackupDeleteCmd() {
 	t := suite.T()
-	ctx, flush := tester.NewContext()
+
+	ctx, flush := tester.NewContext(t)
 	ctx = config.SetViper(ctx, suite.vpr)
 
 	defer flush()
@@ -188,7 +192,8 @@ func (suite *BackupDeleteSharePointE2ESuite) TestSharePointBackupDeleteCmd() {
 
 func (suite *BackupDeleteSharePointE2ESuite) TestSharePointBackupDeleteCmd_unknownID() {
 	t := suite.T()
-	ctx, flush := tester.NewContext()
+
+	ctx, flush := tester.NewContext(t)
 	ctx = config.SetViper(ctx, suite.vpr)
 
 	defer flush()

--- a/src/cli/backup/sharepoint_test.go
+++ b/src/cli/backup/sharepoint_test.go
@@ -243,10 +243,10 @@ func (suite *SharePointUnitSuite) TestSharePointBackupCreateSelectors() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
-			defer flush()
-
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			sel, err := sharePointBackupCreateSelectors(ctx, ins, test.site, test.weburl, test.data)
 			require.NoError(t, err, clues.ToCore(err))
@@ -256,14 +256,14 @@ func (suite *SharePointUnitSuite) TestSharePointBackupCreateSelectors() {
 }
 
 func (suite *SharePointUnitSuite) TestSharePointBackupDetailsSelectors() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	for v := 0; v <= version.Backup; v++ {
 		suite.Run(fmt.Sprintf("version%d", v), func() {
 			for _, test := range testdata.SharePointOptionDetailLookups {
 				suite.Run(test.Name, func() {
 					t := suite.T()
+
+					ctx, flush := tester.NewContext(t)
+					defer flush()
 
 					bg := testdata.VersionedBackupGetter{
 						Details: dtd.GetDetailsSetForVersion(t, v),
@@ -284,12 +284,12 @@ func (suite *SharePointUnitSuite) TestSharePointBackupDetailsSelectors() {
 }
 
 func (suite *SharePointUnitSuite) TestSharePointBackupDetailsSelectorsBadFormats() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	for _, test := range testdata.BadSharePointOptionsFormats {
 		suite.Run(test.Name, func() {
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			output, err := runDetailsSharePointCmd(
 				ctx,

--- a/src/cli/print/print_test.go
+++ b/src/cli/print/print_test.go
@@ -21,10 +21,11 @@ func TestPrintUnitSuite(t *testing.T) {
 }
 
 func (suite *PrintUnitSuite) TestOnly() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	t := suite.T()
 	c := &cobra.Command{}
 	ctx = SetRootCmd(ctx, c)
 

--- a/src/cli/repo/s3_e2e_test.go
+++ b/src/cli/repo/s3_e2e_test.go
@@ -55,7 +55,7 @@ func (suite *S3E2ESuite) TestInitS3Cmd() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			st := tester.NewPrefixedS3Storage(t)
@@ -91,7 +91,7 @@ func (suite *S3E2ESuite) TestInitS3Cmd() {
 
 func (suite *S3E2ESuite) TestInitMultipleTimes() {
 	t := suite.T()
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 
 	defer flush()
 
@@ -121,7 +121,7 @@ func (suite *S3E2ESuite) TestInitMultipleTimes() {
 
 func (suite *S3E2ESuite) TestInitS3Cmd_missingBucket() {
 	t := suite.T()
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 
 	defer flush()
 
@@ -171,7 +171,7 @@ func (suite *S3E2ESuite) TestConnectS3Cmd() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			st := tester.NewPrefixedS3Storage(t)
@@ -214,7 +214,7 @@ func (suite *S3E2ESuite) TestConnectS3Cmd() {
 
 func (suite *S3E2ESuite) TestConnectS3Cmd_BadBucket() {
 	t := suite.T()
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 
 	defer flush()
 
@@ -240,7 +240,7 @@ func (suite *S3E2ESuite) TestConnectS3Cmd_BadBucket() {
 
 func (suite *S3E2ESuite) TestConnectS3Cmd_BadPrefix() {
 	t := suite.T()
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 
 	defer flush()
 

--- a/src/cli/restore/exchange_e2e_test.go
+++ b/src/cli/restore/exchange_e2e_test.go
@@ -55,7 +55,7 @@ func TestRestoreExchangeE2ESuite(t *testing.T) {
 func (suite *RestoreExchangeE2ESuite) SetupSuite() {
 	t := suite.T()
 
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	// aggregate required details
@@ -127,7 +127,7 @@ func (suite *RestoreExchangeE2ESuite) TestExchangeRestoreCmd() {
 		suite.Run(set.String(), func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			ctx = config.SetViper(ctx, suite.vpr)
 
 			defer flush()
@@ -154,7 +154,7 @@ func (suite *RestoreExchangeE2ESuite) TestExchangeRestoreCmd_badTimeFlags() {
 		suite.Run(set.String(), func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			ctx = config.SetViper(ctx, suite.vpr)
 
 			defer flush()
@@ -192,7 +192,7 @@ func (suite *RestoreExchangeE2ESuite) TestExchangeRestoreCmd_badBoolFlags() {
 
 			//nolint:forbidigo
 			ctx := config.SetViper(context.Background(), suite.vpr)
-			ctx, flush := tester.WithContext(ctx)
+			ctx, flush := tester.WithContext(t, ctx)
 			defer flush()
 
 			var timeFilter string

--- a/src/cli/utils/sharepoint_test.go
+++ b/src/cli/utils/sharepoint_test.go
@@ -194,7 +194,9 @@ func (suite *SharePointUtilsSuite) TestIncludeSharePointRestoreDataSelectors() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			sel := utils.IncludeSharePointRestoreDataSelectors(ctx, test.opts)
@@ -252,7 +254,9 @@ func (suite *SharePointUtilsSuite) TestIncludeSharePointRestoreDataSelectors_nor
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			var (

--- a/src/cmd/factory/impl/common.go
+++ b/src/cmd/factory/impl/common.go
@@ -222,7 +222,7 @@ func generateAndRestoreDriveItems(
 	*details.Details,
 	error,
 ) {
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(nil)
 	defer flush()
 
 	dest := control.DefaultRestoreDestination(dttm.SafeForTesting)

--- a/src/internal/common/crash/crash_test.go
+++ b/src/internal/common/crash/crash_test.go
@@ -49,7 +49,7 @@ func (suite *CrashTestDummySuite) TestRecovery() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 
 			defer func() {
 				err := crash.Recovery(ctx, recover(), "test")

--- a/src/internal/connector/data_collections_test.go
+++ b/src/internal/connector/data_collections_test.go
@@ -55,7 +55,7 @@ func (suite *DataCollectionIntgSuite) SetupSuite() {
 // - contacts
 // - events
 func (suite *DataCollectionIntgSuite) TestExchangeDataCollection() {
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(suite.T())
 	defer flush()
 
 	selUsers := []string{suite.user}
@@ -107,6 +107,9 @@ func (suite *DataCollectionIntgSuite) TestExchangeDataCollection() {
 			suite.Run(name, func() {
 				t := suite.T()
 
+				ctx, flush := tester.NewContext(t)
+				defer flush()
+
 				sel := test.getSelector(t)
 
 				ctrlOpts := control.Defaults()
@@ -151,7 +154,7 @@ func (suite *DataCollectionIntgSuite) TestExchangeDataCollection() {
 
 // TestInvalidUserForDataCollections ensures verification process for users
 func (suite *DataCollectionIntgSuite) TestDataCollections_invalidResourceOwner() {
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(suite.T())
 	defer flush()
 
 	owners := []string{"snuffleupagus"}
@@ -218,6 +221,9 @@ func (suite *DataCollectionIntgSuite) TestDataCollections_invalidResourceOwner()
 		suite.Run(test.name, func() {
 			t := suite.T()
 
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
 			collections, excludes, err := connector.ProduceBackupCollections(
 				ctx,
 				test.getSelector(t),
@@ -237,7 +243,7 @@ func (suite *DataCollectionIntgSuite) TestDataCollections_invalidResourceOwner()
 // GraphConnector remains stable to receive a non-zero amount of Collections
 // for the SharePoint Package.
 func (suite *DataCollectionIntgSuite) TestSharePointDataCollection() {
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(suite.T())
 	defer flush()
 
 	selSites := []string{suite.site}
@@ -270,6 +276,10 @@ func (suite *DataCollectionIntgSuite) TestSharePointDataCollection() {
 	for _, test := range tests {
 		suite.Run(test.name, func() {
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
 			sel := test.getSelector()
 
 			collections, excludes, err := sharepoint.DataCollections(
@@ -330,7 +340,7 @@ func TestSPCollectionIntgSuite(t *testing.T) {
 }
 
 func (suite *SPCollectionIntgSuite) SetupSuite() {
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(suite.T())
 	defer flush()
 
 	suite.connector = loadConnector(ctx, suite.T(), Sites)
@@ -340,11 +350,12 @@ func (suite *SPCollectionIntgSuite) SetupSuite() {
 }
 
 func (suite *SPCollectionIntgSuite) TestCreateSharePointCollection_Libraries() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t       = suite.T()
 		siteID  = tester.M365SiteID(t)
 		gc      = loadConnector(ctx, t, Sites)
 		siteIDs = []string{siteID}
@@ -385,11 +396,12 @@ func (suite *SPCollectionIntgSuite) TestCreateSharePointCollection_Libraries() {
 }
 
 func (suite *SPCollectionIntgSuite) TestCreateSharePointCollection_Lists() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t       = suite.T()
 		siteID  = tester.M365SiteID(t)
 		gc      = loadConnector(ctx, t, Sites)
 		siteIDs = []string{siteID}

--- a/src/internal/connector/discovery/discovery_test.go
+++ b/src/internal/connector/discovery/discovery_test.go
@@ -31,11 +31,12 @@ func TestDiscoveryIntgSuite(t *testing.T) {
 }
 
 func (suite *DiscoveryIntgSuite) TestUsers() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t    = suite.T()
 		acct = tester.NewM365Account(t)
 		errs = fault.New(true)
 	)
@@ -82,10 +83,11 @@ func (suite *DiscoveryIntgSuite) TestUsers_InvalidCredentials() {
 
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			t := suite.T()
 			acct := test.acct(t)
 
 			creds, err := acct.M365Config()
@@ -102,11 +104,12 @@ func (suite *DiscoveryIntgSuite) TestUsers_InvalidCredentials() {
 }
 
 func (suite *DiscoveryIntgSuite) TestSites() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t    = suite.T()
 		acct = tester.NewM365Account(t)
 		errs = fault.New(true)
 	)
@@ -121,9 +124,6 @@ func (suite *DiscoveryIntgSuite) TestSites() {
 }
 
 func (suite *DiscoveryIntgSuite) TestSites_InvalidCredentials() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	table := []struct {
 		name string
 		acct func(t *testing.T) account.Account
@@ -159,10 +159,13 @@ func (suite *DiscoveryIntgSuite) TestSites_InvalidCredentials() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			var (
-				t    = suite.T()
-				a    = test.acct(t)
-				errs = fault.New(true)
+				t          = suite.T()
+				a          = test.acct(t)
+				errs       = fault.New(true)
+				ctx, flush = tester.NewContext(t)
 			)
+
+			defer flush()
 
 			sites, err := discovery.Sites(ctx, a, errs)
 			assert.Empty(t, sites, "returned some sites")
@@ -216,10 +219,10 @@ func (suite *DiscoveryIntgSuite) TestUserInfo() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
-			defer flush()
-
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			result, err := discovery.UserInfo(ctx, uapi, test.user)
 			test.expectErr(t, err, clues.ToCore(err))
@@ -270,10 +273,10 @@ func (suite *DiscoveryIntgSuite) TestUserWithoutDrive() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
-			defer flush()
-
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			result, err := discovery.GetUserInfo(ctx, acct, test.user, fault.New(true))
 			require.NoError(t, err, clues.ToCore(err))

--- a/src/internal/connector/exchange/container_resolver_test.go
+++ b/src/internal/connector/exchange/container_resolver_test.go
@@ -356,10 +356,10 @@ func TestConfiguredFolderCacheUnitSuite(t *testing.T) {
 }
 
 func (suite *ConfiguredFolderCacheUnitSuite) TestRefreshContainer_RefreshParent() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	resolver, containers := resolverWithContainers(4, true)
 	almostLast := containers[len(containers)-2]
@@ -388,10 +388,10 @@ func (suite *ConfiguredFolderCacheUnitSuite) TestRefreshContainer_RefreshParent(
 }
 
 func (suite *ConfiguredFolderCacheUnitSuite) TestRefreshContainer_RefreshParent_NotFoundDeletes() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	resolver, containers := resolverWithContainers(4, true)
 	almostLast := containers[len(containers)-2]
@@ -416,10 +416,10 @@ func (suite *ConfiguredFolderCacheUnitSuite) TestRefreshContainer_RefreshParent_
 }
 
 func (suite *ConfiguredFolderCacheUnitSuite) TestRefreshContainer_RefreshAncestor_NotFoundDeletes() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	resolver, containers := resolverWithContainers(4, true)
 	gone := containers[0]
@@ -445,10 +445,10 @@ func (suite *ConfiguredFolderCacheUnitSuite) TestRefreshContainer_RefreshAncesto
 }
 
 func (suite *ConfiguredFolderCacheUnitSuite) TestRefreshContainer_RefreshAncestor_NewParent() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	resolver, containers := resolverWithContainers(4, true)
 	other := containers[len(containers)-3]
@@ -482,10 +482,10 @@ func (suite *ConfiguredFolderCacheUnitSuite) TestRefreshContainer_RefreshAncesto
 }
 
 func (suite *ConfiguredFolderCacheUnitSuite) TestRefreshContainer_RefreshFolder_FolderDeleted() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	resolver, containers := resolverWithContainers(4, true)
 	parent := containers[len(containers)-2]
@@ -510,9 +510,6 @@ func (suite *ConfiguredFolderCacheUnitSuite) TestRefreshContainer_RefreshFolder_
 }
 
 func (suite *ConfiguredFolderCacheUnitSuite) TestDepthLimit() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	table := []struct {
 		name          string
 		numContainers int
@@ -532,18 +529,23 @@ func (suite *ConfiguredFolderCacheUnitSuite) TestDepthLimit() {
 
 	for _, test := range table {
 		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
 			resolver, containers := resolverWithContainers(test.numContainers, false)
 			_, err := resolver.idToPath(ctx, containers[len(containers)-1].id, 0)
-			test.check(suite.T(), err, clues.ToCore(err))
+			test.check(t, err, clues.ToCore(err))
 		})
 	}
 }
 
 func (suite *ConfiguredFolderCacheUnitSuite) TestPopulatePaths() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	err := suite.fc.populatePaths(ctx, fault.New(true))
 	require.NoError(t, err, clues.ToCore(err))
@@ -564,7 +566,9 @@ func (suite *ConfiguredFolderCacheUnitSuite) TestPopulatePaths() {
 }
 
 func (suite *ConfiguredFolderCacheUnitSuite) TestLookupCachedFolderNoPathsCached() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	err := suite.fc.populatePaths(ctx, fault.New(true))
@@ -573,6 +577,9 @@ func (suite *ConfiguredFolderCacheUnitSuite) TestLookupCachedFolderNoPathsCached
 	for _, c := range suite.allContainers {
 		suite.Run(ptr.Val(c.GetDisplayName()), func() {
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			p, l, err := suite.fc.IDToPath(ctx, c.id)
 			require.NoError(t, err, clues.ToCore(err))
@@ -583,10 +590,11 @@ func (suite *ConfiguredFolderCacheUnitSuite) TestLookupCachedFolderNoPathsCached
 }
 
 func (suite *ConfiguredFolderCacheUnitSuite) TestLookupCachedFolderCachesPaths() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	t := suite.T()
 	c := suite.allContainers[len(suite.allContainers)-1]
 
 	err := suite.fc.populatePaths(ctx, fault.New(true))
@@ -606,10 +614,11 @@ func (suite *ConfiguredFolderCacheUnitSuite) TestLookupCachedFolderCachesPaths()
 }
 
 func (suite *ConfiguredFolderCacheUnitSuite) TestLookupCachedFolderErrorsParentNotFound() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	t := suite.T()
 	almostLast := suite.allContainers[len(suite.allContainers)-2]
 
 	delete(suite.fc.cache, almostLast.id)
@@ -619,32 +628,33 @@ func (suite *ConfiguredFolderCacheUnitSuite) TestLookupCachedFolderErrorsParentN
 }
 
 func (suite *ConfiguredFolderCacheUnitSuite) TestLookupCachedFolder_Errors_PathsNotBuilt() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	_, _, err := suite.fc.IDToPath(ctx, suite.allContainers[len(suite.allContainers)-1].id)
 	assert.Error(t, err, clues.ToCore(err))
 }
 
 func (suite *ConfiguredFolderCacheUnitSuite) TestLookupCachedFolderErrorsNotFound() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	_, _, err := suite.fc.IDToPath(ctx, "foo")
 	assert.Error(t, err, clues.ToCore(err))
 }
 
 func (suite *ConfiguredFolderCacheUnitSuite) TestAddToCache() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
 		dest = "testAddFolder"
-		t    = suite.T()
 		last = suite.allContainers[len(suite.allContainers)-1]
 		m    = newMockCachedContainer(dest)
 	)
@@ -701,9 +711,6 @@ func (suite *FolderCacheIntegrationSuite) SetupSuite() {
 
 // Testing to ensure that cache system works for in multiple different environments
 func (suite *FolderCacheIntegrationSuite) TestCreateContainerDestination() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	a := tester.NewM365Account(suite.T())
 	m365, err := a.M365Config()
 	require.NoError(suite.T(), err, clues.ToCore(err))
@@ -809,6 +816,9 @@ func (suite *FolderCacheIntegrationSuite) TestCreateContainerDestination() {
 	for _, test := range tests {
 		suite.Run(test.name, func() {
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			folderID, err := CreateContainerDestination(
 				ctx,

--- a/src/internal/connector/exchange/data_collections_test.go
+++ b/src/internal/connector/exchange/data_collections_test.go
@@ -171,7 +171,7 @@ func (suite *DataCollectionsUnitSuite) TestParseMetadataCollections() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			entries := []graph.MetadataCollectionEntry{}
@@ -243,9 +243,6 @@ func (suite *DataCollectionsIntegrationSuite) SetupSuite() {
 }
 
 func (suite *DataCollectionsIntegrationSuite) TestMailFetch() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	var (
 		userID    = tester.M365UserID(suite.T())
 		users     = []string{userID}
@@ -288,6 +285,9 @@ func (suite *DataCollectionsIntegrationSuite) TestMailFetch() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
 			ctrlOpts := control.Defaults()
 			ctrlOpts.ToggleFeatures.DisableDelta = !test.canMakeDeltaQueries
 
@@ -328,9 +328,6 @@ func (suite *DataCollectionsIntegrationSuite) TestMailFetch() {
 }
 
 func (suite *DataCollectionsIntegrationSuite) TestDelta() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	var (
 		userID    = tester.M365UserID(suite.T())
 		users     = []string{userID}
@@ -368,6 +365,9 @@ func (suite *DataCollectionsIntegrationSuite) TestDelta() {
 	for _, test := range tests {
 		suite.Run(test.name, func() {
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			// get collections without providing any delta history (ie: full backup)
 			collections, err := createCollections(
@@ -432,11 +432,12 @@ func (suite *DataCollectionsIntegrationSuite) TestDelta() {
 // test account can be successfully downloaded into bytes and restored into
 // M365 mail objects
 func (suite *DataCollectionsIntegrationSuite) TestMailSerializationRegression() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t     = suite.T()
 		wg    sync.WaitGroup
 		users = []string{suite.user}
 	)
@@ -463,6 +464,9 @@ func (suite *DataCollectionsIntegrationSuite) TestMailSerializationRegression() 
 	for _, edc := range collections {
 		suite.Run(edc.FullPath().String(), func() {
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			isMetadata := edc.FullPath().Service() == path.ExchangeMetadataService
 			streamChannel := edc.Items(ctx, fault.New(true))
@@ -493,9 +497,6 @@ func (suite *DataCollectionsIntegrationSuite) TestMailSerializationRegression() 
 // and to store contact within Collection. Downloaded contacts are run through
 // a regression test to ensure that downloaded items can be uploaded.
 func (suite *DataCollectionsIntegrationSuite) TestContactSerializationRegression() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	acct, err := tester.NewM365Account(suite.T()).M365Config()
 	require.NoError(suite.T(), err, clues.ToCore(err))
 
@@ -515,10 +516,12 @@ func (suite *DataCollectionsIntegrationSuite) TestContactSerializationRegression
 
 	for _, test := range tests {
 		suite.Run(test.name, func() {
-			var (
-				wg sync.WaitGroup
-				t  = suite.T()
-			)
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			var wg sync.WaitGroup
 
 			edcs, err := createCollections(
 				ctx,
@@ -581,16 +584,18 @@ func (suite *DataCollectionsIntegrationSuite) TestContactSerializationRegression
 // TestEventsSerializationRegression ensures functionality of createCollections
 // to be able to successfully query, download and restore event objects
 func (suite *DataCollectionsIntegrationSuite) TestEventsSerializationRegression() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	acct, err := tester.NewM365Account(suite.T()).M365Config()
-	require.NoError(suite.T(), err, clues.ToCore(err))
+	acct, err := tester.NewM365Account(t).M365Config()
+	require.NoError(t, err, clues.ToCore(err))
 
 	users := []string{suite.user}
 
 	ac, err := api.NewClient(acct)
-	require.NoError(suite.T(), err, "creating client", clues.ToCore(err))
+	require.NoError(t, err, "creating client", clues.ToCore(err))
 
 	var (
 		calID  string
@@ -610,7 +615,7 @@ func (suite *DataCollectionsIntegrationSuite) TestEventsSerializationRegression(
 	}
 
 	err = ac.Events().EnumerateContainers(ctx, suite.user, DefaultCalendar, fn, fault.New(true))
-	require.NoError(suite.T(), err, clues.ToCore(err))
+	require.NoError(t, err, clues.ToCore(err))
 
 	tests := []struct {
 		name, expected string
@@ -636,10 +641,12 @@ func (suite *DataCollectionsIntegrationSuite) TestEventsSerializationRegression(
 
 	for _, test := range tests {
 		suite.Run(test.name, func() {
-			var (
-				wg sync.WaitGroup
-				t  = suite.T()
-			)
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			var wg sync.WaitGroup
 
 			collections, err := createCollections(
 				ctx,

--- a/src/internal/connector/exchange/exchange_data_collection_test.go
+++ b/src/internal/connector/exchange/exchange_data_collection_test.go
@@ -225,12 +225,14 @@ func (suite *ExchangeDataCollectionSuite) TestGetItemWithRetries() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			// itemer is mocked, so only the errors are configured atm.
 			_, _, err := test.items.GetItem(ctx, "userID", "itemID", false, fault.New(true))
-			test.expectErr(suite.T(), err)
+			test.expectErr(t, err)
 		})
 	}
 }

--- a/src/internal/connector/exchange/folder_resolver_test.go
+++ b/src/internal/connector/exchange/folder_resolver_test.go
@@ -40,9 +40,6 @@ func (suite *CacheResolverSuite) SetupSuite() {
 }
 
 func (suite *CacheResolverSuite) TestPopulate() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	ac, err := api.NewClient(suite.credentials)
 	require.NoError(suite.T(), err, clues.ToCore(err))
 
@@ -116,6 +113,10 @@ func (suite *CacheResolverSuite) TestPopulate() {
 	for _, test := range tests {
 		suite.Run(test.name, func() {
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
 			resolver := test.resolverFunc(t)
 
 			err := resolver.Populate(ctx, fault.New(true), test.root, test.basePath)

--- a/src/internal/connector/exchange/mail_folder_cache_test.go
+++ b/src/internal/connector/exchange/mail_folder_cache_test.go
@@ -54,9 +54,6 @@ func (suite *MailFolderCacheIntegrationSuite) SetupSuite() {
 func (suite *MailFolderCacheIntegrationSuite) TestDeltaFetch() {
 	suite.T().Skipf("Test depends on hardcoded folder names. Skipping till that is fixed")
 
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	tests := []struct {
 		name string
 		root string
@@ -81,6 +78,9 @@ func (suite *MailFolderCacheIntegrationSuite) TestDeltaFetch() {
 	for _, test := range tests {
 		suite.Run(test.name, func() {
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			ac, err := api.NewClient(suite.credentials)
 			require.NoError(t, err, clues.ToCore(err))

--- a/src/internal/connector/exchange/mock/mock_test.go
+++ b/src/internal/connector/exchange/mock/mock_test.go
@@ -26,7 +26,9 @@ func TestMockSuite(t *testing.T) {
 }
 
 func (suite *MockSuite) TestMockExchangeCollection() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	mdc := NewCollection(nil, nil, 2)
@@ -34,18 +36,19 @@ func (suite *MockSuite) TestMockExchangeCollection() {
 
 	for item := range mdc.Items(ctx, fault.New(true)) {
 		_, err := io.ReadAll(item.ToReader())
-		assert.NoError(suite.T(), err, clues.ToCore(err))
+		assert.NoError(t, err, clues.ToCore(err))
 		messagesRead++
 	}
 
-	assert.Equal(suite.T(), 2, messagesRead)
+	assert.Equal(t, 2, messagesRead)
 }
 
 func (suite *MockSuite) TestMockExchangeCollectionItemSize() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	t := suite.T()
 	mdc := NewCollection(nil, nil, 2)
 	mdc.Data[1] = []byte("This is some buffer of data so that the size is different than the default")
 
@@ -62,10 +65,11 @@ func (suite *MockSuite) TestMockExchangeCollectionItemSize() {
 // NewExchangeCollectionMail_Hydration tests that mock exchange mail data collection can be used for restoration
 // functions by verifying no failures on (de)serializing steps using kiota serialization library
 func (suite *MockSuite) TestMockExchangeCollection_NewExchangeCollectionMail_Hydration() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	t := suite.T()
 	mdc := NewCollection(nil, nil, 3)
 
 	for stream := range mdc.Items(ctx, fault.New(true)) {

--- a/src/internal/connector/exchange/restore_test.go
+++ b/src/internal/connector/exchange/restore_test.go
@@ -58,11 +58,12 @@ func (suite *RestoreIntgSuite) SetupSuite() {
 // TestRestoreContact ensures contact object can be created, placed into
 // the Corso Folder. The function handles test clean-up.
 func (suite *RestoreIntgSuite) TestRestoreContact() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t          = suite.T()
 		userID     = tester.M365UserID(t)
 		folderName = tester.DefaultTestRestoreDestination("contact").ContainerName
 	)
@@ -92,11 +93,12 @@ func (suite *RestoreIntgSuite) TestRestoreContact() {
 // TestRestoreEvent verifies that event object is able to created
 // and sent into the test account of the Corso user in the newly created Corso Calendar
 func (suite *RestoreIntgSuite) TestRestoreEvent() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t       = suite.T()
 		userID  = tester.M365UserID(t)
 		subject = tester.DefaultTestRestoreDestination("event").ContainerName
 	)
@@ -130,7 +132,7 @@ func (suite *RestoreIntgSuite) TestRestoreEvent() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			info, err := RestoreExchangeEvent(
@@ -359,7 +361,7 @@ func (suite *RestoreIntgSuite) TestRestoreExchangeObject() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			destination := test.destination(t, ctx)

--- a/src/internal/connector/exchange/service_iterators_test.go
+++ b/src/internal/connector/exchange/service_iterators_test.go
@@ -320,7 +320,7 @@ func (suite *ServiceIteratorsSuite) TestFilterContainersAndFillCollections() {
 			suite.Run(name, func() {
 				t := suite.T()
 
-				ctx, flush := tester.NewContext()
+				ctx, flush := tester.NewContext(t)
 				defer flush()
 
 				ctrlOpts := control.Options{FailureHandling: test.failFast}
@@ -657,7 +657,7 @@ func (suite *ServiceIteratorsSuite) TestFilterContainersAndFillCollections_Dupli
 				suite.Run(test.name, func() {
 					t := suite.T()
 
-					ctx, flush := tester.NewContext()
+					ctx, flush := tester.NewContext(t)
 					defer flush()
 
 					collections, err := filterContainersAndFillCollections(
@@ -796,7 +796,7 @@ func (suite *ServiceIteratorsSuite) TestFilterContainersAndFillCollections_repea
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			var (
@@ -1215,7 +1215,7 @@ func (suite *ServiceIteratorsSuite) TestFilterContainersAndFillCollections_incre
 				suite.Run(name, func() {
 					t := suite.T()
 
-					ctx, flush := tester.NewContext()
+					ctx, flush := tester.NewContext(t)
 					defer flush()
 
 					ctrlOpts := control.Defaults()

--- a/src/internal/connector/graph/betasdk/beta_client_test.go
+++ b/src/internal/connector/graph/betasdk/beta_client_test.go
@@ -51,10 +51,10 @@ func (suite *BetaClientSuite) TestCreateBetaClient() {
 // be handled within the /internal/connector/sharepoint when
 // additional features are added.
 func (suite *BetaClientSuite) TestBasicClientGetFunctionality() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	adpt, err := graph.CreateAdapter(
 		suite.credentials.AzureTenantID,

--- a/src/internal/connector/graph/concurrency_middleware_test.go
+++ b/src/internal/connector/graph/concurrency_middleware_test.go
@@ -122,10 +122,11 @@ func (suite *ConcurrencyMWUnitTestSuite) TestGenerateConcurrencyLimiter() {
 }
 
 func (suite *ConcurrencyMWUnitTestSuite) TestTimedFence_Block() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	t := suite.T()
 	tf := newTimedFence()
 
 	// raise multiple fences, the longest at 5 seconds
@@ -159,12 +160,13 @@ func (suite *ConcurrencyMWUnitTestSuite) TestTimedFence_Block() {
 }
 
 func (suite *ConcurrencyMWUnitTestSuite) TestTimedFence_Block_ctxDeadline() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	ctx, _ = context.WithDeadline(ctx, time.Now().Add(2*time.Second))
 
-	t := suite.T()
 	tf := newTimedFence()
 
 	// raise multiple fences, the longest at 10 seconds
@@ -297,10 +299,11 @@ func (suite *ConcurrencyMWUnitTestSuite) TestThrottlingMiddleware() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			t := suite.T()
 			tm := throttlingMiddleware{newTimedFence()}
 
 			req := &http.Request{}

--- a/src/internal/connector/graph/http_wrapper_test.go
+++ b/src/internal/connector/graph/http_wrapper_test.go
@@ -26,13 +26,12 @@ func TestHTTPWrapperIntgSuite(t *testing.T) {
 }
 
 func (suite *HTTPWrapperIntgSuite) TestNewHTTPWrapper() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	var (
-		t  = suite.T()
-		hw = NewHTTPWrapper()
-	)
+	hw := NewHTTPWrapper()
 
 	resp, err := hw.Request(
 		ctx,
@@ -76,11 +75,12 @@ func TestHTTPWrapperUnitSuite(t *testing.T) {
 }
 
 func (suite *HTTPWrapperUnitSuite) TestNewHTTPWrapper_redirectMiddleware() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t    = suite.T()
 		uri  = "https://graph.microsoft.com"
 		path = "/fnords/beaux/regard"
 		url  = uri + path

--- a/src/internal/connector/graph/metadata_collection_test.go
+++ b/src/internal/connector/graph/metadata_collection_test.go
@@ -43,10 +43,10 @@ func (suite *MetadataCollectionUnitSuite) TestFullPath() {
 }
 
 func (suite *MetadataCollectionUnitSuite) TestItems() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	itemNames := []string{
 		"a",
@@ -158,7 +158,7 @@ func (suite *MetadataCollectionUnitSuite) TestMakeMetadataCollection() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			col, err := MakeMetadataCollection(

--- a/src/internal/connector/graph/middleware_test.go
+++ b/src/internal/connector/graph/middleware_test.go
@@ -169,10 +169,11 @@ func (suite *RetryMWIntgSuite) TestRetryMiddleware_Intercept_byStatusCode() {
 
 	for _, test := range tests {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			t := suite.T()
 			called := 0
 			mw := newTestMW(
 				func(*http.Request) { called++ },
@@ -194,11 +195,12 @@ func (suite *RetryMWIntgSuite) TestRetryMiddleware_Intercept_byStatusCode() {
 }
 
 func (suite *RetryMWIntgSuite) TestRetryMiddleware_RetryRequest_resetBodyAfter500() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t                = suite.T()
 		body             = models.NewMailFolder()
 		checkOnIntercept = func(req *http.Request) {
 			bs, err := io.ReadAll(req.Body)
@@ -243,11 +245,13 @@ func TestMiddlewareUnitSuite(t *testing.T) {
 }
 
 func (suite *MiddlewareUnitSuite) TestBindExtractLimiterConfig() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	// an unpopulated ctx should produce the default limiter
-	assert.Equal(suite.T(), defaultLimiter, ctxLimiter(ctx))
+	assert.Equal(t, defaultLimiter, ctxLimiter(ctx))
 
 	table := []struct {
 		name          string
@@ -295,11 +299,13 @@ func (suite *MiddlewareUnitSuite) TestBindExtractLimiterConfig() {
 }
 
 func (suite *MiddlewareUnitSuite) TestLimiterConsumption() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	// an unpopulated ctx should produce the default consumption
-	assert.Equal(suite.T(), defaultLC, ctxLimiterConsumption(ctx, defaultLC))
+	assert.Equal(t, defaultLC, ctxLimiterConsumption(ctx, defaultLC))
 
 	table := []struct {
 		name   string

--- a/src/internal/connector/graph_connector_disconnected_test.go
+++ b/src/internal/connector/graph_connector_disconnected_test.go
@@ -29,8 +29,12 @@ func TestDisconnectedGraphSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
-func statusTestTask(gc *GraphConnector, objects, success, folder int) {
-	ctx, flush := tester.NewContext()
+func statusTestTask(
+	t *testing.T,
+	gc *GraphConnector,
+	objects, success, folder int,
+) {
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	status := support.CreateStatus(
@@ -46,6 +50,7 @@ func statusTestTask(gc *GraphConnector, objects, success, folder int) {
 }
 
 func (suite *DisconnectedGraphConnectorSuite) TestGraphConnector_Status() {
+	t := suite.T()
 	gc := GraphConnector{wg: &sync.WaitGroup{}}
 
 	// Two tasks
@@ -53,11 +58,10 @@ func (suite *DisconnectedGraphConnectorSuite) TestGraphConnector_Status() {
 	gc.incrementAwaitingMessages()
 
 	// Each helper task processes 4 objects, 1 success, 3 errors, 1 folders
-	go statusTestTask(&gc, 4, 1, 1)
-	go statusTestTask(&gc, 4, 1, 1)
+	go statusTestTask(t, &gc, 4, 1, 1)
+	go statusTestTask(t, &gc, 4, 1, 1)
 
 	stats := gc.Wait()
-	t := suite.T()
 
 	assert.NotEmpty(t, gc.PrintableStatus())
 	// Expect 8 objects

--- a/src/internal/connector/graph_connector_onedrive_test.go
+++ b/src/internal/connector/graph_connector_onedrive_test.go
@@ -167,7 +167,9 @@ func TestGraphConnectorSharePointIntegrationSuite(t *testing.T) {
 }
 
 func (suite *GraphConnectorSharePointIntegrationSuite) SetupSuite() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	si := suiteInfoImpl{
@@ -183,15 +185,15 @@ func (suite *GraphConnectorSharePointIntegrationSuite) SetupSuite() {
 	si.resourceOwner = tester.M365SiteID(suite.T())
 
 	user, err := si.connector.Discovery.Users().GetByID(ctx, si.user)
-	require.NoError(suite.T(), err, "fetching user", si.user, clues.ToCore(err))
+	require.NoError(t, err, "fetching user", si.user, clues.ToCore(err))
 	si.userID = ptr.Val(user.GetId())
 
 	secondaryUser, err := si.connector.Discovery.Users().GetByID(ctx, si.secondaryUser)
-	require.NoError(suite.T(), err, "fetching user", si.secondaryUser, clues.ToCore(err))
+	require.NoError(t, err, "fetching user", si.secondaryUser, clues.ToCore(err))
 	si.secondaryUserID = ptr.Val(secondaryUser.GetId())
 
 	tertiaryUser, err := si.connector.Discovery.Users().GetByID(ctx, si.tertiaryUser)
-	require.NoError(suite.T(), err, "fetching user", si.tertiaryUser, clues.ToCore(err))
+	require.NoError(t, err, "fetching user", si.tertiaryUser, clues.ToCore(err))
 	si.tertiaryUserID = ptr.Val(tertiaryUser.GetId())
 
 	suite.suiteInfo = si
@@ -236,14 +238,16 @@ func TestGraphConnectorOneDriveIntegrationSuite(t *testing.T) {
 }
 
 func (suite *GraphConnectorOneDriveIntegrationSuite) SetupSuite() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	si := suiteInfoImpl{
-		connector:     loadConnector(ctx, suite.T(), Users),
-		user:          tester.M365UserID(suite.T()),
-		secondaryUser: tester.SecondaryM365UserID(suite.T()),
-		acct:          tester.NewM365Account(suite.T()),
+		connector:     loadConnector(ctx, t, Users),
+		user:          tester.M365UserID(t),
+		secondaryUser: tester.SecondaryM365UserID(t),
+		acct:          tester.NewM365Account(t),
 		service:       path.OneDriveService,
 		resourceType:  Users,
 	}
@@ -251,11 +255,11 @@ func (suite *GraphConnectorOneDriveIntegrationSuite) SetupSuite() {
 	si.resourceOwner = si.user
 
 	user, err := si.connector.Discovery.Users().GetByID(ctx, si.user)
-	require.NoError(suite.T(), err, "fetching user", si.user, clues.ToCore(err))
+	require.NoError(t, err, "fetching user", si.user, clues.ToCore(err))
 	si.userID = ptr.Val(user.GetId())
 
 	secondaryUser, err := si.connector.Discovery.Users().GetByID(ctx, si.secondaryUser)
-	require.NoError(suite.T(), err, "fetching user", si.secondaryUser, clues.ToCore(err))
+	require.NoError(t, err, "fetching user", si.secondaryUser, clues.ToCore(err))
 	si.secondaryUserID = ptr.Val(secondaryUser.GetId())
 
 	suite.suiteInfo = si
@@ -300,14 +304,16 @@ func TestGraphConnectorOneDriveNightlySuite(t *testing.T) {
 }
 
 func (suite *GraphConnectorOneDriveNightlySuite) SetupSuite() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	si := suiteInfoImpl{
-		connector:     loadConnector(ctx, suite.T(), Users),
-		user:          tester.M365UserID(suite.T()),
-		secondaryUser: tester.SecondaryM365UserID(suite.T()),
-		acct:          tester.NewM365Account(suite.T()),
+		connector:     loadConnector(ctx, t, Users),
+		user:          tester.M365UserID(t),
+		secondaryUser: tester.SecondaryM365UserID(t),
+		acct:          tester.NewM365Account(t),
 		service:       path.OneDriveService,
 		resourceType:  Users,
 	}
@@ -315,11 +321,11 @@ func (suite *GraphConnectorOneDriveNightlySuite) SetupSuite() {
 	si.resourceOwner = si.user
 
 	user, err := si.connector.Discovery.Users().GetByID(ctx, si.user)
-	require.NoError(suite.T(), err, "fetching user", si.user, clues.ToCore(err))
+	require.NoError(t, err, "fetching user", si.user, clues.ToCore(err))
 	si.userID = ptr.Val(user.GetId())
 
 	secondaryUser, err := si.connector.Discovery.Users().GetByID(ctx, si.secondaryUser)
-	require.NoError(suite.T(), err, "fetching user", si.secondaryUser, clues.ToCore(err))
+	require.NoError(t, err, "fetching user", si.secondaryUser, clues.ToCore(err))
 	si.secondaryUserID = ptr.Val(secondaryUser.GetId())
 
 	suite.suiteInfo = si
@@ -351,12 +357,14 @@ func testRestoreAndBackupMultipleFilesAndFoldersNoPermissions(
 	suite oneDriveSuite,
 	startVersion int,
 ) {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	// Get the default drive ID for the test user.
 	driveID := mustGetDefaultDriveID(
-		suite.T(),
+		t,
 		ctx,
 		suite.BackupService(),
 		suite.Service(),
@@ -493,14 +501,16 @@ func testRestoreAndBackupMultipleFilesAndFoldersNoPermissions(
 }
 
 func testPermissionsRestoreAndBackup(suite oneDriveSuite, startVersion int) {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	secondaryUserName, secondaryUserID := suite.SecondaryUser()
 
 	// Get the default drive ID for the test user.
 	driveID := mustGetDefaultDriveID(
-		suite.T(),
+		t,
 		ctx,
 		suite.BackupService(),
 		suite.Service(),
@@ -708,14 +718,16 @@ func testPermissionsRestoreAndBackup(suite oneDriveSuite, startVersion int) {
 }
 
 func testPermissionsBackupAndNoRestore(suite oneDriveSuite, startVersion int) {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	secondaryUserName, secondaryUserID := suite.SecondaryUser()
 
 	// Get the default drive ID for the test user.
 	driveID := mustGetDefaultDriveID(
-		suite.T(),
+		t,
 		ctx,
 		suite.BackupService(),
 		suite.Service(),
@@ -794,7 +806,9 @@ func testPermissionsBackupAndNoRestore(suite oneDriveSuite, startVersion int) {
 // This is similar to TestPermissionsRestoreAndBackup but tests purely
 // for inheritance and that too only with newer versions
 func testPermissionsInheritanceRestoreAndBackup(suite oneDriveSuite, startVersion int) {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	secondaryUserName, secondaryUserID := suite.SecondaryUser()
@@ -802,7 +816,7 @@ func testPermissionsInheritanceRestoreAndBackup(suite oneDriveSuite, startVersio
 
 	// Get the default drive ID for the test user.
 	driveID := mustGetDefaultDriveID(
-		suite.T(),
+		t,
 		ctx,
 		suite.BackupService(),
 		suite.Service(),
@@ -977,7 +991,9 @@ func testRestoreFolderNamedFolderRegression(
 	suite oneDriveSuite,
 	startVersion int,
 ) {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	// Get the default drive ID for the test user.

--- a/src/internal/connector/graph_connector_test.go
+++ b/src/internal/connector/graph_connector_test.go
@@ -207,13 +207,12 @@ func (suite *GraphConnectorUnitSuite) TestPopulateOwnerIDAndNamesFrom() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			var (
-				t  = suite.T()
-				gc = &GraphConnector{ownerLookup: test.rc}
-			)
+			gc := &GraphConnector{ownerLookup: test.rc}
 
 			rID, rName, err := gc.PopulateOwnerIDAndNamesFrom(ctx, test.owner, test.ins)
 			test.expectErr(t, err, clues.ToCore(err))
@@ -224,11 +223,12 @@ func (suite *GraphConnectorUnitSuite) TestPopulateOwnerIDAndNamesFrom() {
 }
 
 func (suite *GraphConnectorUnitSuite) TestGraphConnector_Wait() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t  = suite.T()
 		gc = &GraphConnector{
 			wg:     &sync.WaitGroup{},
 			region: &trace.Region{},
@@ -276,23 +276,26 @@ func TestGraphConnectorIntegrationSuite(t *testing.T) {
 }
 
 func (suite *GraphConnectorIntegrationSuite) SetupSuite() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	suite.connector = loadConnector(ctx, suite.T(), Users)
-	suite.user = tester.M365UserID(suite.T())
-	suite.secondaryUser = tester.SecondaryM365UserID(suite.T())
-	suite.acct = tester.NewM365Account(suite.T())
+	suite.connector = loadConnector(ctx, t, Users)
+	suite.user = tester.M365UserID(t)
+	suite.secondaryUser = tester.SecondaryM365UserID(t)
+	suite.acct = tester.NewM365Account(t)
 
-	tester.LogTimeOfTest(suite.T())
+	tester.LogTimeOfTest(t)
 }
 
 func (suite *GraphConnectorIntegrationSuite) TestRestoreFailsBadService() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t    = suite.T()
 		acct = tester.NewM365Account(t)
 		dest = tester.DefaultTestRestoreDestination("")
 		sel  = selectors.Selector{
@@ -376,7 +379,7 @@ func (suite *GraphConnectorIntegrationSuite) TestEmptyCollections() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			deets, err := suite.connector.ConsumeRestoreCollections(
@@ -531,7 +534,7 @@ func runRestoreBackupTest(
 	resourceOwners []string,
 	opts control.Options,
 ) {
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	config := ConfigInfo{
@@ -578,7 +581,7 @@ func runRestoreTestWithVerion(
 	resourceOwners []string,
 	opts control.Options,
 ) {
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	config := ConfigInfo{
@@ -617,7 +620,7 @@ func runRestoreBackupTestVersions(
 	resourceOwners []string,
 	opts control.Options,
 ) {
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	config := ConfigInfo{
@@ -995,7 +998,7 @@ func (suite *GraphConnectorIntegrationSuite) TestMultiFolderBackupDifferentNames
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			restoreSel := getSelectorWith(t, test.service, []string{suite.user}, true)
@@ -1211,11 +1214,12 @@ func (suite *GraphConnectorIntegrationSuite) TestBackup_CreatesPrefixCollections
 
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			var (
-				t         = suite.T()
 				backupGC  = loadConnector(ctx, t, test.resource)
 				backupSel = test.selectorFunc(t)
 				errs      = fault.New(true)

--- a/src/internal/connector/onedrive/collection_test.go
+++ b/src/internal/connector/onedrive/collection_test.go
@@ -194,11 +194,12 @@ func (suite *CollectionUnitTestSuite) TestCollection() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			var (
-				t          = suite.T()
 				wg         = sync.WaitGroup{}
 				collStatus = support.ConnectorOperationStatus{}
 				readItems  = []data.Stream{}
@@ -332,11 +333,12 @@ func (suite *CollectionUnitTestSuite) TestCollectionReadError() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			var (
-				t          = suite.T()
 				testItemID = "fakeItemID"
 				collStatus = support.ConnectorOperationStatus{}
 				wg         = sync.WaitGroup{}
@@ -422,11 +424,12 @@ func (suite *CollectionUnitTestSuite) TestCollectionReadUnauthorizedErrorRetry()
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			var (
-				t          = suite.T()
 				testItemID = "fakeItemID"
 				collStatus = support.ConnectorOperationStatus{}
 				wg         = sync.WaitGroup{}
@@ -523,11 +526,12 @@ func (suite *CollectionUnitTestSuite) TestCollectionPermissionBackupLatestModTim
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			var (
-				t            = suite.T()
 				testItemID   = "fakeItemID"
 				testItemName = "Fake Item"
 				testItemSize = int64(10)
@@ -679,11 +683,12 @@ func (suite *GetDriveItemUnitTestSuite) TestGetDriveItem_error() {
 
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			var (
-				t    = suite.T()
 				errs = fault.New(false)
 				item = models.NewDriveItem()
 				col  = &Collection{scope: test.colScope}
@@ -815,10 +820,10 @@ func (suite *GetDriveItemUnitTestSuite) TestDownloadContent() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
-			defer flush()
-
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			r, err := downloadContent(ctx, svc, test.igf, test.irf, gr, item, driveID)
 

--- a/src/internal/connector/onedrive/collections_test.go
+++ b/src/internal/connector/onedrive/collections_test.go
@@ -765,11 +765,12 @@ func (suite *OneDriveCollectionsUnitSuite) TestUpdateCollections() {
 
 	for _, tt := range tests {
 		suite.Run(tt.testCase, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			var (
-				t               = suite.T()
 				excludes        = map[string]struct{}{}
 				outputFolderMap = map[string]string{}
 				itemCollection  = map[string]map[string]string{
@@ -1150,10 +1151,11 @@ func (suite *OneDriveCollectionsUnitSuite) TestDeserializeMetadata() {
 
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			t := suite.T()
 			cols := []data.RestoreCollection{}
 
 			for _, c := range test.cols {
@@ -2292,7 +2294,7 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			drivePagerFunc := func(
@@ -2611,7 +2613,7 @@ func (suite *OneDriveCollectionsUnitSuite) TestCollectItems() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			itemPager := &mockItemPager{

--- a/src/internal/connector/onedrive/drive_test.go
+++ b/src/internal/connector/onedrive/drive_test.go
@@ -52,7 +52,9 @@ func odErr(code string) *odataerrors.ODataError {
 }
 
 func (suite *OneDriveUnitSuite) TestDrives() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	numDriveResults := 4
@@ -263,7 +265,7 @@ func (suite *OneDriveUnitSuite) TestDrives() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			pager := &mock.DrivePager{
@@ -307,11 +309,12 @@ func (suite *OneDriveIntgSuite) SetupSuite() {
 }
 
 func (suite *OneDriveIntgSuite) TestCreateGetDeleteFolder() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t              = suite.T()
 		folderIDs      = []string{}
 		folderName1    = "Corso_Folder_Test_" + dttm.FormatNow(dttm.SafeForTesting)
 		folderElements = []string{folderName1}
@@ -438,11 +441,12 @@ func (suite *OneDriveIntgSuite) TestOneDriveNewCollections() {
 
 	for _, test := range tests {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			var (
-				t       = suite.T()
 				service = loadTestService(t)
 				scope   = selectors.
 					NewOneDriveBackup([]string{test.user}).

--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -40,7 +40,7 @@ func TestItemIntegrationSuite(t *testing.T) {
 func (suite *ItemIntegrationSuite) SetupSuite() {
 	t := suite.T()
 
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	suite.service = loadTestService(t)
@@ -64,7 +64,9 @@ func (suite *ItemIntegrationSuite) SetupSuite() {
 // 2) It assumes the drive has a file it can use to test `driveItemReader`
 // The test checks these in below
 func (suite *ItemIntegrationSuite) TestItemReader_oneDrive() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var driveItem models.DriveItemable
@@ -102,30 +104,29 @@ func (suite *ItemIntegrationSuite) TestItemReader_oneDrive() {
 		map[string]string{},
 		"",
 		fault.New(true))
-	require.NoError(suite.T(), err, clues.ToCore(err))
+	require.NoError(t, err, clues.ToCore(err))
 
 	// Test Requirement 2: Need a file
 	require.NotEmpty(
-		suite.T(),
+		t,
 		driveItem,
 		"no file item found for user %s drive %s",
 		suite.user,
-		suite.userDriveID,
-	)
+		suite.userDriveID)
 
 	// Read data for the file
 	itemInfo, itemData, err := oneDriveItemReader(ctx, graph.NewNoTimeoutHTTPWrapper(), driveItem)
 
-	require.NoError(suite.T(), err, clues.ToCore(err))
-	require.NotNil(suite.T(), itemInfo.OneDrive)
-	require.NotEmpty(suite.T(), itemInfo.OneDrive.ItemName)
+	require.NoError(t, err, clues.ToCore(err))
+	require.NotNil(t, itemInfo.OneDrive)
+	require.NotEmpty(t, itemInfo.OneDrive.ItemName)
 
 	size, err := io.Copy(io.Discard, itemData)
-	require.NoError(suite.T(), err, clues.ToCore(err))
-	require.NotZero(suite.T(), size)
-	require.Equal(suite.T(), size, itemInfo.OneDrive.Size)
+	require.NoError(t, err, clues.ToCore(err))
+	require.NotZero(t, size)
+	require.Equal(t, size, itemInfo.OneDrive.Size)
 
-	suite.T().Logf("Read %d bytes from file %s.", size, itemInfo.OneDrive.ItemName)
+	t.Logf("Read %d bytes from file %s.", size, itemInfo.OneDrive.ItemName)
 }
 
 // TestItemWriter is an integration test for uploading data to OneDrive
@@ -146,10 +147,11 @@ func (suite *ItemIntegrationSuite) TestItemWriter() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			t := suite.T()
 			srv := suite.service
 
 			root, err := srv.Client().Drives().ByDriveId(test.driveID).Root().Get(ctx, nil)
@@ -224,10 +226,11 @@ func (suite *ItemIntegrationSuite) TestDriveGetFolder() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			t := suite.T()
 			srv := suite.service
 
 			root, err := srv.Client().Drives().ByDriveId(test.driveID).Root().Get(ctx, nil)
@@ -425,11 +428,13 @@ func (suite *ItemUnitTestSuite) TestDrivePermissionsFilter() {
 	}
 	for _, tc := range cases {
 		suite.Run(tc.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			actual := filterUserPermissions(ctx, tc.graphPermissions)
-			assert.ElementsMatch(suite.T(), tc.parsedPermissions, actual)
+			assert.ElementsMatch(t, tc.parsedPermissions, actual)
 		})
 	}
 }

--- a/src/internal/connector/onedrive/metadata/permissions_test.go
+++ b/src/internal/connector/onedrive/metadata/permissions_test.go
@@ -135,10 +135,10 @@ func (suite *PermissionsUnitTestSuite) TestDiffPermissions() {
 
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			_, flush := tester.NewContext()
-			defer flush()
-
 			t := suite.T()
+
+			_, flush := tester.NewContext(t)
+			defer flush()
 
 			added, removed := DiffPermissions(test.before, test.after)
 

--- a/src/internal/connector/onedrive/permission_test.go
+++ b/src/internal/connector/onedrive/permission_test.go
@@ -151,10 +151,10 @@ func runComputeParentPermissionsTest(
 
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
-			defer flush()
-
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			m, err := computeParentPermissions(ctx, test.item, test.parentPerms)
 			require.NoError(t, err, "compute permissions")

--- a/src/internal/connector/onedrive/restore_test.go
+++ b/src/internal/connector/onedrive/restore_test.go
@@ -167,7 +167,7 @@ func (suite *RestoreUnitSuite) TestAugmentRestorePaths() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			_, flush := tester.NewContext()
+			_, flush := tester.NewContext(t)
 			defer flush()
 
 			base := "id/onedrive/user/files/drives/driveID/root:/"
@@ -271,7 +271,7 @@ func (suite *RestoreUnitSuite) TestAugmentRestorePaths_DifferentRestorePath() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			_, flush := tester.NewContext()
+			_, flush := tester.NewContext(t)
 			defer flush()
 
 			base := "id/onedrive/user/files/drives/driveID/root:/"

--- a/src/internal/connector/sharepoint/api/pages_test.go
+++ b/src/internal/connector/sharepoint/api/pages_test.go
@@ -55,10 +55,11 @@ func TestSharePointPageSuite(t *testing.T) {
 }
 
 func (suite *SharePointPageSuite) TestFetchPages() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	t := suite.T()
 	pgs, err := api.FetchPages(ctx, suite.service, suite.siteID)
 	assert.NoError(t, err, clues.ToCore(err))
 	require.NotNil(t, pgs)
@@ -70,10 +71,11 @@ func (suite *SharePointPageSuite) TestFetchPages() {
 }
 
 func (suite *SharePointPageSuite) TestGetSitePages() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	t := suite.T()
 	tuples, err := api.FetchPages(ctx, suite.service, suite.siteID)
 	require.NoError(t, err, clues.ToCore(err))
 	require.NotNil(t, tuples)
@@ -85,10 +87,10 @@ func (suite *SharePointPageSuite) TestGetSitePages() {
 }
 
 func (suite *SharePointPageSuite) TestRestoreSinglePage() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	destName := tester.DefaultTestRestoreDestination("").ContainerName
 	testName := "MockPage"

--- a/src/internal/connector/sharepoint/collection_test.go
+++ b/src/internal/connector/sharepoint/collection_test.go
@@ -149,7 +149,7 @@ func (suite *SharePointCollectionSuite) TestCollection_Items() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			col := NewCollection(test.getDir(t), nil, test.category, nil, control.Defaults())
@@ -178,7 +178,7 @@ func (suite *SharePointCollectionSuite) TestListCollection_Restore() {
 	// https://github.com/microsoftgraph/msgraph-sdk-go/issues/490
 	t.Skip("disabled until upstream issue with list restore is fixed.")
 
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	service := createTestService(t, suite.creds)

--- a/src/internal/connector/sharepoint/data_collections_test.go
+++ b/src/internal/connector/sharepoint/data_collections_test.go
@@ -93,11 +93,12 @@ func (suite *SharePointLibrariesUnitSuite) TestUpdateCollections() {
 
 	for _, test := range tests {
 		suite.Run(test.testCase, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			var (
-				t         = suite.T()
 				paths     = map[string]string{}
 				newPaths  = map[string]string{}
 				excluded  = map[string]struct{}{}
@@ -192,11 +193,12 @@ func TestSharePointPagesSuite(t *testing.T) {
 }
 
 func (suite *SharePointPagesSuite) TestCollectPages() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t      = suite.T()
 		siteID = tester.M365SiteID(t)
 		a      = tester.NewM365Account(t)
 	)

--- a/src/internal/connector/sharepoint/list_test.go
+++ b/src/internal/connector/sharepoint/list_test.go
@@ -48,10 +48,11 @@ func TestSharePointSuite(t *testing.T) {
 // - fetchContentBaseTypes
 // - fetchColumnPositions
 func (suite *SharePointSuite) TestLoadList() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	t := suite.T()
 	service := createTestService(t, suite.creds)
 	tuples, err := preFetchLists(ctx, service, "root")
 	require.NoError(t, err, clues.ToCore(err))

--- a/src/internal/connector/support/status_test.go
+++ b/src/internal/connector/support/status_test.go
@@ -47,7 +47,7 @@ func (suite *StatusUnitSuite) TestCreateStatus() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			result := CreateStatus(
@@ -64,7 +64,9 @@ func (suite *StatusUnitSuite) TestCreateStatus() {
 }
 
 func (suite *StatusUnitSuite) TestMergeStatus() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	table := []struct {

--- a/src/internal/events/events_test.go
+++ b/src/internal/events/events_test.go
@@ -26,10 +26,10 @@ func TestMetricsIntegrationSuite(t *testing.T) {
 }
 
 func (suite *EventsIntegrationSuite) TestNewBus() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	s, err := storage.NewStorage(
 		storage.ProviderS3,

--- a/src/internal/kopia/conn_test.go
+++ b/src/internal/kopia/conn_test.go
@@ -44,12 +44,14 @@ func TestWrapperUnitSuite(t *testing.T) {
 }
 
 func (suite *WrapperUnitSuite) TestCloseWithoutOpenDoesNotCrash() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	k := conn{}
 
-	assert.NotPanics(suite.T(), func() {
+	assert.NotPanics(t, func() {
 		k.Close(ctx)
 	})
 }
@@ -71,10 +73,10 @@ func TestWrapperIntegrationSuite(t *testing.T) {
 }
 
 func (suite *WrapperIntegrationSuite) TestRepoExistsError() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	st := tester.NewPrefixedS3Storage(t)
 	k := NewConn(st)
@@ -91,10 +93,11 @@ func (suite *WrapperIntegrationSuite) TestRepoExistsError() {
 }
 
 func (suite *WrapperIntegrationSuite) TestBadProviderErrors() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	t := suite.T()
 	st := tester.NewPrefixedS3Storage(t)
 	st.Provider = storage.ProviderUnknown
 	k := NewConn(st)
@@ -104,10 +107,11 @@ func (suite *WrapperIntegrationSuite) TestBadProviderErrors() {
 }
 
 func (suite *WrapperIntegrationSuite) TestConnectWithoutInitErrors() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	t := suite.T()
 	st := tester.NewPrefixedS3Storage(t)
 	k := NewConn(st)
 
@@ -116,10 +120,10 @@ func (suite *WrapperIntegrationSuite) TestConnectWithoutInitErrors() {
 }
 
 func (suite *WrapperIntegrationSuite) TestCloseTwiceDoesNotCrash() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	k, err := openKopiaRepo(t, ctx)
 	require.NoError(t, err, clues.ToCore(err))
@@ -133,10 +137,10 @@ func (suite *WrapperIntegrationSuite) TestCloseTwiceDoesNotCrash() {
 }
 
 func (suite *WrapperIntegrationSuite) TestCloseAfterWrap() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	k, err := openKopiaRepo(t, ctx)
 	require.NoError(t, err, clues.ToCore(err))
@@ -158,10 +162,10 @@ func (suite *WrapperIntegrationSuite) TestCloseAfterWrap() {
 }
 
 func (suite *WrapperIntegrationSuite) TestOpenAfterClose() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	k, err := openKopiaRepo(t, ctx)
 	require.NoError(t, err, clues.ToCore(err))
@@ -174,10 +178,10 @@ func (suite *WrapperIntegrationSuite) TestOpenAfterClose() {
 }
 
 func (suite *WrapperIntegrationSuite) TestBadCompressorType() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	k, err := openKopiaRepo(t, ctx)
 	require.NoError(t, err, clues.ToCore(err))
@@ -192,10 +196,10 @@ func (suite *WrapperIntegrationSuite) TestBadCompressorType() {
 }
 
 func (suite *WrapperIntegrationSuite) TestGetPolicyOrDefault_GetsDefault() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	k, err := openKopiaRepo(t, ctx)
 	require.NoError(t, err, clues.ToCore(err))
@@ -217,10 +221,11 @@ func (suite *WrapperIntegrationSuite) TestGetPolicyOrDefault_GetsDefault() {
 }
 
 func (suite *WrapperIntegrationSuite) TestSetCompressor() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	t := suite.T()
 	compressor := "pgzip"
 
 	k, err := openKopiaRepo(t, ctx)
@@ -336,10 +341,10 @@ func (suite *WrapperIntegrationSuite) TestConfigDefaultsSetOnInitAndNotOnConnect
 
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
-			defer flush()
-
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			k, err := openKopiaRepo(t, ctx)
 			require.NoError(t, err, clues.ToCore(err))
@@ -374,10 +379,10 @@ func (suite *WrapperIntegrationSuite) TestConfigDefaultsSetOnInitAndNotOnConnect
 }
 
 func (suite *WrapperIntegrationSuite) TestInitAndConnWithTempDirectory() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	k, err := openKopiaRepo(t, ctx)
 	require.NoError(t, err, clues.ToCore(err))
@@ -394,7 +399,9 @@ func (suite *WrapperIntegrationSuite) TestInitAndConnWithTempDirectory() {
 }
 
 func (suite *WrapperIntegrationSuite) TestSetUserAndHost() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	opts := repository.Options{
@@ -402,7 +409,6 @@ func (suite *WrapperIntegrationSuite) TestSetUserAndHost() {
 		Host: "bar",
 	}
 
-	t := suite.T()
 	st := tester.NewPrefixedS3Storage(t)
 	k := NewConn(st)
 

--- a/src/internal/kopia/data_collection_test.go
+++ b/src/internal/kopia/data_collection_test.go
@@ -212,10 +212,10 @@ func (suite *KopiaDataCollectionUnitSuite) TestReturnsStreams() {
 
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
-			defer flush()
-
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			c := kopiaDataCollection{
 				dir:             getLayout(),
@@ -366,10 +366,10 @@ func (suite *KopiaDataCollectionUnitSuite) TestFetch() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
-			defer flush()
-
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			root := getLayout(test.inputSerializationVersion)
 			c := &i64counter{}

--- a/src/internal/kopia/merge_collection_test.go
+++ b/src/internal/kopia/merge_collection_test.go
@@ -47,10 +47,11 @@ func (suite *MergeCollectionUnitSuite) TestReturnsPath() {
 }
 
 func (suite *MergeCollectionUnitSuite) TestItems() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	t := suite.T()
 	storagePaths := []string{
 		"tenant-id/exchange/user-id/mail/some/folder/path1",
 		"tenant-id/exchange/user-id/mail/some/folder/path2",
@@ -253,10 +254,11 @@ func (suite *MergeCollectionUnitSuite) TestFetch() {
 
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			t := suite.T()
 			c := &i64counter{}
 
 			dc := mergeCollection{fullPath: pth}

--- a/src/internal/kopia/model_store_test.go
+++ b/src/internal/kopia/model_store_test.go
@@ -45,8 +45,10 @@ func TestModelStoreUnitSuite(t *testing.T) {
 }
 
 func (suite *ModelStoreUnitSuite) TestCloseWithoutInitDoesNotPanic() {
-	assert.NotPanics(suite.T(), func() {
-		ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	assert.NotPanics(t, func() {
+		ctx, flush := tester.NewContext(t)
 		defer flush()
 
 		m := &ModelStore{}
@@ -74,7 +76,7 @@ func TestModelStoreIntegrationSuite(t *testing.T) {
 }
 
 func (suite *ModelStoreIntegrationSuite) SetupTest() {
-	suite.ctx, suite.flush = tester.NewContext()
+	suite.ctx, suite.flush = tester.NewContext(suite.T())
 	suite.m = getModelStore(suite.T(), suite.ctx)
 }
 
@@ -587,10 +589,11 @@ func (suite *ModelStoreIntegrationSuite) TestPutUpdate() {
 
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			t := suite.T()
 			theModelType := model.BackupOpSchema
 
 			m := getModelStore(t, ctx)
@@ -669,7 +672,7 @@ func (suite *ModelStoreIntegrationSuite) TestPutUpdate_FailsNotMatchingPrev() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			m := getModelStore(t, ctx)
@@ -739,10 +742,10 @@ func TestModelStoreRegressionSuite(t *testing.T) {
 // Tests that if we get an error or crash while in the middle of an Update no
 // results will be visible to higher layers.
 func (suite *ModelStoreRegressionSuite) TestFailDuringWriteSessionHasNoVisibleEffect() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	m := getModelStore(t, ctx)
 	defer func() {
@@ -840,10 +843,11 @@ func reconnectToModelStore(
 // Ensures there's no shared configuration state between different instances of
 // the ModelStore (and consequently the underlying kopia instances).
 func (suite *ModelStoreRegressionSuite) TestMultipleConfigs() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	t := suite.T()
 	backupModel := backup.Backup{
 		SnapshotID: "snapshotID",
 	}

--- a/src/internal/kopia/snapshot_manager_test.go
+++ b/src/internal/kopia/snapshot_manager_test.go
@@ -755,7 +755,7 @@ func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshots() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			msm := &mockSnapshotManager{
@@ -879,7 +879,7 @@ func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshots_customTags() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			msm := &mockSnapshotManager{
@@ -952,10 +952,10 @@ func (msm *mockErrorSnapshotManager) LoadSnapshots(
 }
 
 func (suite *SnapshotFetchUnitSuite) TestFetchPrevSnapshots_withErrors() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	input := testAllUsersMail
 	mockData := []manifestInfo{

--- a/src/internal/kopia/upload_test.go
+++ b/src/internal/kopia/upload_test.go
@@ -659,13 +659,13 @@ func TestHierarchyBuilderUnitSuite(t *testing.T) {
 }
 
 func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree() {
-	tester.LogTimeOfTest(suite.T())
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+	tester.LogTimeOfTest(t)
 
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t            = suite.T()
 		tenant       = "a-tenant"
 		user1        = testUser
 		user1Encoded = encodeAsPath(user1)
@@ -744,9 +744,6 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree() {
 }
 
 func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_MixedDirectory() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	var (
 		subfldID  = "subfolder_ID"
 		subfldDir = "subfolder"
@@ -799,6 +796,9 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_MixedDirectory() 
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			progress := &corsoProgress{
 				pending: map[string]*itemDetails{},
@@ -901,11 +901,11 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_Fails() {
 	}
 
 	for _, test := range table {
-		ctx, flush := tester.NewContext()
-		defer flush()
-
 		suite.Run(test.name, func() {
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			progress := &corsoProgress{
 				toMerge: newMergeDetails(),
@@ -1000,7 +1000,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeErrors() {
 
 			tester.LogTimeOfTest(t)
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			progress := &corsoProgress{
@@ -1294,7 +1294,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
 
 			tester.LogTimeOfTest(t)
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			progress := &corsoProgress{
@@ -2217,7 +2217,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 
 			tester.LogTimeOfTest(t)
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			progress := &corsoProgress{
@@ -2254,7 +2254,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSkipsDeletedSubtre
 	tester.LogTimeOfTest(suite.T())
 	t := suite.T()
 
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	const (
@@ -2416,7 +2416,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_HandleEmptyBase()
 	tester.LogTimeOfTest(suite.T())
 	t := suite.T()
 
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
@@ -2533,7 +2533,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSelectsCorrectSubt
 	tester.LogTimeOfTest(suite.T())
 	t := suite.T()
 
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	const contactsDir = "contacts"
@@ -2772,7 +2772,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSelectsMigrateSubt
 	tester.LogTimeOfTest(suite.T())
 	t := suite.T()
 
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	const (

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -148,7 +148,7 @@ func TestKopiaUnitSuite(t *testing.T) {
 
 func (suite *KopiaUnitSuite) TestCloseWithoutInitDoesNotPanic() {
 	assert.NotPanics(suite.T(), func() {
-		ctx, flush := tester.NewContext()
+		ctx, flush := tester.NewContext(suite.T())
 		defer flush()
 
 		w := &Wrapper{}
@@ -176,10 +176,10 @@ func TestBasicKopiaIntegrationSuite(t *testing.T) {
 // cause maintenance to run. It treats kopia maintenance as a black box and
 // only checks the returned error.
 func (suite *BasicKopiaIntegrationSuite) TestMaintenance_FirstRun_NoChanges() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	k, err := openKopiaRepo(t, ctx)
 	require.NoError(t, err, clues.ToCore(err))
@@ -196,10 +196,10 @@ func (suite *BasicKopiaIntegrationSuite) TestMaintenance_FirstRun_NoChanges() {
 }
 
 func (suite *BasicKopiaIntegrationSuite) TestMaintenance_WrongUser_NoForce_Fails() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	k, err := openKopiaRepo(t, ctx)
 	require.NoError(t, err, clues.ToCore(err))
@@ -233,10 +233,10 @@ func (suite *BasicKopiaIntegrationSuite) TestMaintenance_WrongUser_NoForce_Fails
 }
 
 func (suite *BasicKopiaIntegrationSuite) TestMaintenance_WrongUser_Force_Succeeds() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	k, err := openKopiaRepo(t, ctx)
 	require.NoError(t, err, clues.ToCore(err))
@@ -328,7 +328,7 @@ func (suite *KopiaIntegrationSuite) SetupSuite() {
 
 func (suite *KopiaIntegrationSuite) SetupTest() {
 	t := suite.T()
-	suite.ctx, suite.flush = tester.NewContext()
+	suite.ctx, suite.flush = tester.NewContext(t)
 
 	c, err := openKopiaRepo(t, suite.ctx)
 	require.NoError(t, err, clues.ToCore(err))
@@ -662,10 +662,10 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_NoDetailsForMeta() {
 }
 
 func (suite *KopiaIntegrationSuite) TestRestoreAfterCompressionChange() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	k, err := openKopiaRepo(t, ctx)
 	require.NoError(t, err, clues.ToCore(err))
@@ -880,7 +880,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollectionsHandlesNoCollections() 
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			s, d, _, err := suite.w.ConsumeBackupCollections(
@@ -1309,10 +1309,10 @@ func (suite *KopiaSimpleRepoIntegrationSuite) TestProduceRestoreCollections() {
 
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
-			defer flush()
-
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			// May slightly overallocate as only items that are actually in our map
 			// are expected. The rest are errors, but best-effort says it should carry
@@ -1434,10 +1434,11 @@ func (suite *KopiaSimpleRepoIntegrationSuite) TestProduceRestoreCollections_Path
 
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			t := suite.T()
 			expected := make(map[string][]byte, len(test.inputPaths))
 
 			for _, pth := range test.inputPaths {
@@ -1471,10 +1472,10 @@ func (suite *KopiaSimpleRepoIntegrationSuite) TestProduceRestoreCollections_Path
 // properly even with different Restore and Storage paths and items from
 // different kopia directories.
 func (suite *KopiaSimpleRepoIntegrationSuite) TestProduceRestoreCollections_Fetch() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	rp1, err := path.Build(
 		testTenant,

--- a/src/internal/observe/observe_test.go
+++ b/src/internal/observe/observe_test.go
@@ -35,10 +35,10 @@ var (
 )
 
 func (suite *ObserveProgressUnitSuite) TestItemProgress() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	recorder := strings.Builder{}
 	SeedWriter(ctx, &recorder, nil)
@@ -88,12 +88,12 @@ func (suite *ObserveProgressUnitSuite) TestItemProgress() {
 }
 
 func (suite *ObserveProgressUnitSuite) TestCollectionProgress_unblockOnCtxCancel() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	ctx, cancel := context.WithCancel(ctx)
-
-	t := suite.T()
 
 	recorder := strings.Builder{}
 	SeedWriter(ctx, &recorder, nil)
@@ -125,10 +125,10 @@ func (suite *ObserveProgressUnitSuite) TestCollectionProgress_unblockOnCtxCancel
 }
 
 func (suite *ObserveProgressUnitSuite) TestCollectionProgress_unblockOnChannelClose() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	recorder := strings.Builder{}
 	SeedWriter(ctx, &recorder, nil)
@@ -158,7 +158,9 @@ func (suite *ObserveProgressUnitSuite) TestCollectionProgress_unblockOnChannelCl
 }
 
 func (suite *ObserveProgressUnitSuite) TestObserveProgress() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	recorder := strings.Builder{}
@@ -174,12 +176,14 @@ func (suite *ObserveProgressUnitSuite) TestObserveProgress() {
 
 	Message(ctx, message)
 	Complete()
-	require.NotEmpty(suite.T(), recorder.String())
-	require.Contains(suite.T(), recorder.String(), message)
+	require.NotEmpty(t, recorder.String())
+	require.Contains(t, recorder.String(), message)
 }
 
 func (suite *ObserveProgressUnitSuite) TestObserveProgressWithCompletion() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	recorder := strings.Builder{}
@@ -203,13 +207,15 @@ func (suite *ObserveProgressUnitSuite) TestObserveProgressWithCompletion() {
 
 	Complete()
 
-	require.NotEmpty(suite.T(), recorder.String())
-	require.Contains(suite.T(), recorder.String(), message)
-	require.Contains(suite.T(), recorder.String(), "done")
+	require.NotEmpty(t, recorder.String())
+	require.Contains(t, recorder.String(), message)
+	require.Contains(t, recorder.String(), "done")
 }
 
 func (suite *ObserveProgressUnitSuite) TestObserveProgressWithChannelClosed() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	recorder := strings.Builder{}
@@ -233,13 +239,15 @@ func (suite *ObserveProgressUnitSuite) TestObserveProgressWithChannelClosed() {
 
 	Complete()
 
-	require.NotEmpty(suite.T(), recorder.String())
-	require.Contains(suite.T(), recorder.String(), message)
-	require.Contains(suite.T(), recorder.String(), "done")
+	require.NotEmpty(t, recorder.String())
+	require.Contains(t, recorder.String(), message)
+	require.Contains(t, recorder.String(), "done")
 }
 
 func (suite *ObserveProgressUnitSuite) TestObserveProgressWithContextCancelled() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -265,12 +273,14 @@ func (suite *ObserveProgressUnitSuite) TestObserveProgressWithContextCancelled()
 
 	Complete()
 
-	require.NotEmpty(suite.T(), recorder.String())
-	require.Contains(suite.T(), recorder.String(), message)
+	require.NotEmpty(t, recorder.String())
+	require.Contains(t, recorder.String(), message)
 }
 
 func (suite *ObserveProgressUnitSuite) TestObserveProgressWithCount() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	recorder := strings.Builder{}
@@ -297,13 +307,15 @@ func (suite *ObserveProgressUnitSuite) TestObserveProgressWithCount() {
 
 	Complete()
 
-	require.NotEmpty(suite.T(), recorder.String())
-	require.Contains(suite.T(), recorder.String(), message)
-	require.Contains(suite.T(), recorder.String(), fmt.Sprintf("%d/%d", count, count))
+	require.NotEmpty(t, recorder.String())
+	require.Contains(t, recorder.String(), message)
+	require.Contains(t, recorder.String(), fmt.Sprintf("%d/%d", count, count))
 }
 
 func (suite *ObserveProgressUnitSuite) TestrogressWithCountChannelClosed() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	recorder := strings.Builder{}
@@ -328,17 +340,18 @@ func (suite *ObserveProgressUnitSuite) TestrogressWithCountChannelClosed() {
 
 	Complete()
 
-	require.NotEmpty(suite.T(), recorder.String())
-	require.Contains(suite.T(), recorder.String(), message)
-	require.Contains(suite.T(), recorder.String(), fmt.Sprintf("%d/%d", 0, count))
+	require.NotEmpty(t, recorder.String())
+	require.Contains(t, recorder.String(), message)
+	require.Contains(t, recorder.String(), fmt.Sprintf("%d/%d", 0, count))
 }
 
 func (suite *ObserveProgressUnitSuite) TestListen() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t     = suite.T()
 		ch    = make(chan struct{})
 		end   bool
 		onEnd = func() { end = true }
@@ -361,11 +374,12 @@ func (suite *ObserveProgressUnitSuite) TestListen() {
 }
 
 func (suite *ObserveProgressUnitSuite) TestListen_close() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t     = suite.T()
 		ch    = make(chan struct{})
 		end   bool
 		onEnd = func() { end = true }
@@ -385,13 +399,14 @@ func (suite *ObserveProgressUnitSuite) TestListen_close() {
 }
 
 func (suite *ObserveProgressUnitSuite) TestListen_cancel() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	ctx, cancelFn := context.WithCancel(ctx)
 
 	var (
-		t     = suite.T()
 		ch    = make(chan struct{})
 		end   bool
 		onEnd = func() { end = true }

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -550,7 +550,9 @@ func (suite *BackupOpIntegrationSuite) TestNewBackupOperation() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			sel := selectors.Selector{DiscreteOwner: "test"}
@@ -565,7 +567,7 @@ func (suite *BackupOpIntegrationSuite) TestNewBackupOperation() {
 				sel,
 				sel,
 				evmock.NewBus())
-			test.errCheck(suite.T(), err, clues.ToCore(err))
+			test.errCheck(t, err, clues.ToCore(err))
 		})
 	}
 }
@@ -577,9 +579,6 @@ func (suite *BackupOpIntegrationSuite) TestNewBackupOperation() {
 // TestBackup_Run ensures that Integration Testing works
 // for the following scopes: Contacts, Events, and Mail
 func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchange() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	tests := []struct {
 		name          string
 		selector      func() *selectors.ExchangeBackup
@@ -621,8 +620,12 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_exchange() {
 	}
 	for _, test := range tests {
 		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
 			var (
-				t       = suite.T()
 				mb      = evmock.NewBus()
 				sel     = test.selector().Selector
 				ffs     = control.Toggles{}
@@ -719,13 +722,14 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_nonIncrementalExchange() {
 }
 
 func testExchangeContinuousBackups(suite *BackupOpIntegrationSuite, toggles control.Toggles) {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	tester.LogTimeOfTest(suite.T())
+	tester.LogTimeOfTest(t)
 
 	var (
-		t          = suite.T()
 		acct       = tester.NewM365Account(t)
 		mb         = evmock.NewBus()
 		now        = dttm.Now()
@@ -1293,11 +1297,12 @@ func testExchangeContinuousBackups(suite *BackupOpIntegrationSuite, toggles cont
 // ---------------------------------------------------------------------------
 
 func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDrive() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t      = suite.T()
 		tenID  = tester.M365TenantID(t)
 		mb     = evmock.NewBus()
 		userID = tester.SecondaryM365UserID(t)
@@ -1407,11 +1412,12 @@ func runDriveIncrementalTest(
 	getTestDriveID func(*testing.T, context.Context, graph.Servicer) string,
 	skipPermissionsTests bool,
 ) {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t    = suite.T()
 		acct = tester.NewM365Account(t)
 		ffs  = control.Toggles{}
 		mb   = evmock.NewBus()
@@ -1915,11 +1921,12 @@ func runDriveIncrementalTest(
 }
 
 func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveOwnerMigration() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t    = suite.T()
 		acct = tester.NewM365Account(t)
 		ffs  = control.Toggles{}
 		mb   = evmock.NewBus()
@@ -2037,11 +2044,12 @@ func (suite *BackupOpIntegrationSuite) TestBackup_Run_oneDriveOwnerMigration() {
 // ---------------------------------------------------------------------------
 
 func (suite *BackupOpIntegrationSuite) TestBackup_Run_sharePoint() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t   = suite.T()
 		mb  = evmock.NewBus()
 		sel = selectors.NewSharePointBackup([]string{suite.site})
 	)

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -411,9 +411,6 @@ func TestBackupOpUnitSuite(t *testing.T) {
 }
 
 func (suite *BackupOpUnitSuite) TestBackupOperation_PersistResults() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	var (
 		kw   = &kopia.Wrapper{}
 		sw   = &store.Wrapper{}
@@ -462,6 +459,10 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_PersistResults() {
 	for _, test := range table {
 		suite.Run(test.expectStatus.String(), func() {
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
 			sel := selectors.Selector{}
 			sel.DiscreteOwner = "bombadil"
 
@@ -616,7 +617,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_ConsumeBackupDataCollections
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			mbu := &mockBackupConsumer{
@@ -1191,7 +1192,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			mds := ssmock.Streamer{Deets: test.populatedDetails}
@@ -1302,7 +1303,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsFolde
 			details.ExchangeMail))
 	}
 
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (

--- a/src/internal/operations/helpers_test.go
+++ b/src/internal/operations/helpers_test.go
@@ -89,10 +89,11 @@ func (suite *HelpersUnitSuite) TestFinalizeErrorHandling() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			t := suite.T()
 			errs := test.errs()
 
 			finalizeErrorHandling(ctx, test.opts, errs, "test")

--- a/src/internal/operations/maintenance_test.go
+++ b/src/internal/operations/maintenance_test.go
@@ -35,7 +35,7 @@ func (suite *MaintenanceOpIntegrationSuite) TestRepoMaintenance() {
 		k  = kopia.NewConn(st)
 	)
 
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	err := k.Initialize(ctx, repository.Options{})

--- a/src/internal/operations/manifests_test.go
+++ b/src/internal/operations/manifests_test.go
@@ -239,7 +239,7 @@ func (suite *OperationsManifestsUnitSuite) TestCollectMetadata() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			paths := test.expectPaths(t, test.fileNames)
@@ -414,7 +414,7 @@ func (suite *OperationsManifestsUnitSuite) TestVerifyDistinctBases() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(suite.T())
 			defer flush()
 
 			err := verifyDistinctBases(ctx, test.mans)
@@ -670,7 +670,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			mans, dcs, b, err := produceManifestsAndMetadata(
@@ -979,7 +979,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_fallb
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			mainReasons := []kopia.Reason{}
@@ -1196,7 +1196,7 @@ func (suite *BackupManifestUnitSuite) TestBackupOperation_VerifyDistinctBases() 
 
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(suite.T())
 			defer flush()
 
 			err := verifyDistinctBases(ctx, test.input)
@@ -1315,7 +1315,7 @@ func (suite *BackupManifestUnitSuite) TestBackupOperation_CollectMetadata() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			mr := &mockRestoreProducer{}

--- a/src/internal/operations/pathtransformer/restore_path_transformer_test.go
+++ b/src/internal/operations/pathtransformer/restore_path_transformer_test.go
@@ -296,10 +296,10 @@ func (suite *RestorePathTransformerUnitSuite) TestGetPaths() {
 
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
-			defer flush()
-
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			paths, err := pathtransformer.GetPaths(
 				ctx,

--- a/src/internal/operations/restore_test.go
+++ b/src/internal/operations/restore_test.go
@@ -46,9 +46,6 @@ func TestRestoreOpSuite(t *testing.T) {
 }
 
 func (suite *RestoreOpSuite) TestRestoreOperation_PersistResults() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	var (
 		kw   = &kopia.Wrapper{}
 		sw   = &store.Wrapper{}
@@ -105,6 +102,9 @@ func (suite *RestoreOpSuite) TestRestoreOperation_PersistResults() {
 	for _, test := range table {
 		suite.Run(test.expectStatus.String(), func() {
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			op, err := NewRestoreOperation(
 				ctx,
@@ -165,11 +165,12 @@ func TestRestoreOpIntegrationSuite(t *testing.T) {
 }
 
 func (suite *RestoreOpIntegrationSuite) SetupSuite() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t  = suite.T()
 		st = tester.NewPrefixedS3Storage(t)
 		k  = kopia.NewConn(st)
 	)
@@ -198,7 +199,7 @@ func (suite *RestoreOpIntegrationSuite) SetupSuite() {
 }
 
 func (suite *RestoreOpIntegrationSuite) TearDownSuite() {
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(suite.T())
 	defer flush()
 
 	if suite.ms != nil {
@@ -240,7 +241,7 @@ func (suite *RestoreOpIntegrationSuite) TestNewRestoreOperation() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(suite.T())
 			defer flush()
 
 			_, err := NewRestoreOperation(
@@ -266,7 +267,7 @@ func setupExchangeBackup(
 	acct account.Account,
 	owner string,
 ) bupResults {
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
@@ -316,7 +317,7 @@ func setupSharePointBackup(
 	acct account.Account,
 	owner string,
 ) bupResults {
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
@@ -379,9 +380,6 @@ func setupSharePointBackup(
 }
 
 func (suite *RestoreOpIntegrationSuite) TestRestore_Run() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	tables := []struct {
 		name        string
 		owner       string
@@ -423,6 +421,9 @@ func (suite *RestoreOpIntegrationSuite) TestRestore_Run() {
 				bup = test.setup(t, suite.kw, suite.sw, suite.acct, test.owner)
 			)
 
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
 			require.NotZero(t, bup.items)
 			require.NotEmpty(t, bup.backupID)
 
@@ -459,11 +460,12 @@ func (suite *RestoreOpIntegrationSuite) TestRestore_Run() {
 }
 
 func (suite *RestoreOpIntegrationSuite) TestRestore_Run_errorNoBackup() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t    = suite.T()
 		dest = tester.DefaultTestRestoreDestination("")
 		mb   = evmock.NewBus()
 	)

--- a/src/internal/streamstore/collectables_test.go
+++ b/src/internal/streamstore/collectables_test.go
@@ -33,10 +33,10 @@ func TestStreamStoreIntgSuite(t *testing.T) {
 }
 
 func (suite *StreamStoreIntgSuite) SetupSubTest() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	// need to initialize the repository before we can test connecting to it.
 	st := tester.NewPrefixedS3Storage(t)
@@ -148,11 +148,12 @@ func (suite *StreamStoreIntgSuite) TestStreamer() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			var (
-				t   = suite.T()
 				ss  = suite.ss
 				err error
 			)

--- a/src/internal/tester/context.go
+++ b/src/internal/tester/context.go
@@ -3,14 +3,14 @@ package tester
 import (
 	"context"
 	"os"
+	"testing"
 
 	"github.com/alcionai/clues"
-	"github.com/google/uuid"
 
 	"github.com/alcionai/corso/src/pkg/logger"
 )
 
-func NewContext() (context.Context, func()) {
+func NewContext(t *testing.T) (context.Context, func()) {
 	level := logger.LLInfo
 	format := logger.LFText
 
@@ -29,19 +29,27 @@ func NewContext() (context.Context, func()) {
 	ctx, _ := logger.CtxOrSeed(context.Background(), ls)
 
 	// ensure logs can be easily associated with each test
-	// todo: replace with test name.  starting off with
-	// uuid to avoid million-line PR change.
-	ctx = clues.Add(ctx, "test_name", uuid.NewString())
+	if t != nil {
+		ctx = clues.Add(ctx, "test_name", t.Name())
+	}
 
 	return ctx, func() { logger.Flush(ctx) }
 }
 
-func WithContext(ctx context.Context) (context.Context, func()) {
+func WithContext(
+	t *testing.T,
+	ctx context.Context, //revive:disable-line:context-as-argument
+) (context.Context, func()) {
 	ls := logger.Settings{
 		Level:  logger.LLDebug,
 		Format: logger.LFText,
 	}
 	ctx, _ = logger.CtxOrSeed(ctx, ls)
+
+	// ensure logs can be easily associated with each test
+	// todo: replace with test name.  starting off with
+	// uuid to avoid million-line PR change.
+	ctx = clues.Add(ctx, "test_name", t.Name())
 
 	return ctx, func() { logger.Flush(ctx) }
 }

--- a/src/pkg/repository/loadtest/repository_load_test.go
+++ b/src/pkg/repository/loadtest/repository_load_test.go
@@ -55,7 +55,7 @@ func TestMain(m *testing.M) {
 		return
 	}
 
-	ctx, logFlush := tester.NewContext()
+	ctx, logFlush := tester.NewContext(nil)
 	loadCtx = ctx
 
 	if err := D.InitCollector(); err != nil {
@@ -89,7 +89,7 @@ func initM365Repo(t *testing.T) (
 ) {
 	tester.MustGetEnvSets(t, tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs)
 
-	ctx, flush := tester.WithContext(loadCtx)
+	ctx, flush := tester.WithContext(t, loadCtx)
 	defer flush()
 
 	st := tester.NewPrefixedS3Storage(t)
@@ -432,7 +432,7 @@ func (suite *LoadExchangeSuite) TeardownSuite() {
 }
 
 func (suite *LoadExchangeSuite) TestExchange() {
-	ctx, flush := tester.WithContext(suite.ctx)
+	ctx, flush := tester.WithContext(suite.T(), suite.ctx)
 	defer flush()
 
 	bsel := selectors.NewExchangeBackup(suite.usersUnderTest)
@@ -484,7 +484,7 @@ func (suite *IndividualLoadExchangeSuite) TeardownSuite() {
 }
 
 func (suite *IndividualLoadExchangeSuite) TestExchange() {
-	ctx, flush := tester.WithContext(suite.ctx)
+	ctx, flush := tester.WithContext(suite.T(), suite.ctx)
 	defer flush()
 
 	bsel := selectors.NewExchangeBackup(suite.usersUnderTest)
@@ -538,7 +538,7 @@ func (suite *LoadOneDriveSuite) TeardownSuite() {
 }
 
 func (suite *LoadOneDriveSuite) TestOneDrive() {
-	ctx, flush := tester.WithContext(suite.ctx)
+	ctx, flush := tester.WithContext(suite.T(), suite.ctx)
 	defer flush()
 
 	bsel := selectors.NewOneDriveBackup(suite.usersUnderTest)
@@ -585,7 +585,7 @@ func (suite *IndividualLoadOneDriveSuite) TeardownSuite() {
 }
 
 func (suite *IndividualLoadOneDriveSuite) TestOneDrive() {
-	ctx, flush := tester.WithContext(suite.ctx)
+	ctx, flush := tester.WithContext(suite.T(), suite.ctx)
 	defer flush()
 
 	bsel := selectors.NewOneDriveBackup(suite.usersUnderTest)
@@ -637,7 +637,7 @@ func (suite *LoadSharePointSuite) TeardownSuite() {
 }
 
 func (suite *LoadSharePointSuite) TestSharePoint() {
-	ctx, flush := tester.WithContext(suite.ctx)
+	ctx, flush := tester.WithContext(suite.T(), suite.ctx)
 	defer flush()
 
 	bsel := selectors.NewSharePointBackup(suite.sitesUnderTest)
@@ -685,7 +685,7 @@ func (suite *IndividualLoadSharePointSuite) TeardownSuite() {
 }
 
 func (suite *IndividualLoadSharePointSuite) TestSharePoint() {
-	ctx, flush := tester.WithContext(suite.ctx)
+	ctx, flush := tester.WithContext(suite.T(), suite.ctx)
 	defer flush()
 
 	bsel := selectors.NewSharePointBackup(suite.sitesUnderTest)

--- a/src/pkg/repository/repository_test.go
+++ b/src/pkg/repository/repository_test.go
@@ -51,7 +51,7 @@ func (suite *RepositoryUnitSuite) TestInitialize() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			st, err := test.storage()
@@ -85,7 +85,7 @@ func (suite *RepositoryUnitSuite) TestConnect() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			st, err := test.storage()
@@ -114,9 +114,6 @@ func TestRepositoryIntegrationSuite(t *testing.T) {
 }
 
 func (suite *RepositoryIntegrationSuite) TestInitialize() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	table := []struct {
 		name     string
 		account  account.Account
@@ -132,6 +129,9 @@ func (suite *RepositoryIntegrationSuite) TestInitialize() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			st := test.storage(t)
 			r, err := repository.Initialize(ctx, test.account, st, control.Defaults())
@@ -157,7 +157,7 @@ func (suite *RepositoryIntegrationSuite) TestInitializeWithRole() {
 		suite.T().Skip(roleARNEnvKey + " not set")
 	}
 
-	ctx, flush := tester.NewContext()
+	ctx, flush := tester.NewContext(suite.T())
 	defer flush()
 
 	st := tester.NewPrefixedS3Storage(suite.T())
@@ -175,10 +175,10 @@ func (suite *RepositoryIntegrationSuite) TestInitializeWithRole() {
 }
 
 func (suite *RepositoryIntegrationSuite) TestConnect() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	// need to initialize the repository before we can test connecting to it.
 	st := tester.NewPrefixedS3Storage(t)
@@ -192,10 +192,10 @@ func (suite *RepositoryIntegrationSuite) TestConnect() {
 }
 
 func (suite *RepositoryIntegrationSuite) TestConnect_sameID() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	// need to initialize the repository before we can test connecting to it.
 	st := tester.NewPrefixedS3Storage(t)
@@ -215,10 +215,10 @@ func (suite *RepositoryIntegrationSuite) TestConnect_sameID() {
 }
 
 func (suite *RepositoryIntegrationSuite) TestNewBackup() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	acct := tester.NewM365Account(t)
 
@@ -236,10 +236,10 @@ func (suite *RepositoryIntegrationSuite) TestNewBackup() {
 }
 
 func (suite *RepositoryIntegrationSuite) TestNewRestore() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	acct := tester.NewM365Account(t)
 	dest := tester.DefaultTestRestoreDestination("")
@@ -256,10 +256,10 @@ func (suite *RepositoryIntegrationSuite) TestNewRestore() {
 }
 
 func (suite *RepositoryIntegrationSuite) TestNewMaintenance() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	acct := tester.NewM365Account(t)
 
@@ -275,10 +275,10 @@ func (suite *RepositoryIntegrationSuite) TestNewMaintenance() {
 }
 
 func (suite *RepositoryIntegrationSuite) TestConnect_DisableMetrics() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	// need to initialize the repository before we can test connecting to it.
 	st := tester.NewPrefixedS3Storage(t)

--- a/src/pkg/repository/repository_unexported_test.go
+++ b/src/pkg/repository/repository_unexported_test.go
@@ -81,10 +81,10 @@ func (suite *RepositoryBackupsUnitSuite) TestGetBackup() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
-			defer flush()
-
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			b, err := getBackup(ctx, string(bup.ID), test.sw)
 			test.expectErr(t, err)
@@ -193,10 +193,10 @@ func (suite *RepositoryBackupsUnitSuite) TestDeleteBackup() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
-			defer flush()
-
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
 			err := deleteBackup(ctx, string(test.sw.Backup.ID), test.kw, test.sw)
 			test.expectErr(t, err)
@@ -225,11 +225,12 @@ func TestRepositoryModelIntgSuite(t *testing.T) {
 }
 
 func (suite *RepositoryModelIntgSuite) SetupSuite() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t   = suite.T()
 		s   = tester.NewPrefixedS3Storage(t)
 		k   = kopia.NewConn(s)
 		err error
@@ -257,10 +258,10 @@ func (suite *RepositoryModelIntgSuite) SetupSuite() {
 }
 
 func (suite *RepositoryModelIntgSuite) TearDownSuite() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	if suite.ms != nil {
 		err := suite.ms.Close(ctx)
@@ -278,11 +279,12 @@ func (suite *RepositoryModelIntgSuite) TearDownSuite() {
 }
 
 func (suite *RepositoryModelIntgSuite) TestGetRepositoryModel() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t = suite.T()
 		s = tester.NewPrefixedS3Storage(t)
 		k = kopia.NewConn(s)
 	)
@@ -393,23 +395,22 @@ func (suite *RepositoryModelIntgSuite) TestGetBackupDetails() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			var (
-				t = suite.T()
-				b = writeBackup(
-					t,
-					ctx,
-					suite.kw,
-					suite.sw,
-					tenantID, "snapID", test.writeBupID,
-					selectors.NewExchangeBackup([]string{brunhilda}).Selector,
-					brunhilda, brunhilda,
-					test.deets,
-					&fault.Errors{},
-					fault.New(true))
-			)
+			b := writeBackup(
+				t,
+				ctx,
+				suite.kw,
+				suite.sw,
+				tenantID, "snapID", test.writeBupID,
+				selectors.NewExchangeBackup([]string{brunhilda}).Selector,
+				brunhilda, brunhilda,
+				test.deets,
+				&fault.Errors{},
+				fault.New(true))
 
 			rDeets, rBup, err := getBackupDetails(ctx, test.readBupID, tenantID, suite.kw, suite.sw, fault.New(true))
 			test.expectErr(t, err)
@@ -501,23 +502,22 @@ func (suite *RepositoryModelIntgSuite) TestGetBackupErrors() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			var (
-				t = suite.T()
-				b = writeBackup(
-					t,
-					ctx,
-					suite.kw,
-					suite.sw,
-					tenantID, "snapID", test.writeBupID,
-					selectors.NewExchangeBackup([]string{brunhilda}).Selector,
-					brunhilda, brunhilda,
-					test.deets,
-					test.errors,
-					fault.New(failFast))
-			)
+			b := writeBackup(
+				t,
+				ctx,
+				suite.kw,
+				suite.sw,
+				tenantID, "snapID", test.writeBupID,
+				selectors.NewExchangeBackup([]string{brunhilda}).Selector,
+				brunhilda, brunhilda,
+				test.deets,
+				test.errors,
+				fault.New(failFast))
 
 			rErrors, rBup, err := getBackupErrors(ctx, test.readBupID, tenantID, suite.kw, suite.sw, fault.New(failFast))
 			test.expectErr(t, err)

--- a/src/pkg/selectors/exchange_test.go
+++ b/src/pkg/selectors/exchange_test.go
@@ -1045,7 +1045,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			sel := test.makeSelector()
@@ -1271,7 +1271,7 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			sel := test.makeSelector()

--- a/src/pkg/selectors/onedrive_test.go
+++ b/src/pkg/selectors/onedrive_test.go
@@ -298,7 +298,7 @@ func (suite *OneDriveSelectorSuite) TestOneDriveRestore_Reduce() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			sel := test.makeSelector()

--- a/src/pkg/selectors/scopes_test.go
+++ b/src/pkg/selectors/scopes_test.go
@@ -279,7 +279,7 @@ func (suite *SelectorScopesSuite) TestReduce() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			errs := fault.New(true)
@@ -325,7 +325,7 @@ func (suite *SelectorScopesSuite) TestReduce_locationRef() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			ds := deets()

--- a/src/pkg/selectors/selectors_reduce_test.go
+++ b/src/pkg/selectors/selectors_reduce_test.go
@@ -27,9 +27,6 @@ func TestSelectorReduceSuite(t *testing.T) {
 }
 
 func (suite *SelectorReduceSuite) TestReduce() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	table := []struct {
 		name     string
 		selFunc  func(t *testing.T, wantVersion int) selectors.Reducer
@@ -388,6 +385,9 @@ func (suite *SelectorReduceSuite) TestReduce() {
 			for _, test := range table {
 				suite.Run(test.name, func() {
 					t := suite.T()
+
+					ctx, flush := tester.NewContext(t)
+					defer flush()
 
 					allDetails := testdata.GetDetailsSetForVersion(t, v)
 					output := test.selFunc(t, v).Reduce(ctx, allDetails, fault.New(true))

--- a/src/pkg/selectors/sharepoint_test.go
+++ b/src/pkg/selectors/sharepoint_test.go
@@ -399,7 +399,7 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			sel := test.makeSelector()

--- a/src/pkg/services/m365/api/drive_test.go
+++ b/src/pkg/services/m365/api/drive_test.go
@@ -45,10 +45,11 @@ func TestOneDriveAPIs(t *testing.T) {
 }
 
 func (suite *OneDriveAPISuite) TestCreatePagerAndGetPage() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	t := suite.T()
 	siteID := tester.M365SiteID(t)
 	pager := api.NewSiteDrivePager(suite.service, siteID, []string{"name"})
 	a, err := pager.GetPage(ctx)

--- a/src/pkg/services/m365/api/item_pager_test.go
+++ b/src/pkg/services/m365/api/item_pager_test.go
@@ -263,7 +263,9 @@ func (suite *ItemPagerUnitSuite) TestGetAddedAndRemovedItemIDs() {
 
 	for _, tt := range tests {
 		suite.Run(tt.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			pager, _ := tt.pagerGetter(ctx, graph.Service{}, "user", "directory", false)
@@ -275,13 +277,12 @@ func (suite *ItemPagerUnitSuite) TestGetAddedAndRemovedItemIDs() {
 				pager,
 				deltaPager,
 				tt.delta,
-				tt.canMakeDeltaQueries,
-			)
+				tt.canMakeDeltaQueries)
 
-			require.NoError(suite.T(), err, "getting added and removed item IDs")
-			require.EqualValues(suite.T(), tt.added, added, "added item IDs")
-			require.EqualValues(suite.T(), tt.removed, removed, "removed item IDs")
-			require.Equal(suite.T(), tt.deltaUpdate, deltaUpdate, "delta update")
+			require.NoError(t, err, "getting added and removed item IDs")
+			require.EqualValues(t, tt.added, added, "added item IDs")
+			require.EqualValues(t, tt.removed, removed, "removed item IDs")
+			require.Equal(t, tt.deltaUpdate, deltaUpdate, "delta update")
 		})
 	}
 }

--- a/src/pkg/services/m365/api/item_serialization_test.go
+++ b/src/pkg/services/m365/api/item_serialization_test.go
@@ -115,10 +115,11 @@ func (suite *ItemSerializationUnitSuite) TestConcurrentItemSerialization() {
 
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flusher := tester.NewContext()
+			t := suite.T()
+
+			ctx, flusher := tester.NewContext(t)
 			defer flusher()
 
-			t := suite.T()
 			output := make([][]byte, instances)
 
 			for i := 0; i < instances; i++ {

--- a/src/pkg/services/m365/api/mail_test.go
+++ b/src/pkg/services/m365/api/mail_test.go
@@ -343,17 +343,19 @@ func (suite *MailAPIIntgSuite) TestHugeAttachmentListDownload() {
 
 	for _, tt := range tests {
 		suite.Run(tt.name, func() {
-			ctx, flush := tester.NewContext()
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			defer gock.Off()
 			tt.setupf()
 
 			item, _, err := suite.ac.Mail().GetItem(ctx, "user", mid, false, fault.New(true))
-			tt.expect(suite.T(), err)
+			tt.expect(t, err)
 
 			it, ok := item.(models.Messageable)
-			require.True(suite.T(), ok, "convert to messageable")
+			require.True(t, ok, "convert to messageable")
 
 			var size int64
 			mailBody := it.GetBody()
@@ -369,10 +371,10 @@ func (suite *MailAPIIntgSuite) TestHugeAttachmentListDownload() {
 				size = +int64(*attachment.GetSize())
 			}
 
-			assert.Equal(suite.T(), *it.GetId(), mid)
-			assert.Equal(suite.T(), tt.attachmentCount, len(attachments), "attachment count")
-			assert.Equal(suite.T(), tt.size, size, "mail size")
-			assert.True(suite.T(), gock.IsDone(), "made all requests")
+			assert.Equal(t, *it.GetId(), mid)
+			assert.Equal(t, tt.attachmentCount, len(attachments), "attachment count")
+			assert.Equal(t, tt.size, size, "mail size")
+			assert.True(t, gock.IsDone(), "made all requests")
 		})
 	}
 }

--- a/src/pkg/services/m365/api/sites_test.go
+++ b/src/pkg/services/m365/api/sites_test.go
@@ -130,10 +130,10 @@ func (suite *SitesIntgSuite) SetupSuite() {
 }
 
 func (suite *SitesIntgSuite) TestGetAll() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
 	cli, err := NewClient(suite.creds)
 	require.NoError(t, err, clues.ToCore(err))
@@ -181,7 +181,7 @@ func (suite *SitesIntgSuite) TestSites_GetByID() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			t := suite.T()

--- a/src/pkg/services/m365/api/users.go
+++ b/src/pkg/services/m365/api/users.go
@@ -133,16 +133,13 @@ func (ui *UserInfo) CanMakeDeltaQueries() bool {
 //nolint:lll
 var userFilterNoGuests = "onPremisesSyncEnabled eq true OR userType ne 'Guest'"
 
-// I can't believe I have to do this.
-var t = true
-
 func userOptions(fs *string) *users.UsersRequestBuilderGetRequestConfiguration {
 	return &users.UsersRequestBuilderGetRequestConfiguration{
 		Headers: newEventualConsistencyHeaders(),
 		QueryParameters: &users.UsersRequestBuilderGetQueryParameters{
 			Select: idAnd(userPrincipalName, displayName),
 			Filter: fs,
-			Count:  &t,
+			Count:  ptr.To(true),
 		},
 	}
 }

--- a/src/pkg/services/m365/m365_test.go
+++ b/src/pkg/services/m365/m365_test.go
@@ -28,13 +28,12 @@ func TestM365IntegrationSuite(t *testing.T) {
 }
 
 func (suite *M365IntegrationSuite) TestUsers() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	var (
-		t    = suite.T()
-		acct = tester.NewM365Account(suite.T())
-	)
+	acct := tester.NewM365Account(suite.T())
 
 	users, err := m365.Users(ctx, acct, fault.New(true))
 	assert.NoError(t, err, clues.ToCore(err))
@@ -53,13 +52,12 @@ func (suite *M365IntegrationSuite) TestUsers() {
 }
 
 func (suite *M365IntegrationSuite) TestUsersCompat_HasNoInfo() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	var (
-		t    = suite.T()
-		acct = tester.NewM365Account(suite.T())
-	)
+	acct := tester.NewM365Account(suite.T())
 
 	users, err := m365.UsersCompatNoInfo(ctx, acct)
 	assert.NoError(t, err, clues.ToCore(err))
@@ -77,11 +75,12 @@ func (suite *M365IntegrationSuite) TestUsersCompat_HasNoInfo() {
 }
 
 func (suite *M365IntegrationSuite) TestGetUserInfo() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t    = suite.T()
 		acct = tester.NewM365Account(t)
 		uid  = tester.M365UserID(t)
 	)
@@ -103,11 +102,12 @@ func (suite *M365IntegrationSuite) TestGetUserInfo() {
 }
 
 func (suite *M365IntegrationSuite) TestUserHasMailbox() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t    = suite.T()
 		acct = tester.NewM365Account(t)
 		uid  = tester.M365UserID(t)
 	)
@@ -118,11 +118,12 @@ func (suite *M365IntegrationSuite) TestUserHasMailbox() {
 }
 
 func (suite *M365IntegrationSuite) TestUserHasDrive() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
 	var (
-		t    = suite.T()
 		acct = tester.NewM365Account(t)
 		uid  = tester.M365UserID(t)
 	)
@@ -133,13 +134,12 @@ func (suite *M365IntegrationSuite) TestUserHasDrive() {
 }
 
 func (suite *M365IntegrationSuite) TestSites() {
-	ctx, flush := tester.NewContext()
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	var (
-		t    = suite.T()
-		acct = tester.NewM365Account(suite.T())
-	)
+	acct := tester.NewM365Account(suite.T())
 
 	sites, err := m365.Sites(ctx, acct, fault.New(true))
 	assert.NoError(t, err, clues.ToCore(err))

--- a/src/pkg/store/backup_test.go
+++ b/src/pkg/store/backup_test.go
@@ -43,9 +43,6 @@ func TestStoreBackupUnitSuite(t *testing.T) {
 }
 
 func (suite *StoreBackupUnitSuite) TestGetBackup() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	table := []struct {
 		name   string
 		mock   *mock.ModelStore
@@ -65,6 +62,10 @@ func (suite *StoreBackupUnitSuite) TestGetBackup() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
 			sm := &store.Wrapper{Storer: test.mock}
 
 			result, err := sm.GetBackup(ctx, model.StableID(uuid.NewString()))
@@ -80,9 +81,6 @@ func (suite *StoreBackupUnitSuite) TestGetBackup() {
 }
 
 func (suite *StoreBackupUnitSuite) TestGetBackups() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	table := []struct {
 		name   string
 		mock   *mock.ModelStore
@@ -102,6 +100,10 @@ func (suite *StoreBackupUnitSuite) TestGetBackups() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
 			sm := &store.Wrapper{Storer: test.mock}
 
 			result, err := sm.GetBackups(ctx)
@@ -118,9 +120,6 @@ func (suite *StoreBackupUnitSuite) TestGetBackups() {
 }
 
 func (suite *StoreBackupUnitSuite) TestDeleteBackup() {
-	ctx, flush := tester.NewContext()
-	defer flush()
-
 	table := []struct {
 		name   string
 		mock   *mock.ModelStore
@@ -140,6 +139,10 @@ func (suite *StoreBackupUnitSuite) TestDeleteBackup() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
 			sm := &store.Wrapper{Storer: test.mock}
 
 			err := sm.DeleteBackup(ctx, model.StableID(uuid.NewString()))


### PR DESCRIPTION
populate a "test_name" clues field in the
tester context, so that logs can be associated
with the calling test.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Supportability/Tests

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
