### PR TITLE
adds test coverage for events in exchange incrementals

### DIFF
--- a/src/internal/m365/exchange/mock/event.go
+++ b/src/internal/m365/exchange/mock/event.go
@@ -407,8 +407,8 @@ func EventWithAttendeesBytes(subject string) []byte {
 // Body must contain a well-formatted string, consumable in a json payload.  IE: no unescaped newlines.
 func EventWith(
 	organizer, subject, body, bodyPreview,
-	originalStartDate, startDateTime, endDateTime, recurrence, attendees string,
-	attachments string, cancelledOccurrences, exceptionOccurrences string,
+	originalStartDate, startDateTime, endDateTime, recurrence, attendees,
+	attachments, cancelledOccurrences, exceptionOccurrences string,
 ) []byte {
 	hasAttachments := len(attachments) > 0
 	startDateTime = strings.TrimSuffix(startDateTime, "Z")

--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -1278,8 +1278,9 @@ func testExchangeContinuousBackups(suite *BackupOpIntegrationSuite, toggles cont
 			checkMetadataFilesExist(t, ctx, bupID, kw, ms, atid, uidn.ID(), service, categories)
 			deeTD.CheckBackupDetails(t, ctx, bupID, whatSet, ms, ss, expectDeets, true)
 
-			// FIXME: commented tests are flaky due to interference with other tests
-			// we need to find a better way to make good assertions here.
+			// FIXME: commented tests are flaky due to delta calls retaining data that is
+			// out of scope of the test data.
+			// we need to find a better way to make isolated assertions here.
 			// The addition of the deeTD package gives us enough coverage to comment
 			// out the tests for now and look to their improvemeng later.
 


### PR DESCRIPTION
We still have events excluded from the exchange
incrementals integration tests.  For future safety, these need to be part of the testing group.

However, there's a hitch.  Our primary test user is broken again, and cannot retrieve any calendars
except for the well-known set: calendars, birthdays, holidays.  We'll have to fix that before merging.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Supportability/Tests

#### Test Plan

- [x] :green_heart: E2E
