### PR TITLE
Don't try to delete test data in the test

### DIFF
--- a/src/internal/connector/exchange/restore_test.go
+++ b/src/internal/connector/exchange/restore_test.go
@@ -151,10 +151,6 @@ func (suite *RestoreIntgSuite) TestRestoreEvent() {
 	}
 }
 
-type containerDeleter interface {
-	DeleteContainer(context.Context, string, string) error
-}
-
 // TestRestoreExchangeObject verifies path.Category usage for restored objects
 func (suite *RestoreIntgSuite) TestRestoreExchangeObject() {
 	t := suite.T()
@@ -164,12 +160,6 @@ func (suite *RestoreIntgSuite) TestRestoreExchangeObject() {
 
 	service, err := createService(m365)
 	require.NoError(t, err, clues.ToCore(err))
-
-	deleters := map[path.CategoryType]containerDeleter{
-		path.EmailCategory:    suite.ac.Mail(),
-		path.ContactsCategory: suite.ac.Contacts(),
-		path.EventsCategory:   suite.ac.Events(),
-	}
 
 	userID := tester.M365UserID(suite.T())
 
@@ -379,10 +369,6 @@ func (suite *RestoreIntgSuite) TestRestoreExchangeObject() {
 				fault.New(true))
 			assert.NoError(t, err, clues.ToCore(err))
 			assert.NotNil(t, info, "item info was not populated")
-			assert.NotNil(t, deleters)
-
-			err = deleters[test.category].DeleteContainer(ctx, userID, destination)
-			assert.NoError(t, err, clues.ToCore(err))
 		})
 	}
 }


### PR DESCRIPTION
Data should be cleaned up by purge script when it runs so there's no need to risk test failures by trying to clean it up at the end of the test

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
