### PR TITLE
Follow up to handling link shares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - If a link share is created for an item with inheritance disabled
   (via the Graph API), the link shares restored in that item will
   not be inheritable by children
-- Link shares with password protection cannot be restored
+- Link shares with password protection can't be restored
 
 ## [v0.10.0] (beta) - 2023-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Return a ServiceNotEnabled error when a tenant has no active SharePoint license.
 
 ### Known issues
-- Partial inheritance of link shares from a parent folder can't be restored.
+* If a link share is created for an item with inheritance disabled
+  (via the Graph API), Corso does not restore any link shares on that
+  item that may be inherited after that
 - Link shares with password cannot be restored
 
 ## [v0.10.0] (beta) - 2023-06-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] (beta)
 
+### Added
+- Added support for backing up and restoring link shares
+
 ### Fixed
 - Return a ServiceNotEnabled error when a tenant has no active SharePoint license.
+
+### Known issues
+- Partial inheritance of link shares from a parent folder can't be restored.
+- Link shares with password cannot be restored
 
 ## [v0.10.0] (beta) - 2023-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] (beta)
 
 ### Added
-- Added support for backing up and restoring link shares
+- Drive items backup and restore link shares
 
 ### Fixed
 - Return a ServiceNotEnabled error when a tenant has no active SharePoint license.
 
 ### Known issues
-* If a link share is created for an item with inheritance disabled
-  (via the Graph API), Corso does not restore any link shares on that
-  item that may be inherited after that
-- Link shares with password cannot be restored
+- If a link share is created for an item with inheritance disabled
+  (via the Graph API), the link shares restored in that item will
+  not be inheritable by children
+- Link shares with password protection cannot be restored
 
 ## [v0.10.0] (beta) - 2023-06-26
 

--- a/src/internal/m365/onedrive/item.go
+++ b/src/internal/m365/onedrive/item.go
@@ -108,9 +108,8 @@ func downloadItemMeta(
 			return nil, 0, err
 		}
 
-		// TODO(meain): Enable links shares once we have the edge cases sorted out
-		// meta.LinkShares = metadata.FilterLinkShares(ctx, perm.GetValue())
 		meta.Permissions = metadata.FilterPermissions(ctx, perm.GetValue())
+		meta.LinkShares = metadata.FilterLinkShares(ctx, perm.GetValue())
 	}
 
 	metaJSON, err := json.Marshal(meta)

