### PR TITLE
Fix TestExchangeBackupListCmd_empty now that we print log file name

### DIFF
--- a/src/cli/backup/exchange_e2e_test.go
+++ b/src/cli/backup/exchange_e2e_test.go
@@ -98,7 +98,7 @@ func (suite *NoBackupExchangeE2ESuite) TestExchangeBackupListCmd_empty() {
 	result := suite.recorder.String()
 
 	// as an offhand check: the result should contain the m365 user id
-	assert.Equal(t, "No backups available\n", result)
+	assert.True(t, strings.HasSuffix(result, "No backups available\n"))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
This should fix the nightly build.

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
