### PR TITLE
Integrate URL cache into onedrive backup flows

### DIFF
--- a/src/internal/m365/onedrive/collection.go
+++ b/src/internal/m365/onedrive/collection.go
@@ -347,7 +347,6 @@ func downloadContent(
 	content, err = readItemContents(ctx, iaag, uc, itemID)
 	if err == nil {
 		logger.Ctx(ctx).Debug("found item in url cache")
-
 		return content, nil
 	}
 

--- a/src/internal/m365/onedrive/collection.go
+++ b/src/internal/m365/onedrive/collection.go
@@ -84,6 +84,8 @@ type Collection struct {
 
 	// should only be true if the old delta token expired
 	doNotMergeItems bool
+
+	cache *urlCache
 }
 
 func pathToLocation(p path.Path) (*path.Builder, error) {
@@ -109,6 +111,7 @@ func NewCollection(
 	ctrlOpts control.Options,
 	colScope collectionScope,
 	doNotMergeItems bool,
+	cache *urlCache,
 ) (*Collection, error) {
 	// TODO(ashmrtn): If OneDrive switches to using folder IDs then this will need
 	// to be changed as we won't be able to extract path information from the
@@ -132,7 +135,8 @@ func NewCollection(
 		statusUpdater,
 		ctrlOpts,
 		colScope,
-		doNotMergeItems)
+		doNotMergeItems,
+		cache)
 
 	c.locPath = locPath
 	c.prevLocPath = prevLocPath
@@ -149,6 +153,7 @@ func newColl(
 	ctrlOpts control.Options,
 	colScope collectionScope,
 	doNotMergeItems bool,
+	cache *urlCache,
 ) *Collection {
 	c := &Collection{
 		handler:         handler,
@@ -162,6 +167,7 @@ func newColl(
 		state:           data.StateOf(prevPath, currPath),
 		scope:           colScope,
 		doNotMergeItems: doNotMergeItems,
+		cache:           cache,
 	}
 
 	return c
@@ -267,7 +273,7 @@ func (oc *Collection) getDriveItemContent(
 		el       = errs.Local()
 	)
 
-	itemData, err := downloadContent(ctx, oc.handler, item, oc.driveID)
+	itemData, err := oc.downloadContent(ctx, oc.handler, item, oc.driveID)
 	if err != nil {
 		if clues.HasLabel(err, graph.LabelsMalware) || (item != nil && item.GetMalware() != nil) {
 			logger.CtxErr(ctx, err).With("skipped_reason", fault.SkipMalware).Info("item flagged as malware")
@@ -317,12 +323,15 @@ type itemAndAPIGetter interface {
 // downloadContent attempts to fetch the item content.  If the content url
 // is expired (ie, returns a 401), it re-fetches the item to get a new download
 // url and tries again.
-func downloadContent(
+func (oc *Collection) downloadContent(
 	ctx context.Context,
 	iaag itemAndAPIGetter,
 	item models.DriveItemable,
 	driveID string,
 ) (io.ReadCloser, error) {
+	itemID := ptr.Val(item.GetId())
+	ctx = clues.Add(ctx, "item_id", itemID)
+
 	content, err := downloadItem(ctx, iaag, item)
 	if err == nil {
 		return content, nil
@@ -332,8 +341,20 @@ func downloadContent(
 
 	// Assume unauthorized requests are a sign of an expired jwt
 	// token, and that we've overrun the available window to
-	// download the actual file.  Re-downloading the item will
-	// refresh that download url.
+	// download the file.  Get a fresh url from the cache and attempt to
+	// download again.
+	content, err = oc.readFromCache(ctx, iaag, itemID)
+	if err == nil {
+		logger.Ctx(ctx).Debug("found item in cache", itemID)
+
+		return content, nil
+	}
+
+	// Consider cache errors(including deleted items) as cache misses. This is
+	// to preserve existing behavior. Fallback to refetching the item using the
+	// API.
+	logger.CtxErr(ctx, err).Info("cache miss. refetching from API")
+
 	di, err := iaag.GetItem(ctx, driveID, ptr.Val(item.GetId()))
 	if err != nil {
 		return nil, clues.Wrap(err, "retrieving expired item")
@@ -345,6 +366,41 @@ func downloadContent(
 	}
 
 	return content, nil
+}
+
+// readFromCache fetches latest download URL from the cache and attempts to
+// download the file using the new URL.
+func (oc *Collection) readFromCache(
+	ctx context.Context,
+	iaag itemAndAPIGetter,
+	itemID string,
+) (io.ReadCloser, error) {
+	if oc.cache == nil {
+		return nil, clues.New("nil url cache")
+	}
+
+	props, err := oc.cache.getItemProperties(ctx, itemID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle newly deleted items
+	if props.isDeleted {
+		logger.Ctx(ctx).Info("item deleted in cache")
+
+		return nil, graph.ErrDeletedInFlight
+	}
+
+	rc, err := downloadFile(ctx, iaag, props.downloadURL)
+	if graph.IsErrUnauthorized(err) {
+		logger.CtxErr(ctx, err).Info("stale item in cache")
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return rc, nil
 }
 
 // populateItems iterates through items added to the collection

--- a/src/internal/m365/onedrive/collection.go
+++ b/src/internal/m365/onedrive/collection.go
@@ -85,7 +85,7 @@ type Collection struct {
 	// should only be true if the old delta token expired
 	doNotMergeItems bool
 
-	cache *urlCache
+	cache urlCacher
 }
 
 func pathToLocation(p path.Path) (*path.Builder, error) {
@@ -111,7 +111,7 @@ func NewCollection(
 	ctrlOpts control.Options,
 	colScope collectionScope,
 	doNotMergeItems bool,
-	cache *urlCache,
+	cache urlCacher,
 ) (*Collection, error) {
 	// TODO(ashmrtn): If OneDrive switches to using folder IDs then this will need
 	// to be changed as we won't be able to extract path information from the
@@ -153,7 +153,7 @@ func newColl(
 	ctrlOpts control.Options,
 	colScope collectionScope,
 	doNotMergeItems bool,
-	cache *urlCache,
+	cache urlCacher,
 ) *Collection {
 	c := &Collection{
 		handler:         handler,
@@ -376,7 +376,7 @@ func (oc *Collection) readFromCache(
 	itemID string,
 ) (io.ReadCloser, error) {
 	if oc.cache == nil {
-		return nil, clues.New("nil url cache")
+		return nil, clues.New("nil cache")
 	}
 
 	props, err := oc.cache.getItemProperties(ctx, itemID)

--- a/src/internal/m365/onedrive/collection_test.go
+++ b/src/internal/m365/onedrive/collection_test.go
@@ -204,7 +204,8 @@ func (suite *CollectionUnitTestSuite) TestCollection() {
 				suite.testStatusUpdater(&wg, &collStatus),
 				control.Options{ToggleFeatures: control.Toggles{}},
 				CollectionScopeFolder,
-				true)
+				true,
+				nil)
 			require.NoError(t, err, clues.ToCore(err))
 			require.NotNil(t, coll)
 			assert.Equal(t, folderPath, coll.FullPath())
@@ -312,7 +313,8 @@ func (suite *CollectionUnitTestSuite) TestCollectionReadError() {
 		suite.testStatusUpdater(&wg, &collStatus),
 		control.Options{ToggleFeatures: control.Toggles{}},
 		CollectionScopeFolder,
-		true)
+		true,
+		nil)
 	require.NoError(t, err, clues.ToCore(err))
 
 	stubItem := odTD.NewStubDriveItem(
@@ -388,7 +390,8 @@ func (suite *CollectionUnitTestSuite) TestCollectionReadUnauthorizedErrorRetry()
 		suite.testStatusUpdater(&wg, &collStatus),
 		control.Options{ToggleFeatures: control.Toggles{}},
 		CollectionScopeFolder,
-		true)
+		true,
+		nil)
 	require.NoError(t, err, clues.ToCore(err))
 
 	coll.Add(stubItem)
@@ -442,7 +445,8 @@ func (suite *CollectionUnitTestSuite) TestCollectionPermissionBackupLatestModTim
 		suite.testStatusUpdater(&wg, &collStatus),
 		control.Options{ToggleFeatures: control.Toggles{}},
 		CollectionScopeFolder,
-		true)
+		true,
+		nil)
 	require.NoError(t, err, clues.ToCore(err))
 
 	mtime := time.Now().AddDate(0, -1, 0)
@@ -685,7 +689,19 @@ func (suite *GetDriveItemUnitTestSuite) TestDownloadContent() {
 			mbh.GetResps = resps
 			mbh.GetErrs = test.getErr
 
-			r, err := downloadContent(ctx, mbh, item, driveID)
+			coll, err := NewCollection(
+				mbh,
+				nil,
+				nil,
+				"drive-id",
+				nil,
+				control.Options{ToggleFeatures: control.Toggles{}},
+				CollectionScopeFolder,
+				true,
+				nil)
+			require.NoError(t, err, clues.ToCore(err))
+
+			r, err := coll.downloadContent(ctx, mbh, item, driveID)
 			test.expect(t, r)
 			test.expectErr(t, err, clues.ToCore(err))
 		})

--- a/src/internal/m365/onedrive/collection_test.go
+++ b/src/internal/m365/onedrive/collection_test.go
@@ -605,7 +605,7 @@ func (suite *GetDriveItemUnitTestSuite) TestGetDriveItem_error() {
 	}
 }
 
-var _ urlCacher = &mockURLCache{}
+var _ getItemPropertyer = &mockURLCache{}
 
 type mockURLCache struct {
 	Get func(ctx context.Context, itemID string) (itemProps, error)
@@ -765,19 +765,7 @@ func (suite *GetDriveItemUnitTestSuite) TestDownloadContent() {
 			mbh.GetResps = resps
 			mbh.GetErrs = test.getErr
 
-			coll, err := NewCollection(
-				mbh,
-				nil,
-				nil,
-				driveID,
-				nil,
-				control.Options{ToggleFeatures: control.Toggles{}},
-				CollectionScopeFolder,
-				true,
-				test.muc)
-			require.NoError(t, err, clues.ToCore(err))
-
-			r, err := coll.downloadContent(ctx, mbh, item, driveID)
+			r, err := downloadContent(ctx, mbh, test.muc, item, driveID)
 			test.expect(t, r)
 			test.expectErr(t, err, clues.ToCore(err))
 		})

--- a/src/internal/m365/onedrive/collection_test.go
+++ b/src/internal/m365/onedrive/collection_test.go
@@ -613,7 +613,8 @@ type mockURLCache struct {
 
 func (muc *mockURLCache) getItemProperties(
 	ctx context.Context,
-	itemID string) (itemProps, error) {
+	itemID string,
+) (itemProps, error) {
 	return muc.Get(ctx, itemID)
 }
 

--- a/src/internal/m365/onedrive/collections.go
+++ b/src/internal/m365/onedrive/collections.go
@@ -385,7 +385,7 @@ func (c *Collections) Get(
 
 		// Only create a drive cache if there are less than 300k items in the drive.
 		if numDriveItems < urlCacheDriveItemThreshold {
-			logger.Ctx(ictx).Info("adding url cache for drive ", driveID)
+			logger.Ctx(ictx).Info("adding url cache for drive")
 
 			err = c.addURLCacheToDriveCollections(
 				ictx,
@@ -457,7 +457,7 @@ func (c *Collections) Get(
 	return collections, canUsePreviousBackup, nil
 }
 
-// addURLCacheToDriveCollections adds a URL cache to all collections belonging to
+// addURLCacheToDriveCollections adds an URL cache to all collections belonging to
 // a drive.
 func (c *Collections) addURLCacheToDriveCollections(
 	ctx context.Context,
@@ -476,7 +476,7 @@ func (c *Collections) addURLCacheToDriveCollections(
 	// Set the URL cache for all collections in this drive
 	for _, driveColls := range c.CollectionMap {
 		for _, coll := range driveColls {
-			coll.cache = uc
+			coll.urlCache = uc
 		}
 	}
 

--- a/src/internal/m365/onedrive/collections.go
+++ b/src/internal/m365/onedrive/collections.go
@@ -384,7 +384,6 @@ func (c *Collections) Get(
 		numPrevItems = c.NumItems
 
 		// Only create a drive cache if there are less than 300k items in the drive.
-		// TODO: Tune this number. Delta query for 300k items takes ~20 mins.
 		if numDriveItems < urlCacheDriveItemThreshold {
 			logger.Ctx(ictx).Info("adding url cache for drive ", driveID)
 

--- a/src/internal/m365/onedrive/collections.go
+++ b/src/internal/m365/onedrive/collections.go
@@ -467,8 +467,8 @@ func (c *Collections) addURLCacheToDriveCollections(
 	uc, err := newURLCache(
 		driveID,
 		urlCacheRefreshInterval,
-		errs,
-		c.handler.ItemPager(driveID, "", api.DriveItemSelectDefault()))
+		c.handler.NewItemPager(driveID, "", api.DriveItemSelectDefault()),
+		errs)
 	if err != nil {
 		return err
 	}

--- a/src/internal/m365/onedrive/collections.go
+++ b/src/internal/m365/onedrive/collections.go
@@ -391,7 +391,6 @@ func (c *Collections) Get(
 			err = c.addURLCacheToDriveCollections(
 				ictx,
 				driveID,
-				c.handler.ItemPager(driveID, "", api.DriveItemSelectDefault()),
 				errs)
 			if err != nil {
 				return nil, err
@@ -459,17 +458,18 @@ func (c *Collections) Get(
 	return collections, canUsePreviousBackup, nil
 }
 
+// addURLCacheToDriveCollections adds a URL cache to all collections belonging to
+// a drive.
 func (c *Collections) addURLCacheToDriveCollections(
 	ctx context.Context,
 	driveID string,
-	pager api.DriveItemEnumerator,
 	errs *fault.Bus,
 ) error {
 	uc, err := newURLCache(
 		driveID,
 		urlCacheRefreshInterval,
 		errs,
-		pager)
+		c.handler.ItemPager(driveID, "", api.DriveItemSelectDefault()))
 	if err != nil {
 		return err
 	}

--- a/src/internal/m365/onedrive/collections.go
+++ b/src/internal/m365/onedrive/collections.go
@@ -64,9 +64,6 @@ type Collections struct {
 	NumItems      int
 	NumFiles      int
 	NumContainers int
-
-	// drive ID -> url cache instance
-	driveURLCache map[string]*urlCache
 }
 
 func NewCollections(
@@ -83,7 +80,6 @@ func NewCollections(
 		CollectionMap: map[string]map[string]*Collection{},
 		statusUpdater: statusUpdater,
 		ctrl:          ctrlOpts,
-		driveURLCache: map[string]*urlCache{},
 	}
 }
 
@@ -386,7 +382,7 @@ func (c *Collections) Get(
 		}
 
 		numDriveItems := c.NumItems - numPrevItems
-		numPrevItems += numDriveItems
+		numPrevItems = c.NumItems
 
 		// Only create a drive cache if there are less than 300k items in the drive.
 		// TODO: Tune this number. Delta query for 300k items takes ~20 mins.
@@ -473,8 +469,6 @@ func (c *Collections) addURLCacheToDriveCollections(
 	if err != nil {
 		return err
 	}
-
-	c.driveURLCache[driveID] = uc
 
 	// Set the URL cache for all collections in this drive
 	for _, driveColls := range c.CollectionMap {

--- a/src/internal/m365/onedrive/collections.go
+++ b/src/internal/m365/onedrive/collections.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"time"
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -386,7 +385,7 @@ func (c *Collections) Get(
 
 		// Only create a drive cache if there are less than 300k items in the drive.
 		// TODO: Tune this number. Delta query for 300k items takes ~20 mins.
-		if numDriveItems < 300*1000 {
+		if numDriveItems < urlCacheDriveItemThreshold {
 			logger.Ctx(ictx).Info("adding url cache for drive ", driveID)
 
 			err = c.addURLCacheToDriveCollections(ictx, driveID, errs)
@@ -463,7 +462,7 @@ func (c *Collections) addURLCacheToDriveCollections(
 ) error {
 	uc, err := newURLCache(
 		driveID,
-		1*time.Hour, // TODO: Add const
+		urlCacheRefreshInterval,
 		errs,
 		c.handler.ItemPager(driveID, "", api.DriveItemSelectDefault()))
 	if err != nil {

--- a/src/internal/m365/onedrive/collections.go
+++ b/src/internal/m365/onedrive/collections.go
@@ -392,7 +392,7 @@ func (c *Collections) Get(
 				driveID,
 				errs)
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 		}
 	}

--- a/src/internal/m365/onedrive/collections.go
+++ b/src/internal/m365/onedrive/collections.go
@@ -388,7 +388,11 @@ func (c *Collections) Get(
 		if numDriveItems < urlCacheDriveItemThreshold {
 			logger.Ctx(ictx).Info("adding url cache for drive ", driveID)
 
-			err = c.addURLCacheToDriveCollections(ictx, driveID, errs)
+			err = c.addURLCacheToDriveCollections(
+				ictx,
+				driveID,
+				c.handler.ItemPager(driveID, "", api.DriveItemSelectDefault()),
+				errs)
 			if err != nil {
 				return nil, err
 			}
@@ -458,13 +462,14 @@ func (c *Collections) Get(
 func (c *Collections) addURLCacheToDriveCollections(
 	ctx context.Context,
 	driveID string,
+	pager api.DriveItemEnumerator,
 	errs *fault.Bus,
 ) error {
 	uc, err := newURLCache(
 		driveID,
 		urlCacheRefreshInterval,
 		errs,
-		c.handler.ItemPager(driveID, "", api.DriveItemSelectDefault()))
+		pager)
 	if err != nil {
 		return err
 	}

--- a/src/internal/m365/onedrive/collections_test.go
+++ b/src/internal/m365/onedrive/collections_test.go
@@ -2692,7 +2692,6 @@ func (suite *OneDriveCollectionsUnitSuite) TestURLCacheIntegration() {
 		prevDelta        string
 		err              error
 	}{
-
 		{
 			name: "cache is attached",
 		},
@@ -2704,8 +2703,11 @@ func (suite *OneDriveCollectionsUnitSuite) TestURLCacheIntegration() {
 			ctx, flush := tester.NewContext()
 			defer flush()
 
+			mbh := mock.DefaultOneDriveBH()
+			mbh.ItemPagerV = map[string]api.DriveItemEnumerator{}
+
 			c := NewCollections(
-				&itemBackupHandler{api.Drives{}},
+				mbh,
 				"test-tenant",
 				"test-user",
 				testFolderMatcher{(&selectors.OneDriveBackup{}).Folders(selectors.Any())[0]},
@@ -2737,7 +2739,6 @@ func (suite *OneDriveCollectionsUnitSuite) TestURLCacheIntegration() {
 			err := c.addURLCacheToDriveCollections(
 				ctx,
 				driveID,
-				&mockItemPager{},
 				fault.New(true))
 
 			require.NoError(t, err, clues.ToCore(err))

--- a/src/internal/m365/onedrive/collections_test.go
+++ b/src/internal/m365/onedrive/collections_test.go
@@ -2683,6 +2683,7 @@ func (suite *OneDriveCollectionsUnitSuite) TestCollectItems() {
 func (suite *OneDriveCollectionsUnitSuite) TestURLCacheIntegration() {
 	driveID := "test-drive"
 	collCount := 3
+	anyFolder := (&selectors.OneDriveBackup{}).Folders(selectors.Any())[0]
 
 	table := []struct {
 		name             string
@@ -2710,7 +2711,6 @@ func (suite *OneDriveCollectionsUnitSuite) TestURLCacheIntegration() {
 				mbh,
 				"test-tenant",
 				"test-user",
-				testFolderMatcher{(&selectors.OneDriveBackup{}).Folders(selectors.Any())[0]},
 				nil,
 				control.Options{ToggleFeatures: control.Toggles{}})
 
@@ -2721,7 +2721,7 @@ func (suite *OneDriveCollectionsUnitSuite) TestURLCacheIntegration() {
 			// Add a few collections
 			for i := 0; i < collCount; i++ {
 				coll, err := NewCollection(
-					&itemBackupHandler{api.Drives{}},
+					&itemBackupHandler{api.Drives{}, anyFolder},
 					nil,
 					nil,
 					driveID,

--- a/src/internal/m365/onedrive/collections_test.go
+++ b/src/internal/m365/onedrive/collections_test.go
@@ -2733,14 +2733,13 @@ func (suite *OneDriveCollectionsUnitSuite) TestURLCacheIntegration() {
 				require.NoError(t, err, clues.ToCore(err))
 
 				c.CollectionMap[driveID][strconv.Itoa(i)] = coll
-				require.Equal(t, nil, coll.cache, "cache not nil")
+				require.Equal(t, nil, coll.urlCache, "cache not nil")
 			}
 
 			err := c.addURLCacheToDriveCollections(
 				ctx,
 				driveID,
 				fault.New(true))
-
 			require.NoError(t, err, clues.ToCore(err))
 
 			// Check that all collections have the same cache instance attached
@@ -2748,11 +2747,11 @@ func (suite *OneDriveCollectionsUnitSuite) TestURLCacheIntegration() {
 			var uc *urlCache
 			for _, driveColls := range c.CollectionMap {
 				for _, coll := range driveColls {
-					require.NotNil(t, coll.cache, "cache is nil")
+					require.NotNil(t, coll.urlCache, "cache is nil")
 					if uc == nil {
-						uc = coll.cache.(*urlCache)
+						uc = coll.urlCache.(*urlCache)
 					} else {
-						require.Equal(t, uc, coll.cache, "cache not equal")
+						require.Equal(t, uc, coll.urlCache, "cache not equal")
 					}
 				}
 			}

--- a/src/internal/m365/onedrive/collections_test.go
+++ b/src/internal/m365/onedrive/collections_test.go
@@ -2680,7 +2680,7 @@ func (suite *OneDriveCollectionsUnitSuite) TestCollectItems() {
 	}
 }
 
-func (suite *OneDriveCollectionsUnitSuite) TestURLCacheIntegration() {
+func (suite *OneDriveCollectionsUnitSuite) TestAddURLCacheToDriveCollections() {
 	driveID := "test-drive"
 	collCount := 3
 	anyFolder := (&selectors.OneDriveBackup{}).Folders(selectors.Any())[0]
@@ -2704,8 +2704,11 @@ func (suite *OneDriveCollectionsUnitSuite) TestURLCacheIntegration() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
+			itemPagers := map[string]api.DriveItemEnumerator{}
+			itemPagers[driveID] = &mockItemPager{}
+
 			mbh := mock.DefaultOneDriveBH()
-			mbh.ItemPagerV = map[string]api.DriveItemEnumerator{}
+			mbh.ItemPagerV = itemPagers
 
 			c := NewCollections(
 				mbh,

--- a/src/internal/m365/onedrive/collections_test.go
+++ b/src/internal/m365/onedrive/collections_test.go
@@ -2700,7 +2700,7 @@ func (suite *OneDriveCollectionsUnitSuite) TestURLCacheIntegration() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			ctx, flush := tester.NewContext()
+			ctx, flush := tester.NewContext(t)
 			defer flush()
 
 			mbh := mock.DefaultOneDriveBH()

--- a/src/internal/m365/onedrive/item.go
+++ b/src/internal/m365/onedrive/item.go
@@ -77,7 +77,7 @@ func downloadFile(
 		return nil, clues.New("malware detected").Label(graph.LabelsMalware)
 	}
 
-	if (resp.StatusCode / 100) != 2 {
+	if resp != nil && (resp.StatusCode/100) != 2 {
 		// upstream error checks can compare the status with
 		// clues.HasLabel(err, graph.LabelStatus(http.KnownStatusCode))
 		return nil, clues.

--- a/src/internal/m365/onedrive/url_cache.go
+++ b/src/internal/m365/onedrive/url_cache.go
@@ -15,7 +15,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
-type urlCacher interface {
+type getItemPropertyer interface {
 	getItemProperties(
 		ctx context.Context,
 		itemID string,
@@ -27,7 +27,7 @@ type itemProps struct {
 	isDeleted   bool
 }
 
-var _ urlCacher = &urlCache{}
+var _ getItemPropertyer = &urlCache{}
 
 // urlCache caches download URLs for drive items
 type urlCache struct {

--- a/src/internal/m365/onedrive/url_cache.go
+++ b/src/internal/m365/onedrive/url_cache.go
@@ -15,6 +15,11 @@ import (
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
+const (
+	urlCacheDriveItemThreshold = 300 * 1000
+	urlCacheRefreshInterval    = 1 * time.Hour
+)
+
 type getItemPropertyer interface {
 	getItemProperties(
 		ctx context.Context,

--- a/src/internal/m365/onedrive/url_cache.go
+++ b/src/internal/m365/onedrive/url_cache.go
@@ -15,10 +15,19 @@ import (
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
+type urlCacher interface {
+	getItemProperties(
+		ctx context.Context,
+		itemID string,
+	) (itemProps, error)
+}
+
 type itemProps struct {
 	downloadURL string
 	isDeleted   bool
 }
+
+var _ urlCacher = &urlCache{}
 
 // urlCache caches download URLs for drive items
 type urlCache struct {

--- a/src/internal/m365/onedrive/url_cache_test.go
+++ b/src/internal/m365/onedrive/url_cache_test.go
@@ -118,9 +118,6 @@ func (suite *URLCacheIntegrationSuite) TestURLCacheBasic() {
 
 	require.NoError(t, err, clues.ToCore(err))
 
-	err = cache.refreshCache(ctx)
-	require.NoError(t, err, clues.ToCore(err))
-
 	// Launch parallel requests to the cache, one per item
 	var wg sync.WaitGroup
 	for i := 0; i < len(items); i++ {


### PR DESCRIPTION
Changes:

* Attach URL cache to a collection only if it's parent drive has < 300k items. Higher item count reduces the ROI of using cache, and can even degrade performance in severe cases. We will stick to per item GETs for those scenarios, until we figure out a longer term solution.
* 
---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* https://github.com/alcionai/corso/issues/3069

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
