### PR TITLE
Skip any attachment fetches that fail with OLE conversion error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Exchange folder cache population error when parent folder isn't found.
 - Fix Exchange backup issue caused by incorrect json serialization
 - Fix issues with details model containing duplicate entry for api consumers
+- Handle OLE conversion errors when trying to fetch attachments
 
 ### Changed
 - Do not display all the items that we restored at the end if there are more than 15. You can override this with `--verbose`.

--- a/src/internal/m365/graph/errors.go
+++ b/src/internal/m365/graph/errors.go
@@ -44,6 +44,10 @@ const (
 	// the same name as another folder in the same parent. Such duplicate folder
 	// names are not allowed by graph.
 	folderExists errorCode = "ErrorFolderExists"
+	// cannotOpenFileAttachment happen when an attachment is
+	// inaccessible. The error message is usually "OLE conversion
+	// failed for an attachment."
+	cannotOpenFileAttachment errorCode = "ErrorCannotOpenFileAttachment"
 )
 
 type errorMessage string
@@ -124,6 +128,10 @@ func IsErrUserNotFound(err error) bool {
 
 func IsErrResourceNotFound(err error) bool {
 	return hasErrorCode(err, resourceNotFound)
+}
+
+func IsErrCannotOpenFileAttachment(err error) bool {
+	return hasErrorCode(err, cannotOpenFileAttachment)
 }
 
 func IsErrAccessDenied(err error) bool {

--- a/src/internal/m365/graph/errors_test.go
+++ b/src/internal/m365/graph/errors_test.go
@@ -384,3 +384,42 @@ func (suite *GraphErrorsUnitSuite) TestIsErrFolderExists() {
 		})
 	}
 }
+
+func (suite *GraphErrorsUnitSuite) TestIsErrCannotOpenFileAttachment() {
+	table := []struct {
+		name   string
+		err    error
+		expect assert.BoolAssertionFunc
+	}{
+		{
+			name:   "nil",
+			err:    nil,
+			expect: assert.False,
+		},
+		{
+			name:   "non-matching",
+			err:    assert.AnError,
+			expect: assert.False,
+		},
+		{
+			name:   "as",
+			err:    ErrInvalidDelta,
+			expect: assert.False,
+		},
+		{
+			name:   "non-matching oDataErr",
+			err:    odErr("fnords"),
+			expect: assert.False,
+		},
+		{
+			name:   "quota-exceeded oDataErr",
+			err:    odErr(string(cannotOpenFileAttachment)),
+			expect: assert.True,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			test.expect(suite.T(), IsErrCannotOpenFileAttachment(test.err))
+		})
+	}
+}

--- a/src/pkg/fault/item.go
+++ b/src/pkg/fault/item.go
@@ -15,6 +15,7 @@ type itemType string
 
 const (
 	FileType          itemType = "file"
+	AttachmentType    itemType = "attachment"
 	ContainerType     itemType = "container"
 	ResourceOwnerType itemType = "resource_owner"
 )
@@ -248,6 +249,11 @@ func ContainerSkip(cause skipCause, namespace, id, name string, addtl map[string
 // FileSkip produces a File-kind Item for tracking skipped items.
 func FileSkip(cause skipCause, namespace, id, name string, addtl map[string]any) *Skipped {
 	return itemSkip(FileType, cause, namespace, id, name, addtl)
+}
+
+// AttachmentSkip produces a Attachment-kind Item for tracking skipped items.
+func AttachmentSkip(cause skipCause, namespace, id, name string, addtl map[string]any) *Skipped {
+	return itemSkip(AttachmentType, cause, namespace, id, name, addtl)
 }
 
 // OnwerSkip produces a ResourceOwner-kind Item for tracking skipped items.

--- a/src/pkg/fault/item.go
+++ b/src/pkg/fault/item.go
@@ -15,7 +15,6 @@ type itemType string
 
 const (
 	FileType          itemType = "file"
-	AttachmentType    itemType = "attachment"
 	ContainerType     itemType = "container"
 	ResourceOwnerType itemType = "resource_owner"
 )
@@ -249,11 +248,6 @@ func ContainerSkip(cause skipCause, namespace, id, name string, addtl map[string
 // FileSkip produces a File-kind Item for tracking skipped items.
 func FileSkip(cause skipCause, namespace, id, name string, addtl map[string]any) *Skipped {
 	return itemSkip(FileType, cause, namespace, id, name, addtl)
-}
-
-// AttachmentSkip produces a Attachment-kind Item for tracking skipped items.
-func AttachmentSkip(cause skipCause, namespace, id, name string, addtl map[string]any) *Skipped {
-	return itemSkip(AttachmentType, cause, namespace, id, name, addtl)
 }
 
 // OnwerSkip produces a ResourceOwner-kind Item for tracking skipped items.


### PR DESCRIPTION
These files from what we can understand are not available and thus can't be fetched. This change ensures that we don't fail the backup just because of this error.

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
