### PR TITLE
ensure od and exchange can restore in-place

### DIFF
--- a/src/internal/m365/exchange/contacts_restore.go
+++ b/src/internal/m365/exchange/contacts_restore.go
@@ -47,16 +47,16 @@ func (h contactRestoreHandler) formatRestoreDestination(
 
 func (h contactRestoreHandler) CreateContainer(
 	ctx context.Context,
-	userID, containerName, _ string, // parent container not used
+	userID, _, containerName string, // parent container not used
 ) (graph.Container, error) {
-	return h.ac.CreateContainer(ctx, userID, containerName, "")
+	return h.ac.CreateContainer(ctx, userID, "", containerName)
 }
 
 func (h contactRestoreHandler) GetContainerByName(
 	ctx context.Context,
-	userID, containerName string,
+	userID, _, containerName string, // parent container not used
 ) (graph.Container, error) {
-	return h.ac.GetContainerByName(ctx, userID, containerName)
+	return h.ac.GetContainerByName(ctx, userID, "", containerName)
 }
 
 // always returns the provided value

--- a/src/internal/m365/exchange/contacts_restore.go
+++ b/src/internal/m365/exchange/contacts_restore.go
@@ -52,8 +52,11 @@ func (h contactRestoreHandler) CreateContainer(
 	return h.ac.CreateContainer(ctx, userID, containerName, "")
 }
 
-func (h contactRestoreHandler) containerSearcher() containerByNamer {
-	return nil
+func (h contactRestoreHandler) GetContainerByName(
+	ctx context.Context,
+	userID, containerName string,
+) (graph.Container, error) {
+	return h.ac.GetContainerByName(ctx, userID, containerName)
 }
 
 // always returns the provided value

--- a/src/internal/m365/exchange/events_restore.go
+++ b/src/internal/m365/exchange/events_restore.go
@@ -48,16 +48,16 @@ func (h eventRestoreHandler) formatRestoreDestination(
 
 func (h eventRestoreHandler) CreateContainer(
 	ctx context.Context,
-	userID, containerName, _ string, // parent container not used
+	userID, _, containerName string, // parent container not used
 ) (graph.Container, error) {
-	return h.ac.CreateContainer(ctx, userID, containerName, "")
+	return h.ac.CreateContainer(ctx, userID, "", containerName)
 }
 
 func (h eventRestoreHandler) GetContainerByName(
 	ctx context.Context,
-	userID, containerName string,
+	userID, _, containerName string, // parent container not used
 ) (graph.Container, error) {
-	return h.ac.GetContainerByName(ctx, userID, containerName)
+	return h.ac.GetContainerByName(ctx, userID, "", containerName)
 }
 
 // always returns the provided value

--- a/src/internal/m365/exchange/events_restore.go
+++ b/src/internal/m365/exchange/events_restore.go
@@ -53,8 +53,11 @@ func (h eventRestoreHandler) CreateContainer(
 	return h.ac.CreateContainer(ctx, userID, containerName, "")
 }
 
-func (h eventRestoreHandler) containerSearcher() containerByNamer {
-	return h.ac
+func (h eventRestoreHandler) GetContainerByName(
+	ctx context.Context,
+	userID, containerName string,
+) (graph.Container, error) {
+	return h.ac.GetContainerByName(ctx, userID, containerName)
 }
 
 // always returns the provided value

--- a/src/internal/m365/exchange/handlers.go
+++ b/src/internal/m365/exchange/handlers.go
@@ -86,18 +86,13 @@ type itemRestorer interface {
 // produces structs that interface with the graph/cache_container
 // CachedContainer interface.
 type containerAPI interface {
+	containerByNamer
+
 	// POSTs the creation of a new container
 	CreateContainer(
 		ctx context.Context,
 		userID, containerName, parentContainerID string,
 	) (graph.Container, error)
-
-	// GETs a container by name.
-	// if containerByNamer is nil, this functionality is not supported
-	// and should be skipped by the caller.
-	// normally, we'd alias the func directly.  The indirection here
-	// is because not all types comply with GetContainerByName.
-	containerSearcher() containerByNamer
 
 	// returns either the provided value (assumed to be the root
 	// folder for that cache tree), or the default root container

--- a/src/internal/m365/exchange/handlers.go
+++ b/src/internal/m365/exchange/handlers.go
@@ -91,7 +91,7 @@ type containerAPI interface {
 	// POSTs the creation of a new container
 	CreateContainer(
 		ctx context.Context,
-		userID, containerName, parentContainerID string,
+		userID, parentContainerID, containerName string,
 	) (graph.Container, error)
 
 	// returns either the provided value (assumed to be the root
@@ -105,7 +105,7 @@ type containerByNamer interface {
 	// searches for a container by name.
 	GetContainerByName(
 		ctx context.Context,
-		userID, containerName string,
+		userID, parentContainerID, containerName string,
 	) (graph.Container, error)
 }
 

--- a/src/internal/m365/exchange/mail_restore.go
+++ b/src/internal/m365/exchange/mail_restore.go
@@ -48,20 +48,20 @@ func (h mailRestoreHandler) formatRestoreDestination(
 
 func (h mailRestoreHandler) CreateContainer(
 	ctx context.Context,
-	userID, containerName, parentContainerID string,
+	userID, parentContainerID, containerName string,
 ) (graph.Container, error) {
 	if len(parentContainerID) == 0 {
 		parentContainerID = rootFolderAlias
 	}
 
-	return h.ac.CreateContainer(ctx, userID, containerName, parentContainerID)
+	return h.ac.CreateContainer(ctx, userID, parentContainerID, containerName)
 }
 
 func (h mailRestoreHandler) GetContainerByName(
 	ctx context.Context,
-	userID, containerName string,
+	userID, parentContainerID, containerName string,
 ) (graph.Container, error) {
-	return h.ac.GetContainerByName(ctx, userID, containerName)
+	return h.ac.GetContainerByName(ctx, userID, parentContainerID, containerName)
 }
 
 // always returns rootFolderAlias

--- a/src/internal/m365/exchange/mail_restore.go
+++ b/src/internal/m365/exchange/mail_restore.go
@@ -57,8 +57,11 @@ func (h mailRestoreHandler) CreateContainer(
 	return h.ac.CreateContainer(ctx, userID, containerName, parentContainerID)
 }
 
-func (h mailRestoreHandler) containerSearcher() containerByNamer {
-	return nil
+func (h mailRestoreHandler) GetContainerByName(
+	ctx context.Context,
+	userID, containerName string,
+) (graph.Container, error) {
+	return h.ac.GetContainerByName(ctx, userID, containerName)
 }
 
 // always returns rootFolderAlias

--- a/src/internal/m365/exchange/restore.go
+++ b/src/internal/m365/exchange/restore.go
@@ -290,7 +290,7 @@ func getOrPopulateContainer(
 		return cached, nil
 	}
 
-	c, err := ca.CreateContainer(ctx, userID, containerName, containerParentID)
+	c, err := ca.CreateContainer(ctx, userID, containerParentID, containerName)
 
 	// 409 handling case:
 	// attempt to fetch the container by name and add that result to the cache.
@@ -298,7 +298,7 @@ func getOrPopulateContainer(
 	// sometimes the backend will create the folder despite the 5xx response,
 	// leaving our local containerResolver with inconsistent state.
 	if graph.IsErrFolderExists(err) {
-		cc, e := ca.GetContainerByName(ctx, userID, containerName)
+		cc, e := ca.GetContainerByName(ctx, userID, containerParentID, containerName)
 		if e != nil {
 			err = clues.Stack(err, e)
 		} else {

--- a/src/internal/m365/exchange/restore.go
+++ b/src/internal/m365/exchange/restore.go
@@ -44,6 +44,7 @@ func ConsumeRestoreCollections(
 		el             = errs.Local()
 	)
 
+	// FIXME: should be user name
 	ctx = clues.Add(ctx, "resource_owner", clues.Hide(userID))
 
 	for _, dc := range dcs {
@@ -297,11 +298,12 @@ func getOrPopulateContainer(
 	// sometimes the backend will create the folder despite the 5xx response,
 	// leaving our local containerResolver with inconsistent state.
 	if graph.IsErrFolderExists(err) {
-		cs := ca.containerSearcher()
-		if cs != nil {
-			cc, e := cs.GetContainerByName(ctx, userID, containerName)
-			c = cc
+		cc, e := ca.GetContainerByName(ctx, userID, containerName)
+		if e != nil {
 			err = clues.Stack(err, e)
+		} else {
+			c = cc
+			err = nil
 		}
 	}
 

--- a/src/internal/m365/exchange/restore_test.go
+++ b/src/internal/m365/exchange/restore_test.go
@@ -60,7 +60,7 @@ func (suite *RestoreIntgSuite) TestRestoreContact() {
 		handler    = newContactRestoreHandler(suite.ac)
 	)
 
-	aFolder, err := handler.ac.CreateContainer(ctx, userID, folderName, "")
+	aFolder, err := handler.ac.CreateContainer(ctx, userID, "", folderName)
 	require.NoError(t, err, clues.ToCore(err))
 
 	folderID := ptr.Val(aFolder.GetId())
@@ -96,7 +96,7 @@ func (suite *RestoreIntgSuite) TestRestoreEvent() {
 		handler = newEventRestoreHandler(suite.ac)
 	)
 
-	calendar, err := handler.ac.CreateContainer(ctx, userID, subject, "")
+	calendar, err := handler.ac.CreateContainer(ctx, userID, "", subject)
 	require.NoError(t, err, clues.ToCore(err))
 
 	calendarID := ptr.Val(calendar.GetId())
@@ -179,7 +179,7 @@ func (suite *RestoreIntgSuite) TestRestoreExchangeObject() {
 			destination: func(t *testing.T, ctx context.Context) string {
 				folderName := testdata.DefaultRestoreConfig("mailobj").Location
 				folder, err := handlers[path.EmailCategory].
-					CreateContainer(ctx, userID, folderName, "")
+					CreateContainer(ctx, userID, "", folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
 				return ptr.Val(folder.GetId())
@@ -192,7 +192,7 @@ func (suite *RestoreIntgSuite) TestRestoreExchangeObject() {
 			destination: func(t *testing.T, ctx context.Context) string {
 				folderName := testdata.DefaultRestoreConfig("mailwattch").Location
 				folder, err := handlers[path.EmailCategory].
-					CreateContainer(ctx, userID, folderName, "")
+					CreateContainer(ctx, userID, "", folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
 				return ptr.Val(folder.GetId())
@@ -205,7 +205,7 @@ func (suite *RestoreIntgSuite) TestRestoreExchangeObject() {
 			destination: func(t *testing.T, ctx context.Context) string {
 				folderName := testdata.DefaultRestoreConfig("eventwattch").Location
 				folder, err := handlers[path.EmailCategory].
-					CreateContainer(ctx, userID, folderName, "")
+					CreateContainer(ctx, userID, "", folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
 				return ptr.Val(folder.GetId())
@@ -218,7 +218,7 @@ func (suite *RestoreIntgSuite) TestRestoreExchangeObject() {
 			destination: func(t *testing.T, ctx context.Context) string {
 				folderName := testdata.DefaultRestoreConfig("mailitemattch").Location
 				folder, err := handlers[path.EmailCategory].
-					CreateContainer(ctx, userID, folderName, "")
+					CreateContainer(ctx, userID, "", folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
 				return ptr.Val(folder.GetId())
@@ -234,7 +234,7 @@ func (suite *RestoreIntgSuite) TestRestoreExchangeObject() {
 			destination: func(t *testing.T, ctx context.Context) string {
 				folderName := testdata.DefaultRestoreConfig("mailbasicattch").Location
 				folder, err := handlers[path.EmailCategory].
-					CreateContainer(ctx, userID, folderName, "")
+					CreateContainer(ctx, userID, "", folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
 				return ptr.Val(folder.GetId())
@@ -250,7 +250,7 @@ func (suite *RestoreIntgSuite) TestRestoreExchangeObject() {
 			destination: func(t *testing.T, ctx context.Context) string {
 				folderName := testdata.DefaultRestoreConfig("mailnestattch").Location
 				folder, err := handlers[path.EmailCategory].
-					CreateContainer(ctx, userID, folderName, "")
+					CreateContainer(ctx, userID, "", folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
 				return ptr.Val(folder.GetId())
@@ -266,7 +266,7 @@ func (suite *RestoreIntgSuite) TestRestoreExchangeObject() {
 			destination: func(t *testing.T, ctx context.Context) string {
 				folderName := testdata.DefaultRestoreConfig("mailcontactattch").Location
 				folder, err := handlers[path.EmailCategory].
-					CreateContainer(ctx, userID, folderName, "")
+					CreateContainer(ctx, userID, "", folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
 				return ptr.Val(folder.GetId())
@@ -279,7 +279,7 @@ func (suite *RestoreIntgSuite) TestRestoreExchangeObject() {
 			destination: func(t *testing.T, ctx context.Context) string {
 				folderName := testdata.DefaultRestoreConfig("nestedattch").Location
 				folder, err := handlers[path.EmailCategory].
-					CreateContainer(ctx, userID, folderName, "")
+					CreateContainer(ctx, userID, "", folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
 				return ptr.Val(folder.GetId())
@@ -292,7 +292,7 @@ func (suite *RestoreIntgSuite) TestRestoreExchangeObject() {
 			destination: func(t *testing.T, ctx context.Context) string {
 				folderName := testdata.DefaultRestoreConfig("maillargeattch").Location
 				folder, err := handlers[path.EmailCategory].
-					CreateContainer(ctx, userID, folderName, "")
+					CreateContainer(ctx, userID, "", folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
 				return ptr.Val(folder.GetId())
@@ -305,7 +305,7 @@ func (suite *RestoreIntgSuite) TestRestoreExchangeObject() {
 			destination: func(t *testing.T, ctx context.Context) string {
 				folderName := testdata.DefaultRestoreConfig("mailtwoattch").Location
 				folder, err := handlers[path.EmailCategory].
-					CreateContainer(ctx, userID, folderName, "")
+					CreateContainer(ctx, userID, "", folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
 				return ptr.Val(folder.GetId())
@@ -318,7 +318,7 @@ func (suite *RestoreIntgSuite) TestRestoreExchangeObject() {
 			destination: func(t *testing.T, ctx context.Context) string {
 				folderName := testdata.DefaultRestoreConfig("mailrefattch").Location
 				folder, err := handlers[path.EmailCategory].
-					CreateContainer(ctx, userID, folderName, "")
+					CreateContainer(ctx, userID, "", folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
 				return ptr.Val(folder.GetId())
@@ -331,7 +331,7 @@ func (suite *RestoreIntgSuite) TestRestoreExchangeObject() {
 			destination: func(t *testing.T, ctx context.Context) string {
 				folderName := testdata.DefaultRestoreConfig("contact").Location
 				folder, err := handlers[path.ContactsCategory].
-					CreateContainer(ctx, userID, folderName, "")
+					CreateContainer(ctx, userID, "", folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
 				return ptr.Val(folder.GetId())
@@ -344,7 +344,7 @@ func (suite *RestoreIntgSuite) TestRestoreExchangeObject() {
 			destination: func(t *testing.T, ctx context.Context) string {
 				folderName := testdata.DefaultRestoreConfig("event").Location
 				calendar, err := handlers[path.EventsCategory].
-					CreateContainer(ctx, userID, folderName, "")
+					CreateContainer(ctx, userID, "", folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
 				return ptr.Val(calendar.GetId())
@@ -357,7 +357,7 @@ func (suite *RestoreIntgSuite) TestRestoreExchangeObject() {
 			destination: func(t *testing.T, ctx context.Context) string {
 				folderName := testdata.DefaultRestoreConfig("eventobj").Location
 				calendar, err := handlers[path.EventsCategory].
-					CreateContainer(ctx, userID, folderName, "")
+					CreateContainer(ctx, userID, "", folderName)
 				require.NoError(t, err, clues.ToCore(err))
 
 				return ptr.Val(calendar.GetId())
@@ -400,7 +400,7 @@ func (suite *RestoreIntgSuite) TestRestoreAndBackupEvent_recurringInstancesWithA
 		handler = newEventRestoreHandler(suite.ac)
 	)
 
-	calendar, err := handler.ac.CreateContainer(ctx, userID, subject, "")
+	calendar, err := handler.ac.CreateContainer(ctx, userID, "", subject)
 	require.NoError(t, err, clues.ToCore(err))
 
 	calendarID := ptr.Val(calendar.GetId())

--- a/src/pkg/services/m365/api/contacts.go
+++ b/src/pkg/services/m365/api/contacts.go
@@ -37,8 +37,8 @@ type Contacts struct {
 // If successful, returns the created folder object.
 func (c Contacts) CreateContainer(
 	ctx context.Context,
-	userID, containerName string,
-	_ string, // parentContainerID needed for iface, doesn't apply to contacts
+	// parentContainerID needed for iface, doesn't apply to contacts
+	userID, _, containerName string,
 ) (graph.Container, error) {
 	body := models.NewContactFolder()
 	body.SetDisplayName(ptr.To(containerName))
@@ -120,7 +120,8 @@ func (c Contacts) GetContainerByID(
 // GetContainerByName fetches a folder by name
 func (c Contacts) GetContainerByName(
 	ctx context.Context,
-	userID, containerName string,
+	// parentContainerID needed for iface, doesn't apply to contacts
+	userID, _, containerName string,
 ) (graph.Container, error) {
 	filter := fmt.Sprintf("displayName eq '%s'", containerName)
 	options := &users.ItemContactFoldersRequestBuilderGetRequestConfiguration{

--- a/src/pkg/services/m365/api/contacts.go
+++ b/src/pkg/services/m365/api/contacts.go
@@ -117,6 +117,55 @@ func (c Contacts) GetContainerByID(
 	return c.GetFolder(ctx, userID, containerID)
 }
 
+// GetContainerByName fetches a folder by name
+func (c Contacts) GetContainerByName(
+	ctx context.Context,
+	userID, containerName string,
+) (graph.Container, error) {
+	filter := fmt.Sprintf("displayName eq '%s'", containerName)
+	options := &users.ItemContactFoldersRequestBuilderGetRequestConfiguration{
+		QueryParameters: &users.ItemContactFoldersRequestBuilderGetQueryParameters{
+			Filter: &filter,
+		},
+	}
+
+	ctx = clues.Add(ctx, "container_name", containerName)
+
+	resp, err := c.Stable.
+		Client().
+		Users().
+		ByUserId(userID).
+		ContactFolders().
+		Get(ctx, options)
+	if err != nil {
+		return nil, graph.Stack(ctx, err).WithClues(ctx)
+	}
+
+	gv := resp.GetValue()
+
+	if len(gv) == 0 {
+		return nil, clues.New("container not found").WithClues(ctx)
+	}
+
+	// We only allow the api to match one container with the provided name.
+	// Return an error if multiple container exist (unlikely) or if no container
+	// is found.
+	if len(gv) != 1 {
+		return nil, clues.New("unexpected number of folders returned").
+			With("returned_container_count", len(gv)).
+			WithClues(ctx)
+	}
+
+	// Sanity check ID and name
+	container := gv[0]
+
+	if err := graph.CheckIDAndName(container); err != nil {
+		return nil, clues.Stack(err).WithClues(ctx)
+	}
+
+	return container, nil
+}
+
 func (c Contacts) PatchFolder(
 	ctx context.Context,
 	userID, containerID string,

--- a/src/pkg/services/m365/api/contacts_test.go
+++ b/src/pkg/services/m365/api/contacts_test.go
@@ -141,8 +141,8 @@ func (suite *ContactsAPIIntgSuite) TestContacts_GetContainerByName() {
 	cc, err := suite.its.ac.Contacts().CreateContainer(
 		ctx,
 		suite.its.userID,
-		rc.Location,
-		"")
+		"",
+		rc.Location)
 	require.NoError(t, err, clues.ToCore(err))
 
 	table := []struct {
@@ -167,7 +167,7 @@ func (suite *ContactsAPIIntgSuite) TestContacts_GetContainerByName() {
 
 			_, err := suite.its.ac.
 				Contacts().
-				GetContainerByName(ctx, suite.its.userID, test.name)
+				GetContainerByName(ctx, suite.its.userID, "", test.name)
 			test.expectErr(t, err, clues.ToCore(err))
 		})
 	}

--- a/src/pkg/services/m365/api/events.go
+++ b/src/pkg/services/m365/api/events.go
@@ -21,6 +21,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/logger"
 )
 
 // ---------------------------------------------------------------------------
@@ -160,15 +161,9 @@ func (c Events) GetContainerByName(
 		return nil, clues.New("container not found").WithClues(ctx)
 	}
 
-	// Return an error if no calendar is found.
-	if len(resp.GetValue()) == 0 {
-		return nil, clues.New("unexpected number of calendars returned").
-			With("returned_container_count", len(gv)).
-			WithClues(ctx)
-	}
-
 	// We only allow the api to match one calendar with the provided name.
 	// If we match multiples, we'll eagerly return the first one.
+	logger.Ctx(ctx).Debugw("calendars matched the name search", "calendar_count", len(gv))
 
 	// Sanity check ID and name
 	cal := gv[0]

--- a/src/pkg/services/m365/api/events_test.go
+++ b/src/pkg/services/m365/api/events_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/alcionai/clues"
+	"github.com/h2non/gock"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -245,7 +246,7 @@ func (suite *EventsAPIIntgSuite) TestEvents_RestoreLargeAttachment() {
 
 	folderName := testdata.DefaultRestoreConfig("eventlargeattachmenttest").Location
 	evts := suite.its.ac.Events()
-	calendar, err := evts.CreateContainer(ctx, userID, folderName, "")
+	calendar, err := evts.CreateContainer(ctx, userID, "", folderName)
 	require.NoError(t, err, clues.ToCore(err))
 
 	tomorrow := time.Now().Add(24 * time.Hour)
@@ -287,7 +288,7 @@ func (suite *EventsAPIIntgSuite) TestEvents_canFindNonStandardFolder() {
 	ac := suite.its.ac.Events()
 	rc := testdata.DefaultRestoreConfig("api_calendar_discovery")
 
-	cal, err := ac.CreateContainer(ctx, suite.its.userID, rc.Location, "")
+	cal, err := ac.CreateContainer(ctx, suite.its.userID, "", rc.Location)
 	require.NoError(t, err, clues.ToCore(err))
 
 	var (
@@ -340,8 +341,67 @@ func (suite *EventsAPIIntgSuite) TestEvents_GetContainerByName() {
 
 			_, err := suite.its.ac.
 				Events().
-				GetContainerByName(ctx, suite.its.userID, test.name)
+				GetContainerByName(ctx, suite.its.userID, "", test.name)
 			test.expectErr(t, err, clues.ToCore(err))
+		})
+	}
+}
+
+func (suite *EventsAPIIntgSuite) TestEvents_GetContainerByName_mocked() {
+	c := models.NewCalendar()
+	c.SetId(ptr.To("id"))
+	c.SetName(ptr.To("display name"))
+
+	table := []struct {
+		name      string
+		results   func(*testing.T) map[string]any
+		expectErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "zero",
+			results: func(t *testing.T) map[string]any {
+				return parseableToMap(t, models.NewCalendarCollectionResponse())
+			},
+			expectErr: assert.Error,
+		},
+		{
+			name: "one",
+			results: func(t *testing.T) map[string]any {
+				mfcr := models.NewCalendarCollectionResponse()
+				mfcr.SetValue([]models.Calendarable{c})
+
+				return parseableToMap(t, mfcr)
+			},
+			expectErr: assert.NoError,
+		},
+		{
+			name: "two",
+			results: func(t *testing.T) map[string]any {
+				mfcr := models.NewCalendarCollectionResponse()
+				mfcr.SetValue([]models.Calendarable{c, c})
+
+				return parseableToMap(t, mfcr)
+			},
+			expectErr: assert.NoError,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+			ctx, flush := tester.NewContext(t)
+
+			defer flush()
+			defer gock.Off()
+
+			interceptV1Path("users", "u", "calendars").
+				Reply(200).
+				JSON(test.results(t))
+
+			_, err := suite.its.gockAC.
+				Events().
+				GetContainerByName(ctx, "u", "", test.name)
+			test.expectErr(t, err, clues.ToCore(err))
+			assert.True(t, gock.IsDone())
 		})
 	}
 }

--- a/src/pkg/services/m365/api/events_test.go
+++ b/src/pkg/services/m365/api/events_test.go
@@ -235,7 +235,7 @@ func (suite *EventsAPIIntgSuite) SetupSuite() {
 	suite.its = newIntegrationTesterSetup(suite.T())
 }
 
-func (suite *EventsAPIIntgSuite) TestRestoreLargeAttachment() {
+func (suite *EventsAPIIntgSuite) TestEvents_RestoreLargeAttachment() {
 	t := suite.T()
 
 	ctx, flush := tester.NewContext(t)
@@ -315,4 +315,33 @@ func (suite *EventsAPIIntgSuite) TestEvents_canFindNonStandardFolder() {
 		"the restored container was discovered when enumerating containers.  "+
 			"If this fails, the user's calendars have probably broken, "+
 			"and the user will need to be rotated")
+}
+
+func (suite *EventsAPIIntgSuite) TestEvents_GetContainerByName() {
+	table := []struct {
+		name      string
+		expectErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:      "Calendar",
+			expectErr: assert.NoError,
+		},
+		{
+			name:      "smarfs",
+			expectErr: assert.Error,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			_, err := suite.its.ac.
+				Events().
+				GetContainerByName(ctx, suite.its.userID, test.name)
+			test.expectErr(t, err, clues.ToCore(err))
+		})
+	}
 }

--- a/src/pkg/services/m365/api/mail_test.go
+++ b/src/pkg/services/m365/api/mail_test.go
@@ -339,7 +339,12 @@ func (suite *MailAPIIntgSuite) TestHugeAttachmentListDownload() {
 			defer gock.Off()
 			tt.setupf()
 
-			item, _, err := suite.its.ac.Mail().GetItem(ctx, "user", mid, false, fault.New(true))
+			item, _, err := suite.its.gockAC.Mail().GetItem(
+				ctx,
+				"user",
+				mid,
+				false,
+				fault.New(true))
 			tt.expect(t, err)
 
 			it, ok := item.(models.Messageable)

--- a/src/pkg/services/m365/api/mail_test.go
+++ b/src/pkg/services/m365/api/mail_test.go
@@ -446,6 +446,21 @@ func (suite *MailAPIIntgSuite) TestMail_GetContainerByName() {
 			test.expectErr(t, err, clues.ToCore(err))
 		})
 	}
+
+	suite.Run("child folder with same name", func() {
+		pid := ptr.Val(parent.GetId())
+		t := suite.T()
+
+		ctx, flush := tester.NewContext(t)
+		defer flush()
+
+		child, err := acm.CreateContainer(ctx, suite.its.userID, pid, rc.Location)
+		require.NoError(t, err, clues.ToCore(err))
+
+		result, err := acm.GetContainerByName(ctx, suite.its.userID, pid, rc.Location)
+		assert.NoError(t, err, clues.ToCore(err))
+		assert.Equal(t, ptr.Val(child.GetId()), ptr.Val(result.GetId()))
+	})
 }
 
 func (suite *MailAPIIntgSuite) TestMail_GetContainerByName_mocked() {

--- a/src/pkg/services/m365/api/mail_test.go
+++ b/src/pkg/services/m365/api/mail_test.go
@@ -408,7 +408,7 @@ func (suite *MailAPIIntgSuite) TestMail_GetContainerByName() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	parent, err := acm.CreateContainer(ctx, suite.its.userID, "Inbox", rc.Location)
+	parent, err := acm.CreateContainer(ctx, suite.its.userID, "msgfolderroot", rc.Location)
 	require.NoError(t, err, clues.ToCore(err))
 
 	table := []struct {


### PR DESCRIPTION
Adds changes (mostly to exchange) that allow in- place item restoration.  Onedrive basically already supported in-place restores, however we weren't attempting them.  Exchange needed full support of GetContainerByName across its categories.

Next steps: add CLI integration to simplify manual testing.  Then add automation testing to exercise all in-place restore conditions and configurations.

---

#### Does this PR need a docs update or release note?

- [x] :clock1: Yes, but in a later PR

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #3562

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
