### PR TITLE
Fix uploading large attachments for exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Exchange backup issue caused by incorrect json serialization
 - Fix issues with details model containing duplicate entry for api consumers
 - Handle OLE conversion errors when trying to fetch attachments
+- Fix uploading large attachments for emails and calendar
 
 ### Changed
 - Do not display all the items that we restored at the end if there are more than 15. You can override this with `--verbose`.

--- a/src/internal/m365/exchange/attachment.go
+++ b/src/internal/m365/exchange/attachment.go
@@ -95,6 +95,8 @@ func uploadAttachment(
 
 	// for file attachments sized >= 3MB
 	if attachmentType == models.FILE_ATTACHMENTTYPE && size >= largeAttachmentSize {
+		// We expect the entire attachment to fit in memory.
+		// Max attachment size is 150MB.
 		content, err := api.GetAttachmentContent(attachment)
 		if err != nil {
 			return clues.Wrap(err, "serializing attachment content").WithClues(ctx)

--- a/src/internal/m365/exchange/attachment.go
+++ b/src/internal/m365/exchange/attachment.go
@@ -61,16 +61,8 @@ func uploadAttachment(
 		attachmentType = attachmentType(attachment)
 		id             = ptr.Val(attachment.GetId())
 		name           = ptr.Val(attachment.GetName())
+		size           = ptr.Val(attachment.GetSize())
 	)
-
-	content, err := api.GetAttachmentContent(attachment)
-	if err != nil {
-		return clues.Wrap(err, "serializing attachment content").WithClues(ctx)
-	}
-
-	// We cannot rely on attachment.GetSize() as that seems to be
-	// higher than the actual size for some reason
-	size := len(content)
 
 	ctx = clues.Add(
 		ctx,
@@ -103,7 +95,13 @@ func uploadAttachment(
 
 	// for file attachments sized >= 3MB
 	if attachmentType == models.FILE_ATTACHMENTTYPE && size >= largeAttachmentSize {
-		_, err := cli.PostLargeAttachment(ctx, userID, containerID, parentItemID, name, content)
+		content, err := api.GetAttachmentContent(attachment)
+		if err != nil {
+			return clues.Wrap(err, "serializing attachment content").WithClues(ctx)
+		}
+
+		_, err = cli.PostLargeAttachment(ctx, userID, containerID, parentItemID, name, content)
+
 		return err
 	}
 

--- a/src/internal/m365/exchange/attachment.go
+++ b/src/internal/m365/exchange/attachment.go
@@ -22,7 +22,7 @@ type attachmentPoster interface {
 		ctx context.Context,
 		userID, containerID, itemID, name string,
 		content []byte,
-	) (models.UploadSessionable, error)
+	) (string, error)
 }
 
 const (

--- a/src/internal/m365/exchange/attachment.go
+++ b/src/internal/m365/exchange/attachment.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/pkg/logger"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type attachmentPoster interface {
@@ -20,15 +21,14 @@ type attachmentPoster interface {
 	PostLargeAttachment(
 		ctx context.Context,
 		userID, containerID, itemID, name string,
-		size int64,
-		body models.Attachmentable,
+		content []byte,
 	) (models.UploadSessionable, error)
 }
 
 const (
 	// Use large attachment logic for attachments > 3MB
 	// https://learn.microsoft.com/en-us/graph/outlook-large-attachments
-	largeAttachmentSize           = int32(3 * 1024 * 1024)
+	largeAttachmentSize           = 3 * 1024 * 1024
 	fileAttachmentOdataValue      = "#microsoft.graph.fileAttachment"
 	itemAttachmentOdataValue      = "#microsoft.graph.itemAttachment"
 	referenceAttachmentOdataValue = "#microsoft.graph.referenceAttachment"
@@ -61,8 +61,16 @@ func uploadAttachment(
 		attachmentType = attachmentType(attachment)
 		id             = ptr.Val(attachment.GetId())
 		name           = ptr.Val(attachment.GetName())
-		size           = ptr.Val(attachment.GetSize())
 	)
+
+	content, err := api.GetAttachmentContent(attachment)
+	if err != nil {
+		return clues.Wrap(err, "serializing attachment content").WithClues(ctx)
+	}
+
+	// We cannot rely on attachment.GetSize() as that seems to be
+	// higher than the actual size for some reason
+	size := len(content)
 
 	ctx = clues.Add(
 		ctx,
@@ -95,7 +103,7 @@ func uploadAttachment(
 
 	// for file attachments sized >= 3MB
 	if attachmentType == models.FILE_ATTACHMENTTYPE && size >= largeAttachmentSize {
-		_, err := cli.PostLargeAttachment(ctx, userID, containerID, parentItemID, name, int64(size), attachment)
+		_, err := cli.PostLargeAttachment(ctx, userID, containerID, parentItemID, name, content)
 		return err
 	}
 

--- a/src/internal/m365/graph/uploadsession.go
+++ b/src/internal/m365/graph/uploadsession.go
@@ -89,10 +89,11 @@ func (iw *largeItemWriter) Write(p []byte) (int, error) {
 	// item. This will only be available after we have uploaded the
 	// entire content(based on the size in the req header).
 	// https://outlook.office.com/api/v2.0/Users('<user-id>')/Messages('<message-id>')/Attachments('<attachment-id>')
+	// Ref: https://learn.microsoft.com/en-us/graph/outlook-large-attachments?tabs=http
 	loc := resp.Header.Get("Location")
 	if loc != "" {
 		splits := strings.Split(loc, "'")
-		if len(splits) != 7 || splits[4] != ")/Attachments(" || splits[5] == "" {
+		if len(splits) != 7 || splits[4] != ")/Attachments(" || len(splits[5]) == 0 {
 			return 0, clues.New("invalid format for upload completion url").
 				With("location", loc)
 		}

--- a/src/pkg/services/m365/api/events.go
+++ b/src/pkg/services/m365/api/events.go
@@ -514,7 +514,7 @@ func (c Events) PostLargeAttachment(
 	ctx context.Context,
 	userID, containerID, parentItemID, itemName string,
 	content []byte,
-) (models.UploadSessionable, error) {
+) (string, error) {
 	size := int64(len(content))
 	session := users.NewItemCalendarEventsItemAttachmentsCreateUploadSessionPostRequestBody()
 	session.SetAttachmentItem(makeSessionAttachment(itemName, size))
@@ -531,7 +531,7 @@ func (c Events) PostLargeAttachment(
 		CreateUploadSession().
 		Post(ctx, session, nil)
 	if err != nil {
-		return nil, graph.Wrap(ctx, err, "uploading large event attachment")
+		return "", graph.Wrap(ctx, err, "uploading large event attachment")
 	}
 
 	url := ptr.Val(us.GetUploadUrl())
@@ -540,10 +540,10 @@ func (c Events) PostLargeAttachment(
 
 	_, err = io.CopyBuffer(w, bytes.NewReader(content), copyBuffer)
 	if err != nil {
-		return nil, clues.Wrap(err, "buffering large attachment content").WithClues(ctx)
+		return "", clues.Wrap(err, "buffering large attachment content").WithClues(ctx)
 	}
 
-	return us, nil
+	return w.ID, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/services/m365/api/events.go
+++ b/src/pkg/services/m365/api/events.go
@@ -513,14 +513,9 @@ func (c Events) PostSmallAttachment(
 func (c Events) PostLargeAttachment(
 	ctx context.Context,
 	userID, containerID, parentItemID, itemName string,
-	size int64,
-	body models.Attachmentable,
+	content []byte,
 ) (models.UploadSessionable, error) {
-	bs, err := GetAttachmentContent(body)
-	if err != nil {
-		return nil, clues.Wrap(err, "serializing attachment content").WithClues(ctx)
-	}
-
+	size := int64(len(content))
 	session := users.NewItemCalendarEventsItemAttachmentsCreateUploadSessionPostRequestBody()
 	session.SetAttachmentItem(makeSessionAttachment(itemName, size))
 
@@ -543,7 +538,7 @@ func (c Events) PostLargeAttachment(
 	w := graph.NewLargeItemWriter(parentItemID, url, size)
 	copyBuffer := make([]byte, graph.AttachmentChunkSize)
 
-	_, err = io.CopyBuffer(w, bytes.NewReader(bs), copyBuffer)
+	_, err = io.CopyBuffer(w, bytes.NewReader(content), copyBuffer)
 	if err != nil {
 		return nil, clues.Wrap(err, "buffering large attachment content").WithClues(ctx)
 	}

--- a/src/pkg/services/m365/api/events_test.go
+++ b/src/pkg/services/m365/api/events_test.go
@@ -250,13 +250,10 @@ func (suite *EventsAPIIntgSuite) TestRestoreLargeAttachment() {
 
 	userID := tester.M365UserID(suite.T())
 
-	folderName := testdata.DefaultRestoreConfig("eventrestoretest").Location
+	folderName := testdata.DefaultRestoreConfig("eventlargeattachmenttest").Location
 	evts := suite.ac.Events()
 	calendar, err := evts.CreateContainer(ctx, userID, folderName, "")
 	require.NoError(t, err, clues.ToCore(err))
-
-	// Delete on exit
-	defer func() { _ = evts.DeleteContainer(ctx, userID, ptr.Val(calendar.GetId())) }()
 
 	tomorrow := time.Now().Add(24 * time.Hour)
 	evt := models.NewEvent()

--- a/src/pkg/services/m365/api/mail.go
+++ b/src/pkg/services/m365/api/mail.go
@@ -408,7 +408,7 @@ func (c Mail) PostLargeAttachment(
 	ctx context.Context,
 	userID, containerID, parentItemID, itemName string,
 	content []byte,
-) (models.UploadSessionable, error) {
+) (string, error) {
 	size := int64(len(content))
 	session := users.NewItemMailFoldersItemMessagesItemAttachmentsCreateUploadSessionPostRequestBody()
 	session.SetAttachmentItem(makeSessionAttachment(itemName, size))
@@ -425,7 +425,7 @@ func (c Mail) PostLargeAttachment(
 		CreateUploadSession().
 		Post(ctx, session, nil)
 	if err != nil {
-		return nil, graph.Wrap(ctx, err, "uploading large mail attachment")
+		return "", graph.Wrap(ctx, err, "uploading large mail attachment")
 	}
 
 	url := ptr.Val(us.GetUploadUrl())
@@ -434,10 +434,10 @@ func (c Mail) PostLargeAttachment(
 
 	_, err = io.CopyBuffer(w, bytes.NewReader(content), copyBuffer)
 	if err != nil {
-		return nil, clues.Wrap(err, "buffering large attachment content").WithClues(ctx)
+		return "", clues.Wrap(err, "buffering large attachment content").WithClues(ctx)
 	}
 
-	return us, nil
+	return w.ID, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/services/m365/api/mail.go
+++ b/src/pkg/services/m365/api/mail.go
@@ -407,14 +407,9 @@ func (c Mail) PostSmallAttachment(
 func (c Mail) PostLargeAttachment(
 	ctx context.Context,
 	userID, containerID, parentItemID, itemName string,
-	size int64,
-	body models.Attachmentable,
+	content []byte,
 ) (models.UploadSessionable, error) {
-	bs, err := GetAttachmentContent(body)
-	if err != nil {
-		return nil, clues.Wrap(err, "serializing attachment content").WithClues(ctx)
-	}
-
+	size := int64(len(content))
 	session := users.NewItemMailFoldersItemMessagesItemAttachmentsCreateUploadSessionPostRequestBody()
 	session.SetAttachmentItem(makeSessionAttachment(itemName, size))
 
@@ -437,7 +432,7 @@ func (c Mail) PostLargeAttachment(
 	w := graph.NewLargeItemWriter(parentItemID, url, size)
 	copyBuffer := make([]byte, graph.AttachmentChunkSize)
 
-	_, err = io.CopyBuffer(w, bytes.NewReader(bs), copyBuffer)
+	_, err = io.CopyBuffer(w, bytes.NewReader(content), copyBuffer)
 	if err != nil {
 		return nil, clues.Wrap(err, "buffering large attachment content").WithClues(ctx)
 	}

--- a/src/pkg/services/m365/api/mail.go
+++ b/src/pkg/services/m365/api/mail.go
@@ -63,6 +63,23 @@ func (c Mail) CreateMailFolder(
 	return mdl, nil
 }
 
+func (c Mail) DeleteMailFolder(
+	ctx context.Context,
+	userID, id string,
+) error {
+	err := c.Stable.Client().
+		Users().
+		ByUserId(userID).
+		MailFolders().
+		ByMailFolderId(id).
+		Delete(ctx, nil)
+	if err != nil {
+		return graph.Wrap(ctx, err, "deleting mail folder")
+	}
+
+	return nil
+}
+
 func (c Mail) CreateContainer(
 	ctx context.Context,
 	userID, containerName, parentContainerID string,

--- a/src/pkg/services/m365/api/mail_test.go
+++ b/src/pkg/services/m365/api/mail_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/mock"
@@ -409,4 +410,38 @@ func (suite *MailAPIIntgSuite) TestHugeAttachmentListDownload() {
 			assert.True(t, gock.IsDone(), "made all requests")
 		})
 	}
+}
+
+func (suite *MailAPIIntgSuite) TestRestoreLargeAttachment() {
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	userID := tester.M365UserID(suite.T())
+
+	folderName := testdata.DefaultRestoreConfig("mailrestoretest").Location
+	msgs := suite.ac.Mail()
+	mailfolder, err := msgs.CreateMailFolder(ctx, userID, folderName)
+	require.NoError(t, err, clues.ToCore(err))
+
+	// Delete on exit
+	defer func() { _ = msgs.DeleteMailFolder(ctx, userID, ptr.Val(mailfolder.GetId())) }()
+
+	msg := models.NewMessage()
+	msg.SetSubject(ptr.To("Mail with attachment"))
+
+	item, err := msgs.PostItem(ctx, userID, ptr.Val(mailfolder.GetId()), msg)
+	require.NoError(t, err, clues.ToCore(err))
+
+	id, err := msgs.PostLargeAttachment(
+		ctx,
+		userID,
+		ptr.Val(mailfolder.GetId()),
+		ptr.Val(item.GetId()),
+		"raboganm",
+		[]byte("mangobar"),
+	)
+	require.NoError(t, err, clues.ToCore(err))
+	require.NotEmpty(t, id, "empty id for large attachment")
 }

--- a/src/pkg/services/m365/api/mail_test.go
+++ b/src/pkg/services/m365/api/mail_test.go
@@ -420,13 +420,10 @@ func (suite *MailAPIIntgSuite) TestRestoreLargeAttachment() {
 
 	userID := tester.M365UserID(suite.T())
 
-	folderName := testdata.DefaultRestoreConfig("mailrestoretest").Location
+	folderName := testdata.DefaultRestoreConfig("maillargeattachmenttest").Location
 	msgs := suite.ac.Mail()
 	mailfolder, err := msgs.CreateMailFolder(ctx, userID, folderName)
 	require.NoError(t, err, clues.ToCore(err))
-
-	// Delete on exit
-	defer func() { _ = msgs.DeleteMailFolder(ctx, userID, ptr.Val(mailfolder.GetId())) }()
 
 	msg := models.NewMessage()
 	msg.SetSubject(ptr.To("Mail with attachment"))


### PR DESCRIPTION
Upload of large attachments were broken previously.

Previously we were relying on the size reported by Graph API, but
that is not reliable and we were not completing uploads because of that.

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
