### PR TITLE
use counter to display restore items skipped

### DIFF
--- a/src/cli/restore/onedrive.go
+++ b/src/cli/restore/onedrive.go
@@ -1,18 +1,12 @@
 package restore
 
 import (
-	"github.com/alcionai/clues"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"github.com/alcionai/corso/src/cli/flags"
-	. "github.com/alcionai/corso/src/cli/print"
-	"github.com/alcionai/corso/src/cli/repo"
 	"github.com/alcionai/corso/src/cli/utils"
 	"github.com/alcionai/corso/src/internal/common/dttm"
-	"github.com/alcionai/corso/src/internal/data"
-	"github.com/alcionai/corso/src/pkg/path"
 )
 
 // called by restore.go to map subcommands to provider-specific handling.
@@ -84,6 +78,7 @@ func restoreOneDriveCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	opts := utils.MakeOneDriveOpts(cmd)
+	opts.RestoreCfg.DTTMFormat = dttm.HumanReadableDriveItem
 
 	if flags.RunModeFV == flags.RunModeFlagTest {
 		return nil
@@ -93,33 +88,14 @@ func restoreOneDriveCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	r, _, _, err := utils.GetAccountAndConnect(ctx, path.OneDriveService, repo.S3Overrides(cmd))
-	if err != nil {
-		return Only(ctx, err)
-	}
-
-	defer utils.CloseRepo(ctx, r)
-
 	sel := utils.IncludeOneDriveRestoreDataSelectors(opts)
 	utils.FilterOneDriveRestoreInfoSelectors(sel, opts)
 
-	restoreCfg := utils.MakeRestoreConfig(ctx, opts.RestoreCfg, dttm.HumanReadableDriveItem)
-
-	ro, err := r.NewRestore(ctx, flags.BackupIDFV, sel.Selector, restoreCfg)
-	if err != nil {
-		return Only(ctx, clues.Wrap(err, "Failed to initialize OneDrive restore"))
-	}
-
-	ds, err := ro.Run(ctx)
-	if err != nil {
-		if errors.Is(err, data.ErrNotFound) {
-			return Only(ctx, clues.New("Backup or backup details missing for id "+flags.BackupIDFV))
-		}
-
-		return Only(ctx, clues.Wrap(err, "Failed to run OneDrive restore"))
-	}
-
-	ds.Items().MaybePrintEntries(ctx)
-
-	return nil
+	return runRestore(
+		ctx,
+		cmd,
+		opts.RestoreCfg,
+		sel.Selector,
+		flags.BackupIDFV,
+		"OneDrive")
 }

--- a/src/cli/utils/restore_config.go
+++ b/src/cli/utils/restore_config.go
@@ -15,6 +15,10 @@ import (
 type RestoreCfgOpts struct {
 	Collisions  string
 	Destination string
+	// DTTMFormat is the timestamp format appended
+	// to the default folder name.  Defaults to
+	// dttm.HumanReadable.
+	DTTMFormat dttm.TimeFormat
 
 	Populated flags.PopulatedFlags
 }
@@ -23,6 +27,7 @@ func makeRestoreCfgOpts(cmd *cobra.Command) RestoreCfgOpts {
 	return RestoreCfgOpts{
 		Collisions:  flags.CollisionsFV,
 		Destination: flags.DestinationFV,
+		DTTMFormat:  dttm.HumanReadable,
 
 		// populated contains the list of flags that appear in the
 		// command, according to pflags.  Use this to differentiate
@@ -47,9 +52,12 @@ func validateRestoreConfigFlags(fv string, opts RestoreCfgOpts) error {
 func MakeRestoreConfig(
 	ctx context.Context,
 	opts RestoreCfgOpts,
-	locationTimeFormat dttm.TimeFormat,
 ) control.RestoreConfig {
-	restoreCfg := control.DefaultRestoreConfig(locationTimeFormat)
+	if len(opts.DTTMFormat) == 0 {
+		opts.DTTMFormat = dttm.HumanReadable
+	}
+
+	restoreCfg := control.DefaultRestoreConfig(opts.DTTMFormat)
 
 	if _, ok := opts.Populated[flags.CollisionsFN]; ok {
 		restoreCfg.OnCollision = control.CollisionPolicy(opts.Collisions)

--- a/src/cli/utils/restore_config_test.go
+++ b/src/cli/utils/restore_config_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/cli/flags"
-	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/control"
 )
@@ -129,7 +128,7 @@ func (suite *RestoreCfgUnitSuite) TestMakeRestoreConfig() {
 			opts := *rco
 			opts.Populated = test.populated
 
-			result := MakeRestoreConfig(ctx, opts, dttm.HumanReadable)
+			result := MakeRestoreConfig(ctx, opts)
 			assert.Equal(t, test.expect.OnCollision, result.OnCollision)
 			assert.Contains(t, result.Location, test.expect.Location)
 		})

--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -179,6 +179,7 @@ func (op *RestoreOperation) Run(ctx context.Context) (restoreDetails *details.De
 
 	finalizeErrorHandling(ctx, op.Options, op.Errors, "running restore")
 	LogFaultErrors(ctx, op.Errors.Errors(), "running restore")
+	logger.Ctx(ctx).With("total_counts", op.Counter.Values()).Info("restore stats")
 
 	// -----
 	// Persistence


### PR DESCRIPTION
Currently, if you run a restore and all items are
skipped, the cli output ends without confirming
the result of the restore operation.   This change
uses the new counter to display the number of
items that were skipped due to collision.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #3562

#### Test Plan

- [x] :muscle: Manual
- [x] :green_heart: E2E
