### PR TITLE
add counting for replace and new items

### DIFF
--- a/src/internal/m365/exchange/contacts_restore.go
+++ b/src/internal/m365/exchange/contacts_restore.go
@@ -146,17 +146,19 @@ func restoreContact(
 	// at least we'll have accidentally over-produced data instead of deleting
 	// the user's data.
 	if shouldDeleteOriginal {
-		ctr.Inc(count.CollisionReplace)
-
 		if err := cr.DeleteItem(ctx, userID, collisionID); err != nil && !graph.IsErrDeletedInFlight(err) {
 			return nil, graph.Wrap(ctx, err, "deleting colliding contact")
 		}
-	} else {
-		ctr.Inc(count.NewItemCreated)
 	}
 
 	info := api.ContactInfo(item)
 	info.Size = int64(len(body))
+
+	if shouldDeleteOriginal {
+		ctr.Inc(count.CollisionReplace)
+	} else {
+		ctr.Inc(count.NewItemCreated)
+	}
 
 	return info, nil
 }

--- a/src/internal/m365/exchange/contacts_restore.go
+++ b/src/internal/m365/exchange/contacts_restore.go
@@ -146,9 +146,13 @@ func restoreContact(
 	// at least we'll have accidentally over-produced data instead of deleting
 	// the user's data.
 	if shouldDeleteOriginal {
+		ctr.Inc(count.CollisionReplace)
+
 		if err := cr.DeleteItem(ctx, userID, collisionID); err != nil && !graph.IsErrDeletedInFlight(err) {
 			return nil, graph.Wrap(ctx, err, "deleting colliding contact")
 		}
+	} else {
+		ctr.Inc(count.NewItemCreated)
 	}
 
 	info := api.ContactInfo(item)

--- a/src/internal/m365/exchange/events_restore.go
+++ b/src/internal/m365/exchange/events_restore.go
@@ -155,9 +155,13 @@ func restoreEvent(
 	// at least we'll have accidentally over-produced data instead of deleting
 	// the user's data.
 	if shouldDeleteOriginal {
+		ctr.Inc(count.CollisionReplace)
+
 		if err := er.DeleteItem(ctx, userID, collisionID); err != nil && !graph.IsErrDeletedInFlight(err) {
 			return nil, graph.Wrap(ctx, err, "deleting colliding event")
 		}
+	} else {
+		ctr.Inc(count.NewItemCreated)
 	}
 
 	err = uploadAttachments(

--- a/src/internal/m365/exchange/events_restore.go
+++ b/src/internal/m365/exchange/events_restore.go
@@ -155,13 +155,9 @@ func restoreEvent(
 	// at least we'll have accidentally over-produced data instead of deleting
 	// the user's data.
 	if shouldDeleteOriginal {
-		ctr.Inc(count.CollisionReplace)
-
 		if err := er.DeleteItem(ctx, userID, collisionID); err != nil && !graph.IsErrDeletedInFlight(err) {
 			return nil, graph.Wrap(ctx, err, "deleting colliding event")
 		}
-	} else {
-		ctr.Inc(count.NewItemCreated)
 	}
 
 	err = uploadAttachments(
@@ -199,6 +195,12 @@ func restoreEvent(
 
 	info := api.EventInfo(event)
 	info.Size = int64(len(body))
+
+	if shouldDeleteOriginal {
+		ctr.Inc(count.CollisionReplace)
+	} else {
+		ctr.Inc(count.NewItemCreated)
+	}
 
 	return info, nil
 }

--- a/src/internal/m365/exchange/mail_restore.go
+++ b/src/internal/m365/exchange/mail_restore.go
@@ -150,9 +150,13 @@ func restoreMail(
 	// at least we'll have accidentally over-produced data instead of deleting
 	// the user's data.
 	if shouldDeleteOriginal {
+		ctr.Inc(count.CollisionReplace)
+
 		if err := mr.DeleteItem(ctx, userID, collisionID); err != nil && !graph.IsErrDeletedInFlight(err) {
 			return nil, graph.Wrap(ctx, err, "deleting colliding mail message")
 		}
+	} else {
+		ctr.Inc(count.NewItemCreated)
 	}
 
 	err = uploadAttachments(

--- a/src/internal/m365/exchange/mail_restore.go
+++ b/src/internal/m365/exchange/mail_restore.go
@@ -150,13 +150,9 @@ func restoreMail(
 	// at least we'll have accidentally over-produced data instead of deleting
 	// the user's data.
 	if shouldDeleteOriginal {
-		ctr.Inc(count.CollisionReplace)
-
 		if err := mr.DeleteItem(ctx, userID, collisionID); err != nil && !graph.IsErrDeletedInFlight(err) {
 			return nil, graph.Wrap(ctx, err, "deleting colliding mail message")
 		}
-	} else {
-		ctr.Inc(count.NewItemCreated)
 	}
 
 	err = uploadAttachments(
@@ -176,6 +172,12 @@ func restoreMail(
 	if msg.GetBody() != nil {
 		bc := ptr.Val(msg.GetBody().GetContent())
 		size = int64(len(bc))
+	}
+
+	if shouldDeleteOriginal {
+		ctr.Inc(count.CollisionReplace)
+	} else {
+		ctr.Inc(count.NewItemCreated)
 	}
 
 	return api.MailInfo(msg, size), nil

--- a/src/internal/m365/exchange/restore.go
+++ b/src/internal/m365/exchange/restore.go
@@ -108,7 +108,7 @@ func ConsumeRestoreCollections(
 			restoreCfg.OnCollision,
 			deets,
 			errs,
-			ctr.Local())
+			ctr)
 
 		metrics = support.CombineMetrics(metrics, temp)
 

--- a/src/internal/m365/onedrive/restore.go
+++ b/src/internal/m365/onedrive/restore.go
@@ -853,13 +853,9 @@ func restoreFile(
 	// risk failures in the middle, or we post w/ copy, then delete, then patch
 	// the name, which could triple our graph calls in the worst case.
 	if shouldDeleteOriginal {
-		ctr.Inc(count.CollisionReplace)
-
 		if err := ir.DeleteItem(ctx, driveID, collision.ItemID); err != nil && !graph.IsErrDeletedInFlight(err) {
 			return "", details.ItemInfo{}, clues.New("deleting colliding item")
 		}
-	} else {
-		ctr.Inc(count.NewItemCreated)
 	}
 
 	// Create Item
@@ -940,6 +936,12 @@ func restoreFile(
 	}
 
 	dii := ir.AugmentItemInfo(details.ItemInfo{}, newItem, written, nil)
+
+	if shouldDeleteOriginal {
+		ctr.Inc(count.CollisionReplace)
+	} else {
+		ctr.Inc(count.NewItemCreated)
+	}
 
 	return ptr.Val(newItem.GetId()), dii, nil
 }

--- a/src/internal/m365/onedrive/restore.go
+++ b/src/internal/m365/onedrive/restore.go
@@ -853,9 +853,13 @@ func restoreFile(
 	// risk failures in the middle, or we post w/ copy, then delete, then patch
 	// the name, which could triple our graph calls in the worst case.
 	if shouldDeleteOriginal {
+		ctr.Inc(count.CollisionReplace)
+
 		if err := ir.DeleteItem(ctx, driveID, collision.ItemID); err != nil && !graph.IsErrDeletedInFlight(err) {
 			return "", details.ItemInfo{}, clues.New("deleting colliding item")
 		}
+	} else {
+		ctr.Inc(count.NewItemCreated)
 	}
 
 	// Create Item

--- a/src/internal/operations/test/exchange_test.go
+++ b/src/internal/operations/test/exchange_test.go
@@ -996,7 +996,7 @@ func (suite *ExchangeRestoreIntgSuite) TestRestore_Run_exchangeWithAdvancedOptio
 		defer flush()
 
 		mb := evmock.NewBus()
-		ctr := count.New()
+		ctr2 := count.New()
 
 		restoreCfg.OnCollision = control.Skip
 
@@ -1006,7 +1006,7 @@ func (suite *ExchangeRestoreIntgSuite) TestRestore_Run_exchangeWithAdvancedOptio
 			bod.st,
 			bo.Results.BackupID,
 			mb,
-			ctr,
+			ctr2,
 			sel,
 			opts,
 			restoreCfg)
@@ -1018,7 +1018,7 @@ func (suite *ExchangeRestoreIntgSuite) TestRestore_Run_exchangeWithAdvancedOptio
 			len(deets.Entries),
 			"no items should have been restored")
 
-		checkRestoreCounts(t, ctr, countItemsInRestore, 0, 0)
+		checkRestoreCounts(t, ctr2, countItemsInRestore, 0, 0)
 
 		// get all files in folder, use these as the base
 		// set of files to compare against.
@@ -1117,7 +1117,7 @@ func (suite *ExchangeRestoreIntgSuite) TestRestore_Run_exchangeWithAdvancedOptio
 		defer flush()
 
 		mb := evmock.NewBus()
-		ctr := count.New()
+		ctr4 := count.New()
 
 		restoreCfg.OnCollision = control.Copy
 
@@ -1127,7 +1127,7 @@ func (suite *ExchangeRestoreIntgSuite) TestRestore_Run_exchangeWithAdvancedOptio
 			bod.st,
 			bo.Results.BackupID,
 			mb,
-			ctr,
+			ctr4,
 			sel,
 			opts,
 			restoreCfg)
@@ -1147,7 +1147,7 @@ func (suite *ExchangeRestoreIntgSuite) TestRestore_Run_exchangeWithAdvancedOptio
 			countItemsInRestore,
 			"every item should have been copied")
 
-		checkRestoreCounts(t, ctr, 0, 0, countItemsInRestore)
+		checkRestoreCounts(t, ctr4, 0, 0, countItemsInRestore)
 
 		result := filterCollisionKeyResults(
 			t,

--- a/src/internal/operations/test/onedrive_test.go
+++ b/src/internal/operations/test/onedrive_test.go
@@ -960,7 +960,7 @@ func (suite *OneDriveRestoreIntgSuite) TestRestore_Run_onedriveWithAdvancedOptio
 			opts,
 			restoreCfg)
 
-		runAndCheckRestore(t, ctx, &ro, mb, -1, false)
+		runAndCheckRestore(t, ctx, &ro, mb, false)
 
 		// get all files in folder, use these as the base
 		// set of files to compare against.
@@ -1008,7 +1008,7 @@ func (suite *OneDriveRestoreIntgSuite) TestRestore_Run_onedriveWithAdvancedOptio
 			opts,
 			restoreCfg)
 
-		deets := runAndCheckRestore(t, ctx, &ro, mb, 0, false)
+		deets := runAndCheckRestore(t, ctx, &ro, mb, false)
 
 		checkRestoreCounts(t, ctr, countItemsInRestore, 0, 0)
 		assert.Zero(
@@ -1054,7 +1054,7 @@ func (suite *OneDriveRestoreIntgSuite) TestRestore_Run_onedriveWithAdvancedOptio
 			opts,
 			restoreCfg)
 
-		deets := runAndCheckRestore(t, ctx, &ro, mb, len(collKeys), false)
+		deets := runAndCheckRestore(t, ctx, &ro, mb, false)
 		filtEnts := []details.Entry{}
 
 		for _, e := range deets.Entries {
@@ -1064,11 +1064,11 @@ func (suite *OneDriveRestoreIntgSuite) TestRestore_Run_onedriveWithAdvancedOptio
 		}
 
 		checkRestoreCounts(t, ctr, 0, countItemsInRestore, 0)
-		assert.Equal(
+		assert.Len(
 			t,
-			len(filtEnts),
+			filtEnts,
 			countItemsInRestore,
-			"every item should have been replaced: %+v", filtEnts)
+			"every item should have been replaced")
 
 		result := filterCollisionKeyResults(
 			t,
@@ -1109,7 +1109,7 @@ func (suite *OneDriveRestoreIntgSuite) TestRestore_Run_onedriveWithAdvancedOptio
 			opts,
 			restoreCfg)
 
-		deets := runAndCheckRestore(t, ctx, &ro, mb, len(collKeys), false)
+		deets := runAndCheckRestore(t, ctx, &ro, mb, false)
 		filtEnts := []details.Entry{}
 
 		for _, e := range deets.Entries {
@@ -1119,11 +1119,11 @@ func (suite *OneDriveRestoreIntgSuite) TestRestore_Run_onedriveWithAdvancedOptio
 		}
 
 		checkRestoreCounts(t, ctr, 0, 0, countItemsInRestore)
-		assert.Equal(
+		assert.Len(
 			t,
-			len(filtEnts),
-			len(collKeys),
-			"every item should have been copied: %+v", filtEnts)
+			filtEnts,
+			countItemsInRestore,
+			"every item should have been copied")
 
 		result := filterCollisionKeyResults(
 			t,

--- a/src/internal/operations/test/onedrive_test.go
+++ b/src/internal/operations/test/onedrive_test.go
@@ -955,7 +955,7 @@ func (suite *OneDriveRestoreIntgSuite) TestRestore_Run_onedriveWithAdvancedOptio
 			bod.st,
 			bo.Results.BackupID,
 			mb,
-			count.New(),
+			ctr,
 			sel,
 			opts,
 			restoreCfg)

--- a/src/internal/operations/test/restore_helper_test.go
+++ b/src/internal/operations/test/restore_helper_test.go
@@ -242,3 +242,33 @@ func filterCollisionKeyResults[T any](
 
 	return m
 }
+
+func checkRestoreCounts(
+	t *testing.T,
+	ctr *count.Bus,
+	expectSkips, expectReplaces, expectNew int,
+) {
+	if expectSkips >= 0 {
+		assert.Equal(
+			t,
+			int64(expectSkips),
+			ctr.Total(count.CollisionSkip),
+			"count of collisions resolved by skip")
+	}
+
+	if expectReplaces >= 0 {
+		assert.Equal(
+			t,
+			int64(expectReplaces),
+			ctr.Total(count.CollisionReplace),
+			"count of collisions resolved by replace")
+	}
+
+	if expectNew >= 0 {
+		assert.Equal(
+			t,
+			int64(expectNew),
+			ctr.Total(count.NewItemCreated),
+			"count of new items or collisions resolved by copy")
+	}
+}

--- a/src/internal/operations/test/sharepoint_test.go
+++ b/src/internal/operations/test/sharepoint_test.go
@@ -260,7 +260,7 @@ func (suite *SharePointRestoreIntgSuite) TestRestore_Run_sharepointWithAdvancedO
 			opts,
 			restoreCfg)
 
-		runAndCheckRestore(t, ctx, &ro, mb, -1, false)
+		runAndCheckRestore(t, ctx, &ro, mb, false)
 
 		// get all files in folder, use these as the base
 		// set of files to compare against.
@@ -308,7 +308,7 @@ func (suite *SharePointRestoreIntgSuite) TestRestore_Run_sharepointWithAdvancedO
 			opts,
 			restoreCfg)
 
-		deets := runAndCheckRestore(t, ctx, &ro, mb, 0, false)
+		deets := runAndCheckRestore(t, ctx, &ro, mb, false)
 
 		assert.Zero(
 			t,
@@ -352,7 +352,7 @@ func (suite *SharePointRestoreIntgSuite) TestRestore_Run_sharepointWithAdvancedO
 			opts,
 			restoreCfg)
 
-		deets := runAndCheckRestore(t, ctx, &ro, mb, len(collKeys), false)
+		deets := runAndCheckRestore(t, ctx, &ro, mb, false)
 		filtEnts := []details.Entry{}
 
 		for _, e := range deets.Entries {
@@ -361,11 +361,11 @@ func (suite *SharePointRestoreIntgSuite) TestRestore_Run_sharepointWithAdvancedO
 			}
 		}
 
-		assert.Equal(
+		assert.Len(
 			t,
-			len(filtEnts),
-			len(collKeys),
-			"every item should have been replaced: %+v", filtEnts)
+			filtEnts,
+			countItemsInRestore,
+			"every item should have been replaced")
 		checkRestoreCounts(t, ctr, 0, countItemsInRestore, 0)
 
 		result := filterCollisionKeyResults(
@@ -407,7 +407,7 @@ func (suite *SharePointRestoreIntgSuite) TestRestore_Run_sharepointWithAdvancedO
 			opts,
 			restoreCfg)
 
-		deets := runAndCheckRestore(t, ctx, &ro, mb, len(collKeys), false)
+		deets := runAndCheckRestore(t, ctx, &ro, mb, false)
 		filtEnts := []details.Entry{}
 
 		for _, e := range deets.Entries {
@@ -416,11 +416,11 @@ func (suite *SharePointRestoreIntgSuite) TestRestore_Run_sharepointWithAdvancedO
 			}
 		}
 
-		assert.Equal(
+		assert.Len(
 			t,
-			len(filtEnts),
-			len(collKeys),
-			"every item should have been copied: %+v", filtEnts)
+			filtEnts,
+			countItemsInRestore,
+			"every item should have been copied")
 		checkRestoreCounts(t, ctr, 0, 0, countItemsInRestore)
 
 		result := filterCollisionKeyResults(

--- a/src/internal/operations/test/sharepoint_test.go
+++ b/src/internal/operations/test/sharepoint_test.go
@@ -227,12 +227,13 @@ func (suite *SharePointRestoreIntgSuite) TestRestore_Run_sharepointWithAdvancedO
 	require.NoError(t, err, clues.ToCore(err))
 
 	var (
-		restoreCfg  = ctrlTD.DefaultRestoreConfig("sharepoint_adv_restore")
-		sel         = rsel.Selector
-		siteDriveID = suite.its.siteDriveID
-		containerID string
-		collKeys    = map[string]api.DriveCollisionItem{}
-		acd         = suite.its.ac.Drives()
+		restoreCfg          = ctrlTD.DefaultRestoreConfig("sharepoint_adv_restore")
+		sel                 = rsel.Selector
+		siteDriveID         = suite.its.siteDriveID
+		containerID         string
+		countItemsInRestore int
+		collKeys            = map[string]api.DriveCollisionItem{}
+		acd                 = suite.its.ac.Drives()
 	)
 
 	// initial restore
@@ -244,6 +245,7 @@ func (suite *SharePointRestoreIntgSuite) TestRestore_Run_sharepointWithAdvancedO
 		defer flush()
 
 		mb := evmock.NewBus()
+		ctr := count.New()
 
 		restoreCfg.OnCollision = control.Copy
 
@@ -253,7 +255,7 @@ func (suite *SharePointRestoreIntgSuite) TestRestore_Run_sharepointWithAdvancedO
 			bod.st,
 			bo.Results.BackupID,
 			mb,
-			count.New(),
+			ctr,
 			sel,
 			opts,
 			restoreCfg)
@@ -276,6 +278,10 @@ func (suite *SharePointRestoreIntgSuite) TestRestore_Run_sharepointWithAdvancedO
 			siteDriveID,
 			containerID)
 		require.NoError(t, err, clues.ToCore(err))
