### PR TITLE
Don't fail on permissions fetch 404

### DIFF
--- a/src/internal/connector/graph/errors.go
+++ b/src/internal/connector/graph/errors.go
@@ -31,7 +31,7 @@ const (
 	activityLimitReached        errorCode = "activityLimitReached"
 	emailFolderNotFound         errorCode = "ErrorSyncFolderNotFound"
 	errorAccessDenied           errorCode = "ErrorAccessDenied"
-	itemNotFound                errorCode = "ErrorItemNotFound"
+	ItemNotFound                errorCode = "ErrorItemNotFound"
 	itemNotFoundShort           errorCode = "itemNotFound"
 	mailboxNotEnabledForRESTAPI errorCode = "MailboxNotEnabledForRESTAPI"
 	malwareDetected             errorCode = "malwareDetected"
@@ -97,7 +97,7 @@ func IsErrDeletedInFlight(err error) bool {
 
 	if hasErrorCode(
 		err,
-		itemNotFound,
+		ItemNotFound,
 		itemNotFoundShort,
 		syncFolderNotFound,
 	) {

--- a/src/internal/connector/graph/errors_test.go
+++ b/src/internal/connector/graph/errors_test.go
@@ -90,7 +90,7 @@ func (suite *GraphErrorsUnitSuite) TestIsErrDeletedInFlight() {
 		},
 		{
 			name:   "not-found oDataErr",
-			err:    odErr(string(itemNotFound)),
+			err:    odErr(string(ItemNotFound)),
 			expect: assert.True,
 		},
 		{

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -513,8 +513,7 @@ func (oc *Collection) populateItems(ctx context.Context, errs *fault.Bus) {
 					oc.driveID,
 					ptr.Val(item.GetId()))
 				if e != nil && !graph.IsErrDeletedInFlight(e) {
-					// something else happened, bail
-					logger.CtxErr(ctx, err).Error("getting item")
+					logger.CtxErr(ctx, e).Error("getting item")
 				} else if graph.IsErrDeletedInFlight(e) ||
 					(e == nil && di.GetDeleted() != nil) {
 					logger.CtxErr(ctx, err).
@@ -529,11 +528,13 @@ func (oc *Collection) populateItems(ctx context.Context, errs *fault.Bus) {
 						graph.ItemInfo(item))
 
 					el.AddSkip(skip)
-				} else {
-					el.AddRecoverable(
-						clues.Wrap(err, "getting item metadata").
-							Label(fault.LabelForceNoBackupCreation))
+
+					return
 				}
+
+				el.AddRecoverable(
+					clues.Wrap(err, "getting item metadata").
+						Label(fault.LabelForceNoBackupCreation))
 
 				return
 			}

--- a/src/internal/connector/onedrive/collection_test.go
+++ b/src/internal/connector/onedrive/collection_test.go
@@ -847,7 +847,6 @@ func (suite *CollectionUnitTestSuite) TestGetPermissionFailures() {
 	table := []struct {
 		name           string
 		recoveredCount int
-		item           models.DriveItemable
 		itemMetaReader itemMetaReaderFunc
 	}{
 		{
@@ -921,7 +920,7 @@ func (suite *CollectionUnitTestSuite) TestGetPermissionFailures() {
 				true)
 			require.NoError(t, err, clues.ToCore(err))
 
-			coll.Add(test.item)
+			coll.Add(item)
 
 			coll.itemReader = func(
 				context.Context,

--- a/src/internal/connector/onedrive/collection_test.go
+++ b/src/internal/connector/onedrive/collection_test.go
@@ -612,6 +612,132 @@ func (suite *CollectionUnitTestSuite) TestCollectionPermissionBackupLatestModTim
 	}
 }
 
+func (suite *CollectionUnitTestSuite) TestFileDeletedDuringGetPermissions() {
+	fp := "drive/driveID1/root:/"
+
+	table := []struct {
+		name           string
+		source         driveSource
+		skipCount      int
+		recoveredCount int
+		item           models.DriveItemable
+		readItemCount  int
+		itemMetaReader itemMetaReaderFunc
+	}{
+		{
+			name:           "file present during permissions fetch",
+			source:         SharePointSource,
+			skipCount:      0,
+			recoveredCount: 1,
+			item: driveItem("file_id",
+				"file_name",
+				fp,
+				"root",
+				true,
+				false,
+				false),
+			readItemCount: 0,
+			itemMetaReader: func(
+				context.Context,
+				graph.Servicer,
+				string,
+				models.DriveItemable,
+			) (io.ReadCloser, int, error) {
+				// Simulate 404
+				return io.NopCloser(strings.NewReader(`{}`)),
+					16,
+					clues.New("item not found")
+			},
+		},
+		{
+			name:           "deleted file during permissions fetch",
+			source:         SharePointSource,
+			skipCount:      1,
+			recoveredCount: 0,
+			item: delItem("file_id",
+				fp,
+				"root",
+				true,
+				false,
+				false),
+			readItemCount: 0,
+			itemMetaReader: func(
+				context.Context,
+				graph.Servicer,
+				string,
+				models.DriveItemable,
+			) (io.ReadCloser, int, error) {
+				// Simulate 404
+				return io.NopCloser(strings.NewReader(`{}`)),
+					16,
+					clues.New("item not found")
+			},
+		},
+	}
+
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			ctx, flush := tester.NewContext()
+			defer flush()
+
+			var (
+				t          = suite.T()
+				collStatus = support.ConnectorOperationStatus{}
+				wg         = sync.WaitGroup{}
+				errs       = fault.New(true)
+			)
+
+			wg.Add(1)
+
+			folderPath, err := GetCanonicalPath(fp, "a-tenant", "a-user", SharePointSource)
+			require.NoError(t, err, clues.ToCore(err))
+
+			coll, err := NewCollection(
+				graph.NewNoTimeoutHTTPWrapper(),
+				folderPath,
+				nil,
+				"drive-id",
+				suite,
+				suite.testStatusUpdater(&wg, &collStatus),
+				test.source,
+				control.Options{ToggleFeatures: control.Toggles{}},
+				CollectionScopeFolder,
+				true)
+			require.NoError(t, err, clues.ToCore(err))
+
+			coll.Add(test.item)
+
+			coll.itemReader = func(
+				context.Context,
+				graph.Requester,
+				models.DriveItemable,
+			) (details.ItemInfo, io.ReadCloser, error) {
+				return details.ItemInfo{
+						OneDrive: &details.OneDriveInfo{
+							ItemName: "fakeName",
+							Modified: time.Now(),
+						},
+					},
+					io.NopCloser(strings.NewReader("fake data")),
+					nil
+			}
+
+			coll.itemMetaReader = test.itemMetaReader
+
+			readItems := []data.Stream{}
+			for item := range coll.Items(ctx, errs) {
+				readItems = append(readItems, item)
+			}
+
+			wg.Wait()
+
+			require.Equal(t, test.readItemCount, len(readItems), "read items")
+			require.Equal(t, test.skipCount, len(errs.Skipped()), "skipped items")
+			require.Equal(t, test.recoveredCount, len(errs.Recovered()), "recovered items")
+		})
+	}
+}
+
 type GetDriveItemUnitTestSuite struct {
 	tester.Suite
 }

--- a/src/pkg/services/m365/api/drive.go
+++ b/src/pkg/services/m365/api/drive.go
@@ -12,9 +12,44 @@ import (
 	"github.com/alcionai/corso/src/pkg/account"
 )
 
-// ---------------------------------------------------------------------------
-// Drives
-// ---------------------------------------------------------------------------
+// generic drive item getter
+func GetDriveItem(
+	ctx context.Context,
+	srv graph.Servicer,
+	driveID, itemID string,
+) (models.DriveItemable, error) {
+	di, err := srv.Client().
+		Drives().
+		ByDriveId(driveID).
+		Items().
+		ByDriveItemId(itemID).
+		Get(ctx, nil)
+	if err != nil {
+		return nil, graph.Wrap(ctx, err, "getting item")
+	}
+
+	return di, nil
+}
+
+func GetItemPermission(
+	ctx context.Context,
+	service graph.Servicer,
+	driveID, itemID string,
+) (models.PermissionCollectionResponseable, error) {
+	perm, err := service.
+		Client().
+		Drives().
+		ByDriveId(driveID).
+		Items().
+		ByDriveItemId(itemID).
+		Permissions().
+		Get(ctx, nil)
+	if err != nil {
+		return nil, graph.Wrap(ctx, err, "getting item permissions").With("item_id", itemID)
+	}
+
+	return perm, nil
+}
 
 func GetUsersDrive(
 	ctx context.Context,

--- a/src/pkg/services/m365/api/drive.go
+++ b/src/pkg/services/m365/api/drive.go
@@ -12,45 +12,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/account"
 )
 
-// generic drive item getter
-func GetDriveItem(
-	ctx context.Context,
-	srv graph.Servicer,
-	driveID, itemID string,
-) (models.DriveItemable, error) {
-	di, err := srv.Client().
-		Drives().
-		ByDriveId(driveID).
-		Items().
-		ByDriveItemId(itemID).
-		Get(ctx, nil)
-	if err != nil {
-		return nil, graph.Wrap(ctx, err, "getting item")
-	}
-
-	return di, nil
-}
-
-func GetItemPermission(
-	ctx context.Context,
-	service graph.Servicer,
-	driveID, itemID string,
-) (models.PermissionCollectionResponseable, error) {
-	perm, err := service.
-		Client().
-		Drives().
-		ByDriveId(driveID).
-		Items().
-		ByDriveItemId(itemID).
-		Permissions().
-		Get(ctx, nil)
-	if err != nil {
-		return nil, graph.Wrap(ctx, err, "getting item permissions").With("item_id", itemID)
-	}
-
-	return perm, nil
-}
-
 func GetUsersDrive(
 	ctx context.Context,
 	srv graph.Servicer,
@@ -258,7 +219,7 @@ func GetItemPermission(
 		Permissions().
 		Get(ctx, nil)
 	if err != nil {
-		return nil, graph.Wrap(ctx, err, "getting item metadata").With("item_id", itemID)
+		return nil, graph.Wrap(ctx, err, "getting item permission").With("item_id", itemID)
 	}
 
 	return perm, nil


### PR DESCRIPTION
This PR fixes sharepoint sanity test failure [here](https://github.com/alcionai/corso/actions/runs/5060632811/jobs/9083768294). 

Context:
It's possible that by the time we read item permissions(for metadata serialization), the item may have been deleted.  In that case, we currently fail with a 404, recoverable error. Since the graph call here [looks up the item by id](https://github.com/alcionai/corso/blob/main/src/pkg/services/m365/api/drive.go#L217), and not the permissions by id, we can assume the item was deleted on a 404

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
