### PR TITLE
od: add per-container collision caching and checks

### DIFF
--- a/src/internal/m365/onedrive/handlers.go
+++ b/src/internal/m365/onedrive/handlers.go
@@ -80,7 +80,10 @@ type GetItemer interface {
 // ---------------------------------------------------------------------------
 
 type RestoreHandler interface {
+	DeleteItemer
+	DeleteItemPermissioner
 	GetFolderByNamer
+	GetItemsByCollisionKeyser
 	GetRootFolderer
 	ItemInfoAugmenter
 	NewItemContentUploader
@@ -90,13 +93,11 @@ type RestoreHandler interface {
 	UpdateItemLinkSharer
 }
 
-type NewItemContentUploader interface {
-	// NewItemContentUpload creates an upload session which is used as a writer
-	// for large item content.
-	NewItemContentUpload(
+type DeleteItemer interface {
+	DeleteItem(
 		ctx context.Context,
 		driveID, itemID string,
-	) (models.UploadSessionable, error)
+	) error
 }
 
 type DeleteItemPermissioner interface {
@@ -104,6 +105,28 @@ type DeleteItemPermissioner interface {
 		ctx context.Context,
 		driveID, itemID, permissionID string,
 	) error
+}
+
+type GetItemsByCollisionKeyser interface {
+	// GetItemsInContainerByCollisionKey looks up all items currently in
+	// the container, and returns them in a map[collisionKey]itemID.
+	// The collision key is uniquely defined by each category of data.
+	// Collision key checks are used during restore to handle the on-
+	// collision restore configurations that cause the item restore to get
+	// skipped, replaced, or copied.
+	GetItemsInContainerByCollisionKey(
+		ctx context.Context,
+		driveID, containerID string,
+	) (map[string]string, error)
+}
+
+type NewItemContentUploader interface {
+	// NewItemContentUpload creates an upload session which is used as a writer
+	// for large item content.
+	NewItemContentUpload(
+		ctx context.Context,
+		driveID, itemID string,
+	) (models.UploadSessionable, error)
 }
 
 type UpdateItemPermissioner interface {

--- a/src/internal/m365/onedrive/item_handler.go
+++ b/src/internal/m365/onedrive/item_handler.go
@@ -147,11 +147,11 @@ func (h itemRestoreHandler) AugmentItemInfo(
 	return augmentItemInfo(dii, item, size, parentPath)
 }
 
-func (h itemRestoreHandler) NewItemContentUpload(
+func (h itemRestoreHandler) DeleteItem(
 	ctx context.Context,
 	driveID, itemID string,
-) (models.UploadSessionable, error) {
-	return h.ac.NewItemContentUpload(ctx, driveID, itemID)
+) error {
+	return h.ac.DeleteItem(ctx, driveID, itemID)
 }
 
 func (h itemRestoreHandler) DeleteItemPermission(
@@ -159,6 +159,25 @@ func (h itemRestoreHandler) DeleteItemPermission(
 	driveID, itemID, permissionID string,
 ) error {
 	return h.ac.DeleteItemPermission(ctx, driveID, itemID, permissionID)
+}
+
+func (h itemRestoreHandler) GetItemsInContainerByCollisionKey(
+	ctx context.Context,
+	driveID, containerID string,
+) (map[string]string, error) {
+	m, err := h.ac.GetItemsInContainerByCollisionKey(ctx, driveID, containerID)
+	if err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+func (h itemRestoreHandler) NewItemContentUpload(
+	ctx context.Context,
+	driveID, itemID string,
+) (models.UploadSessionable, error) {
+	return h.ac.NewItemContentUpload(ctx, driveID, itemID)
 }
 
 func (h itemRestoreHandler) PostItemPermissionUpdate(

--- a/src/internal/m365/onedrive/mock/handlers.go
+++ b/src/internal/m365/onedrive/mock/handlers.go
@@ -235,8 +235,9 @@ type RestoreHandler struct {
 
 	CollisionKeyMap map[string]string
 
-	CalledDeleteItem bool
-	DeleteItemErr    error
+	CalledDeleteItem   bool
+	CalledDeleteItemOn string
+	DeleteItemErr      error
 
 	CalledPostItem bool
 	PostItemResp   models.DriveItemable
@@ -262,10 +263,12 @@ func (h *RestoreHandler) GetItemsInContainerByCollisionKey(
 }
 
 func (h *RestoreHandler) DeleteItem(
-	context.Context,
-	string, string,
+	_ context.Context,
+	_, itemID string,
 ) error {
 	h.CalledDeleteItem = true
+	h.CalledDeleteItemOn = itemID
+
 	return h.DeleteItemErr
 }
 

--- a/src/internal/m365/onedrive/mock/handlers.go
+++ b/src/internal/m365/onedrive/mock/handlers.go
@@ -233,11 +233,19 @@ func (m GetsItemPermission) GetItemPermission(
 type RestoreHandler struct {
 	ItemInfo details.ItemInfo
 
-	PostItemResp models.DriveItemable
-	PostItemErr  error
+	CollisionKeyMap map[string]string
+
+	CalledDeleteItem bool
+	DeleteItemErr    error
+
+	CalledPostItem bool
+	PostItemResp   models.DriveItemable
+	PostItemErr    error
+
+	UploadSessionErr error
 }
 
-func (h RestoreHandler) AugmentItemInfo(
+func (h *RestoreHandler) AugmentItemInfo(
 	details.ItemInfo,
 	models.DriveItemable,
 	int64,
@@ -246,29 +254,44 @@ func (h RestoreHandler) AugmentItemInfo(
 	return h.ItemInfo
 }
 
-func (h RestoreHandler) NewItemContentUpload(
+func (h *RestoreHandler) GetItemsInContainerByCollisionKey(
 	context.Context,
 	string, string,
-) (models.UploadSessionable, error) {
-	return nil, clues.New("not implemented")
+) (map[string]string, error) {
+	return h.CollisionKeyMap, nil
 }
 
-func (h RestoreHandler) DeleteItemPermission(
+func (h *RestoreHandler) DeleteItem(
+	context.Context,
+	string, string,
+) error {
+	h.CalledDeleteItem = true
+	return h.DeleteItemErr
+}
+
+func (h *RestoreHandler) DeleteItemPermission(
 	context.Context,
 	string, string, string,
 ) error {
-	return clues.New("not implemented")
+	return nil
 }
 
-func (h RestoreHandler) PostItemPermissionUpdate(
+func (h *RestoreHandler) NewItemContentUpload(
+	context.Context,
+	string, string,
+) (models.UploadSessionable, error) {
+	return models.NewUploadSession(), h.UploadSessionErr
+}
+
+func (h *RestoreHandler) PostItemPermissionUpdate(
 	context.Context,
 	string, string,
 	*drives.ItemItemsItemInvitePostRequestBody,
 ) (drives.ItemItemsItemInviteResponseable, error) {
-	return nil, clues.New("not implemented")
+	return drives.NewItemItemsItemInviteResponse(), nil
 }
 
-func (h RestoreHandler) PostItemLinkShareUpdate(
+func (h *RestoreHandler) PostItemLinkShareUpdate(
 	ctx context.Context,
 	driveID, itemID string,
 	body *drives.ItemItemsItemCreateLinkPostRequestBody,
@@ -276,25 +299,26 @@ func (h RestoreHandler) PostItemLinkShareUpdate(
 	return nil, clues.New("not implemented")
 }
 
-func (h RestoreHandler) PostItemInContainer(
+func (h *RestoreHandler) PostItemInContainer(
 	context.Context,
 	string, string,
 	models.DriveItemable,
 	control.CollisionPolicy,
 ) (models.DriveItemable, error) {
+	h.CalledPostItem = true
 	return h.PostItemResp, h.PostItemErr
 }
 
-func (h RestoreHandler) GetFolderByName(
+func (h *RestoreHandler) GetFolderByName(
 	context.Context,
 	string, string, string,
 ) (models.DriveItemable, error) {
-	return nil, clues.New("not implemented")
+	return models.NewDriveItem(), nil
 }
 
-func (h RestoreHandler) GetRootFolder(
+func (h *RestoreHandler) GetRootFolder(
 	context.Context,
 	string,
 ) (models.DriveItemable, error) {
-	return nil, clues.New("not implemented")
+	return models.NewDriveItem(), nil
 }

--- a/src/internal/m365/onedrive/mock/item.go
+++ b/src/internal/m365/onedrive/mock/item.go
@@ -81,9 +81,10 @@ func FileRespReadCloser(pl string) io.ReadCloser {
 	return io.NopCloser(bytes.NewReader([]byte(pl)))
 }
 
-const DriveFileMetaData = `{
-    "fileName": "fnords.txt"
-}`
+const (
+	DriveItemFileName = "fnords.txt"
+	DriveFileMetaData = `{"fileName": "` + DriveItemFileName + `"}`
+)
 
 //nolint:lll
 const DriveFilePayloadData = `{

--- a/src/internal/m365/onedrive/restore_test.go
+++ b/src/internal/m365/onedrive/restore_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	odConsts "github.com/alcionai/corso/src/internal/m365/onedrive/consts"
 	"github.com/alcionai/corso/src/internal/m365/onedrive/mock"
@@ -323,6 +324,8 @@ func (suite *RestoreUnitSuite) TestAugmentRestorePaths_DifferentRestorePath() {
 }
 
 func (suite *RestoreUnitSuite) TestRestoreItem_collisionHandling() {
+	const mndiID = "mndi-id"
+
 	table := []struct {
 		name          string
 		collisionKeys map[string]string
@@ -362,7 +365,7 @@ func (suite *RestoreUnitSuite) TestRestoreItem_collisionHandling() {
 		},
 		{
 			name:          "collision, copy",
-			collisionKeys: map[string]string{mock.DriveItemFileName: "smarf"},
+			collisionKeys: map[string]string{mock.DriveItemFileName: mndiID},
 			onCollision:   control.Copy,
 			expectSkipped: assert.False,
 			expectMock: func(t *testing.T, rh *mock.RestoreHandler) {
@@ -372,17 +375,18 @@ func (suite *RestoreUnitSuite) TestRestoreItem_collisionHandling() {
 		},
 		{
 			name:          "collision, replace",
-			collisionKeys: map[string]string{mock.DriveItemFileName: "smarf"},
+			collisionKeys: map[string]string{mock.DriveItemFileName: mndiID},
 			onCollision:   control.Replace,
 			expectSkipped: assert.False,
 			expectMock: func(t *testing.T, rh *mock.RestoreHandler) {
 				assert.True(t, rh.CalledPostItem, "new item posted")
 				assert.True(t, rh.CalledDeleteItem, "new item deleted")
+				assert.Equal(t, mndiID, rh.CalledDeleteItemOn, "deleted the correct item")
 			},
 		},
 		{
 			name:          "collision, skip",
-			collisionKeys: map[string]string{mock.DriveItemFileName: "smarf"},
+			collisionKeys: map[string]string{mock.DriveItemFileName: mndiID},
 			onCollision:   control.Skip,
 			expectSkipped: assert.True,
 			expectMock: func(t *testing.T, rh *mock.RestoreHandler) {
@@ -398,11 +402,12 @@ func (suite *RestoreUnitSuite) TestRestoreItem_collisionHandling() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
+			mndi := models.NewDriveItem()
+			mndi.SetId(ptr.To(mndiID))
+
 			var (
-				caches = NewRestoreCaches()
-				rh     = &mock.RestoreHandler{
-					PostItemResp: models.NewDriveItem(),
-				}
+				caches     = NewRestoreCaches()
+				rh         = &mock.RestoreHandler{PostItemResp: mndi}
 				restoreCfg = control.RestoreConfig{OnCollision: test.onCollision}
 				dpb        = odConsts.DriveFolderPrefixBuilder("driveID1")
 			)

--- a/src/internal/m365/sharepoint/library_handler.go
+++ b/src/internal/m365/sharepoint/library_handler.go
@@ -173,11 +173,11 @@ func (h libraryRestoreHandler) AugmentItemInfo(
 	return augmentItemInfo(dii, item, size, parentPath)
 }
 
-func (h libraryRestoreHandler) NewItemContentUpload(
+func (h libraryRestoreHandler) DeleteItem(
 	ctx context.Context,
 	driveID, itemID string,
-) (models.UploadSessionable, error) {
-	return h.ac.NewItemContentUpload(ctx, driveID, itemID)
+) error {
+	return h.ac.DeleteItem(ctx, driveID, itemID)
 }
 
 func (h libraryRestoreHandler) DeleteItemPermission(
@@ -185,6 +185,25 @@ func (h libraryRestoreHandler) DeleteItemPermission(
 	driveID, itemID, permissionID string,
 ) error {
 	return h.ac.DeleteItemPermission(ctx, driveID, itemID, permissionID)
+}
+
+func (h libraryRestoreHandler) GetItemsInContainerByCollisionKey(
+	ctx context.Context,
+	driveID, containerID string,
+) (map[string]string, error) {
+	m, err := h.ac.GetItemsInContainerByCollisionKey(ctx, driveID, containerID)
+	if err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+func (h libraryRestoreHandler) NewItemContentUpload(
+	ctx context.Context,
+	driveID, itemID string,
+) (models.UploadSessionable, error) {
+	return h.ac.NewItemContentUpload(ctx, driveID, itemID)
 }
 
 func (h libraryRestoreHandler) PostItemPermissionUpdate(


### PR DESCRIPTION
pushes collision checks in onedrive upward from the api layer (due to the bug with ConflictBehavior) and into the restore controller.  Collision resolution in drive follows the same pattern that we use in exchange.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #3562

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
