### PR TITLE
Update attachments for events which drift from series master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Do not display all the items that we restored at the end if there are more than 15. You can override this with `--verbose`.
 
-### Known Issues
-- Changes to attachments in instances of recurring events compared to the series master aren't restored
-
 ## [v0.8.0] (beta) - 2023-05-15
 
 ### Added

--- a/src/pkg/services/m365/api/events.go
+++ b/src/pkg/services/m365/api/events.go
@@ -241,9 +241,12 @@ func (c Events) GetItem(
 		return nil, nil, clues.Wrap(err, "fixup exception occurrences")
 	}
 
-	attachments, err := c.getAttachments(ctx, event, immutableIDs, userID, itemID)
-	if err != nil {
-		return nil, nil, err
+	var attachments []models.Attachmentable
+	if ptr.Val(event.GetHasAttachments()) || HasAttachments(event.GetBody()) {
+		attachments, err = c.GetAttachments(ctx, immutableIDs, userID, itemID)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	event.SetAttachments(attachments)
@@ -286,10 +289,14 @@ func fixupExceptionOccurrences(
 
 		// OPTIMIZATION: We don't have to store any of the
 		// attachments that carry over from the original
-		attachments, err := client.getAttachments(ctx, evt, immutableIDs, userID, ptr.Val(evt.GetId()))
-		if err != nil {
-			return clues.Wrap(err, "getting exception attachments").
-				With("exception_event_id", ptr.Val(evt.GetId()))
+
+		var attachments []models.Attachmentable
+		if ptr.Val(event.GetHasAttachments()) || HasAttachments(event.GetBody()) {
+			attachments, err = client.GetAttachments(ctx, immutableIDs, userID, ptr.Val(evt.GetId()))
+			if err != nil {
+				return clues.Wrap(err, "getting exception attachments").
+					With("exception_event_id", ptr.Val(evt.GetId()))
+			}
 		}
 
 		// This odd roundabout way of doing this is required as
@@ -370,17 +377,12 @@ func parseableToMap(att serialization.Parsable) (map[string]any, error) {
 	return item, nil
 }
 
-func (c Events) getAttachments(
+func (c Events) GetAttachments(
 	ctx context.Context,
-	event models.Eventable,
 	immutableIDs bool,
 	userID string,
 	itemID string,
 ) ([]models.Attachmentable, error) {
-	if !ptr.Val(event.GetHasAttachments()) && !HasAttachments(event.GetBody()) {
-		return nil, nil
-	}
-
 	config := &users.ItemEventsItemAttachmentsRequestBuilderGetRequestConfiguration{
 		QueryParameters: &users.ItemEventsItemAttachmentsRequestBuilderGetQueryParameters{
 			Expand: []string{"microsoft.graph.itemattachment/item"},
@@ -401,6 +403,21 @@ func (c Events) getAttachments(
 	}
 
 	return attached.GetValue(), nil
+}
+
+func (c Events) DeleteAttachment(
+	ctx context.Context,
+	userID, eventID, attachmentID string,
+) error {
+	return c.Stable.
+		Client().
+		Users().
+		ByUserId(userID).
+		Events().
+		ByEventId(eventID).
+		Attachments().
+		ByAttachmentId(attachmentID).
+		Delete(ctx, nil)
 }
 
 func (c Events) GetItemInstances(

--- a/website/docs/support/known-issues.md
+++ b/website/docs/support/known-issues.md
@@ -26,5 +26,3 @@ included in backup and restore.
 * SharePoint document library data can't be restored after the library has been deleted.
 
 * Sharing information of items in OneDrive/SharePoint using sharing links aren't backed up and restored.
-
-* Changes to attachments in instances of recurring events compared to the series master aren't restored


### PR DESCRIPTION
This updates any changes to attachments for individual event instances
for the ones that differ from the series master.<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
