### PR TITLE
create missing drives on restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] (beta)
 
+### Fixed
+- SharePoint document libraries deleted after the last backup can now be restored.
+
 ## [v0.11.0] (beta) - 2023-07-18
 
 ### Added
@@ -17,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Return a ServiceNotEnabled error when a tenant has no active SharePoint license.
 - Added retries for http/2 stream connection failures when downloading large item content.
+- SharePoint document libraries that were deleted after the last backup can now be restored.
 
 ### Known issues
 - If a link share is created for an item with inheritance disabled

--- a/src/internal/m365/onedrive/item_collector_test.go
+++ b/src/internal/m365/onedrive/item_collector_test.go
@@ -362,7 +362,7 @@ func (suite *OneDriveIntgSuite) TestCreateGetDeleteFolder() {
 	}
 
 	caches := NewRestoreCaches()
-	caches.DriveIDToRootFolderID[driveID] = ptr.Val(rootFolder.GetId())
+	caches.DriveIDToDriveInfo[driveID] = driveInfo{rootFolderID: ptr.Val(rootFolder.GetId())}
 
 	rh := NewRestoreHandler(suite.ac)
 

--- a/src/internal/m365/onedrive/item_handler.go
+++ b/src/internal/m365/onedrive/item_handler.go
@@ -5,10 +5,10 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/drives"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
-	"github.com/alcionai/clues"
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	odConsts "github.com/alcionai/corso/src/internal/m365/onedrive/consts"
 	"github.com/alcionai/corso/src/pkg/backup/details"

