### PR TITLE
add extra restore checks

### DIFF
--- a/src/internal/m365/onedrive/handlers.go
+++ b/src/internal/m365/onedrive/handlers.go
@@ -117,7 +117,7 @@ type GetItemsByCollisionKeyser interface {
 	GetItemsInContainerByCollisionKey(
 		ctx context.Context,
 		driveID, containerID string,
-	) (map[string]api.DriveCollisionItem, error)
+	) (map[string]api.DriveItemIDType, error)
 }
 
 type NewItemContentUploader interface {

--- a/src/internal/m365/onedrive/item_handler.go
+++ b/src/internal/m365/onedrive/item_handler.go
@@ -164,7 +164,7 @@ func (h itemRestoreHandler) DeleteItemPermission(
 func (h itemRestoreHandler) GetItemsInContainerByCollisionKey(
 	ctx context.Context,
 	driveID, containerID string,
-) (map[string]api.DriveCollisionItem, error) {
+) (map[string]api.DriveItemIDType, error) {
 	m, err := h.ac.GetItemsInContainerByCollisionKey(ctx, driveID, containerID)
 	if err != nil {
 		return nil, err

--- a/src/internal/m365/onedrive/mock/handlers.go
+++ b/src/internal/m365/onedrive/mock/handlers.go
@@ -239,7 +239,7 @@ func (m GetsItemPermission) GetItemPermission(
 type RestoreHandler struct {
 	ItemInfo details.ItemInfo
 
-	CollisionKeyMap map[string]api.DriveCollisionItem
+	CollisionKeyMap map[string]api.DriveItemIDType
 
 	CalledDeleteItem   bool
 	CalledDeleteItemOn string
@@ -264,7 +264,7 @@ func (h *RestoreHandler) AugmentItemInfo(
 func (h *RestoreHandler) GetItemsInContainerByCollisionKey(
 	context.Context,
 	string, string,
-) (map[string]api.DriveCollisionItem, error) {
+) (map[string]api.DriveItemIDType, error) {
 	return h.CollisionKeyMap, nil
 }
 

--- a/src/internal/m365/onedrive/restore.go
+++ b/src/internal/m365/onedrive/restore.go
@@ -38,7 +38,7 @@ const (
 )
 
 type restoreCaches struct {
-	collisionKeyToItemID  map[string]api.DriveCollisionItem
+	collisionKeyToItemID  map[string]api.DriveItemIDType
 	DriveIDToRootFolderID map[string]string
 	Folders               *folderCache
 	OldLinkShareIDToNewID map[string]string
@@ -50,7 +50,7 @@ type restoreCaches struct {
 
 func NewRestoreCaches() *restoreCaches {
 	return &restoreCaches{
-		collisionKeyToItemID:  map[string]api.DriveCollisionItem{},
+		collisionKeyToItemID:  map[string]api.DriveItemIDType{},
 		DriveIDToRootFolderID: map[string]string{},
 		Folders:               NewFolderCache(),
 		OldLinkShareIDToNewID: map[string]string{},
@@ -478,7 +478,7 @@ func restoreV0File(
 	fibn data.FetchItemByNamer,
 	restoreFolderID string,
 	copyBuffer []byte,
-	collisionKeyToItemID map[string]api.DriveCollisionItem,
+	collisionKeyToItemID map[string]api.DriveItemIDType,
 	itemData data.Stream,
 	ctr *count.Bus,
 ) (details.ItemInfo, error) {
@@ -808,7 +808,7 @@ func restoreFile(
 	name string,
 	itemData data.Stream,
 	driveID, parentFolderID string,
-	collisionKeyToItemID map[string]api.DriveCollisionItem,
+	collisionKeyToItemID map[string]api.DriveItemIDType,
 	copyBuffer []byte,
 	ctr *count.Bus,
 ) (string, details.ItemInfo, error) {
@@ -826,7 +826,7 @@ func restoreFile(
 	var (
 		item                 = newItem(name, false)
 		collisionKey         = api.DriveItemCollisionKey(item)
-		collision            api.DriveCollisionItem
+		collision            api.DriveItemIDType
 		shouldDeleteOriginal bool
 	)
 

--- a/src/internal/m365/onedrive/restore_test.go
+++ b/src/internal/m365/onedrive/restore_test.go
@@ -337,7 +337,7 @@ func (suite *RestoreUnitSuite) TestRestoreItem_collisionHandling() {
 
 	table := []struct {
 		name          string
-		collisionKeys map[string]api.DriveCollisionItem
+		collisionKeys map[string]api.DriveItemIDType
 		onCollision   control.CollisionPolicy
 		deleteErr     error
 		expectSkipped assert.BoolAssertionFunc
@@ -346,7 +346,7 @@ func (suite *RestoreUnitSuite) TestRestoreItem_collisionHandling() {
 	}{
 		{
 			name:          "no collision, copy",
-			collisionKeys: map[string]api.DriveCollisionItem{},
+			collisionKeys: map[string]api.DriveItemIDType{},
 			onCollision:   control.Copy,
 			expectSkipped: assert.False,
 			expectMock: func(t *testing.T, rh *mock.RestoreHandler) {
@@ -357,7 +357,7 @@ func (suite *RestoreUnitSuite) TestRestoreItem_collisionHandling() {
 		},
 		{
 			name:          "no collision, replace",
-			collisionKeys: map[string]api.DriveCollisionItem{},
+			collisionKeys: map[string]api.DriveItemIDType{},
 			onCollision:   control.Replace,
 			expectSkipped: assert.False,
 			expectMock: func(t *testing.T, rh *mock.RestoreHandler) {
@@ -368,7 +368,7 @@ func (suite *RestoreUnitSuite) TestRestoreItem_collisionHandling() {
 		},
 		{
 			name:          "no collision, skip",
-			collisionKeys: map[string]api.DriveCollisionItem{},
+			collisionKeys: map[string]api.DriveItemIDType{},
 			onCollision:   control.Skip,
 			expectSkipped: assert.False,
 			expectMock: func(t *testing.T, rh *mock.RestoreHandler) {
@@ -379,7 +379,7 @@ func (suite *RestoreUnitSuite) TestRestoreItem_collisionHandling() {
 		},
 		{
 			name: "collision, copy",
-			collisionKeys: map[string]api.DriveCollisionItem{
+			collisionKeys: map[string]api.DriveItemIDType{
 				mock.DriveItemFileName: {ItemID: mndiID},
 			},
 			onCollision:   control.Copy,
@@ -392,7 +392,7 @@ func (suite *RestoreUnitSuite) TestRestoreItem_collisionHandling() {
 		},
 		{
 			name: "collision, replace",
-			collisionKeys: map[string]api.DriveCollisionItem{
+			collisionKeys: map[string]api.DriveItemIDType{
 				mock.DriveItemFileName: {ItemID: mndiID},
 			},
 			onCollision:   control.Replace,
@@ -406,7 +406,7 @@ func (suite *RestoreUnitSuite) TestRestoreItem_collisionHandling() {
 		},
 		{
 			name: "collision, replace - err already deleted",
-			collisionKeys: map[string]api.DriveCollisionItem{
+			collisionKeys: map[string]api.DriveItemIDType{
 				mock.DriveItemFileName: {ItemID: "smarf"},
 			},
 			onCollision:   control.Replace,
@@ -420,7 +420,7 @@ func (suite *RestoreUnitSuite) TestRestoreItem_collisionHandling() {
 		},
 		{
 			name: "collision, skip",
-			collisionKeys: map[string]api.DriveCollisionItem{
+			collisionKeys: map[string]api.DriveItemIDType{
 				mock.DriveItemFileName: {ItemID: mndiID},
 			},
 			onCollision:   control.Skip,
@@ -433,7 +433,7 @@ func (suite *RestoreUnitSuite) TestRestoreItem_collisionHandling() {
 		},
 		{
 			name: "file-folder collision, copy",
-			collisionKeys: map[string]api.DriveCollisionItem{
+			collisionKeys: map[string]api.DriveItemIDType{
 				mock.DriveItemFileName: {
 					ItemID:   mndiID,
 					IsFolder: true,
@@ -449,7 +449,7 @@ func (suite *RestoreUnitSuite) TestRestoreItem_collisionHandling() {
 		},
 		{
 			name: "file-folder collision, replace",
-			collisionKeys: map[string]api.DriveCollisionItem{
+			collisionKeys: map[string]api.DriveItemIDType{
 				mock.DriveItemFileName: {
 					ItemID:   mndiID,
 					IsFolder: true,
@@ -465,7 +465,7 @@ func (suite *RestoreUnitSuite) TestRestoreItem_collisionHandling() {
 		},
 		{
 			name: "file-folder collision, skip",
-			collisionKeys: map[string]api.DriveCollisionItem{
+			collisionKeys: map[string]api.DriveItemIDType{
 				mock.DriveItemFileName: {
 					ItemID:   mndiID,
 					IsFolder: true,

--- a/src/internal/m365/sharepoint/library_handler.go
+++ b/src/internal/m365/sharepoint/library_handler.go
@@ -190,7 +190,7 @@ func (h libraryRestoreHandler) DeleteItemPermission(
 func (h libraryRestoreHandler) GetItemsInContainerByCollisionKey(
 	ctx context.Context,
 	driveID, containerID string,
-) (map[string]api.DriveCollisionItem, error) {
+) (map[string]api.DriveItemIDType, error) {
 	m, err := h.ac.GetItemsInContainerByCollisionKey(ctx, driveID, containerID)
 	if err != nil {
 		return nil, err

--- a/src/internal/operations/test/exchange_test.go
+++ b/src/internal/operations/test/exchange_test.go
@@ -1238,7 +1238,7 @@ func (suite *ExchangeRestoreIntgSuite) TestRestore_Run_exchangeWithAdvancedOptio
 		require.NoError(t, err, clues.ToCore(err))
 
 		assert.Equal(t, 2*len(mailIDs), len(currentMailIDs), "count of ids should be double from before")
-		assert.Subset(t, maps.Keys(mailIDs), maps.Keys(currentMailIDs), "original item should exist after copy")
+		assert.Subset(t, maps.Keys(currentMailIDs), maps.Keys(mailIDs), "original item should exist after copy")
 
 		// TODO: we have the option of modifying copy creations in exchange
 		// so that the results don't collide.  But we haven't made that

--- a/src/internal/operations/test/exchange_test.go
+++ b/src/internal/operations/test/exchange_test.go
@@ -1129,10 +1129,9 @@ func (suite *ExchangeRestoreIntgSuite) TestRestore_Run_exchangeWithAdvancedOptio
 		currentContactIDs, err := acCont.GetItemIDsInContainer(ctx, userID, cIDs[path.ContactsCategory])
 		require.NoError(t, err, clues.ToCore(err))
 
-		assert.Equal(t, len(contactIDs), len(currentContactIDs), "count of ids ids are equal")
+		assert.Equal(t, len(contactIDs), len(currentContactIDs), "count of ids are equal")
 		for orig := range contactIDs {
-			_, ok := currentContactIDs[orig]
-			assert.False(t, ok, "original item should not exist after replacement")
+			assert.NotContains(t, currentContactIDs, orig, "original item should not exist after replacement")
 		}
 
 		contactIDs = currentContactIDs
@@ -1160,8 +1159,7 @@ func (suite *ExchangeRestoreIntgSuite) TestRestore_Run_exchangeWithAdvancedOptio
 
 		assert.Equal(t, len(mailIDs), len(currentMailIDs), "count of ids are equal")
 		for orig := range mailIDs {
-			_, ok := currentMailIDs[orig]
-			assert.False(t, ok, "original item should not exist after replacement")
+			assert.NotContains(t, currentMailIDs, orig, "original item should not exist after replacement")
 		}
 
 		mailIDs = currentMailIDs
@@ -1222,10 +1220,7 @@ func (suite *ExchangeRestoreIntgSuite) TestRestore_Run_exchangeWithAdvancedOptio
 		require.NoError(t, err, clues.ToCore(err))
 
 		assert.Equal(t, 2*len(contactIDs), len(currentContactIDs), "count of ids should be double from before")
-		for orig := range contactIDs {
-			_, ok := currentContactIDs[orig]
-			assert.True(t, ok, "original item should exist after copy")
-		}
+		assert.Subset(t, maps.Keys(currentContactIDs), maps.Keys(contactIDs), "original item should exist after copy")
 
 		// m = checkCollisionKeyResults(t, ctx, userID, cIDs[path.EventsCategory], acEvts, collKeys[path.EventsCategory])
 		// maps.Copy(result, m)
@@ -1243,10 +1238,7 @@ func (suite *ExchangeRestoreIntgSuite) TestRestore_Run_exchangeWithAdvancedOptio
 		require.NoError(t, err, clues.ToCore(err))
 
 		assert.Equal(t, 2*len(mailIDs), len(currentMailIDs), "count of ids should be double from before")
-		for orig := range mailIDs {
-			_, ok := currentMailIDs[orig]
-			assert.True(t, ok, "original item should exist after copy")
-		}
+		assert.Subset(t, maps.Keys(mailIDs), maps.Keys(currentMailIDs), "original item should exist after copy")
 
 		// TODO: we have the option of modifying copy creations in exchange
 		// so that the results don't collide.  But we haven't made that

--- a/src/internal/operations/test/onedrive_test.go
+++ b/src/internal/operations/test/onedrive_test.go
@@ -1106,8 +1106,7 @@ func runDriveRestoreWithAdvancedOptions(
 
 		assert.Equal(t, len(fileIDs), len(currentFileIDs), "count of ids ids are equal")
 		for orig := range fileIDs {
-			_, ok := currentFileIDs[orig]
-			assert.False(t, ok, "original item should not exist after replacement")
+			assert.NotContains(t, currentFileIDs, orig, "original item should not exist after replacement")
 		}
 
 		fileIDs = currentFileIDs
@@ -1167,9 +1166,6 @@ func runDriveRestoreWithAdvancedOptions(
 		require.NoError(t, err, clues.ToCore(err))
 
 		assert.Equal(t, 2*len(fileIDs), len(currentFileIDs), "count of ids should be double from before")
-		for orig := range fileIDs {
-			_, ok := currentFileIDs[orig]
-			assert.True(t, ok, "original item should exist after copy")
-		}
+		assert.Subset(t, maps.Keys(currentFileIDs), maps.Keys(fileIDs), "original item should exist after copy")
 	})
 }

--- a/src/pkg/services/m365/api/contacts_pager.go
+++ b/src/pkg/services/m365/api/contacts_pager.go
@@ -166,6 +166,27 @@ func (c Contacts) GetItemsInContainerByCollisionKey(
 	return m, nil
 }
 
+func (c Contacts) GetItemIDsInContainer(
+	ctx context.Context,
+	userID, containerID string,
+) (map[string]struct{}, error) {
+	ctx = clues.Add(ctx, "container_id", containerID)
+	pager := c.NewContactsPager(userID, containerID, "id")
+
+	items, err := enumerateItems(ctx, pager)
+	if err != nil {
+		return nil, graph.Wrap(ctx, err, "enumerating contacts")
+	}
+
+	m := map[string]struct{}{}
+
+	for _, item := range items {
+		m[ptr.Val(item.GetId())] = struct{}{}
+	}
+
+	return m, nil
+}
+
 // ---------------------------------------------------------------------------
 // item ID pager
 // ---------------------------------------------------------------------------

--- a/src/pkg/services/m365/api/drive_pager_test.go
+++ b/src/pkg/services/m365/api/drive_pager_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
@@ -68,7 +69,7 @@ func (suite *DrivePagerIntgSuite) TestDrives_GetItemsInContainerByCollisionKey()
 			require.NoError(t, err, clues.ToCore(err))
 
 			ims := items.GetValue()
-			expect := make([]api.DriveCollisionItem, 0, len(ims))
+			expect := make([]api.DriveItemIDType, 0, len(ims))
 
 			assert.NotEmptyf(
 				t,
@@ -100,6 +101,80 @@ func (suite *DrivePagerIntgSuite) TestDrives_GetItemsInContainerByCollisionKey()
 				assert.Truef(t, ok, "expected results to contain collision key: %s", e)
 				assert.Equal(t, e, r)
 			}
+		})
+	}
+}
+
+func (suite *DrivePagerIntgSuite) TestDrives_GetItemIDsInContainer() {
+	table := []struct {
+		name         string
+		driveID      string
+		rootFolderID string
+	}{
+		{
+			name:         "user drive",
+			driveID:      suite.its.userDriveID,
+			rootFolderID: suite.its.userDriveRootFolderID,
+		},
+		{
+			name:         "site drive",
+			driveID:      suite.its.siteDriveID,
+			rootFolderID: suite.its.siteDriveRootFolderID,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			t.Log("drive", test.driveID)
+			t.Log("rootFolder", test.rootFolderID)
+
+			items, err := suite.its.ac.Stable.
+				Client().
+				Drives().
+				ByDriveId(test.driveID).
+				Items().
+				ByDriveItemId(test.rootFolderID).
+				Children().
+				Get(ctx, nil)
+			require.NoError(t, err, clues.ToCore(err))
+
+			igv := items.GetValue()
+			expect := map[string]api.DriveItemIDType{}
+
+			assert.NotEmptyf(
+				t,
+				igv,
+				"need at least one item to compare in user %s drive %s folder %s",
+				suite.its.userID, test.driveID, test.rootFolderID)
+
+			for _, itm := range igv {
+				expect[ptr.Val(itm.GetId())] = api.DriveItemIDType{
+					ItemID:   ptr.Val(itm.GetId()),
+					IsFolder: itm.GetFolder() != nil,
+				}
+			}
+
+			results, err := suite.its.ac.
+				Drives().
+				GetItemIDsInContainer(ctx, test.driveID, test.rootFolderID)
+			require.NoError(t, err, clues.ToCore(err))
+			require.NotEmpty(t, results)
+			require.Equal(t, len(expect), len(results), "must have same count of items")
+
+			for k := range expect {
+				t.Log("expects key", k)
+			}
+
+			for k, v := range results {
+				t.Log("results key", k)
+				assert.NotEmpty(t, v, "all values should be populated")
+			}
+
+			assert.Equal(t, expect, results)
 		})
 	}
 }

--- a/src/pkg/services/m365/api/mail_pager.go
+++ b/src/pkg/services/m365/api/mail_pager.go
@@ -247,6 +247,27 @@ func (c Mail) GetItemsInContainerByCollisionKey(
 	return m, nil
 }
 
+func (c Mail) GetItemIDsInContainer(
+	ctx context.Context,
+	userID, containerID string,
+) (map[string]struct{}, error) {
+	ctx = clues.Add(ctx, "container_id", containerID)
+	pager := c.NewMailPager(userID, containerID, "id")
+
+	items, err := enumerateItems(ctx, pager)
+	if err != nil {
+		return nil, graph.Wrap(ctx, err, "enumerating contacts")
+	}
+
+	m := map[string]struct{}{}
+
+	for _, item := range items {
+		m[ptr.Val(item.GetId())] = struct{}{}
+	}
+
+	return m, nil
+}
+
 // ---------------------------------------------------------------------------
 // delta item ID pager
 // ---------------------------------------------------------------------------

--- a/src/pkg/services/m365/api/mail_pager_test.go
+++ b/src/pkg/services/m365/api/mail_pager_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/alcionai/clues"
+	"github.com/microsoftgraph/msgraph-sdk-go/users"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -82,4 +83,51 @@ func (suite *MailPagerIntgSuite) TestMail_GetItemsInContainerByCollisionKey() {
 		_, ok := results[e]
 		assert.Truef(t, ok, "expected results to contain collision key: %s", e)
 	}
+}
+
+func (suite *MailPagerIntgSuite) TestMail_GetItemsIDsInContainer() {
+	t := suite.T()
+	ac := suite.its.ac.Mail()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	config := &users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration{
+		QueryParameters: &users.ItemMailFoldersItemMessagesRequestBuilderGetQueryParameters{
+			Top: ptr.To[int32](1000),
+		},
+	}
+
+	msgs, err := ac.Stable.
+		Client().
+		Users().
+		ByUserId(suite.its.userID).
+		MailFolders().
+		ByMailFolderId(api.MailInbox).
+		Messages().
+		Get(ctx, config)
+	require.NoError(t, err, clues.ToCore(err))
+
+	ms := msgs.GetValue()
+	expect := map[string]struct{}{}
+
+	for _, m := range ms {
+		expect[ptr.Val(m.GetId())] = struct{}{}
+	}
+
+	results, err := suite.its.ac.Mail().
+		GetItemIDsInContainer(ctx, suite.its.userID, api.MailInbox)
+	require.NoError(t, err, clues.ToCore(err))
+	require.Less(t, 0, len(results), "requires at least one result")
+	require.Equal(t, len(expect), len(results), "must have same count of items")
+
+	for k := range expect {
+		t.Log("expects key", k)
+	}
+
+	for k := range results {
+		t.Log("results key", k)
+	}
+
+	assert.Equal(t, expect, results)
 }


### PR DESCRIPTION
Adds extra checks to the restore op tests that
retrieves and compares the lists of item ids
after each restore step.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Supportability/Tests

#### Issue(s)

* #3562

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
