### PR TITLE
move details hooks into drive handlers

### DIFF
--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -257,21 +257,7 @@ func (oc Collection) PreviousLocationPath() details.LocationIDer {
 		return nil
 	}
 
-	var ider details.LocationIDer
-
-	switch oc.source {
-	case OneDriveSource:
-		ider = details.NewOneDriveLocationIDer(
-			oc.driveID,
-			oc.prevLocPath.Elements()...)
-
-	default:
-		ider = details.NewSharePointLocationIDer(
-			oc.driveID,
-			oc.prevLocPath.Elements()...)
-	}
-
-	return ider
+	return oc.handler.NewLocationIDer(oc.driveID, oc.prevLocPath.Elements()...)
 }
 
 func (oc Collection) State() data.CollectionState {
@@ -411,16 +397,13 @@ func (oc *Collection) populateItems(ctx context.Context, errs *fault.Bus) {
 
 	// Retrieve the OneDrive folder path to set later in
 	// `details.OneDriveInfo`
-	parentPathString, err := path.GetDriveFolderPath(oc.folderPath)
+	parentPath, err := path.GetDriveFolderPath(oc.folderPath)
 	if err != nil {
 		oc.reportAsCompleted(ctx, 0, 0, 0)
 		return
 	}
 
-	queuedPath := "/" + parentPathString
-	if oc.source == SharePointSource && len(oc.driveName) > 0 {
-		queuedPath = "/" + oc.driveName + queuedPath
-	}
+	queuedPath := oc.handler.FormatDisplayPath(oc.driveName, parentPath)
 
 	folderProgress, colCloser := observe.ProgressWithCount(
 		ctx,
@@ -489,14 +472,7 @@ func (oc *Collection) populateItems(ctx context.Context, errs *fault.Bus) {
 				return
 			}
 
-			switch oc.source {
-			case SharePointSource:
-				itemInfo.SharePoint = sharePointItemInfo(item, itemSize)
-				itemInfo.SharePoint.ParentPath = parentPathString
-			default:
-				itemInfo.OneDrive = oneDriveItemInfo(item, itemSize)
-				itemInfo.OneDrive.ParentPath = parentPathString
-			}
+			itemInfo = oc.handler.AugmentItemInfo(itemInfo, item, itemSize, parentPath)
 
 			ctx = clues.Add(ctx, "item_info", itemInfo)
 

--- a/src/internal/connector/onedrive/handlers.go
+++ b/src/internal/connector/onedrive/handlers.go
@@ -1,6 +1,9 @@
 package onedrive
 
 import (
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+
+	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
@@ -17,4 +20,12 @@ type BackupHandler interface {
 	) (path.Path, error)
 	ServiceCat() (path.ServiceType, path.CategoryType)
 	DrivePager(resourceOwner string, fields []string) api.DrivePager
+	AugmentItemInfo(
+		dii details.ItemInfo,
+		item models.DriveItemable,
+		size int64,
+		parentPath *path.Builder,
+	) details.ItemInfo
+	FormatDisplayPath(driveName string, parentPath *path.Builder) string
+	NewLocationIDer(driveID string, elems ...string) details.LocationIDer
 }

--- a/src/internal/connector/onedrive/item_backup_handler.go
+++ b/src/internal/connector/onedrive/item_backup_handler.go
@@ -1,9 +1,14 @@
 package onedrive
 
 import (
+	"strings"
+
+	"github.com/alcionai/corso/src/internal/common/ptr"
 	odConsts "github.com/alcionai/corso/src/internal/connector/onedrive/consts"
+	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
 )
 
 var _ BackupHandler = &itemBackupHandler{}
@@ -40,5 +45,61 @@ func (h itemBackupHandler) ServiceCat() (path.ServiceType, path.CategoryType) {
 func (h itemBackupHandler) DrivePager(
 	resourceOwner string, fields []string,
 ) api.DrivePager {
-	return api.NewUserDrivePager(nil, resourceOwner, fields)
+	return h.ac.NewUserDrivePager(resourceOwner, fields)
+}
+
+// AugmentItemInfo will populate a details.OneDriveInfo struct
+// with properties from the drive item.  ItemSize is specified
+// separately for restore processes because the local itemable
+// doesn't have its size value updated as a side effect of creation,
+// and kiota drops any SetSize update.
+func (h itemBackupHandler) AugmentItemInfo(
+	dii details.ItemInfo,
+	item models.DriveItemable,
+	size int64,
+	parentPath *path.Builder,
+) details.ItemInfo {
+	var email, driveName, driveID string
+
+	if item.GetCreatedBy() != nil && item.GetCreatedBy().GetUser() != nil {
+		// User is sometimes not available when created via some
+		// external applications (like backup/restore solutions)
+		ed, ok := item.GetCreatedBy().GetUser().GetAdditionalData()["email"]
+		if ok {
+			email = *ed.(*string)
+		}
+	}
+
+	if item.GetParentReference() != nil {
+		driveID = ptr.Val(item.GetParentReference().GetDriveId())
+		driveName = strings.TrimSpace(ptr.Val(item.GetParentReference().GetName()))
+	}
+
+	dii.OneDrive = &details.OneDriveInfo{
+		Created:    ptr.Val(item.GetCreatedDateTime()),
+		DriveID:    driveID,
+		DriveName:  driveName,
+		ItemName:   ptr.Val(item.GetName()),
+		ItemType:   details.OneDriveItem,
+		Modified:   ptr.Val(item.GetLastModifiedDateTime()),
+		Owner:      email,
+		ParentPath: parentPath.String(),
+		Size:       size,
+	}
+
+	return dii
+}
+
+func (h itemBackupHandler) FormatDisplayPath(
+	_ string, // drive name not displayed for onedrive
+	pb *path.Builder,
+) string {
+	return "/" + pb.String()
+}
+
+func (h itemBackupHandler) NewLocationIDer(
+	driveID string,
+	elems ...string,
+) details.LocationIDer {
+	return details.NewOneDriveLocationIDer(driveID, elems...)
 }

--- a/src/internal/connector/sharepoint/library_backup_handler.go
+++ b/src/internal/connector/sharepoint/library_backup_handler.go
@@ -1,10 +1,15 @@
 package sharepoint
 
 import (
+	"strings"
+
+	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/connector/onedrive"
 	odConsts "github.com/alcionai/corso/src/internal/connector/onedrive/consts"
+	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
 )
 
 var _ onedrive.BackupHandler = &libraryBackupHandler{}
@@ -42,4 +47,115 @@ func (h libraryBackupHandler) DrivePager(
 	resourceOwner string, fields []string,
 ) api.DrivePager {
 	return h.ac.NewSiteDrivePager(resourceOwner, fields)
+}
+
+// AugmentItemInfo will populate a details.SharePointInfo struct
+// with properties from the drive item.  ItemSize is specified
+// separately for restore processes because the local itemable
+// doesn't have its size value updated as a side effect of creation,
+// and kiota drops any SetSize update.
+func (h libraryBackupHandler) AugmentItemInfo(
+	dii details.ItemInfo,
+	item models.DriveItemable,
+	size int64,
+	parentPath *path.Builder,
+) details.ItemInfo {
+	var driveName, siteID, driveID, weburl, creatorEmail string
+
+	// TODO: we rely on this info for details/restore lookups,
+	// so if it's nil we have an issue, and will need an alternative
+	// way to source the data.
+
+	if item.GetCreatedBy() != nil && item.GetCreatedBy().GetUser() != nil {
+		// User is sometimes not available when created via some
+		// external applications (like backup/restore solutions)
+		additionalData := item.GetCreatedBy().GetUser().GetAdditionalData()
+
+		ed, ok := additionalData["email"]
+		if !ok {
+			ed = additionalData["displayName"]
+		}
+
+		if ed != nil {
+			creatorEmail = *ed.(*string)
+		}
+	}
+
+	gsi := item.GetSharepointIds()
+	if gsi != nil {
+		siteID = ptr.Val(gsi.GetSiteId())
+		weburl = ptr.Val(gsi.GetSiteUrl())
+
+		if len(weburl) == 0 {
+			weburl = constructWebURL(item.GetAdditionalData())
+		}
+	}
+
+	if item.GetParentReference() != nil {
+		driveID = ptr.Val(item.GetParentReference().GetDriveId())
+		driveName = strings.TrimSpace(ptr.Val(item.GetParentReference().GetName()))
+	}
+
+	dii.SharePoint = &details.SharePointInfo{
+		Created:    ptr.Val(item.GetCreatedDateTime()),
+		DriveID:    driveID,
+		DriveName:  driveName,
+		ItemName:   ptr.Val(item.GetName()),
+		ItemType:   details.SharePointLibrary,
+		Modified:   ptr.Val(item.GetLastModifiedDateTime()),
+		ParentPath: parentPath.String(),
+		Owner:      creatorEmail,
+		SiteID:     siteID,
+		Size:       size,
+		WebURL:     weburl,
+	}
+
+	return dii
+}
+
+// constructWebURL helper function for recreating the webURL
+// for the originating SharePoint site. Uses additional data map
+// from a models.DriveItemable that possesses a downloadURL within the map.
+// Returns "" if map nil or key is not present.
+func constructWebURL(adtl map[string]any) string {
+	var (
+		desiredKey = "@microsoft.graph.downloadUrl"
+		sep        = `/_layouts`
+		url        string
+	)
+
+	if adtl == nil {
+		return url
+	}
+
+	r := adtl[desiredKey]
+	point, ok := r.(*string)
+
+	if !ok {
+		return url
+	}
+
+	value := ptr.Val(point)
+	if len(value) == 0 {
+		return url
+	}
+
+	temp := strings.Split(value, sep)
+	url = temp[0]
+
+	return url
+}
+
+func (h libraryBackupHandler) FormatDisplayPath(
+	driveName string,
+	pb *path.Builder,
+) string {
+	return "/" + driveName + "/" + pb.String()
+}
+
+func (h libraryBackupHandler) NewLocationIDer(
+	driveID string,
+	elems ...string,
+) details.LocationIDer {
+	return details.NewSharePointLocationIDer(driveID, elems...)
 }

--- a/src/pkg/path/drive.go
+++ b/src/pkg/path/drive.go
@@ -30,13 +30,13 @@ func ToDrivePath(p Path) (*DrivePath, error) {
 }
 
 // Returns the path to the folder within the drive (i.e. under `root:`)
-func GetDriveFolderPath(p Path) (string, error) {
+func GetDriveFolderPath(p Path) (*Builder, error) {
 	drivePath, err := ToDrivePath(p)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return Builder{}.Append(drivePath.Folders...).String(), nil
+	return Builder{}.Append(drivePath.Folders...), nil
 }
 
 // BuildDriveLocation takes a driveID and a set of unescaped element names,


### PR DESCRIPTION
Moves various hooks into the details library out of a onedrive.Source switch and into the different
handlers.

This pr is in a bad state (ie: linter & build failures).
This is known and expected. This change covers so many
different pieces that the easiest path forward is to aim for
success as an end goal. Please review the changes
as they are currently presented.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #1996

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
