### PR TITLE
Revert "don't match config in init repo (#3726)"

### DIFF
--- a/src/cli/config/account.go
+++ b/src/cli/config/account.go
@@ -40,7 +40,6 @@ func m365Overrides(in map[string]string) map[string]string {
 func configureAccount(
 	vpr *viper.Viper,
 	readConfigFromViper bool,
-	matchFromConfig bool,
 	overrides map[string]string,
 ) (account.Account, error) {
 	var (
@@ -50,7 +49,7 @@ func configureAccount(
 		err     error
 	)
 
-	if matchFromConfig {
+	if readConfigFromViper {
 		m365Cfg, err = m365ConfigsFromViper(vpr)
 		if err != nil {
 			return acct, clues.Wrap(err, "reading m365 configs from corso config file")

--- a/src/cli/config/config.go
+++ b/src/cli/config/config.go
@@ -284,7 +284,7 @@ func getStorageAndAccountWithViper(
 		config.RepoID = vpr.GetString(RepoID)
 	}
 
-	config.Account, err = configureAccount(vpr, readConfigFromViper, mustMatchFromConfig, overrides)
+	config.Account, err = configureAccount(vpr, readConfigFromViper, overrides)
 	if err != nil {
 		return config, clues.Wrap(err, "retrieving account configuration details")
 	}

--- a/src/cli/config/config_test.go
+++ b/src/cli/config/config_test.go
@@ -270,7 +270,7 @@ func (suite *ConfigIntegrationSuite) TestGetStorageAndAccount() {
 	err = vpr.ReadInConfig()
 	require.NoError(t, err, "reading repo config", clues.ToCore(err))
 
-	config, err := getStorageAndAccountWithViper(vpr, true, true, nil)
+	config, err := getStorageAndAccountWithViper(vpr, true, false, nil)
 	require.NoError(t, err, "getting storage and account from config", clues.ToCore(err))
 
 	readS3Cfg, err := config.Storage.S3Config()

--- a/src/cli/config/storage.go
+++ b/src/cli/config/storage.go
@@ -69,6 +69,10 @@ func configureStorage(
 	)
 
 	if readConfigFromViper {
+		if s3Cfg, err = s3ConfigsFromViper(vpr); err != nil {
+			return store, clues.Wrap(err, "reading s3 configs from corso config file")
+		}
+
 		if b, ok := overrides[storage.Bucket]; ok {
 			overrides[storage.Bucket] = common.NormalizeBucket(b)
 		}
@@ -79,10 +83,6 @@ func configureStorage(
 	}
 
 	if matchFromConfig {
-		if s3Cfg, err = s3ConfigsFromViper(vpr); err != nil {
-			return store, clues.Wrap(err, "reading s3 configs from corso config file")
-		}
-
 		if err := mustMatchConfig(vpr, s3Overrides(overrides)); err != nil {
 			return store, clues.Wrap(err, "verifying s3 configs in corso config file")
 		}


### PR DESCRIPTION
This reverts commit 9a7213baa6f6858b92c47d5d28b8e39c180e64c0.

See sanity test failure: https://github.com/alcionai/corso/actions/runs/5425405323

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix

#### Test Plan

- [x] :green_heart: E2E
