### PR TITLE
Add option to export data for OneDrive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ testlog/
 
 # Export dirs
 Corso_Restore_*
+*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ testlog/
 /bin
 /docker/bin
 /website/dist
+
+# Export dirs
+Corso_Restore_*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Drive items backup and restore link shares
 - Restore commands now accept an optional top-level restore destination with the `--destination` flag.  Setting the destination to '/' will restore items back into their original location.  
 - Restore commands can specify item collision behavior.  Options are Skip (default), Replace, and Copy.
+- Added option to export data from OneDrive backups
 
 ### Fixed
 - Return a ServiceNotEnabled error when a tenant has no active SharePoint license.

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/alcionai/corso/src/cli/backup"
 	"github.com/alcionai/corso/src/cli/config"
+	"github.com/alcionai/corso/src/cli/export"
 	"github.com/alcionai/corso/src/cli/flags"
 	"github.com/alcionai/corso/src/cli/help"
 	"github.com/alcionai/corso/src/cli/print"
@@ -53,7 +54,7 @@ func preRun(cc *cobra.Command, args []string) error {
 	}
 
 	avoidTheseCommands := []string{
-		"corso", "env", "help", "backup", "details", "list", "restore", "delete", "repo", "init", "connect",
+		"corso", "env", "help", "backup", "details", "list", "restore", "export", "delete", "repo", "init", "connect",
 	}
 
 	if len(logger.ResolvedLogFile) > 0 && !slices.Contains(avoidTheseCommands, cc.Use) {
@@ -150,6 +151,7 @@ func BuildCommandTree(cmd *cobra.Command) {
 	repo.AddCommands(cmd)
 	backup.AddCommands(cmd)
 	restore.AddCommands(cmd)
+	export.AddCommands(cmd)
 	help.AddCommands(cmd)
 }
 

--- a/src/cli/export/export.go
+++ b/src/cli/export/export.go
@@ -1,0 +1,41 @@
+package export
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var exportCommands = []func(cmd *cobra.Command) *cobra.Command{
+	addOneDriveCommands,
+	// addExchangeCommands,
+	// addSharePointCommands,
+}
+
+// AddCommands attaches all `corso export * *` commands to the parent.
+func AddCommands(cmd *cobra.Command) {
+	exportC := exportCmd()
+	cmd.AddCommand(exportC)
+
+	for _, addExportTo := range exportCommands {
+		addExportTo(exportC)
+	}
+}
+
+const exportCommand = "export"
+
+// The export category of commands.
+// `corso export [<subcommand>] [<flag>...]`
+func exportCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   exportCommand,
+		Short: "Export your service data",
+		Long:  `Export the data stored in one of your M365 services.`,
+		RunE:  handleExportCmd,
+		Args:  cobra.NoArgs,
+	}
+}
+
+// Handler for flat calls to `corso export`.
+// Produces the same output as `corso export --help`.
+func handleExportCmd(cmd *cobra.Command, args []string) error {
+	return cmd.Help()
+}

--- a/src/cli/export/onedrive.go
+++ b/src/cli/export/onedrive.go
@@ -114,13 +114,13 @@ func exportOneDriveCmd(cmd *cobra.Command, args []string) error {
 		exportCfg.Archive = true
 	}
 