+
+		countItemsInRestore = len(collKeys)
+
+		checkRestoreCounts(t, ctr, 0, 0, countItemsInRestore)
 	})
 
 	// skip restore
@@ -304,15 +310,11 @@ func (suite *SharePointRestoreIntgSuite) TestRestore_Run_sharepointWithAdvancedO
 
 		deets := runAndCheckRestore(t, ctx, &ro, mb, 0, false)
 
-		assert.Equal(
-			t,
-			int64(len(collKeys)),
-			ctr.Total(count.CollisionSkip),
-			"all attempted item restores should have been skipped")
 		assert.Zero(
 			t,
 			len(deets.Entries),
 			"no items should have been restored")
+		checkRestoreCounts(t, ctr, countItemsInRestore, 0, 0)
 
 		// get all files in folder, use these as the base
 		// set of files to compare against.
@@ -359,15 +361,12 @@ func (suite *SharePointRestoreIntgSuite) TestRestore_Run_sharepointWithAdvancedO
 			}
 		}
 
-		assert.Zero(
-			t,
-			ctr.Total(count.CollisionSkip),
-			"no attempted item restores should have been skipped")
 		assert.Equal(
 			t,
 			len(filtEnts),
 			len(collKeys),
 			"every item should have been replaced: %+v", filtEnts)
