### PR TITLE
fix bad user info conditional on spo license

### DIFF
--- a/src/internal/m365/discovery/discovery.go
+++ b/src/internal/m365/discovery/discovery.go
@@ -85,7 +85,12 @@ func GetUserInfo(
 		return nil, err
 	}
 
-	return client.Users().GetInfo(ctx, userID)
+	aui, err := client.Users().GetInfo(ctx, userID)
+	if err != nil {
+		return nil, clues.Stack(err)
+	}
+
+	return aui, nil
 }
 
 // User fetches a single user's data.

--- a/src/internal/m365/graph/errors.go
+++ b/src/internal/m365/graph/errors.go
@@ -31,7 +31,7 @@ const (
 	errorAccessDenied           errorCode = "ErrorAccessDenied"
 	itemNotFound                errorCode = "ErrorItemNotFound"
 	itemNotFoundShort           errorCode = "itemNotFound"
-	mailboxNotEnabledForRESTAPI errorCode = "MailboxNotEnabledForRESTAPI"
+	MailboxNotEnabledForRESTAPI errorCode = "MailboxNotEnabledForRESTAPI"
 	malwareDetected             errorCode = "malwareDetected"
 	// nameAlreadyExists occurs when a request with
 	// @microsoft.graph.conflictBehavior=fail finds a conflicting file.
@@ -39,7 +39,7 @@ const (
 	quotaExceeded           errorCode = "ErrorQuotaExceeded"
 	RequestResourceNotFound errorCode = "Request_ResourceNotFound"
 	// Returned when we try to get the inbox of a user that doesn't exist.
-	resourceNotFound errorCode = "ResourceNotFound"
+	ResourceNotFound errorCode = "ResourceNotFound"
 	// Some datacenters are returning this when we try to get the inbox of a user
 	// that doesn't exist.
 	invalidUser        errorCode = "ErrorInvalidUser"
@@ -131,7 +131,7 @@ func IsErrQuotaExceeded(err error) bool {
 }
 
 func IsErrExchangeMailFolderNotFound(err error) bool {
-	return hasErrorCode(err, resourceNotFound, mailboxNotEnabledForRESTAPI)
+	return hasErrorCode(err, ResourceNotFound, MailboxNotEnabledForRESTAPI)
 }
 
 func IsErrUserNotFound(err error) bool {
@@ -139,7 +139,7 @@ func IsErrUserNotFound(err error) bool {
 		return true
 	}
 
-	if hasErrorCode(err, resourceNotFound) {
+	if hasErrorCode(err, ResourceNotFound) {
 		var odErr odataerrors.ODataErrorable
 		if !errors.As(err, &odErr) {
 			return false
@@ -154,7 +154,7 @@ func IsErrUserNotFound(err error) bool {
 }
 
 func IsErrResourceNotFound(err error) bool {
-	return hasErrorCode(err, resourceNotFound)
+	return hasErrorCode(err, ResourceNotFound)
 }
 
 func IsErrCannotOpenFileAttachment(err error) bool {

--- a/src/internal/m365/graph/errors_test.go
+++ b/src/internal/m365/graph/errors_test.go
@@ -235,7 +235,7 @@ func (suite *GraphErrorsUnitSuite) TestIsErrUserNotFound() {
 		{
 			name: "non-matching resource not found",
 			err: func() error {
-				res := odErr(string(resourceNotFound))
+				res := odErr(string(ResourceNotFound))
 				res.GetError().SetMessage(ptr.To("Calendar not found"))
 
 				return res
@@ -255,7 +255,7 @@ func (suite *GraphErrorsUnitSuite) TestIsErrUserNotFound() {
 		{
 			name: "resource not found oDataErr",
 			err: func() error {
-				res := odErr(string(resourceNotFound))
+				res := odErr(string(ResourceNotFound))
 				res.GetError().SetMessage(ptr.To("User not found"))
 
 				return res

--- a/src/pkg/services/m365/api/sites.go
+++ b/src/pkg/services/m365/api/sites.go
@@ -35,21 +35,29 @@ type Sites struct {
 // api calls
 // ---------------------------------------------------------------------------
 
-// GetAll retrieves all sites.
-func (c Sites) GetAll(ctx context.Context, errs *fault.Bus) ([]models.Siteable, error) {
-	service, err := c.Service()
+func (c Sites) GetRoot(ctx context.Context) (models.Siteable, error) {
+	resp, err := c.Stable.
+		Client().
+		Sites().
+		BySiteId("root").
+		Get(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, graph.Wrap(ctx, err, "getting root site")
 	}
 
-	resp, err := service.Client().Sites().Get(ctx, nil)
+	return resp, nil
+}
+
+// GetAll retrieves all sites.
+func (c Sites) GetAll(ctx context.Context, errs *fault.Bus) ([]models.Siteable, error) {
+	resp, err := c.Stable.Client().Sites().Get(ctx, nil)
 	if err != nil {
 		return nil, graph.Wrap(ctx, err, "getting all sites")
 	}
 
 	iter, err := msgraphgocore.NewPageIterator[models.Siteable](
 		resp,
-		service.Adapter(),
+		c.Stable.Adapter(),
 		models.CreateSiteCollectionResponseFromDiscriminatorValue)
 	if err != nil {
 		return nil, graph.Wrap(ctx, err, "creating sites iterator")
@@ -65,8 +73,8 @@ func (c Sites) GetAll(ctx context.Context, errs *fault.Bus) ([]models.Siteable, 
 			return false
 		}
 
-		err := validateSite(item)
-		if errors.Is(err, errKnownSkippableCase) {
+		err := ValidateSite(item)
+		if errors.Is(err, ErrKnownSkippableCase) {
 			// safe to no-op
 			return true
 		}
@@ -182,14 +190,14 @@ func (c Sites) GetDefaultDrive(
 // helpers
 // ---------------------------------------------------------------------------
 
-var errKnownSkippableCase = clues.New("case is known and skippable")
+var ErrKnownSkippableCase = clues.New("case is known and skippable")
 
-const personalSitePath = "sharepoint.com/personal/"
+const PersonalSitePath = "sharepoint.com/personal/"
 
-// validateSite ensures the item is a Siteable, and contains the necessary
+// ValidateSite ensures the item is a Siteable, and contains the necessary
 // identifiers that we handle with all users.
 // returns the item as a Siteable model.
-func validateSite(item models.Siteable) error {
+func ValidateSite(item models.Siteable) error {
 	id := ptr.Val(item.GetId())
 	if len(id) == 0 {
 		return clues.New("missing ID")
@@ -201,8 +209,8 @@ func validateSite(item models.Siteable) error {
 	}
 
 	// personal (ie: oneDrive) sites have to be filtered out server-side.
-	if strings.Contains(wURL, personalSitePath) {
-		return clues.Stack(errKnownSkippableCase).
+	if strings.Contains(wURL, PersonalSitePath) {
+		return clues.Stack(ErrKnownSkippableCase).
 			With("site_id", id, "site_web_url", wURL) // TODO: pii
 	}
 
@@ -210,7 +218,7 @@ func validateSite(item models.Siteable) error {
 	if len(name) == 0 {
 		// the built-in site at "https://{tenant-domain}/search" never has a name.
 		if strings.HasSuffix(wURL, "/search") {
-			return clues.Stack(errKnownSkippableCase).
+			return clues.Stack(ErrKnownSkippableCase).
 				With("site_id", id, "site_web_url", wURL) // TODO: pii
 		}
 

--- a/src/pkg/services/m365/api/users_test.go
+++ b/src/pkg/services/m365/api/users_test.go
@@ -1,14 +1,17 @@
-package api
+package api_test
 
 import (
 	"testing"
 
 	"github.com/alcionai/clues"
+	"github.com/h2non/gock"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type UsersUnitSuite struct {
@@ -57,8 +60,129 @@ func (suite *UsersUnitSuite) TestValidateUser() {
 		suite.Run(tt.name, func() {
 			t := suite.T()
 
-			err := validateUser(tt.args)
+			err := api.ValidateUser(tt.args)
 			tt.errCheck(t, err, clues.ToCore(err))
+		})
+	}
+}
+
+type UsersIntgSuite struct {
+	tester.Suite
+	its intgTesterSetup
+}
+
+func TestUsersIntgSuite(t *testing.T) {
+	suite.Run(t, &UsersIntgSuite{
+		Suite: tester.NewIntegrationSuite(
+			t,
+			[][]string{tester.M365AcctCredEnvs}),
+	})
+}
+
+func (suite *UsersIntgSuite) SetupSuite() {
+	suite.its = newIntegrationTesterSetup(suite.T())
+}
+
+func (suite *UsersIntgSuite) TestUsers_GetInfo_errors() {
+	table := []struct {
+		name      string
+		setGocks  func(t *testing.T)
+		expectErr func(t *testing.T, err error)
+	}{
+		{
+			name: "default drive err - mysite not found",
+			setGocks: func(t *testing.T) {
+				interceptV1Path("users", "user", "drive").
+					Reply(400).
+					JSON(parseableToMap(t, odErrMsg("anycode", string(graph.MysiteNotFound))))
+				interceptV1Path("users", "user", "mailFolders", "inbox").
+					Reply(400).
+					JSON(parseableToMap(t, odErr(string(graph.ResourceNotFound))))
+			},
+			expectErr: func(t *testing.T, err error) {
+				assert.NoError(t, err, clues.ToCore(err))
+			},
+		},
+		{
+			name: "default drive err - no sharepoint license",
+			setGocks: func(t *testing.T) {
+				interceptV1Path("users", "user", "drive").
+					Reply(400).
+					JSON(parseableToMap(t, odErrMsg("anycode", string(graph.NoSPLicense))))
+				interceptV1Path("users", "user", "mailFolders", "inbox").
+					Reply(400).
+					JSON(parseableToMap(t, odErr(string(graph.ResourceNotFound))))
+			},
+			expectErr: func(t *testing.T, err error) {
+				assert.NoError(t, err, clues.ToCore(err))
+			},
+		},
+		{
+			name: "default drive err - other error",
+			setGocks: func(t *testing.T) {
+				interceptV1Path("users", "user", "drive").
+					Reply(400).
+					JSON(parseableToMap(t, odErrMsg("somecode", "somemessage")))
+			},
+			expectErr: func(t *testing.T, err error) {
+				assert.Error(t, err, clues.ToCore(err))
+			},
+		},
+		{
+			name: "mail inbox err - user not found",
+			setGocks: func(t *testing.T) {
+				interceptV1Path("users", "user", "drive").
+					Reply(200).
+					JSON(parseableToMap(t, models.NewDrive()))
+				interceptV1Path("users", "user", "mailFolders", "inbox").
+					Reply(400).
+					JSON(parseableToMap(t, odErr(string(graph.RequestResourceNotFound))))
+			},
+			expectErr: func(t *testing.T, err error) {
+				assert.ErrorIs(t, err, graph.ErrResourceOwnerNotFound, clues.ToCore(err))
+			},
+		},
+		{
+			name: "mail inbox err - user not found",
+			setGocks: func(t *testing.T) {
+				interceptV1Path("users", "user", "drive").
+					Reply(200).
+					JSON(parseableToMap(t, models.NewDrive()))
+				interceptV1Path("users", "user", "mailFolders", "inbox").
+					Reply(400).
+					JSON(parseableToMap(t, odErr(string(graph.MailboxNotEnabledForRESTAPI))))
+			},
+			expectErr: func(t *testing.T, err error) {
+				assert.NoError(t, err, clues.ToCore(err))
+			},
+		},
+		{
+			name: "mail inbox err - other error",
+			setGocks: func(t *testing.T) {
+				interceptV1Path("users", "user", "drive").
+					Reply(200).
+					JSON(parseableToMap(t, models.NewDrive()))
+				interceptV1Path("users", "user", "mailFolders", "inbox").
+					Reply(400).
+					JSON(parseableToMap(t, odErrMsg("somecode", "somemessage")))
+			},
+			expectErr: func(t *testing.T, err error) {
+				assert.Error(t, err, clues.ToCore(err))
+			},
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+			ctx, flush := tester.NewContext(t)
+
+			defer flush()
+			defer gock.Off()
+
+			test.setGocks(t)
+
+			_, err := suite.its.gockAC.Users().GetInfo(ctx, "user")
+			test.expectErr(t, err)
 		})
 	}
 }


### PR DESCRIPTION
Primary change is fixing the spo license check in
GetUserInfo from a || to a && !.  Currently the check returns the spo license error instead of treating it as a drive access condition.

Additionally adds a root site check in the m365
isServiceEnabled call, instead of always returning true for sharepoint.  This should catch spo license issues on a per-site basis, if someone makes it that far.

Finally, adds extra testing (plus some test code
consolidation and refactoring) to ensure GetUserInfo is properly tested.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix

#### Issue(s)

* #3671

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