-	restoreLocation := args[0]
-	if restoreLocation == "" {
+	exportLocation := args[0]
+	if exportLocation == "" {
 		// This is unlikely, but adding it just in case.
-		restoreLocation = control.DefaultRestoreLocation + dttm.FormatNow(dttm.HumanReadableDriveItem)
+		exportLocation = control.DefaultRestoreLocation + dttm.FormatNow(dttm.HumanReadableDriveItem)
 	}
 
-	Infof(ctx, "Restoring to folder %s", restoreLocation)
+	Infof(ctx, "Exporting to folder %s", exportLocation)
 
 	sel := utils.IncludeOneDriveRestoreDataSelectors(opts)
 	utils.FilterOneDriveRestoreInfoSelectors(sel, opts)
@@ -145,7 +145,7 @@ func exportOneDriveCmd(cmd *cobra.Command, args []string) error {
 	defer close(diskWriteComplete)
 
 	for _, col := range expColl {
-		folder := ospath.Join(restoreLocation, col.GetBasePath())
+		folder := ospath.Join(exportLocation, col.GetBasePath())
 
 		for item := range col.GetItems(ctx) {
 			err := item.Error

--- a/src/cli/export/onedrive.go
+++ b/src/cli/export/onedrive.go
@@ -167,6 +167,7 @@ func exportOneDriveCmd(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// writeFile writes an ExportItem to disk in the specified folder.
 func writeFile(ctx context.Context, item data.ExportItem, folder string) error {
 	name := item.Data.Name
 	fpath := ospath.Join(folder, name)

--- a/src/cli/export/onedrive.go
+++ b/src/cli/export/onedrive.go
@@ -1,0 +1,172 @@
+package export
+
+import (
+	"io"
+	"os"
+	ospath "path"
+
+	"github.com/alcionai/clues"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/alcionai/corso/src/cli/flags"
+	. "github.com/alcionai/corso/src/cli/print"
+	"github.com/alcionai/corso/src/cli/repo"
+	"github.com/alcionai/corso/src/cli/utils"
+	"github.com/alcionai/corso/src/internal/common/dttm"
+	"github.com/alcionai/corso/src/internal/data"
+	"github.com/alcionai/corso/src/internal/observe"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/path"
+)
+
+// called by export.go to map subcommands to provider-specific handling.
+func addOneDriveCommands(cmd *cobra.Command) *cobra.Command {
+	var (
+		c  *cobra.Command
+		fs *pflag.FlagSet
+	)
+
+	switch cmd.Use {
+	case exportCommand:
+		c, fs = utils.AddCommand(cmd, oneDriveExportCmd())
+
+		c.Use = c.Use + " " + oneDriveServiceCommandUseSuffix
+
+		// Flags addition ordering should follow the order we want them to appear in help and docs:
+		// More generic (ex: --user) and more frequently used flags take precedence.
+		fs.SortFlags = false
+
+		flags.AddBackupIDFlag(c, true)
+		flags.AddOneDriveDetailsAndRestoreFlags(c)
+		flags.AddExportConfigFlags(c)
+		flags.AddFailFastFlag(c)
+		flags.AddCorsoPassphaseFlags(c)
+		flags.AddAWSCredsFlags(c)
+	}
+
+	return c
+}
+
+const (
+	oneDriveServiceCommand          = "onedrive"
+	oneDriveServiceCommandUseSuffix = "--backup <backupId>"
+
+	oneDriveServiceCommandExportExamples = `# Export file with ID 98765abcdef in Bob's last backup (1234abcd...)
+corso export onedrive --backup 1234abcd-12ab-cd34-56de-1234abcd --file 98765abcdef
+
+# Export files named "FY2021 Planning.xlsx" in "Documents/Finance Reports"
+corso export onedrive --backup 1234abcd-12ab-cd34-56de-1234abcd \
+    --file "FY2021 Planning.xlsx" --folder "Documents/Finance Reports"
+
+# Export all files and folders in folder "Documents/Finance Reports" that were created before 2020
+corso export onedrive --backup 1234abcd-12ab-cd34-56de-1234abcd 
+    --folder "Documents/Finance Reports" --file-created-before 2020-01-01T00:00:00`
+)
+
+// `corso export onedrive [<flag>...]`
+func oneDriveExportCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     oneDriveServiceCommand,
+		Short:   "Export M365 OneDrive service data",
+		RunE:    exportOneDriveCmd,
+		Args:    cobra.NoArgs,
+		Example: oneDriveServiceCommandExportExamples,
+	}
+}
+
+// processes an onedrive service export.
+func exportOneDriveCmd(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	if utils.HasNoFlagsAndShownHelp(cmd) {
+		return nil
+	}
+
+	opts := utils.MakeOneDriveOpts(cmd)
+
+	if flags.RunModeFV == flags.RunModeFlagTest {
+		return nil
+	}
+
+	if err := utils.ValidateOneDriveRestoreFlags(flags.BackupIDFV, opts); err != nil {
+		return err
+	}
+
+	r, _, _, err := utils.GetAccountAndConnect(ctx, path.OneDriveService, repo.S3Overrides(cmd))
+	if err != nil {
+		return Only(ctx, err)
+	}
+
+	defer utils.CloseRepo(ctx, r)
+
+	exportCfg := control.DefaultExportConfig()
+	if flags.ArchiveFV {
+		exportCfg.Archive = true
+	}
+
+	restoreLocation := flags.ExportDestFV
+	if restoreLocation == "" {
+		restoreLocation = control.DefaultRestoreLocation + dttm.FormatNow(dttm.HumanReadableDriveItem)
+	}
+
+	Infof(ctx, "Restoring to folder %s", restoreLocation)
+
+	sel := utils.IncludeOneDriveRestoreDataSelectors(opts)
+	utils.FilterOneDriveRestoreInfoSelectors(sel, opts)
+
+	eo, err := r.NewExport(ctx, flags.BackupIDFV, sel.Selector, exportCfg)
+	if err != nil {
+		return Only(ctx, clues.Wrap(err, "Failed to initialize OneDrive export"))
+	}
+
+	expColl, err := eo.Run(ctx)
+	if err != nil {
+		if errors.Is(err, data.ErrNotFound) {
+			return Only(ctx, clues.New("Backup or backup details missing for id "+flags.BackupIDFV))
+		}
+
+		return Only(ctx, clues.Wrap(err, "Failed to run OneDrive export"))
+	}
+
+	// It would be better to give a progressbar than a spinner, but we
+	// have know way of knowing how many files are available as of now.
+	diskWriteComplete := observe.MessageWithCompletion(ctx, "Writing data to disk")
+	defer close(diskWriteComplete)
+
+	for _, col := range expColl {
+		folder := ospath.Join(restoreLocation, col.GetBasePath())
+
+		for item := range col.GetItems(ctx) {
+			err := item.Error
+			if err != nil {
+				return Only(ctx, clues.Wrap(err, "getting item").With("dir_name", folder))
+			}
+
+			name := item.Data.Name
+			fpath := ospath.Join(folder, name)
+
+			err = os.MkdirAll(folder, os.ModePerm)
+			if err != nil {
+				return Only(ctx, clues.Wrap(err, "creating directory").With("dir_name", folder))
+			}
+
+			// In case the user tries to restore to a non-clean
+			// directory, we might run into collisions an fail.
+			f, err := os.Create(fpath)
+			if err != nil {
+				return Only(ctx, clues.Wrap(err, "creating file").With("file_name", name, "file_dir", folder))
+			}
+
+			_, err = io.Copy(f, item.Data.Body)
+			if err != nil {
+				return Only(ctx, clues.Wrap(err, "writing file").With("file_name", name, "file_dir", folder))
+			}
+		}
+	}
+
+	diskWriteComplete <- struct{}{}
+
+	return nil
+}

--- a/src/cli/export/onedrive_test.go
+++ b/src/cli/export/onedrive_test.go
@@ -1,0 +1,175 @@
+package export
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/data"
+	"github.com/alcionai/corso/src/internal/tester"
+)
+
+type ExportE2ESuite struct {
+	tester.Suite
+	called bool
+}
+
+func TestExportE2ESuite(t *testing.T) {
+	suite.Run(t, &ExportE2ESuite{Suite: tester.NewE2ESuite(t, nil)})
+}
+
+func (suite *ExportE2ESuite) SetupSuite() {
+	suite.called = true
+}
+
+type mockExportCollection struct {
+	path  string
+	items []data.ExportItem
+}
+
+func (mec mockExportCollection) GetBasePath() string { return mec.path }
+func (mec mockExportCollection) GetItems(context.Context) <-chan data.ExportItem {
+	ch := make(chan data.ExportItem)
+
+	go func() {
+		defer close(ch)
+
+		for _, item := range mec.items {
+			ch <- item
+		}
+	}()
+
+	return ch
+}
+
+func (suite *ExportE2ESuite) TestWriteExportCollection() {
+	type ei struct {
+		name string
+		body string
+	}
+
+	type i struct {
+		path  string
+		items []ei
+	}
+
+	table := []struct {
+		name string
+		cols []i
+	}{
+		{
+			name: "single root collection single item",
+			cols: []i{
+				{
+					path: "",
+					items: []ei{
+						{
+							name: "name1",
+							body: "body1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "single root collection multiple items",
+			cols: []i{
+				{
+					path: "",
+					items: []ei{
+						{
+							name: "name1",
+							body: "body1",
+						},
+						{
+							name: "name2",
+							body: "body2",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple collections multiple items",
+			cols: []i{
+				{
+					path: "",
+					items: []ei{
+						{
+							name: "name1",
+							body: "body1",
+						},
+						{
+							name: "name2",
+							body: "body2",
+						},
+					},
+				},
+				{
+					path: "folder",
+					items: []ei{
+						{
+							name: "name3",
+							body: "body3",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			ecs := []data.ExportCollection{}
+			for _, col := range test.cols {
+				items := []data.ExportItem{}
+				for _, item := range col.items {
+					items = append(items, data.ExportItem{
+						Data: data.ExportItemData{
+							Name: item.name,
+							Body: io.NopCloser((bytes.NewBufferString(item.body))),
+						},
+					})
+				}
+
+				ecs = append(ecs, mockExportCollection{
+					path:  col.path,
+					items: items,
+				})
+			}
+
+			dir, err := os.MkdirTemp("", "export-test")
+			require.NoError(t, err)
+			defer os.RemoveAll(dir)
+
+			err = writeExportCollections(ctx, dir, ecs)
+			require.NoError(t, err, "writing data")
+
+			for _, col := range test.cols {
+				for _, item := range col.items {
+					f, err := os.Open(filepath.Join(dir, col.path, item.name))
+					require.NoError(t, err, "opening file")
+
+					buf := new(bytes.Buffer)
+
+					_, err = buf.ReadFrom(f)
+					require.NoError(t, err, "reading file")
+
+					assert.Equal(t, item.body, buf.String(), "file contents")
+				}
+			}
+		})
+	}
+}

--- a/src/cli/flags/export.go
+++ b/src/cli/flags/export.go
@@ -1,0 +1,31 @@
+package flags
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/alcionai/corso/src/pkg/control"
+)
+
+const (
+	ArchiveFN    = "archive"
+	ExportDestFN = "destination"
+)
+
+var (
+	ArchiveFV    bool
+	ExportDestFV string
+)
+
+// AddExportConfigFlags adds the restore config flag set.
+func AddExportConfigFlags(cmd *cobra.Command) {
+	fs := cmd.Flags()
+	fs.BoolVar(&ArchiveFV, ArchiveFN, false, "Archive contents")
+
+	// TODO(meain): convert to mandatory positional argument
+	fs.StringVar(
+		&ExportDestFV,
+		ExportDestFN,
+		"",
+		"Folder to export to (default:"+control.DefaultRestoreLocation+"<timestamp>)",
+	)
+}

--- a/src/cli/flags/export.go
+++ b/src/cli/flags/export.go
@@ -2,30 +2,14 @@ package flags
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/alcionai/corso/src/pkg/control"
 )
 
-const (
-	ArchiveFN    = "archive"
-	ExportDestFN = "destination"
-)
+const ArchiveFN = "archive"
 
-var (
-	ArchiveFV    bool
-	ExportDestFV string
-)
+var ArchiveFV bool
 
 // AddExportConfigFlags adds the restore config flag set.
 func AddExportConfigFlags(cmd *cobra.Command) {
 	fs := cmd.Flags()
 	fs.BoolVar(&ArchiveFV, ArchiveFN, false, "Archive contents")
-
-	// TODO(meain): convert to mandatory positional argument
-	fs.StringVar(
-		&ExportDestFV,
-		ExportDestFN,
-		"",
-		"Folder to export to (default:"+control.DefaultRestoreLocation+"<timestamp>)",
-	)
 }

--- a/src/internal/data/data_collection.go
+++ b/src/internal/data/data_collection.go
@@ -91,6 +91,11 @@ func (c NoFetchRestoreCollection) FetchItemByName(context.Context, string) (Stre
 	return nil, ErrNotFound
 }
 
+type FetchRestoreCollection struct {
+	Collection
+	FetchItemByNamer
+}
+
 // Stream represents a single item within a Collection
 // that can be consumed as a stream (it embeds io.Reader)
 type Stream interface {

--- a/src/internal/data/data_collection.go
+++ b/src/internal/data/data_collection.go
@@ -154,3 +154,24 @@ func StateOf(prev, curr path.Path) CollectionState {
 
 	return NotMovedState
 }
+
+// ExportCollection is the interface that is returned to the SDK consumer
+type ExportCollection interface {
+	// GetBasePath gets the base path of the collection
+	GetBasePath() string
+
+	// GetItems gets the items within the collection(folder)
+	GetItems(context.Context) <-chan ExportItem
+}
+
+type ExportItemData struct {
+	Name string
+	Body io.Reader
+}
+
+// ExportItem is the item that is returned to the SDK consumer
+type ExportItem struct {
+	ID    string
+	Data  ExportItemData
+	Error error
+}

--- a/src/internal/data/data_collection.go
+++ b/src/internal/data/data_collection.go
@@ -166,7 +166,7 @@ type ExportCollection interface {
 
 type ExportItemData struct {
 	Name string
-	Body io.Reader
+	Body io.ReadCloser
 }
 
 // ExportItem is the item that is returned to the SDK consumer

--- a/src/internal/events/events.go
+++ b/src/internal/events/events.go
@@ -35,6 +35,8 @@ const (
 	BackupEnd        = "Backup End"
 	RestoreStart     = "Restore Start"
 	RestoreEnd       = "Restore End"
+	ExportStart      = "Export Start"
+	ExportEnd        = "Export End"
 	MaintenanceStart = "Maintenance Start"
 	MaintenanceEnd   = "Maintenance End"
 
@@ -49,6 +51,7 @@ const (
 	ItemsWritten     = "items_written"
 	Resources        = "resources"
 	RestoreID        = "restore_id"
+	ExportID         = "export_id"
 	Service          = "service"
 	StartTime        = "start_time"
 	Status           = "status"

--- a/src/internal/m365/controller.go
+++ b/src/internal/m365/controller.go
@@ -23,6 +23,7 @@ import (
 var (
 	_ inject.BackupProducer  = &Controller{}
 	_ inject.RestoreConsumer = &Controller{}
+	_ inject.ExportConsumer  = &Controller{}
 )
 
 // Controller is a struct used to wrap the GraphServiceClient and

--- a/src/internal/m365/export.go
+++ b/src/internal/m365/export.go
@@ -1,0 +1,60 @@
+package m365
+
+import (
+	"context"
+
+	"github.com/alcionai/clues"
+
+	"github.com/alcionai/corso/src/internal/data"
+	"github.com/alcionai/corso/src/internal/diagnostics"
+	"github.com/alcionai/corso/src/internal/m365/graph"
+	"github.com/alcionai/corso/src/internal/m365/onedrive"
+	"github.com/alcionai/corso/src/internal/m365/support"
+	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/selectors"
+)
+
+// ExportRestoreCollections exports data from the specified collections
+func (ctrl *Controller) ExportRestoreCollections(
+	ctx context.Context,
+	backupVersion int,
+	sels selectors.Selector,
+	exportCfg control.ExportConfig,
+	opts control.Options,
+	dcs []data.RestoreCollection,
+	errs *fault.Bus,
+) ([]data.ExportCollection, error) {
+	ctx, end := diagnostics.Span(ctx, "m365:export")
+	defer end()
+
+	ctx = graph.BindRateLimiterConfig(ctx, graph.LimiterCfg{Service: sels.PathService()})
+	ctx = clues.Add(ctx, "export_config", exportCfg) // TODO(rkeepers): needs PII control
+
+	var (
+		expCollections []data.ExportCollection
+		status         *support.ControllerOperationStatus
+		deets          = &details.Builder{}
+		err            error
+	)
+
+	switch sels.Service {
+	case selectors.ServiceOneDrive:
+		expCollections, err = onedrive.ExportRestoreCollections(
+			ctx,
+			backupVersion,
+			exportCfg,
+			opts,
+			dcs,
+			deets,
+			errs)
+	default:
+		err = clues.Wrap(clues.New(sels.Service.String()), "service not supported")
+	}
+
+	ctrl.incrementAwaitingMessages()
+	ctrl.UpdateStatus(status)
+
+	return expCollections, err
+}

--- a/src/internal/m365/mock/connector.go
+++ b/src/internal/m365/mock/connector.go
@@ -69,3 +69,15 @@ func (ctrl Controller) ConsumeRestoreCollections(
 ) (*details.Details, error) {
 	return ctrl.Deets, ctrl.Err
 }
+
+func (ctrl Controller) ExportRestoreCollections(
+	_ context.Context,
+	_ int,
+	_ selectors.Selector,
+	_ control.ExportConfig,
+	_ control.Options,
+	_ []data.RestoreCollection,
+	_ *fault.Bus,
+) ([]data.ExportCollection, error) {
+	return nil, ctrl.Err
+}

--- a/src/internal/m365/onedrive/export.go
+++ b/src/internal/m365/onedrive/export.go
@@ -1,0 +1,159 @@
+package onedrive
+
+import (
+	"context"
+	"strings"
+
+	"github.com/alcionai/clues"
+
+	"github.com/alcionai/corso/src/internal/data"
+	"github.com/alcionai/corso/src/internal/m365/onedrive/metadata"
+	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/path"
+)
+
+type exportCollection struct {
+	// baseDir contains the path of the collection
+	baseDir string
+
+	// backingCollections will, in most cases contain just one
+	// collection. However, in cases where we have to combine multiple
+	// collections, like when generating pst files for outlook, this
+	// will contain multiple collections.
+	backingCollections []data.RestoreCollection
+
+	// version is the version of the backup this collection was part
+	// of. This is required to figure out how to get the name of the
+	// item.
+	version int
+}
+
+func (ec exportCollection) GetBasePath() string {
+	return ec.baseDir
+}
+
+func (ec exportCollection) GetItems(ctx context.Context) <-chan data.ExportItem {
+	ch := make(chan data.ExportItem)
+
+	go func() {
+		defer close(ch)
+
+		errs := fault.New(false)
+
+		// There will only be a single item in the backingCollections
+		// for OneDrive
+		for _, c := range ec.backingCollections {
+			for item := range c.Items(ctx, errs) {
+				itemUUID := item.UUID()
+				if isMetadataFile(itemUUID, ec.version) {
+					continue
+				}
+
+				name, err := getItemName(ctx, itemUUID, ec.version, c)
+
+				ch <- data.ExportItem{
+					ID: itemUUID,
+					Data: data.ExportItemData{
+						Name: name,
+						Body: item.ToReader(),
+					},
+					Error: err,
+				}
+			}
+		}
+
+		// Return all the errored items at the end
+		for _, err := range errs.Errors().Items {
+			ch <- data.ExportItem{
+				ID:    err.ID,
+				Error: &err,
+			}
+		}
+	}()
+
+	return ch
+}
+
+// isMetadataFile is used to determine if a path corresponds to a
+// metadata file.  This is OneDrive specific logic and depends on the
+// version of the backup unlike metadata.IsMetadataFile which only has
+// to be concerned about the current version.
+func isMetadataFile(id string, version int) bool {
+	if version < 1 {
+		return false
+	}
+
+	return strings.HasSuffix(id, metadata.MetaFileSuffix) ||
+		strings.HasSuffix(id, metadata.DirMetaFileSuffix)
+}
+
+// getItemName is used to get the name of the item as how we get the
+// name depends on the version of the backup.
+func getItemName(
+	ctx context.Context,
+	id string,
+	version int,
+	fin data.FetchItemByNamer,
+) (string, error) {
+	if version < 1 {
+		return id, nil
+	}
+
+	if version < 5 {
+		return strings.TrimSuffix(id, metadata.DataFileSuffix), nil
+	}
+
+	if strings.HasSuffix(id, metadata.DataFileSuffix) {
+		trimmedName := strings.TrimSuffix(id, metadata.DataFileSuffix)
+		metaName := trimmedName + metadata.MetaFileSuffix
+
+		meta, err := fetchAndReadMetadata(ctx, fin, metaName)
+		if err != nil {
+			return "", clues.Wrap(err, "getting metadata").WithClues(ctx)
+		}
+
+		return meta.FileName, nil
+	}
+
+	return "", clues.New("invalid item id").WithClues(ctx)
+}
+
+// ExportRestoreCollections will create the export collections for the
+// given restore collections.
+func ExportRestoreCollections(
+	ctx context.Context,
+	backupVersion int,
+	exportCfg control.ExportConfig,
+	opts control.Options,
+	dcs []data.RestoreCollection,
+	deets *details.Builder,
+	errs *fault.Bus,
+) ([]data.ExportCollection, error) {
+	el := errs.Local()
+
+	// Reorder collections so that the parents directories are created
+	// before the child directories; a requirement for permissions.
+	data.SortRestoreCollections(dcs)
+
+	ec := make([]data.ExportCollection, 0, len(dcs))
+
+	for _, dc := range dcs {
+		drivePath, err := path.ToDrivePath(dc.FullPath())
+		if err != nil {
+			return nil, clues.Wrap(err, "creating drive path").WithClues(ctx)
+		}
+
+		baseDir := &path.Builder{}
+		baseDir = baseDir.Append(drivePath.Folders...)
+
+		ec = append(ec, exportCollection{
+			baseDir:            baseDir.String(),
+			backingCollections: []data.RestoreCollection{dc},
+			version:            backupVersion,
+		})
+	}
+
+	return ec, el.Failure()
+}

--- a/src/internal/m365/onedrive/export.go
+++ b/src/internal/m365/onedrive/export.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
+// exportCollection is the implementation of data.ExportCollection for OneDrive
 type exportCollection struct {
 	// baseDir contains the path of the collection
 	baseDir string

--- a/src/internal/m365/onedrive/export_test.go
+++ b/src/internal/m365/onedrive/export_test.go
@@ -6,6 +6,9 @@ import (
 	"io"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/alcionai/corso/src/internal/data"
 	odConsts "github.com/alcionai/corso/src/internal/m365/onedrive/consts"
 	"github.com/alcionai/corso/src/internal/m365/onedrive/metadata"
@@ -14,8 +17,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
 )
 
 type ExportUnitSuite struct {
@@ -161,6 +162,7 @@ func (rc mockRestoreCollection) Items(ctx context.Context, errs *fault.Bus) <-ch
 
 	go func() {
 		defer close(ch)
+
 		for _, item := range rc.items {
 			ch <- item
 		}

--- a/src/internal/m365/onedrive/export_test.go
+++ b/src/internal/m365/onedrive/export_test.go
@@ -1,8 +1,12 @@
 package onedrive
 
 import (
+	"bytes"
+	"context"
+	"io"
 	"testing"
 
+	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/m365/onedrive/metadata"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/stretchr/testify/assert"
@@ -52,6 +56,92 @@ func (suite *ExportUnitSuite) TestIsMetadataFile() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			assert.Equal(suite.T(), test.isMeta, isMetadataFile(test.id, test.version), "is metadata")
+		})
+	}
+}
+
+type metadataStream struct {
+	id   string
+	name string
+}
+
+func (ms metadataStream) ToReader() io.ReadCloser {
+	return io.NopCloser(bytes.NewBufferString(`{"filename": "` + ms.name + `"}`))
+}
+func (ms metadataStream) UUID() string  { return ms.id }
+func (ms metadataStream) Deleted() bool { return false }
+
+type finD struct {
+	id   string
+	name string
+	err  error
+}
+
+func (fd finD) FetchItemByName(ctx context.Context, name string) (data.Stream, error) {
+	if fd.err != nil {
+		return nil, fd.err
+	}
+
+	return metadataStream{id: fd.id, name: fd.name}, nil
+}
+
+func (suite *ExportUnitSuite) TestGetItemName() {
+	table := []struct {
+		tname   string
+		id      string
+		version int
+		name    string
+		fin     data.FetchItemByNamer
+		errFunc assert.ErrorAssertionFunc
+	}{
+		{
+			tname:   "legacy",
+			id:      "name",
+			version: 1,
+			name:    "name",
+			errFunc: assert.NoError,
+		},
+		{
+			tname:   "name in filename",
+			id:      "name.data",
+			version: 4,
+			name:    "name",
+			errFunc: assert.NoError,
+		},
+		{
+			tname:   "name in metadata",
+			id:      "name.data",
+			version: 5,
+			name:    "name",
+			fin:     finD{id: "name.data", name: "name"},
+			errFunc: assert.NoError,
+		},
+		{
+			tname:   "name in metadata but error",
+			id:      "name.data",
+			version: 5,
+			name:    "",
+			fin:     finD{err: assert.AnError},
+			errFunc: assert.Error,
+		},
+	}
+
+	for _, test := range table {
+		suite.Run(test.tname, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			name, err := getItemName(
+				ctx,
+				test.id,
+				test.version,
+				test.fin,
+			)
+			test.errFunc(t, err)
+
+			assert.Equal(t, test.name, name, "name")
 		})
 	}
 }

--- a/src/internal/m365/onedrive/export_test.go
+++ b/src/internal/m365/onedrive/export_test.go
@@ -1,0 +1,57 @@
+package onedrive
+
+import (
+	"testing"
+
+	"github.com/alcionai/corso/src/internal/m365/onedrive/metadata"
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type ExportUnitSuite struct {
+	tester.Suite
+}
+
+func TestExportUnitSuite(t *testing.T) {
+	suite.Run(t, &ExportUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *ExportUnitSuite) TestIsMetadataFile() {
+	table := []struct {
+		name    string
+		id      string
+		version int
+		isMeta  bool
+	}{
+		{
+			name:    "legacy",
+			version: 1,
+			isMeta:  false,
+		},
+		{
+			name:    "metadata file",
+			version: 2,
+			id:      "name" + metadata.MetaFileSuffix,
+			isMeta:  true,
+		},
+		{
+			name:    "dir metadata file",
+			version: 2,
+			id:      "name" + metadata.DirMetaFileSuffix,
+			isMeta:  true,
+		},
+		{
+			name:    "non metadata file",
+			version: 2,
+			id:      "name" + metadata.DataFileSuffix,
+			isMeta:  false,
+		},
+	}
+
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			assert.Equal(suite.T(), test.isMeta, isMetadataFile(test.id, test.version), "is metadata")
+		})
+	}
+}

--- a/src/internal/m365/onedrive/export_test.go
+++ b/src/internal/m365/onedrive/export_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/m365/onedrive/metadata"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -142,6 +144,204 @@ func (suite *ExportUnitSuite) TestGetItemName() {
 			test.errFunc(t, err)
 
 			assert.Equal(t, test.name, name, "name")
+		})
+	}
+}
+
+type mockRestoreCollection struct {
+	path  path.Path
+	items []data.Stream
+}
+
+func (rc mockRestoreCollection) Items(ctx context.Context, errs *fault.Bus) <-chan data.Stream {
+	ch := make(chan data.Stream)
+
+	go func() {
+		defer close(ch)
+		for _, item := range rc.items {
+			ch <- item
+		}
+	}()
+
+	return ch
+}
+
+func (rc mockRestoreCollection) FullPath() path.Path {
+	return rc.path
+}
+
+type mockDataStream struct {
+	id   string
+	data string
+}
+
+func (ms mockDataStream) ToReader() io.ReadCloser {
+	if ms.data == "" {
+		return io.NopCloser(bytes.NewBufferString(ms.data))
+	}
+
+	return nil
+}
+func (ms mockDataStream) UUID() string  { return ms.id }
+func (ms mockDataStream) Deleted() bool { return false }
+
+func (suite *ExportUnitSuite) TestGetItems() {
+	table := []struct {
+		name               string
+		version            int
+		backingCollections []data.RestoreCollection
+		expectedItems      []data.ExportItem
+	}{
+		{
+			name:    "single item",
+			version: 1,
+			backingCollections: []data.RestoreCollection{
+				data.NoFetchRestoreCollection{
+					Collection: mockRestoreCollection{
+						items: []data.Stream{
+							mockDataStream{id: "name1", data: "body1"},
+						},
+					},
+				},
+			},
+			expectedItems: []data.ExportItem{
+				{
+					ID: "name1",
+					Data: data.ExportItemData{
+						Name: "name1",
+						Body: io.NopCloser((bytes.NewBufferString("body1"))),
+					},
+				},
+			},
+		},
+		{
+			name:    "multiple items",
+			version: 1,
+			backingCollections: []data.RestoreCollection{
+				data.NoFetchRestoreCollection{
+					Collection: mockRestoreCollection{
+						items: []data.Stream{
+							mockDataStream{id: "name1", data: "body1"},
+							mockDataStream{id: "name2", data: "body2"},
+						},
+					},
+				},
+			},
+			expectedItems: []data.ExportItem{
+				{
+					ID: "name1",
+					Data: data.ExportItemData{
+						Name: "name1",
+						Body: io.NopCloser((bytes.NewBufferString("body1"))),
+					},
+				},
+				{
+					ID: "name2",
+					Data: data.ExportItemData{
+						Name: "name2",
+						Body: io.NopCloser((bytes.NewBufferString("body2"))),
+					},
+				},
+			},
+		},
+		{
+			name:    "single item with data suffix",
+			version: 2,
+			backingCollections: []data.RestoreCollection{
+				data.NoFetchRestoreCollection{
+					Collection: mockRestoreCollection{
+						items: []data.Stream{
+							mockDataStream{id: "name1.data", data: "body1"},
+						},
+					},
+				},
+			},
+			expectedItems: []data.ExportItem{
+				{
+					ID: "name1.data",
+					Data: data.ExportItemData{
+						Name: "name1",
+						Body: io.NopCloser((bytes.NewBufferString("body1"))),
+					},
+				},
+			},
+		},
+		{
+			name:    "single item name from metadata",
+			version: 5,
+			backingCollections: []data.RestoreCollection{
+				data.FetchRestoreCollection{
+					Collection: mockRestoreCollection{
+						items: []data.Stream{
+							mockDataStream{id: "id1.data", data: "body1"},
+						},
+					},
+					FetchItemByNamer: finD{id: "id1.data", name: "name1"},
+				},
+			},
+			expectedItems: []data.ExportItem{
+				{
+					ID: "id1.data",
+					Data: data.ExportItemData{
+						Name: "name1",
+						Body: io.NopCloser((bytes.NewBufferString("body1"))),
+					},
+				},
+			},
+		},
+		{
+			name:    "single item name from metadata with error",
+			version: 5,
+			backingCollections: []data.RestoreCollection{
+				data.FetchRestoreCollection{
+					Collection: mockRestoreCollection{
+						items: []data.Stream{
+							mockDataStream{id: "id1.data"},
+						},
+					},
+					FetchItemByNamer: finD{err: assert.AnError},
+				},
+			},
+			expectedItems: []data.ExportItem{
+				{
+					ID:    "id1.data",
+					Error: assert.AnError,
+				},
+			},
+		},
+	}
+
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			ec := exportCollection{
+				baseDir:            "",
+				backingCollections: test.backingCollections,
+				version:            test.version,
+			}
+
+			items := ec.GetItems(ctx)
+
+			fitems := []data.ExportItem{}
+			for item := range items {
+				fitems = append(fitems, item)
+			}
+
+			assert.Len(t, fitems, len(test.expectedItems), "num of items")
+
+			for i, item := range fitems {
+				assert.Equal(t, test.expectedItems[i].ID, item.ID, "id")
+				assert.Equal(t, test.expectedItems[i].Data.Name, item.Data.Name, "name")
+				assert.Equal(t, test.expectedItems[i].Data.Body, item.Data.Body, "body")
+
+				if test.expectedItems[i].Error != nil {
+					assert.Contains(t, item.Error.Error(), test.expectedItems[i].Error.Error(), "error")
+				}
+			}
 		})
 	}
 }

--- a/src/internal/m365/support/status.go
+++ b/src/internal/m365/support/status.go
@@ -40,6 +40,7 @@ const (
 	OpUnknown Operation = iota
 	Backup
 	Restore
+	Export
 )
 
 // Constructor for ConnectorOperationStatus. If the counts do not agree, an error is returned.

--- a/src/internal/observe/observe.go
+++ b/src/internal/observe/observe.go
@@ -133,6 +133,7 @@ func Complete() {
 const (
 	ItemBackupMsg  = "Backing up item"
 	ItemRestoreMsg = "Restoring item"
+	ItemExportMsg  = "Exporting item"
 	ItemQueueMsg   = "Queuing items"
 )
 
@@ -267,6 +268,51 @@ func ItemProgress(
 	}
 
 	bar := progress.New(totalBytes, mpb.NopStyle(), barOpts...)
+
+	go waitAndCloseBar(bar, func() {
+		// might be overly chatty, we can remove if needed.
+		log.Debug("done - " + header)
+	})()
+
+	abort := func() {
+		bar.SetTotal(-1, true)
+		bar.Abort(true)
+	}
+
+	return bar.ProxyReader(rc), abort
+}
+
+// ItemSpinner is similar to ItemProgress, but for use in cases where
+// we don't know the file size but want to show progress.
+func ItemSpinner(
+	ctx context.Context,
+	rc io.ReadCloser,
+	header string,
+	iname any,
+) (io.ReadCloser, func()) {
+	plain := plainString(iname)
+	log := logger.Ctx(ctx).With("item", iname)
+	log.Debug(header)
+
+	if cfg.hidden() || rc == nil {
+		defer log.Debug("done - " + header)
+		return rc, func() {}
+	}
+
+	wg.Add(1)
+
+	barOpts := []mpb.BarOption{
+		mpb.PrependDecorators(
+			decor.Name(header, decor.WCSyncSpaceR),
+			decor.Name(plain, decor.WCSyncSpaceR),
+			decor.CurrentKibiByte(" %.1f", decor.WC{W: 8})),
+	}
+
+	if !cfg.keepBarsAfterComplete {
+		barOpts = append(barOpts, mpb.BarRemoveOnComplete())
+	}
+
+	bar := progress.New(-1, mpb.NopStyle(), barOpts...)
 
 	go waitAndCloseBar(bar, func() {
 		// might be overly chatty, we can remove if needed.

--- a/src/internal/operations/export.go
+++ b/src/internal/operations/export.go
@@ -24,6 +24,7 @@ import (
 	"github.com/alcionai/corso/src/internal/streamstore"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/count"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/selectors"
@@ -58,7 +59,7 @@ func NewExportOperation(
 	bus events.Eventer,
 ) (ExportOperation, error) {
 	op := ExportOperation{
-		operation: newOperation(opts, bus, kw, sw),
+		operation: newOperation(opts, bus, count.New(), kw, sw),
 		acct:      acct,
 		BackupID:  backupID,
 		ExportCfg: exportCfg,

--- a/src/internal/operations/export.go
+++ b/src/internal/operations/export.go
@@ -35,7 +35,7 @@ type ExportOperation struct {
 	operation
 
 	BackupID  model.StableID
-	Results   RestoreResults // TODO(meain): populate written?
+	Results   RestoreResults
 	Selectors selectors.Selector
 	ExportCfg control.ExportConfig
 	Version   string
@@ -349,7 +349,6 @@ func (op *ExportOperation) do(
 		return nil, clues.Wrap(err, "restoring collections")
 	}
 
-	// TODO(meain): look into this
 	opStats.ctrl = op.ec.Wait()
 
 	logger.Ctx(ctx).Debug(opStats.ctrl)
@@ -394,7 +393,8 @@ func (op *ExportOperation) persistResults(
 		op.Status = NoData
 	}
 
-	op.Results.ItemsWritten = opStats.ctrl.Successes
+	// We don't have data on what all items were written
+	// op.Results.ItemsWritten = opStats.ctrl.Successes
 
 	return op.Errors.Failure()
 }

--- a/src/internal/operations/export.go
+++ b/src/internal/operations/export.go
@@ -1,0 +1,435 @@
+package operations
+
+import (
+	"archive/zip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/alcionai/clues"
+	"github.com/google/uuid"
+
+	"github.com/alcionai/corso/src/internal/common/crash"
+	"github.com/alcionai/corso/src/internal/common/dttm"
+	"github.com/alcionai/corso/src/internal/data"
+	"github.com/alcionai/corso/src/internal/diagnostics"
+	"github.com/alcionai/corso/src/internal/events"
+	"github.com/alcionai/corso/src/internal/kopia"
+	"github.com/alcionai/corso/src/internal/model"
+	"github.com/alcionai/corso/src/internal/observe"
+	"github.com/alcionai/corso/src/internal/operations/inject"
+	"github.com/alcionai/corso/src/internal/stats"
+	"github.com/alcionai/corso/src/internal/streamstore"
+	"github.com/alcionai/corso/src/pkg/account"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/logger"
+	"github.com/alcionai/corso/src/pkg/selectors"
+	"github.com/alcionai/corso/src/pkg/store"
+)
+
+// ExportOperation wraps an operation with export-specific props.
+type ExportOperation struct {
+	operation
+
+	BackupID  model.StableID
+	Results   RestoreResults // TODO(meain): populate written?
+	Selectors selectors.Selector
+	ExportCfg control.ExportConfig
+	Version   string
+
+	acct account.Account
+	ec   inject.ExportConsumer
+}
+
+// NewExportOperation constructs and validates a export operation.
+func NewExportOperation(
+	ctx context.Context,
+	opts control.Options,
+	kw *kopia.Wrapper,
+	sw *store.Wrapper,
+	ec inject.ExportConsumer,
+	acct account.Account,
+	backupID model.StableID,
+	sel selectors.Selector,
+	exportCfg control.ExportConfig,
+	bus events.Eventer,
+) (ExportOperation, error) {
+	op := ExportOperation{
+		operation: newOperation(opts, bus, kw, sw),
+		acct:      acct,
+		BackupID:  backupID,
+		ExportCfg: exportCfg,
+		Selectors: sel,
+		Version:   "v0",
+		ec:        ec,
+	}
+	if err := op.validate(); err != nil {
+		return ExportOperation{}, err
+	}
+
+	return op, nil
+}
+
+func (op ExportOperation) validate() error {
+	if op.ec == nil {
+		return clues.New("missing export consumer")
+	}
+
+	return op.operation.validate()
+}
+
+// aggregates stats from the export.Run().
+// primarily used so that the defer can take in a
+// pointer wrapping the values, while those values
+// get populated asynchronously.
+type exportStats struct {
+	cs            []data.RestoreCollection
+	ctrl          *data.CollectionStats
+	bytesRead     *stats.ByteCounter
+	resourceCount int
+
+	// a transient value only used to pair up start-end events.
+	exportID string
+}
+
+// Run begins a synchronous export operation.
+func (op *ExportOperation) Run(ctx context.Context) (
+	expColl []data.ExportCollection,
+	err error,
+) {
+	defer func() {
+		if crErr := crash.Recovery(ctx, recover(), "export"); crErr != nil {
+			err = crErr
+		}
+	}()
+
+	var (
+		opStats = exportStats{
+			bytesRead: &stats.ByteCounter{},
+			exportID:  uuid.NewString(),
+		}
+		start  = time.Now()
+		sstore = streamstore.NewStreamer(op.kopia, op.acct.ID(), op.Selectors.PathService())
+	)
+
+	// -----
+	// Setup
+	// -----
+
+	ctx, end := diagnostics.Span(ctx, "operations:export:run")
+	defer func() {
+		end()
+		// wait for the progress display to clean up
+		observe.Complete()
+	}()
+
+	ctx, flushMetrics := events.NewMetrics(ctx, logger.Writer{Ctx: ctx})
+	defer flushMetrics()
+
+	ctx = clues.Add(
+		ctx,
+		"tenant_id", clues.Hide(op.acct.ID()),
+		"backup_id", op.BackupID,
+		"service", op.Selectors.Service)
+
+	defer func() {
+		op.bus.Event(
+			ctx,
+			events.ExportEnd,
+			map[string]any{
+				events.BackupID:      op.BackupID,
+				events.DataRetrieved: op.Results.BytesRead,
+				events.Duration:      op.Results.CompletedAt.Sub(op.Results.StartedAt),
+				events.EndTime:       dttm.Format(op.Results.CompletedAt),
+				events.ItemsRead:     op.Results.ItemsRead,
+				events.ItemsWritten:  op.Results.ItemsWritten,
+				events.Resources:     op.Results.ResourceOwners,
+				events.ExportID:      opStats.exportID,
+				events.Service:       op.Selectors.Service.String(),
+				events.StartTime:     dttm.Format(op.Results.StartedAt),
+				events.Status:        op.Status.String(),
+			})
+	}()
+
+	// -----
+	// Execution
+	// -----
+
+	expCollections, err := op.do(ctx, &opStats, sstore, start)
+	if err != nil {
+		// No return here!  We continue down to persistResults, even in case of failure.
+		logger.CtxErr(ctx, err).Error("running export")
+
+		if errors.Is(err, kopia.ErrNoRestorePath) {
+			op.Errors.Fail(clues.New("empty backup or unknown path provided"))
+		}
+
+		op.Errors.Fail(clues.Wrap(err, "running export"))
+	}
+
+	finalizeErrorHandling(ctx, op.Options, op.Errors, "running export")
+	LogFaultErrors(ctx, op.Errors.Errors(), "running export")
+
+	// -----
+	// Persistence
+	// -----
+
+	err = op.persistResults(ctx, start, &opStats)
+	if err != nil {
+		op.Errors.Fail(clues.Wrap(err, "persisting export results"))
+		return nil, op.Errors.Failure()
+	}
+
+	logger.Ctx(ctx).Infow("completed export", "results", op.Results)
+
+	return expCollections, nil
+}
+
+type zipExportCol struct {
+	reader io.Reader
+}
+
+func (z zipExportCol) GetBasePath() string {
+	return ""
+}
+
+func (z zipExportCol) GetItems(ctx context.Context) <-chan data.ExportItem {
+	rc := make(chan data.ExportItem, 1)
+	defer close(rc)
+
+	rc <- data.ExportItem{
+		Data: data.ExportItemData{
+			Name: "export.zip",
+			Body: z.reader,
+		},
+	}
+
+	return rc
+}
+
+// zipExportCollection takes a list of export collections and zips
+// them into a single collection.
+func zipExportCollection(
+	ctx context.Context,
+	expCollections []data.ExportCollection,
+	errs *fault.Bus,
+) (data.ExportCollection, error) {
+	reader, writer := io.Pipe()
+	wr := zip.NewWriter(writer)
+
+	el := errs.Local()
+
+	go func() {
+		// TODO(meain): This blocks disk write somehow
+		// zipComplete := observe.MessageWithCompletion(ctx, "Zipping data")
+		// defer func() {
+		// 	zipComplete <- struct{}{}
+		// 	close(zipComplete)
+		// }()
+		defer writer.Close()
+		defer wr.Close()
+
+		for _, ec := range expCollections {
+			if el.Failure() != nil {
+				break
+			}
+
+			folder := ec.GetBasePath()
+			items := ec.GetItems(ctx)
+
+			// for each item in dc add contents to tarball
+			for item := range items {
+				if el.Failure() != nil {
+					break
+				}
+
+				err := item.Error
+				if err != nil {
+					el.AddRecoverable(ctx, clues.Wrap(err, "getting export item").With("id", item.ID))
+					continue
+				}
+
+				name := item.Data.Name
+
+				f, err := wr.Create(folder + "/" + name)
+				if err != nil {
+					el.AddRecoverable(ctx, clues.Wrap(err, "creating zip entry").With("name", name).With("id", item.ID))
+					continue
+				}
+
+				_, err = io.Copy(f, item.Data.Body)
+				if err != nil {
+					el.AddRecoverable(ctx, clues.Wrap(err, "writing zip entry").With("name", name).With("id", item.ID))
+					continue
+				}
+			}
+		}
+	}()
+
+	return zipExportCol{reader}, el.Failure()
+}
+
+func (op *ExportOperation) do(
+	ctx context.Context,
+	opStats *exportStats,
+	detailsStore streamstore.Reader,
+	start time.Time,
+) ([]data.ExportCollection, error) {
+	logger.Ctx(ctx).
+		With("control_options", op.Options, "selectors", op.Selectors).
+		Info("restoring selection")
+
+	bup, deets, err := getBackupAndDetailsFromID(
+		ctx,
+		op.BackupID,
+		op.store,
+		detailsStore,
+		op.Errors)
+	if err != nil {
+		return nil, clues.Wrap(err, "getting backup and details")
+	}
+
+	observe.Message(ctx, "Restoring", observe.Bullet, clues.Hide(bup.Selector.DiscreteOwner))
+
+	paths, err := formatDetailsForRestoration(ctx, bup.Version, op.Selectors, deets, op.Errors)
+	if err != nil {
+		return nil, clues.Wrap(err, "formatting paths from details")
+	}
+
+	ctx = clues.Add(
+		ctx,
+		"resource_owner_id", bup.Selector.ID(),
+		"resource_owner_name", clues.Hide(bup.Selector.Name()),
+		"details_entries", len(deets.Entries),
+		"details_paths", len(paths),
+		"backup_snapshot_id", bup.SnapshotID,
+		"backup_version", bup.Version)
+
+	op.bus.Event(
+		ctx,
+		events.ExportStart,
+		map[string]any{
+			events.StartTime:        start,
+			events.BackupID:         op.BackupID,
+			events.BackupCreateTime: bup.CreationTime,
+			events.ExportID:         opStats.exportID,
+		})
+
+	observe.Message(ctx, fmt.Sprintf("Discovered %d items in backup %s to export", len(paths), op.BackupID))
+
+	kopiaComplete := observe.MessageWithCompletion(ctx, "Enumerating items in repository")
+	defer close(kopiaComplete)
+
+	dcs, err := op.kopia.ProduceRestoreCollections(ctx, bup.SnapshotID, paths, opStats.bytesRead, op.Errors)
+	if err != nil {
+		return nil, clues.Wrap(err, "producing collections to export")
+	}
+
+	kopiaComplete <- struct{}{}
+
+	ctx = clues.Add(ctx, "coll_count", len(dcs))
+
+	// should always be 1, since backups are 1:1 with resourceOwners.
+	opStats.resourceCount = 1
+	opStats.cs = dcs
+
+	expCollections, err := exportRestoreCollections(
+		ctx,
+		op.ec,
+		bup.Version,
+		op.Selectors,
+		op.ExportCfg,
+		op.Options,
+		dcs,
+		op.Errors)
+	if err != nil {
+		return nil, clues.Wrap(err, "restoring collections")
+	}
+
+	// TODO(meain): look into this
+	opStats.ctrl = op.ec.Wait()
+
+	logger.Ctx(ctx).Debug(opStats.ctrl)
+
+	if op.ExportCfg.Archive {
+		zc, err := zipExportCollection(ctx, expCollections, op.Errors)
+		if err != nil {
+			return nil, clues.Wrap(err, "zipping exports")
+		}
+
+		return []data.ExportCollection{zc}, nil
+	}
+
+	return expCollections, nil
+}
+
+// persists details and statistics about the export operation.
+func (op *ExportOperation) persistResults(
+	ctx context.Context,
+	started time.Time,
+	opStats *exportStats,
+) error {
+	op.Results.StartedAt = started
+	op.Results.CompletedAt = time.Now()
+
+	op.Status = Completed
+
+	if op.Errors.Failure() != nil {
+		op.Status = Failed
+	}
+
+	op.Results.BytesRead = opStats.bytesRead.NumBytes
+	op.Results.ItemsRead = len(opStats.cs) // TODO: file count, not collection count
+	op.Results.ResourceOwners = opStats.resourceCount
+
+	if opStats.ctrl == nil {
+		op.Status = Failed
+		return clues.New("restoration never completed")
+	}
+
+	if op.Status != Failed && opStats.ctrl.IsZero() {
+		op.Status = NoData
+	}
+
+	op.Results.ItemsWritten = opStats.ctrl.Successes
+
+	return op.Errors.Failure()
+}
+
+// ---------------------------------------------------------------------------
+// Exportr funcs
+// ---------------------------------------------------------------------------
+
+func exportRestoreCollections(
+	ctx context.Context,
+	ec inject.ExportConsumer,
+	backupVersion int,
+	sel selectors.Selector,
+	exportCfg control.ExportConfig,
+	opts control.Options,
+	dcs []data.RestoreCollection,
+	errs *fault.Bus,
+) ([]data.ExportCollection, error) {
+	complete := observe.MessageWithCompletion(ctx, "Preparing export")
+	defer func() {
+		complete <- struct{}{}
+		close(complete)
+	}()
+
+	expCollections, err := ec.ExportRestoreCollections(
+		ctx,
+		backupVersion,
+		sel,
+		exportCfg,
+		opts,
+		dcs,
+		errs)
+	if err != nil {
+		return nil, clues.Wrap(err, "exporting collections")
+	}
+
+	return expCollections, nil
+}

--- a/src/internal/operations/export.go
+++ b/src/internal/operations/export.go
@@ -189,7 +189,7 @@ func (op *ExportOperation) Run(ctx context.Context) (
 }
 
 type zipExportCol struct {
-	reader io.Reader
+	reader io.ReadCloser
 }
 
 func (z zipExportCol) GetBasePath() string {

--- a/src/internal/operations/export_test.go
+++ b/src/internal/operations/export_test.go
@@ -8,6 +8,10 @@ import (
 	"time"
 
 	"github.com/alcionai/clues"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/alcionai/corso/src/internal/data"
 	evmock "github.com/alcionai/corso/src/internal/events/mock"
 	"github.com/alcionai/corso/src/internal/kopia"
@@ -19,9 +23,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/store"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 )
 
 type ExportOpSuite struct {

--- a/src/internal/operations/export_test.go
+++ b/src/internal/operations/export_test.go
@@ -1,0 +1,265 @@
+package operations
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/alcionai/clues"
+	"github.com/alcionai/corso/src/internal/data"
+	evmock "github.com/alcionai/corso/src/internal/events/mock"
+	"github.com/alcionai/corso/src/internal/kopia"
+	exchMock "github.com/alcionai/corso/src/internal/m365/exchange/mock"
+	"github.com/alcionai/corso/src/internal/m365/mock"
+	"github.com/alcionai/corso/src/internal/stats"
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/account"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/selectors"
+	"github.com/alcionai/corso/src/pkg/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type ExportOpSuite struct {
+	tester.Suite
+}
+
+func TestExportOpSuite(t *testing.T) {
+	suite.Run(t, &ExportOpSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *ExportOpSuite) TestExportOperation_PersistResults() {
+	var (
+		kw        = &kopia.Wrapper{}
+		sw        = &store.Wrapper{}
+		ctrl      = &mock.Controller{}
+		now       = time.Now()
+		exportCfg = control.DefaultExportConfig()
+	)
+
+	table := []struct {
+		expectStatus OpStatus
+		expectErr    assert.ErrorAssertionFunc
+		stats        exportStats
+		fail         error
+	}{
+		{
+			expectStatus: Completed,
+			expectErr:    assert.NoError,
+			stats: exportStats{
+				resourceCount: 1,
+				bytesRead: &stats.ByteCounter{
+					NumBytes: 42,
+				},
+				cs: []data.RestoreCollection{
+					data.NoFetchRestoreCollection{
+						Collection: &exchMock.DataCollection{},
+					},
+				},
+				ctrl: &data.CollectionStats{
+					Objects:   1,
+					Successes: 1,
+				},
+			},
+		},
+		{
+			expectStatus: Failed,
+			expectErr:    assert.Error,
+			fail:         assert.AnError,
+			stats: exportStats{
+				bytesRead: &stats.ByteCounter{},
+				ctrl:      &data.CollectionStats{},
+			},
+		},
+		{
+			expectStatus: NoData,
+			expectErr:    assert.NoError,
+			stats: exportStats{
+				bytesRead: &stats.ByteCounter{},
+				cs:        []data.RestoreCollection{},
+				ctrl:      &data.CollectionStats{},
+			},
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.expectStatus.String(), func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			op, err := NewExportOperation(
+				ctx,
+				control.Defaults(),
+				kw,
+				sw,
+				ctrl,
+				account.Account{},
+				"foo",
+				selectors.Selector{DiscreteOwner: "test"},
+				exportCfg,
+				evmock.NewBus())
+			require.NoError(t, err, clues.ToCore(err))
+
+			op.Errors.Fail(test.fail)
+
+			err = op.persistResults(ctx, now, &test.stats)
+			test.expectErr(t, err, clues.ToCore(err))
+
+			assert.Equal(t, test.expectStatus.String(), op.Status.String(), "status")
+			assert.Equal(t, len(test.stats.cs), op.Results.ItemsRead, "items read")
+			assert.Equal(t, test.stats.bytesRead.NumBytes, op.Results.BytesRead, "resource owners")
+			assert.Equal(t, test.stats.resourceCount, op.Results.ResourceOwners, "resource owners")
+			assert.Equal(t, now, op.Results.StartedAt, "started at")
+			assert.Less(t, now, op.Results.CompletedAt, "completed at")
+		})
+	}
+}
+
+type expCol struct {
+	base  string
+	items []data.ExportItem
+}
+
+func (ec expCol) GetBasePath() string { return ec.base }
+func (ec expCol) GetItems(ctx context.Context) <-chan data.ExportItem {
+	ch := make(chan data.ExportItem)
+
+	go func() {
+		defer close(ch)
+
+		for _, item := range ec.items {
+			ch <- item
+		}
+	}()
+
+	return ch
+}
+
+func (suite *ExportOpSuite) TestZipExports() {
+	table := []struct {
+		name       string
+		collection []data.ExportCollection
+		shouldErr  bool
+		readErr    bool
+	}{
+		{
+			name:       "nothing",
+			collection: []data.ExportCollection{},
+			shouldErr:  true,
+		},
+		{
+			name: "empty",
+			collection: []data.ExportCollection{
+				expCol{
+					base:  "",
+					items: []data.ExportItem{},
+				},
+			},
+		},
+		{
+			name: "one item",
+			collection: []data.ExportCollection{
+				expCol{
+					base: "",
+					items: []data.ExportItem{
+						{
+							ID: "id1",
+							Data: data.ExportItemData{
+								Name: "test.data",
+								Body: io.NopCloser(bytes.NewBufferString("test")),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple items",
+			collection: []data.ExportCollection{
+				expCol{
+					base: "",
+					items: []data.ExportItem{
+						{
+							ID: "id1",
+							Data: data.ExportItemData{
+								Name: "test.data",
+								Body: io.NopCloser(bytes.NewBufferString("test")),
+							},
+						},
+					},
+				},
+				expCol{
+					base: "/fold",
+					items: []data.ExportItem{
+						{
+							ID: "id2",
+							Data: data.ExportItemData{
+								Name: "test2.data",
+								Body: io.NopCloser(bytes.NewBufferString("test2")),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "one item with err",
+			collection: []data.ExportCollection{
+				expCol{
+					base: "",
+					items: []data.ExportItem{
+						{
+							ID:    "id3",
+							Error: assert.AnError,
+						},
+					},
+				},
+			},
+			readErr: true,
+		},
+	}
+
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			zc, err := zipExportCollection(ctx, test.collection)
+
+			if test.shouldErr {
+				assert.Error(t, err, "error")
+				return
+			}
+
+			require.NoError(t, err, "error")
+
+			assert.Empty(t, zc.GetBasePath(), "base path")
+
+			count := 0
+			for item := range zc.GetItems(ctx) {
+				assert.Equal(t, "export.zip", item.Data.Name, "name")
+
+				_, err := io.Copy(io.Discard, item.Data.Body)
+				if test.readErr {
+					assert.Error(t, err, "read error")
+					return
+				}
+
+				require.NoError(t, err, "read item")
+
+				item.Data.Body.Close()
+
+				count++
+			}
+
+			assert.Equal(t, 1, count, "single item")
+		})
+	}
+}

--- a/src/internal/operations/inject/inject.go
+++ b/src/internal/operations/inject/inject.go
@@ -48,6 +48,20 @@ type (
 		Wait() *data.CollectionStats
 	}
 
+	ExportConsumer interface {
+		ExportRestoreCollections(
+			ctx context.Context,
+			backupVersion int,
+			selector selectors.Selector,
+			exportCfg control.ExportConfig,
+			opts control.Options,
+			dcs []data.RestoreCollection,
+			errs *fault.Bus,
+		) ([]data.ExportCollection, error)
+
+		Wait() *data.CollectionStats
+	}
+
 	RepoMaintenancer interface {
 		RepoMaintenance(ctx context.Context, opts repository.Maintenance) error
 	}

--- a/src/pkg/control/export.go
+++ b/src/pkg/control/export.go
@@ -1,0 +1,22 @@
+package control
+
+// ExportConfig contains config for exports
+type ExportConfig struct {
+	// Archive decides if we should create an archive from the data
+	// instead of just returning all the files. If Archive is set to
+	// true, we return a single collection with a single file which is
+	// the archive.
+	Archive bool
+
+	// DataFormat decides the format in which we return the data. This is
+	// only useful for outlook exports, for example they can be in eml
+	// or pst for emails.
+	// TODO: Enable once we support outlook exports
+	// DataFormat string
+}
+
+func DefaultExportConfig() ExportConfig {
+	return ExportConfig{
+		Archive: false,
+	}
+}

--- a/src/pkg/control/restore.go
+++ b/src/pkg/control/restore.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	defaultRestoreLocation = "Corso_Restore_"
+	DefaultRestoreLocation = "Corso_Restore_"
 )
 
 // CollisionPolicy describes how the datalayer behaves in case of a collision.
@@ -61,7 +61,7 @@ type RestoreConfig struct {
 func DefaultRestoreConfig(timeFormat dttm.TimeFormat) RestoreConfig {
 	return RestoreConfig{
 		OnCollision: Skip,
-		Location:    defaultRestoreLocation + dttm.FormatNow(timeFormat),
+		Location:    DefaultRestoreLocation + dttm.FormatNow(timeFormat),
 	}
 }
 


### PR DESCRIPTION
This adds the option to export data for OneDrive. This can be used to export the full backup, a single file or a subset of files.

Here is what the cli usage looks like:

```
corso export <service> [flags] [--archive] <destination>
```

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* fixes https://github.com/alcionai/corso/issues/3670
* fixes https://github.com/alcionai/corso/issues/2536

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
