### PR TITLE
add the non-delta item pager to drives

### DIFF
--- a/src/pkg/services/m365/api/contacts_pager_test.go
+++ b/src/pkg/services/m365/api/contacts_pager_test.go
@@ -30,7 +30,7 @@ func (suite *ContactsPagerIntgSuite) SetupSuite() {
 	suite.its = newIntegrationTesterSetup(suite.T())
 }
 
-func (suite *ContactsPagerIntgSuite) TestGetItemsInContainerByCollisionKey() {
+func (suite *ContactsPagerIntgSuite) TestContacts_GetItemsInContainerByCollisionKey() {
 	t := suite.T()
 	ac := suite.its.ac.Contacts()
 

--- a/src/pkg/services/m365/api/drive.go
+++ b/src/pkg/services/m365/api/drive.go
@@ -37,14 +37,14 @@ var ErrFolderNotFound = clues.New("folder not found")
 // GetFolderByName will lookup the specified folder by name within the parentFolderID folder.
 func (c Drives) GetFolderByName(
 	ctx context.Context,
-	driveID, parentFolderID, folderID string,
+	driveID, parentFolderID, folderName string,
 ) (models.DriveItemable, error) {
 	// The `Children().Get()` API doesn't yet support $filter, so using that to find a folder
 	// will be sub-optimal.
 	// Instead, we leverage OneDrive path-based addressing -
 	// https://learn.microsoft.com/en-us/graph/onedrive-addressing-driveitems#path-based-addressing
 	// - which allows us to lookup an item by its path relative to the parent ID
-	rawURL := fmt.Sprintf(itemByPathRawURLFmt, driveID, parentFolderID, folderID)
+	rawURL := fmt.Sprintf(itemByPathRawURLFmt, driveID, parentFolderID, folderName)
 	builder := drives.NewItemItemsDriveItemItemRequestBuilder(rawURL, c.Stable.Adapter())
 
 	foundItem, err := builder.Get(ctx, nil)

--- a/src/pkg/services/m365/api/drive_pager.go
+++ b/src/pkg/services/m365/api/drive_pager.go
@@ -18,6 +18,84 @@ import (
 )
 
 // ---------------------------------------------------------------------------
+// non-delta item pager
+// ---------------------------------------------------------------------------
+
+var _ itemPager[models.DriveItemable] = &driveItemPageCtrl{}
+
+type driveItemPageCtrl struct {
+	gs      graph.Servicer
+	builder *drives.ItemItemsItemChildrenRequestBuilder
+	options *drives.ItemItemsItemChildrenRequestBuilderGetRequestConfiguration
+}
+
+func (c Drives) NewDriveItemPager(
+	driveID, containerID string,
+	selectProps ...string,
+) itemPager[models.DriveItemable] {
+	options := &drives.ItemItemsItemChildrenRequestBuilderGetRequestConfiguration{
+		QueryParameters: &drives.ItemItemsItemChildrenRequestBuilderGetQueryParameters{
+			Top: ptr.To(maxNonDeltaPageSize),
+		},
+	}
+
+	if len(selectProps) > 0 {
+		options.QueryParameters.Select = selectProps
+	}
+
+	builder := c.Stable.
+		Client().
+		Drives().
+		ByDriveId(driveID).
+		Items().
+		ByDriveItemId(containerID).
+		Children()
+
+	return &driveItemPageCtrl{c.Stable, builder, options}
+}
+
+func (p *driveItemPageCtrl) getPage(ctx context.Context) (PageLinkValuer[models.DriveItemable], error) {
+	page, err := p.builder.Get(ctx, p.options)
+	if err != nil {
+		return nil, graph.Stack(ctx, err)
+	}
+
+	return EmptyDeltaLinker[models.DriveItemable]{PageLinkValuer: page}, nil
+}
+
+func (p *driveItemPageCtrl) setNext(nextLink string) {
+	p.builder = drives.NewItemItemsItemChildrenRequestBuilder(nextLink, p.gs.Adapter())
+}
+
+func (c Drives) GetItemsInContainerByCollisionKey(
+	ctx context.Context,
+	driveID, containerID string,
+) (map[string]string, error) {
+	ctx = clues.Add(ctx, "container_id", containerID)
+	pager := c.NewDriveItemPager(driveID, containerID, idAnd("name", "file", "folder")...)
+
+	items, err := enumerateItems(ctx, pager)
+	if err != nil {
+		return nil, graph.Wrap(ctx, err, "enumerating drive items")
+	}
+
+	m := map[string]string{}
+
+	for _, item := range items {
+		// folders are returned in this query, we only want the files
+		if item.GetFile() == nil {
+			continue
+		}
+
+		m[DriveItemCollisionKey(item)] = ptr.Val(item.GetId())
+	}
+
+	return m, nil
+}
+
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
 // delta item pager
 // ---------------------------------------------------------------------------
 

--- a/src/pkg/services/m365/api/drive_pager.go
+++ b/src/pkg/services/m365/api/drive_pager.go
@@ -54,6 +54,7 @@ func (c Drives) NewDriveItemPager(
 	return &driveItemPageCtrl{c.Stable, builder, options}
 }
 
+//lint:ignore U1000 False Positive
 func (p *driveItemPageCtrl) getPage(ctx context.Context) (PageLinkValuer[models.DriveItemable], error) {
 	page, err := p.builder.Get(ctx, p.options)
 	if err != nil {
@@ -63,6 +64,7 @@ func (p *driveItemPageCtrl) getPage(ctx context.Context) (PageLinkValuer[models.
 	return EmptyDeltaLinker[models.DriveItemable]{PageLinkValuer: page}, nil
 }
 
+//lint:ignore U1000 False Positive
 func (p *driveItemPageCtrl) setNext(nextLink string) {
 	p.builder = drives.NewItemItemsItemChildrenRequestBuilder(nextLink, p.gs.Adapter())
 }
@@ -72,7 +74,7 @@ func (c Drives) GetItemsInContainerByCollisionKey(
 	driveID, containerID string,
 ) (map[string]string, error) {
 	ctx = clues.Add(ctx, "container_id", containerID)
-	pager := c.NewDriveItemPager(driveID, containerID, idAnd("name", "file", "folder")...)
+	pager := c.NewDriveItemPager(driveID, containerID, idAnd("name")...)
 
 	items, err := enumerateItems(ctx, pager)
 	if err != nil {
@@ -82,11 +84,6 @@ func (c Drives) GetItemsInContainerByCollisionKey(
 	m := map[string]string{}
 
 	for _, item := range items {
-		// folders are returned in this query, we only want the files
-		if item.GetFile() == nil {
-			continue
-		}
-
 		m[DriveItemCollisionKey(item)] = ptr.Val(item.GetId())
 	}
 

--- a/src/pkg/services/m365/api/drive_pager_test.go
+++ b/src/pkg/services/m365/api/drive_pager_test.go
@@ -1,0 +1,65 @@
+package api_test
+
+import (
+	"testing"
+
+	"github.com/alcionai/clues"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/tester"
+)
+
+type DrivePagerIntgSuite struct {
+	tester.Suite
+	its intgTesterSetup
+}
+
+func TestDrivePagerIntgSuite(t *testing.T) {
+	suite.Run(t, &MailPagerIntgSuite{
+		Suite: tester.NewIntegrationSuite(
+			t,
+			[][]string{tester.M365AcctCredEnvs}),
+	})
+}
+
+func (suite *DrivePagerIntgSuite) SetupSuite() {
+	suite.its = newIntegrationTesterSetup(suite.T())
+}
+
+func (suite *DrivePagerIntgSuite) TestGetItemsInContainerByCollisionKey() {
+	table := []struct {
+		name         string
+		driveID      string
+		rootFolderID string
+	}{
+		{
+			name:         "user drive",
+			driveID:      suite.its.userDriveID,
+			rootFolderID: suite.its.userDriveRootFolderID,
+		},
+		{
+			name:         "site drive",
+			driveID:      suite.its.siteDriveID,
+			rootFolderID: suite.its.siteDriveRootFolderID,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			results, err := suite.its.ac.Drives().GetItemsInContainerByCollisionKey(ctx, test.driveID, test.rootFolderID)
+			require.NoError(t, err, clues.ToCore(err))
+			require.Less(t, 0, len(results), "requires at least one result")
+
+			for k, v := range results {
+				assert.NotEmpty(t, k, "all keys should be populated")
+				assert.NotEmpty(t, v, "all values should be populated")
+			}
+		})
+	}
+}

--- a/src/pkg/services/m365/api/drive_pager_test.go
+++ b/src/pkg/services/m365/api/drive_pager_test.go
@@ -52,8 +52,7 @@ func (suite *DrivePagerIntgSuite) TestDrives_GetItemsInContainerByCollisionKey()
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			ac := suite.its.ac.Drives()
-			items, err := ac.Stable.
+			items, err := suite.its.ac.Stable.
 				Client().
 				Drives().
 				ByDriveId(test.driveID).
@@ -63,14 +62,18 @@ func (suite *DrivePagerIntgSuite) TestDrives_GetItemsInContainerByCollisionKey()
 				Get(ctx, nil)
 			require.NoError(t, err, clues.ToCore(err))
 
-			is := items.GetValue()
-			expect := make([]string, 0, len(is))
+			ims := items.GetValue()
+			expect := make([]string, 0, len(ims))
 
-			require.NotZero(t, len(expect), "need at least one item to compare against")
+			assert.NotEmptyf(
+				t,
+				ims,
+				"need at least one item to compare in user %s drive %s folder %s",
+				suite.its.userID, test.driveID, test.rootFolderID)
 
-			results, err := ac.GetItemsInContainerByCollisionKey(ctx, test.driveID, test.rootFolderID)
+			results, err := suite.its.ac.Drives().GetItemsInContainerByCollisionKey(ctx, test.driveID, test.rootFolderID)
 			require.NoError(t, err, clues.ToCore(err))
-			require.Less(t, 0, len(results), "requires at least one result")
+			require.NotEmpty(t, results)
 
 			for k, v := range results {
 				assert.NotEmpty(t, k, "all keys should be populated")

--- a/src/pkg/services/m365/api/events_pager_test.go
+++ b/src/pkg/services/m365/api/events_pager_test.go
@@ -30,7 +30,7 @@ func (suite *EventsPagerIntgSuite) SetupSuite() {
 	suite.its = newIntegrationTesterSetup(suite.T())
 }
 
-func (suite *EventsPagerIntgSuite) TestGetItemsInContainerByCollisionKey() {
+func (suite *EventsPagerIntgSuite) TestEvents_GetItemsInContainerByCollisionKey() {
 	t := suite.T()
 	ac := suite.its.ac.Events()
 

--- a/src/pkg/services/m365/api/helper_test.go
+++ b/src/pkg/services/m365/api/helper_test.go
@@ -18,11 +18,9 @@ type intgTesterSetup struct {
 	userID                string
 	userDriveID           string
 	userDriveRootFolderID string
-	userDriveTestFolderID string // root:/test
 	siteID                string
 	siteDriveID           string
 	siteDriveRootFolderID string
-	siteDriveTestFolderID string // root:/test
 }
 
 func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {

--- a/src/pkg/services/m365/api/helper_test.go
+++ b/src/pkg/services/m365/api/helper_test.go
@@ -9,16 +9,20 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
+	"github.com/alcionai/corso/src/pkg/services/m365/api/mock"
 )
 
 type intgTesterSetup struct {
 	ac                    api.Client
+	gockAC                api.Client
 	userID                string
 	userDriveID           string
 	userDriveRootFolderID string
+	userDriveTestFolderID string // root:/test
 	siteID                string
 	siteDriveID           string
 	siteDriveRootFolderID string
+	siteDriveTestFolderID string // root:/test
 }
 
 func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
@@ -34,6 +38,11 @@ func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
 	its.ac, err = api.NewClient(creds)
 	require.NoError(t, err, clues.ToCore(err))
 
+	its.gockAC, err = mock.NewClient(creds)
+	require.NoError(t, err, clues.ToCore(err))
+
+	// user drive
+
 	its.userID = tester.M365UserID(t)
 
 	userDrive, err := its.ac.Users().GetDefaultDrive(ctx, its.userID)
@@ -47,6 +56,8 @@ func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
 	its.userDriveRootFolderID = ptr.Val(userDriveRootFolder.GetId())
 
 	its.siteID = tester.M365SiteID(t)
+
+	// site
 
 	siteDrive, err := its.ac.Sites().GetDefaultDrive(ctx, its.siteID)
 	require.NoError(t, err, clues.ToCore(err))

--- a/src/pkg/services/m365/api/mail_pager_test.go
+++ b/src/pkg/services/m365/api/mail_pager_test.go
@@ -30,7 +30,7 @@ func (suite *MailPagerIntgSuite) SetupSuite() {
 	suite.its = newIntegrationTesterSetup(suite.T())
 }
 
-func (suite *MailPagerIntgSuite) TestGetItemsInContainerByCollisionKey() {
+func (suite *MailPagerIntgSuite) TestMail_GetItemsInContainerByCollisionKey() {
 	t := suite.T()
 	ac := suite.its.ac.Mail()
 


### PR DESCRIPTION
introduces a non-delta item pager to drives_pager, and a func for building an item collision detection cache.  Implementation is coming in the next PR.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #3562

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
