### PR TITLE
migrate last funcs into backupHandler

### DIFF
--- a/src/cmd/purge/purge.go
+++ b/src/cmd/purge/purge.go
@@ -15,7 +15,6 @@ import (
 	"github.com/alcionai/corso/src/internal/common/str"
 	"github.com/alcionai/corso/src/internal/connector"
 	"github.com/alcionai/corso/src/internal/connector/graph"
-	"github.com/alcionai/corso/src/internal/connector/onedrive"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/credentials"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -164,31 +163,8 @@ func purgeOneDriveFolders(
 	boundary time.Time,
 	uid string,
 ) error {
-	getter := func(gs graph.Servicer, uid, prefix string) ([]purgable, error) {
-		pager, err := onedrive.PagerForSource(onedrive.OneDriveSource, gs, uid, nil)
-		if err != nil {
-			return nil, err
-		}
-
-		cfs, err := onedrive.GetAllFolders(ctx, gs, pager, prefix, fault.New(true))
-		if err != nil {
-			return nil, err
-		}
-
-		purgables := make([]purgable, len(cfs))
-
-		for i, v := range cfs {
-			purgables[i] = v
-		}
-
-		return purgables, nil
-	}
-
-	deleter := func(gs graph.Servicer, uid string, f purgable) error {
-		return nil
-	}
-
-	return purgeFolders(ctx, gc, boundary, "OneDrive Folders", uid, getter, deleter)
+	// going to delete this file in a later pr
+	return nil
 }
 
 // ----- controller

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -53,9 +53,9 @@ type Collection struct {
 	driveItems map[string]models.DriveItemable
 
 	// Primary M365 ID of the drive this collection was created from
-	driveID string
-	// Display Name of the associated drive
-	driveName     string
+	driveID   string
+	driveName string
+
 	statusUpdater support.StatusUpdater
 	ctrl          control.Options
 
@@ -84,28 +84,6 @@ type Collection struct {
 	// should only be true if the old delta token expired
 	doNotMergeItems bool
 }
-
-// itemGetterFunc gets a specified item
-// type itemGetterFunc func(
-// 	ctx context.Context,
-// 	driveID, itemID string,
-// ) (models.DriveItemable, error)
-
-// itemReadFunc returns a reader for the specified item
-// type itemReaderFunc func(
-// 	ctx context.Context,
-// 	client graph.Requester,
-// 	item models.DriveItemable,
-// ) (details.ItemInfo, io.ReadCloser, error)
-
-// itemMetaReaderFunc returns a reader for the metadata of the
-// specified item
-// type itemMetaReaderFunc func(
-// 	ctx context.Context,
-// 	ad api.Drives,
-// 	driveID string,
-// 	item models.DriveItemable,
-// ) (io.ReadCloser, int, error)
 
 func pathToLocation(p path.Path) (*path.Builder, error) {
 	if p == nil {
@@ -183,16 +161,6 @@ func newColl(
 		state:           data.StateOf(prevPath, currPath),
 		scope:           colScope,
 		doNotMergeItems: doNotMergeItems,
-	}
-
-	// Allows tests to set a mock populator
-	switch source {
-	case SharePointSource:
-		c.itemReader = sharePointItemReader
-		c.itemMetaReader = sharePointItemMetaReader
-	default:
-		c.itemReader = oneDriveItemReader
-		c.itemMetaReader = oneDriveItemMetaReader
 	}
 
 	return c
@@ -297,14 +265,7 @@ func (oc *Collection) getDriveItemContent(
 		el       = errs.Local()
 	)
 
-	itemData, err := downloadContent(
-		ctx,
-		oc.service,
-		oc.itemGetter,
-		oc.itemReader,
-		oc.itemClient,
-		item,
-		oc.driveID)
+	itemData, err := downloadContent(ctx, oc.handler, item, oc.driveID)
 	if err != nil {
 		if clues.HasLabel(err, graph.LabelsMalware) || (item != nil && item.GetMalware() != nil) {
 			logger.CtxErr(ctx, err).With("skipped_reason", fault.SkipMalware).Info("item flagged as malware")
@@ -351,14 +312,11 @@ func (oc *Collection) getDriveItemContent(
 // url and tries again.
 func downloadContent(
 	ctx context.Context,
-	svc graph.Servicer,
-	igf itemGetterFunc,
-	irf itemReaderFunc,
-	gr graph.Requester,
+	bh BackupHandler,
 	item models.DriveItemable,
 	driveID string,
 ) (io.ReadCloser, error) {
-	_, content, err := irf(ctx, gr, item)
+	_, content, err := downloadItem(ctx, bh, item)
 	if err == nil {
 		return content, nil
 	} else if !graph.IsErrUnauthorized(err) {
@@ -369,12 +327,12 @@ func downloadContent(
 	// token, and that we've overrun the available window to
 	// download the actual file.  Re-downloading the item will
 	// refresh that download url.
-	di, err := igf(ctx, driveID, ptr.Val(item.GetId()))
+	di, err := bh.ItemGetter().GetItem(ctx, driveID, ptr.Val(item.GetId()))
 	if err != nil {
 		return nil, clues.Wrap(err, "retrieving expired item")
 	}
 
-	_, content, err = irf(ctx, gr, di)
+	_, content, err = downloadItem(ctx, bh, di)
 	if err != nil {
 		return nil, clues.Wrap(err, "content download retry")
 	}
@@ -465,7 +423,7 @@ func (oc *Collection) populateItems(ctx context.Context, errs *fault.Bus) {
 			}
 
 			// Fetch metadata for the file
-			itemMeta, itemMetaSize, err = oc.itemMetaReader(ctx, oc.ad, oc.driveID, item)
+			itemMeta, itemMetaSize, err = downloadItemMeta(ctx, oc.handler, oc.driveID, item)
 
 			if err != nil {
 				el.AddRecoverable(clues.Wrap(err, "getting item metadata").Label(fault.LabelForceNoBackupCreation))

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -297,7 +297,7 @@ func (c *Collections) Get(
 
 		delta, paths, excluded, err := collectItems(
 			ictx,
-			api.NewItemPager(nil, driveID, "", api.DriveItemSelectDefault()),
+			c.handler.ItemPager(driveID, "", api.DriveItemSelectDefault()),
 			driveID,
 			driveName,
 			c.UpdateCollections,
@@ -839,7 +839,7 @@ func shouldSkipDrive(ctx context.Context, drivePath path.Path, m folderMatcher, 
 
 func includePath(ctx context.Context, m folderMatcher, folderPath path.Path) bool {
 	// Check if the folder is allowed by the scope.
-	folderPathString, err := path.GetDriveFolderPath(folderPath)
+	pb, err := path.GetDriveFolderPath(folderPath)
 	if err != nil {
 		logger.Ctx(ctx).With("err", err).Error("getting drive folder path")
 		return true
@@ -847,11 +847,11 @@ func includePath(ctx context.Context, m folderMatcher, folderPath path.Path) boo
 
 	// Hack for the edge case where we're looking at the root folder and can
 	// select any folder. Right now the root folder has an empty folder path.
-	if len(folderPathString) == 0 && m.IsAny() {
+	if len(pb.Elements()) == 0 && m.IsAny() {
 		return true
 	}
 
-	return m.Matches(folderPathString)
+	return m.Matches(pb.String())
 }
 
 func updatePath(paths map[string]string, id, newPath string) {

--- a/src/internal/connector/onedrive/drive.go
+++ b/src/internal/connector/onedrive/drive.go
@@ -55,7 +55,7 @@ type DeltaUpdate struct {
 // provided `collector` method
 func collectItems(
 	ctx context.Context,
-	pager api.DriveItemPager,
+	pager api.DriveItemEnumerator,
 	driveID, driveName string,
 	collector itemCollector,
 	oldPaths map[string]string,

--- a/src/internal/connector/onedrive/handlers.go
+++ b/src/internal/connector/onedrive/handlers.go
@@ -1,8 +1,11 @@
 package onedrive
 
 import (
+	"context"
+
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
+	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
@@ -20,6 +23,7 @@ type BackupHandler interface {
 	) (path.Path, error)
 	ServiceCat() (path.ServiceType, path.CategoryType)
 	DrivePager(resourceOwner string, fields []string) api.DrivePager
+	ItemPager(driveID, link string, fields []string) api.DriveItemEnumerator
 	AugmentItemInfo(
 		dii details.ItemInfo,
 		item models.DriveItemable,
@@ -28,4 +32,22 @@ type BackupHandler interface {
 	) details.ItemInfo
 	FormatDisplayPath(driveName string, parentPath *path.Builder) string
 	NewLocationIDer(driveID string, elems ...string) details.LocationIDer
+	Requester() graph.Requester
+
+	PermissionGetter() GetItemPermissioner
+	ItemGetter() GetItemer
+}
+
+type GetItemPermissioner interface {
+	GetItemPermission(
+		ctx context.Context,
+		driveID, itemID string,
+	) (models.PermissionCollectionResponseable, error)
+}
+
+type GetItemer interface {
+	GetItem(
+		ctx context.Context,
+		driveID, itemID string,
+	) (models.DriveItemable, error)
 }

--- a/src/internal/connector/sharepoint/library_backup_handler.go
+++ b/src/internal/connector/sharepoint/library_backup_handler.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/onedrive"
 	odConsts "github.com/alcionai/corso/src/internal/connector/onedrive/consts"
 	"github.com/alcionai/corso/src/pkg/backup/details"
@@ -47,6 +48,13 @@ func (h libraryBackupHandler) DrivePager(
 	resourceOwner string, fields []string,
 ) api.DrivePager {
 	return h.ac.NewSiteDrivePager(resourceOwner, fields)
+}
+
+func (h libraryBackupHandler) ItemPager(
+	driveID, link string,
+	fields []string,
+) api.DriveItemEnumerator {
+	return h.ac.NewItemPager(driveID, link, fields)
 }
 
 // AugmentItemInfo will populate a details.SharePointInfo struct
@@ -96,6 +104,11 @@ func (h libraryBackupHandler) AugmentItemInfo(
 		driveName = strings.TrimSpace(ptr.Val(item.GetParentReference().GetName()))
 	}
 
+	var pps string
+	if parentPath != nil {
+		pps = parentPath.String()
+	}
+
 	dii.SharePoint = &details.SharePointInfo{
 		Created:    ptr.Val(item.GetCreatedDateTime()),
 		DriveID:    driveID,
@@ -103,8 +116,8 @@ func (h libraryBackupHandler) AugmentItemInfo(
 		ItemName:   ptr.Val(item.GetName()),
 		ItemType:   details.SharePointLibrary,
 		Modified:   ptr.Val(item.GetLastModifiedDateTime()),
-		ParentPath: parentPath.String(),
 		Owner:      creatorEmail,
+		ParentPath: pps,
 		SiteID:     siteID,
 		Size:       size,
 		WebURL:     weburl,
@@ -159,3 +172,7 @@ func (h libraryBackupHandler) NewLocationIDer(
 ) details.LocationIDer {
 	return details.NewSharePointLocationIDer(driveID, elems...)
 }
+
+func (h libraryBackupHandler) Requester() graph.Requester                     { return h.ac.Requester }
+func (h libraryBackupHandler) PermissionGetter() onedrive.GetItemPermissioner { return h.ac }
+func (h libraryBackupHandler) ItemGetter() onedrive.GetItemer                 { return h.ac }

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -725,6 +725,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 	)
 
 	itemParents1, err := path.GetDriveFolderPath(itemPath1)
+	itemParents1String := itemParents1.String()
 	require.NoError(suite.T(), err, clues.ToCore(err))
 
 	table := []struct {
@@ -899,7 +900,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 								ItemInfo: details.ItemInfo{
 									OneDrive: &details.OneDriveInfo{
 										ItemType:   details.OneDriveItem,
-										ParentPath: itemParents1,
+										ParentPath: itemParents1String,
 										Size:       42,
 									},
 								},

--- a/src/pkg/services/m365/api/client.go
+++ b/src/pkg/services/m365/api/client.go
@@ -27,6 +27,11 @@ type Client struct {
 	// downloading large items such as drive item content or outlook
 	// mail and event attachments.
 	LargeItem graph.Servicer
+
+	// The Requester provides a client specifically for calling
+	// arbitrary urls instead of constructing queries using the
+	// graph api client.
+	Requester graph.Requester
 }
 
 // NewClient produces a new exchange api client.  Must be used in
@@ -42,7 +47,9 @@ func NewClient(creds account.M365Config) (Client, error) {
 		return Client{}, err
 	}
 
-	return Client{creds, s, li}, nil
+	rqr := graph.NewNoTimeoutHTTPWrapper()
+
+	return Client{creds, s, li, rqr}, nil
 }
 
 // Service generates a new graph servicer.  New servicers are used for paged

--- a/src/pkg/services/m365/api/drive_item_pager.go
+++ b/src/pkg/services/m365/api/drive_item_pager.go
@@ -6,7 +6,7 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 )
 
-type DriveItemPager interface {
+type DriveItemEnumerator interface {
 	GetPage(context.Context) (DeltaPageLinker, error)
 	SetNext(nextLink string)
 	Reset()

--- a/src/pkg/services/m365/api/drive_pager.go
+++ b/src/pkg/services/m365/api/drive_pager.go
@@ -21,7 +21,7 @@ import (
 // item pager
 // ---------------------------------------------------------------------------
 
-type driveItemPager struct {
+type DriveItemPager struct {
 	gs      graph.Servicer
 	driveID string
 	builder *drives.ItemItemsItemDeltaRequestBuilder
@@ -31,7 +31,7 @@ type driveItemPager struct {
 func (c Drives) NewItemPager(
 	driveID, link string,
 	selectFields []string,
-) *driveItemPager {
+) *DriveItemPager {
 	preferHeaderItems := []string{
 		"deltashowremovedasdeleted",
 		"deltatraversepermissiongaps",
@@ -47,7 +47,7 @@ func (c Drives) NewItemPager(
 		},
 	}
 
-	res := &driveItemPager{
+	res := &DriveItemPager{
 		gs:      c.Stable,
 		driveID: driveID,
 		options: requestConfig,
@@ -65,7 +65,7 @@ func (c Drives) NewItemPager(
 	return res
 }
 
-func (p *driveItemPager) GetPage(ctx context.Context) (DeltaPageLinker, error) {
+func (p *DriveItemPager) GetPage(ctx context.Context) (DeltaPageLinker, error) {
 	var (
 		resp DeltaPageLinker
 		err  error
@@ -79,11 +79,11 @@ func (p *driveItemPager) GetPage(ctx context.Context) (DeltaPageLinker, error) {
 	return resp, nil
 }
 
-func (p *driveItemPager) SetNext(link string) {
+func (p *DriveItemPager) SetNext(link string) {
 	p.builder = drives.NewItemItemsItemDeltaRequestBuilder(link, p.gs.Adapter())
 }
 
-func (p *driveItemPager) Reset() {
+func (p *DriveItemPager) Reset() {
 	p.builder = p.gs.Client().
 		Drives().
 		ByDriveId(p.driveID).
@@ -92,7 +92,7 @@ func (p *driveItemPager) Reset() {
 		Delta()
 }
 
-func (p *driveItemPager) ValuesIn(l DeltaPageLinker) ([]models.DriveItemable, error) {
+func (p *DriveItemPager) ValuesIn(l DeltaPageLinker) ([]models.DriveItemable, error) {
 	return getValues[models.DriveItemable](l)
 }
 


### PR DESCRIPTION
migrates the last of the per-type funcs into the onedrive backupHandler.  Or, in some cases, produces a generic func instead of making an addition to the interface.

This pr is in a bad state (ie: linter & build failures).
This is known and expected. This change covers so many
different pieces that the easiest path forward is to aim for
success as an end goal. Please review the changes
as they are currently presented.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #1996

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
