### PR TITLE
Reenable test for event exception attachments

### DIFF
--- a/src/internal/m365/exchange/restore_test.go
+++ b/src/internal/m365/exchange/restore_test.go
@@ -134,11 +134,6 @@ func (suite *RestoreIntgSuite) TestRestoreEvent() {
 	}
 
 	for _, test := range tests {
-		// Skip till https://github.com/alcionai/corso/issues/3675 is fixed
-		if test.name == "Test exceptionOccurrences" {
-			t.Skip("Bug 3675")
-		}
-
 		suite.Run(test.name, func() {
 			t := suite.T()
 


### PR DESCRIPTION
Seems like it was just a CI flake

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* https://github.com/alcionai/corso/issues/3675

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
