### PR TITLE
Fix nightly tests

### DIFF
--- a/.github/workflows/nightly_test.yml
+++ b/.github/workflows/nightly_test.yml
@@ -43,39 +43,6 @@ jobs:
   SetM365App:
     uses: alcionai/corso/.github/workflows/accSelector.yaml@main
 
-  SetEnv:
-    environment: Testing
-    runs-on: ubuntu-latest
-    outputs:
-      environment: ${{ steps.environment.outputs.environment }}
-      version: ${{ steps.version.outputs.version }}
-      website-bucket: ${{ steps.website-bucket.outputs.website-bucket }}
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Figure out environment
-        id: environment
-        run: |
-            echo "environment=Testing" | tee -a $GITHUB_OUTPUT
-
-      - name: Get version string
-        id: version
-        run: |
-          if ${{ startsWith(github.ref, 'refs/tags/') }}; then
-            echo "version=$(git describe --exact-match --tags $(git rev-parse HEAD))" | tee -a $GITHUB_OUTPUT
-          else
-            echo "version=$(echo unreleased-$(git rev-parse --short HEAD))" | tee -a $GITHUB_OUTPUT
-          fi
-
-      - name: Get bucket name for website
-        id: website-bucket
-        run: |
-          if ${{ startsWith(github.ref, 'refs/tags/') }}; then
-            echo "website-bucket=corsobackup.io" | tee -a $GITHUB_OUTPUT
-          else
-            echo "website-bucket=test-corso-docs" | tee -a $GITHUB_OUTPUT
-          fi
-
   # ----------------------------------------------------------------------------------------------------
   # --- Nightly Testing -------------------------------------------------------------------
   # ----------------------------------------------------------------------------------------------------

--- a/src/cli/backup/onedrive_e2e_test.go
+++ b/src/cli/backup/onedrive_e2e_test.go
@@ -211,8 +211,12 @@ func (suite *BackupDeleteOneDriveE2ESuite) TestOneDriveBackupDeleteCmd() {
 	require.NoError(t, err, clues.ToCore(err))
 
 	result := suite.recorder.String()
-
-	assert.Equal(t, fmt.Sprintf("Deleted OneDrive backup %s\n", string(suite.backupOp.Results.BackupID)), result)
+	assert.True(t,
+		strings.HasSuffix(
+			result,
+			fmt.Sprintf("Deleted OneDrive backup %s\n", string(suite.backupOp.Results.BackupID)),
+		),
+	)
 
 	// a follow-up details call should fail, due to the backup ID being deleted
 	cmd = tester.StubRootCmd(

--- a/src/cli/backup/sharepoint_e2e_test.go
+++ b/src/cli/backup/sharepoint_e2e_test.go
@@ -175,8 +175,12 @@ func (suite *BackupDeleteSharePointE2ESuite) TestSharePointBackupDeleteCmd() {
 	require.NoError(t, err, clues.ToCore(err))
 
 	result := suite.recorder.String()
-	expect := fmt.Sprintf("Deleted SharePoint backup %s\n", string(suite.backupOp.Results.BackupID))
-	assert.Equal(t, expect, result)
+	assert.True(t,
+		strings.HasSuffix(
+			result,
+			fmt.Sprintf("Deleted SharePoint backup %s\n", string(suite.backupOp.Results.BackupID)),
+		),
+	)
 }
 
 // moved out of the func above to make the linter happy


### PR DESCRIPTION
Few more assertion changes due to print out log path.<!-- PR description-->

Successful run: https://github.com/alcionai/corso/actions/runs/5110627324

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
