### PR TITLE
auto-log recoverable errors with stack

### DIFF
--- a/src/internal/kopia/data_collection.go
+++ b/src/internal/kopia/data_collection.go
@@ -42,7 +42,7 @@ func (kdc *kopiaDataCollection) Items(
 		for _, item := range kdc.items {
 			s, err := kdc.FetchItemByName(ctx, item)
 			if err != nil {
-				el.AddRecoverable(clues.Wrap(err, "fetching item").
+				el.AddRecoverable(ctx, clues.Wrap(err, "fetching item").
 					WithClues(ctx).
 					Label(fault.LabelForceNoBackupCreation))
 

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -183,7 +183,7 @@ func (cp *corsoProgress) FinishedFile(relativePath string, err error) {
 	// never had to materialize their details in-memory.
 	if d.info == nil {
 		if d.prevPath == nil {
-			cp.errs.AddRecoverable(clues.New("item sourced from previous backup with no previous path").
+			cp.errs.AddRecoverable(ctx, clues.New("item sourced from previous backup with no previous path").
 				With(
 					"service", d.repoPath.Service().String(),
 					"category", d.repoPath.Category().String(),
@@ -198,7 +198,7 @@ func (cp *corsoProgress) FinishedFile(relativePath string, err error) {
 
 		err := cp.toMerge.addRepoRef(d.prevPath.ToBuilder(), d.repoPath, d.locationPath)
 		if err != nil {
-			cp.errs.AddRecoverable(clues.Wrap(err, "adding item to merge list").
+			cp.errs.AddRecoverable(ctx, clues.Wrap(err, "adding item to merge list").
 				With(
 					"service", d.repoPath.Service().String(),
 					"category", d.repoPath.Category().String(),
@@ -215,7 +215,7 @@ func (cp *corsoProgress) FinishedFile(relativePath string, err error) {
 		!d.cached,
 		*d.info)
 	if err != nil {
-		cp.errs.AddRecoverable(clues.New("adding item to details").
+		cp.errs.AddRecoverable(ctx, clues.New("adding item to details").
 			With(
 				"service", d.repoPath.Service().String(),
 				"category", d.repoPath.Category().String(),
@@ -278,7 +278,7 @@ func (cp *corsoProgress) Error(relpath string, err error, isIgnored bool) {
 
 	defer cp.UploadProgress.Error(relpath, err, isIgnored)
 
-	cp.errs.AddRecoverable(clues.Wrap(err, "kopia reported error").
+	cp.errs.AddRecoverable(ctx, clues.Wrap(err, "kopia reported error").
 		With("is_ignored", isIgnored, "relative_path", relpath).
 		Label(fault.LabelForceNoBackupCreation))
 }
@@ -350,7 +350,7 @@ func collectionEntries(
 			itemPath, err := streamedEnts.FullPath().AppendItem(e.UUID())
 			if err != nil {
 				err = clues.Wrap(err, "getting full item path")
-				progress.errs.AddRecoverable(err)
+				progress.errs.AddRecoverable(ctx, err)
 
 				logger.CtxErr(ctx, err).Error("getting full item path")
 

--- a/src/internal/kopia/upload_test.go
+++ b/src/internal/kopia/upload_test.go
@@ -472,8 +472,12 @@ func (suite *CorsoProgressUnitSuite) TestFinishedFile() {
 				suite.Run(test.name, func() {
 					t := suite.T()
 
+					ctx, flush := tester.NewContext(t)
+					defer flush()
+
 					bd := &details.Builder{}
 					cp := corsoProgress{
+						ctx:            ctx,
 						UploadProgress: &snapshotfs.NullUploadProgress{},
 						deets:          bd,
 						pending:        map[string]*itemDetails{},
@@ -526,6 +530,10 @@ func (suite *CorsoProgressUnitSuite) TestFinishedFile() {
 
 func (suite *CorsoProgressUnitSuite) TestFinishedFileCachedNoPrevPathErrors() {
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
 	bd := &details.Builder{}
 	cachedItems := map[string]testInfo{
 		suite.targetFileName: {
@@ -535,6 +543,7 @@ func (suite *CorsoProgressUnitSuite) TestFinishedFileCachedNoPrevPathErrors() {
 		},
 	}
 	cp := corsoProgress{
+		ctx:            ctx,
 		UploadProgress: &snapshotfs.NullUploadProgress{},
 		deets:          bd,
 		pending:        map[string]*itemDetails{},
@@ -565,6 +574,9 @@ func (suite *CorsoProgressUnitSuite) TestFinishedFileBaseItemDoesntBuildHierarch
 
 	t := suite.T()
 
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
 	prevPath := makePath(
 		suite.T(),
 		[]string{testTenant, service, testUser, category, testInboxDir, testFileName2},
@@ -582,6 +594,7 @@ func (suite *CorsoProgressUnitSuite) TestFinishedFileBaseItemDoesntBuildHierarch
 	// Setup stuff.
 	db := &details.Builder{}
 	cp := corsoProgress{
+		ctx:            ctx,
 		UploadProgress: &snapshotfs.NullUploadProgress{},
 		deets:          db,
 		pending:        map[string]*itemDetails{},
@@ -617,8 +630,12 @@ func (suite *CorsoProgressUnitSuite) TestFinishedHashingFile() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
 			bd := &details.Builder{}
 			cp := corsoProgress{
+				ctx:            ctx,
 				UploadProgress: &snapshotfs.NullUploadProgress{},
 				deets:          bd,
 				pending:        map[string]*itemDetails{},
@@ -682,6 +699,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree() {
 	}
 
 	progress := &corsoProgress{
+		ctx:     ctx,
 		pending: map[string]*itemDetails{},
 		toMerge: newMergeDetails(),
 		errs:    fault.New(true),
@@ -801,6 +819,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_MixedDirectory() 
 			defer flush()
 
 			progress := &corsoProgress{
+				ctx:     ctx,
 				pending: map[string]*itemDetails{},
 				toMerge: newMergeDetails(),
 				errs:    fault.New(true),
@@ -908,6 +927,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_Fails() {
 			defer flush()
 
 			progress := &corsoProgress{
+				ctx:     ctx,
 				toMerge: newMergeDetails(),
 				errs:    fault.New(true),
 			}
@@ -1004,6 +1024,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeErrors() {
 			defer flush()
 
 			progress := &corsoProgress{
+				ctx:     ctx,
 				pending: map[string]*itemDetails{},
 				toMerge: newMergeDetails(),
 				errs:    fault.New(true),
@@ -1298,6 +1319,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSingleSubtree() {
 			defer flush()
 
 			progress := &corsoProgress{
+				ctx:     ctx,
 				pending: map[string]*itemDetails{},
 				toMerge: newMergeDetails(),
 				errs:    fault.New(true),
@@ -2221,6 +2243,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeMultipleSubdirecto
 			defer flush()
 
 			progress := &corsoProgress{
+				ctx:     ctx,
 				pending: map[string]*itemDetails{},
 				toMerge: newMergeDetails(),
 				errs:    fault.New(true),
@@ -2375,6 +2398,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSkipsDeletedSubtre
 	)
 
 	progress := &corsoProgress{
+		ctx:     ctx,
 		pending: map[string]*itemDetails{},
 		toMerge: newMergeDetails(),
 		errs:    fault.New(true),
@@ -2477,6 +2501,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_HandleEmptyBase()
 	)
 
 	progress := &corsoProgress{
+		ctx:     ctx,
 		pending: map[string]*itemDetails{},
 		toMerge: newMergeDetails(),
 		errs:    fault.New(true),
@@ -2733,6 +2758,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSelectsCorrectSubt
 	)
 
 	progress := &corsoProgress{
+		ctx:     ctx,
 		pending: map[string]*itemDetails{},
 		toMerge: newMergeDetails(),
 		errs:    fault.New(true),
@@ -2901,6 +2927,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSelectsMigrateSubt
 	)
 
 	progress := &corsoProgress{
+		ctx:     ctx,
 		pending: map[string]*itemDetails{},
 		toMerge: newMergeDetails(),
 		errs:    fault.New(true),

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -160,6 +160,7 @@ func (w Wrapper) ConsumeBackupCollections(
 	}
 
 	progress := &corsoProgress{
+		ctx:     ctx,
 		pending: map[string]*itemDetails{},
 		deets:   &details.Builder{},
 		toMerge: newMergeDetails(),
@@ -415,7 +416,7 @@ func loadDirsAndItems(
 
 			dir, err := getDir(ictx, dirItems.dir, snapshotRoot)
 			if err != nil {
-				el.AddRecoverable(clues.Wrap(err, "loading storage directory").
+				el.AddRecoverable(ctx, clues.Wrap(err, "loading storage directory").
 					WithClues(ictx).
 					Label(fault.LabelForceNoBackupCreation))
 
@@ -431,7 +432,7 @@ func loadDirsAndItems(
 			}
 
 			if err := mergeCol.addCollection(dirItems.dir.String(), dc); err != nil {
-				el.AddRecoverable(clues.Wrap(err, "adding collection to merge collection").
+				el.AddRecoverable(ctx, clues.Wrap(err, "adding collection to merge collection").
 					WithClues(ctx).
 					Label(fault.LabelForceNoBackupCreation))
 
@@ -493,7 +494,7 @@ func (w Wrapper) ProduceRestoreCollections(
 
 		parentStoragePath, err := itemPaths.StoragePath.Dir()
 		if err != nil {
-			el.AddRecoverable(clues.Wrap(err, "getting storage directory path").
+			el.AddRecoverable(ictx, clues.Wrap(err, "getting storage directory path").
 				WithClues(ictx).
 				Label(fault.LabelForceNoBackupCreation))
 

--- a/src/internal/m365/exchange/backup.go
+++ b/src/internal/m365/exchange/backup.go
@@ -224,7 +224,7 @@ func ProduceBackupCollections(
 			su,
 			errs)
 		if err != nil {
-			el.AddRecoverable(err)
+			el.AddRecoverable(ctx, err)
 			continue
 		}
 

--- a/src/internal/m365/exchange/backup.go
+++ b/src/internal/m365/exchange/backup.go
@@ -404,7 +404,7 @@ func populateCollections(
 				!ctrlOpts.ToggleFeatures.DisableDelta)
 		if err != nil {
 			if !graph.IsErrDeletedInFlight(err) {
-				el.AddRecoverable(clues.Stack(err).Label(fault.LabelForceNoBackupCreation))
+				el.AddRecoverable(ctx, clues.Stack(err).Label(fault.LabelForceNoBackupCreation))
 				continue
 			}
 
@@ -467,7 +467,7 @@ func populateCollections(
 		)
 
 		if collections[id] != nil {
-			el.AddRecoverable(clues.Wrap(err, "conflict: tombstone exists for a live collection").WithClues(ictx))
+			el.AddRecoverable(ctx, clues.Wrap(err, "conflict: tombstone exists for a live collection").WithClues(ictx))
 			continue
 		}
 

--- a/src/internal/m365/exchange/backup_test.go
+++ b/src/internal/m365/exchange/backup_test.go
@@ -332,7 +332,7 @@ func (f failingColl) Items(ctx context.Context, errs *fault.Bus) <-chan data.Str
 	ic := make(chan data.Stream)
 	defer close(ic)
 
-	errs.AddRecoverable(assert.AnError)
+	errs.AddRecoverable(ctx, assert.AnError)
 
 	return ic
 }

--- a/src/internal/m365/exchange/collection.go
+++ b/src/internal/m365/exchange/collection.go
@@ -230,7 +230,7 @@ func (col *Collection) streamItems(ctx context.Context, errs *fault.Bus) {
 					atomic.AddInt64(&success, 1)
 					log.With("err", err).Infow("item not found", clues.InErr(err).Slice()...)
 				} else {
-					errs.AddRecoverable(clues.Wrap(err, "fetching item").Label(fault.LabelForceNoBackupCreation))
+					errs.AddRecoverable(ctx, clues.Wrap(err, "fetching item").Label(fault.LabelForceNoBackupCreation))
 				}
 
 				return
@@ -238,7 +238,7 @@ func (col *Collection) streamItems(ctx context.Context, errs *fault.Bus) {
 
 			data, err := col.items.Serialize(ctx, item, user, id)
 			if err != nil {
-				errs.AddRecoverable(clues.Wrap(err, "serializing item").Label(fault.LabelForceNoBackupCreation))
+				errs.AddRecoverable(ctx, clues.Wrap(err, "serializing item").Label(fault.LabelForceNoBackupCreation))
 				return
 			}
 

--- a/src/internal/m365/exchange/container_resolver.go
+++ b/src/internal/m365/exchange/container_resolver.go
@@ -403,7 +403,7 @@ func (cr *containerResolver) populatePaths(
 		_, err := cr.idToPath(ctx, ptr.Val(f.GetId()), 0)
 		if err != nil {
 			err = clues.Wrap(err, "populating path")
-			el.AddRecoverable(err)
+			el.AddRecoverable(ctx, err)
 			lastErr = err
 		}
 	}

--- a/src/internal/m365/exchange/restore.go
+++ b/src/internal/m365/exchange/restore.go
@@ -64,7 +64,7 @@ func ConsumeRestoreCollections(
 
 		handler, ok := handlers[category]
 		if !ok {
-			el.AddRecoverable(clues.New("unsupported restore path category").WithClues(ictx))
+			el.AddRecoverable(ctx, clues.New("unsupported restore path category").WithClues(ictx))
 			continue
 		}
 
@@ -82,7 +82,7 @@ func ConsumeRestoreCollections(
 			isNewCache,
 			errs)
 		if err != nil {
-			el.AddRecoverable(err)
+			el.AddRecoverable(ctx, err)
 			continue
 		}
 
@@ -107,7 +107,7 @@ func ConsumeRestoreCollections(
 				break
 			}
 
-			el.AddRecoverable(err)
+			el.AddRecoverable(ctx, err)
 		}
 	}
 
@@ -166,7 +166,7 @@ func restoreCollection(
 
 			_, err := buf.ReadFrom(itemData.ToReader())
 			if err != nil {
-				el.AddRecoverable(clues.Wrap(err, "reading item bytes").WithClues(ictx))
+				el.AddRecoverable(ctx, clues.Wrap(err, "reading item bytes").WithClues(ictx))
 				continue
 			}
 
@@ -174,7 +174,7 @@ func restoreCollection(
 
 			info, err := ir.restore(ictx, body, userID, destinationID, errs)
 			if err != nil {
-				el.AddRecoverable(err)
+				el.AddRecoverable(ctx, err)
 				continue
 			}
 
@@ -185,7 +185,7 @@ func restoreCollection(
 			// destination folder, then the restore path no longer matches the fullPath.
 			itemPath, err := fullPath.AppendItem(itemData.UUID())
 			if err != nil {
-				el.AddRecoverable(clues.Wrap(err, "adding item to collection path").WithClues(ctx))
+				el.AddRecoverable(ctx, clues.Wrap(err, "adding item to collection path").WithClues(ctx))
 				continue
 			}
 
@@ -343,7 +343,7 @@ func uploadAttachments(
 				continue
 			}
 
-			el.AddRecoverable(clues.Wrap(err, "uploading mail attachment").WithClues(ctx))
+			el.AddRecoverable(ctx, clues.Wrap(err, "uploading mail attachment").WithClues(ctx))
 		}
 	}
 

--- a/src/internal/m365/graph/collections.go
+++ b/src/internal/m365/graph/collections.go
@@ -83,7 +83,7 @@ func BaseCollections(
 		if err != nil {
 			// Shouldn't happen.
 			err = clues.Wrap(err, "making path").WithClues(ictx)
-			el.AddRecoverable(err)
+			el.AddRecoverable(ctx, err)
 			lastErr = err
 
 			continue

--- a/src/internal/m365/onedrive/backup.go
+++ b/src/internal/m365/onedrive/backup.go
@@ -77,7 +77,7 @@ func ProduceBackupCollections(
 
 		odcs, canUsePreviousBackup, err = nc.Get(ctx, metadata, ssmb, errs)
 		if err != nil {
-			el.AddRecoverable(clues.Stack(err).Label(fault.LabelForceNoBackupCreation))
+			el.AddRecoverable(ctx, clues.Stack(err).Label(fault.LabelForceNoBackupCreation))
 		}
 
 		categories[scope.Category().PathType()] = struct{}{}

--- a/src/internal/m365/onedrive/collections.go
+++ b/src/internal/m365/onedrive/collections.go
@@ -663,7 +663,7 @@ func (c *Collections) UpdateCollections(
 				skip = fault.ContainerSkip(fault.SkipMalware, driveID, itemID, itemName, addtl)
 			}
 
-			errs.AddSkip(skip)
+			errs.AddSkip(ctx, skip)
 			logger.Ctx(ctx).Infow("malware detected", "item_details", addtl)
 
 			continue
@@ -689,7 +689,7 @@ func (c *Collections) UpdateCollections(
 
 		collectionPath, err := c.getCollectionPath(driveID, item)
 		if err != nil {
-			el.AddRecoverable(clues.Stack(err).
+			el.AddRecoverable(ctx, clues.Stack(err).
 				WithClues(ictx).
 				Label(fault.LabelForceNoBackupCreation))
 
@@ -711,7 +711,7 @@ func (c *Collections) UpdateCollections(
 			if ok {
 				prevPath, err = path.FromDataLayerPath(prevPathStr, false)
 				if err != nil {
-					el.AddRecoverable(clues.Wrap(err, "invalid previous path").
+					el.AddRecoverable(ctx, clues.Wrap(err, "invalid previous path").
 						WithClues(ictx).
 						With("path_string", prevPathStr))
 				}

--- a/src/internal/m365/onedrive/collections_test.go
+++ b/src/internal/m365/onedrive/collections_test.go
@@ -1157,7 +1157,7 @@ func (f failingColl) Items(ctx context.Context, errs *fault.Bus) <-chan data.Str
 	ic := make(chan data.Stream)
 	defer close(ic)
 
-	errs.AddRecoverable(assert.AnError)
+	errs.AddRecoverable(ctx, assert.AnError)
 
 	return ic
 }

--- a/src/internal/m365/onedrive/drive.go
+++ b/src/internal/m365/onedrive/drive.go
@@ -238,7 +238,7 @@ func GetAllFolders(
 			"",
 			errs)
 		if err != nil {
-			el.AddRecoverable(clues.Wrap(err, "enumerating items in drive"))
+			el.AddRecoverable(ctx, clues.Wrap(err, "enumerating items in drive"))
 		}
 	}
 

--- a/src/internal/m365/onedrive/restore.go
+++ b/src/internal/m365/onedrive/restore.go
@@ -113,7 +113,7 @@ func RestoreCollections(
 			opts.RestorePermissions,
 			errs)
 		if err != nil {
-			el.AddRecoverable(err)
+			el.AddRecoverable(ctx, err)
 		}
 
 		restoreMetrics = support.CombineMetrics(restoreMetrics, metrics)
@@ -273,7 +273,7 @@ func ProduceRestoreCollection(
 
 				itemPath, err := dc.FullPath().AppendItem(itemData.UUID())
 				if err != nil {
-					el.AddRecoverable(clues.Wrap(err, "appending item to full path").WithClues(ictx))
+					el.AddRecoverable(ctx, clues.Wrap(err, "appending item to full path").WithClues(ictx))
 					return
 				}
 
@@ -297,7 +297,7 @@ func ProduceRestoreCollection(
 				}
 
 				if err != nil {
-					el.AddRecoverable(clues.Wrap(err, "restoring item"))
+					el.AddRecoverable(ctx, clues.Wrap(err, "restoring item"))
 					return
 				}
 

--- a/src/internal/m365/sharepoint/api/pages.go
+++ b/src/internal/m365/sharepoint/api/pages.go
@@ -70,7 +70,7 @@ func GetSitePages(
 
 			page, err = serv.Client().SitesById(siteID).PagesById(pageID).Get(ctx, opts)
 			if err != nil {
-				el.AddRecoverable(graph.Wrap(ctx, err, "fetching page"))
+				el.AddRecoverable(ctx, graph.Wrap(ctx, err, "fetching page"))
 				return
 			}
 

--- a/src/internal/m365/sharepoint/backup.go
+++ b/src/internal/m365/sharepoint/backup.go
@@ -80,7 +80,7 @@ func ProduceBackupCollections(
 				ctrlOpts,
 				errs)
 			if err != nil {
-				el.AddRecoverable(err)
+				el.AddRecoverable(ctx, err)
 				continue
 			}
 
@@ -101,7 +101,7 @@ func ProduceBackupCollections(
 				ctrlOpts,
 				errs)
 			if err != nil {
-				el.AddRecoverable(err)
+				el.AddRecoverable(ctx, err)
 				continue
 			}
 
@@ -115,7 +115,7 @@ func ProduceBackupCollections(
 				ctrlOpts,
 				errs)
 			if err != nil {
-				el.AddRecoverable(err)
+				el.AddRecoverable(ctx, err)
 				continue
 			}
 
@@ -184,7 +184,7 @@ func collectLists(
 			false,
 			tuple.name)
 		if err != nil {
-			el.AddRecoverable(clues.Wrap(err, "creating list collection path").WithClues(ctx))
+			el.AddRecoverable(ctx, clues.Wrap(err, "creating list collection path").WithClues(ctx))
 		}
 
 		collection := NewCollection(
@@ -284,7 +284,7 @@ func collectPages(
 			false,
 			tuple.Name)
 		if err != nil {
-			el.AddRecoverable(clues.Wrap(err, "creating page collection path").WithClues(ctx))
+			el.AddRecoverable(ctx, clues.Wrap(err, "creating page collection path").WithClues(ctx))
 		}
 
 		collection := NewCollection(

--- a/src/internal/m365/sharepoint/collection.go
+++ b/src/internal/m365/sharepoint/collection.go
@@ -239,7 +239,7 @@ func (sc *Collection) retrieveLists(
 
 		byteArray, err := serializeContent(ctx, wtr, lst)
 		if err != nil {
-			el.AddRecoverable(clues.Wrap(err, "serializing list").WithClues(ctx).Label(fault.LabelForceNoBackupCreation))
+			el.AddRecoverable(ctx, clues.Wrap(err, "serializing list").WithClues(ctx).Label(fault.LabelForceNoBackupCreation))
 			continue
 		}
 
@@ -308,7 +308,7 @@ func (sc *Collection) retrievePages(
 
 		byteArray, err := serializeContent(ctx, wtr, pg)
 		if err != nil {
-			el.AddRecoverable(clues.Wrap(err, "serializing page").WithClues(ctx).Label(fault.LabelForceNoBackupCreation))
+			el.AddRecoverable(ctx, clues.Wrap(err, "serializing page").WithClues(ctx).Label(fault.LabelForceNoBackupCreation))
 			continue
 		}
 

--- a/src/internal/m365/sharepoint/list.go
+++ b/src/internal/m365/sharepoint/list.go
@@ -130,13 +130,13 @@ func loadSiteLists(
 
 			entry, err = gs.Client().Sites().BySiteId(siteID).Lists().ByListId(id).Get(ctx, nil)
 			if err != nil {
-				el.AddRecoverable(graph.Wrap(ctx, err, "getting site list"))
+				el.AddRecoverable(ctx, graph.Wrap(ctx, err, "getting site list"))
 				return
 			}
 
 			cols, cTypes, lItems, err := fetchListContents(ctx, gs, siteID, id, errs)
 			if err != nil {
-				el.AddRecoverable(clues.Wrap(err, "getting list contents"))
+				el.AddRecoverable(ctx, clues.Wrap(err, "getting list contents"))
 				return
 			}
 
@@ -220,7 +220,7 @@ func fetchListItems(
 
 			fields, err := newPrefix.Fields().Get(ctx, nil)
 			if err != nil {
-				el.AddRecoverable(graph.Wrap(ctx, err, "getting list fields"))
+				el.AddRecoverable(ctx, graph.Wrap(ctx, err, "getting list fields"))
 				continue
 			}
 
@@ -336,7 +336,7 @@ func fetchContentTypes(
 
 			links, err := fetchColumnLinks(ctx, gs, siteID, listID, id)
 			if err != nil {
-				el.AddRecoverable(err)
+				el.AddRecoverable(ctx, err)
 				continue
 			}
 
@@ -344,7 +344,7 @@ func fetchContentTypes(
 
 			cs, err := fetchColumns(ctx, gs, siteID, listID, id)
 			if err != nil {
-				el.AddRecoverable(err)
+				el.AddRecoverable(ctx, err)
 				continue
 			}
 

--- a/src/internal/m365/sharepoint/restore.go
+++ b/src/internal/m365/sharepoint/restore.go
@@ -101,7 +101,7 @@ func ConsumeRestoreCollections(
 		restoreMetrics = support.CombineMetrics(restoreMetrics, metrics)
 
 		if err != nil {
-			el.AddRecoverable(err)
+			el.AddRecoverable(ctx, err)
 		}
 
 		if errors.Is(err, context.Canceled) {
@@ -238,7 +238,7 @@ func RestoreListCollection(
 				siteID,
 				restoreContainerName)
 			if err != nil {
-				el.AddRecoverable(err)
+				el.AddRecoverable(ctx, err)
 				continue
 			}
 
@@ -246,7 +246,7 @@ func RestoreListCollection(
 
 			itemPath, err := dc.FullPath().AppendItem(itemData.UUID())
 			if err != nil {
-				el.AddRecoverable(clues.Wrap(err, "appending item to full path").WithClues(ctx))
+				el.AddRecoverable(ctx, clues.Wrap(err, "appending item to full path").WithClues(ctx))
 				continue
 			}
 
@@ -318,7 +318,7 @@ func RestorePageCollection(
 				siteID,
 				restoreContainerName)
 			if err != nil {
-				el.AddRecoverable(err)
+				el.AddRecoverable(ctx, err)
 				continue
 			}
 
@@ -326,7 +326,7 @@ func RestorePageCollection(
 
 			itemPath, err := dc.FullPath().AppendItem(itemData.UUID())
 			if err != nil {
-				el.AddRecoverable(clues.Wrap(err, "appending item to full path").WithClues(ctx))
+				el.AddRecoverable(ctx, clues.Wrap(err, "appending item to full path").WithClues(ctx))
 				continue
 			}
 

--- a/src/internal/operations/pathtransformer/restore_path_transformer.go
+++ b/src/internal/operations/pathtransformer/restore_path_transformer.go
@@ -168,7 +168,7 @@ func GetPaths(
 
 		restorePaths, err := makeRestorePathsForEntry(ctx, backupVersion, ent)
 		if err != nil {
-			el.AddRecoverable(clues.Wrap(err, "getting restore paths"))
+			el.AddRecoverable(ctx, clues.Wrap(err, "getting restore paths"))
 			continue
 		}
 

--- a/src/internal/streamstore/collectables_test.go
+++ b/src/internal/streamstore/collectables_test.go
@@ -109,7 +109,9 @@ func (suite *StreamStoreIntgSuite) TestStreamer() {
 				bus := fault.New(false)
 				bus.Fail(clues.New("foo"))
 				bus.AddRecoverable(ctx, clues.New("bar"))
-				bus.AddRecoverable(ctx, fault.FileErr(clues.New("file"), "ns", "file-id", "file-name", map[string]any{"foo": "bar"}))
+				bus.AddRecoverable(
+					ctx,
+					fault.FileErr(clues.New("file"), "ns", "file-id", "file-name", map[string]any{"foo": "bar"}))
 				bus.AddSkip(ctx, fault.FileSkip(fault.SkipMalware, "ns", "file-id", "file-name", map[string]any{"foo": "bar"}))
 
 				fe := bus.Errors()
@@ -138,7 +140,9 @@ func (suite *StreamStoreIntgSuite) TestStreamer() {
 				bus := fault.New(false)
 				bus.Fail(clues.New("foo"))
 				bus.AddRecoverable(ctx, clues.New("bar"))
-				bus.AddRecoverable(ctx, fault.FileErr(clues.New("file"), "ns", "file-id", "file-name", map[string]any{"foo": "bar"}))
+				bus.AddRecoverable(
+					ctx,
+					fault.FileErr(clues.New("file"), "ns", "file-id", "file-name", map[string]any{"foo": "bar"}))
 				bus.AddSkip(ctx, fault.FileSkip(fault.SkipMalware, "ns", "file-id", "file-name", map[string]any{"foo": "bar"}))
 
 				fe := bus.Errors()

--- a/src/pkg/fault/fault.go
+++ b/src/pkg/fault/fault.go
@@ -186,7 +186,7 @@ func (e *Bus) logAndAddSkip(ctx context.Context, s *Skipped, skip int) {
 	logger.CtxStack(ctx, skip+1).
 		With("skipped", s).
 		Info("recoverable error")
-	e.AddSkip(ctx, s)
+	e.addSkip(s)
 }
 
 func (e *Bus) addSkip(s *Skipped) *Bus {

--- a/src/pkg/logger/logger.go
+++ b/src/pkg/logger/logger.go
@@ -442,14 +442,7 @@ func Ctx(ctx context.Context) *zap.SugaredLogger {
 // If skip is non-zero, it skips the stack calls starting from the
 // first.  Skip always adds +1 to account for this wrapper.
 func CtxStack(ctx context.Context, skip int) *zap.SugaredLogger {
-	l := ctx.Value(ctxKey)
-	if l == nil {
-		l = singleton(Settings{}.EnsureDefaults())
-	}
-
-	return l.(*zap.SugaredLogger).
-		With(zap.StackSkip("trace", skip+1)).
-		With(clues.In(ctx).Slice()...)
+	return Ctx(ctx).With(zap.StackSkip("trace", skip+1))
 }
 
 // CtxErr retrieves the logger embedded in the context

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -402,7 +402,7 @@ func (r repository) Backups(ctx context.Context, ids []string) ([]*backup.Backup
 
 		b, err := sw.GetBackup(ictx, model.StableID(id))
 		if err != nil {
-			errs.AddRecoverable(errWrapper(err))
+			errs.AddRecoverable(ctx, errWrapper(err))
 		}
 
 		bups = append(bups, b)

--- a/src/pkg/selectors/scopes.go
+++ b/src/pkg/selectors/scopes.go
@@ -368,7 +368,7 @@ func reduce[T scopeT, C categoryT](
 
 		repoPath, err := path.FromDataLayerPath(ent.RepoRef, true)
 		if err != nil {
-			el.AddRecoverable(clues.Wrap(err, "transforming repoRef to path").WithClues(ictx))
+			el.AddRecoverable(ctx, clues.Wrap(err, "transforming repoRef to path").WithClues(ictx))
 			continue
 		}
 
@@ -391,7 +391,7 @@ func reduce[T scopeT, C categoryT](
 
 		pv, err := dc.pathValues(repoPath, *ent, s.Cfg)
 		if err != nil {
-			el.AddRecoverable(clues.Wrap(err, "getting path values").WithClues(ictx))
+			el.AddRecoverable(ctx, clues.Wrap(err, "getting path values").WithClues(ictx))
 			continue
 		}
 

--- a/src/pkg/services/m365/api/contacts.go
+++ b/src/pkg/services/m365/api/contacts.go
@@ -183,7 +183,7 @@ func (c Contacts) EnumerateContainers(
 			}
 
 			if err := graph.CheckIDNameAndParentFolderID(fold); err != nil {
-				errs.AddRecoverable(graph.Stack(ctx, err).Label(fault.LabelForceNoBackupCreation))
+				errs.AddRecoverable(ctx, graph.Stack(ctx, err).Label(fault.LabelForceNoBackupCreation))
 				continue
 			}
 
@@ -194,7 +194,7 @@ func (c Contacts) EnumerateContainers(
 
 			temp := graph.NewCacheFolder(fold, nil, nil)
 			if err := fn(&temp); err != nil {
-				errs.AddRecoverable(graph.Stack(fctx, err).Label(fault.LabelForceNoBackupCreation))
+				errs.AddRecoverable(ctx, graph.Stack(fctx, err).Label(fault.LabelForceNoBackupCreation))
 				continue
 			}
 		}

--- a/src/pkg/services/m365/api/events.go
+++ b/src/pkg/services/m365/api/events.go
@@ -236,7 +236,7 @@ func (c Events) EnumerateContainers(
 
 			cd := CalendarDisplayable{Calendarable: cal}
 			if err := graph.CheckIDAndName(cd); err != nil {
-				errs.AddRecoverable(graph.Stack(ctx, err).Label(fault.LabelForceNoBackupCreation))
+				errs.AddRecoverable(ctx, graph.Stack(ctx, err).Label(fault.LabelForceNoBackupCreation))
 				continue
 			}
 
@@ -250,7 +250,7 @@ func (c Events) EnumerateContainers(
 				path.Builder{}.Append(ptr.Val(cd.GetId())),          // storage path
 				path.Builder{}.Append(ptr.Val(cd.GetDisplayName()))) // display location
 			if err := fn(&temp); err != nil {
-				errs.AddRecoverable(graph.Stack(fctx, err).Label(fault.LabelForceNoBackupCreation))
+				errs.AddRecoverable(ctx, graph.Stack(fctx, err).Label(fault.LabelForceNoBackupCreation))
 				continue
 			}
 		}

--- a/src/pkg/services/m365/api/mail.go
+++ b/src/pkg/services/m365/api/mail.go
@@ -264,7 +264,7 @@ func (c Mail) EnumerateContainers(
 			}
 
 			if err := graph.CheckIDNameAndParentFolderID(fold); err != nil {
-				errs.AddRecoverable(graph.Stack(ctx, err).Label(fault.LabelForceNoBackupCreation))
+				errs.AddRecoverable(ctx, graph.Stack(ctx, err).Label(fault.LabelForceNoBackupCreation))
 				continue
 			}
 
@@ -275,7 +275,7 @@ func (c Mail) EnumerateContainers(
 
 			temp := graph.NewCacheFolder(fold, nil, nil)
 			if err := fn(&temp); err != nil {
-				errs.AddRecoverable(graph.Stack(fctx, err).Label(fault.LabelForceNoBackupCreation))
+				errs.AddRecoverable(ctx, graph.Stack(fctx, err).Label(fault.LabelForceNoBackupCreation))
 				continue
 			}
 		}

--- a/src/pkg/services/m365/api/sites.go
+++ b/src/pkg/services/m365/api/sites.go
@@ -72,7 +72,7 @@ func (c Sites) GetAll(ctx context.Context, errs *fault.Bus) ([]models.Siteable, 
 		}
 
 		if err != nil {
-			el.AddRecoverable(graph.Wrap(ctx, err, "validating site"))
+			el.AddRecoverable(ctx, graph.Wrap(ctx, err, "validating site"))
 			return true
 		}
 

--- a/src/pkg/services/m365/api/users.go
+++ b/src/pkg/services/m365/api/users.go
@@ -97,7 +97,7 @@ func (c Users) GetAll(
 
 		err := validateUser(item)
 		if err != nil {
-			el.AddRecoverable(graph.Wrap(ctx, err, "validating user"))
+			el.AddRecoverable(ctx, graph.Wrap(ctx, err, "validating user"))
 		} else {
 			us = append(us, item)
 		}


### PR DESCRIPTION
automatically log when we add a recoverable error or a skipped item to fault.  This log will include a stack trace of the call from the location of the logged recoverable.  Clues does not have a method for pulling a stack trace out of an error yet; that can be added at a future date.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Supportability/Tests

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
