### PR TITLE
handle restore collisions in exchange

### DIFF
--- a/src/internal/m365/exchange/attachment.go
+++ b/src/internal/m365/exchange/attachment.go
@@ -53,7 +53,7 @@ func attachmentType(attachment models.Attachmentable) models.AttachmentType {
 // uploadAttachment will upload the specified message attachment to M365
 func uploadAttachment(
 	ctx context.Context,
-	cli attachmentPoster,
+	ap attachmentPoster,
 	userID, containerID, parentItemID string,
 	attachment models.Attachmentable,
 ) error {
@@ -102,13 +102,13 @@ func uploadAttachment(
 			return clues.Wrap(err, "serializing attachment content").WithClues(ctx)
 		}
 
-		_, err = cli.PostLargeAttachment(ctx, userID, containerID, parentItemID, name, content)
+		_, err = ap.PostLargeAttachment(ctx, userID, containerID, parentItemID, name, content)
 
 		return err
 	}
 
 	// for all other attachments
-	return cli.PostSmallAttachment(ctx, userID, containerID, parentItemID, attachment)
+	return ap.PostSmallAttachment(ctx, userID, containerID, parentItemID, attachment)
 }
 
 func getOutlookOdataType(query models.Attachmentable) string {

--- a/src/internal/m365/exchange/contacts_restore_test.go
+++ b/src/internal/m365/exchange/contacts_restore_test.go
@@ -1,24 +1,46 @@
 package exchange
 
 import (
+	"context"
 	"testing"
 
 	"github.com/alcionai/clues"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/m365/exchange/mock"
+	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/pkg/account"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
+	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
+var _ postItemer[models.Contactable] = &mockContactRestorer{}
+
+type mockContactRestorer struct {
+	postItemErr error
+}
+
+func (m mockContactRestorer) PostItem(
+	ctx context.Context,
+	userID, containerID string,
+	body models.Contactable,
+) (models.Contactable, error) {
+	return models.NewContact(), m.postItemErr
+}
+
+// ---------------------------------------------------------------------------
+// tests
+// ---------------------------------------------------------------------------
+
 type ContactsRestoreIntgSuite struct {
 	tester.Suite
-	creds  account.M365Config
-	ac     api.Client
-	userID string
+	its intgTesterSetup
 }
 
 func TestContactsRestoreIntgSuite(t *testing.T) {
@@ -30,29 +52,110 @@ func TestContactsRestoreIntgSuite(t *testing.T) {
 }
 
 func (suite *ContactsRestoreIntgSuite) SetupSuite() {
-	t := suite.T()
-
-	a := tester.NewM365Account(t)
-	creds, err := a.M365Config()
-	require.NoError(t, err, clues.ToCore(err))
-
-	suite.creds = creds
-
-	suite.ac, err = api.NewClient(creds)
-	require.NoError(t, err, clues.ToCore(err))
-
-	suite.userID = tester.M365UserID(t)
+	suite.its = newIntegrationTesterSetup(suite.T())
 }
 
 // Testing to ensure that cache system works for in multiple different environments
 func (suite *ContactsRestoreIntgSuite) TestCreateContainerDestination() {
 	runCreateDestinationTest(
 		suite.T(),
-		newMailRestoreHandler(suite.ac),
-		path.EmailCategory,
-		suite.creds.AzureTenantID,
-		suite.userID,
+		newContactRestoreHandler(suite.its.ac),
+		path.ContactsCategory,
+		suite.its.creds.AzureTenantID,
+		suite.its.userID,
 		testdata.DefaultRestoreConfig("").Location,
 		[]string{"Hufflepuff"},
 		[]string{"Ravenclaw"})
+}
+
+func (suite *ContactsRestoreIntgSuite) TestRestoreContact() {
+	body := mock.ContactBytes("middlename")
+
+	stub, err := api.BytesToContactable(body)
+	require.NoError(suite.T(), err, clues.ToCore(err))
+
+	collisionKey := api.ContactCollisionKey(stub)
+
+	table := []struct {
+		name         string
+		apiMock      postItemer[models.Contactable]
+		collisionMap map[string]string
+		onCollision  control.CollisionPolicy
+		expectErr    func(*testing.T, error)
+	}{
+		{
+			name:         "no collision: skip",
+			apiMock:      mockContactRestorer{},
+			collisionMap: map[string]string{},
+			onCollision:  control.Copy,
+			expectErr: func(t *testing.T, err error) {
+				assert.NoError(t, err, clues.ToCore(err))
+			},
+		},
+		{
+			name:         "no collision: copy",
+			apiMock:      mockContactRestorer{},
+			collisionMap: map[string]string{},
+			onCollision:  control.Skip,
+			expectErr: func(t *testing.T, err error) {
+				assert.NoError(t, err, clues.ToCore(err))
+			},
+		},
+		{
+			name:         "no collision: replace",
+			apiMock:      mockContactRestorer{},
+			collisionMap: map[string]string{},
+			onCollision:  control.Replace,
+			expectErr: func(t *testing.T, err error) {
+				assert.NoError(t, err, clues.ToCore(err))
+			},
+		},
+		{
+			name:         "collision: skip",
+			apiMock:      mockContactRestorer{},
+			collisionMap: map[string]string{collisionKey: "smarf"},
+			onCollision:  control.Skip,
+			expectErr: func(t *testing.T, err error) {
+				assert.ErrorIs(t, err, graph.ErrItemAlreadyExistsConflict, clues.ToCore(err))
+			},
+		},
+		{
+			name:         "collision: copy",
+			apiMock:      mockContactRestorer{},
+			collisionMap: map[string]string{collisionKey: "smarf"},
+			onCollision:  control.Copy,
+			expectErr: func(t *testing.T, err error) {
+				assert.NoError(t, err, clues.ToCore(err))
+			},
+		},
+		{
+			name:         "collision: replace",
+			apiMock:      mockContactRestorer{},
+			collisionMap: map[string]string{collisionKey: "smarf"},
+			onCollision:  control.Replace,
+			expectErr: func(t *testing.T, err error) {
+				assert.ErrorIs(t, err, graph.ErrItemAlreadyExistsConflict, clues.ToCore(err))
+			},
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			_, err := restoreContact(
+				ctx,
+				test.apiMock,
+				body,
+				suite.its.userID,
+				"destination",
+				test.collisionMap,
+				test.onCollision,
+				fault.New(true))
+
+			test.expectErr(t, err)
+		})
+	}
 }

--- a/src/internal/m365/exchange/events_restore_test.go
+++ b/src/internal/m365/exchange/events_restore_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/alcionai/clues"
+	"github.com/google/uuid"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,10 +47,46 @@ func (m mockEventRestorer) PostSmallAttachment(
 func (m mockEventRestorer) PostLargeAttachment(
 	_ context.Context,
 	_, _, _, _ string,
-	_ int64,
-	_ models.Attachmentable,
-) (models.UploadSessionable, error) {
-	return models.NewUploadSession(), m.postAttachmentErr
+	_ []byte,
+) (string, error) {
+	return uuid.NewString(), m.postAttachmentErr
+}
+
+func (m mockEventRestorer) DeleteAttachment(
+	ctx context.Context,
+	userID, calendarID, eventID, attachmentID string,
+) error {
+	return nil
+}
+
+func (m mockEventRestorer) DeleteItem(
+	ctx context.Context,
+	userID, itemID string,
+) error {
+	return nil
+}
+
+func (m mockEventRestorer) GetAttachments(
+	_ context.Context,
+	_ bool,
+	_, _ string,
+) ([]models.Attachmentable, error) {
+	return []models.Attachmentable{}, nil
+}
+
+func (m mockEventRestorer) GetItemInstances(
+	_ context.Context,
+	_, _, _, _ string,
+) ([]models.Eventable, error) {
+	return []models.Eventable{}, nil
+}
+
+func (m mockEventRestorer) PatchItem(
+	_ context.Context,
+	_, _ string,
+	_ models.Eventable,
+) (models.Eventable, error) {
+	return models.NewEvent(), nil
 }
 
 // ---------------------------------------------------------------------------

--- a/src/internal/m365/exchange/events_restore_test.go
+++ b/src/internal/m365/exchange/events_restore_test.go
@@ -1,24 +1,64 @@
 package exchange
 
 import (
+	"context"
 	"testing"
 
 	"github.com/alcionai/clues"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/m365/exchange/mock"
+	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/pkg/account"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
+	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
+var _ eventRestorer = &mockEventRestorer{}
+
+type mockEventRestorer struct {
+	postItemErr       error
+	postAttachmentErr error
+}
+
+func (m mockEventRestorer) PostItem(
+	ctx context.Context,
+	userID, containerID string,
+	body models.Eventable,
+) (models.Eventable, error) {
+	return models.NewEvent(), m.postItemErr
+}
+
+func (m mockEventRestorer) PostSmallAttachment(
+	_ context.Context,
+	_, _, _ string,
+	_ models.Attachmentable,
+) error {
+	return m.postAttachmentErr
+}
+
+func (m mockEventRestorer) PostLargeAttachment(
+	_ context.Context,
+	_, _, _, _ string,
+	_ int64,
+	_ models.Attachmentable,
+) (models.UploadSessionable, error) {
+	return models.NewUploadSession(), m.postAttachmentErr
+}
+
+// ---------------------------------------------------------------------------
+// tests
+// ---------------------------------------------------------------------------
+
 type EventsRestoreIntgSuite struct {
 	tester.Suite
-	creds  account.M365Config
-	ac     api.Client
-	userID string
+	its intgTesterSetup
 }
 
 func TestEventsRestoreIntgSuite(t *testing.T) {
@@ -30,29 +70,110 @@ func TestEventsRestoreIntgSuite(t *testing.T) {
 }
 
 func (suite *EventsRestoreIntgSuite) SetupSuite() {
-	t := suite.T()
-
-	a := tester.NewM365Account(t)
-	creds, err := a.M365Config()
-	require.NoError(t, err, clues.ToCore(err))
-
-	suite.creds = creds
-
-	suite.ac, err = api.NewClient(creds)
-	require.NoError(t, err, clues.ToCore(err))
-
-	suite.userID = tester.M365UserID(t)
+	suite.its = newIntegrationTesterSetup(suite.T())
 }
 
 // Testing to ensure that cache system works for in multiple different environments
 func (suite *EventsRestoreIntgSuite) TestCreateContainerDestination() {
 	runCreateDestinationTest(
 		suite.T(),
-		newMailRestoreHandler(suite.ac),
-		path.EmailCategory,
-		suite.creds.AzureTenantID,
-		suite.userID,
+		newEventRestoreHandler(suite.its.ac),
+		path.EventsCategory,
+		suite.its.creds.AzureTenantID,
+		suite.its.userID,
 		testdata.DefaultRestoreConfig("").Location,
 		[]string{"Durmstrang"},
 		[]string{"Beauxbatons"})
+}
+
+func (suite *EventsRestoreIntgSuite) TestRestoreEvent() {
+	body := mock.EventBytes("subject")
+
+	stub, err := api.BytesToEventable(body)
+	require.NoError(suite.T(), err, clues.ToCore(err))
+
+	collisionKey := api.EventCollisionKey(stub)
+
+	table := []struct {
+		name         string
+		apiMock      eventRestorer
+		collisionMap map[string]string
+		onCollision  control.CollisionPolicy
+		expectErr    func(*testing.T, error)
+	}{
+		{
+			name:         "no collision: skip",
+			apiMock:      mockEventRestorer{},
+			collisionMap: map[string]string{},
+			onCollision:  control.Copy,
+			expectErr: func(t *testing.T, err error) {
+				assert.NoError(t, err, clues.ToCore(err))
+			},
+		},
+		{
+			name:         "no collision: copy",
+			apiMock:      mockEventRestorer{},
+			collisionMap: map[string]string{},
+			onCollision:  control.Skip,
+			expectErr: func(t *testing.T, err error) {
+				assert.NoError(t, err, clues.ToCore(err))
+			},
+		},
+		{
+			name:         "no collision: replace",
+			apiMock:      mockEventRestorer{},
+			collisionMap: map[string]string{},
+			onCollision:  control.Replace,
+			expectErr: func(t *testing.T, err error) {
+				assert.NoError(t, err, clues.ToCore(err))
+			},
+		},
+		{
+			name:         "collision: skip",
+			apiMock:      mockEventRestorer{},
+			collisionMap: map[string]string{collisionKey: "smarf"},
+			onCollision:  control.Skip,
+			expectErr: func(t *testing.T, err error) {
+				assert.ErrorIs(t, err, graph.ErrItemAlreadyExistsConflict, clues.ToCore(err))
+			},
+		},
+		{
+			name:         "collision: copy",
+			apiMock:      mockEventRestorer{},
+			collisionMap: map[string]string{collisionKey: "smarf"},
+			onCollision:  control.Copy,
+			expectErr: func(t *testing.T, err error) {
+				assert.NoError(t, err, clues.ToCore(err))
+			},
+		},
+		{
+			name:         "collision: replace",
+			apiMock:      mockEventRestorer{},
+			collisionMap: map[string]string{collisionKey: "smarf"},
+			onCollision:  control.Replace,
+			expectErr: func(t *testing.T, err error) {
+				assert.ErrorIs(t, err, graph.ErrItemAlreadyExistsConflict, clues.ToCore(err))
+			},
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			_, err := restoreEvent(
+				ctx,
+				test.apiMock,
+				body,
+				suite.its.userID,
+				"destination",
+				test.collisionMap,
+				test.onCollision,
+				fault.New(true))
+
+			test.expectErr(t, err)
+		})
+	}
 }

--- a/src/internal/m365/exchange/handlers.go
+++ b/src/internal/m365/exchange/handlers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
@@ -60,6 +61,7 @@ func BackupHandlers(ac api.Client) map[path.CategoryType]backupHandler {
 type restoreHandler interface {
 	itemRestorer
 	containerAPI
+	getItemsByCollisionKeyser
 	newContainerCache(userID string) graph.ContainerResolver
 	formatRestoreDestination(
 		destinationContainerName string,
@@ -75,17 +77,10 @@ type itemRestorer interface {
 		ctx context.Context,
 		body []byte,
 		userID, destinationID string,
+		collisionKeyToItemID map[string]string,
+		collisionPolicy control.CollisionPolicy,
 		errs *fault.Bus,
 	) (*details.ExchangeInfo, error)
-}
-
-// runs the actual graph API post request.
-type itemPoster[T any] interface {
-	PostItem(
-		ctx context.Context,
-		userID, dirID string,
-		body T,
-	) (T, error)
 }
 
 // produces structs that interface with the graph/cache_container
@@ -128,4 +123,25 @@ func restoreHandlers(
 		path.EmailCategory:    newMailRestoreHandler(ac),
 		path.EventsCategory:   newEventRestoreHandler(ac),
 	}
+}
+
+type getItemsByCollisionKeyser interface {
+	// GetItemsInContainerByCollisionKey looks up all items currently in
+	// the container, and returns them in a map[collisionKey]itemID.
+	// The collision key is uniquely defined by each category of data.
+	// Collision key checks are used during restore to handle the on-
+	// collision restore configurations that cause the item restore to get
+	// skipped, replaced, or copied.
+	getItemsInContainerByCollisionKey(
+		ctx context.Context,
+		userID, containerID string,
+	) (map[string]string, error)
+}
+
+type postItemer[T any] interface {
+	PostItem(
+		ctx context.Context,
+		userID, containerID string,
+		body T,
+	) (T, error)
 }

--- a/src/internal/m365/exchange/helper_test.go
+++ b/src/internal/m365/exchange/helper_test.go
@@ -1,0 +1,38 @@
+package exchange
+
+import (
+	"testing"
+
+	"github.com/alcionai/clues"
+	"github.com/stretchr/testify/require"
+
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/account"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+)
+
+type intgTesterSetup struct {
+	ac     api.Client
+	creds  account.M365Config
+	userID string
+}
+
+func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
+	its := intgTesterSetup{}
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	a := tester.NewM365Account(t)
+	creds, err := a.M365Config()
+	require.NoError(t, err, clues.ToCore(err))
+
+	its.creds = creds
+
+	its.ac, err = api.NewClient(creds)
+	require.NoError(t, err, clues.ToCore(err))
+
+	its.userID = tester.GetM365UserID(ctx)
+
+	return its
+}

--- a/src/internal/m365/exchange/mail_restore_test.go
+++ b/src/internal/m365/exchange/mail_restore_test.go
@@ -1,24 +1,64 @@
 package exchange
 
 import (
+	"context"
 	"testing"
 
 	"github.com/alcionai/clues"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/m365/exchange/mock"
+	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/pkg/account"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
+	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
+var _ mailRestorer = &mockMailRestorer{}
+
+type mockMailRestorer struct {
+	postItemErr       error
+	postAttachmentErr error
+}
+
+func (m mockMailRestorer) PostItem(
+	ctx context.Context,
+	userID, containerID string,
+	body models.Messageable,
+) (models.Messageable, error) {
+	return models.NewMessage(), m.postItemErr
+}
+
+func (m mockMailRestorer) PostSmallAttachment(
+	_ context.Context,
+	_, _, _ string,
+	_ models.Attachmentable,
+) error {
+	return m.postAttachmentErr
+}
+
+func (m mockMailRestorer) PostLargeAttachment(
+	_ context.Context,
+	_, _, _, _ string,
+	_ int64,
+	_ models.Attachmentable,
+) (models.UploadSessionable, error) {
+	return models.NewUploadSession(), m.postAttachmentErr
+}
+
+// ---------------------------------------------------------------------------
+// tests
+// ---------------------------------------------------------------------------
+
 type MailRestoreIntgSuite struct {
 	tester.Suite
-	creds  account.M365Config
-	ac     api.Client
-	userID string
+	its intgTesterSetup
 }
 
 func TestMailRestoreIntgSuite(t *testing.T) {
@@ -30,29 +70,109 @@ func TestMailRestoreIntgSuite(t *testing.T) {
 }
 
 func (suite *MailRestoreIntgSuite) SetupSuite() {
-	t := suite.T()
-
-	a := tester.NewM365Account(t)
-	creds, err := a.M365Config()
-	require.NoError(t, err, clues.ToCore(err))
-
-	suite.creds = creds
-
-	suite.ac, err = api.NewClient(creds)
-	require.NoError(t, err, clues.ToCore(err))
-
-	suite.userID = tester.M365UserID(t)
+	suite.its = newIntegrationTesterSetup(suite.T())
 }
 
-// Testing to ensure that cache system works for in multiple different environments
 func (suite *MailRestoreIntgSuite) TestCreateContainerDestination() {
 	runCreateDestinationTest(
 		suite.T(),
-		newMailRestoreHandler(suite.ac),
+		newMailRestoreHandler(suite.its.ac),
 		path.EmailCategory,
-		suite.creds.AzureTenantID,
-		suite.userID,
+		suite.its.creds.AzureTenantID,
+		suite.its.userID,
 		testdata.DefaultRestoreConfig("").Location,
 		[]string{"Griffindor", "Croix"},
 		[]string{"Griffindor", "Felicius"})
+}
+
+func (suite *MailRestoreIntgSuite) TestRestoreMail() {
+	body := mock.MessageBytes("subject")
+
+	stub, err := api.BytesToMessageable(body)
+	require.NoError(suite.T(), err, clues.ToCore(err))
+
+	collisionKey := api.MailCollisionKey(stub)
+
+	table := []struct {
+		name         string
+		apiMock      mailRestorer
+		collisionMap map[string]string
+		onCollision  control.CollisionPolicy
+		expectErr    func(*testing.T, error)
+	}{
+		{
+			name:         "no collision: skip",
+			apiMock:      mockMailRestorer{},
+			collisionMap: map[string]string{},
+			onCollision:  control.Copy,
+			expectErr: func(t *testing.T, err error) {
+				assert.NoError(t, err, clues.ToCore(err))
+			},
+		},
+		{
+			name:         "no collision: copy",
+			apiMock:      mockMailRestorer{},
+			collisionMap: map[string]string{},
+			onCollision:  control.Skip,
+			expectErr: func(t *testing.T, err error) {
+				assert.NoError(t, err, clues.ToCore(err))
+			},
+		},
+		{
+			name:         "no collision: replace",
+			apiMock:      mockMailRestorer{},
+			collisionMap: map[string]string{},
+			onCollision:  control.Replace,
+			expectErr: func(t *testing.T, err error) {
+				assert.NoError(t, err, clues.ToCore(err))
+			},
+		},
+		{
+			name:         "collision: skip",
+			apiMock:      mockMailRestorer{},
+			collisionMap: map[string]string{collisionKey: "smarf"},
+			onCollision:  control.Skip,
+			expectErr: func(t *testing.T, err error) {
+				assert.ErrorIs(t, err, graph.ErrItemAlreadyExistsConflict, clues.ToCore(err))
+			},
+		},
+		{
+			name:         "collision: copy",
+			apiMock:      mockMailRestorer{},
+			collisionMap: map[string]string{collisionKey: "smarf"},
+			onCollision:  control.Copy,
+			expectErr: func(t *testing.T, err error) {
+				assert.NoError(t, err, clues.ToCore(err))
+			},
+		},
+		{
+			name:         "collision: replace",
+			apiMock:      mockMailRestorer{},
+			collisionMap: map[string]string{collisionKey: "smarf"},
+			onCollision:  control.Replace,
+			expectErr: func(t *testing.T, err error) {
+				assert.ErrorIs(t, err, graph.ErrItemAlreadyExistsConflict, clues.ToCore(err))
+			},
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			_, err := restoreMail(
+				ctx,
+				test.apiMock,
+				body,
+				suite.its.userID,
+				"destination",
+				test.collisionMap,
+				test.onCollision,
+				fault.New(true))
+
+			test.expectErr(t, err)
+		})
+	}
 }

--- a/src/internal/m365/exchange/mail_restore_test.go
+++ b/src/internal/m365/exchange/mail_restore_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/alcionai/clues"
+	"github.com/google/uuid"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,10 +47,9 @@ func (m mockMailRestorer) PostSmallAttachment(
 func (m mockMailRestorer) PostLargeAttachment(
 	_ context.Context,
 	_, _, _, _ string,
-	_ int64,
-	_ models.Attachmentable,
-) (models.UploadSessionable, error) {
-	return models.NewUploadSession(), m.postAttachmentErr
+	_ []byte,
+) (string, error) {
+	return uuid.NewString(), m.postAttachmentErr
 }
 
 // ---------------------------------------------------------------------------

--- a/src/internal/m365/exchange/restore_test.go
+++ b/src/internal/m365/exchange/restore_test.go
@@ -403,6 +403,8 @@ func (suite *RestoreIntgSuite) TestRestoreAndBackupEvent_recurringInstancesWithA
 		ctx,
 		bytes,
 		userID, calendarID,
+		nil,
+		control.Copy,
 		fault.New(true))
 	require.NoError(t, err, clues.ToCore(err))
 	assert.NotNil(t, info, "event item info")

--- a/src/internal/m365/exchange/restore_test.go
+++ b/src/internal/m365/exchange/restore_test.go
@@ -13,6 +13,7 @@ import (
 	exchMock "github.com/alcionai/corso/src/internal/m365/exchange/mock"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/account"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -74,6 +75,8 @@ func (suite *RestoreIntgSuite) TestRestoreContact() {
 		ctx,
 		exchMock.ContactBytes("Corso TestContact"),
 		userID, folderID,
+		nil,
+		control.Copy,
 		fault.New(true))
 	assert.NoError(t, err, clues.ToCore(err))
 	assert.NotNil(t, info, "contact item info")
@@ -141,6 +144,8 @@ func (suite *RestoreIntgSuite) TestRestoreEvent() {
 				ctx,
 				test.bytes,
 				userID, calendarID,
+				nil,
+				control.Copy,
 				fault.New(true))
 			assert.NoError(t, err, clues.ToCore(err))
 			assert.NotNil(t, info, "event item info")
@@ -367,6 +372,8 @@ func (suite *RestoreIntgSuite) TestRestoreExchangeObject() {
 				ctx,
 				test.bytes,
 				userID, destination,
+				nil,
+				control.Copy,
 				fault.New(true))
 			assert.NoError(t, err, clues.ToCore(err))
 			assert.NotNil(t, info, "item info was not populated")

--- a/src/pkg/services/m365/api/events.go
+++ b/src/pkg/services/m365/api/events.go
@@ -380,8 +380,7 @@ func parseableToMap(att serialization.Parsable) (map[string]any, error) {
 func (c Events) GetAttachments(
 	ctx context.Context,
 	immutableIDs bool,
-	userID string,
-	itemID string,
+	userID, itemID string,
 ) ([]models.Attachmentable, error) {
 	config := &users.ItemEventsItemAttachmentsRequestBuilderGetRequestConfiguration{
 		QueryParameters: &users.ItemEventsItemAttachmentsRequestBuilderGetQueryParameters{
@@ -424,8 +423,7 @@ func (c Events) DeleteAttachment(
 
 func (c Events) GetItemInstances(
 	ctx context.Context,
-	userID, itemID string,
-	startDate, endDate string,
+	userID, itemID, startDate, endDate string,
 ) ([]models.Eventable, error) {
 	config := &users.ItemEventsItemInstancesRequestBuilderGetRequestConfiguration{
 		QueryParameters: &users.ItemEventsItemInstancesRequestBuilderGetQueryParameters{


### PR DESCRIPTION
adds item collision handling to exchange restores. Currently an incomplete implementation; the replace setting will skip the restore altogether (no-op) as a first pass.  The next PR will finish out the replace behavior.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #3562

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
