### PR TITLE
increase page size for all exchange pagers

### DIFF
--- a/src/internal/m365/exchange/backup_test.go
+++ b/src/internal/m365/exchange/backup_test.go
@@ -382,7 +382,7 @@ func newStatusUpdater(t *testing.T, wg *sync.WaitGroup) func(status *support.Con
 	return updater
 }
 
-type DataCollectionsIntegrationSuite struct {
+type BackupIntgSuite struct {
 	tester.Suite
 	user     string
 	site     string
@@ -390,16 +390,15 @@ type DataCollectionsIntegrationSuite struct {
 	ac       api.Client
 }
 
-func TestDataCollectionsIntegrationSuite(t *testing.T) {
-	suite.Run(t, &DataCollectionsIntegrationSuite{
+func TestBackupIntgSuite(t *testing.T) {
+	suite.Run(t, &BackupIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs},
-		),
+			[][]string{tester.M365AcctCredEnvs}),
 	})
 }
 
-func (suite *DataCollectionsIntegrationSuite) SetupSuite() {
+func (suite *BackupIntgSuite) SetupSuite() {
 	suite.user = tester.M365UserID(suite.T())
 	suite.site = tester.M365SiteID(suite.T())
 
@@ -415,7 +414,7 @@ func (suite *DataCollectionsIntegrationSuite) SetupSuite() {
 	tester.LogTimeOfTest(suite.T())
 }
 
-func (suite *DataCollectionsIntegrationSuite) TestMailFetch() {
+func (suite *BackupIntgSuite) TestMailFetch() {
 	var (
 		userID   = tester.M365UserID(suite.T())
 		users    = []string{userID}
@@ -499,7 +498,7 @@ func (suite *DataCollectionsIntegrationSuite) TestMailFetch() {
 	}
 }
 
-func (suite *DataCollectionsIntegrationSuite) TestDelta() {
+func (suite *BackupIntgSuite) TestDelta() {
 	var (
 		userID   = tester.M365UserID(suite.T())
 		users    = []string{userID}
@@ -604,7 +603,7 @@ func (suite *DataCollectionsIntegrationSuite) TestDelta() {
 // TestMailSerializationRegression verifies that all mail data stored in the
 // test account can be successfully downloaded into bytes and restored into
 // M365 mail objects
-func (suite *DataCollectionsIntegrationSuite) TestMailSerializationRegression() {
+func (suite *BackupIntgSuite) TestMailSerializationRegression() {
 	t := suite.T()
 
 	ctx, flush := tester.NewContext(t)
@@ -668,7 +667,7 @@ func (suite *DataCollectionsIntegrationSuite) TestMailSerializationRegression() 
 // TestContactSerializationRegression verifies ability to query contact items
 // and to store contact within Collection. Downloaded contacts are run through
 // a regression test to ensure that downloaded items can be uploaded.
-func (suite *DataCollectionsIntegrationSuite) TestContactSerializationRegression() {
+func (suite *BackupIntgSuite) TestContactSerializationRegression() {
 	var (
 		users    = []string{suite.user}
 		handlers = BackupHandlers(suite.ac)
@@ -756,7 +755,7 @@ func (suite *DataCollectionsIntegrationSuite) TestContactSerializationRegression
 
 // TestEventsSerializationRegression ensures functionality of createCollections
 // to be able to successfully query, download and restore event objects
-func (suite *DataCollectionsIntegrationSuite) TestEventsSerializationRegression() {
+func (suite *BackupIntgSuite) TestEventsSerializationRegression() {
 	t := suite.T()
 
 	ctx, flush := tester.NewContext(t)

--- a/src/pkg/services/m365/api/contacts_pager.go
+++ b/src/pkg/services/m365/api/contacts_pager.go
@@ -249,7 +249,7 @@ func (c Contacts) NewContactDeltaIDsPager(
 	options := &users.ItemContactFoldersItemContactsDeltaRequestBuilderGetRequestConfiguration{
 		QueryParameters: &users.ItemContactFoldersItemContactsDeltaRequestBuilderGetQueryParameters{
 			Select: idAnd(parentFolderID),
-			Top:    ptr.To[int32](maxDeltaPageSize),
+			// TOP is not allowed
 		},
 		Headers: newPreferHeaders(preferPageSize(maxDeltaPageSize), preferImmutableIDs(immutableIDs)),
 	}

--- a/src/pkg/services/m365/api/contacts_pager.go
+++ b/src/pkg/services/m365/api/contacts_pager.go
@@ -104,12 +104,13 @@ func (c Contacts) NewContactsPager(
 ) itemPager[models.Contactable] {
 	options := &users.ItemContactFoldersItemContactsRequestBuilderGetRequestConfiguration{
 		Headers: newPreferHeaders(preferPageSize(maxNonDeltaPageSize)),
+		QueryParameters: &users.ItemContactFoldersItemContactsRequestBuilderGetQueryParameters{
+			Top: ptr.To[int32](maxNonDeltaPageSize),
+		},
 	}
 
 	if len(selectProps) > 0 {
-		options.QueryParameters = &users.ItemContactFoldersItemContactsRequestBuilderGetQueryParameters{
-			Select: selectProps,
-		}
+		options.QueryParameters.Select = selectProps
 	}
 
 	builder := c.Stable.
@@ -180,6 +181,7 @@ func (c Contacts) NewContactIDsPager(
 	config := &users.ItemContactFoldersItemContactsRequestBuilderGetRequestConfiguration{
 		QueryParameters: &users.ItemContactFoldersItemContactsRequestBuilderGetQueryParameters{
 			Select: idAnd(parentFolderID),
+			Top:    ptr.To[int32](maxNonDeltaPageSize),
 		},
 		Headers: newPreferHeaders(preferPageSize(maxNonDeltaPageSize), preferImmutableIDs(immutableIDs)),
 	}
@@ -247,6 +249,7 @@ func (c Contacts) NewContactDeltaIDsPager(
 	options := &users.ItemContactFoldersItemContactsDeltaRequestBuilderGetRequestConfiguration{
 		QueryParameters: &users.ItemContactFoldersItemContactsDeltaRequestBuilderGetQueryParameters{
 			Select: idAnd(parentFolderID),
+			Top:    ptr.To[int32](maxDeltaPageSize),
 		},
 		Headers: newPreferHeaders(preferPageSize(maxDeltaPageSize), preferImmutableIDs(immutableIDs)),
 	}

--- a/src/pkg/services/m365/api/events_pager.go
+++ b/src/pkg/services/m365/api/events_pager.go
@@ -112,12 +112,13 @@ func (c Events) NewEventsPager(
 ) itemPager[models.Eventable] {
 	options := &users.ItemCalendarsItemEventsRequestBuilderGetRequestConfiguration{
 		Headers: newPreferHeaders(preferPageSize(maxNonDeltaPageSize)),
+		QueryParameters: &users.ItemCalendarsItemEventsRequestBuilderGetQueryParameters{
+			Top: ptr.To[int32](maxNonDeltaPageSize),
+		},
 	}
 
 	if len(selectProps) > 0 {
-		options.QueryParameters = &users.ItemCalendarsItemEventsRequestBuilderGetQueryParameters{
-			Select: selectProps,
-		}
+		options.QueryParameters.Select = selectProps
 	}
 
 	builder := c.Stable.
@@ -187,6 +188,9 @@ func (c Events) NewEventIDsPager(
 ) (itemIDPager, error) {
 	options := &users.ItemCalendarsItemEventsRequestBuilderGetRequestConfiguration{
 		Headers: newPreferHeaders(preferPageSize(maxNonDeltaPageSize), preferImmutableIDs(immutableIDs)),
+		QueryParameters: &users.ItemCalendarsItemEventsRequestBuilderGetQueryParameters{
+			Top: ptr.To[int32](maxNonDeltaPageSize),
+		},
 	}
 
 	builder := c.Stable.
@@ -241,6 +245,9 @@ func (c Events) NewEventDeltaIDsPager(
 ) (itemIDPager, error) {
 	options := &users.ItemCalendarsItemEventsDeltaRequestBuilderGetRequestConfiguration{
 		Headers: newPreferHeaders(preferPageSize(maxDeltaPageSize), preferImmutableIDs(immutableIDs)),
+		QueryParameters: &users.ItemCalendarsItemEventsDeltaRequestBuilderGetQueryParameters{
+			Top: ptr.To[int32](maxDeltaPageSize),
+		},
 	}
 
 	var builder *users.ItemCalendarsItemEventsDeltaRequestBuilder

--- a/src/pkg/services/m365/api/mail_pager.go
+++ b/src/pkg/services/m365/api/mail_pager.go
@@ -135,12 +135,13 @@ func (c Mail) NewMailPager(
 ) itemPager[models.Messageable] {
 	options := &users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration{
 		Headers: newPreferHeaders(preferPageSize(maxNonDeltaPageSize)),
+		QueryParameters: &users.ItemMailFoldersItemMessagesRequestBuilderGetQueryParameters{
+			Top: ptr.To[int32](maxNonDeltaPageSize),
+		},
 	}
 
 	if len(selectProps) > 0 {
-		options.QueryParameters = &users.ItemMailFoldersItemMessagesRequestBuilderGetQueryParameters{
-			Select: selectProps,
-		}
+		options.QueryParameters.Select = selectProps
 	}
 
 	builder := c.Stable.
@@ -189,6 +190,7 @@ func (c Mail) NewMailIDsPager(
 	config := &users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration{
 		QueryParameters: &users.ItemMailFoldersItemMessagesRequestBuilderGetQueryParameters{
 			Select: idAnd("isRead"),
+			Top:    ptr.To[int32](maxNonDeltaPageSize),
 		},
 		Headers: newPreferHeaders(preferPageSize(maxNonDeltaPageSize), preferImmutableIDs(immutableIDs)),
 	}
@@ -285,6 +287,7 @@ func (c Mail) NewMailDeltaIDsPager(
 	config := &users.ItemMailFoldersItemMessagesDeltaRequestBuilderGetRequestConfiguration{
 		QueryParameters: &users.ItemMailFoldersItemMessagesDeltaRequestBuilderGetQueryParameters{
 			Select: idAnd("isRead"),
+			Top:    ptr.To[int32](maxDeltaPageSize),
 		},
 		Headers: newPreferHeaders(preferPageSize(maxDeltaPageSize), preferImmutableIDs(immutableIDs)),
 	}


### PR DESCRIPTION
Noticed during testing that we're still paging 10 items at a time for exchange item pager queries.  This increases that limit to the consts we have set for max delta and non-delta pages, respectively.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix

#### Issue(s)

* #3562

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