--- a/src/internal/m365/onedrive/metadata/permissions.go
+++ b/src/internal/m365/onedrive/metadata/permissions.go
@@ -76,6 +76,8 @@ func (p Permission) Equals(other Permission) bool {
 //     user and so restoring links without users is not useful.
 func DiffLinkShares(before, after []LinkShare) ([]LinkShare, []LinkShare) {
 	filteredBefore := []LinkShare{}
+	filteredAfter := []LinkShare{}
+
 	for _, ls := range before {
 		if len(ls.Entities) == 0 {
 			continue
@@ -84,7 +86,6 @@ func DiffLinkShares(before, after []LinkShare) ([]LinkShare, []LinkShare) {
 		filteredBefore = append(filteredBefore, ls)
 	}
 
-	filteredAfter := []LinkShare{}
 	for _, ls := range after {
 		if len(ls.Entities) == 0 {
 			continue

--- a/src/internal/m365/onedrive/metadata/permissions.go
+++ b/src/internal/m365/onedrive/metadata/permissions.go
@@ -90,7 +90,7 @@ func DiffLinkShares(before, after []LinkShare) ([]LinkShare, []LinkShare) {
 			continue
 		}
 
-		filteredAfter = append(filteredBefore, ls)
+		filteredAfter = append(filteredAfter, ls)
 	}
 
 	return DiffPermissions(filteredBefore, filteredAfter)

--- a/src/internal/m365/onedrive/metadata/permissions.go
+++ b/src/internal/m365/onedrive/metadata/permissions.go
@@ -69,47 +69,47 @@ func (p Permission) Equals(other Permission) bool {
 // filter out link shares which do not have any associated users. This
 // is useful for two reason:
 //   - When a user creates a link share on parent after creating a child
-//     link with `retainInheritedPermisisons`, all the previous link shares
+//     link with `retainInheritedPermissisons`, all the previous link shares
 //     are inherited onto the child but without any users associated with
 //     the share. We have to drop the empty ones to make sure we reset.
 //   - We are restoring link shares so that we can restore permissions for
 //     the user, but restoring links without users is not useful.
-func DiffLinkShares(before, after []LinkShare) ([]LinkShare, []LinkShare) {
-	filteredBefore := []LinkShare{}
-	filteredAfter := []LinkShare{}
+func DiffLinkShares(current, expected []LinkShare) ([]LinkShare, []LinkShare) {
+	filteredCurrent := []LinkShare{}
+	filteredExpected := []LinkShare{}
 
-	for _, ls := range before {
+	for _, ls := range current {
 		if len(ls.Entities) == 0 {
 			continue
 		}
 
-		filteredBefore = append(filteredBefore, ls)
+		filteredCurrent = append(filteredCurrent, ls)
 	}
 
-	for _, ls := range after {
+	for _, ls := range expected {
 		if len(ls.Entities) == 0 {
 			continue
 		}
 
-		filteredAfter = append(filteredAfter, ls)
+		filteredExpected = append(filteredExpected, ls)
 	}
 
-	return DiffPermissions(filteredBefore, filteredAfter)
+	return DiffPermissions(filteredCurrent, filteredExpected)
 }
 
 // DiffPermissions compares the before and after set, returning
 // the permissions that were added and removed (in that order)
 // in the after set.
-func DiffPermissions[T interface{ Equals(T) bool }](before, after []T) ([]T, []T) {
+func DiffPermissions[T interface{ Equals(T) bool }](current, expected []T) ([]T, []T) {
 	var (
 		added   = []T{}
 		removed = []T{}
 	)
 
-	for _, cp := range after {
+	for _, cp := range expected {
 		found := false
 
-		for _, pp := range before {
+		for _, pp := range current {
 			if cp.Equals(pp) {
 				found = true
 				break
@@ -121,10 +121,10 @@ func DiffPermissions[T interface{ Equals(T) bool }](before, after []T) ([]T, []T
 		}
 	}
 
-	for _, pp := range before {
+	for _, pp := range current {
 		found := false
 
-		for _, cp := range after {
+		for _, cp := range expected {
 			if cp.Equals(pp) {
 				found = true
 				break

--- a/src/internal/m365/onedrive/metadata/permissions.go
+++ b/src/internal/m365/onedrive/metadata/permissions.go
@@ -73,7 +73,7 @@ func (p Permission) Equals(other Permission) bool {
 //     are inherited onto the child but without any users associated with
 //     the share. We have to drop the empty ones to make sure we reset.
 //   - We are restoring link shares so that we can restore permissions for
-//     user and so restoring links without users is not useful.
+//     the user, but restoring links without users is not useful.
 func DiffLinkShares(before, after []LinkShare) ([]LinkShare, []LinkShare) {
 	filteredBefore := []LinkShare{}
 	filteredAfter := []LinkShare{}

--- a/src/internal/m365/onedrive/metadata/permissions_test.go
+++ b/src/internal/m365/onedrive/metadata/permissions_test.go
@@ -158,8 +158,8 @@ func (suite *PermissionsUnitTestSuite) TestDiffLinkShares() {
 	}
 
 	lsempty := LinkShare{
-		ID:   "id1",
-		Link: LinkShareLink{WebURL: "id1"},
+		ID:   "id2",
+		Link: LinkShareLink{WebURL: "id2"},
 	}
 
 	table := []struct {

--- a/src/internal/m365/onedrive/metadata/permissions_test.go
+++ b/src/internal/m365/onedrive/metadata/permissions_test.go
@@ -149,6 +149,71 @@ func (suite *PermissionsUnitTestSuite) TestDiffPermissions() {
 	}
 }
 
+func (suite *PermissionsUnitTestSuite) TestDiffLinkShares() {
+	entities1 := []Entity{{ID: "e1"}}
+	ls1 := LinkShare{
+		ID:       "id1",
+		Entities: entities1,
+		Link:     LinkShareLink{WebURL: "id1"},
+	}
+
+	lsempty := LinkShare{
+		ID:   "id1",
+		Link: LinkShareLink{WebURL: "id1"},
+	}
+
+	table := []struct {
+		name    string
+		before  []LinkShare
+		after   []LinkShare
+		added   []LinkShare
+		removed []LinkShare
+	}{
+		{
+			name:    "single link share added",
+			before:  []LinkShare{},
+			after:   []LinkShare{ls1},
+			added:   []LinkShare{ls1},
+			removed: []LinkShare{},
+		},
+		{
+			name:    "empty filtered from before",
+			before:  []LinkShare{lsempty},
+			after:   []LinkShare{},
+			added:   []LinkShare{},
+			removed: []LinkShare{},
+		},
+		{
+			name:    "empty filtered from after",
+			before:  []LinkShare{},
+			after:   []LinkShare{lsempty},
+			added:   []LinkShare{},
+			removed: []LinkShare{},
+		},
+		{
+			name:    "empty filtered from both",
+			before:  []LinkShare{lsempty, ls1},
+			after:   []LinkShare{lsempty},
+			added:   []LinkShare{},
+			removed: []LinkShare{ls1},
+		},
+	}
+
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			_, flush := tester.NewContext(t)
+			defer flush()
+
+			added, removed := DiffLinkShares(test.before, test.after)
+
+			assert.Equal(t, added, test.added, "added link shares")
+			assert.Equal(t, removed, test.removed, "removed link shares")
+		})
+	}
+}
+
 func getPermsAndResourceOwnerPerms(
 	permID, resourceOwner string,
 	gv2t GV2Type,

--- a/src/internal/m365/onedrive/permission.go
+++ b/src/internal/m365/onedrive/permission.go
@@ -350,7 +350,7 @@ func RestorePermissions(
 	}
 
 	permAdded, permRemoved := metadata.DiffPermissions(previous.Permissions, current.Permissions)
-	lsAdded, lsRemoved := metadata.DiffPermissions(previous.LinkShares, current.LinkShares)
+	lsAdded, lsRemoved := metadata.DiffLinkShares(previous.LinkShares, current.LinkShares)
 
 	err = UpdatePermissions(
 		ctx,

--- a/src/internal/m365/onedrive/permission.go
+++ b/src/internal/m365/onedrive/permission.go
@@ -372,7 +372,7 @@ func UpdateLinkShares(
 	// It is possible to have empty link shares even though we should
 	// have inherited one if the user creates a link using
 	// `retainInheritedPermissions` as false, but then deleted it.  We
-	// can recreate this by creating an anonymous one and deleting it.
+	// can recreate this by creating a link with no users and deleting it.
 	if len(lsRemoved) > 0 && len(lsAdded) == 0 {
 		lsbody := drives.NewItemItemsItemCreateLinkPostRequestBody()
 		lsbody.SetType(ptr.To("view"))
@@ -424,6 +424,9 @@ func RestorePermissions(
 
 	lsAdded, lsRemoved := metadata.DiffLinkShares(previousLinkShares, current.LinkShares)
 
+	// Link shares have to be updated before permissions as we have to
+	// use the information about if we had to reset the inheritance to
+	// decide if we have to restore all the permissions.
 	didReset, err := UpdateLinkShares(
 		ctx,
 		rh,

--- a/src/internal/m365/onedrive/permission.go
+++ b/src/internal/m365/onedrive/permission.go
@@ -439,6 +439,7 @@ func RestorePermissions(
 
 	permRemoved := []metadata.Permission{}
 	permAdded := current.Permissions
+
 	if !didReset {
 		// In case we did a reset of permissions when restoring link
 		// shares, we have to make sure to restore all the permissions

--- a/src/internal/m365/onedrive/stub/stub.go
+++ b/src/internal/m365/onedrive/stub/stub.go
@@ -45,25 +45,27 @@ func getMetadata(fileName string, meta MetaData, permUseID bool) metadata.Metada
 		testMeta.Permissions = []metadata.Permission{uperm}
 	}
 
-	if len(meta.LinkShares.EntityIDs) != 0 {
-		id := strings.Join(meta.LinkShares.EntityIDs, "-") + meta.LinkShares.Scope + meta.LinkShares.Type
+	if len(meta.LinkShares) != 0 {
+		for _, ls := range meta.LinkShares {
+			id := strings.Join(ls.EntityIDs, "-") + ls.Scope + ls.Type
 
-		entities := []metadata.Entity{}
-		for _, e := range meta.LinkShares.EntityIDs {
-			entities = append(entities, metadata.Entity{ID: e, EntityType: "user"})
+			entities := []metadata.Entity{}
+			for _, e := range ls.EntityIDs {
+				entities = append(entities, metadata.Entity{ID: e, EntityType: "user"})
+			}
+
+			ls := metadata.LinkShare{
+				ID: id, // id is required for mapping from parent
+				Link: metadata.LinkShareLink{
+					Scope:  ls.Scope,
+					Type:   ls.Type,
+					WebURL: id,
+				},
+				Entities: entities,
+			}
+
+			testMeta.LinkShares = append(testMeta.LinkShares, ls)
 		}
-
-		ls := metadata.LinkShare{
-			ID: id, // id is required for mapping from parent
-			Link: metadata.LinkShareLink{
-				Scope:  meta.LinkShares.Scope,
-				Type:   meta.LinkShares.Type,
-				WebURL: id,
-			},
-			Entities: entities,
-		}
-
-		testMeta.LinkShares = []metadata.LinkShare{ls}
 	}
 
 	return testMeta
@@ -84,7 +86,7 @@ type LinkShareData struct {
 type MetaData struct {
 	SharingMode metadata.SharingMode
 	Perms       PermData
-	LinkShares  LinkShareData
+	LinkShares  []LinkShareData
 }
 
 type ItemData struct {

--- a/src/internal/m365/onedrive_test.go
+++ b/src/internal/m365/onedrive_test.go
@@ -1039,6 +1039,7 @@ func testLinkSharesInheritanceRestoreAndBackup(suite oneDriveSuite, startVersion
 
 	folderAName := "custom"
 	folderBName := "inherited"
+	folderCName := "empty"
 
 	rootPath := []string{
 		odConsts.DrivesPathDir,
@@ -1065,6 +1066,13 @@ func testLinkSharesInheritanceRestoreAndBackup(suite oneDriveSuite, startVersion
 		folderAName,
 		folderBName,
 	}
+	subfolderACPath := []string{
+		odConsts.DrivesPathDir,
+		driveID,
+		odConsts.RootPathDir,
+		folderAName,
+		folderCName,
+	}
 
 	fileSet := []stub.ItemData{
 		{
@@ -1086,18 +1094,32 @@ func testLinkSharesInheritanceRestoreAndBackup(suite oneDriveSuite, startVersion
 				SharingMode: metadata.SharingModeInherited,
 			},
 		},
+		{
+			Name: "file-empty",
+			Data: fileCData,
+			Meta: stub.MetaData{
+				SharingMode: metadata.SharingModeCustom,
+			},
+		},
 	}
 
 	// Here is what this test is testing
 	// - custom-link-share-folder
 	//   - custom-link-share-file
 	//   - inherted-link-share-file
+	//   - empty-link-share-file
 	//   - custom-link-share-folder
 	// 	   - custom-link-share-file
 	// 	   - inherted-link-share-file
+	//     - empty-link-share-file
 	//   - inherted-link-share-folder
 	// 	   - custom-link-share-file
 	// 	   - inherted-link-share-file
+	//     - empty-link-share-file
+	//   - empty-link-share-folder
+	// 	   - custom-link-share-file
+	// 	   - inherted-link-share-file
+	//     - empty-link-share-file
 
 	cols := []stub.ColInfo{
 		{
@@ -1113,6 +1135,7 @@ func testLinkSharesInheritanceRestoreAndBackup(suite oneDriveSuite, startVersion
 			Folders: []stub.ItemData{
 				{Name: folderAName},
 				{Name: folderBName},
+				{Name: folderCName},
 			},
 			Meta: stub.MetaData{
 				LinkShares: stub.LinkShareData{
@@ -1139,6 +1162,13 @@ func testLinkSharesInheritanceRestoreAndBackup(suite oneDriveSuite, startVersion
 			Files:        fileSet,
 			Meta: stub.MetaData{
 				SharingMode: metadata.SharingModeInherited,
+			},
+		},
+		{
+			PathElements: subfolderACPath,
+			Files:        fileSet,
+			Meta: stub.MetaData{
+				SharingMode: metadata.SharingModeCustom,
 			},
 		},
 	}

--- a/src/internal/m365/onedrive_test.go
+++ b/src/internal/m365/onedrive_test.go
@@ -1079,10 +1079,12 @@ func testLinkSharesInheritanceRestoreAndBackup(suite oneDriveSuite, startVersion
 			Name: "file-custom",
 			Data: fileAData,
 			Meta: stub.MetaData{
-				LinkShares: stub.LinkShareData{
-					EntityIDs: []string{secondaryUserID},
-					Scope:     "users",
-					Type:      "edit",
+				LinkShares: []stub.LinkShareData{
+					{
+						EntityIDs: []string{secondaryUserID},
+						Scope:     "users",
+						Type:      "edit",
+					},
 				},
 				SharingMode: metadata.SharingModeCustom,
 			},
@@ -1138,10 +1140,12 @@ func testLinkSharesInheritanceRestoreAndBackup(suite oneDriveSuite, startVersion
 				{Name: folderCName},
 			},
 			Meta: stub.MetaData{
-				LinkShares: stub.LinkShareData{
-					EntityIDs: []string{tertiaryUserID},
-					Scope:     "users",
-					Type:      "view",
+				LinkShares: []stub.LinkShareData{
+					{
+						EntityIDs: []string{tertiaryUserID},
+						Scope:     "anonymous",
+						Type:      "edit",
+					},
 				},
 			},
 		},
@@ -1149,10 +1153,12 @@ func testLinkSharesInheritanceRestoreAndBackup(suite oneDriveSuite, startVersion
 			PathElements: subfolderAAPath,
 			Files:        fileSet,
 			Meta: stub.MetaData{
-				LinkShares: stub.LinkShareData{
-					EntityIDs: []string{tertiaryUserID},
-					Scope:     "users",
-					Type:      "edit",
+				LinkShares: []stub.LinkShareData{
+					{
+						EntityIDs: []string{tertiaryUserID},
+						Scope:     "users",
+						Type:      "edit",
+					},
 				},
 				SharingMode: metadata.SharingModeCustom,
 			},

--- a/src/internal/m365/onedrive_test.go
+++ b/src/internal/m365/onedrive_test.go
@@ -420,13 +420,17 @@ func testRestoreAndBackupMultipleFilesAndFoldersNoPermissions(
 		folderBName,
 	}
 
+	defaultMetadata := stub.MetaData{SharingMode: metadata.SharingModeInherited}
+
 	cols := []stub.ColInfo{
 		{
 			PathElements: rootPath,
+			Meta:         defaultMetadata,
 			Files: []stub.ItemData{
 				{
 					Name: fileName,
 					Data: fileAData,
+					Meta: defaultMetadata,
 				},
 			},
 			Folders: []stub.ItemData{
@@ -440,10 +444,12 @@ func testRestoreAndBackupMultipleFilesAndFoldersNoPermissions(
 		},
 		{
 			PathElements: folderAPath,
+			Meta:         defaultMetadata,
 			Files: []stub.ItemData{
 				{
 					Name: fileName,
 					Data: fileBData,
+					Meta: defaultMetadata,
 				},
 			},
 			Folders: []stub.ItemData{
@@ -454,10 +460,12 @@ func testRestoreAndBackupMultipleFilesAndFoldersNoPermissions(
 		},
 		{
 			PathElements: subfolderBPath,
+			Meta:         defaultMetadata,
 			Files: []stub.ItemData{
 				{
 					Name: fileName,
 					Data: fileCData,
+					Meta: defaultMetadata,
 				},
 			},
 			Folders: []stub.ItemData{
@@ -468,19 +476,23 @@ func testRestoreAndBackupMultipleFilesAndFoldersNoPermissions(
 		},
 		{
 			PathElements: subfolderAPath,
+			Meta:         defaultMetadata,
 			Files: []stub.ItemData{
 				{
 					Name: fileName,
 					Data: fileDData,
+					Meta: defaultMetadata,
 				},
 			},
 		},
 		{
 			PathElements: folderBPath,
+			Meta:         defaultMetadata,
 			Files: []stub.ItemData{
 				{
 					Name: fileName,
 					Data: fileEData,
+					Meta: defaultMetadata,
 				},
 			},
 		},

--- a/src/internal/m365/onedrive_test.go
+++ b/src/internal/m365/onedrive_test.go
@@ -361,6 +361,10 @@ func (suite *OneDriveNightlySuite) TestPermissionsInheritanceRestoreAndBackup() 
 	testPermissionsInheritanceRestoreAndBackup(suite, version.OneDrive4DirIncludesPermissions)
 }
 
+func (suite *OneDriveNightlySuite) TestLinkSharesInheritanceRestoreAndBackup() {
+	testLinkSharesInheritanceRestoreAndBackup(suite, version.Backup)
+}
+
 func (suite *OneDriveNightlySuite) TestRestoreFolderNamedFolderRegression() {
 	// No reason why it couldn't work with previous versions, but this is when it got introduced.
 	testRestoreFolderNamedFolderRegression(suite, version.All8MigrateUserPNToID)

--- a/src/internal/m365/onedrive_test.go
+++ b/src/internal/m365/onedrive_test.go
@@ -582,6 +582,9 @@ func testPermissionsRestoreAndBackup(suite oneDriveSuite, startVersion int) {
 	cols := []stub.ColInfo{
 		{
 			PathElements: rootPath,
+			Meta: stub.MetaData{
+				SharingMode: metadata.SharingModeInherited,
+			},
 			Files: []stub.ItemData{
 				{
 					// Test restoring a file that doesn't inherit permissions.
@@ -600,11 +603,17 @@ func testPermissionsRestoreAndBackup(suite oneDriveSuite, startVersion int) {
 					// no permissions.
 					Name: fileName2,
 					Data: fileBData,
+					Meta: stub.MetaData{
+						SharingMode: metadata.SharingModeInherited,
+					},
 				},
 			},
 			Folders: []stub.ItemData{
 				{
 					Name: folderBName,
+					Meta: stub.MetaData{
+						SharingMode: metadata.SharingModeInherited,
+					},
 				},
 				{
 					Name: folderAName,
@@ -630,6 +639,9 @@ func testPermissionsRestoreAndBackup(suite oneDriveSuite, startVersion int) {
 		},
 		{
 			PathElements: folderBPath,
+			Meta: stub.MetaData{
+				SharingMode: metadata.SharingModeInherited,
+			},
 			Files: []stub.ItemData{
 				{
 					// Test restoring a file in a non-root folder that doesn't inherit
@@ -714,6 +726,9 @@ func testPermissionsRestoreAndBackup(suite oneDriveSuite, startVersion int) {
 				{
 					Name: fileName,
 					Data: fileAData,
+					Meta: stub.MetaData{
+						SharingMode: metadata.SharingModeInherited,
+					},
 				},
 			},
 			Meta: stub.MetaData{
@@ -793,6 +808,7 @@ func testPermissionsBackupAndNoRestore(suite oneDriveSuite, startVersion int) {
 							EntityID: secondaryUserID,
 							Roles:    writePerm,
 						},
+						SharingMode: metadata.SharingModeCustom,
 					},
 				},
 			},
@@ -903,34 +919,44 @@ func testPermissionsInheritanceRestoreAndBackup(suite oneDriveSuite, startVersio
 		folderCName,
 	}
 
-	fileSet := []stub.ItemData{
-		{
-			Name: "file-custom",
-			Data: fileAData,
-			Meta: stub.MetaData{
-				Perms: stub.PermData{
-					User:     secondaryUserName,
-					EntityID: secondaryUserID,
-					Roles:    writePerm,
-				},
-				SharingMode: metadata.SharingModeCustom,
+	fileCustom := stub.ItemData{
+		Name: "file-custom",
+		Data: fileAData,
+		Meta: stub.MetaData{
+			Perms: stub.PermData{
+				User:     secondaryUserName,
+				EntityID: secondaryUserID,
+				Roles:    writePerm,
 			},
-		},
-		{
-			Name: "file-inherited",
-			Data: fileAData,
-			Meta: stub.MetaData{
-				SharingMode: metadata.SharingModeInherited,
-			},
-		},
-		{
-			Name: "file-empty",
-			Data: fileAData,
-			Meta: stub.MetaData{
-				SharingMode: metadata.SharingModeCustom,
-			},
+			SharingMode: metadata.SharingModeCustom,
 		},
 	}
+	fileInherited := stub.ItemData{
+		Name: "file-inherited",
+		Data: fileAData,
+		Meta: stub.MetaData{
+			SharingMode: metadata.SharingModeInherited,
+		},
+	}
+	fileEmpty := stub.ItemData{
+		Name: "file-empty",
+		Data: fileAData,
+		Meta: stub.MetaData{
+			SharingMode: metadata.SharingModeCustom,
+		},
+	}
+
+	// If parent is empty, then empty permissions would be inherited
+	fileEmptyInherited := stub.ItemData{
+		Name: "file-empty",
+		Data: fileAData,
+		Meta: stub.MetaData{
+			SharingMode: metadata.SharingModeInherited,
+		},
+	}
+
+	fileSet := []stub.ItemData{fileCustom, fileInherited, fileEmpty}
+	fileSetEmpty := []stub.ItemData{fileCustom, fileInherited, fileEmptyInherited}
 
 	// Here is what this test is testing
 	// - custom-permission-folder
@@ -957,6 +983,9 @@ func testPermissionsInheritanceRestoreAndBackup(suite oneDriveSuite, startVersio
 			Folders: []stub.ItemData{
 				{Name: folderAName},
 			},
+			Meta: stub.MetaData{
+				SharingMode: metadata.SharingModeInherited,
+			},
 		},
 		{
 			PathElements: folderAPath,
@@ -972,6 +1001,7 @@ func testPermissionsInheritanceRestoreAndBackup(suite oneDriveSuite, startVersio
 					EntityID: tertiaryUserID,
 					Roles:    readPerm,
 				},
+				SharingMode: metadata.SharingModeCustom,
 			},
 		},
 		{
@@ -995,7 +1025,7 @@ func testPermissionsInheritanceRestoreAndBackup(suite oneDriveSuite, startVersio
 		},
 		{
 			PathElements: subfolderACPath,
-			Files:        fileSet,
+			Files:        fileSetEmpty,
 			Meta: stub.MetaData{
 				SharingMode: metadata.SharingModeCustom,
 			},

--- a/website/docs/support/known-issues.md
+++ b/website/docs/support/known-issues.md
@@ -28,3 +28,7 @@ included in backup and restore.
 * Sharing information of items in OneDrive/SharePoint using sharing links aren't backed up and restored.
 
 * Permissions/Access given to a site group can't be restored
+
+* If a link share is created for an item with inheritance disabled
+  (via the Graph API), Corso does not restore any link shares on that
+  item that may be inherited after that

--- a/website/docs/support/known-issues.md
+++ b/website/docs/support/known-issues.md
@@ -33,4 +33,4 @@ included in backup and restore.
   (via the Graph API), the link shares restored in that item will
   not be inheritable by children
 
-* Link shares with password protection cannot be restored
+* Link shares with password protection can't be restored

--- a/website/docs/support/known-issues.md
+++ b/website/docs/support/known-issues.md
@@ -30,5 +30,7 @@ included in backup and restore.
 * Permissions/Access given to a site group can't be restored
 
 * If a link share is created for an item with inheritance disabled
-  (via the Graph API), Corso does not restore any link shares on that
-  item that may be inherited after that
+  (via the Graph API), the link shares restored in that item will
+  not be inheritable by children
+
+* Link shares with password protection cannot be restored


### PR DESCRIPTION
Handle a few edge cases with link shares. Also handle empty link shares, plus inheritence works a bit differently for link shares compared to permissions.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* https://github.com/alcionai/corso/pull/3655
* https://github.com/alcionai/corso/issues/3605

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
