### PR TITLE
skip events in integration backup operations test

### DIFF
--- a/src/internal/operations/backup_integration_test.go
+++ b/src/internal/operations/backup_integration_test.go
@@ -749,7 +749,7 @@ func testExchangeContinuousBackups(suite *BackupOpIntegrationSuite, toggles cont
 		categories = map[path.CategoryType][]string{
 			path.EmailCategory:    exchange.MetadataFileNames(path.EmailCategory),
 			path.ContactsCategory: exchange.MetadataFileNames(path.ContactsCategory),
-			path.EventsCategory:   exchange.MetadataFileNames(path.EventsCategory),
+			// path.EventsCategory:   exchange.MetadataFileNames(path.EventsCategory),
 		}
 		container1      = fmt.Sprintf("%s%d_%s", incrementalsDestContainerPrefix, 1, now)
 		container2      = fmt.Sprintf("%s%d_%s", incrementalsDestContainerPrefix, 2, now)
@@ -772,8 +772,8 @@ func testExchangeContinuousBackups(suite *BackupOpIntegrationSuite, toggles cont
 
 	sel.Include(
 		sel.MailFolders(containers, selectors.PrefixMatch()),
-		sel.ContactFolders(containers, selectors.PrefixMatch()),
-		sel.EventCalendars(containers, selectors.PrefixMatch()))
+		sel.ContactFolders(containers, selectors.PrefixMatch()))
+	// sel.EventCalendars(containers, selectors.PrefixMatch()))
 
 	creds, err := acct.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
@@ -838,13 +838,13 @@ func testExchangeContinuousBackups(suite *BackupOpIntegrationSuite, toggles cont
 				container2: {},
 			},
 		},
-		path.EventsCategory: {
-			dbf: eventDBF,
-			dests: map[string]contDeets{
-				container1: {},
-				container2: {},
-			},
-		},
+		// path.EventsCategory: {
+		// 	dbf: eventDBF,
+		// 	dests: map[string]contDeets{
+		// 		container1: {},
+		// 		container2: {},
+		// 	},
+		// },
 	}
 
 	// populate initial test data

--- a/src/pkg/services/m365/api/events_test.go
+++ b/src/pkg/services/m365/api/events_test.go
@@ -1,4 +1,4 @@
-package api
+package api_test
 
 import (
 	"testing"
@@ -13,10 +13,12 @@ import (
 	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	exchMock "github.com/alcionai/corso/src/internal/m365/exchange/mock"
+	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type EventsAPIUnitSuite struct {
@@ -129,7 +131,7 @@ func (suite *EventsAPIUnitSuite) TestEventInfo() {
 					future       = time.Now().UTC().AddDate(0, 0, 1)
 					eventTime    = time.Date(future.Year(), future.Month(), future.Day(), future.Hour(), 0, 0, 0, time.UTC)
 					eventEndTime = eventTime.Add(30 * time.Minute)
-					event, err   = BytesToEventable(bytes)
+					event, err   = api.BytesToEventable(bytes)
 				)
 
 				require.NoError(suite.T(), err, clues.ToCore(err))
@@ -149,7 +151,7 @@ func (suite *EventsAPIUnitSuite) TestEventInfo() {
 			t := suite.T()
 
 			event, expected := test.evtAndRP()
-			result := EventInfo(event)
+			result := api.EventInfo(event)
 
 			assert.Equal(t, expected.Subject, result.Subject, "subject")
 			assert.Equal(t, expected.Sender, result.Sender, "sender")
@@ -209,7 +211,7 @@ func (suite *EventsAPIUnitSuite) TestBytesToEventable() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			result, err := BytesToEventable(test.byteArray)
+			result, err := api.BytesToEventable(test.byteArray)
 			test.checkError(t, err, clues.ToCore(err))
 			test.isNil(t, result)
 		})
@@ -218,8 +220,7 @@ func (suite *EventsAPIUnitSuite) TestBytesToEventable() {
 
 type EventsAPIIntgSuite struct {
 	tester.Suite
-	credentials account.M365Config
-	ac          Client
+	its intgTesterSetup
 }
 
 func TestEventsAPIntgSuite(t *testing.T) {
@@ -231,15 +232,7 @@ func TestEventsAPIntgSuite(t *testing.T) {
 }
 
 func (suite *EventsAPIIntgSuite) SetupSuite() {
-	t := suite.T()
-
-	a := tester.NewM365Account(t)
-	m365, err := a.M365Config()
-	require.NoError(t, err, clues.ToCore(err))
-
-	suite.credentials = m365
-	suite.ac, err = NewClient(m365)
-	require.NoError(t, err, clues.ToCore(err))
+	suite.its = newIntegrationTesterSetup(suite.T())
 }
 
 func (suite *EventsAPIIntgSuite) TestRestoreLargeAttachment() {
@@ -251,7 +244,7 @@ func (suite *EventsAPIIntgSuite) TestRestoreLargeAttachment() {
 	userID := tester.M365UserID(suite.T())
 
 	folderName := testdata.DefaultRestoreConfig("eventlargeattachmenttest").Location
-	evts := suite.ac.Events()
+	evts := suite.its.ac.Events()
 	calendar, err := evts.CreateContainer(ctx, userID, folderName, "")
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -281,4 +274,45 @@ func (suite *EventsAPIIntgSuite) TestRestoreLargeAttachment() {
 	)
 	require.NoError(t, err, clues.ToCore(err))
 	require.NotEmpty(t, id, "empty id for large attachment")
+}
+
+func (suite *EventsAPIIntgSuite) TestEvents_canFindNonStandardFolder() {
+	t := suite.T()
+
+	t.Skip("currently broken: the test user needs to get rotated")
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	ac := suite.its.ac.Events()
+	rc := testdata.DefaultRestoreConfig("api_calendar_discovery")
+
+	cal, err := ac.CreateContainer(ctx, suite.its.userID, rc.Location, "")
+	require.NoError(t, err, clues.ToCore(err))
+
+	var (
+		found         bool
+		calID         = ptr.Val(cal.GetId())
+		findContainer = func(gcc graph.CachedContainer) error {
+			if ptr.Val(gcc.GetId()) == calID {
+				found = true
+			}
+
+			return nil
+		}
+	)
+
+	err = ac.EnumerateContainers(
+		ctx,
+		suite.its.userID,
+		"Calendar",
+		findContainer,
+		fault.New(true))
+	require.NoError(t, err, clues.ToCore(err))
+	require.True(
+		t,
+		found,
+		"the restored container was discovered when enumerating containers.  "+
+			"If this fails, the user's calendars have probably broken, "+
+			"and the user will need to be rotated")
 }


### PR DESCRIPTION
skip incremental backup tests that depend on
events, due to the test user having a bad calendar loadout.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix

#### Test Plan

- [x] :muscle: Manual
- [x] :green_heart: E2E
