### PR TITLE
handle no sharepoint license err

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Handle OLE conversion errors when trying to fetch attachments
 - Fix uploading large attachments for emails and calendar
+- Return a ServiceNotEnabled error when a tenant has no active SharePoint license.
 
 ## [v0.9.0] (beta) - 2023-06-05
 

--- a/src/internal/m365/discovery/discovery.go
+++ b/src/internal/m365/discovery/discovery.go
@@ -29,6 +29,10 @@ type getWithInfoer interface {
 	GetInfoer
 }
 
+type GetDefaultDriver interface {
+	GetDefaultDrive(ctx context.Context, userID string) (models.Driveable, error)
+}
+
 type getAller interface {
 	GetAll(ctx context.Context, errs *fault.Bus) ([]models.Userable, error)
 }

--- a/src/internal/m365/graph/errors.go
+++ b/src/internal/m365/graph/errors.go
@@ -37,7 +37,7 @@ const (
 	// @microsoft.graph.conflictBehavior=fail finds a conflicting file.
 	nameAlreadyExists       errorCode = "nameAlreadyExists"
 	quotaExceeded           errorCode = "ErrorQuotaExceeded"
-	requestResourceNotFound errorCode = "Request_ResourceNotFound"
+	RequestResourceNotFound errorCode = "Request_ResourceNotFound"
 	resourceNotFound        errorCode = "ResourceNotFound"
 	resyncRequired          errorCode = "ResyncRequired" // alt: resyncRequired
 	syncFolderNotFound      errorCode = "ErrorSyncFolderNotFound"
@@ -56,17 +56,16 @@ const (
 type errorMessage string
 
 const (
-	IOErrDuringRead errorMessage = "IO error during request payload read"
+	IOErrDuringRead   errorMessage = "IO error during request payload read"
+	MysiteURLNotFound errorMessage = "unable to retrieve user's mysite url"
+	MysiteNotFound    errorMessage = "user's mysite not found"
+	NoSPLicense       errorMessage = "Tenant does not have a SPO license"
 )
 
 const (
-	mysiteURLNotFound = "unable to retrieve user's mysite url"
-	mysiteNotFound    = "user's mysite not found"
-)
-
-const (
-	LabelsMalware        = "malware_detected"
-	LabelsMysiteNotFound = "mysite_not_found"
+	LabelsMalware             = "malware_detected"
+	LabelsMysiteNotFound      = "mysite_not_found"
+	LabelsNoSharePointLicense = "no_sharepoint_license"
 
 	// LabelsSkippable is used to determine if an error is skippable
 	LabelsSkippable = "skippable_errors"
@@ -132,7 +131,7 @@ func IsErrExchangeMailFolderNotFound(err error) bool {
 }
 
 func IsErrUserNotFound(err error) bool {
-	return hasErrorCode(err, requestResourceNotFound)
+	return hasErrorCode(err, RequestResourceNotFound)
 }
 
 func IsErrResourceNotFound(err error) bool {
@@ -297,9 +296,15 @@ func setLabels(err *clues.Err, msg string) *clues.Err {
 		return nil
 	}
 
-	ml := strings.ToLower(msg)
-	if strings.Contains(ml, mysiteNotFound) || strings.Contains(ml, mysiteURLNotFound) {
+	f := filters.Contains([]string{msg})
+
+	if f.Compare(string(MysiteNotFound)) ||
+		f.Compare(string(MysiteURLNotFound)) {
 		err = err.Label(LabelsMysiteNotFound)
+	}
+
+	if f.Compare(string(NoSPLicense)) {
+		err = err.Label(LabelsNoSharePointLicense)
 	}
 
 	if IsMalware(err) {

--- a/src/pkg/services/m365/api/drive_pager.go
+++ b/src/pkg/services/m365/api/drive_pager.go
@@ -292,8 +292,8 @@ func GetAllDrives(
 		for i := 0; i <= maxRetryCount; i++ {
 			page, err = pager.GetPage(ctx)
 			if err != nil {
-				if clues.HasLabel(err, graph.LabelsMysiteNotFound) {
-					logger.Ctx(ctx).Infof("resource owner does not have a drive")
+				if clues.HasLabel(err, graph.LabelsMysiteNotFound) || clues.HasLabel(err, graph.LabelsNoSharePointLicense) {
+					logger.CtxErr(ctx, err).Infof("resource owner does not have a drive")
 					return make([]models.Driveable, 0), nil // no license or drives.
 				}
 

--- a/src/pkg/services/m365/api/mail_test.go
+++ b/src/pkg/services/m365/api/mail_test.go
@@ -203,8 +203,7 @@ func TestMailAPIIntgSuite(t *testing.T) {
 	suite.Run(t, &MailAPIIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs},
-		),
+			[][]string{tester.M365AcctCredEnvs}),
 	})
 }
 
@@ -219,7 +218,7 @@ func (suite *MailAPIIntgSuite) SetupSuite() {
 	suite.ac, err = mock.NewClient(m365)
 	require.NoError(t, err, clues.ToCore(err))
 
-	suite.user = tester.M365UserID(suite.T())
+	suite.user = tester.M365UserID(t)
 }
 
 func getJSONObject(t *testing.T, thing serialization.Parsable) map[string]interface{} {

--- a/src/pkg/services/m365/api/users.go
+++ b/src/pkg/services/m365/api/users.go
@@ -183,7 +183,7 @@ func (c Users) GetInfo(ctx context.Context, userID string) (*UserInfo, error) {
 	// check whether the user is able to access their onedrive drive.
 	// if they cannot, we can assume they are ineligible for onedrive backups.
 	if _, err := c.GetDefaultDrive(ctx, userID); err != nil {
-		if !clues.HasLabel(err, graph.LabelsMysiteNotFound) {
+		if !clues.HasLabel(err, graph.LabelsMysiteNotFound) || clues.HasLabel(err, graph.LabelsNoSharePointLicense) {
 			logger.CtxErr(ctx, err).Error("getting user's drive")
 			return nil, graph.Wrap(ctx, err, "getting user's drive")
 		}


### PR DESCRIPTION
adds handling for graph api responses
where the tenant does not have an active
sharepoint license.  For user's drives, this
will fall under the same "service not enabled"
behavior we use to determine if the drive can
get backed up.  For sites, this causes the
"get all sites" call to return a serviceNotEnabled error.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

#### Type of change

- [x] :bug: Bugfix

#### Issue(s)

* #3671

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