--- a/src/internal/m365/onedrive/mock/handlers.go
+++ b/src/internal/m365/onedrive/mock/handlers.go
@@ -249,7 +249,23 @@ type RestoreHandler struct {
 	PostItemResp   models.DriveItemable
 	PostItemErr    error
 
+	DrivePagerV api.DrivePager
+
+	PostDriveResp models.Driveable
+	PostDriveErr  error
+
 	UploadSessionErr error
+}
+
+func (h RestoreHandler) PostDrive(
+	ctx context.Context,
+	protectedResourceID, driveName string,
+) (models.Driveable, error) {
+	return h.PostDriveResp, h.PostDriveErr
+}
+
+func (h RestoreHandler) NewDrivePager(string, []string) api.DrivePager {
+	return h.DrivePagerV
 }
 
 func (h *RestoreHandler) AugmentItemInfo(

--- a/src/internal/m365/onedrive/restore.go
+++ b/src/internal/m365/onedrive/restore.go
@@ -255,7 +255,7 @@ func RestoreCollection(
 		protectedResourceID,
 		fallbackDriveName)
 	if err != nil {
-		return metrics, clues.Wrap(err, "ensureing drive exists")
+		return metrics, clues.Wrap(err, "ensuring drive exists")
 	}
 
 	// Assemble folder hierarchy we're going to restore into (we recreate the folder hierarchy
@@ -1217,12 +1217,10 @@ func ensureDriveExists(
 		newDriveName = driveName
 		newDrive     models.Driveable
 		err          error
-		i            = 1
 	)
 
 	if _, ok := caches.DriveNameToDriveInfo[newDriveName]; ok {
 		newDriveName = fmt.Sprintf("%s %d", driveName, 1)
-		i++
 	}
 
 	// if not, double check that the name won't collide by looking
@@ -1235,7 +1233,7 @@ func ensureDriveExists(
 	// names with document libraries.  In those cases it's not enough
 	// to compare the names of drives; we also need to continue this
 	// loop until we can create a drive without error.
-	for {
+	for i := 2; ; i++ {
 		ictx := clues.Add(ctx, "new_drive_name", clues.Hide(newDriveName))
 
 		newDrive, err = pdagrf.PostDrive(ictx, protectedResourceID, newDriveName)
@@ -1248,7 +1246,6 @@ func ensureDriveExists(
 		}
 
 		newDriveName = fmt.Sprintf("%s %d", driveName, i)
-		i++
 	}
 
 	err = caches.AddDrive(ctx, newDrive, pdagrf)

--- a/src/internal/m365/onedrive/restore.go
+++ b/src/internal/m365/onedrive/restore.go
@@ -37,9 +37,16 @@ const (
 	maxUploadRetries = 3
 )
 
+type driveInfo struct {
+	id           string
+	name         string
+	rootFolderID string
+}
+
 type restoreCaches struct {
 	collisionKeyToItemID  map[string]api.DriveItemIDType
-	DriveIDToRootFolderID map[string]string
+	DriveIDToDriveInfo    map[string]driveInfo
+	DriveNameToDriveInfo  map[string]driveInfo
 	Folders               *folderCache
 	OldLinkShareIDToNewID map[string]string
 	OldPermIDToNewID      map[string]string
@@ -48,10 +55,66 @@ type restoreCaches struct {
 	pool sync.Pool
 }
 
+func (rc *restoreCaches) AddDrive(
+	ctx context.Context,
+	md models.Driveable,
+	grf GetRootFolderer,
+) error {
+	di := driveInfo{
+		id:   ptr.Val(md.GetId()),
+		name: ptr.Val(md.GetName()),
+	}
+
+	ctx = clues.Add(ctx, "drive_info", di)
+
+	root, err := grf.GetRootFolder(ctx, di.id)
+	if err != nil {
+		return clues.Wrap(err, "getting drive root id")
+	}
+
+	di.rootFolderID = ptr.Val(root.GetId())
+
+	rc.DriveIDToDriveInfo[di.id] = di
+	rc.DriveNameToDriveInfo[di.name] = di
+
+	return nil
+}
+
+// Populate looks up drive items available to the protectedResource
+// and adds their info to the caches.
+func (rc *restoreCaches) Populate(
+	ctx context.Context,
+	gdparf GetDrivePagerAndRootFolderer,
+	protectedResourceID string,
+) error {
+	drives, err := api.GetAllDrives(
+		ctx,
+		gdparf.NewDrivePager(protectedResourceID, nil),
+		true,
+		maxDrivesRetries)
+	if err != nil {
+		return clues.Wrap(err, "getting drives")
+	}
+
+	for _, md := range drives {
+		if err := rc.AddDrive(ctx, md, gdparf); err != nil {
+			return clues.Wrap(err, "caching drive")
+		}
+	}
+
+	return nil
+}
+
+type GetDrivePagerAndRootFolderer interface {
+	GetRootFolderer
+	NewDrivePagerer
+}
+
 func NewRestoreCaches() *restoreCaches {
 	return &restoreCaches{
 		collisionKeyToItemID:  map[string]api.DriveItemIDType{},
-		DriveIDToRootFolderID: map[string]string{},
+		DriveIDToDriveInfo:    map[string]driveInfo{},
+		DriveNameToDriveInfo:  map[string]driveInfo{},
 		Folders:               NewFolderCache(),
 		OldLinkShareIDToNewID: map[string]string{},
 		OldPermIDToNewID:      map[string]string{},
@@ -79,12 +142,19 @@ func ConsumeRestoreCollections(
 	ctr *count.Bus,
 ) (*support.ControllerOperationStatus, error) {
 	var (
-		restoreMetrics support.CollectionMetrics
-		caches         = NewRestoreCaches()
-		el             = errs.Local()
+		restoreMetrics      support.CollectionMetrics
+		el                  = errs.Local()
+		caches              = NewRestoreCaches()
+		protectedResourceID = dcs[0].FullPath().ResourceOwner()
+		fallbackDriveName   = "" // onedrive cannot create drives
 	)
 
 	ctx = clues.Add(ctx, "backup_version", backupVersion)
+
+	err := caches.Populate(ctx, rh, protectedResourceID)
+	if err != nil {
+		return nil, clues.Wrap(err, "initializing restore caches")
+	}
 
 	// Reorder collections so that the parents directories are created
 	// before the child directories; a requirement for permissions.
@@ -102,7 +172,7 @@ func ConsumeRestoreCollections(
 			ictx    = clues.Add(
 				ctx,
 				"category", dc.FullPath().Category(),
-				"resource_owner", clues.Hide(dc.FullPath().ResourceOwner()),
+				"resource_owner", clues.Hide(protectedResourceID),
 				"full_path", dc.FullPath())
 		)
 
@@ -115,6 +185,7 @@ func ConsumeRestoreCollections(
 			caches,
 			deets,
 			opts.RestorePermissions,
+			fallbackDriveName,
 			errs,
 			ctr.Local())
 		if err != nil {
@@ -152,18 +223,20 @@ func RestoreCollection(
 	caches *restoreCaches,
 	deets *details.Builder,
 	restorePerms bool, // TODD: move into restoreConfig
+	fallbackDriveName string,
 	errs *fault.Bus,
 	ctr *count.Bus,
 ) (support.CollectionMetrics, error) {
 	var (
-		metrics        = support.CollectionMetrics{}
-		directory      = dc.FullPath()
-		el             = errs.Local()
-		metricsObjects int64
-		metricsBytes   int64
-		metricsSuccess int64
-		wg             sync.WaitGroup
-		complete       bool
+		metrics             = support.CollectionMetrics{}
+		directory           = dc.FullPath()
+		protectedResourceID = directory.ResourceOwner()
+		el                  = errs.Local()
+		metricsObjects      int64
+		metricsBytes        int64
+		metricsSuccess      int64
+		wg                  sync.WaitGroup
+		complete            bool
 	)
 
 	ctx, end := diagnostics.Span(ctx, "gc:drive:restoreCollection", diagnostics.Label("path", directory))
@@ -174,13 +247,15 @@ func RestoreCollection(
 		return metrics, clues.Wrap(err, "creating drive path").WithClues(ctx)
 	}
 
-	if _, ok := caches.DriveIDToRootFolderID[drivePath.DriveID]; !ok {
-		root, err := rh.GetRootFolder(ctx, drivePath.DriveID)
-		if err != nil {
-			return metrics, clues.Wrap(err, "getting drive root id")
-		}
-
-		caches.DriveIDToRootFolderID[drivePath.DriveID] = ptr.Val(root.GetId())
+	err = ensureDriveExists(
+		ctx,
+		rh,
+		caches,
+		drivePath,
+		protectedResourceID,
+		fallbackDriveName)
+	if err != nil {
+		return metrics, clues.Wrap(err, "ensureing drive exists")
 	}
 
 	// Assemble folder hierarchy we're going to restore into (we recreate the folder hierarchy
@@ -704,7 +779,7 @@ func createRestoreFolders(
 		driveID        = drivePath.DriveID
 		folders        = restoreDir.Elements()
 		location       = path.Builder{}.Append(driveID)
-		parentFolderID = caches.DriveIDToRootFolderID[drivePath.DriveID]
+		parentFolderID = caches.DriveIDToDriveInfo[drivePath.DriveID].id
 	)
 
 	ctx = clues.Add(
@@ -1112,4 +1187,71 @@ func AugmentRestorePaths(
 	})
 
 	return paths, nil
+}
+
+type PostDriveAndGetRootFolderer interface {
+	PostDriver
+	GetRootFolderer
+}
+
+// ensureDriveExists looks up the drive by its id.  If no drive is found with
+// that ID, a new drive is generated with the same name.  If the name collides
+// with an existing drive, a number is appended to the drive name.  Eg: foo ->
+// foo 1.  This will repeat as many times as is needed.
+// Returns the root folder of the drive
+func ensureDriveExists(
+	ctx context.Context,
+	pdagrf PostDriveAndGetRootFolderer,
+	caches *restoreCaches,
+	drivePath *path.DrivePath,
+	protectedResourceID, driveName string,
+) error {
+	driveID := drivePath.DriveID
+
+	// the drive might already be cached
+	if _, ok := caches.DriveIDToDriveInfo[driveID]; ok {
+		return nil
+	}
+
+	var (
+		newDriveName = driveName
+		newDrive     models.Driveable
+		err          error
+		i            = 1
+	)
+
+	if _, ok := caches.DriveNameToDriveInfo[newDriveName]; ok {
+		newDriveName = fmt.Sprintf("%s %d", driveName, 1)
+		i++
+	}
+
+	// if not, double check that the name won't collide by looking
+	// up drives by name until we can make some name like `foo N` that
+	// doesn't collide with `foo` or other values of N in `foo N`.
+	// Ex: foo -> foo 1 -> foo 2 -> ... -> foo N
+	//
+	// For sharepoint, document libraries can collide by name with
+	// item types beyond just drive.  Lists, for example, cannot share
+	// names with document libraries.  In those cases it's not enough
+	// to compare the names of drives; we also need to continue this
+	// loop until we can create a drive without error.
+	for {
+		ictx := clues.Add(ctx, "new_drive_name", clues.Hide(newDriveName))
+
+		newDrive, err = pdagrf.PostDrive(ictx, protectedResourceID, newDriveName)
+		if err != nil && !errors.Is(err, graph.ErrItemAlreadyExistsConflict) {
+			return clues.Wrap(err, "creating new drive")
+		}
+
+		if err == nil {
+			break
+		}
+
+		newDriveName = fmt.Sprintf("%s %d", driveName, i)
+		i++
+	}
+
+	err = caches.AddDrive(ctx, newDrive, pdagrf)
+
+	return clues.Wrap(err, "adding drive to cache").OrNil()
 }

--- a/src/internal/m365/onedrive/restore_test.go
+++ b/src/internal/m365/onedrive/restore_test.go
@@ -736,9 +736,8 @@ func (suite *RestoreUnitSuite) TestRestoreCaches_Populate() {
 					{Drives: []models.Driveable{}},
 				},
 			},
-			expectErr:   require.NoError,
-			expectLen:   0,
-			checkValues: true,
+			expectErr: require.NoError,
+			expectLen: 0,
 		},
 		{
 			name: "one result",

--- a/src/pkg/control/restore.go
+++ b/src/pkg/control/restore.go
@@ -52,8 +52,9 @@ type RestoreConfig struct {
 	// Defaults to "Corso_Restore_<current_dttm>"
 	Location string
 
-	// Drive specifies the drive into which the data will be restored.
-	// If empty, data is restored to the same drive that was backed up.
+	// Drive specifies the name of the drive into which the data will be
+	// restored. If empty, data is restored to the same drive that was backed
+	// up.
 	// Defaults to empty.
 	Drive string
 }
@@ -63,6 +64,10 @@ func DefaultRestoreConfig(timeFormat dttm.TimeFormat) RestoreConfig {
 		OnCollision: Skip,
 		Location:    defaultRestoreLocation + dttm.FormatNow(timeFormat),
 	}
+}
+
+func DefaultRestoreContainerName(timeFormat dttm.TimeFormat) string {
+	return defaultRestoreLocation + dttm.FormatNow(timeFormat)
 }
 
 // EnsureRestoreConfigDefaults sets all non-supported values in the config

--- a/src/pkg/services/m365/api/lists_test.go
+++ b/src/pkg/services/m365/api/lists_test.go
@@ -52,6 +52,6 @@ func (suite *ListsAPIIntgSuite) TestLists_PostDrive() {
 	assert.Equal(t, driveName, ptr.Val(list.GetName()))
 
 	// second post, same name, should error on name conflict]
-	list, err = acl.PostDrive(ctx, siteID, driveName)
+	_, err = acl.PostDrive(ctx, siteID, driveName)
 	require.ErrorIs(t, err, graph.ErrItemAlreadyExistsConflict, clues.ToCore(err))
 }

--- a/website/docs/support/known-issues.md
+++ b/website/docs/support/known-issues.md
@@ -16,8 +16,6 @@ Below is a list of known Corso issues and limitations:
   from M365 while a backup creation is running.
   The next backup creation will correct any missing data.
 
-* SharePoint document library data can't be restored after the library has been deleted.
-
 * Sharing information of items in OneDrive/SharePoint using sharing links aren't backed up and restored.
 
 * Permissions/Access given to a site group can't be restored.


### PR DESCRIPTION
when restoring sharepoint, if a document library
was deleted between the time of backup and restore, create a new drive to hold the restored data.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

#### Type of change

- [x] :bug: Bugfix

#### Issue(s)

* #3562

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
