### PR TITLE
split tester into separate files

### DIFF
--- a/src/cli/backup/exchange_e2e_test.go
+++ b/src/cli/backup/exchange_e2e_test.go
@@ -18,15 +18,18 @@ import (
 	"github.com/alcionai/corso/src/cli/config"
 	"github.com/alcionai/corso/src/cli/flags"
 	"github.com/alcionai/corso/src/cli/print"
+	cliTD "github.com/alcionai/corso/src/cli/testdata"
 	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/m365/exchange"
 	"github.com/alcionai/corso/src/internal/operations"
 	"github.com/alcionai/corso/src/internal/tester"
+	tconfig "github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/repository"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/storage"
+	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
 )
 
 var (
@@ -51,10 +54,11 @@ type ExchangeCMDWithFlagsE2ESuite struct {
 }
 
 func TestExchangeCMDWithFlagsE2ESuite(t *testing.T) {
-	suite.Run(t, &ExchangeCMDWithFlagsE2ESuite{Suite: tester.NewE2ESuite(
-		t,
-		[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
-	)})
+	suite.Run(t, &ExchangeCMDWithFlagsE2ESuite{
+		Suite: tester.NewE2ESuite(
+			t,
+			[][]string{storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs}),
+	})
 }
 
 func (suite *ExchangeCMDWithFlagsE2ESuite) SetupSuite() {
@@ -71,7 +75,7 @@ func (suite *ExchangeCMDWithFlagsE2ESuite) SetupSuite() {
 	suite.vpr = vpr
 	suite.recorder = recorder
 	suite.cfgFP = cfgFilePath
-	suite.m365UserID = tester.M365UserID(t)
+	suite.m365UserID = tconfig.M365UserID(t)
 }
 
 func (suite *ExchangeCMDWithFlagsE2ESuite) TestBackupCreateExchange_badAzureClientID() {
@@ -82,7 +86,7 @@ func (suite *ExchangeCMDWithFlagsE2ESuite) TestBackupCreateExchange_badAzureClie
 
 	suite.recorder.Reset()
 
-	cmd := tester.StubRootCmd(
+	cmd := cliTD.StubRootCmd(
 		"backup", "create", "exchange",
 		"--user", suite.m365UserID,
 		"--azure-client-id", "invalid-value",
@@ -107,7 +111,7 @@ func (suite *ExchangeCMDWithFlagsE2ESuite) TestBackupCreateExchange_azureIDFromC
 
 	suite.recorder.Reset()
 
-	cmd := tester.StubRootCmd(
+	cmd := cliTD.StubRootCmd(
 		"backup", "create", "exchange",
 		"--user", suite.m365UserID,
 		"--config-file", suite.cfgFP)
@@ -137,7 +141,7 @@ func (suite *ExchangeCMDWithFlagsE2ESuite) TestExchangeBackupValueFromEnvCmd_emp
 
 	suite.recorder.Reset()
 
-	cmd := tester.StubRootCmd(
+	cmd := cliTD.StubRootCmd(
 		"backup", "create", "exchange",
 		"--user", suite.m365UserID)
 	cli.BuildCommandTree(cmd)
@@ -166,7 +170,7 @@ func (suite *ExchangeCMDWithFlagsE2ESuite) TestExchangeBackupInvalidAWSClientIDC
 
 	suite.recorder.Reset()
 
-	cmd := tester.StubRootCmd(
+	cmd := cliTD.StubRootCmd(
 		"backup", "create", "exchange",
 		"--user", suite.m365UserID,
 		"--aws-access-key", "invalid-value",
@@ -193,7 +197,7 @@ func (suite *ExchangeCMDWithFlagsE2ESuite) TestExchangeBackupAWSValueFromEnvCmd_
 
 	suite.recorder.Reset()
 
-	cmd := tester.StubRootCmd(
+	cmd := cliTD.StubRootCmd(
 		"backup", "create", "exchange",
 		"--user", suite.m365UserID)
 	cli.BuildCommandTree(cmd)
@@ -231,7 +235,7 @@ type NoBackupExchangeE2ESuite struct {
 func TestNoBackupExchangeE2ESuite(t *testing.T) {
 	suite.Run(t, &NoBackupExchangeE2ESuite{Suite: tester.NewE2ESuite(
 		t,
-		[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
+		[][]string{storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs},
 	)})
 }
 
@@ -249,7 +253,7 @@ func (suite *NoBackupExchangeE2ESuite) SetupSuite() {
 	suite.vpr = vpr
 	suite.recorder = recorder
 	suite.cfgFP = cfgFilePath
-	suite.m365UserID = tester.M365UserID(t)
+	suite.m365UserID = tconfig.M365UserID(t)
 }
 
 func (suite *NoBackupExchangeE2ESuite) TestExchangeBackupListCmd_empty() {
@@ -261,7 +265,7 @@ func (suite *NoBackupExchangeE2ESuite) TestExchangeBackupListCmd_empty() {
 
 	suite.recorder.Reset()
 
-	cmd := tester.StubRootCmd(
+	cmd := cliTD.StubRootCmd(
 		"backup", "list", "exchange",
 		"--config-file", suite.cfgFP)
 	cli.BuildCommandTree(cmd)
@@ -297,7 +301,7 @@ type BackupExchangeE2ESuite struct {
 func TestBackupExchangeE2ESuite(t *testing.T) {
 	suite.Run(t, &BackupExchangeE2ESuite{Suite: tester.NewE2ESuite(
 		t,
-		[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
+		[][]string{storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs},
 	)})
 }
 
@@ -314,7 +318,7 @@ func (suite *BackupExchangeE2ESuite) SetupSuite() {
 	suite.repo = repo
 	suite.vpr = vpr
 	suite.cfgFP = cfgFilePath
-	suite.m365UserID = tester.M365UserID(t)
+	suite.m365UserID = tconfig.M365UserID(t)
 }
 
 func (suite *BackupExchangeE2ESuite) TestExchangeBackupCmd_email() {
@@ -373,7 +377,7 @@ func runExchangeBackupServiceNotEnabledTest(suite *BackupExchangeE2ESuite, categ
 	cmd, ctx := buildExchangeBackupCmd(
 		ctx,
 		suite.cfgFP,
-		fmt.Sprintf("%s,%s", tester.UnlicensedM365UserID(suite.T()), suite.m365UserID),
+		fmt.Sprintf("%s,%s", tconfig.UnlicensedM365UserID(suite.T()), suite.m365UserID),
 		category,
 		&recorder)
 	err := cmd.ExecuteContext(ctx)
@@ -445,7 +449,7 @@ type PreparedBackupExchangeE2ESuite struct {
 func TestPreparedBackupExchangeE2ESuite(t *testing.T) {
 	suite.Run(t, &PreparedBackupExchangeE2ESuite{Suite: tester.NewE2ESuite(
 		t,
-		[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
+		[][]string{storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs},
 	)})
 }
 
@@ -463,7 +467,7 @@ func (suite *PreparedBackupExchangeE2ESuite) SetupSuite() {
 	suite.vpr = vpr
 	suite.recorder = recorder
 	suite.cfgFP = cfgFilePath
-	suite.m365UserID = tester.M365UserID(t)
+	suite.m365UserID = tconfig.M365UserID(t)
 	suite.backupOps = make(map[path.CategoryType]string)
 
 	var (
@@ -534,7 +538,7 @@ func runExchangeListCmdTest(suite *PreparedBackupExchangeE2ESuite, category path
 
 	defer flush()
 
-	cmd := tester.StubRootCmd(
+	cmd := cliTD.StubRootCmd(
 		"backup", "list", "exchange",
 		"--config-file", suite.cfgFP)
 	cli.BuildCommandTree(cmd)
@@ -575,7 +579,7 @@ func runExchangeListSingleCmdTest(suite *PreparedBackupExchangeE2ESuite, categor
 
 	bID := suite.backupOps[category]
 
-	cmd := tester.StubRootCmd(
+	cmd := cliTD.StubRootCmd(
 		"backup", "list", "exchange",
 		"--config-file", suite.cfgFP,
 		"--backup", string(bID))
@@ -602,7 +606,7 @@ func (suite *PreparedBackupExchangeE2ESuite) TestExchangeListCmd_badID() {
 
 	defer flush()
 
-	cmd := tester.StubRootCmd(
+	cmd := cliTD.StubRootCmd(
 		"backup", "list", "exchange",
 		"--config-file", suite.cfgFP,
 		"--backup", "smarfs")
@@ -644,7 +648,7 @@ func runExchangeDetailsCmdTest(suite *PreparedBackupExchangeE2ESuite, category p
 	require.NoError(t, errs.Failure(), clues.ToCore(errs.Failure()))
 	require.Empty(t, errs.Recovered())
 
-	cmd := tester.StubRootCmd(
+	cmd := cliTD.StubRootCmd(
 		"backup", "details", "exchange",
 		"--config-file", suite.cfgFP,
 		"--"+flags.BackupFN, string(bID))
@@ -700,7 +704,7 @@ func TestBackupDeleteExchangeE2ESuite(t *testing.T) {
 	suite.Run(t, &BackupDeleteExchangeE2ESuite{
 		Suite: tester.NewE2ESuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
+			[][]string{storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs},
 		),
 	})
 }
@@ -719,7 +723,7 @@ func (suite *BackupDeleteExchangeE2ESuite) SetupSuite() {
 	suite.vpr = vpr
 	suite.cfgFP = cfgFilePath
 
-	m365UserID := tester.M365UserID(t)
+	m365UserID := tconfig.M365UserID(t)
 	users := []string{m365UserID}
 
 	// some tests require an existing backup
@@ -743,7 +747,7 @@ func (suite *BackupDeleteExchangeE2ESuite) TestExchangeBackupDeleteCmd() {
 
 	defer flush()
 
-	cmd := tester.StubRootCmd(
+	cmd := cliTD.StubRootCmd(
 		"backup", "delete", "exchange",
 		"--config-file", suite.cfgFP,
 		"--"+flags.BackupFN, string(suite.backupOp.Results.BackupID))
@@ -754,7 +758,7 @@ func (suite *BackupDeleteExchangeE2ESuite) TestExchangeBackupDeleteCmd() {
 	require.NoError(t, err, clues.ToCore(err))
 
 	// a follow-up details call should fail, due to the backup ID being deleted
-	cmd = tester.StubRootCmd(
+	cmd = cliTD.StubRootCmd(
 		"backup", "details", "exchange",
 		"--config-file", suite.cfgFP,
 		"--backup", string(suite.backupOp.Results.BackupID))
@@ -772,7 +776,7 @@ func (suite *BackupDeleteExchangeE2ESuite) TestExchangeBackupDeleteCmd_UnknownID
 
 	defer flush()
 
-	cmd := tester.StubRootCmd(
+	cmd := cliTD.StubRootCmd(
 		"backup", "delete", "exchange",
 		"--config-file", suite.cfgFP,
 		"--"+flags.BackupFN, uuid.NewString())
@@ -792,7 +796,7 @@ func buildExchangeBackupCmd(
 	configFile, user, category string,
 	recorder *strings.Builder,
 ) (*cobra.Command, context.Context) {
-	cmd := tester.StubRootCmd(
+	cmd := cliTD.StubRootCmd(
 		"backup", "create", "exchange",
 		"--config-file", configFile,
 		"--"+flags.UserFN, user,

--- a/src/cli/backup/exchange_e2e_test.go
+++ b/src/cli/backup/exchange_e2e_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/exchange"
 	"github.com/alcionai/corso/src/internal/operations"
 	"github.com/alcionai/corso/src/internal/tester"
-	tconfig "github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/repository"

--- a/src/cli/backup/help_e2e_test.go
+++ b/src/cli/backup/help_e2e_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/alcionai/corso/src/cli/config"
-	tconfig "github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/repository"

--- a/src/cli/backup/help_e2e_test.go
+++ b/src/cli/backup/help_e2e_test.go
@@ -10,11 +10,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/alcionai/corso/src/cli/config"
-	"github.com/alcionai/corso/src/internal/tester"
+	tconfig "github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/repository"
 	"github.com/alcionai/corso/src/pkg/storage"
+	"github.com/alcionai/corso/src/pkg/storage/testdata"
 )
 
 func prepM365Test(
@@ -29,8 +30,8 @@ func prepM365Test(
 	string,
 ) {
 	var (
-		acct     = tester.NewM365Account(t)
-		st       = tester.NewPrefixedS3Storage(t)
+		acct     = tconfig.NewM365Account(t)
+		st       = testdata.NewPrefixedS3Storage(t)
 		recorder = strings.Builder{}
 	)
 
@@ -38,12 +39,12 @@ func prepM365Test(
 	require.NoError(t, err, clues.ToCore(err))
 
 	force := map[string]string{
-		tester.TestCfgAccountProvider: "M365",
-		tester.TestCfgStorageProvider: "S3",
-		tester.TestCfgPrefix:          cfg.Prefix,
+		tconfig.TestCfgAccountProvider: "M365",
+		tconfig.TestCfgStorageProvider: "S3",
+		tconfig.TestCfgPrefix:          cfg.Prefix,
 	}
 
-	vpr, cfgFP := tester.MakeTempTestConfigClone(t, force)
+	vpr, cfgFP := tconfig.MakeTempTestConfigClone(t, force)
 	ctx = config.SetViper(ctx, vpr)
 
 	repo, err := repository.Initialize(ctx, acct, st, control.Defaults())

--- a/src/cli/backup/onedrive_e2e_test.go
+++ b/src/cli/backup/onedrive_e2e_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/operations"
 	"github.com/alcionai/corso/src/internal/tester"
-	tconfig "github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/repository"
 	"github.com/alcionai/corso/src/pkg/selectors"

--- a/src/cli/backup/onedrive_e2e_test.go
+++ b/src/cli/backup/onedrive_e2e_test.go
@@ -16,14 +16,17 @@ import (
 	"github.com/alcionai/corso/src/cli/config"
 	"github.com/alcionai/corso/src/cli/flags"
 	"github.com/alcionai/corso/src/cli/print"
+	cliTD "github.com/alcionai/corso/src/cli/testdata"
 	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/operations"
 	"github.com/alcionai/corso/src/internal/tester"
+	tconfig "github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/repository"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	selTD "github.com/alcionai/corso/src/pkg/selectors/testdata"
 	"github.com/alcionai/corso/src/pkg/storage"
+	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
 )
 
 // ---------------------------------------------------------------------------
@@ -45,7 +48,7 @@ func TestNoBackupOneDriveE2ESuite(t *testing.T) {
 	suite.Run(t, &NoBackupOneDriveE2ESuite{
 		Suite: tester.NewE2ESuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs}),
+			[][]string{storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs}),
 	})
 }
 
@@ -63,7 +66,7 @@ func (suite *NoBackupOneDriveE2ESuite) SetupSuite() {
 	suite.recorder = recorder
 	suite.vpr = vpr
 	suite.cfgFP = cfgFilePath
-	suite.m365UserID = tester.M365UserID(t)
+	suite.m365UserID = tconfig.M365UserID(t)
 }
 
 func (suite *NoBackupOneDriveE2ESuite) TestOneDriveBackupListCmd_empty() {
@@ -76,7 +79,7 @@ func (suite *NoBackupOneDriveE2ESuite) TestOneDriveBackupListCmd_empty() {
 
 	suite.recorder.Reset()
 
-	cmd := tester.StubRootCmd(
+	cmd := cliTD.StubRootCmd(
 		"backup", "list", "onedrive",
 		"--config-file", suite.cfgFP)
 	cli.BuildCommandTree(cmd)
@@ -105,7 +108,7 @@ func (suite *NoBackupOneDriveE2ESuite) TestOneDriveBackupCmd_UserNotInTenant() {
 
 	ctx = config.SetViper(ctx, suite.vpr)
 
-	cmd := tester.StubRootCmd(
+	cmd := cliTD.StubRootCmd(
 		"backup", "create", "onedrive",
 		"--config-file", suite.cfgFP,
 		"--"+flags.UserFN, "foo@nothere.com")
@@ -149,7 +152,7 @@ func TestBackupDeleteOneDriveE2ESuite(t *testing.T) {
 	suite.Run(t, &BackupDeleteOneDriveE2ESuite{
 		Suite: tester.NewE2ESuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs}),
+			[][]string{storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs}),
 	})
 }
 
@@ -169,7 +172,7 @@ func (suite *BackupDeleteOneDriveE2ESuite) SetupSuite() {
 	suite.cfgFP = cfgFilePath
 
 	var (
-		m365UserID = tester.M365UserID(t)
+		m365UserID = tconfig.M365UserID(t)
 		users      = []string{m365UserID}
 		ins        = idname.NewCache(map[string]string{m365UserID: m365UserID})
 	)
@@ -197,7 +200,7 @@ func (suite *BackupDeleteOneDriveE2ESuite) TestOneDriveBackupDeleteCmd() {
 
 	suite.recorder.Reset()
 
-	cmd := tester.StubRootCmd(
+	cmd := cliTD.StubRootCmd(
 		"backup", "delete", "onedrive",
 		"--config-file", suite.cfgFP,
 		"--"+flags.BackupFN, string(suite.backupOp.Results.BackupID))
@@ -219,7 +222,7 @@ func (suite *BackupDeleteOneDriveE2ESuite) TestOneDriveBackupDeleteCmd() {
 	)
 
 	// a follow-up details call should fail, due to the backup ID being deleted
-	cmd = tester.StubRootCmd(
+	cmd = cliTD.StubRootCmd(
 		"backup", "details", "onedrive",
 		"--config-file", suite.cfgFP,
 		"--backup", string(suite.backupOp.Results.BackupID))
@@ -237,7 +240,7 @@ func (suite *BackupDeleteOneDriveE2ESuite) TestOneDriveBackupDeleteCmd_unknownID
 
 	defer flush()
 
-	cmd := tester.StubRootCmd(
+	cmd := cliTD.StubRootCmd(
 		"backup", "delete", "onedrive",
 		"--config-file", suite.cfgFP,
 		"--"+flags.BackupFN, uuid.NewString())

--- a/src/cli/backup/sharepoint_e2e_test.go
+++ b/src/cli/backup/sharepoint_e2e_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/operations"
 	"github.com/alcionai/corso/src/internal/tester"
-	tconfig "github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/repository"
 	"github.com/alcionai/corso/src/pkg/selectors"

--- a/src/cli/backup/sharepoint_e2e_test.go
+++ b/src/cli/backup/sharepoint_e2e_test.go
@@ -16,14 +16,17 @@ import (
 	"github.com/alcionai/corso/src/cli/config"
 	"github.com/alcionai/corso/src/cli/flags"
 	"github.com/alcionai/corso/src/cli/print"
+	cliTD "github.com/alcionai/corso/src/cli/testdata"
 	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/operations"
 	"github.com/alcionai/corso/src/internal/tester"
+	tconfig "github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/repository"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/selectors/testdata"
 	"github.com/alcionai/corso/src/pkg/storage"
+	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
 )
 
 // ---------------------------------------------------------------------------
@@ -44,7 +47,7 @@ type NoBackupSharePointE2ESuite struct {
 func TestNoBackupSharePointE2ESuite(t *testing.T) {
 	suite.Run(t, &NoBackupSharePointE2ESuite{Suite: tester.NewE2ESuite(
 		t,
-		[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
+		[][]string{storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs},
 	)})
 }
 
@@ -62,7 +65,7 @@ func (suite *NoBackupSharePointE2ESuite) SetupSuite() {
 	suite.vpr = vpr
 	suite.recorder = recorder
 	suite.cfgFP = cfgFilePath
-	suite.m365SiteID = tester.M365SiteID(t)
+	suite.m365SiteID = tconfig.M365SiteID(t)
 }
 
 func (suite *NoBackupSharePointE2ESuite) TestSharePointBackupListCmd_empty() {
@@ -75,7 +78,7 @@ func (suite *NoBackupSharePointE2ESuite) TestSharePointBackupListCmd_empty() {
 
 	suite.recorder.Reset()
 
-	cmd := tester.StubRootCmd(
+	cmd := cliTD.StubRootCmd(
 		"backup", "list", "sharepoint",
 		"--config-file", suite.cfgFP)
 	cli.BuildCommandTree(cmd)
@@ -113,7 +116,7 @@ func TestBackupDeleteSharePointE2ESuite(t *testing.T) {
 	suite.Run(t, &BackupDeleteSharePointE2ESuite{
 		Suite: tester.NewE2ESuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs}),
+			[][]string{storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs}),
 	})
 }
 
@@ -133,7 +136,7 @@ func (suite *BackupDeleteSharePointE2ESuite) SetupSuite() {
 	suite.cfgFP = cfgFilePath
 
 	var (
-		m365SiteID = tester.M365SiteID(t)
+		m365SiteID = tconfig.M365SiteID(t)
 		sites      = []string{m365SiteID}
 		ins        = idname.NewCache(map[string]string{m365SiteID: m365SiteID})
 	)
@@ -161,7 +164,7 @@ func (suite *BackupDeleteSharePointE2ESuite) TestSharePointBackupDeleteCmd() {
 
 	suite.recorder.Reset()
 
-	cmd := tester.StubRootCmd(
+	cmd := cliTD.StubRootCmd(
 		"backup", "delete", "sharepoint",
 		"--config-file", suite.cfgFP,
 		"--"+flags.BackupFN, string(suite.backupOp.Results.BackupID))
@@ -185,7 +188,7 @@ func (suite *BackupDeleteSharePointE2ESuite) TestSharePointBackupDeleteCmd() {
 
 // moved out of the func above to make the linter happy
 // // a follow-up details call should fail, due to the backup ID being deleted
-// cmd = tester.StubRootCmd(
+// cmd = cliTD.StubRootCmd(
 // 	"backup", "details", "sharepoint",
 // 	"--config-file", suite.cfgFP,
 // 	"--backup", string(suite.backupOp.Results.BackupID))
@@ -202,7 +205,7 @@ func (suite *BackupDeleteSharePointE2ESuite) TestSharePointBackupDeleteCmd_unkno
 
 	defer flush()
 
-	cmd := tester.StubRootCmd(
+	cmd := cliTD.StubRootCmd(
 		"backup", "delete", "sharepoint",
 		"--config-file", suite.cfgFP,
 		"--"+flags.BackupFN, uuid.NewString())

--- a/src/cli/config/config_test.go
+++ b/src/cli/config/config_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/alcionai/corso/src/cli/flags"
 	"github.com/alcionai/corso/src/internal/common/str"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/credentials"
 	"github.com/alcionai/corso/src/pkg/storage"
@@ -353,7 +353,7 @@ type ConfigIntegrationSuite struct {
 func TestConfigIntegrationSuite(t *testing.T) {
 	suite.Run(t, &ConfigIntegrationSuite{Suite: tester.NewIntegrationSuite(
 		t,
-		[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs},
+		[][]string{storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs},
 	)})
 }
 

--- a/src/cli/config/config_test.go
+++ b/src/cli/config/config_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/alcionai/corso/src/cli/flags"
 	"github.com/alcionai/corso/src/internal/common/str"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/credentials"
 	"github.com/alcionai/corso/src/pkg/storage"
+	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
 )
 
 const (
@@ -351,7 +353,7 @@ type ConfigIntegrationSuite struct {
 func TestConfigIntegrationSuite(t *testing.T) {
 	suite.Run(t, &ConfigIntegrationSuite{Suite: tester.NewIntegrationSuite(
 		t,
-		[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
+		[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs},
 	)})
 }
 
@@ -387,23 +389,23 @@ func (suite *ConfigIntegrationSuite) TestGetStorageAndAccount() {
 	err = vpr.ReadInConfig()
 	require.NoError(t, err, "reading repo config", clues.ToCore(err))
 
-	config, err := getStorageAndAccountWithViper(vpr, true, true, nil)
+	cfg, err := getStorageAndAccountWithViper(vpr, true, true, nil)
 	require.NoError(t, err, "getting storage and account from config", clues.ToCore(err))
 
-	readS3Cfg, err := config.Storage.S3Config()
+	readS3Cfg, err := cfg.Storage.S3Config()
 	require.NoError(t, err, "reading s3 config from storage", clues.ToCore(err))
 	assert.Equal(t, readS3Cfg.Bucket, s3Cfg.Bucket)
 	assert.Equal(t, readS3Cfg.Endpoint, s3Cfg.Endpoint)
 	assert.Equal(t, readS3Cfg.Prefix, s3Cfg.Prefix)
 	assert.Equal(t, readS3Cfg.DoNotUseTLS, s3Cfg.DoNotUseTLS)
 	assert.Equal(t, readS3Cfg.DoNotVerifyTLS, s3Cfg.DoNotVerifyTLS)
-	assert.Equal(t, config.RepoID, "repoid")
+	assert.Equal(t, cfg.RepoID, "repoid")
 
-	common, err := config.Storage.CommonConfig()
+	common, err := cfg.Storage.CommonConfig()
 	require.NoError(t, err, "reading common config from storage", clues.ToCore(err))
 	assert.Equal(t, common.CorsoPassphrase, os.Getenv(credentials.CorsoPassphrase))
 
-	readM365, err := config.Account.M365Config()
+	readM365, err := cfg.Account.M365Config()
 	require.NoError(t, err, "reading m365 config from account", clues.ToCore(err))
 	// Env var gets preference here. Where to get env tenantID from
 	// assert.Equal(t, readM365.AzureTenantID, m365.AzureTenantID)
@@ -435,23 +437,23 @@ func (suite *ConfigIntegrationSuite) TestGetStorageAndAccount_noFileOnlyOverride
 		StorageProviderTypeKey: storage.ProviderS3.String(),
 	}
 
-	config, err := getStorageAndAccountWithViper(vpr, false, false, overrides)
+	cfg, err := getStorageAndAccountWithViper(vpr, false, false, overrides)
 	require.NoError(t, err, "getting storage and account from config", clues.ToCore(err))
 
-	readS3Cfg, err := config.Storage.S3Config()
+	readS3Cfg, err := cfg.Storage.S3Config()
 	require.NoError(t, err, "reading s3 config from storage", clues.ToCore(err))
 	assert.Equal(t, readS3Cfg.Bucket, bkt)
-	assert.Equal(t, config.RepoID, "")
+	assert.Equal(t, cfg.RepoID, "")
 	assert.Equal(t, readS3Cfg.Endpoint, end)
 	assert.Equal(t, readS3Cfg.Prefix, pfx)
 	assert.True(t, readS3Cfg.DoNotUseTLS)
 	assert.True(t, readS3Cfg.DoNotVerifyTLS)
 
-	common, err := config.Storage.CommonConfig()
+	common, err := cfg.Storage.CommonConfig()
 	require.NoError(t, err, "reading common config from storage", clues.ToCore(err))
 	assert.Equal(t, common.CorsoPassphrase, os.Getenv(credentials.CorsoPassphrase))
 
-	readM365, err := config.Account.M365Config()
+	readM365, err := cfg.Account.M365Config()
 	require.NoError(t, err, "reading m365 config from account", clues.ToCore(err))
 	assert.Equal(t, readM365.AzureTenantID, m365.AzureTenantID)
 	assert.Equal(t, readM365.AzureClientID, os.Getenv(credentials.AzureClientID))

--- a/src/cli/repo/s3_e2e_test.go
+++ b/src/cli/repo/s3_e2e_test.go
@@ -11,10 +11,13 @@ import (
 
 	"github.com/alcionai/corso/src/cli"
 	"github.com/alcionai/corso/src/cli/config"
+	cliTD "github.com/alcionai/corso/src/cli/testdata"
 	"github.com/alcionai/corso/src/internal/tester"
+	tconfig "github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/repository"
+	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
 )
 
 type S3E2ESuite struct {
@@ -24,7 +27,7 @@ type S3E2ESuite struct {
 func TestS3E2ESuite(t *testing.T) {
 	suite.Run(t, &S3E2ESuite{Suite: tester.NewE2ESuite(
 		t,
-		[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
+		[][]string{storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs},
 	)})
 }
 
@@ -58,11 +61,11 @@ func (suite *S3E2ESuite) TestInitS3Cmd() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			st := tester.NewPrefixedS3Storage(t)
+			st := storeTD.NewPrefixedS3Storage(t)
 			cfg, err := st.S3Config()
 			require.NoError(t, err, clues.ToCore(err))
 
-			vpr, configFP := tester.MakeTempTestConfigClone(t, nil)
+			vpr, configFP := tconfig.MakeTempTestConfigClone(t, nil)
 			if !test.hasConfigFile {
 				// Ideally we could use `/dev/null`, but you need a
 				// toml file plus this works cross platform
@@ -71,7 +74,7 @@ func (suite *S3E2ESuite) TestInitS3Cmd() {
 
 			ctx = config.SetViper(ctx, vpr)
 
-			cmd := tester.StubRootCmd(
+			cmd := cliTD.StubRootCmd(
 				"repo", "init", "s3",
 				"--config-file", configFP,
 				"--bucket", test.bucketPrefix+cfg.Bucket,
@@ -95,16 +98,16 @@ func (suite *S3E2ESuite) TestInitMultipleTimes() {
 
 	defer flush()
 
-	st := tester.NewPrefixedS3Storage(t)
+	st := storeTD.NewPrefixedS3Storage(t)
 	cfg, err := st.S3Config()
 	require.NoError(t, err, clues.ToCore(err))
 
-	vpr, configFP := tester.MakeTempTestConfigClone(t, nil)
+	vpr, configFP := tconfig.MakeTempTestConfigClone(t, nil)
 
 	ctx = config.SetViper(ctx, vpr)
 
 	for i := 0; i < 2; i++ {
-		cmd := tester.StubRootCmd(
+		cmd := cliTD.StubRootCmd(
 			"repo", "init", "s3",
 			"--config-file", configFP,
 			"--bucket", cfg.Bucket,
@@ -125,15 +128,15 @@ func (suite *S3E2ESuite) TestInitS3Cmd_missingBucket() {
 
 	defer flush()
 
-	st := tester.NewPrefixedS3Storage(t)
+	st := storeTD.NewPrefixedS3Storage(t)
 	cfg, err := st.S3Config()
 	require.NoError(t, err, clues.ToCore(err))
 
-	vpr, configFP := tester.MakeTempTestConfigClone(t, nil)
+	vpr, configFP := tconfig.MakeTempTestConfigClone(t, nil)
 
 	ctx = config.SetViper(ctx, vpr)
 
-	cmd := tester.StubRootCmd(
+	cmd := cliTD.StubRootCmd(
 		"repo", "init", "s3",
 		"--config-file", configFP,
 		"--prefix", cfg.Prefix)
@@ -174,16 +177,16 @@ func (suite *S3E2ESuite) TestConnectS3Cmd() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			st := tester.NewPrefixedS3Storage(t)
+			st := storeTD.NewPrefixedS3Storage(t)
 			cfg, err := st.S3Config()
 			require.NoError(t, err, clues.ToCore(err))
 
 			force := map[string]string{
-				tester.TestCfgAccountProvider: "M365",
-				tester.TestCfgStorageProvider: "S3",
-				tester.TestCfgPrefix:          cfg.Prefix,
+				tconfig.TestCfgAccountProvider: "M365",
+				tconfig.TestCfgStorageProvider: "S3",
+				tconfig.TestCfgPrefix:          cfg.Prefix,
 			}
-			vpr, configFP := tester.MakeTempTestConfigClone(t, force)
+			vpr, configFP := tconfig.MakeTempTestConfigClone(t, force)
 			if !test.hasConfigFile {
 				// Ideally we could use `/dev/null`, but you need a
 				// toml file plus this works cross platform
@@ -197,7 +200,7 @@ func (suite *S3E2ESuite) TestConnectS3Cmd() {
 			require.NoError(t, err, clues.ToCore(err))
 
 			// then test it
-			cmd := tester.StubRootCmd(
+			cmd := cliTD.StubRootCmd(
 				"repo", "connect", "s3",
 				"--config-file", configFP,
 				"--bucket", test.bucketPrefix+cfg.Bucket,
@@ -218,15 +221,15 @@ func (suite *S3E2ESuite) TestConnectS3Cmd_BadBucket() {
 
 	defer flush()
 
-	st := tester.NewPrefixedS3Storage(t)
+	st := storeTD.NewPrefixedS3Storage(t)
 	cfg, err := st.S3Config()
 	require.NoError(t, err, clues.ToCore(err))
 
-	vpr, configFP := tester.MakeTempTestConfigClone(t, nil)
+	vpr, configFP := tconfig.MakeTempTestConfigClone(t, nil)
 
 	ctx = config.SetViper(ctx, vpr)
 
-	cmd := tester.StubRootCmd(
+	cmd := cliTD.StubRootCmd(
 		"repo", "connect", "s3",
 		"--config-file", configFP,
 		"--bucket", "wrong",
@@ -244,15 +247,15 @@ func (suite *S3E2ESuite) TestConnectS3Cmd_BadPrefix() {
 
 	defer flush()
 
-	st := tester.NewPrefixedS3Storage(t)
+	st := storeTD.NewPrefixedS3Storage(t)
 	cfg, err := st.S3Config()
 	require.NoError(t, err, clues.ToCore(err))
 
-	vpr, configFP := tester.MakeTempTestConfigClone(t, nil)
+	vpr, configFP := tconfig.MakeTempTestConfigClone(t, nil)
 
 	ctx = config.SetViper(ctx, vpr)
 
-	cmd := tester.StubRootCmd(
+	cmd := cliTD.StubRootCmd(
 		"repo", "connect", "s3",
 		"--config-file", configFP,
 		"--bucket", cfg.Bucket,

--- a/src/cli/repo/s3_e2e_test.go
+++ b/src/cli/repo/s3_e2e_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/alcionai/corso/src/cli/config"
 	cliTD "github.com/alcionai/corso/src/cli/testdata"
 	"github.com/alcionai/corso/src/internal/tester"
-	tconfig "github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/repository"

--- a/src/cli/restore/exchange_e2e_test.go
+++ b/src/cli/restore/exchange_e2e_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/exchange"
 	"github.com/alcionai/corso/src/internal/operations"
 	"github.com/alcionai/corso/src/internal/tester"
-	tconfig "github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"

--- a/src/cli/restore/exchange_e2e_test.go
+++ b/src/cli/restore/exchange_e2e_test.go
@@ -13,16 +13,19 @@ import (
 	"github.com/alcionai/corso/src/cli"
 	"github.com/alcionai/corso/src/cli/config"
 	"github.com/alcionai/corso/src/cli/flags"
+	cliTD "github.com/alcionai/corso/src/cli/testdata"
 	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/m365/exchange"
 	"github.com/alcionai/corso/src/internal/operations"
 	"github.com/alcionai/corso/src/internal/tester"
+	tconfig "github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/repository"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/storage"
+	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
 )
 
 var (
@@ -48,7 +51,7 @@ func TestRestoreExchangeE2ESuite(t *testing.T) {
 	suite.Run(t, &RestoreExchangeE2ESuite{
 		Suite: tester.NewE2ESuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs}),
+			[][]string{storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs}),
 	})
 }
 
@@ -59,20 +62,20 @@ func (suite *RestoreExchangeE2ESuite) SetupSuite() {
 	defer flush()
 
 	// aggregate required details
-	suite.acct = tester.NewM365Account(t)
-	suite.st = tester.NewPrefixedS3Storage(t)
+	suite.acct = tconfig.NewM365Account(t)
+	suite.st = storeTD.NewPrefixedS3Storage(t)
 
 	cfg, err := suite.st.S3Config()
 	require.NoError(t, err, clues.ToCore(err))
 
 	force := map[string]string{
-		tester.TestCfgAccountProvider: "M365",
-		tester.TestCfgStorageProvider: "S3",
-		tester.TestCfgPrefix:          cfg.Prefix,
+		tconfig.TestCfgAccountProvider: "M365",
+		tconfig.TestCfgStorageProvider: "S3",
+		tconfig.TestCfgPrefix:          cfg.Prefix,
 	}
-	suite.vpr, suite.cfgFP = tester.MakeTempTestConfigClone(t, force)
+	suite.vpr, suite.cfgFP = tconfig.MakeTempTestConfigClone(t, force)
 
-	suite.m365UserID = strings.ToLower(tester.M365UserID(t))
+	suite.m365UserID = strings.ToLower(tconfig.M365UserID(t))
 
 	var (
 		users = []string{suite.m365UserID}
@@ -132,7 +135,7 @@ func (suite *RestoreExchangeE2ESuite) TestExchangeRestoreCmd() {
 
 			defer flush()
 
-			cmd := tester.StubRootCmd(
+			cmd := cliTD.StubRootCmd(
 				"restore", "exchange",
 				"--config-file", suite.cfgFP,
 				"--"+flags.BackupFN, string(suite.backupOps[set].Results.BackupID))
@@ -167,7 +170,7 @@ func (suite *RestoreExchangeE2ESuite) TestExchangeRestoreCmd_badTimeFlags() {
 				timeFilter = "--" + flags.EventStartsAfterFN
 			}
 
-			cmd := tester.StubRootCmd(
+			cmd := cliTD.StubRootCmd(
 				"restore", "exchange",
 				"--config-file", suite.cfgFP,
 				"--"+flags.BackupFN, string(suite.backupOps[set].Results.BackupID),
@@ -201,7 +204,7 @@ func (suite *RestoreExchangeE2ESuite) TestExchangeRestoreCmd_badBoolFlags() {
 				timeFilter = "--" + flags.EventRecursFN
 			}
 
-			cmd := tester.StubRootCmd(
+			cmd := cliTD.StubRootCmd(
 				"restore", "exchange",
 				"--config-file", suite.cfgFP,
 				"--"+flags.BackupFN, string(suite.backupOps[set].Results.BackupID),

--- a/src/cli/testdata/cli.go
+++ b/src/cli/testdata/cli.go
@@ -1,4 +1,4 @@
-package tester
+package testdata
 
 import (
 	"fmt"

--- a/src/cmd/sanity_test/sanity_tests.go
+++ b/src/cmd/sanity_test/sanity_tests.go
@@ -18,7 +18,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
-	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/filters"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -56,7 +56,7 @@ func main() {
 	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
 	adapter, err := graph.CreateAdapter(
-		tester.GetM365TenantID(ctx),
+		config.GetM365TenantID(ctx),
 		os.Getenv("AZURE_CLIENT_ID"),
 		os.Getenv("AZURE_CLIENT_SECRET"))
 	if err != nil {
@@ -65,8 +65,8 @@ func main() {
 
 	var (
 		client           = msgraphsdk.NewGraphServiceClient(adapter)
-		testUser         = tester.GetM365UserID(ctx)
-		testSite         = tester.GetM365SiteID(ctx)
+		testUser         = config.GetM365UserID(ctx)
+		testSite         = config.GetM365SiteID(ctx)
 		testService      = os.Getenv("SANITY_RESTORE_SERVICE")
 		folder           = strings.TrimSpace(os.Getenv("SANITY_RESTORE_FOLDER"))
 		startTime, _     = mustGetTimeFromName(ctx, folder)

--- a/src/cmd/sanity_test/sanity_tests.go
+++ b/src/cmd/sanity_test/sanity_tests.go
@@ -18,7 +18,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/filters"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -56,7 +56,7 @@ func main() {
 	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
 	adapter, err := graph.CreateAdapter(
-		config.GetM365TenantID(ctx),
+		tconfig.GetM365TenantID(ctx),
 		os.Getenv("AZURE_CLIENT_ID"),
 		os.Getenv("AZURE_CLIENT_SECRET"))
 	if err != nil {
@@ -65,8 +65,8 @@ func main() {
 
 	var (
 		client           = msgraphsdk.NewGraphServiceClient(adapter)
-		testUser         = config.GetM365UserID(ctx)
-		testSite         = config.GetM365SiteID(ctx)
+		testUser         = tconfig.GetM365UserID(ctx)
+		testSite         = tconfig.GetM365SiteID(ctx)
 		testService      = os.Getenv("SANITY_RESTORE_SERVICE")
 		folder           = strings.TrimSpace(os.Getenv("SANITY_RESTORE_FOLDER"))
 		startTime, _     = mustGetTimeFromName(ctx, folder)

--- a/src/internal/kopia/conn_test.go
+++ b/src/internal/kopia/conn_test.go
@@ -16,13 +16,14 @@ import (
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/control/repository"
 	"github.com/alcionai/corso/src/pkg/storage"
+	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
 )
 
 func openKopiaRepo(
 	t *testing.T,
 	ctx context.Context, //revive:disable-line:context-as-argument
 ) (*conn, error) {
-	st := tester.NewPrefixedS3Storage(t)
+	st := storeTD.NewPrefixedS3Storage(t)
 
 	k := NewConn(st)
 	if err := k.Initialize(ctx, repository.Options{}); err != nil {
@@ -67,7 +68,7 @@ func TestWrapperIntegrationSuite(t *testing.T) {
 	suite.Run(t, &WrapperIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs},
+			[][]string{storeTD.AWSStorageCredEnvs},
 		),
 	})
 }
@@ -78,7 +79,7 @@ func (suite *WrapperIntegrationSuite) TestRepoExistsError() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	st := tester.NewPrefixedS3Storage(t)
+	st := storeTD.NewPrefixedS3Storage(t)
 	k := NewConn(st)
 
 	err := k.Initialize(ctx, repository.Options{})
@@ -98,7 +99,7 @@ func (suite *WrapperIntegrationSuite) TestBadProviderErrors() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	st := tester.NewPrefixedS3Storage(t)
+	st := storeTD.NewPrefixedS3Storage(t)
 	st.Provider = storage.ProviderUnknown
 	k := NewConn(st)
 
@@ -112,7 +113,7 @@ func (suite *WrapperIntegrationSuite) TestConnectWithoutInitErrors() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	st := tester.NewPrefixedS3Storage(t)
+	st := storeTD.NewPrefixedS3Storage(t)
 	k := NewConn(st)
 
 	err := k.Connect(ctx, repository.Options{})
@@ -409,7 +410,7 @@ func (suite *WrapperIntegrationSuite) TestSetUserAndHost() {
 		Host: "bar",
 	}
 
-	st := tester.NewPrefixedS3Storage(t)
+	st := storeTD.NewPrefixedS3Storage(t)
 	k := NewConn(st)
 
 	err := k.Initialize(ctx, opts)

--- a/src/internal/kopia/model_store_test.go
+++ b/src/internal/kopia/model_store_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/control/repository"
+	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
 )
 
 type fooModel struct {
@@ -70,7 +71,7 @@ func TestModelStoreIntegrationSuite(t *testing.T) {
 	suite.Run(t, &ModelStoreIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs},
+			[][]string{storeTD.AWSStorageCredEnvs},
 		),
 	})
 }
@@ -731,7 +732,7 @@ func TestModelStoreRegressionSuite(t *testing.T) {
 	suite.Run(t, &ModelStoreRegressionSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs},
+			[][]string{storeTD.AWSStorageCredEnvs},
 		),
 	})
 }
@@ -804,7 +805,7 @@ func openConnAndModelStore(
 	t *testing.T,
 	ctx context.Context, //revive:disable-line:context-as-argument
 ) (*conn, *ModelStore) {
-	st := tester.NewPrefixedS3Storage(t)
+	st := storeTD.NewPrefixedS3Storage(t)
 	c := NewConn(st)
 
 	err := c.Initialize(ctx, repository.Options{})

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
+	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
 )
 
 const (
@@ -167,7 +168,7 @@ func TestBasicKopiaIntegrationSuite(t *testing.T) {
 	suite.Run(t, &BasicKopiaIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs},
+			[][]string{storeTD.AWSStorageCredEnvs},
 		),
 	})
 }
@@ -295,7 +296,7 @@ func TestKopiaIntegrationSuite(t *testing.T) {
 	suite.Run(t, &KopiaIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs},
+			[][]string{storeTD.AWSStorageCredEnvs},
 		),
 	})
 }
@@ -930,7 +931,7 @@ func TestKopiaSimpleRepoIntegrationSuite(t *testing.T) {
 	suite.Run(t, &KopiaSimpleRepoIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs},
+			[][]string{storeTD.AWSStorageCredEnvs},
 		),
 	})
 }

--- a/src/internal/m365/backup_test.go
+++ b/src/internal/m365/backup_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/resource"
 	"github.com/alcionai/corso/src/internal/m365/sharepoint"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -40,17 +41,17 @@ func TestDataCollectionIntgSuite(t *testing.T) {
 	suite.Run(t, &DataCollectionIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 
 func (suite *DataCollectionIntgSuite) SetupSuite() {
 	t := suite.T()
 
-	suite.user = tester.M365UserID(t)
-	suite.site = tester.M365SiteID(t)
+	suite.user = config.M365UserID(t)
+	suite.site = config.M365SiteID(t)
 
-	acct := tester.NewM365Account(t)
+	acct := config.NewM365Account(t)
 	creds, err := acct.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -339,7 +340,7 @@ func TestSPCollectionIntgSuite(t *testing.T) {
 	suite.Run(t, &SPCollectionIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs},
+			[][]string{config.M365AcctCredEnvs},
 		),
 	})
 }
@@ -349,7 +350,7 @@ func (suite *SPCollectionIntgSuite) SetupSuite() {
 	defer flush()
 
 	suite.connector = newController(ctx, suite.T(), resource.Sites, path.SharePointService)
-	suite.user = tester.M365UserID(suite.T())
+	suite.user = config.M365UserID(suite.T())
 
 	tester.LogTimeOfTest(suite.T())
 }
@@ -361,7 +362,7 @@ func (suite *SPCollectionIntgSuite) TestCreateSharePointCollection_Libraries() {
 	defer flush()
 
 	var (
-		siteID  = tester.M365SiteID(t)
+		siteID  = config.M365SiteID(t)
 		ctrl    = newController(ctx, t, resource.Sites, path.SharePointService)
 		siteIDs = []string{siteID}
 	)
@@ -408,7 +409,7 @@ func (suite *SPCollectionIntgSuite) TestCreateSharePointCollection_Lists() {
 	defer flush()
 
 	var (
-		siteID  = tester.M365SiteID(t)
+		siteID  = config.M365SiteID(t)
 		ctrl    = newController(ctx, t, resource.Sites, path.SharePointService)
 		siteIDs = []string{siteID}
 	)

--- a/src/internal/m365/backup_test.go
+++ b/src/internal/m365/backup_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/resource"
 	"github.com/alcionai/corso/src/internal/m365/sharepoint"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -41,17 +41,17 @@ func TestDataCollectionIntgSuite(t *testing.T) {
 	suite.Run(t, &DataCollectionIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 
 func (suite *DataCollectionIntgSuite) SetupSuite() {
 	t := suite.T()
 
-	suite.user = config.M365UserID(t)
-	suite.site = config.M365SiteID(t)
+	suite.user = tconfig.M365UserID(t)
+	suite.site = tconfig.M365SiteID(t)
 
-	acct := config.NewM365Account(t)
+	acct := tconfig.NewM365Account(t)
 	creds, err := acct.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -340,7 +340,7 @@ func TestSPCollectionIntgSuite(t *testing.T) {
 	suite.Run(t, &SPCollectionIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs},
+			[][]string{tconfig.M365AcctCredEnvs},
 		),
 	})
 }
@@ -350,7 +350,7 @@ func (suite *SPCollectionIntgSuite) SetupSuite() {
 	defer flush()
 
 	suite.connector = newController(ctx, suite.T(), resource.Sites, path.SharePointService)
-	suite.user = config.M365UserID(suite.T())
+	suite.user = tconfig.M365UserID(suite.T())
 
 	tester.LogTimeOfTest(suite.T())
 }
@@ -362,7 +362,7 @@ func (suite *SPCollectionIntgSuite) TestCreateSharePointCollection_Libraries() {
 	defer flush()
 
 	var (
-		siteID  = config.M365SiteID(t)
+		siteID  = tconfig.M365SiteID(t)
 		ctrl    = newController(ctx, t, resource.Sites, path.SharePointService)
 		siteIDs = []string{siteID}
 	)
@@ -409,7 +409,7 @@ func (suite *SPCollectionIntgSuite) TestCreateSharePointCollection_Lists() {
 	defer flush()
 
 	var (
-		siteID  = config.M365SiteID(t)
+		siteID  = tconfig.M365SiteID(t)
 		ctrl    = newController(ctx, t, resource.Sites, path.SharePointService)
 		siteIDs = []string{siteID}
 	)

--- a/src/internal/m365/controller_test.go
+++ b/src/internal/m365/controller_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/stub"
 	"github.com/alcionai/corso/src/internal/m365/support"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
@@ -273,7 +273,7 @@ func TestControllerIntegrationSuite(t *testing.T) {
 	suite.Run(t, &ControllerIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs},
+			[][]string{tconfig.M365AcctCredEnvs},
 		),
 	})
 }
@@ -285,8 +285,8 @@ func (suite *ControllerIntegrationSuite) SetupSuite() {
 	defer flush()
 
 	suite.ctrl = newController(ctx, t, resource.Users, path.ExchangeService)
-	suite.user = config.M365UserID(t)
-	suite.secondaryUser = config.SecondaryM365UserID(t)
+	suite.user = tconfig.M365UserID(t)
+	suite.secondaryUser = tconfig.SecondaryM365UserID(t)
 
 	tester.LogTimeOfTest(t)
 }
@@ -1182,7 +1182,7 @@ func (suite *ControllerIntegrationSuite) TestBackup_CreatesPrefixCollections() {
 			name:        "SharePoint",
 			resourceCat: resource.Sites,
 			selectorFunc: func(t *testing.T) selectors.Selector {
-				sel := selectors.NewSharePointBackup([]string{config.M365SiteID(t)})
+				sel := selectors.NewSharePointBackup([]string{tconfig.M365SiteID(t)})
 				sel.Include(
 					sel.LibraryFolders([]string{selectors.NoneTgt}),
 					// not yet in use

--- a/src/internal/m365/exchange/backup_test.go
+++ b/src/internal/m365/exchange/backup_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/m365/support"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -394,7 +395,7 @@ func TestBackupIntgSuite(t *testing.T) {
 	suite.Run(t, &BackupIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 
@@ -406,10 +407,10 @@ func (suite *BackupIntgSuite) SetupSuite() {
 
 	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
-	suite.user = tester.M365UserID(t)
-	suite.site = tester.M365SiteID(t)
+	suite.user = config.M365UserID(t)
+	suite.site = config.M365SiteID(t)
 
-	acct := tester.NewM365Account(t)
+	acct := config.NewM365Account(t)
 	creds, err := acct.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -423,7 +424,7 @@ func (suite *BackupIntgSuite) SetupSuite() {
 
 func (suite *BackupIntgSuite) TestMailFetch() {
 	var (
-		userID   = tester.M365UserID(suite.T())
+		userID   = config.M365UserID(suite.T())
 		users    = []string{userID}
 		handlers = BackupHandlers(suite.ac)
 	)
@@ -507,7 +508,7 @@ func (suite *BackupIntgSuite) TestMailFetch() {
 
 func (suite *BackupIntgSuite) TestDelta() {
 	var (
-		userID   = tester.M365UserID(suite.T())
+		userID   = config.M365UserID(suite.T())
 		users    = []string{userID}
 		handlers = BackupHandlers(suite.ac)
 	)
@@ -878,7 +879,7 @@ func TestServiceIteratorsUnitSuite(t *testing.T) {
 }
 
 func (suite *CollectionPopulationSuite) SetupSuite() {
-	a := tester.NewMockM365Account(suite.T())
+	a := config.NewFakeM365Account(suite.T())
 	m365, err := a.M365Config()
 	require.NoError(suite.T(), err, clues.ToCore(err))
 	suite.creds = m365

--- a/src/internal/m365/exchange/backup_test.go
+++ b/src/internal/m365/exchange/backup_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/m365/support"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -395,7 +395,7 @@ func TestBackupIntgSuite(t *testing.T) {
 	suite.Run(t, &BackupIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 
@@ -407,10 +407,10 @@ func (suite *BackupIntgSuite) SetupSuite() {
 
 	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
-	suite.user = config.M365UserID(t)
-	suite.site = config.M365SiteID(t)
+	suite.user = tconfig.M365UserID(t)
+	suite.site = tconfig.M365SiteID(t)
 
-	acct := config.NewM365Account(t)
+	acct := tconfig.NewM365Account(t)
 	creds, err := acct.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -424,7 +424,7 @@ func (suite *BackupIntgSuite) SetupSuite() {
 
 func (suite *BackupIntgSuite) TestMailFetch() {
 	var (
-		userID   = config.M365UserID(suite.T())
+		userID   = tconfig.M365UserID(suite.T())
 		users    = []string{userID}
 		handlers = BackupHandlers(suite.ac)
 	)
@@ -508,7 +508,7 @@ func (suite *BackupIntgSuite) TestMailFetch() {
 
 func (suite *BackupIntgSuite) TestDelta() {
 	var (
-		userID   = config.M365UserID(suite.T())
+		userID   = tconfig.M365UserID(suite.T())
 		users    = []string{userID}
 		handlers = BackupHandlers(suite.ac)
 	)
@@ -879,7 +879,7 @@ func TestServiceIteratorsUnitSuite(t *testing.T) {
 }
 
 func (suite *CollectionPopulationSuite) SetupSuite() {
-	a := config.NewFakeM365Account(suite.T())
+	a := tconfig.NewFakeM365Account(suite.T())
 	m365, err := a.M365Config()
 	require.NoError(suite.T(), err, clues.ToCore(err))
 	suite.creds = m365

--- a/src/internal/m365/exchange/contacts_restore_test.go
+++ b/src/internal/m365/exchange/contacts_restore_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/exchange/mock"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -60,7 +60,7 @@ func TestContactsRestoreIntgSuite(t *testing.T) {
 	suite.Run(t, &ContactsRestoreIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/internal/m365/exchange/contacts_restore_test.go
+++ b/src/internal/m365/exchange/contacts_restore_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/exchange/mock"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -59,7 +60,7 @@ func TestContactsRestoreIntgSuite(t *testing.T) {
 	suite.Run(t, &ContactsRestoreIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/internal/m365/exchange/container_resolver_test.go
+++ b/src/internal/m365/exchange/container_resolver_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -683,14 +683,14 @@ func TestContainerResolverIntegrationSuite(t *testing.T) {
 	suite.Run(t, &ContainerResolverSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 
 func (suite *ContainerResolverSuite) SetupSuite() {
 	t := suite.T()
 
-	a := config.NewM365Account(t)
+	a := tconfig.NewM365Account(t)
 	m365, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -703,7 +703,7 @@ func (suite *ContainerResolverSuite) TestPopulate() {
 
 	eventFunc := func(t *testing.T) graph.ContainerResolver {
 		return &eventContainerCache{
-			userID: config.M365UserID(t),
+			userID: tconfig.M365UserID(t),
 			enumer: ac.Events(),
 			getter: ac.Events(),
 		}
@@ -711,7 +711,7 @@ func (suite *ContainerResolverSuite) TestPopulate() {
 
 	contactFunc := func(t *testing.T) graph.ContainerResolver {
 		return &contactContainerCache{
-			userID: config.M365UserID(t),
+			userID: tconfig.M365UserID(t),
 			enumer: ac.Contacts(),
 			getter: ac.Contacts(),
 		}

--- a/src/internal/m365/exchange/container_resolver_test.go
+++ b/src/internal/m365/exchange/container_resolver_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -682,14 +683,14 @@ func TestContainerResolverIntegrationSuite(t *testing.T) {
 	suite.Run(t, &ContainerResolverSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 
 func (suite *ContainerResolverSuite) SetupSuite() {
 	t := suite.T()
 
-	a := tester.NewM365Account(t)
+	a := config.NewM365Account(t)
 	m365, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -702,7 +703,7 @@ func (suite *ContainerResolverSuite) TestPopulate() {
 
 	eventFunc := func(t *testing.T) graph.ContainerResolver {
 		return &eventContainerCache{
-			userID: tester.M365UserID(t),
+			userID: config.M365UserID(t),
 			enumer: ac.Events(),
 			getter: ac.Events(),
 		}
@@ -710,7 +711,7 @@ func (suite *ContainerResolverSuite) TestPopulate() {
 
 	contactFunc := func(t *testing.T) graph.ContainerResolver {
 		return &contactContainerCache{
-			userID: tester.M365UserID(t),
+			userID: config.M365UserID(t),
 			enumer: ac.Contacts(),
 			getter: ac.Contacts(),
 		}

--- a/src/internal/m365/exchange/events_restore_test.go
+++ b/src/internal/m365/exchange/events_restore_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/exchange/mock"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -107,7 +108,7 @@ func TestEventsRestoreIntgSuite(t *testing.T) {
 	suite.Run(t, &EventsRestoreIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/internal/m365/exchange/events_restore_test.go
+++ b/src/internal/m365/exchange/events_restore_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/exchange/mock"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -108,7 +108,7 @@ func TestEventsRestoreIntgSuite(t *testing.T) {
 	suite.Run(t, &EventsRestoreIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/internal/m365/exchange/helper_test.go
+++ b/src/internal/m365/exchange/helper_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
@@ -24,7 +24,7 @@ func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	a := config.NewM365Account(t)
+	a := tconfig.NewM365Account(t)
 	creds, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -33,7 +33,7 @@ func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
 	its.ac, err = api.NewClient(creds)
 	require.NoError(t, err, clues.ToCore(err))
 
-	its.userID = config.GetM365UserID(ctx)
+	its.userID = tconfig.GetM365UserID(ctx)
 
 	return its
 }

--- a/src/internal/m365/exchange/helper_test.go
+++ b/src/internal/m365/exchange/helper_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
@@ -23,7 +24,7 @@ func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	a := tester.NewM365Account(t)
+	a := config.NewM365Account(t)
 	creds, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -32,7 +33,7 @@ func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
 	its.ac, err = api.NewClient(creds)
 	require.NoError(t, err, clues.ToCore(err))
 
-	its.userID = tester.GetM365UserID(ctx)
+	its.userID = config.GetM365UserID(ctx)
 
 	return its
 }

--- a/src/internal/m365/exchange/mail_container_cache_test.go
+++ b/src/internal/m365/exchange/mail_container_cache_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
@@ -37,7 +37,7 @@ func TestMailFolderCacheIntegrationSuite(t *testing.T) {
 	suite.Run(t, &MailFolderCacheIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs},
+			[][]string{tconfig.M365AcctCredEnvs},
 		),
 	})
 }
@@ -45,7 +45,7 @@ func TestMailFolderCacheIntegrationSuite(t *testing.T) {
 func (suite *MailFolderCacheIntegrationSuite) SetupSuite() {
 	t := suite.T()
 
-	a := config.NewM365Account(t)
+	a := tconfig.NewM365Account(t)
 	m365, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -74,7 +74,7 @@ func (suite *MailFolderCacheIntegrationSuite) TestDeltaFetch() {
 			path: []string{"some", "leading", "path"},
 		},
 	}
-	userID := config.M365UserID(suite.T())
+	userID := tconfig.M365UserID(suite.T())
 
 	for _, test := range tests {
 		suite.Run(test.name, func() {

--- a/src/internal/m365/exchange/mail_container_cache_test.go
+++ b/src/internal/m365/exchange/mail_container_cache_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
@@ -36,7 +37,7 @@ func TestMailFolderCacheIntegrationSuite(t *testing.T) {
 	suite.Run(t, &MailFolderCacheIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs},
+			[][]string{config.M365AcctCredEnvs},
 		),
 	})
 }
@@ -44,7 +45,7 @@ func TestMailFolderCacheIntegrationSuite(t *testing.T) {
 func (suite *MailFolderCacheIntegrationSuite) SetupSuite() {
 	t := suite.T()
 
-	a := tester.NewM365Account(t)
+	a := config.NewM365Account(t)
 	m365, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -73,7 +74,7 @@ func (suite *MailFolderCacheIntegrationSuite) TestDeltaFetch() {
 			path: []string{"some", "leading", "path"},
 		},
 	}
-	userID := tester.M365UserID(suite.T())
+	userID := config.M365UserID(suite.T())
 
 	for _, test := range tests {
 		suite.Run(test.name, func() {

--- a/src/internal/m365/exchange/mail_restore_test.go
+++ b/src/internal/m365/exchange/mail_restore_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/exchange/mock"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -78,7 +78,7 @@ func TestMailRestoreIntgSuite(t *testing.T) {
 	suite.Run(t, &MailRestoreIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/internal/m365/exchange/mail_restore_test.go
+++ b/src/internal/m365/exchange/mail_restore_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/exchange/mock"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -77,7 +78,7 @@ func TestMailRestoreIntgSuite(t *testing.T) {
 	suite.Run(t, &MailRestoreIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/internal/m365/exchange/restore_test.go
+++ b/src/internal/m365/exchange/restore_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	exchMock "github.com/alcionai/corso/src/internal/m365/exchange/mock"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
@@ -31,14 +31,14 @@ func TestRestoreIntgSuite(t *testing.T) {
 	suite.Run(t, &RestoreIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 
 func (suite *RestoreIntgSuite) SetupSuite() {
 	t := suite.T()
 
-	a := config.NewM365Account(t)
+	a := tconfig.NewM365Account(t)
 	m365, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -56,7 +56,7 @@ func (suite *RestoreIntgSuite) TestRestoreContact() {
 	defer flush()
 
 	var (
-		userID     = config.M365UserID(t)
+		userID     = tconfig.M365UserID(t)
 		folderName = testdata.DefaultRestoreConfig("contact").Location
 		handler    = newContactRestoreHandler(suite.ac)
 	)
@@ -92,7 +92,7 @@ func (suite *RestoreIntgSuite) TestRestoreEvent() {
 	defer flush()
 
 	var (
-		userID  = config.M365UserID(t)
+		userID  = tconfig.M365UserID(t)
 		subject = testdata.DefaultRestoreConfig("event").Location
 		handler = newEventRestoreHandler(suite.ac)
 	)
@@ -165,7 +165,7 @@ func (suite *RestoreIntgSuite) TestRestoreExchangeObject() {
 
 	handlers := restoreHandlers(suite.ac)
 
-	userID := config.M365UserID(suite.T())
+	userID := tconfig.M365UserID(suite.T())
 
 	tests := []struct {
 		name        string
@@ -396,7 +396,7 @@ func (suite *RestoreIntgSuite) TestRestoreAndBackupEvent_recurringInstancesWithA
 	defer flush()
 
 	var (
-		userID  = config.M365UserID(t)
+		userID  = tconfig.M365UserID(t)
 		subject = testdata.DefaultRestoreConfig("event").Location
 		handler = newEventRestoreHandler(suite.ac)
 	)

--- a/src/internal/m365/exchange/restore_test.go
+++ b/src/internal/m365/exchange/restore_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	exchMock "github.com/alcionai/corso/src/internal/m365/exchange/mock"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
@@ -30,14 +31,14 @@ func TestRestoreIntgSuite(t *testing.T) {
 	suite.Run(t, &RestoreIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 
 func (suite *RestoreIntgSuite) SetupSuite() {
 	t := suite.T()
 
-	a := tester.NewM365Account(t)
+	a := config.NewM365Account(t)
 	m365, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -55,7 +56,7 @@ func (suite *RestoreIntgSuite) TestRestoreContact() {
 	defer flush()
 
 	var (
-		userID     = tester.M365UserID(t)
+		userID     = config.M365UserID(t)
 		folderName = testdata.DefaultRestoreConfig("contact").Location
 		handler    = newContactRestoreHandler(suite.ac)
 	)
@@ -91,7 +92,7 @@ func (suite *RestoreIntgSuite) TestRestoreEvent() {
 	defer flush()
 
 	var (
-		userID  = tester.M365UserID(t)
+		userID  = config.M365UserID(t)
 		subject = testdata.DefaultRestoreConfig("event").Location
 		handler = newEventRestoreHandler(suite.ac)
 	)
@@ -164,7 +165,7 @@ func (suite *RestoreIntgSuite) TestRestoreExchangeObject() {
 
 	handlers := restoreHandlers(suite.ac)
 
-	userID := tester.M365UserID(suite.T())
+	userID := config.M365UserID(suite.T())
 
 	tests := []struct {
 		name        string
@@ -395,7 +396,7 @@ func (suite *RestoreIntgSuite) TestRestoreAndBackupEvent_recurringInstancesWithA
 	defer flush()
 
 	var (
-		userID  = tester.M365UserID(t)
+		userID  = config.M365UserID(t)
 		subject = testdata.DefaultRestoreConfig("event").Location
 		handler = newEventRestoreHandler(suite.ac)
 	)

--- a/src/internal/m365/graph/betasdk/beta_client_test.go
+++ b/src/internal/m365/graph/betasdk/beta_client_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 )
 
@@ -21,7 +21,7 @@ type BetaClientSuite struct {
 
 func TestBetaClientSuite(t *testing.T) {
 	suite.Run(t, &BetaClientSuite{
-		Suite: tester.NewIntegrationSuite(t, [][]string{config.M365AcctCredEnvs}),
+		Suite: tester.NewIntegrationSuite(t, [][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 
@@ -33,7 +33,7 @@ func (suite *BetaClientSuite) SetupSuite() {
 
 	graph.InitializeConcurrencyLimiter(ctx, false, 4)
 
-	a := config.NewM365Account(t)
+	a := tconfig.NewM365Account(t)
 	m365, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -72,7 +72,7 @@ func (suite *BetaClientSuite) TestBasicClientGetFunctionality() {
 	client := NewBetaClient(adpt)
 	require.NotNil(t, client)
 
-	siteID := config.M365SiteID(t)
+	siteID := tconfig.M365SiteID(t)
 
 	// TODO(dadams39) document allowable calls in main
 	collection, err := client.SitesById(siteID).Pages().Get(ctx, nil)

--- a/src/internal/m365/graph/betasdk/beta_client_test.go
+++ b/src/internal/m365/graph/betasdk/beta_client_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 )
 
@@ -20,7 +21,7 @@ type BetaClientSuite struct {
 
 func TestBetaClientSuite(t *testing.T) {
 	suite.Run(t, &BetaClientSuite{
-		Suite: tester.NewIntegrationSuite(t, [][]string{tester.M365AcctCredEnvs}),
+		Suite: tester.NewIntegrationSuite(t, [][]string{config.M365AcctCredEnvs}),
 	})
 }
 
@@ -32,7 +33,7 @@ func (suite *BetaClientSuite) SetupSuite() {
 
 	graph.InitializeConcurrencyLimiter(ctx, false, 4)
 
-	a := tester.NewM365Account(t)
+	a := config.NewM365Account(t)
 	m365, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -71,7 +72,7 @@ func (suite *BetaClientSuite) TestBasicClientGetFunctionality() {
 	client := NewBetaClient(adpt)
 	require.NotNil(t, client)
 
-	siteID := tester.M365SiteID(t)
+	siteID := config.M365SiteID(t)
 
 	// TODO(dadams39) document allowable calls in main
 	collection, err := client.SitesById(siteID).Pages().Get(ctx, nil)

--- a/src/internal/m365/graph/http_wrapper_test.go
+++ b/src/internal/m365/graph/http_wrapper_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 )
 
 type HTTPWrapperIntgSuite struct {
@@ -21,7 +22,7 @@ func TestHTTPWrapperIntgSuite(t *testing.T) {
 	suite.Run(t, &HTTPWrapperIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/internal/m365/graph/http_wrapper_test.go
+++ b/src/internal/m365/graph/http_wrapper_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 )
 
 type HTTPWrapperIntgSuite struct {
@@ -22,7 +22,7 @@ func TestHTTPWrapperIntgSuite(t *testing.T) {
 	suite.Run(t, &HTTPWrapperIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/internal/m365/graph/middleware_test.go
+++ b/src/internal/m365/graph/middleware_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/path"
 )
@@ -126,13 +126,13 @@ func TestRetryMWIntgSuite(t *testing.T) {
 	suite.Run(t, &RetryMWIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 
 func (suite *RetryMWIntgSuite) SetupSuite() {
 	var (
-		a   = config.NewM365Account(suite.T())
+		a   = tconfig.NewM365Account(suite.T())
 		err error
 	)
 

--- a/src/internal/m365/graph/middleware_test.go
+++ b/src/internal/m365/graph/middleware_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/path"
 )
@@ -125,13 +126,13 @@ func TestRetryMWIntgSuite(t *testing.T) {
 	suite.Run(t, &RetryMWIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 
 func (suite *RetryMWIntgSuite) SetupSuite() {
 	var (
-		a   = tester.NewM365Account(suite.T())
+		a   = config.NewM365Account(suite.T())
 		err error
 	)
 

--- a/src/internal/m365/graph/service_test.go
+++ b/src/internal/m365/graph/service_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 )
 
@@ -27,7 +27,7 @@ func TestGraphUnitSuite(t *testing.T) {
 
 func (suite *GraphUnitSuite) SetupSuite() {
 	t := suite.T()
-	a := config.NewFakeM365Account(t)
+	a := tconfig.NewFakeM365Account(t)
 	m365, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 

--- a/src/internal/m365/graph/service_test.go
+++ b/src/internal/m365/graph/service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 )
 
@@ -26,7 +27,7 @@ func TestGraphUnitSuite(t *testing.T) {
 
 func (suite *GraphUnitSuite) SetupSuite() {
 	t := suite.T()
-	a := tester.NewMockM365Account(t)
+	a := config.NewFakeM365Account(t)
 	m365, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 

--- a/src/internal/m365/helper_test.go
+++ b/src/internal/m365/helper_test.go
@@ -22,7 +22,7 @@ import (
 	odStub "github.com/alcionai/corso/src/internal/m365/onedrive/stub"
 	"github.com/alcionai/corso/src/internal/m365/resource"
 	m365Stub "github.com/alcionai/corso/src/internal/m365/stub"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -1197,7 +1197,7 @@ func newController(
 	r resource.Category,
 	pst path.ServiceType,
 ) *Controller {
-	a := config.NewM365Account(t)
+	a := tconfig.NewM365Account(t)
 
 	controller, err := NewController(ctx, a, r, pst, control.Options{})
 	require.NoError(t, err, clues.ToCore(err))

--- a/src/internal/m365/helper_test.go
+++ b/src/internal/m365/helper_test.go
@@ -22,7 +22,7 @@ import (
 	odStub "github.com/alcionai/corso/src/internal/m365/onedrive/stub"
 	"github.com/alcionai/corso/src/internal/m365/resource"
 	m365Stub "github.com/alcionai/corso/src/internal/m365/stub"
-	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -716,7 +716,7 @@ func compareDriveItem(
 	t *testing.T,
 	expected map[string][]byte,
 	item data.Stream,
-	config m365Stub.ConfigInfo,
+	mci m365Stub.ConfigInfo,
 	rootDir bool,
 ) bool {
 	// Skip Drive permissions in the folder that used to be the root. We don't
@@ -796,7 +796,7 @@ func compareDriveItem(
 			assert.Equal(t, expectedMeta.FileName, itemMeta.FileName)
 		}
 
-		if !config.Opts.RestorePermissions {
+		if !mci.Opts.RestorePermissions {
 			assert.Equal(t, 0, len(itemMeta.Permissions))
 			return true
 		}
@@ -819,7 +819,7 @@ func compareDriveItem(
 			// sharepoint retrieves a superset of permissions
 			// (all site admins, site groups, built in by default)
 			// relative to the permissions changed by the test.
-			config.Service == path.SharePointService,
+			mci.Service == path.SharePointService,
 			permissionEqual)
 
 		testElementsMatch(
@@ -868,7 +868,7 @@ func compareItem(
 	service path.ServiceType,
 	category path.CategoryType,
 	item data.Stream,
-	config m365Stub.ConfigInfo,
+	mci m365Stub.ConfigInfo,
 	rootDir bool,
 ) bool {
 	if mt, ok := item.(data.StreamModTime); ok {
@@ -889,7 +889,7 @@ func compareItem(
 		}
 
 	case path.OneDriveService:
-		return compareDriveItem(t, expected, item, config, rootDir)
+		return compareDriveItem(t, expected, item, mci, rootDir)
 
 	case path.SharePointService:
 		if category != path.LibrariesCategory {
@@ -897,7 +897,7 @@ func compareItem(
 		}
 
 		// SharePoint libraries reuses OneDrive code.
-		return compareDriveItem(t, expected, item, config, rootDir)
+		return compareDriveItem(t, expected, item, mci, rootDir)
 
 	default:
 		assert.FailNowf(t, "unexpected service: %s", service.String())
@@ -962,7 +962,7 @@ func checkCollections(
 	expectedItems int,
 	expected map[string]map[string][]byte,
 	got []data.BackupCollection,
-	config m365Stub.ConfigInfo,
+	mci m365Stub.ConfigInfo,
 ) int {
 	collectionsWithItems := []data.BackupCollection{}
 
@@ -976,7 +976,7 @@ func checkCollections(
 			category        = returned.FullPath().Category()
 			expectedColData = expected[returned.FullPath().String()]
 			folders         = returned.FullPath().Elements()
-			rootDir         = folders[len(folders)-1] == config.RestoreCfg.Location
+			rootDir         = folders[len(folders)-1] == mci.RestoreCfg.Location
 		)
 
 		// Need to iterate through all items even if we don't expect to find a match
@@ -1009,7 +1009,7 @@ func checkCollections(
 				service,
 				category,
 				item,
-				config,
+				mci,
 				rootDir) {
 				gotItems--
 			}
@@ -1197,7 +1197,7 @@ func newController(
 	r resource.Category,
 	pst path.ServiceType,
 ) *Controller {
-	a := tester.NewM365Account(t)
+	a := config.NewM365Account(t)
 
 	controller, err := NewController(ctx, a, r, pst, control.Options{})
 	require.NoError(t, err, clues.ToCore(err))

--- a/src/internal/m365/onedrive/item_collector_test.go
+++ b/src/internal/m365/onedrive/item_collector_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -292,7 +293,7 @@ func TestOneDriveSuite(t *testing.T) {
 	suite.Run(t, &OneDriveIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 
@@ -304,9 +305,9 @@ func (suite *OneDriveIntgSuite) SetupSuite() {
 
 	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
-	suite.userID = tester.SecondaryM365UserID(t)
+	suite.userID = config.SecondaryM365UserID(t)
 
-	acct := tester.NewM365Account(t)
+	acct := config.NewM365Account(t)
 	creds, err := acct.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -424,7 +425,7 @@ func (suite *OneDriveIntgSuite) TestCreateGetDeleteFolder() {
 }
 
 func (suite *OneDriveIntgSuite) TestOneDriveNewCollections() {
-	creds, err := tester.NewM365Account(suite.T()).M365Config()
+	creds, err := config.NewM365Account(suite.T()).M365Config()
 	require.NoError(suite.T(), err, clues.ToCore(err))
 
 	tests := []struct {

--- a/src/internal/m365/onedrive/item_collector_test.go
+++ b/src/internal/m365/onedrive/item_collector_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -293,7 +293,7 @@ func TestOneDriveSuite(t *testing.T) {
 	suite.Run(t, &OneDriveIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 
@@ -305,9 +305,9 @@ func (suite *OneDriveIntgSuite) SetupSuite() {
 
 	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
-	suite.userID = config.SecondaryM365UserID(t)
+	suite.userID = tconfig.SecondaryM365UserID(t)
 
-	acct := config.NewM365Account(t)
+	acct := tconfig.NewM365Account(t)
 	creds, err := acct.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -425,7 +425,7 @@ func (suite *OneDriveIntgSuite) TestCreateGetDeleteFolder() {
 }
 
 func (suite *OneDriveIntgSuite) TestOneDriveNewCollections() {
-	creds, err := config.NewM365Account(suite.T()).M365Config()
+	creds, err := tconfig.NewM365Account(suite.T()).M365Config()
 	require.NoError(suite.T(), err, clues.ToCore(err))
 
 	tests := []struct {

--- a/src/internal/m365/onedrive/item_test.go
+++ b/src/internal/m365/onedrive/item_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -34,7 +34,7 @@ func TestItemIntegrationSuite(t *testing.T) {
 	suite.Run(t, &ItemIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 
@@ -45,7 +45,7 @@ func (suite *ItemIntegrationSuite) SetupSuite() {
 	defer flush()
 
 	suite.service = loadTestService(t)
-	suite.user = config.SecondaryM365UserID(t)
+	suite.user = tconfig.SecondaryM365UserID(t)
 
 	pager := suite.service.ac.Drives().NewUserDrivePager(suite.user, nil)
 

--- a/src/internal/m365/onedrive/item_test.go
+++ b/src/internal/m365/onedrive/item_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -33,8 +34,7 @@ func TestItemIntegrationSuite(t *testing.T) {
 	suite.Run(t, &ItemIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs},
-		),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 
@@ -45,7 +45,7 @@ func (suite *ItemIntegrationSuite) SetupSuite() {
 	defer flush()
 
 	suite.service = loadTestService(t)
-	suite.user = tester.SecondaryM365UserID(t)
+	suite.user = config.SecondaryM365UserID(t)
 
 	pager := suite.service.ac.Drives().NewUserDrivePager(suite.user, nil)
 

--- a/src/internal/m365/onedrive/service_test.go
+++ b/src/internal/m365/onedrive/service_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/alcionai/corso/src/internal/m365/support"
-	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
@@ -42,7 +42,7 @@ func (ods *oneDriveService) updateStatus(status *support.ControllerOperationStat
 }
 
 func loadTestService(t *testing.T) *oneDriveService {
-	a := tester.NewM365Account(t)
+	a := config.NewM365Account(t)
 
 	creds, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))

--- a/src/internal/m365/onedrive/service_test.go
+++ b/src/internal/m365/onedrive/service_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/alcionai/corso/src/internal/m365/support"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
@@ -42,7 +42,7 @@ func (ods *oneDriveService) updateStatus(status *support.ControllerOperationStat
 }
 
 func loadTestService(t *testing.T) *oneDriveService {
-	a := config.NewM365Account(t)
+	a := tconfig.NewM365Account(t)
 
 	creds, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))

--- a/src/internal/m365/onedrive/url_cache_test.go
+++ b/src/internal/m365/onedrive/url_cache_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -36,7 +36,7 @@ func TestURLCacheIntegrationSuite(t *testing.T) {
 	suite.Run(t, &URLCacheIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 
@@ -46,9 +46,9 @@ func (suite *URLCacheIntegrationSuite) SetupSuite() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	suite.user = config.SecondaryM365UserID(t)
+	suite.user = tconfig.SecondaryM365UserID(t)
 
-	acct := config.NewM365Account(t)
+	acct := tconfig.NewM365Account(t)
 
 	creds, err := acct.M365Config()
 	require.NoError(t, err, clues.ToCore(err))

--- a/src/internal/m365/onedrive/url_cache_test.go
+++ b/src/internal/m365/onedrive/url_cache_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -35,7 +36,7 @@ func TestURLCacheIntegrationSuite(t *testing.T) {
 	suite.Run(t, &URLCacheIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 
@@ -45,9 +46,9 @@ func (suite *URLCacheIntegrationSuite) SetupSuite() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	suite.user = tester.SecondaryM365UserID(t)
+	suite.user = config.SecondaryM365UserID(t)
 
-	acct := tester.NewM365Account(t)
+	acct := config.NewM365Account(t)
 
 	creds, err := acct.M365Config()
 	require.NoError(t, err, clues.ToCore(err))

--- a/src/internal/m365/onedrive_test.go
+++ b/src/internal/m365/onedrive_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/onedrive/stub"
 	"github.com/alcionai/corso/src/internal/m365/resource"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -128,10 +129,10 @@ func NewSuiteInfoImpl(
 		controller:       ctrl,
 		resourceOwner:    resourceOwner,
 		resourceCategory: rsc,
-		secondaryUser:    tester.SecondaryM365UserID(t),
+		secondaryUser:    config.SecondaryM365UserID(t),
 		service:          service,
-		tertiaryUser:     tester.TertiaryM365UserID(t),
-		user:             tester.M365UserID(t),
+		tertiaryUser:     config.TertiaryM365UserID(t),
+		user:             config.M365UserID(t),
 	}
 }
 
@@ -183,7 +184,7 @@ func TestSharePointIntegrationSuite(t *testing.T) {
 	suite.Run(t, &SharePointIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 
@@ -193,7 +194,7 @@ func (suite *SharePointIntegrationSuite) SetupSuite() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	si := NewSuiteInfoImpl(suite.T(), ctx, tester.M365SiteID(suite.T()), path.SharePointService)
+	si := NewSuiteInfoImpl(suite.T(), ctx, config.M365SiteID(suite.T()), path.SharePointService)
 
 	// users needed for permissions
 	user, err := si.controller.AC.Users().GetByID(ctx, si.user)
@@ -253,7 +254,7 @@ func TestOneDriveIntegrationSuite(t *testing.T) {
 	suite.Run(t, &OneDriveIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 
@@ -263,7 +264,7 @@ func (suite *OneDriveIntegrationSuite) SetupSuite() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	si := NewSuiteInfoImpl(t, ctx, tester.M365UserID(t), path.OneDriveService)
+	si := NewSuiteInfoImpl(t, ctx, config.M365UserID(t), path.OneDriveService)
 
 	user, err := si.controller.AC.Users().GetByID(ctx, si.user)
 	require.NoError(t, err, "fetching user", si.user, clues.ToCore(err))
@@ -317,7 +318,7 @@ func TestOneDriveNightlySuite(t *testing.T) {
 	suite.Run(t, &OneDriveNightlySuite{
 		Suite: tester.NewNightlySuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 
@@ -327,7 +328,7 @@ func (suite *OneDriveNightlySuite) SetupSuite() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	si := NewSuiteInfoImpl(t, ctx, tester.M365UserID(t), path.OneDriveService)
+	si := NewSuiteInfoImpl(t, ctx, config.M365UserID(t), path.OneDriveService)
 
 	user, err := si.controller.AC.Users().GetByID(ctx, si.user)
 	require.NoError(t, err, "fetching user", si.user, clues.ToCore(err))

--- a/src/internal/m365/onedrive_test.go
+++ b/src/internal/m365/onedrive_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/onedrive/stub"
 	"github.com/alcionai/corso/src/internal/m365/resource"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -129,10 +129,10 @@ func NewSuiteInfoImpl(
 		controller:       ctrl,
 		resourceOwner:    resourceOwner,
 		resourceCategory: rsc,
-		secondaryUser:    config.SecondaryM365UserID(t),
+		secondaryUser:    tconfig.SecondaryM365UserID(t),
 		service:          service,
-		tertiaryUser:     config.TertiaryM365UserID(t),
-		user:             config.M365UserID(t),
+		tertiaryUser:     tconfig.TertiaryM365UserID(t),
+		user:             tconfig.M365UserID(t),
 	}
 }
 
@@ -184,7 +184,7 @@ func TestSharePointIntegrationSuite(t *testing.T) {
 	suite.Run(t, &SharePointIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 
@@ -194,7 +194,7 @@ func (suite *SharePointIntegrationSuite) SetupSuite() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	si := NewSuiteInfoImpl(suite.T(), ctx, config.M365SiteID(suite.T()), path.SharePointService)
+	si := NewSuiteInfoImpl(suite.T(), ctx, tconfig.M365SiteID(suite.T()), path.SharePointService)
 
 	// users needed for permissions
 	user, err := si.controller.AC.Users().GetByID(ctx, si.user)
@@ -254,7 +254,7 @@ func TestOneDriveIntegrationSuite(t *testing.T) {
 	suite.Run(t, &OneDriveIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 
@@ -264,7 +264,7 @@ func (suite *OneDriveIntegrationSuite) SetupSuite() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	si := NewSuiteInfoImpl(t, ctx, config.M365UserID(t), path.OneDriveService)
+	si := NewSuiteInfoImpl(t, ctx, tconfig.M365UserID(t), path.OneDriveService)
 
 	user, err := si.controller.AC.Users().GetByID(ctx, si.user)
 	require.NoError(t, err, "fetching user", si.user, clues.ToCore(err))
@@ -318,7 +318,7 @@ func TestOneDriveNightlySuite(t *testing.T) {
 	suite.Run(t, &OneDriveNightlySuite{
 		Suite: tester.NewNightlySuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 
@@ -328,7 +328,7 @@ func (suite *OneDriveNightlySuite) SetupSuite() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	si := NewSuiteInfoImpl(t, ctx, config.M365UserID(t), path.OneDriveService)
+	si := NewSuiteInfoImpl(t, ctx, tconfig.M365UserID(t), path.OneDriveService)
 
 	user, err := si.controller.AC.Users().GetByID(ctx, si.user)
 	require.NoError(t, err, "fetching user", si.user, clues.ToCore(err))

--- a/src/internal/m365/sharepoint/api/beta_service_test.go
+++ b/src/internal/m365/sharepoint/api/beta_service_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/m365/graph/betasdk/models"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 )
 
 type BetaUnitSuite struct {
@@ -24,7 +24,7 @@ func TestBetaUnitSuite(t *testing.T) {
 
 func (suite *BetaUnitSuite) TestBetaService_Adapter() {
 	t := suite.T()
-	a := config.NewFakeM365Account(t)
+	a := tconfig.NewFakeM365Account(t)
 	m365, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 

--- a/src/internal/m365/sharepoint/api/beta_service_test.go
+++ b/src/internal/m365/sharepoint/api/beta_service_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/m365/graph/betasdk/models"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 )
 
 type BetaUnitSuite struct {
@@ -23,7 +24,7 @@ func TestBetaUnitSuite(t *testing.T) {
 
 func (suite *BetaUnitSuite) TestBetaService_Adapter() {
 	t := suite.T()
-	a := tester.NewMockM365Account(t)
+	a := config.NewFakeM365Account(t)
 	m365, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 

--- a/src/internal/m365/sharepoint/api/pages_test.go
+++ b/src/internal/m365/sharepoint/api/pages_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/sharepoint/api"
 	spMock "github.com/alcionai/corso/src/internal/m365/sharepoint/mock"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -46,8 +46,8 @@ func (suite *SharePointPageSuite) SetupSuite() {
 
 	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
-	suite.siteID = config.M365SiteID(t)
-	a := config.NewM365Account(t)
+	suite.siteID = tconfig.M365SiteID(t)
+	a := tconfig.NewM365Account(t)
 	m365, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -57,7 +57,7 @@ func (suite *SharePointPageSuite) SetupSuite() {
 
 func TestSharePointPageSuite(t *testing.T) {
 	suite.Run(t, &SharePointPageSuite{
-		Suite: tester.NewIntegrationSuite(t, [][]string{config.M365AcctCredEnvs}),
+		Suite: tester.NewIntegrationSuite(t, [][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/internal/m365/sharepoint/api/pages_test.go
+++ b/src/internal/m365/sharepoint/api/pages_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/sharepoint/api"
 	spMock "github.com/alcionai/corso/src/internal/m365/sharepoint/mock"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -45,8 +46,8 @@ func (suite *SharePointPageSuite) SetupSuite() {
 
 	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
-	suite.siteID = tester.M365SiteID(t)
-	a := tester.NewM365Account(t)
+	suite.siteID = config.M365SiteID(t)
+	a := config.NewM365Account(t)
 	m365, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -56,7 +57,7 @@ func (suite *SharePointPageSuite) SetupSuite() {
 
 func TestSharePointPageSuite(t *testing.T) {
 	suite.Run(t, &SharePointPageSuite{
-		Suite: tester.NewIntegrationSuite(t, [][]string{tester.M365AcctCredEnvs}),
+		Suite: tester.NewIntegrationSuite(t, [][]string{config.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/internal/m365/sharepoint/backup_test.go
+++ b/src/internal/m365/sharepoint/backup_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/onedrive"
 	odConsts "github.com/alcionai/corso/src/internal/m365/onedrive/consts"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -176,7 +176,7 @@ func TestSharePointPagesSuite(t *testing.T) {
 	suite.Run(t, &SharePointPagesSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 
@@ -194,8 +194,8 @@ func (suite *SharePointPagesSuite) TestCollectPages() {
 	defer flush()
 
 	var (
-		siteID = config.M365SiteID(t)
-		a      = config.NewM365Account(t)
+		siteID = tconfig.M365SiteID(t)
+		a      = tconfig.NewM365Account(t)
 	)
 
 	creds, err := a.M365Config()

--- a/src/internal/m365/sharepoint/backup_test.go
+++ b/src/internal/m365/sharepoint/backup_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/onedrive"
 	odConsts "github.com/alcionai/corso/src/internal/m365/onedrive/consts"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -175,7 +176,7 @@ func TestSharePointPagesSuite(t *testing.T) {
 	suite.Run(t, &SharePointPagesSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 
@@ -193,8 +194,8 @@ func (suite *SharePointPagesSuite) TestCollectPages() {
 	defer flush()
 
 	var (
-		siteID = tester.M365SiteID(t)
-		a      = tester.NewM365Account(t)
+		siteID = config.M365SiteID(t)
+		a      = config.NewM365Account(t)
 	)
 
 	creds, err := a.M365Config()

--- a/src/internal/m365/sharepoint/collection_test.go
+++ b/src/internal/m365/sharepoint/collection_test.go
@@ -17,6 +17,7 @@ import (
 	betaAPI "github.com/alcionai/corso/src/internal/m365/sharepoint/api"
 	spMock "github.com/alcionai/corso/src/internal/m365/sharepoint/mock"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
@@ -35,8 +36,8 @@ type SharePointCollectionSuite struct {
 func (suite *SharePointCollectionSuite) SetupSuite() {
 	t := suite.T()
 
-	suite.siteID = tester.M365SiteID(t)
-	a := tester.NewM365Account(t)
+	suite.siteID = config.M365SiteID(t)
+	a := config.NewM365Account(t)
 	m365, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -52,7 +53,7 @@ func TestSharePointCollectionSuite(t *testing.T) {
 	suite.Run(t, &SharePointCollectionSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs},
+			[][]string{config.M365AcctCredEnvs},
 		),
 	})
 }

--- a/src/internal/m365/sharepoint/collection_test.go
+++ b/src/internal/m365/sharepoint/collection_test.go
@@ -17,7 +17,7 @@ import (
 	betaAPI "github.com/alcionai/corso/src/internal/m365/sharepoint/api"
 	spMock "github.com/alcionai/corso/src/internal/m365/sharepoint/mock"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
@@ -36,8 +36,8 @@ type SharePointCollectionSuite struct {
 func (suite *SharePointCollectionSuite) SetupSuite() {
 	t := suite.T()
 
-	suite.siteID = config.M365SiteID(t)
-	a := config.NewM365Account(t)
+	suite.siteID = tconfig.M365SiteID(t)
+	a := tconfig.NewM365Account(t)
 	m365, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -53,7 +53,7 @@ func TestSharePointCollectionSuite(t *testing.T) {
 	suite.Run(t, &SharePointCollectionSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs},
+			[][]string{tconfig.M365AcctCredEnvs},
 		),
 	})
 }

--- a/src/internal/m365/sharepoint/lists_test.go
+++ b/src/internal/m365/sharepoint/lists_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -23,7 +23,7 @@ type ListsUnitSuite struct {
 
 func (suite *ListsUnitSuite) SetupSuite() {
 	t := suite.T()
-	a := config.NewM365Account(t)
+	a := tconfig.NewM365Account(t)
 	m365, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -34,7 +34,7 @@ func TestListsUnitSuite(t *testing.T) {
 	suite.Run(t, &ListsUnitSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs},
+			[][]string{tconfig.M365AcctCredEnvs},
 		),
 	})
 }

--- a/src/internal/m365/sharepoint/lists_test.go
+++ b/src/internal/m365/sharepoint/lists_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -22,7 +23,7 @@ type ListsUnitSuite struct {
 
 func (suite *ListsUnitSuite) SetupSuite() {
 	t := suite.T()
-	a := tester.NewM365Account(t)
+	a := config.NewM365Account(t)
 	m365, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -33,7 +34,7 @@ func TestListsUnitSuite(t *testing.T) {
 	suite.Run(t, &ListsUnitSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs},
+			[][]string{config.M365AcctCredEnvs},
 		),
 	})
 }

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/alcionai/corso/src/internal/operations/inject"
 	ssmock "github.com/alcionai/corso/src/internal/streamstore/mock"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
@@ -31,6 +32,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
+	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
 	"github.com/alcionai/corso/src/pkg/store"
 )
 
@@ -1209,7 +1211,7 @@ func TestBackupOpIntegrationSuite(t *testing.T) {
 	suite.Run(t, &BackupOpIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs}),
+			[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs}),
 	})
 }
 
@@ -1221,10 +1223,10 @@ func (suite *BackupOpIntegrationSuite) SetupSuite() {
 
 	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
-	suite.user = tester.M365UserID(t)
-	suite.site = tester.M365SiteID(t)
+	suite.user = config.M365UserID(t)
+	suite.site = config.M365SiteID(t)
 
-	a := tester.NewM365Account(t)
+	a := config.NewM365Account(t)
 
 	creds, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
@@ -1238,7 +1240,7 @@ func (suite *BackupOpIntegrationSuite) TestNewBackupOperation() {
 		kw   = &kopia.Wrapper{}
 		sw   = &store.Wrapper{}
 		ctrl = &mock.Controller{}
-		acct = tester.NewM365Account(suite.T())
+		acct = config.NewM365Account(suite.T())
 		opts = control.Defaults()
 	)
 

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/alcionai/corso/src/internal/operations/inject"
 	ssmock "github.com/alcionai/corso/src/internal/streamstore/mock"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
@@ -1211,7 +1211,7 @@ func TestBackupOpIntegrationSuite(t *testing.T) {
 	suite.Run(t, &BackupOpIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs}),
+			[][]string{storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs}),
 	})
 }
 
@@ -1223,10 +1223,10 @@ func (suite *BackupOpIntegrationSuite) SetupSuite() {
 
 	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
-	suite.user = config.M365UserID(t)
-	suite.site = config.M365SiteID(t)
+	suite.user = tconfig.M365UserID(t)
+	suite.site = tconfig.M365SiteID(t)
 
-	a := config.NewM365Account(t)
+	a := tconfig.NewM365Account(t)
 
 	creds, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
@@ -1240,7 +1240,7 @@ func (suite *BackupOpIntegrationSuite) TestNewBackupOperation() {
 		kw   = &kopia.Wrapper{}
 		sw   = &store.Wrapper{}
 		ctrl = &mock.Controller{}
-		acct = config.NewM365Account(suite.T())
+		acct = tconfig.NewM365Account(suite.T())
 		opts = control.Defaults()
 	)
 

--- a/src/internal/operations/maintenance_test.go
+++ b/src/internal/operations/maintenance_test.go
@@ -11,8 +11,10 @@ import (
 	evmock "github.com/alcionai/corso/src/internal/events/mock"
 	"github.com/alcionai/corso/src/internal/kopia"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/repository"
+	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
 )
 
 type MaintenanceOpIntegrationSuite struct {
@@ -23,7 +25,7 @@ func TestMaintenanceOpIntegrationSuite(t *testing.T) {
 	suite.Run(t, &MaintenanceOpIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs}),
+			[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs}),
 	})
 }
 
@@ -31,7 +33,7 @@ func (suite *MaintenanceOpIntegrationSuite) TestRepoMaintenance() {
 	var (
 		t = suite.T()
 		// need to initialize the repository before we can test connecting to it.
-		st = tester.NewPrefixedS3Storage(t)
+		st = storeTD.NewPrefixedS3Storage(t)
 		k  = kopia.NewConn(st)
 	)
 

--- a/src/internal/operations/maintenance_test.go
+++ b/src/internal/operations/maintenance_test.go
@@ -11,7 +11,7 @@ import (
 	evmock "github.com/alcionai/corso/src/internal/events/mock"
 	"github.com/alcionai/corso/src/internal/kopia"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/repository"
 	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
@@ -25,7 +25,7 @@ func TestMaintenanceOpIntegrationSuite(t *testing.T) {
 	suite.Run(t, &MaintenanceOpIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs}),
+			[][]string{storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/internal/operations/restore_test.go
+++ b/src/internal/operations/restore_test.go
@@ -26,12 +26,14 @@ import (
 	"github.com/alcionai/corso/src/internal/operations/inject"
 	"github.com/alcionai/corso/src/internal/stats"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/repository"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
+	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
 	"github.com/alcionai/corso/src/pkg/store"
 )
 
@@ -161,7 +163,7 @@ func TestRestoreOpIntegrationSuite(t *testing.T) {
 	suite.Run(t, &RestoreOpIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs}),
+			[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs}),
 	})
 }
 
@@ -174,11 +176,11 @@ func (suite *RestoreOpIntegrationSuite) SetupSuite() {
 	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
 	var (
-		st = tester.NewPrefixedS3Storage(t)
+		st = storeTD.NewPrefixedS3Storage(t)
 		k  = kopia.NewConn(st)
 	)
 
-	suite.acct = tester.NewM365Account(t)
+	suite.acct = config.NewM365Account(t)
 
 	err := k.Initialize(ctx, repository.Options{})
 	require.NoError(t, err, clues.ToCore(err))
@@ -253,7 +255,7 @@ func (suite *RestoreOpIntegrationSuite) TestNewRestoreOperation() {
 				test.kw,
 				test.sw,
 				test.rc,
-				tester.NewM365Account(t),
+				config.NewM365Account(t),
 				"backup-id",
 				selectors.Selector{DiscreteOwner: "test"},
 				restoreCfg,
@@ -381,7 +383,7 @@ func (suite *RestoreOpIntegrationSuite) TestRestore_Run() {
 	}{
 		{
 			name:       "Exchange_Restore",
-			owner:      tester.M365UserID(suite.T()),
+			owner:      config.M365UserID(suite.T()),
 			restoreCfg: testdata.DefaultRestoreConfig(""),
 			getSelector: func(t *testing.T, owners []string) selectors.Selector {
 				rsel := selectors.NewExchangeRestore(owners)
@@ -393,7 +395,7 @@ func (suite *RestoreOpIntegrationSuite) TestRestore_Run() {
 		},
 		{
 			name:       "SharePoint_Restore",
-			owner:      tester.M365SiteID(suite.T()),
+			owner:      config.M365SiteID(suite.T()),
 			restoreCfg: control.DefaultRestoreConfig(dttm.SafeForTesting),
 			getSelector: func(t *testing.T, owners []string) selectors.Selector {
 				rsel := selectors.NewSharePointRestore(owners)
@@ -425,7 +427,7 @@ func (suite *RestoreOpIntegrationSuite) TestRestore_Run() {
 				suite.kw,
 				suite.sw,
 				bup.ctrl,
-				tester.NewM365Account(t),
+				config.NewM365Account(t),
 				bup.backupID,
 				test.getSelector(t, bup.selectorResourceOwners),
 				test.restoreCfg,
@@ -479,7 +481,7 @@ func (suite *RestoreOpIntegrationSuite) TestRestore_Run_errorNoBackup() {
 		suite.kw,
 		suite.sw,
 		ctrl,
-		tester.NewM365Account(t),
+		config.NewM365Account(t),
 		"backupID",
 		rsel.Selector,
 		restoreCfg,

--- a/src/internal/operations/restore_test.go
+++ b/src/internal/operations/restore_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/alcionai/corso/src/internal/operations/inject"
 	"github.com/alcionai/corso/src/internal/stats"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/repository"
@@ -163,7 +163,7 @@ func TestRestoreOpIntegrationSuite(t *testing.T) {
 	suite.Run(t, &RestoreOpIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs}),
+			[][]string{storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs}),
 	})
 }
 
@@ -180,7 +180,7 @@ func (suite *RestoreOpIntegrationSuite) SetupSuite() {
 		k  = kopia.NewConn(st)
 	)
 
-	suite.acct = config.NewM365Account(t)
+	suite.acct = tconfig.NewM365Account(t)
 
 	err := k.Initialize(ctx, repository.Options{})
 	require.NoError(t, err, clues.ToCore(err))
@@ -255,7 +255,7 @@ func (suite *RestoreOpIntegrationSuite) TestNewRestoreOperation() {
 				test.kw,
 				test.sw,
 				test.rc,
-				config.NewM365Account(t),
+				tconfig.NewM365Account(t),
 				"backup-id",
 				selectors.Selector{DiscreteOwner: "test"},
 				restoreCfg,
@@ -383,7 +383,7 @@ func (suite *RestoreOpIntegrationSuite) TestRestore_Run() {
 	}{
 		{
 			name:       "Exchange_Restore",
-			owner:      config.M365UserID(suite.T()),
+			owner:      tconfig.M365UserID(suite.T()),
 			restoreCfg: testdata.DefaultRestoreConfig(""),
 			getSelector: func(t *testing.T, owners []string) selectors.Selector {
 				rsel := selectors.NewExchangeRestore(owners)
@@ -395,7 +395,7 @@ func (suite *RestoreOpIntegrationSuite) TestRestore_Run() {
 		},
 		{
 			name:       "SharePoint_Restore",
-			owner:      config.M365SiteID(suite.T()),
+			owner:      tconfig.M365SiteID(suite.T()),
 			restoreCfg: control.DefaultRestoreConfig(dttm.SafeForTesting),
 			getSelector: func(t *testing.T, owners []string) selectors.Selector {
 				rsel := selectors.NewSharePointRestore(owners)
@@ -427,7 +427,7 @@ func (suite *RestoreOpIntegrationSuite) TestRestore_Run() {
 				suite.kw,
 				suite.sw,
 				bup.ctrl,
-				config.NewM365Account(t),
+				tconfig.NewM365Account(t),
 				bup.backupID,
 				test.getSelector(t, bup.selectorResourceOwners),
 				test.restoreCfg,
@@ -481,7 +481,7 @@ func (suite *RestoreOpIntegrationSuite) TestRestore_Run_errorNoBackup() {
 		suite.kw,
 		suite.sw,
 		ctrl,
-		config.NewM365Account(t),
+		tconfig.NewM365Account(t),
 		"backupID",
 		rsel.Selector,
 		restoreCfg,

--- a/src/internal/operations/test/exchange_test.go
+++ b/src/internal/operations/test/exchange_test.go
@@ -23,7 +23,7 @@ import (
 	exchTD "github.com/alcionai/corso/src/internal/m365/exchange/testdata"
 	"github.com/alcionai/corso/src/internal/m365/resource"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/internal/version"
 	deeTD "github.com/alcionai/corso/src/pkg/backup/details/testdata"
 	"github.com/alcionai/corso/src/pkg/control"
@@ -43,7 +43,7 @@ func TestExchangeBackupIntgSuite(t *testing.T) {
 	suite.Run(t, &ExchangeBackupIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs, storeTD.AWSStorageCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs, storeTD.AWSStorageCredEnvs}),
 	})
 }
 
@@ -236,7 +236,7 @@ func testExchangeContinuousBackups(suite *ExchangeBackupIntgSuite, toggles contr
 	tester.LogTimeOfTest(t)
 
 	var (
-		acct       = config.NewM365Account(t)
+		acct       = tconfig.NewM365Account(t)
 		mb         = evmock.NewBus()
 		now        = dttm.Now()
 		service    = path.ExchangeService

--- a/src/internal/operations/test/exchange_test.go
+++ b/src/internal/operations/test/exchange_test.go
@@ -23,6 +23,7 @@ import (
 	exchTD "github.com/alcionai/corso/src/internal/m365/exchange/testdata"
 	"github.com/alcionai/corso/src/internal/m365/resource"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/internal/version"
 	deeTD "github.com/alcionai/corso/src/pkg/backup/details/testdata"
 	"github.com/alcionai/corso/src/pkg/control"
@@ -30,6 +31,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
+	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
 )
 
 type ExchangeBackupIntgSuite struct {
@@ -41,7 +43,7 @@ func TestExchangeBackupIntgSuite(t *testing.T) {
 	suite.Run(t, &ExchangeBackupIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs, tester.AWSStorageCredEnvs}),
+			[][]string{config.M365AcctCredEnvs, storeTD.AWSStorageCredEnvs}),
 	})
 }
 
@@ -234,7 +236,7 @@ func testExchangeContinuousBackups(suite *ExchangeBackupIntgSuite, toggles contr
 	tester.LogTimeOfTest(t)
 
 	var (
-		acct       = tester.NewM365Account(t)
+		acct       = config.NewM365Account(t)
 		mb         = evmock.NewBus()
 		now        = dttm.Now()
 		service    = path.ExchangeService

--- a/src/internal/operations/test/helper_test.go
+++ b/src/internal/operations/test/helper_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/alcionai/corso/src/internal/operations"
 	"github.com/alcionai/corso/src/internal/streamstore"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
@@ -38,6 +39,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/mock"
 	"github.com/alcionai/corso/src/pkg/storage"
+	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
 	"github.com/alcionai/corso/src/pkg/store"
 )
 
@@ -91,8 +93,8 @@ func prepNewTestBackupOp(
 	*backupOpDependencies,
 ) {
 	bod := &backupOpDependencies{
-		acct: tester.NewM365Account(t),
-		st:   tester.NewPrefixedS3Storage(t),
+		acct: config.NewM365Account(t),
+		st:   storeTD.NewPrefixedS3Storage(t),
 	}
 
 	k := kopia.NewConn(bod.st)
@@ -585,7 +587,7 @@ func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
 
 	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
-	a := tester.NewM365Account(t)
+	a := config.NewM365Account(t)
 	creds, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -597,7 +599,7 @@ func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
 
 	// user drive
 
-	its.userID = tester.M365UserID(t)
+	its.userID = config.M365UserID(t)
 
 	userDrive, err := its.ac.Users().GetDefaultDrive(ctx, its.userID)
 	require.NoError(t, err, clues.ToCore(err))
@@ -609,7 +611,7 @@ func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
 
 	its.userDriveRootFolderID = ptr.Val(userDriveRootFolder.GetId())
 
-	its.siteID = tester.M365SiteID(t)
+	its.siteID = config.M365SiteID(t)
 
 	// site
 

--- a/src/internal/operations/test/helper_test.go
+++ b/src/internal/operations/test/helper_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/alcionai/corso/src/internal/operations"
 	"github.com/alcionai/corso/src/internal/streamstore"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
@@ -93,7 +93,7 @@ func prepNewTestBackupOp(
 	*backupOpDependencies,
 ) {
 	bod := &backupOpDependencies{
-		acct: config.NewM365Account(t),
+		acct: tconfig.NewM365Account(t),
 		st:   storeTD.NewPrefixedS3Storage(t),
 	}
 
@@ -587,7 +587,7 @@ func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
 
 	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
-	a := config.NewM365Account(t)
+	a := tconfig.NewM365Account(t)
 	creds, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -599,7 +599,7 @@ func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
 
 	// user drive
 
-	its.userID = config.M365UserID(t)
+	its.userID = tconfig.M365UserID(t)
 
 	userDrive, err := its.ac.Users().GetDefaultDrive(ctx, its.userID)
 	require.NoError(t, err, clues.ToCore(err))
@@ -611,7 +611,7 @@ func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
 
 	its.userDriveRootFolderID = ptr.Val(userDriveRootFolder.GetId())
 
-	its.siteID = config.M365SiteID(t)
+	its.siteID = tconfig.M365SiteID(t)
 
 	// site
 

--- a/src/internal/operations/test/onedrive_test.go
+++ b/src/internal/operations/test/onedrive_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/internal/streamstore"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
@@ -49,7 +49,7 @@ func TestOneDriveBackupIntgSuite(t *testing.T) {
 	suite.Run(t, &OneDriveBackupIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs, storeTD.AWSStorageCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs, storeTD.AWSStorageCredEnvs}),
 	})
 }
 
@@ -64,9 +64,9 @@ func (suite *OneDriveBackupIntgSuite) TestBackup_Run_oneDrive() {
 	defer flush()
 
 	var (
-		tenID  = config.M365TenantID(t)
+		tenID  = tconfig.M365TenantID(t)
 		mb     = evmock.NewBus()
-		userID = config.SecondaryM365UserID(t)
+		userID = tconfig.SecondaryM365UserID(t)
 		osel   = selectors.NewOneDriveBackup([]string{userID})
 		ws     = deeTD.DriveIDFromRepoRef
 		svc    = path.OneDriveService
@@ -162,7 +162,7 @@ func runDriveIncrementalTest(
 	defer flush()
 
 	var (
-		acct = config.NewM365Account(t)
+		acct = tconfig.NewM365Account(t)
 		ffs  = control.Toggles{}
 		mb   = evmock.NewBus()
 		ws   = deeTD.DriveIDFromRepoRef
@@ -700,7 +700,7 @@ func (suite *OneDriveBackupIntgSuite) TestBackup_Run_oneDriveOwnerMigration() {
 	defer flush()
 
 	var (
-		acct = config.NewM365Account(t)
+		acct = tconfig.NewM365Account(t)
 		ffs  = control.Toggles{}
 		mb   = evmock.NewBus()
 

--- a/src/internal/operations/test/onedrive_test.go
+++ b/src/internal/operations/test/onedrive_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/internal/streamstore"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
@@ -36,6 +37,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/selectors"
 	selTD "github.com/alcionai/corso/src/pkg/selectors/testdata"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
+	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
 )
 
 type OneDriveBackupIntgSuite struct {
@@ -47,7 +49,7 @@ func TestOneDriveBackupIntgSuite(t *testing.T) {
 	suite.Run(t, &OneDriveBackupIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs, tester.AWSStorageCredEnvs}),
+			[][]string{config.M365AcctCredEnvs, storeTD.AWSStorageCredEnvs}),
 	})
 }
 
@@ -62,9 +64,9 @@ func (suite *OneDriveBackupIntgSuite) TestBackup_Run_oneDrive() {
 	defer flush()
 
 	var (
-		tenID  = tester.M365TenantID(t)
+		tenID  = config.M365TenantID(t)
 		mb     = evmock.NewBus()
-		userID = tester.SecondaryM365UserID(t)
+		userID = config.SecondaryM365UserID(t)
 		osel   = selectors.NewOneDriveBackup([]string{userID})
 		ws     = deeTD.DriveIDFromRepoRef
 		svc    = path.OneDriveService
@@ -160,7 +162,7 @@ func runDriveIncrementalTest(
 	defer flush()
 
 	var (
-		acct = tester.NewM365Account(t)
+		acct = config.NewM365Account(t)
 		ffs  = control.Toggles{}
 		mb   = evmock.NewBus()
 		ws   = deeTD.DriveIDFromRepoRef
@@ -698,7 +700,7 @@ func (suite *OneDriveBackupIntgSuite) TestBackup_Run_oneDriveOwnerMigration() {
 	defer flush()
 
 	var (
-		acct = tester.NewM365Account(t)
+		acct = config.NewM365Account(t)
 		ffs  = control.Toggles{}
 		mb   = evmock.NewBus()
 

--- a/src/internal/operations/test/sharepoint_test.go
+++ b/src/internal/operations/test/sharepoint_test.go
@@ -15,12 +15,14 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/resource"
 	"github.com/alcionai/corso/src/internal/m365/sharepoint"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	selTD "github.com/alcionai/corso/src/pkg/selectors/testdata"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
+	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
 )
 
 type SharePointBackupIntgSuite struct {
@@ -32,7 +34,7 @@ func TestSharePointBackupIntgSuite(t *testing.T) {
 	suite.Run(t, &SharePointBackupIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs, tester.AWSStorageCredEnvs}),
+			[][]string{config.M365AcctCredEnvs, storeTD.AWSStorageCredEnvs}),
 	})
 }
 

--- a/src/internal/operations/test/sharepoint_test.go
+++ b/src/internal/operations/test/sharepoint_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/resource"
 	"github.com/alcionai/corso/src/internal/m365/sharepoint"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -34,7 +34,7 @@ func TestSharePointBackupIntgSuite(t *testing.T) {
 	suite.Run(t, &SharePointBackupIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs, storeTD.AWSStorageCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs, storeTD.AWSStorageCredEnvs}),
 	})
 }
 

--- a/src/internal/streamstore/collectables_test.go
+++ b/src/internal/streamstore/collectables_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/control/repository"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
+	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
 )
 
 type StreamStoreIntgSuite struct {
@@ -29,7 +30,7 @@ func TestStreamStoreIntgSuite(t *testing.T) {
 	suite.Run(t, &StreamStoreIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs}),
+			[][]string{storeTD.AWSStorageCredEnvs}),
 	})
 }
 
@@ -40,7 +41,7 @@ func (suite *StreamStoreIntgSuite) SetupSubTest() {
 	defer flush()
 
 	// need to initialize the repository before we can test connecting to it.
-	st := tester.NewPrefixedS3Storage(t)
+	st := storeTD.NewPrefixedS3Storage(t)
 
 	k := kopia.NewConn(st)
 	require.NoError(t, k.Initialize(ctx, repository.Options{}))

--- a/src/internal/tester/config/account.go
+++ b/src/internal/tester/config/account.go
@@ -1,4 +1,4 @@
-package tester
+package config
 
 import (
 	"testing"
@@ -18,7 +18,7 @@ var M365AcctCredEnvs = []string{
 // NewM365Account returns an account.Account object initialized with environment
 // variables used for integration tests that use the m365 Controller.
 func NewM365Account(t *testing.T) account.Account {
-	cfg, err := readTestConfig()
+	cfg, err := ReadTestConfig()
 	require.NoError(t, err, "configuring m365 account from test configuration", clues.ToCore(err))
 
 	acc, err := account.NewAccount(
@@ -33,7 +33,7 @@ func NewM365Account(t *testing.T) account.Account {
 	return acc
 }
 
-func NewMockM365Account(t *testing.T) account.Account {
+func NewFakeM365Account(t *testing.T) account.Account {
 	acc, err := account.NewAccount(
 		account.ProviderM365,
 		account.M365Config{

--- a/src/internal/tester/config/config.go
+++ b/src/internal/tester/config/config.go
@@ -1,4 +1,4 @@
-package tester
+package config
 
 import (
 	"os"
@@ -87,7 +87,7 @@ func NewTestViper() (*viper.Viper, error) {
 // reads a corso configuration file with values specific to
 // local integration test controls.  Populates values with
 // defaults where standard.
-func readTestConfig() (map[string]string, error) {
+func ReadTestConfig() (map[string]string, error) {
 	if testConfig != nil {
 		return cloneTestConfig(), nil
 	}
@@ -177,7 +177,7 @@ func readTestConfig() (map[string]string, error) {
 //
 // Returns a filepath string pointing to the location of the temp file.
 func MakeTempTestConfigClone(t *testing.T, overrides map[string]string) (*viper.Viper, string) {
-	cfg, err := readTestConfig()
+	cfg, err := ReadTestConfig()
 	require.NoError(t, err, "reading tester config", clues.ToCore(err))
 
 	fName := filepath.Base(os.Getenv(EnvCorsoTestConfigFilePath))

--- a/src/internal/tester/config/protected_resources.go
+++ b/src/internal/tester/config/protected_resources.go
@@ -1,4 +1,4 @@
-package tester
+package config
 
 import (
 	"context"
@@ -17,7 +17,7 @@ import (
 // file or the default value (in that order of priority).  The default is a
 // last-attempt fallback that will only work on alcion's testing org.
 func M365TenantID(t *testing.T) string {
-	cfg, err := readTestConfig()
+	cfg, err := ReadTestConfig()
 	require.NoError(t, err, "retrieving m365 tenant ID from test configuration", clues.ToCore(err))
 
 	return strings.ToLower(cfg[TestCfgAzureTenantID])
@@ -28,7 +28,7 @@ func M365TenantID(t *testing.T) string {
 // file or the default value (in that order of priority).  The default is a
 // last-attempt fallback that will only work on alcion's testing org.
 func GetM365TenantID(ctx context.Context) string {
-	cfg, err := readTestConfig()
+	cfg, err := ReadTestConfig()
 	if err != nil {
 		logger.Ctx(ctx).Error(err, "retrieving m365 tenant ID from test configuration")
 	}
@@ -41,7 +41,7 @@ func GetM365TenantID(ctx context.Context) string {
 // file or the default value (in that order of priority).  The default is a
 // last-attempt fallback that will only work on alcion's testing org.
 func M365UserID(t *testing.T) string {
-	cfg, err := readTestConfig()
+	cfg, err := ReadTestConfig()
 	require.NoError(t, err, "retrieving m365 user id from test configuration", clues.ToCore(err))
 
 	return strings.ToLower(cfg[TestCfgUserID])
@@ -52,7 +52,7 @@ func M365UserID(t *testing.T) string {
 // file or the default value (in that order of priority).  The default is a
 // last-attempt fallback that will only work on alcion's testing org.
 func GetM365UserID(ctx context.Context) string {
-	cfg, err := readTestConfig()
+	cfg, err := ReadTestConfig()
 	if err != nil {
 		logger.Ctx(ctx).Error(err, "retrieving m365 user id from test configuration")
 	}
@@ -66,7 +66,7 @@ func GetM365UserID(ctx context.Context) string {
 // The default is a last-attempt fallback that will only work on alcion's
 // testing org.
 func SecondaryM365UserID(t *testing.T) string {
-	cfg, err := readTestConfig()
+	cfg, err := ReadTestConfig()
 	require.NoError(t, err, "retrieving secondary m365 user id from test configuration", clues.ToCore(err))
 
 	return strings.ToLower(cfg[TestCfgSecondaryUserID])
@@ -78,7 +78,7 @@ func SecondaryM365UserID(t *testing.T) string {
 // The default is a last-attempt fallback that will only work on alcion's
 // testing org.
 func TertiaryM365UserID(t *testing.T) string {
-	cfg, err := readTestConfig()
+	cfg, err := ReadTestConfig()
 	require.NoError(t, err, "retrieving tertiary m365 user id from test configuration", clues.ToCore(err))
 
 	return strings.ToLower(cfg[TestCfgTertiaryUserID])
@@ -90,7 +90,7 @@ func TertiaryM365UserID(t *testing.T) string {
 // The default is a last-attempt fallback that will only work on alcion's
 // testing org.
 func LoadTestM365SiteID(t *testing.T) string {
-	cfg, err := readTestConfig()
+	cfg, err := ReadTestConfig()
 	require.NoError(t, err, "retrieving load test m365 site id from test configuration", clues.ToCore(err))
 
 	return strings.ToLower(cfg[TestCfgSiteID])
@@ -102,7 +102,7 @@ func LoadTestM365SiteID(t *testing.T) string {
 // The default is a last-attempt fallback that will only work on alcion's
 // testing org.
 func LoadTestM365UserID(t *testing.T) string {
-	cfg, err := readTestConfig()
+	cfg, err := ReadTestConfig()
 	require.NoError(t, err, "retrieving load test m365 user id from test configuration", clues.ToCore(err))
 
 	return strings.ToLower(cfg[TestCfgLoadTestUserID])
@@ -112,7 +112,7 @@ func LoadTestM365UserID(t *testing.T) string {
 // ["site1\,uuid","site2\,uuid"]
 // the delimiter must be a |.
 func LoadTestM365OrgSites(t *testing.T) []string {
-	cfg, err := readTestConfig()
+	cfg, err := ReadTestConfig()
 	require.NoError(t, err, "retrieving load test m365 org sites from test configuration %+v", clues.ToCore(err))
 
 	// TODO: proper handling of site slice input.
@@ -132,7 +132,7 @@ func LoadTestM365OrgSites(t *testing.T) []string {
 // ["foo@example.com","bar@example.com"]
 // the delimiter may be either a , or |.
 func LoadTestM365OrgUsers(t *testing.T) []string {
-	cfg, err := readTestConfig()
+	cfg, err := ReadTestConfig()
 	require.NoError(t, err, "retrieving load test m365 org users from test configuration %+v", clues.ToCore(err))
 
 	users := cfg[TestCfgLoadTestOrgUsers]
@@ -168,7 +168,7 @@ func LoadTestM365OrgUsers(t *testing.T) []string {
 // file or the default value (in that order of priority).  The default is a
 // last-attempt fallback that will only work on alcion's testing org.
 func M365SiteID(t *testing.T) string {
-	cfg, err := readTestConfig()
+	cfg, err := ReadTestConfig()
 	require.NoError(t, err, "retrieving m365 site id from test configuration: %+v", clues.ToCore(err))
 
 	return strings.ToLower(cfg[TestCfgSiteID])
@@ -179,7 +179,7 @@ func M365SiteID(t *testing.T) string {
 // file or the default value (in that order of priority).  The default is a
 // last-attempt fallback that will only work on alcion's testing org.
 func M365SiteURL(t *testing.T) string {
-	cfg, err := readTestConfig()
+	cfg, err := ReadTestConfig()
 	require.NoError(t, err, "retrieving m365 site url from test configuration: %+v", clues.ToCore(err))
 
 	return strings.ToLower(cfg[TestCfgSiteURL])
@@ -190,7 +190,7 @@ func M365SiteURL(t *testing.T) string {
 // file or the default value (in that order of priority).  The default is a
 // last-attempt fallback that will only work on alcion's testing org.
 func GetM365SiteID(ctx context.Context) string {
-	cfg, err := readTestConfig()
+	cfg, err := ReadTestConfig()
 	if err != nil {
 		logger.Ctx(ctx).Error(err, "retrieving m365 user id from test configuration")
 	}
@@ -204,7 +204,7 @@ func GetM365SiteID(ctx context.Context) string {
 // The default is a last-attempt fallback that will only work on alcion's
 // testing org.
 func UnlicensedM365UserID(t *testing.T) string {
-	cfg, err := readTestConfig()
+	cfg, err := ReadTestConfig()
 	require.NoError(t, err, "retrieving unlicensed m365 user id from test configuration: %+v", clues.ToCore(err))
 
 	return strings.ToLower(cfg[TestCfgSecondaryUserID])

--- a/src/internal/tester/tconfig/account.go
+++ b/src/internal/tester/tconfig/account.go
@@ -1,4 +1,4 @@
-package config
+package tconfig
 
 import (
 	"testing"

--- a/src/internal/tester/tconfig/config.go
+++ b/src/internal/tester/tconfig/config.go
@@ -1,4 +1,4 @@
-package config
+package tconfig
 
 import (
 	"os"

--- a/src/internal/tester/tconfig/protected_resources.go
+++ b/src/internal/tester/tconfig/protected_resources.go
@@ -1,4 +1,4 @@
-package config
+package tconfig
 
 import (
 	"context"

--- a/src/pkg/repository/loadtest/repository_load_test.go
+++ b/src/pkg/repository/loadtest/repository_load_test.go
@@ -16,7 +16,7 @@ import (
 	D "github.com/alcionai/corso/src/internal/diagnostics"
 	"github.com/alcionai/corso/src/internal/operations"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
@@ -33,22 +33,22 @@ import (
 
 //lint:ignore U1000 future test use
 func orgSiteSet(t *testing.T) []string {
-	return config.LoadTestM365OrgSites(t)
+	return tconfig.LoadTestM365OrgSites(t)
 }
 
 //lint:ignore U1000 future test use
 func orgUserSet(t *testing.T) []string {
-	return config.LoadTestM365OrgUsers(t)
+	return tconfig.LoadTestM365OrgUsers(t)
 }
 
 //lint:ignore U1000 future test use
 func singleSiteSet(t *testing.T) []string {
-	return []string{config.LoadTestM365SiteID(t)}
+	return []string{tconfig.LoadTestM365SiteID(t)}
 }
 
 //lint:ignore U1000 future test use
 func singleUserSet(t *testing.T) []string {
-	return []string{config.LoadTestM365UserID(t)}
+	return []string{tconfig.LoadTestM365UserID(t)}
 }
 
 var loadCtx context.Context
@@ -90,13 +90,13 @@ func initM365Repo(t *testing.T) (
 	account.Account,
 	storage.Storage,
 ) {
-	tester.MustGetEnvSets(t, storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs)
+	tester.MustGetEnvSets(t, storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs)
 
 	ctx, flush := tester.WithContext(t, loadCtx)
 	defer flush()
 
 	st := storeTD.NewPrefixedS3Storage(t)
-	ac := config.NewM365Account(t)
+	ac := tconfig.NewM365Account(t)
 	opts := control.Options{
 		DisableMetrics:  true,
 		FailureHandling: control.FailFast,
@@ -418,7 +418,7 @@ func TestLoadExchangeSuite(t *testing.T) {
 	suite.Run(t, &LoadExchangeSuite{
 		Suite: tester.NewLoadSuite(
 			t,
-			[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs},
+			[][]string{storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs},
 		),
 	})
 }
@@ -469,7 +469,7 @@ func TestIndividualLoadExchangeSuite(t *testing.T) {
 	suite.Run(t, &IndividualLoadExchangeSuite{
 		Suite: tester.NewLoadSuite(
 			t,
-			[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs},
+			[][]string{storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs},
 		),
 	})
 }
@@ -523,7 +523,7 @@ func TestLoadOneDriveSuite(t *testing.T) {
 	suite.Run(t, &LoadOneDriveSuite{
 		Suite: tester.NewLoadSuite(
 			t,
-			[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs},
+			[][]string{storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs},
 		),
 	})
 }
@@ -571,7 +571,7 @@ func TestIndividualLoadOneDriveSuite(t *testing.T) {
 	suite.Run(t, &IndividualLoadOneDriveSuite{
 		Suite: tester.NewLoadSuite(
 			t,
-			[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs},
+			[][]string{storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs},
 		),
 	})
 }
@@ -622,7 +622,7 @@ func TestLoadSharePointSuite(t *testing.T) {
 	suite.Run(t, &LoadSharePointSuite{
 		Suite: tester.NewLoadSuite(
 			t,
-			[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs},
+			[][]string{storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs},
 		),
 	})
 }
@@ -670,7 +670,7 @@ func TestIndividualLoadSharePointSuite(t *testing.T) {
 	suite.Run(t, &IndividualLoadSharePointSuite{
 		Suite: tester.NewLoadSuite(
 			t,
-			[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs},
+			[][]string{storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs},
 		),
 	})
 }

--- a/src/pkg/repository/loadtest/repository_load_test.go
+++ b/src/pkg/repository/loadtest/repository_load_test.go
@@ -16,6 +16,7 @@ import (
 	D "github.com/alcionai/corso/src/internal/diagnostics"
 	"github.com/alcionai/corso/src/internal/operations"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
@@ -27,26 +28,27 @@ import (
 	"github.com/alcionai/corso/src/pkg/selectors"
 	selTD "github.com/alcionai/corso/src/pkg/selectors/testdata"
 	"github.com/alcionai/corso/src/pkg/storage"
+	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
 )
 
 //lint:ignore U1000 future test use
 func orgSiteSet(t *testing.T) []string {
-	return tester.LoadTestM365OrgSites(t)
+	return config.LoadTestM365OrgSites(t)
 }
 
 //lint:ignore U1000 future test use
 func orgUserSet(t *testing.T) []string {
-	return tester.LoadTestM365OrgUsers(t)
+	return config.LoadTestM365OrgUsers(t)
 }
 
 //lint:ignore U1000 future test use
 func singleSiteSet(t *testing.T) []string {
-	return []string{tester.LoadTestM365SiteID(t)}
+	return []string{config.LoadTestM365SiteID(t)}
 }
 
 //lint:ignore U1000 future test use
 func singleUserSet(t *testing.T) []string {
-	return []string{tester.LoadTestM365UserID(t)}
+	return []string{config.LoadTestM365UserID(t)}
 }
 
 var loadCtx context.Context
@@ -88,13 +90,13 @@ func initM365Repo(t *testing.T) (
 	account.Account,
 	storage.Storage,
 ) {
-	tester.MustGetEnvSets(t, tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs)
+	tester.MustGetEnvSets(t, storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs)
 
 	ctx, flush := tester.WithContext(t, loadCtx)
 	defer flush()
 
-	st := tester.NewPrefixedS3Storage(t)
-	ac := tester.NewM365Account(t)
+	st := storeTD.NewPrefixedS3Storage(t)
+	ac := config.NewM365Account(t)
 	opts := control.Options{
 		DisableMetrics:  true,
 		FailureHandling: control.FailFast,
@@ -416,7 +418,7 @@ func TestLoadExchangeSuite(t *testing.T) {
 	suite.Run(t, &LoadExchangeSuite{
 		Suite: tester.NewLoadSuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
+			[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs},
 		),
 	})
 }
@@ -467,7 +469,7 @@ func TestIndividualLoadExchangeSuite(t *testing.T) {
 	suite.Run(t, &IndividualLoadExchangeSuite{
 		Suite: tester.NewLoadSuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
+			[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs},
 		),
 	})
 }
@@ -521,7 +523,7 @@ func TestLoadOneDriveSuite(t *testing.T) {
 	suite.Run(t, &LoadOneDriveSuite{
 		Suite: tester.NewLoadSuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
+			[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs},
 		),
 	})
 }
@@ -569,7 +571,7 @@ func TestIndividualLoadOneDriveSuite(t *testing.T) {
 	suite.Run(t, &IndividualLoadOneDriveSuite{
 		Suite: tester.NewLoadSuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
+			[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs},
 		),
 	})
 }
@@ -620,7 +622,7 @@ func TestLoadSharePointSuite(t *testing.T) {
 	suite.Run(t, &LoadSharePointSuite{
 		Suite: tester.NewLoadSuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
+			[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs},
 		),
 	})
 }
@@ -668,7 +670,7 @@ func TestIndividualLoadSharePointSuite(t *testing.T) {
 	suite.Run(t, &IndividualLoadSharePointSuite{
 		Suite: tester.NewLoadSuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs},
+			[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs},
 		),
 	})
 }

--- a/src/pkg/repository/repository_test.go
+++ b/src/pkg/repository/repository_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
 	ctrlRepo "github.com/alcionai/corso/src/pkg/control/repository"
@@ -18,6 +19,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/extensions"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/storage"
+	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
 )
 
 // ---------------
@@ -110,7 +112,7 @@ func TestRepositoryIntegrationSuite(t *testing.T) {
 	suite.Run(t, &RepositoryIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs}),
+			[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs}),
 	})
 }
 
@@ -123,7 +125,7 @@ func (suite *RepositoryIntegrationSuite) TestInitialize() {
 	}{
 		{
 			name:     "success",
-			storage:  tester.NewPrefixedS3Storage,
+			storage:  storeTD.NewPrefixedS3Storage,
 			errCheck: assert.NoError,
 		},
 	}
@@ -161,7 +163,7 @@ func (suite *RepositoryIntegrationSuite) TestInitializeWithRole() {
 	ctx, flush := tester.NewContext(suite.T())
 	defer flush()
 
-	st := tester.NewPrefixedS3Storage(suite.T())
+	st := storeTD.NewPrefixedS3Storage(suite.T())
 
 	st.Role = os.Getenv(roleARNEnvKey)
 	st.SessionName = "corso-repository-test"
@@ -182,7 +184,7 @@ func (suite *RepositoryIntegrationSuite) TestConnect() {
 	defer flush()
 
 	// need to initialize the repository before we can test connecting to it.
-	st := tester.NewPrefixedS3Storage(t)
+	st := storeTD.NewPrefixedS3Storage(t)
 
 	repo, err := Initialize(ctx, account.Account{}, st, control.Defaults())
 	require.NoError(t, err, clues.ToCore(err))
@@ -199,7 +201,7 @@ func (suite *RepositoryIntegrationSuite) TestConnect_sameID() {
 	defer flush()
 
 	// need to initialize the repository before we can test connecting to it.
-	st := tester.NewPrefixedS3Storage(t)
+	st := storeTD.NewPrefixedS3Storage(t)
 
 	r, err := Initialize(ctx, account.Account{}, st, control.Defaults())
 	require.NoError(t, err, clues.ToCore(err))
@@ -221,15 +223,15 @@ func (suite *RepositoryIntegrationSuite) TestNewBackup() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	acct := tester.NewM365Account(t)
+	acct := config.NewM365Account(t)
 
 	// need to initialize the repository before we can test connecting to it.
-	st := tester.NewPrefixedS3Storage(t)
+	st := storeTD.NewPrefixedS3Storage(t)
 
 	r, err := Initialize(ctx, acct, st, control.Defaults())
 	require.NoError(t, err, clues.ToCore(err))
 
-	userID := tester.M365UserID(t)
+	userID := config.M365UserID(t)
 
 	bo, err := r.NewBackup(ctx, selectors.Selector{DiscreteOwner: userID})
 	require.NoError(t, err, clues.ToCore(err))
@@ -242,11 +244,11 @@ func (suite *RepositoryIntegrationSuite) TestNewRestore() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	acct := tester.NewM365Account(t)
+	acct := config.NewM365Account(t)
 	restoreCfg := testdata.DefaultRestoreConfig("")
 
 	// need to initialize the repository before we can test connecting to it.
-	st := tester.NewPrefixedS3Storage(t)
+	st := storeTD.NewPrefixedS3Storage(t)
 
 	r, err := Initialize(ctx, acct, st, control.Defaults())
 	require.NoError(t, err, clues.ToCore(err))
@@ -262,10 +264,10 @@ func (suite *RepositoryIntegrationSuite) TestNewMaintenance() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	acct := tester.NewM365Account(t)
+	acct := config.NewM365Account(t)
 
 	// need to initialize the repository before we can test connecting to it.
-	st := tester.NewPrefixedS3Storage(t)
+	st := storeTD.NewPrefixedS3Storage(t)
 
 	r, err := Initialize(ctx, acct, st, control.Defaults())
 	require.NoError(t, err, clues.ToCore(err))
@@ -282,7 +284,7 @@ func (suite *RepositoryIntegrationSuite) TestConnect_DisableMetrics() {
 	defer flush()
 
 	// need to initialize the repository before we can test connecting to it.
-	st := tester.NewPrefixedS3Storage(t)
+	st := storeTD.NewPrefixedS3Storage(t)
 
 	repo, err := Initialize(ctx, account.Account{}, st, control.Defaults())
 	require.NoError(t, err)
@@ -342,8 +344,8 @@ func (suite *RepositoryIntegrationSuite) Test_Options() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
-			acct := tester.NewM365Account(t)
-			st := tester.NewPrefixedS3Storage(t)
+			acct := config.NewM365Account(t)
+			st := storeTD.NewPrefixedS3Storage(t)
 
 			ctx, flush := tester.NewContext(t)
 			defer flush()

--- a/src/pkg/repository/repository_test.go
+++ b/src/pkg/repository/repository_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
 	ctrlRepo "github.com/alcionai/corso/src/pkg/control/repository"
@@ -112,7 +112,7 @@ func TestRepositoryIntegrationSuite(t *testing.T) {
 	suite.Run(t, &RepositoryIntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs}),
+			[][]string{storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs}),
 	})
 }
 
@@ -223,7 +223,7 @@ func (suite *RepositoryIntegrationSuite) TestNewBackup() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	acct := config.NewM365Account(t)
+	acct := tconfig.NewM365Account(t)
 
 	// need to initialize the repository before we can test connecting to it.
 	st := storeTD.NewPrefixedS3Storage(t)
@@ -231,7 +231,7 @@ func (suite *RepositoryIntegrationSuite) TestNewBackup() {
 	r, err := Initialize(ctx, acct, st, control.Defaults())
 	require.NoError(t, err, clues.ToCore(err))
 
-	userID := config.M365UserID(t)
+	userID := tconfig.M365UserID(t)
 
 	bo, err := r.NewBackup(ctx, selectors.Selector{DiscreteOwner: userID})
 	require.NoError(t, err, clues.ToCore(err))
@@ -244,7 +244,7 @@ func (suite *RepositoryIntegrationSuite) TestNewRestore() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	acct := config.NewM365Account(t)
+	acct := tconfig.NewM365Account(t)
 	restoreCfg := testdata.DefaultRestoreConfig("")
 
 	// need to initialize the repository before we can test connecting to it.
@@ -264,7 +264,7 @@ func (suite *RepositoryIntegrationSuite) TestNewMaintenance() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	acct := config.NewM365Account(t)
+	acct := tconfig.NewM365Account(t)
 
 	// need to initialize the repository before we can test connecting to it.
 	st := storeTD.NewPrefixedS3Storage(t)
@@ -344,7 +344,7 @@ func (suite *RepositoryIntegrationSuite) Test_Options() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
-			acct := config.NewM365Account(t)
+			acct := tconfig.NewM365Account(t)
 			st := storeTD.NewPrefixedS3Storage(t)
 
 			ctx, flush := tester.NewContext(t)

--- a/src/pkg/repository/repository_unexported_test.go
+++ b/src/pkg/repository/repository_unexported_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/alcionai/corso/src/internal/stats"
 	"github.com/alcionai/corso/src/internal/streamstore"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
@@ -24,6 +25,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
+	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
 	"github.com/alcionai/corso/src/pkg/store"
 	"github.com/alcionai/corso/src/pkg/store/mock"
 )
@@ -220,7 +222,7 @@ func TestRepositoryModelIntgSuite(t *testing.T) {
 	suite.Run(t, &RepositoryModelIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.AWSStorageCredEnvs, tester.M365AcctCredEnvs}),
+			[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs}),
 	})
 }
 
@@ -231,7 +233,7 @@ func (suite *RepositoryModelIntgSuite) SetupSuite() {
 	defer flush()
 
 	var (
-		s   = tester.NewPrefixedS3Storage(t)
+		s   = storeTD.NewPrefixedS3Storage(t)
 		k   = kopia.NewConn(s)
 		err error
 	)
@@ -285,7 +287,7 @@ func (suite *RepositoryModelIntgSuite) TestGetRepositoryModel() {
 	defer flush()
 
 	var (
-		s = tester.NewPrefixedS3Storage(t)
+		s = storeTD.NewPrefixedS3Storage(t)
 		k = kopia.NewConn(s)
 	)
 

--- a/src/pkg/repository/repository_unexported_test.go
+++ b/src/pkg/repository/repository_unexported_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/alcionai/corso/src/internal/stats"
 	"github.com/alcionai/corso/src/internal/streamstore"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
@@ -222,7 +222,7 @@ func TestRepositoryModelIntgSuite(t *testing.T) {
 	suite.Run(t, &RepositoryModelIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{storeTD.AWSStorageCredEnvs, config.M365AcctCredEnvs}),
+			[][]string{storeTD.AWSStorageCredEnvs, tconfig.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/pkg/services/m365/api/client_test.go
+++ b/src/pkg/services/m365/api/client_test.go
@@ -11,6 +11,7 @@ import (
 
 	exchMock "github.com/alcionai/corso/src/internal/m365/exchange/mock"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 )
 
@@ -23,7 +24,7 @@ func TestExchangeServiceSuite(t *testing.T) {
 	suite.Run(t, &ExchangeServiceSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs},
+			[][]string{config.M365AcctCredEnvs},
 		),
 	})
 }
@@ -31,7 +32,7 @@ func TestExchangeServiceSuite(t *testing.T) {
 func (suite *ExchangeServiceSuite) SetupSuite() {
 	t := suite.T()
 
-	a := tester.NewM365Account(t)
+	a := config.NewM365Account(t)
 	m365, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 

--- a/src/pkg/services/m365/api/client_test.go
+++ b/src/pkg/services/m365/api/client_test.go
@@ -11,7 +11,7 @@ import (
 
 	exchMock "github.com/alcionai/corso/src/internal/m365/exchange/mock"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 )
 
@@ -24,7 +24,7 @@ func TestExchangeServiceSuite(t *testing.T) {
 	suite.Run(t, &ExchangeServiceSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs},
+			[][]string{tconfig.M365AcctCredEnvs},
 		),
 	})
 }
@@ -32,7 +32,7 @@ func TestExchangeServiceSuite(t *testing.T) {
 func (suite *ExchangeServiceSuite) SetupSuite() {
 	t := suite.T()
 
-	a := config.NewM365Account(t)
+	a := tconfig.NewM365Account(t)
 	m365, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 

--- a/src/pkg/services/m365/api/contacts_pager_test.go
+++ b/src/pkg/services/m365/api/contacts_pager_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
@@ -22,7 +23,7 @@ func TestContactsPagerIntgSuite(t *testing.T) {
 	suite.Run(t, &ContactsPagerIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/pkg/services/m365/api/contacts_pager_test.go
+++ b/src/pkg/services/m365/api/contacts_pager_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
@@ -23,7 +23,7 @@ func TestContactsPagerIntgSuite(t *testing.T) {
 	suite.Run(t, &ContactsPagerIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/pkg/services/m365/api/contacts_test.go
+++ b/src/pkg/services/m365/api/contacts_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	exchMock "github.com/alcionai/corso/src/internal/m365/exchange/mock"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
@@ -119,7 +120,7 @@ func TestContactsAPIntgSuite(t *testing.T) {
 	suite.Run(t, &ContactsAPIIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/pkg/services/m365/api/contacts_test.go
+++ b/src/pkg/services/m365/api/contacts_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	exchMock "github.com/alcionai/corso/src/internal/m365/exchange/mock"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
@@ -120,7 +120,7 @@ func TestContactsAPIntgSuite(t *testing.T) {
 	suite.Run(t, &ContactsAPIIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/pkg/services/m365/api/drive_pager_test.go
+++ b/src/pkg/services/m365/api/drive_pager_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
@@ -22,7 +22,7 @@ func TestDrivePagerIntgSuite(t *testing.T) {
 	suite.Run(t, &DrivePagerIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/pkg/services/m365/api/drive_pager_test.go
+++ b/src/pkg/services/m365/api/drive_pager_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
@@ -21,7 +22,7 @@ func TestDrivePagerIntgSuite(t *testing.T) {
 	suite.Run(t, &DrivePagerIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/pkg/services/m365/api/drive_test.go
+++ b/src/pkg/services/m365/api/drive_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 )
@@ -31,7 +32,7 @@ func TestDriveAPIs(t *testing.T) {
 	suite.Run(t, &DriveAPIIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 
@@ -41,7 +42,7 @@ func (suite *DriveAPIIntgSuite) TestDrives_CreatePagerAndGetPage() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	siteID := tester.M365SiteID(t)
+	siteID := config.M365SiteID(t)
 	pager := suite.its.ac.Drives().NewSiteDrivePager(siteID, []string{"name"})
 
 	a, err := pager.GetPage(ctx)

--- a/src/pkg/services/m365/api/drive_test.go
+++ b/src/pkg/services/m365/api/drive_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 )
@@ -32,7 +32,7 @@ func TestDriveAPIs(t *testing.T) {
 	suite.Run(t, &DriveAPIIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 
@@ -42,7 +42,7 @@ func (suite *DriveAPIIntgSuite) TestDrives_CreatePagerAndGetPage() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	siteID := config.M365SiteID(t)
+	siteID := tconfig.M365SiteID(t)
 	pager := suite.its.ac.Drives().NewSiteDrivePager(siteID, []string{"name"})
 
 	a, err := pager.GetPage(ctx)

--- a/src/pkg/services/m365/api/events_pager_test.go
+++ b/src/pkg/services/m365/api/events_pager_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
@@ -22,7 +23,7 @@ func TestEventsPagerIntgSuite(t *testing.T) {
 	suite.Run(t, &EventsPagerIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/pkg/services/m365/api/events_pager_test.go
+++ b/src/pkg/services/m365/api/events_pager_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
@@ -23,7 +23,7 @@ func TestEventsPagerIntgSuite(t *testing.T) {
 	suite.Run(t, &EventsPagerIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/pkg/services/m365/api/events_test.go
+++ b/src/pkg/services/m365/api/events_test.go
@@ -16,6 +16,7 @@ import (
 	exchMock "github.com/alcionai/corso/src/internal/m365/exchange/mock"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -228,7 +229,7 @@ func TestEventsAPIIntgSuite(t *testing.T) {
 	suite.Run(t, &EventsAPIIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 
@@ -242,7 +243,7 @@ func (suite *EventsAPIIntgSuite) TestEvents_RestoreLargeAttachment() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	userID := tester.M365UserID(suite.T())
+	userID := config.M365UserID(suite.T())
 
 	folderName := testdata.DefaultRestoreConfig("eventlargeattachmenttest").Location
 	evts := suite.its.ac.Events()

--- a/src/pkg/services/m365/api/events_test.go
+++ b/src/pkg/services/m365/api/events_test.go
@@ -16,7 +16,7 @@ import (
 	exchMock "github.com/alcionai/corso/src/internal/m365/exchange/mock"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -229,7 +229,7 @@ func TestEventsAPIIntgSuite(t *testing.T) {
 	suite.Run(t, &EventsAPIIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 
@@ -243,7 +243,7 @@ func (suite *EventsAPIIntgSuite) TestEvents_RestoreLargeAttachment() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	userID := config.M365UserID(suite.T())
+	userID := tconfig.M365UserID(suite.T())
 
 	folderName := testdata.DefaultRestoreConfig("eventlargeattachmenttest").Location
 	evts := suite.its.ac.Events()

--- a/src/pkg/services/m365/api/helper_test.go
+++ b/src/pkg/services/m365/api/helper_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/mock"
 )
@@ -92,7 +92,7 @@ func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
 
 	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
-	a := config.NewM365Account(t)
+	a := tconfig.NewM365Account(t)
 	creds, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -104,7 +104,7 @@ func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
 
 	// user drive
 
-	its.userID = config.M365UserID(t)
+	its.userID = tconfig.M365UserID(t)
 
 	userDrive, err := its.ac.Users().GetDefaultDrive(ctx, its.userID)
 	require.NoError(t, err, clues.ToCore(err))
@@ -116,7 +116,7 @@ func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
 
 	its.userDriveRootFolderID = ptr.Val(userDriveRootFolder.GetId())
 
-	its.siteID = config.M365SiteID(t)
+	its.siteID = tconfig.M365SiteID(t)
 
 	// site
 

--- a/src/pkg/services/m365/api/helper_test.go
+++ b/src/pkg/services/m365/api/helper_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/mock"
 )
@@ -91,7 +92,7 @@ func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
 
 	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
-	a := tester.NewM365Account(t)
+	a := config.NewM365Account(t)
 	creds, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -103,7 +104,7 @@ func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
 
 	// user drive
 
-	its.userID = tester.M365UserID(t)
+	its.userID = config.M365UserID(t)
 
 	userDrive, err := its.ac.Users().GetDefaultDrive(ctx, its.userID)
 	require.NoError(t, err, clues.ToCore(err))
@@ -115,7 +116,7 @@ func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
 
 	its.userDriveRootFolderID = ptr.Val(userDriveRootFolder.GetId())
 
-	its.siteID = tester.M365SiteID(t)
+	its.siteID = config.M365SiteID(t)
 
 	// site
 

--- a/src/pkg/services/m365/api/mail_pager_test.go
+++ b/src/pkg/services/m365/api/mail_pager_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
@@ -23,7 +23,7 @@ func TestMailPagerIntgSuite(t *testing.T) {
 	suite.Run(t, &MailPagerIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/pkg/services/m365/api/mail_pager_test.go
+++ b/src/pkg/services/m365/api/mail_pager_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
@@ -22,7 +23,7 @@ func TestMailPagerIntgSuite(t *testing.T) {
 	suite.Run(t, &MailPagerIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/pkg/services/m365/api/mail_test.go
+++ b/src/pkg/services/m365/api/mail_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	exchMock "github.com/alcionai/corso/src/internal/m365/exchange/mock"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -197,7 +197,7 @@ func TestMailAPIIntgSuite(t *testing.T) {
 	suite.Run(t, &MailAPIIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 
@@ -379,7 +379,7 @@ func (suite *MailAPIIntgSuite) TestMail_RestoreLargeAttachment() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	userID := config.M365UserID(suite.T())
+	userID := tconfig.M365UserID(suite.T())
 
 	folderName := testdata.DefaultRestoreConfig("maillargeattachmenttest").Location
 	msgs := suite.its.ac.Mail()

--- a/src/pkg/services/m365/api/mail_test.go
+++ b/src/pkg/services/m365/api/mail_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	exchMock "github.com/alcionai/corso/src/internal/m365/exchange/mock"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -196,7 +197,7 @@ func TestMailAPIIntgSuite(t *testing.T) {
 	suite.Run(t, &MailAPIIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 
@@ -378,7 +379,7 @@ func (suite *MailAPIIntgSuite) TestMail_RestoreLargeAttachment() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	userID := tester.M365UserID(suite.T())
+	userID := config.M365UserID(suite.T())
 
 	folderName := testdata.DefaultRestoreConfig("maillargeattachmenttest").Location
 	msgs := suite.its.ac.Mail()

--- a/src/pkg/services/m365/api/sites_test.go
+++ b/src/pkg/services/m365/api/sites_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
@@ -113,7 +114,7 @@ func TestSitesIntgSuite(t *testing.T) {
 	suite.Run(t, &SitesIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 
@@ -141,10 +142,10 @@ func (suite *SitesIntgSuite) TestGetAll() {
 func (suite *SitesIntgSuite) TestSites_GetByID() {
 	var (
 		t               = suite.T()
-		siteID          = tester.M365SiteID(t)
+		siteID          = config.M365SiteID(t)
 		host            = strings.Split(siteID, ",")[0]
 		shortID         = strings.TrimPrefix(siteID, host+",")
-		siteURL         = tester.M365SiteURL(t)
+		siteURL         = config.M365SiteURL(t)
 		modifiedSiteURL = siteURL + "foo"
 	)
 

--- a/src/pkg/services/m365/api/sites_test.go
+++ b/src/pkg/services/m365/api/sites_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
@@ -114,7 +114,7 @@ func TestSitesIntgSuite(t *testing.T) {
 	suite.Run(t, &SitesIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 
@@ -142,10 +142,10 @@ func (suite *SitesIntgSuite) TestGetAll() {
 func (suite *SitesIntgSuite) TestSites_GetByID() {
 	var (
 		t               = suite.T()
-		siteID          = config.M365SiteID(t)
+		siteID          = tconfig.M365SiteID(t)
 		host            = strings.Split(siteID, ",")[0]
 		shortID         = strings.TrimPrefix(siteID, host+",")
-		siteURL         = config.M365SiteURL(t)
+		siteURL         = tconfig.M365SiteURL(t)
 		modifiedSiteURL = siteURL + "foo"
 	)
 

--- a/src/pkg/services/m365/api/users_test.go
+++ b/src/pkg/services/m365/api/users_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
@@ -124,7 +125,7 @@ func TestUsersIntgSuite(t *testing.T) {
 	suite.Run(t, &UsersIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/pkg/services/m365/api/users_test.go
+++ b/src/pkg/services/m365/api/users_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
@@ -125,7 +125,7 @@ func TestUsersIntgSuite(t *testing.T) {
 	suite.Run(t, &UsersIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 

--- a/src/pkg/services/m365/m365_test.go
+++ b/src/pkg/services/m365/m365_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/credentials"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -31,7 +32,7 @@ func TestM365IntegrationSuite(t *testing.T) {
 	suite.Run(t, &M365IntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 
@@ -50,7 +51,7 @@ func (suite *M365IntegrationSuite) TestUsers() {
 
 	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
-	acct := tester.NewM365Account(suite.T())
+	acct := config.NewM365Account(suite.T())
 
 	users, err := Users(ctx, acct, fault.New(true))
 	assert.NoError(t, err, clues.ToCore(err))
@@ -74,7 +75,7 @@ func (suite *M365IntegrationSuite) TestUsersCompat_HasNoInfo() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	acct := tester.NewM365Account(suite.T())
+	acct := config.NewM365Account(suite.T())
 
 	users, err := UsersCompatNoInfo(ctx, acct)
 	assert.NoError(t, err, clues.ToCore(err))
@@ -98,8 +99,8 @@ func (suite *M365IntegrationSuite) TestUserHasMailbox() {
 	defer flush()
 
 	var (
-		acct = tester.NewM365Account(t)
-		uid  = tester.M365UserID(t)
+		acct = config.NewM365Account(t)
+		uid  = config.M365UserID(t)
 	)
 
 	enabled, err := UserHasMailbox(ctx, acct, uid)
@@ -114,8 +115,8 @@ func (suite *M365IntegrationSuite) TestUserHasDrive() {
 	defer flush()
 
 	var (
-		acct = tester.NewM365Account(t)
-		uid  = tester.M365UserID(t)
+		acct = config.NewM365Account(t)
+		uid  = config.M365UserID(t)
 	)
 
 	enabled, err := UserHasDrives(ctx, acct, uid)
@@ -129,7 +130,7 @@ func (suite *M365IntegrationSuite) TestSites() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	acct := tester.NewM365Account(t)
+	acct := config.NewM365Account(t)
 
 	sites, err := Sites(ctx, acct, fault.New(true))
 	assert.NoError(t, err, clues.ToCore(err))
@@ -355,7 +356,7 @@ func TestDiscoveryIntgSuite(t *testing.T) {
 	suite.Run(t, &DiscoveryIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{tester.M365AcctCredEnvs}),
+			[][]string{config.M365AcctCredEnvs}),
 	})
 }
 
@@ -367,7 +368,7 @@ func (suite *DiscoveryIntgSuite) SetupSuite() {
 
 	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
-	suite.acct = tester.NewM365Account(t)
+	suite.acct = config.NewM365Account(t)
 }
 
 func (suite *DiscoveryIntgSuite) TestUsers() {
@@ -482,7 +483,7 @@ func (suite *DiscoveryIntgSuite) TestGetUserInfo() {
 	}{
 		{
 			name: "standard test user",
-			user: tester.M365UserID(suite.T()),
+			user: config.M365UserID(suite.T()),
 			expect: &api.UserInfo{
 				ServicesEnabled: map[path.ServiceType]struct{}{
 					path.ExchangeService: {},
@@ -527,7 +528,7 @@ func (suite *DiscoveryIntgSuite) TestGetUserInfo() {
 }
 
 func (suite *DiscoveryIntgSuite) TestGetUserInfo_userWithoutDrive() {
-	userID := tester.M365UserID(suite.T())
+	userID := config.M365UserID(suite.T())
 
 	table := []struct {
 		name   string

--- a/src/pkg/services/m365/m365_test.go
+++ b/src/pkg/services/m365/m365_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/credentials"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -32,7 +32,7 @@ func TestM365IntegrationSuite(t *testing.T) {
 	suite.Run(t, &M365IntegrationSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 
@@ -51,7 +51,7 @@ func (suite *M365IntegrationSuite) TestUsers() {
 
 	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
-	acct := config.NewM365Account(suite.T())
+	acct := tconfig.NewM365Account(suite.T())
 
 	users, err := Users(ctx, acct, fault.New(true))
 	assert.NoError(t, err, clues.ToCore(err))
@@ -75,7 +75,7 @@ func (suite *M365IntegrationSuite) TestUsersCompat_HasNoInfo() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	acct := config.NewM365Account(suite.T())
+	acct := tconfig.NewM365Account(suite.T())
 
 	users, err := UsersCompatNoInfo(ctx, acct)
 	assert.NoError(t, err, clues.ToCore(err))
@@ -99,8 +99,8 @@ func (suite *M365IntegrationSuite) TestUserHasMailbox() {
 	defer flush()
 
 	var (
-		acct = config.NewM365Account(t)
-		uid  = config.M365UserID(t)
+		acct = tconfig.NewM365Account(t)
+		uid  = tconfig.M365UserID(t)
 	)
 
 	enabled, err := UserHasMailbox(ctx, acct, uid)
@@ -115,8 +115,8 @@ func (suite *M365IntegrationSuite) TestUserHasDrive() {
 	defer flush()
 
 	var (
-		acct = config.NewM365Account(t)
-		uid  = config.M365UserID(t)
+		acct = tconfig.NewM365Account(t)
+		uid  = tconfig.M365UserID(t)
 	)
 
 	enabled, err := UserHasDrives(ctx, acct, uid)
@@ -130,7 +130,7 @@ func (suite *M365IntegrationSuite) TestSites() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	acct := config.NewM365Account(t)
+	acct := tconfig.NewM365Account(t)
 
 	sites, err := Sites(ctx, acct, fault.New(true))
 	assert.NoError(t, err, clues.ToCore(err))
@@ -356,7 +356,7 @@ func TestDiscoveryIntgSuite(t *testing.T) {
 	suite.Run(t, &DiscoveryIntgSuite{
 		Suite: tester.NewIntegrationSuite(
 			t,
-			[][]string{config.M365AcctCredEnvs}),
+			[][]string{tconfig.M365AcctCredEnvs}),
 	})
 }
 
@@ -368,7 +368,7 @@ func (suite *DiscoveryIntgSuite) SetupSuite() {
 
 	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
-	suite.acct = config.NewM365Account(t)
+	suite.acct = tconfig.NewM365Account(t)
 }
 
 func (suite *DiscoveryIntgSuite) TestUsers() {
@@ -483,7 +483,7 @@ func (suite *DiscoveryIntgSuite) TestGetUserInfo() {
 	}{
 		{
 			name: "standard test user",
-			user: config.M365UserID(suite.T()),
+			user: tconfig.M365UserID(suite.T()),
 			expect: &api.UserInfo{
 				ServicesEnabled: map[path.ServiceType]struct{}{
 					path.ExchangeService: {},
@@ -528,7 +528,7 @@ func (suite *DiscoveryIntgSuite) TestGetUserInfo() {
 }
 
 func (suite *DiscoveryIntgSuite) TestGetUserInfo_userWithoutDrive() {
-	userID := config.M365UserID(suite.T())
+	userID := tconfig.M365UserID(suite.T())
 
 	table := []struct {
 		name   string

--- a/src/pkg/storage/testdata/storage.go
+++ b/src/pkg/storage/testdata/storage.go
@@ -10,7 +10,7 @@ import (
 	"github.com/alcionai/corso/src/cli/flags"
 	"github.com/alcionai/corso/src/internal/common/str"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/config"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/credentials"
 	"github.com/alcionai/corso/src/pkg/storage"
 )
@@ -32,16 +32,16 @@ var AWSStorageCredEnvs = []string{
 func NewPrefixedS3Storage(t *testing.T) storage.Storage {
 	now := tester.LogTimeOfTest(t)
 
-	cfg, err := config.ReadTestConfig()
+	cfg, err := tconfig.ReadTestConfig()
 	require.NoError(t, err, "configuring storage from test file", clues.ToCore(err))
 
 	prefix := testRepoRootPrefix + t.Name() + "-" + now
-	t.Logf("testing at s3 bucket [%s] prefix [%s]", cfg[config.TestCfgBucket], prefix)
+	t.Logf("testing at s3 bucket [%s] prefix [%s]", cfg[tconfig.TestCfgBucket], prefix)
 
 	st, err := storage.NewStorage(
 		storage.ProviderS3,
 		storage.S3Config{
-			Bucket: cfg[config.TestCfgBucket],
+			Bucket: cfg[tconfig.TestCfgBucket],
 			Prefix: prefix,
 		},
 		storage.CommonConfig{

--- a/src/pkg/storage/testdata/storage.go
+++ b/src/pkg/storage/testdata/storage.go
@@ -1,4 +1,4 @@
-package tester
+package testdata
 
 import (
 	"os"
@@ -9,6 +9,8 @@ import (
 
 	"github.com/alcionai/corso/src/cli/flags"
 	"github.com/alcionai/corso/src/internal/common/str"
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/config"
 	"github.com/alcionai/corso/src/pkg/credentials"
 	"github.com/alcionai/corso/src/pkg/storage"
 )
@@ -28,18 +30,18 @@ var AWSStorageCredEnvs = []string{
 // test.  Suites that need to identify this value can retrieve it again from the common
 // configs.
 func NewPrefixedS3Storage(t *testing.T) storage.Storage {
-	now := LogTimeOfTest(t)
+	now := tester.LogTimeOfTest(t)
 
-	cfg, err := readTestConfig()
+	cfg, err := config.ReadTestConfig()
 	require.NoError(t, err, "configuring storage from test file", clues.ToCore(err))
 
 	prefix := testRepoRootPrefix + t.Name() + "-" + now
-	t.Logf("testing at s3 bucket [%s] prefix [%s]", cfg[TestCfgBucket], prefix)
+	t.Logf("testing at s3 bucket [%s] prefix [%s]", cfg[config.TestCfgBucket], prefix)
 
 	st, err := storage.NewStorage(
 		storage.ProviderS3,
 		storage.S3Config{
-			Bucket: cfg[TestCfgBucket],
+			Bucket: cfg[config.TestCfgBucket],
 			Prefix: prefix,
 		},
 		storage.CommonConfig{


### PR DESCRIPTION
This is primarily an exercise in reducing the number of circular imports we get from adding the tester package to other packages.

No logic changes.  Purely movement/renaming.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Supportability/Tests

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
