### PR TITLE
Skip flaky test case for calendar exceptions

### DIFF
--- a/src/internal/m365/exchange/restore_test.go
+++ b/src/internal/m365/exchange/restore_test.go
@@ -389,6 +389,8 @@ func (suite *RestoreIntgSuite) TestRestoreExchangeObject() {
 func (suite *RestoreIntgSuite) TestRestoreAndBackupEvent_recurringInstancesWithAttachments() {
 	t := suite.T()
 
+	t.Skip("Bug 3675")
+
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 

--- a/src/internal/m365/exchange/restore_test.go
+++ b/src/internal/m365/exchange/restore_test.go
@@ -134,6 +134,11 @@ func (suite *RestoreIntgSuite) TestRestoreEvent() {
 	}
 
 	for _, test := range tests {
+		// Skip till https://github.com/alcionai/corso/issues/3675 is fixed
+		if test.name == "Test exceptionOccurrences" {
+			t.Skip("Bug 3675")
+		}
+
 		suite.Run(test.name, func() {
 			t := suite.T()
 


### PR DESCRIPTION
This test needs to be re-enabled with #3675 

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #3675 

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
