### PR TITLE
Refactor itemReaderFunc

### DIFF
--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -114,19 +114,22 @@ func (suite *ItemIntegrationSuite) TestItemReader_oneDrive() {
 		suite.user,
 		suite.userDriveID)
 
+	url, err := getItemDownloadURL(ctx, driveItem)
+	require.NoError(t, err, clues.ToCore(err))
 	// Read data for the file
-	itemInfo, itemData, err := oneDriveItemReader(ctx, graph.NewNoTimeoutHTTPWrapper(), driveItem)
+	itemData, err := oneDriveItemReader(ctx, graph.NewNoTimeoutHTTPWrapper(), url)
 
 	require.NoError(t, err, clues.ToCore(err))
-	require.NotNil(t, itemInfo.OneDrive)
-	require.NotEmpty(t, itemInfo.OneDrive.ItemName)
+	// TODO: check if itemInfo is needed
+	// require.NotNil(t, itemInfo.OneDrive)
+	// require.NotEmpty(t, itemInfo.OneDrive.ItemName)
 
+	// require.Equal(t, size, itemInfo.OneDrive.Size)
+
+	// t.Logf("Read %d bytes from file %s.", size, itemInfo.OneDrive.ItemName)
 	size, err := io.Copy(io.Discard, itemData)
 	require.NoError(t, err, clues.ToCore(err))
 	require.NotZero(t, size)
-	require.Equal(t, size, itemInfo.OneDrive.Size)
-
-	t.Logf("Read %d bytes from file %s.", size, itemInfo.OneDrive.ItemName)
 }
 
 // TestItemWriter is an integration test for uploading data to OneDrive


### PR DESCRIPTION
Draft PR for discussion.

Summary of `itemReaderFunc` refactoring:

* Remove `details.ItemInfo` returned value which is not used anywhere in non-test code. Is this return value important?
* Take in a download `url` as an argument instead of `DriveItemable`. The function currently doesn't operate on any other elements of `DriveItemable` other than the url. 

Reasons for refactoring:
* We are planning to use url cache on 401 inside `downloadContent`. The cache only stores `downloadUrl` and a few other things. It doesn't store `DriveItemable` as it can be memory intensive especially when we do a full delta enum. Adjusting `itemReaderFunc` to take in URLs will help us maintain the same `irf` usage throughout `downloadContent`.
* Simplifies `itemReaderFunc`. It's only fed what it needs to use (i.e. url).


---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
