### PR TITLE
Refresh URL cache using previous delta token

### DIFF
--- a/src/internal/m365/onedrive/collections_test.go
+++ b/src/internal/m365/onedrive/collections_test.go
@@ -2742,6 +2742,7 @@ func (suite *OneDriveCollectionsUnitSuite) TestAddURLCacheToDriveCollections() {
 			err := c.addURLCacheToDriveCollections(
 				ctx,
 				driveID,
+				"",
 				fault.New(true))
 			require.NoError(t, err, clues.ToCore(err))
 

--- a/src/internal/m365/onedrive/url_cache.go
+++ b/src/internal/m365/onedrive/url_cache.go
@@ -37,6 +37,7 @@ var _ getItemPropertyer = &urlCache{}
 // urlCache caches download URLs for drive items
 type urlCache struct {
 	driveID         string
+	prevDelta       string
 	idToProps       map[string]itemProps
 	lastRefreshTime time.Time
 	refreshInterval time.Duration
@@ -53,7 +54,7 @@ type urlCache struct {
 
 // newURLache creates a new URL cache for the specified drive ID
 func newURLCache(
-	driveID string,
+	driveID, prevDelta string,
 	refreshInterval time.Duration,
 	itemPager api.DriveItemEnumerator,
 	errs *fault.Bus,
@@ -70,6 +71,7 @@ func newURLCache(
 			idToProps:       make(map[string]itemProps),
 			lastRefreshTime: time.Time{},
 			driveID:         driveID,
+			prevDelta:       prevDelta,
 			refreshInterval: refreshInterval,
 			itemPager:       itemPager,
 			errs:            errs,
@@ -179,6 +181,8 @@ func (uc *urlCache) deltaQuery(
 	ctx context.Context,
 ) error {
 	logger.Ctx(ctx).Debug("starting delta query")
+	// Reset item pager to remove any previous state
+	uc.itemPager.Reset()
 
 	_, _, _, err := collectItems(
 		ctx,
@@ -187,7 +191,7 @@ func (uc *urlCache) deltaQuery(
 		"",
 		uc.updateCache,
 		map[string]string{},
-		"",
+		uc.prevDelta,
 		uc.errs)
 	if err != nil {
 		return clues.Wrap(err, "delta query")

--- a/src/internal/m365/onedrive/url_cache_test.go
+++ b/src/internal/m365/onedrive/url_cache_test.go
@@ -91,15 +91,16 @@ func (suite *URLCacheIntegrationSuite) TestURLCacheBasic() {
 	nfid := ptr.Val(newFolder.GetId())
 
 	collectorFunc := func(
-		ctx context.Context,
-		driveID, driveName string,
-		driveItems []models.DriveItemable,
-		oldPaths map[string]string,
-		newPaths map[string]string,
-		excluded map[string]struct{},
-		itemCollection map[string]map[string]string,
-		doNotMergeItems bool,
-		errs *fault.Bus,
+		context.Context,
+		string,
+		string,
+		[]models.DriveItemable,
+		map[string]string,
+		map[string]string,
+		map[string]struct{},
+		map[string]map[string]string,
+		bool,
+		*fault.Bus,
 	) error {
 		return nil
 	}

--- a/src/internal/m365/onedrive/url_cache_test.go
+++ b/src/internal/m365/onedrive/url_cache_test.go
@@ -112,6 +112,7 @@ func (suite *URLCacheIntegrationSuite) TestURLCacheBasic() {
 	// Create a new URL cache with a long TTL
 	cache, err := newURLCache(
 		suite.driveID,
+		"",
 		1*time.Hour,
 		driveItemPager,
 		fault.New(true))
@@ -404,6 +405,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 
 			cache, err := newURLCache(
 				driveID,
+				"",
 				1*time.Hour,
 				itemPager,
 				fault.New(true))
@@ -446,6 +448,7 @@ func (suite *URLCacheUnitSuite) TestNeedsRefresh() {
 
 	cache, err := newURLCache(
 		driveID,
+		"",
 		refreshInterval,
 		&mockItemPager{},
 		fault.New(true))
@@ -519,6 +522,7 @@ func (suite *URLCacheUnitSuite) TestNewURLCache() {
 			t := suite.T()
 			_, err := newURLCache(
 				test.driveID,
+				"",
 				test.refreshInt,
 				test.itemPager,
 				test.errors)


### PR DESCRIPTION
<!-- PR description-->

Currently we do full delta enumeration during cache refresh events. It has some disadvantages as listed in https://github.com/alcionai/corso/issues/3482 .

This PR allows us to instantiate the URL cache with a delta token. This delta token is identical to the one used during onedrive item enumeration.

The URL cache might do multiple delta queries(once every hour) using the same delta token.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [x] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)
* https://github.com/alcionai/corso/issues/3482

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
