### PR TITLE
retry on http/2 stream errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Return a ServiceNotEnabled error when a tenant has no active SharePoint license.
+- Added retries for http/2 stream connection failures when downloading large item content.
 
 ### Known issues
 - If a link share is created for an item with inheritance disabled

--- a/src/cmd/getM365/onedrive/get_item.go
+++ b/src/cmd/getM365/onedrive/get_item.go
@@ -194,13 +194,13 @@ func getDriveItemContent(
 
 	resp, err := gr.Request(ctx, http.MethodGet, *url, nil, nil)
 	if err != nil {
-		return nil, clues.New("downloading item").With("error", err)
+		return nil, clues.New("requesting item content").With("error", err)
 	}
 	defer resp.Body.Close()
 
 	content, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, clues.New("read downloaded item").With("error", err)
+		return nil, clues.New("reading item content").With("error", err)
 	}
 
 	return content, nil

--- a/src/internal/m365/graph/http_wrapper.go
+++ b/src/internal/m365/graph/http_wrapper.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"regexp"
+	"time"
 
 	"github.com/alcionai/clues"
 	khttp "github.com/microsoft/kiota-http-go"
 
+	"github.com/alcionai/corso/src/internal/events"
 	"github.com/alcionai/corso/src/internal/version"
+	"github.com/alcionai/corso/src/pkg/logger"
 )
 
 // ---------------------------------------------------------------------------
@@ -70,6 +74,8 @@ func NewNoTimeoutHTTPWrapper(opts ...Option) *httpWrapper {
 // requests
 // ---------------------------------------------------------------------------
 
+var streamErrRE = regexp.MustCompile(`stream error: stream ID \d+; .+; received from peer`)
+
 // Request does the provided request.
 func (hw httpWrapper) Request(
 	ctx context.Context,
@@ -91,7 +97,35 @@ func (hw httpWrapper) Request(
 	// See https://learn.microsoft.com/en-us/sharepoint/dev/general-development/how-to-avoid-getting-throttled-or-blocked-in-sharepoint-online#how-to-decorate-your-http-traffic
 	req.Header.Set("User-Agent", "ISV|Alcion|Corso/"+version.Version)
 
-	resp, err := hw.client.Do(req)
+	var resp *http.Response
+
+	i := 0
+
+	// stream errors from http/2 will fail before we reach
+	// client middleware handling, therefore we don't get to
+	// make use of the retry middleware.  This external
+	// retry wrapper is unsophisticated, but should only
+	// retry in the event of a `stream error`, which is not
+	// a common expectation.
+	for i < 3 {
+		ictx := clues.Add(ctx, "request_retry_iter", i)
+
+		resp, err = hw.client.Do(req)
+		if err != nil && !streamErrRE.MatchString(err.Error()) {
+			return nil, Stack(ictx, err)
+		}
+
+		if err == nil {
+			break
+		}
+
+		logger.Ctx(ictx).Debug("retrying after stream error")
+		events.Inc(events.APICall, "streamerror")
+
+		time.Sleep(3 * time.Second)
+		i++
+	}
+
 	if err != nil {
 		return nil, Stack(ctx, err)
 	}
@@ -135,6 +169,7 @@ func (pl pipeline) Next(req *http.Request, idx int) (*http.Response, error) {
 func defaultTransport() http.RoundTripper {
 	defaultTransport := http.DefaultTransport.(*http.Transport).Clone()
 	defaultTransport.ForceAttemptHTTP2 = true
+	defaultTransport.IdleConnTimeout = 0 // no limit
 
 	return defaultTransport
 }

--- a/src/internal/m365/graph/http_wrapper.go
+++ b/src/internal/m365/graph/http_wrapper.go
@@ -169,7 +169,6 @@ func (pl pipeline) Next(req *http.Request, idx int) (*http.Response, error) {
 func defaultTransport() http.RoundTripper {
 	defaultTransport := http.DefaultTransport.(*http.Transport).Clone()
 	defaultTransport.ForceAttemptHTTP2 = true
-	defaultTransport.IdleConnTimeout = 0 // no limit
 
 	return defaultTransport
 }

--- a/src/pkg/fault/fault.go
+++ b/src/pkg/fault/fault.go
@@ -137,9 +137,9 @@ func (e *Bus) logAndAddRecoverable(ctx context.Context, err error, skip int) {
 	isFail := e.addRecoverableErr(err)
 
 	if isFail {
-		log.Error("recoverable error")
+		log.Errorf("recoverable error: %v", err)
 	} else {
-		log.Info("recoverable error")
+		log.Infof("recoverable error: %v", err)
 	}
 }
 

--- a/src/pkg/selectors/selectors.go
+++ b/src/pkg/selectors/selectors.go
@@ -34,7 +34,7 @@ var serviceToPathType = map[service]path.ServiceType{
 
 var (
 	ErrorBadSelectorCast     = clues.New("wrong selector service type")
-	ErrorNoMatchingItems     = clues.New("no items match the specified selectors")
+	ErrorNoMatchingItems     = clues.New("no items match the provided selectors")
 	ErrorUnrecognizedService = clues.New("unrecognized service")
 )
 


### PR DESCRIPTION
http/2 stream error failures don't allow
us to leverage client middleware.  As a
result we're lacking a retry handler.  This
change adds retries for http_wrapper
in the explicit case of a http/2 stream
error.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

#### Type of change

- [x] :bug: Bugfix

#### Test Plan

- [x] :muscle: Manual
- [x] :green_heart: E2E
