### PR TITLE
Automatically handle post close tasks on progressbar

### DIFF
--- a/src/internal/connector/exchange/data_collections.go
+++ b/src/internal/connector/exchange/data_collections.go
@@ -287,10 +287,9 @@ func createCollections(
 		Credentials:   creds,
 	}
 
-	foldersComplete, closer := observe.MessageWithCompletion(
+	foldersComplete := observe.MessageWithCompletion(
 		ctx,
 		observe.Bulletf("%s", qp.Category))
-	defer closer()
 	defer close(foldersComplete)
 
 	resolver, err := PopulateExchangeContainerResolver(ctx, qp, errs)

--- a/src/internal/connector/exchange/exchange_data_collection.go
+++ b/src/internal/connector/exchange/exchange_data_collection.go
@@ -178,13 +178,10 @@ func (col *Collection) streamItems(ctx context.Context, errs *fault.Bus) {
 	}()
 
 	if len(col.added)+len(col.removed) > 0 {
-		var closer func()
-		colProgress, closer = observe.CollectionProgress(
+		colProgress = observe.CollectionProgress(
 			ctx,
 			col.fullPath.Category().String(),
 			col.LocationPath().Elements())
-
-		go closer()
 
 		defer func() {
 			close(colProgress)

--- a/src/internal/connector/exchange/service_restore.go
+++ b/src/internal/connector/exchange/service_restore.go
@@ -344,11 +344,10 @@ func restoreCollection(
 		"service", service,
 		"category", category)
 
-	colProgress, closer := observe.CollectionProgress(
+	colProgress := observe.CollectionProgress(
 		ctx,
 		category.String(),
 		clues.Hide(directory.Folder(false)))
-	defer closer()
 	defer close(colProgress)
 
 	for {

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -535,13 +535,12 @@ func (oc *Collection) populateItems(ctx context.Context, errs *fault.Bus) {
 					}
 
 					// display/log the item download
-					progReader, closer, _ := observe.ItemProgress(
+					progReader, _ := observe.ItemProgress(
 						ctx,
 						itemData,
 						observe.ItemBackupMsg,
 						clues.Hide(itemName+dataSuffix),
 						itemSize)
-					go closer()
 
 					return progReader, nil
 				})
@@ -554,13 +553,12 @@ func (oc *Collection) populateItems(ctx context.Context, errs *fault.Bus) {
 			}
 
 			metaReader := lazy.NewLazyReadCloser(func() (io.ReadCloser, error) {
-				progReader, closer, _ := observe.ItemProgress(
+				progReader, _ := observe.ItemProgress(
 					ctx,
 					itemMeta,
 					observe.ItemBackupMsg,
 					clues.Hide(itemName+metaSuffix),
 					int64(itemMetaSize))
-				go closer()
 				return progReader, nil
 			})
 

--- a/src/internal/connector/onedrive/collection.go
+++ b/src/internal/connector/onedrive/collection.go
@@ -439,12 +439,11 @@ func (oc *Collection) populateItems(ctx context.Context, errs *fault.Bus) {
 		queuedPath = "/" + oc.driveName + queuedPath
 	}
 
-	folderProgress, colCloser := observe.ProgressWithCount(
+	folderProgress := observe.ProgressWithCount(
 		ctx,
 		observe.ItemQueueMsg,
 		path.NewElements(queuedPath),
 		int64(len(oc.driveItems)))
-	defer colCloser()
 	defer close(folderProgress)
 
 	semaphoreCh := make(chan struct{}, graph.Parallelism(path.OneDriveService).Item())

--- a/src/internal/connector/onedrive/collections.go
+++ b/src/internal/connector/onedrive/collections.go
@@ -283,8 +283,7 @@ func (c *Collections) Get(
 		driveTombstones[driveID] = struct{}{}
 	}
 
-	driveComplete, closer := observe.MessageWithCompletion(ctx, observe.Bulletf("files"))
-	defer closer()
+	driveComplete := observe.MessageWithCompletion(ctx, observe.Bulletf("files"))
 	defer close(driveComplete)
 
 	// Enumerate drives for the specified resourceOwner

--- a/src/internal/connector/onedrive/restore.go
+++ b/src/internal/connector/onedrive/restore.go
@@ -788,14 +788,12 @@ func restoreData(
 			iReader = itemData.ToReader()
 		}
 
-		progReader, closer, abort := observe.ItemProgress(
+		progReader, abort := observe.ItemProgress(
 			ctx,
 			iReader,
 			observe.ItemRestoreMsg,
 			clues.Hide(pname),
 			ss.Size())
-
-		go closer()
 
 		// Upload the stream data
 		written, err = io.CopyBuffer(w, progReader, copyBuffer)

--- a/src/internal/connector/sharepoint/collection.go
+++ b/src/internal/connector/sharepoint/collection.go
@@ -183,11 +183,10 @@ func (sc *Collection) runPopulate(ctx context.Context, errs *fault.Bus) (support
 	)
 
 	// TODO: Insert correct ID for CollectionProgress
-	colProgress, closer := observe.CollectionProgress(
+	colProgress := observe.CollectionProgress(
 		ctx,
 		sc.fullPath.Category().String(),
 		sc.fullPath.Folders())
-	go closer()
 
 	defer func() {
 		close(colProgress)

--- a/src/internal/connector/sharepoint/data_collections.go
+++ b/src/internal/connector/sharepoint/data_collections.go
@@ -61,10 +61,9 @@ func DataCollections(
 			break
 		}
 
-		foldersComplete, closer := observe.MessageWithCompletion(
+		foldersComplete := observe.MessageWithCompletion(
 			ctx,
 			observe.Bulletf("%s", scope.Category().PathType()))
-		defer closer()
 		defer close(foldersComplete)
 
 		var spcs []data.BackupCollection

--- a/src/internal/observe/observe.go
+++ b/src/internal/observe/observe.go
@@ -180,7 +180,7 @@ func Message(ctx context.Context, msgs ...any) {
 func MessageWithCompletion(
 	ctx context.Context,
 	msg any,
-) (chan<- struct{}, func()) {
+) chan<- struct{} {
 	var (
 		plain    = plainString(msg)
 		loggable = fmt.Sprintf("%v", msg)
@@ -191,7 +191,8 @@ func MessageWithCompletion(
 	log.Info(loggable)
 
 	if cfg.hidden() {
-		return ch, func() { log.Info("done - " + loggable) }
+		defer log.Info("done - " + loggable)
+		return ch
 	}
 
 	wg.Add(1)
@@ -219,11 +220,11 @@ func MessageWithCompletion(
 			bar.SetTotal(-1, true)
 		})
 
-	wacb := waitAndCloseBar(bar, func() {
+	go waitAndCloseBar(bar, func() {
 		log.Info("done - " + loggable)
-	})
+	})()
 
-	return ch, wacb
+	return ch
 }
 
 // ---------------------------------------------------------------------------

--- a/src/internal/observe/observe_test.go
+++ b/src/internal/observe/observe_test.go
@@ -285,14 +285,11 @@ func (suite *ObserveProgressUnitSuite) TestObserveProgressWithCount() {
 	message := "Test Message"
 	count := 3
 
-	ch, closer := ProgressWithCount(ctx, header, message, int64(count))
+	ch := ProgressWithCount(ctx, header, message, int64(count))
 
 	for i := 0; i < count; i++ {
 		ch <- struct{}{}
 	}
-
-	// Run the closer - this should complete because the context was closed above
-	closer()
 
 	Complete()
 
@@ -320,12 +317,9 @@ func (suite *ObserveProgressUnitSuite) TestrogressWithCountChannelClosed() {
 	message := "Test Message"
 	count := 3
 
-	ch, closer := ProgressWithCount(ctx, header, message, int64(count))
+	ch := ProgressWithCount(ctx, header, message, int64(count))
 
 	close(ch)
-
-	// Run the closer - this should complete because the context was closed above
-	closer()
 
 	Complete()
 

--- a/src/internal/observe/observe_test.go
+++ b/src/internal/observe/observe_test.go
@@ -103,9 +103,8 @@ func (suite *ObserveProgressUnitSuite) TestCollectionProgress_unblockOnCtxCancel
 		SeedWriter(context.Background(), nil, nil)
 	}()
 
-	progCh, closer := CollectionProgress(ctx, testcat, testertons)
+	progCh := CollectionProgress(ctx, testcat, testertons)
 	require.NotNil(t, progCh)
-	require.NotNil(t, closer)
 
 	defer close(progCh)
 
@@ -117,9 +116,6 @@ func (suite *ObserveProgressUnitSuite) TestCollectionProgress_unblockOnCtxCancel
 		time.Sleep(1 * time.Second)
 		cancel()
 	}()
-
-	// blocks, but should resolve due to the ctx cancel
-	closer()
 }
 
 func (suite *ObserveProgressUnitSuite) TestCollectionProgress_unblockOnChannelClose() {
@@ -138,9 +134,8 @@ func (suite *ObserveProgressUnitSuite) TestCollectionProgress_unblockOnChannelCl
 		SeedWriter(context.Background(), nil, nil)
 	}()
 
-	progCh, closer := CollectionProgress(ctx, testcat, testertons)
+	progCh := CollectionProgress(ctx, testcat, testertons)
 	require.NotNil(t, progCh)
-	require.NotNil(t, closer)
 
 	for i := 0; i < 50; i++ {
 		progCh <- struct{}{}
@@ -150,9 +145,6 @@ func (suite *ObserveProgressUnitSuite) TestCollectionProgress_unblockOnChannelCl
 		time.Sleep(1 * time.Second)
 		close(progCh)
 	}()
-
-	// blocks, but should resolve due to the cancel
-	closer()
 }
 
 func (suite *ObserveProgressUnitSuite) TestObserveProgress() {

--- a/src/internal/observe/observe_test.go
+++ b/src/internal/observe/observe_test.go
@@ -51,16 +51,14 @@ func (suite *ObserveProgressUnitSuite) TestItemProgress() {
 	}()
 
 	from := make([]byte, 100)
-	prog, closer, _ := ItemProgress(
+	prog, abort := ItemProgress(
 		ctx,
 		io.NopCloser(bytes.NewReader(from)),
 		"folder",
 		tst,
 		100)
 	require.NotNil(t, prog)
-	require.NotNil(t, closer)
-
-	defer closer()
+	require.NotNil(t, abort)
 
 	var i int
 

--- a/src/internal/observe/observe_test.go
+++ b/src/internal/observe/observe_test.go
@@ -195,13 +195,10 @@ func (suite *ObserveProgressUnitSuite) TestObserveProgressWithCompletion() {
 
 	message := "Test Message"
 
-	ch, closer := MessageWithCompletion(ctx, message)
+	ch := MessageWithCompletion(ctx, message)
 
 	// Trigger completion
 	ch <- struct{}{}
-
-	// Run the closer - this should complete because the bar was compelted above
-	closer()
 
 	Complete()
 
@@ -227,13 +224,10 @@ func (suite *ObserveProgressUnitSuite) TestObserveProgressWithChannelClosed() {
 
 	message := "Test Message"
 
-	ch, closer := MessageWithCompletion(ctx, message)
+	ch := MessageWithCompletion(ctx, message)
 
 	// Close channel without completing
 	close(ch)
-
-	// Run the closer - this should complete because the channel was closed above
-	closer()
 
 	Complete()
 
@@ -261,13 +255,10 @@ func (suite *ObserveProgressUnitSuite) TestObserveProgressWithContextCancelled()
 
 	message := "Test Message"
 
-	_, closer := MessageWithCompletion(ctx, message)
+	_ = MessageWithCompletion(ctx, message)
 
 	// cancel context
 	cancel()
-
-	// Run the closer - this should complete because the context was closed above
-	closer()
 
 	Complete()
 

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -389,11 +389,10 @@ func produceBackupDataCollections(
 	ctrlOpts control.Options,
 	errs *fault.Bus,
 ) ([]data.BackupCollection, prefixmatcher.StringSetReader, error) {
-	complete, closer := observe.MessageWithCompletion(ctx, "Discovering items to backup")
+	complete := observe.MessageWithCompletion(ctx, "Discovering items to backup")
 	defer func() {
 		complete <- struct{}{}
 		close(complete)
-		closer()
 	}()
 
 	return bp.ProduceBackupCollections(
@@ -472,11 +471,10 @@ func consumeBackupCollections(
 	isIncremental bool,
 	errs *fault.Bus,
 ) (*kopia.BackupStats, *details.Builder, kopia.DetailsMergeInfoer, error) {
-	complete, closer := observe.MessageWithCompletion(ctx, "Backing up data")
+	complete := observe.MessageWithCompletion(ctx, "Backing up data")
 	defer func() {
 		complete <- struct{}{}
 		close(complete)
-		closer()
 	}()
 
 	tags := map[string]string{

--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -232,8 +232,7 @@ func (op *RestoreOperation) do(
 	observe.Message(ctx, fmt.Sprintf("Discovered %d items in backup %s to restore", len(paths), op.BackupID))
 	logger.Ctx(ctx).With("control_options", op.Options, "selectors", op.Selectors).Info("restoring selection")
 
-	kopiaComplete, closer := observe.MessageWithCompletion(ctx, "Enumerating items in repository")
-	defer closer()
+	kopiaComplete := observe.MessageWithCompletion(ctx, "Enumerating items in repository")
 	defer close(kopiaComplete)
 
 	dcs, err := op.kopia.ProduceRestoreCollections(ctx, bup.SnapshotID, paths, opStats.bytesRead, op.Errors)
@@ -318,11 +317,10 @@ func consumeRestoreCollections(
 	dcs []data.RestoreCollection,
 	errs *fault.Bus,
 ) (*details.Details, error) {
-	complete, closer := observe.MessageWithCompletion(ctx, "Restoring data")
+	complete := observe.MessageWithCompletion(ctx, "Restoring data")
 	defer func() {
 		complete <- struct{}{}
 		close(complete)
-		closer()
 	}()
 
 	deets, err := rc.ConsumeRestoreCollections(

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -203,8 +203,7 @@ func Connect(
 	// their output getting clobbered (#1720)
 	defer observe.Complete()
 
-	complete, closer := observe.MessageWithCompletion(ctx, "Connecting to repository")
-	defer closer()
+	complete := observe.MessageWithCompletion(ctx, "Connecting to repository")
 	defer close(complete)
 
 	kopiaRef := kopia.NewConn(s)
@@ -630,11 +629,10 @@ func connectToM365(
 	sel selectors.Selector,
 	acct account.Account,
 ) (*connector.GraphConnector, error) {
-	complete, closer := observe.MessageWithCompletion(ctx, "Connecting to M365")
+	complete := observe.MessageWithCompletion(ctx, "Connecting to M365")
 	defer func() {
 		complete <- struct{}{}
 		close(complete)
-		closer()
 	}()
 
 	// retrieve data from the producer


### PR DESCRIPTION
This ensures that we can just fire and forget about progressbar. No more worry about causing deadlocks.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
