### PR TITLE
remove goreleaser replacements property

### DIFF
--- a/.github/actions/publish-binary/action.yml
+++ b/.github/actions/publish-binary/action.yml
@@ -78,6 +78,7 @@ runs:
         path: src/dist/corso_windows_amd64_v1/corso.exe
 
     - name: SHA info
+      shell: bash
       id: sha-info
       if: failure()
       run: |

--- a/.github/actions/publish-binary/action.yml
+++ b/.github/actions/publish-binary/action.yml
@@ -13,6 +13,9 @@ inputs:
   rudderstack_data_plane_url:
     description: Data plane URL for RudderStack
     required: true
+  slack_webhook_url:
+    description: Slack webhook url
+    required: true
 
 runs:
   using: composite
@@ -73,3 +76,34 @@ runs:
       with:
         name: corso_Windows_amd64
         path: src/dist/corso_windows_amd64_v1/corso.exe
+
+    - name: SHA info
+      id: sha-info
+      if: failure()
+      run: |
+        echo ${GITHUB_REF#refs/heads/}-${GITHUB_SHA}
+        echo SHA=${GITHUB_REF#refs/heads/}-${GITHUB_SHA} >> $GITHUB_OUTPUT
+        echo RUN_URL=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}  >> $GITHUB_OUTPUT
+        echo COMMIT_URL=${{ github.server_url }}/${{ github.repository }}/commit/${GITHUB_SHA} >> $GITHUB_OUTPUT
+
+    - name: Send Github Action failure to Slack
+      id: slack-notification
+      if: failure()
+      uses: slackapi/slack-github-action@v1.24.0
+      with:
+        payload: |
+          {
+            "text": "Publish failure - build: ${{ job.status }} - SHA: ${{  steps.sha-info.outputs.SHA }}",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "[FAILED] Publishing Binary :: <${{  steps.sha-info.outputs.RUN_URL }}|[Logs]> <${{ steps.sha-info.outputs.COMMIT_URL }}|[Base]>\nCommit: <${{  steps.sha-info.outputs.COMMIT_URL }}|${{  steps.sha-info.outputs.SHA }}>"
+                }
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ inputs.slack_webhook_url }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/binary-publish.yml
+++ b/.github/workflows/binary-publish.yml
@@ -35,3 +35,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           rudderstack_write_key: ${{ secrets.RUDDERSTACK_CORSO_WRITE_KEY }}
           rudderstack_data_plane_url: ${{ secrets.RUDDERSTACK_CORSO_DATA_PLANE_URL }}
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,7 +442,8 @@ jobs:
     needs: [Test-Suite-Trusted, Source-Code-Linting, Website-Linting, SetEnv]
     environment: ${{ needs.SetEnv.outputs.environment }}
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
+    # TODO: reinstate before merge
+    # if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
 
     steps:
       - uses: actions/checkout@v3
@@ -454,6 +455,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           rudderstack_write_key: ${{ secrets.RUDDERSTACK_CORSO_WRITE_KEY }}
           rudderstack_data_plane_url: ${{ secrets.RUDDERSTACK_CORSO_DATA_PLANE_URL }}
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   Publish-Image:
     needs: [Test-Suite-Trusted, Source-Code-Linting, Website-Linting, SetEnv]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,8 +442,7 @@ jobs:
     needs: [Test-Suite-Trusted, Source-Code-Linting, Website-Linting, SetEnv]
     environment: ${{ needs.SetEnv.outputs.environment }}
     runs-on: ubuntu-latest
-    # TODO: reinstate before merge
-    # if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
+    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
 
     steps:
       - uses: actions/checkout@v3

--- a/src/.goreleaser.yaml
+++ b/src/.goreleaser.yaml
@@ -18,7 +18,15 @@ builds:
           - -X 'github.com/alcionai/corso/src/internal/events.RudderStackDataPlaneURL={{.Env.RUDDERSTACK_CORSO_DATA_PLANE_URL}}'
 
 archives:
-  - name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+  # this name template makes the OS and Arch compatible with the results of uname.
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- .Tag }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
     format: tar.gz
     format_overrides:
       - goos: windows

--- a/src/.goreleaser.yaml
+++ b/src/.goreleaser.yaml
@@ -18,13 +18,7 @@ builds:
           - -X 'github.com/alcionai/corso/src/internal/events.RudderStackDataPlaneURL={{.Env.RUDDERSTACK_CORSO_DATA_PLANE_URL}}'
 
 archives:
-  - name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}"
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     format: tar.gz
     format_overrides:
       - goos: windows


### PR DESCRIPTION
Goreleaser [deprecated](https://goreleaser.com/deprecations/?h=replacement#archivesreplacements) the replacements yaml property, which has been causing our binary publications to fail for a while now.  This fixes the yaml and introduces a slack message for binary publication failures.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix
- [x] :computer: CI/Deployment

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
