### PR TITLE
getting to green following refactors, part 2

### DIFF
--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -71,16 +71,15 @@ type Collections struct {
 }
 
 func NewCollections(
-	ad api.Drives,
-	itemClient graph.Requester,
+	bh BackupHandler,
 	tenantID string,
 	resourceOwner string,
 	matcher folderMatcher,
-	service graph.Servicer,
 	statusUpdater support.StatusUpdater,
 	ctrlOpts control.Options,
 ) *Collections {
 	return &Collections{
+		handler:       bh,
 		tenantID:      tenantID,
 		resourceOwner: resourceOwner,
 		matcher:       matcher,

--- a/src/internal/connector/onedrive/data_collections.go
+++ b/src/internal/connector/onedrive/data_collections.go
@@ -68,12 +68,10 @@ func DataCollections(
 		logger.Ctx(ctx).Debug("creating OneDrive collections")
 
 		nc := NewCollections(
-			ac.Drives(),
-			itemClient,
+			&itemBackupHandler{ac.Drives()},
 			tenant,
 			user.ID(),
 			odFolderMatcher{scope},
-			service,
 			su,
 			ctrlOpts)
 

--- a/src/internal/connector/onedrive/drive_test.go
+++ b/src/internal/connector/onedrive/drive_test.go
@@ -460,12 +460,10 @@ func (suite *OneDriveIntgSuite) TestOneDriveNewCollections() {
 			)
 
 			colls := NewCollections(
-				suite.ac.Drives(),
-				graph.NewNoTimeoutHTTPWrapper(),
+				&itemBackupHandler{suite.ac.Drives()},
 				creds.AzureTenantID,
 				test.user,
 				testFolderMatcher{scope},
-				service,
 				service.updateStatus,
 				control.Options{
 					ToggleFeatures: control.Toggles{},

--- a/src/internal/connector/onedrive/mock/handlers.go
+++ b/src/internal/connector/onedrive/mock/handlers.go
@@ -31,7 +31,8 @@ type BackupHandler struct {
 	Category path.CategoryType
 
 	DrivePagerV api.DrivePager
-	ItemPagerV  api.DriveItemEnumerator
+	// driveID -> itemPager
+	ItemPagerV map[string]api.DriveItemEnumerator
 
 	DisplayPath string
 
@@ -58,8 +59,8 @@ func (h BackupHandler) DrivePager(string, []string) api.DrivePager {
 	return h.DrivePagerV
 }
 
-func (h BackupHandler) ItemPager(string, string, []string) api.DriveItemEnumerator {
-	return h.ItemPagerV
+func (h BackupHandler) ItemPager(driveID string, _ string, _ []string) api.DriveItemEnumerator {
+	return h.ItemPagerV[driveID]
 }
 
 func (h BackupHandler) FormatDisplayPath(string, *path.Builder) string {

--- a/src/internal/connector/sharepoint/data_collections.go
+++ b/src/internal/connector/sharepoint/data_collections.go
@@ -91,8 +91,6 @@ func DataCollections(
 			spcs, err = collectLibraries(
 				ctx,
 				ac.Drives(),
-				itemClient,
-				gs,
 				creds.AzureTenantID,
 				site,
 				metadata,
@@ -206,8 +204,6 @@ func collectLists(
 func collectLibraries(
 	ctx context.Context,
 	ad api.Drives,
-	itemClient graph.Requester,
-	serv graph.Servicer,
 	tenantID string,
 	site idname.Provider,
 	metadata []data.RestoreCollection,
@@ -222,12 +218,10 @@ func collectLibraries(
 	var (
 		collections = []data.BackupCollection{}
 		colls       = onedrive.NewCollections(
-			ad,
-			itemClient,
+			&libraryBackupHandler{ad},
 			tenantID,
 			site.ID(),
 			folderMatcher{scope},
-			serv,
 			updater.UpdateStatus,
 			ctrlOpts)
 	)

--- a/src/internal/connector/sharepoint/data_collections_test.go
+++ b/src/internal/connector/sharepoint/data_collections_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/common/idname/mock"
-	"github.com/alcionai/corso/src/internal/connector/graph"
 	"github.com/alcionai/corso/src/internal/connector/onedrive"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/control"
@@ -112,12 +111,10 @@ func (suite *SharePointLibrariesUnitSuite) TestUpdateCollections() {
 			)
 
 			c := onedrive.NewCollections(
-				api.Drives{},
-				graph.NewNoTimeoutHTTPWrapper(),
+				&libraryBackupHandler{api.Drives{}},
 				tenantID,
 				site,
 				testFolderMatcher{test.scope},
-				&MockGraphService{},
 				nil,
 				control.Defaults())
 

--- a/src/internal/connector/sharepoint/library_handler.go
+++ b/src/internal/connector/sharepoint/library_handler.go
@@ -153,6 +153,10 @@ type libraryRestoreHandler struct {
 	ac api.Drives
 }
 
+func NewRestoreHandler(ac api.Client) *libraryRestoreHandler {
+	return &libraryRestoreHandler{ac.Drives()}
+}
+
 // AugmentItemInfo will populate a details.OneDriveInfo struct
 // with properties from the drive item.  ItemSize is specified
 // separately for restore processes because the local itemable

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -725,8 +725,9 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 	)
 
 	itemParents1, err := path.GetDriveFolderPath(itemPath1)
-	itemParents1String := itemParents1.String()
 	require.NoError(suite.T(), err, clues.ToCore(err))
+
+	itemParents1String := itemParents1.String()
 
 	table := []struct {
 		name             string


### PR DESCRIPTION
Cleans up the last of the compiler errors.  Next PR will make any changes necessary for passing tests and
ensure everything looks good.

This pr is in a bad state (ie: linter & build failures).
This is known and expected. This change covers so many
different pieces that the easiest path forward is to aim for
success as an end goal. Please review the changes
as they are currently presented.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #1996

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