+		checkRestoreCounts(t, ctr, 0, countItemsInRestore, 0)
 
 		result := filterCollisionKeyResults(
 			t,
@@ -417,15 +416,12 @@ func (suite *SharePointRestoreIntgSuite) TestRestore_Run_sharepointWithAdvancedO
 			}
 		}
 
-		assert.Zero(
-			t,
-			ctr.Total(count.CollisionSkip),
-			"no attempted item restores should have been skipped")
 		assert.Equal(
 			t,
 			len(filtEnts),
 			len(collKeys),
 			"every item should have been copied: %+v", filtEnts)
+		checkRestoreCounts(t, ctr, 0, 0, countItemsInRestore)
 
 		result := filterCollisionKeyResults(
 			t,

--- a/src/pkg/count/keys.go
+++ b/src/pkg/count/keys.go
@@ -3,5 +3,10 @@ package count
 type key string
 
 const (
-	CollisionSkip key = "collision-skip"
+	// NewItemCreated should be used for non-skip, non-replace,
+	// non-meta item creation counting.  IE: use it specifically
+	// for counting new items (no collision) or copied items.
+	NewItemCreated   key = "new-item-created"
+	CollisionReplace key = "collision-replace"
+	CollisionSkip    key = "collision-skip"
 )


### PR DESCRIPTION
adds counters during restoration for
replaced and newly created (copy and
non-colliding) items.  The initial value is
to facilitate test assurances.  But in this we
begin a slow movement towards using
a standardized bus for operations counts instead
of consumer/producer structs.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [x] :robot: Supportability/Tests

#### Issue(s)

* #3562

#### Test Plan

- [x] :muscle: Manual
- [x] :green_heart: E2E
