### PR TITLE
Add tests that boomerang items

### DIFF
--- a/src/internal/operations/test/exchange_test.go
+++ b/src/internal/operations/test/exchange_test.go
@@ -715,16 +715,16 @@ func testExchangeContinuousBackups(suite *ExchangeBackupIntgSuite, toggles contr
 					ctx,
 					uidn.ID(),
 					containerInfo.containerID,
-					oldID,
-					tempContainerID)
+					tempContainerID,
+					oldID)
 				require.NoError(t, err, "moving to temp folder: %s", clues.ToCore(err))
 
 				newID, err = ac.Mail().MoveItem(
 					ctx,
 					uidn.ID(),
 					tempContainerID,
-					newID,
-					containerInfo.containerID)
+					containerInfo.containerID,
+					newID)
 				require.NoError(t, err, "moving back to original folder: %s", clues.ToCore(err))
 
 				expectDeets.RemoveItem(

--- a/src/internal/operations/test/onedrive_test.go
+++ b/src/internal/operations/test/onedrive_test.go
@@ -518,6 +518,38 @@ func runDriveIncrementalTest(
 			nonMetaItemsWritten: 1, // .data file for new item
 		},
 		{
+			name: "boomerang a file",
+			updateFiles: func(t *testing.T, ctx context.Context) {
+				dest := containerInfos[container2]
+				temp := containerInfos[container1]
+
+				driveItem := models.NewDriveItem()
+				parentRef := models.NewItemReference()
+				parentRef.SetId(&temp.id)
+				driveItem.SetParentReference(parentRef)
+
+				err := ac.PatchItem(
+					ctx,
+					driveID,
+					ptr.Val(newFile.GetId()),
+					driveItem)
+				require.NoErrorf(t, err, "moving file to temporary folder %v", clues.ToCore(err))
+
+				parentRef.SetId(&dest.id)
+				driveItem.SetParentReference(parentRef)
+
+				err = ac.PatchItem(
+					ctx,
+					driveID,
+					ptr.Val(newFile.GetId()),
+					driveItem)
+				require.NoErrorf(t, err, "moving file back to folder %v", clues.ToCore(err))
+			},
+			itemsRead:           1, // .data file for newitem
+			itemsWritten:        3, // .data and .meta for newitem, .dirmeta for parent
+			nonMetaItemsWritten: 1, // .data file for new item
+		},
+		{
 			name: "delete file",
 			updateFiles: func(t *testing.T, ctx context.Context) {
 				err := ac.DeleteItem(

--- a/src/pkg/services/m365/api/mail.go
+++ b/src/pkg/services/m365/api/mail.go
@@ -446,7 +446,7 @@ func (c Mail) PostItem(
 
 func (c Mail) MoveItem(
 	ctx context.Context,
-	userID, oldContainerID, itemID, newContainerID string,
+	userID, oldContainerID, newContainerID, itemID string,
 ) (string, error) {
 	body := users.NewItemMailFoldersItemMessagesItemMovePostRequestBody()
 	body.SetDestinationId(ptr.To(newContainerID))

--- a/src/pkg/services/m365/api/mail.go
+++ b/src/pkg/services/m365/api/mail.go
@@ -444,6 +444,30 @@ func (c Mail) PostItem(
 	return itm, nil
 }
 
+func (c Mail) MoveItem(
+	ctx context.Context,
+	userID, oldContainerID, itemID, newContainerID string,
+) (string, error) {
+	body := users.NewItemMailFoldersItemMessagesItemMovePostRequestBody()
+	body.SetDestinationId(ptr.To(newContainerID))
+
+	resp, err := c.Stable.
+		Client().
+		Users().
+		ByUserId(userID).
+		MailFolders().
+		ByMailFolderId(oldContainerID).
+		Messages().
+		ByMessageId(itemID).
+		Move().
+		Post(ctx, body, nil)
+	if err != nil {
+		return "", graph.Wrap(ctx, err, "moving message")
+	}
+
+	return ptr.Val(resp.GetId()), nil
+}
+
 func (c Mail) DeleteItem(
 	ctx context.Context,
 	userID, itemID string,


### PR DESCRIPTION
Add a test that will fail if something is wrong with tracking items that are moved from a folder to a different folder and back to the original folder between incremental backups. This is important as it will help us ensure we don't accidentally turn on Exchange immutable IDs before they're fixed on the Graph side

Only tests Exchange mail and OneDrive/SharePoint as other Exchange data types don't support move operations via Graph API (it is possible to move events between calendars in the web UI though)

Manually tested to ensure it does actually fail if immutable IDs are enabled

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* closes #3755

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
