### PR TITLE
Remove event instance backup issue from known issues

### DIFF
--- a/website/docs/support/known-issues.md
+++ b/website/docs/support/known-issues.md
@@ -20,9 +20,6 @@ Below is a list of known Corso issues and limitations:
   while a backup is being created will be included in the running backup.
   Future backups run when the data isn't modified will include the data.
 
-* Exchange Calender Event instance exceptions (changes to a single event within a recurring series) aren't
-included in backup and restore.
-
 * SharePoint document library data can't be restored after the library has been deleted.
 
 * Sharing information of items in OneDrive/SharePoint using sharing links aren't backed up and restored.


### PR DESCRIPTION
Missed removing this from the known issues list when the issue was fixed.

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
