### PR TITLE
Mark snapshots missing backup as assist bases

### DIFF
--- a/src/internal/kopia/base_finder.go
+++ b/src/internal/kopia/base_finder.go
@@ -192,6 +192,8 @@ func (b *baseFinder) findBasesInSet(
 					Manifest: man,
 					Reasons:  []Reason{reason},
 				})
+
+				logger.Ctx(ictx).Info("found incomplete backup")
 			}
 
 			continue
@@ -212,7 +214,7 @@ func (b *baseFinder) findBasesInSet(
 					Reasons:  []Reason{reason},
 				})
 
-				logger.Ctx(ictx).Infow("found incomplete backup")
+				logger.Ctx(ictx).Info("found incomplete backup")
 			}
 
 			continue
@@ -236,7 +238,9 @@ func (b *baseFinder) findBasesInSet(
 					Reasons:  []Reason{reason},
 				})
 
-				logger.Ctx(ictx).Infow("found incomplete backup")
+				logger.Ctx(ictx).Infow(
+					"found incomplete backup",
+					"search_backup_id", bup.ID)
 			}
 
 			continue

--- a/src/internal/kopia/base_finder.go
+++ b/src/internal/kopia/base_finder.go
@@ -203,6 +203,18 @@ func (b *baseFinder) findBasesInSet(
 			// Safe to continue here as we'll just end up attempting to use an older
 			// backup as the base.
 			logger.CtxErr(ictx, err).Debug("searching for base backup")
+
+			if !foundIncomplete {
+				foundIncomplete = true
+
+				kopiaAssistSnaps = append(kopiaAssistSnaps, ManifestEntry{
+					Manifest: man,
+					Reasons:  []Reason{reason},
+				})
+
+				logger.Ctx(ictx).Infow("found incomplete backup")
+			}
+
 			continue
 		}
 
@@ -215,6 +227,17 @@ func (b *baseFinder) findBasesInSet(
 			logger.Ctx(ictx).Debugw(
 				"empty backup stream store ID",
 				"search_backup_id", bup.ID)
+
+			if !foundIncomplete {
+				foundIncomplete = true
+
+				kopiaAssistSnaps = append(kopiaAssistSnaps, ManifestEntry{
+					Manifest: man,
+					Reasons:  []Reason{reason},
+				})
+
+				logger.Ctx(ictx).Infow("found incomplete backup")
+			}
 
 			continue
 		}

--- a/src/internal/kopia/base_finder_test.go
+++ b/src/internal/kopia/base_finder_test.go
@@ -436,6 +436,7 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 				1: testUser1Mail,
 			},
 			expectedAssistManifestReasons: map[int][]Reason{
+				0: testUser1Mail,
 				1: testUser1Mail,
 			},
 			backupData: []backupInfo{
@@ -470,6 +471,7 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 				1: testUser1Mail,
 			},
 			expectedAssistManifestReasons: map[int][]Reason{
+				0: testUser1Mail,
 				1: testUser1Mail,
 			},
 			backupData: []backupInfo{


### PR DESCRIPTION
Loosen restrictions slightly by returning snapshots that are missing their bakcup or details models as assist bases that can be used by kopia assisted incrementals.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3525

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
