### PR TITLE
Do not print all the restored items if there are a lot of them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Exchange backup issue caused by incorrect json serialization
 
 ### Changed
-- Do not display all the items that we restored at the end if there are more than 15
+- Do not display all the items that we restored at the end if there are more than 15. You can override this with `--verbose`.
 
 ### Known Issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Exchange folder cache population error when parent folder isn't found.
 - Fix Exchange backup issue caused by incorrect json serialization
 
+### Changed
+- Do not display all the items that we restored at the end if there are more than 15
+
 ### Known Issues
 
 ## [v0.8.0] (beta) - 2023-05-15

--- a/src/cli/print/print.go
+++ b/src/cli/print/print.go
@@ -14,6 +14,7 @@ import (
 var (
 	outputAsJSON      bool
 	outputAsJSONDebug bool
+	outputVerbose     bool
 )
 
 type rootCmdCtx struct{}
@@ -48,11 +49,17 @@ func AddOutputFlag(cmd *cobra.Command) {
 	fs.BoolVar(&outputAsJSON, "json", false, "output data in JSON format")
 	fs.BoolVar(&outputAsJSONDebug, "json-debug", false, "output all internal and debugging data in JSON format")
 	cobra.CheckErr(fs.MarkHidden("json-debug"))
+	fs.BoolVar(&outputVerbose, "verbose", false, "do not hide additional information")
 }
 
 // DisplayJSONFormat returns true if the printer plans to output as json.
 func DisplayJSONFormat() bool {
 	return outputAsJSON || outputAsJSONDebug
+}
+
+// DisplayVerbose returns true if verbose output is enabled
+func DisplayVerbose() bool {
+	return outputVerbose
 }
 
 // StderrWriter returns the stderr writer used in the root

--- a/src/cli/print/print.go
+++ b/src/cli/print/print.go
@@ -49,7 +49,7 @@ func AddOutputFlag(cmd *cobra.Command) {
 	fs.BoolVar(&outputAsJSON, "json", false, "output data in JSON format")
 	fs.BoolVar(&outputAsJSONDebug, "json-debug", false, "output all internal and debugging data in JSON format")
 	cobra.CheckErr(fs.MarkHidden("json-debug"))
-	fs.BoolVar(&outputVerbose, "verbose", false, "do not hide additional information")
+	fs.BoolVar(&outputVerbose, "verbose", false, "don't hide additional information")
 }
 
 // DisplayJSONFormat returns true if the printer plans to output as json.

--- a/src/cli/restore/exchange.go
+++ b/src/cli/restore/exchange.go
@@ -116,7 +116,7 @@ func restoreExchangeCmd(cmd *cobra.Command, args []string) error {
 		return Only(ctx, clues.Wrap(err, "Failed to run Exchange restore"))
 	}
 
-	ds.Items().PrintEntries(ctx)
+	ds.Items().MaybePrintEntries(ctx)
 
 	return nil
 }

--- a/src/cli/restore/onedrive.go
+++ b/src/cli/restore/onedrive.go
@@ -117,7 +117,7 @@ func restoreOneDriveCmd(cmd *cobra.Command, args []string) error {
 		return Only(ctx, clues.Wrap(err, "Failed to run OneDrive restore"))
 	}
 
-	ds.Items().PrintEntries(ctx)
+	ds.Items().MaybePrintEntries(ctx)
 
 	return nil
 }

--- a/src/cli/restore/sharepoint.go
+++ b/src/cli/restore/sharepoint.go
@@ -122,7 +122,7 @@ func restoreSharePointCmd(cmd *cobra.Command, args []string) error {
 		return Only(ctx, clues.Wrap(err, "Failed to run SharePoint restore"))
 	}
 
-	ds.Items().PrintEntries(ctx)
+	ds.Items().MaybePrintEntries(ctx)
 
 	return nil
 }

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -482,7 +482,9 @@ func (ents entrySet) PrintEntries(ctx context.Context) {
 // MaybePrintEntries is same as PrintEntries, but only prints if we
 // have less than 15 items or is not json output.
 func (ents entrySet) MaybePrintEntries(ctx context.Context) {
-	if len(ents) > maxPrintLimit && !print.DisplayJSONFormat() {
+	if len(ents) > maxPrintLimit &&
+		!print.DisplayJSONFormat() &&
+		!print.DisplayVerbose() {
 		// TODO: Should we detect if the user is piping the output and
 		// print if that is the case?
 		print.Outf(ctx, "Restored %d items.", len(ents))

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -20,6 +20,10 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
+// Max number of items for which we will print details. If there are
+// more than this, then we just show a summary.
+const maxPrintLimit = 15
+
 // LocationIDer provides access to location information but guarantees that it
 // can also generate a unique location (among items in the same service but
 // possibly across data types within the service) that can be used as a key in
@@ -473,6 +477,18 @@ type entrySet []*Entry
 
 func (ents entrySet) PrintEntries(ctx context.Context) {
 	printEntries(ctx, ents)
+}
+
+// MaybePrintEntries is same as PrintEntries, but only prints if we
+// have less than 15 items or is not json output.
+func (ents entrySet) MaybePrintEntries(ctx context.Context) {
+	if len(ents) > maxPrintLimit && !print.DisplayJSONFormat() {
+		// TODO: Should we detect if the user is piping the output and
+		// print if that is the case?
+		print.Outf(ctx, "Restored %d items.", len(ents))
+	} else {
+		printEntries(ctx, ents)
+	}
 }
 
 // Entry describes a single item stored in a Backup


### PR DESCRIPTION
For large restore, it just ends up printing a lot of text. This change makes it print a summary instead. We still retain printing the full content if the user asks for a json output as we assume they would be piping it somewhere.

```
Connecting to repository:      1s done
Restoring to folder Corso_Restore_24-May-2023_11-49-44
Connecting to M365:         done
Restoring ∙ 7ceb8e03-bdc5-4509-a136-457526165ec0
Discovered 3 items in backup d5c07808-545d-4906-9ade-f224ca8f13de to restore
Enumerating items in repository:      0s done
Restoring data:     54s done
Restored 304 items.
```

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
