### PR TITLE
Refactor downloadItem

### DIFF
--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -46,10 +46,6 @@ func downloadItem(
 			}
 		}
 
-		if len(url) == 0 {
-			return nil, clues.New("extracting file url")
-		}
-
 		rc, err = downloadFile(ctx, ag, url)
 		if err != nil {
 			return nil, err
@@ -64,9 +60,13 @@ func downloadFile(
 	ag api.Getter,
 	url string,
 ) (io.ReadCloser, error) {
+	if len(url) == 0 {
+		return nil, clues.New("empty file url")
+	}
+
 	resp, err := ag.Get(ctx, url, nil)
 	if err != nil {
-		return nil, clues.Wrap(err, "getting item")
+		return nil, clues.Wrap(err, "getting file")
 	}
 
 	if graph.IsMalwareResp(ctx, resp) {

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -27,6 +27,10 @@ func downloadItem(
 	ag api.Getter,
 	item models.DriveItemable,
 ) (io.ReadCloser, error) {
+	if item == nil {
+		return nil, clues.New("nil item")
+	}
+
 	var (
 		rc     io.ReadCloser
 		isFile = item.GetFile() != nil

--- a/src/internal/connector/onedrive/item.go
+++ b/src/internal/connector/onedrive/item.go
@@ -52,7 +52,7 @@ func downloadItem(
 
 		rc, err = downloadFile(ctx, ag, url)
 		if err != nil {
-			return nil, err
+			return nil, clues.Stack(err)
 		}
 	}
 

--- a/src/internal/connector/onedrive/item_test.go
+++ b/src/internal/connector/onedrive/item_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -282,7 +281,7 @@ func TestItemUnitTestSuite(t *testing.T) {
 }
 
 func (suite *ItemUnitTestSuite) TestDownloadItem() {
-	testRc := ioutil.NopCloser(bytes.NewReader([]byte("test")))
+	testRc := io.NopCloser(bytes.NewReader([]byte("test")))
 	url := "https://example.com"
 
 	table := []struct {


### PR DESCRIPTION
This refactor is being done to allow calling `downloadFile` with an URL obtained from URL cache. 


---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
