### PR TITLE
Fix details comparison

### DIFF
--- a/src/pkg/backup/details/testdata/in_deets.go
+++ b/src/pkg/backup/details/testdata/in_deets.go
@@ -329,18 +329,20 @@ func CheckBackupDetails(
 		}
 
 		// Compare folders.
+		// Have result first since it may be a Subset call.
 		check(
 			t,
-			maps.Keys(expect.Sets[set].Locations),
 			maps.Keys(result.Sets[set].Locations),
+			maps.Keys(expect.Sets[set].Locations),
 			"results in %s missing expected location", set)
 
 		// Compare items in folders.
 		for lr, items := range expect.Sets[set].Locations {
+			// Have result first since it may be a Subset call.
 			check(
 				t,
-				maps.Keys(items),
 				maps.Keys(result.Sets[set].Locations[lr]),
+				maps.Keys(items),
 				"results in set %s location %s missing expected item",
 				set,
 				lr)


### PR DESCRIPTION
Reorder comparison parameters since sometimes it's a `Subset`
call instead of `ElementsMatch` call

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3777

#### Test Plan

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
