### PR TITLE
Operations level changes for OneDrive exports

### DIFF
--- a/src/internal/archive/zip.go
+++ b/src/internal/archive/zip.go
@@ -7,6 +7,7 @@ import (
 	"path"
 
 	"github.com/alcionai/clues"
+
 	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/pkg/export"
 )

--- a/src/internal/archive/zip.go
+++ b/src/internal/archive/zip.go
@@ -1,0 +1,98 @@
+package archive
+
+import (
+	"archive/zip"
+	"context"
+	"io"
+	"path"
+
+	"github.com/alcionai/clues"
+	"github.com/alcionai/corso/src/internal/common/dttm"
+	"github.com/alcionai/corso/src/pkg/export"
+)
+
+const (
+	// ZipCopyBufferSize is the size of the copy buffer for zip
+	// write operations
+	// TODO(meain): tweak this value
+	ZipCopyBufferSize = 5 * 1024 * 1024
+)
+
+type zipCollection struct {
+	reader io.ReadCloser
+}
+
+func (z zipCollection) BasePath() string {
+	return ""
+}
+
+func (z zipCollection) Items(ctx context.Context) <-chan export.Item {
+	rc := make(chan export.Item, 1)
+	defer close(rc)
+
+	rc <- export.Item{
+		Data: export.ItemData{
+			Name: "Corso_Export_" + dttm.FormatNow(dttm.HumanReadable) + ".zip",
+			Body: z.reader,
+		},
+	}
+
+	return rc
+}
+
+// ZipExportCollection takes a list of export collections and zips
+// them into a single collection.
+func ZipExportCollection(
+	ctx context.Context,
+	expCollections []export.Collection,
+) (export.Collection, error) {
+	if len(expCollections) == 0 {
+		return nil, clues.New("no export collections provided")
+	}
+
+	reader, writer := io.Pipe()
+	wr := zip.NewWriter(writer)
+
+	go func() {
+		defer writer.Close()
+		defer wr.Close()
+
+		buf := make([]byte, ZipCopyBufferSize)
+
+		for _, ec := range expCollections {
+			folder := ec.BasePath()
+			items := ec.Items(ctx)
+
+			for item := range items {
+				err := item.Error
+				if err != nil {
+					writer.CloseWithError(clues.Wrap(err, "getting export item").With("id", item.ID))
+					return
+				}
+
+				name := item.Data.Name
+
+				// We assume folder and name to not contain any path separators.
+				// Also, this should always use `/` as this is
+				// created within a zip file and not written to disk.
+				// TODO(meain): Exchange paths might contain a path
+				// separator and will have to have special handling.
+
+				//nolint:forbidigo
+				f, err := wr.Create(path.Join(folder, name))
+				if err != nil {
+					writer.CloseWithError(clues.Wrap(err, "creating zip entry").With("name", name).With("id", item.ID))
+					return
+				}
+
+				_, err = io.CopyBuffer(f, item.Data.Body, buf)
+				if err != nil {
+					writer.CloseWithError(clues.Wrap(err, "writing zip entry").With("name", name).With("id", item.ID))
+					return
+				}
+			}
+		}
+	}()
+
+	return zipCollection{reader}, nil
+}

--- a/src/internal/events/events.go
+++ b/src/internal/events/events.go
@@ -35,6 +35,8 @@ const (
 	BackupEnd        = "Backup End"
 	RestoreStart     = "Restore Start"
 	RestoreEnd       = "Restore End"
+	ExportStart      = "Export Start"
+	ExportEnd        = "Export End"
 	MaintenanceStart = "Maintenance Start"
 	MaintenanceEnd   = "Maintenance End"
 
@@ -49,6 +51,7 @@ const (
 	ItemsWritten     = "items_written"
 	Resources        = "resources"
 	RestoreID        = "restore_id"
+	ExportID         = "export_id"
 	Service          = "service"
 	StartTime        = "start_time"
 	Status           = "status"

--- a/src/internal/m365/controller.go
+++ b/src/internal/m365/controller.go
@@ -24,6 +24,7 @@ import (
 var (
 	_ inject.BackupProducer  = &Controller{}
 	_ inject.RestoreConsumer = &Controller{}
+	_ inject.ExportConsumer  = &Controller{}
 )
 
 // Controller is a struct used to wrap the GraphServiceClient and

--- a/src/internal/m365/mock/connector.go
+++ b/src/internal/m365/mock/connector.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/count"
+	"github.com/alcionai/corso/src/pkg/export"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
@@ -71,3 +72,15 @@ func (ctrl Controller) ConsumeRestoreCollections(
 }
 
 func (ctrl Controller) CacheItemInfo(dii details.ItemInfo) {}
+
+func (ctrl Controller) ExportRestoreCollections(
+	_ context.Context,
+	_ int,
+	_ selectors.Selector,
+	_ control.ExportConfig,
+	_ control.Options,
+	_ []data.RestoreCollection,
+	_ *fault.Bus,
+) ([]export.Collection, error) {
+	return nil, ctrl.Err
+}

--- a/src/internal/m365/support/status.go
+++ b/src/internal/m365/support/status.go
@@ -40,6 +40,7 @@ const (
 	OpUnknown Operation = iota
 	Backup
 	Restore
+	Export
 )
 
 // Constructor for ConnectorOperationStatus. If the counts do not agree, an error is returned.

--- a/src/internal/operations/export.go
+++ b/src/internal/operations/export.go
@@ -285,7 +285,7 @@ func (op *ExportOperation) do(
 ) ([]export.Collection, error) {
 	logger.Ctx(ctx).
 		With("control_options", op.Options, "selectors", op.Selectors).
-		Info("restoring selection")
+		Info("exporting selection")
 
 	bup, deets, err := getBackupAndDetailsFromID(
 		ctx,
@@ -297,7 +297,7 @@ func (op *ExportOperation) do(
 		return nil, clues.Wrap(err, "getting backup and details")
 	}
 
-	observe.Message(ctx, "Restoring", observe.Bullet, clues.Hide(bup.Selector.DiscreteOwner))
+	observe.Message(ctx, "Exporting", observe.Bullet, clues.Hide(bup.Selector.DiscreteOwner))
 
 	paths, err := formatDetailsForRestoration(ctx, bup.Version, op.Selectors, deets, op.Errors)
 	if err != nil {
@@ -351,7 +351,7 @@ func (op *ExportOperation) do(
 		dcs,
 		op.Errors)
 	if err != nil {
-		return nil, clues.Wrap(err, "restoring collections")
+		return nil, clues.Wrap(err, "exporting collections")
 	}
 
 	opStats.ctrl = op.ec.Wait()

--- a/src/internal/operations/export.go
+++ b/src/internal/operations/export.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path"
 	"time"
 
 	"github.com/alcionai/clues"
@@ -204,7 +205,7 @@ func (z zipExportCol) Items(ctx context.Context) <-chan export.Item {
 
 	rc <- export.Item{
 		Data: export.ItemData{
-			Name: "export.zip",
+			Name: "Corso_Export_" + dttm.FormatNow(dttm.HumanReadable) + ".zip",
 			Body: z.reader,
 		},
 	}
@@ -242,7 +243,14 @@ func zipExportCollection(
 
 				name := item.Data.Name
 
-				f, err := wr.Create(folder + "/" + name)
+				// We assume folder and name to not contain any path separators.
+				// Also, this should always use `/` as this is
+				// created within a zip file and not written to disk.
+				// TODO(meain): Exchange paths might contain a path
+				// separator and will have to have special handling.
+
+				//nolint:forbidigo
+				f, err := wr.Create(path.Join(folder, name))
 				if err != nil {
 					writer.CloseWithError(clues.Wrap(err, "creating zip entry").With("name", name).With("id", item.ID))
 					return

--- a/src/internal/operations/export.go
+++ b/src/internal/operations/export.go
@@ -187,9 +187,9 @@ func (op *ExportOperation) Run(ctx context.Context) (
 	// Persistence
 	// -----
 
-	err = op.persistResults(ctx, start, &opStats)
+	err = op.finalizeMetrics(ctx, start, &opStats)
 	if err != nil {
-		op.Errors.Fail(clues.Wrap(err, "persisting export results"))
+		op.Errors.Fail(clues.Wrap(err, "finalizing export metrics"))
 		return nil, op.Errors.Failure()
 	}
 
@@ -371,7 +371,7 @@ func (op *ExportOperation) do(
 }
 
 // persists details and statistics about the export operation.
-func (op *ExportOperation) persistResults(
+func (op *ExportOperation) finalizeMetrics(
 	ctx context.Context,
 	started time.Time,
 	opStats *exportStats,

--- a/src/internal/operations/export.go
+++ b/src/internal/operations/export.go
@@ -1,0 +1,423 @@
+package operations
+
+import (
+	"archive/zip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/alcionai/clues"
+	"github.com/google/uuid"
+
+	"github.com/alcionai/corso/src/internal/common/crash"
+	"github.com/alcionai/corso/src/internal/common/dttm"
+	"github.com/alcionai/corso/src/internal/data"
+	"github.com/alcionai/corso/src/internal/diagnostics"
+	"github.com/alcionai/corso/src/internal/events"
+	"github.com/alcionai/corso/src/internal/kopia"
+	"github.com/alcionai/corso/src/internal/model"
+	"github.com/alcionai/corso/src/internal/observe"
+	"github.com/alcionai/corso/src/internal/operations/inject"
+	"github.com/alcionai/corso/src/internal/stats"
+	"github.com/alcionai/corso/src/internal/streamstore"
+	"github.com/alcionai/corso/src/pkg/account"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/count"
+	"github.com/alcionai/corso/src/pkg/export"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/logger"
+	"github.com/alcionai/corso/src/pkg/selectors"
+	"github.com/alcionai/corso/src/pkg/store"
+)
+
+// ExportOperation wraps an operation with export-specific props.
+type ExportOperation struct {
+	operation
+
+	BackupID  model.StableID
+	Results   RestoreResults
+	Selectors selectors.Selector
+	ExportCfg control.ExportConfig
+	Version   string
+
+	acct account.Account
+	ec   inject.ExportConsumer
+}
+
+// NewExportOperation constructs and validates a export operation.
+func NewExportOperation(
+	ctx context.Context,
+	opts control.Options,
+	kw *kopia.Wrapper,
+	sw *store.Wrapper,
+	ec inject.ExportConsumer,
+	acct account.Account,
+	backupID model.StableID,
+	sel selectors.Selector,
+	exportCfg control.ExportConfig,
+	bus events.Eventer,
+) (ExportOperation, error) {
+	op := ExportOperation{
+		operation: newOperation(opts, bus, count.New(), kw, sw),
+		acct:      acct,
+		BackupID:  backupID,
+		ExportCfg: exportCfg,
+		Selectors: sel,
+		Version:   "v0",
+		ec:        ec,
+	}
+	if err := op.validate(); err != nil {
+		return ExportOperation{}, err
+	}
+
+	return op, nil
+}
+
+func (op ExportOperation) validate() error {
+	if op.ec == nil {
+		return clues.New("missing export consumer")
+	}
+
+	return op.operation.validate()
+}
+
+// aggregates stats from the export.Run().
+// primarily used so that the defer can take in a
+// pointer wrapping the values, while those values
+// get populated asynchronously.
+type exportStats struct {
+	cs            []data.RestoreCollection
+	ctrl          *data.CollectionStats
+	bytesRead     *stats.ByteCounter
+	resourceCount int
+
+	// a transient value only used to pair up start-end events.
+	exportID string
+}
+
+// Run begins a synchronous export operation.
+func (op *ExportOperation) Run(ctx context.Context) (
+	expColl []export.Collection,
+	err error,
+) {
+	defer func() {
+		if crErr := crash.Recovery(ctx, recover(), "export"); crErr != nil {
+			err = crErr
+		}
+	}()
+
+	var (
+		opStats = exportStats{
+			bytesRead: &stats.ByteCounter{},
+			exportID:  uuid.NewString(),
+		}
+		start  = time.Now()
+		sstore = streamstore.NewStreamer(op.kopia, op.acct.ID(), op.Selectors.PathService())
+	)
+
+	// -----
+	// Setup
+	// -----
+
+	ctx, end := diagnostics.Span(ctx, "operations:export:run")
+	defer func() {
+		end()
+		// wait for the progress display to clean up
+		observe.Complete()
+	}()
+
+	ctx, flushMetrics := events.NewMetrics(ctx, logger.Writer{Ctx: ctx})
+	defer flushMetrics()
+
+	ctx = clues.Add(
+		ctx,
+		"tenant_id", clues.Hide(op.acct.ID()),
+		"backup_id", op.BackupID,
+		"service", op.Selectors.Service)
+
+	defer func() {
+		op.bus.Event(
+			ctx,
+			events.ExportEnd,
+			map[string]any{
+				events.BackupID:      op.BackupID,
+				events.DataRetrieved: op.Results.BytesRead,
+				events.Duration:      op.Results.CompletedAt.Sub(op.Results.StartedAt),
+				events.EndTime:       dttm.Format(op.Results.CompletedAt),
+				events.ItemsRead:     op.Results.ItemsRead,
+				events.ItemsWritten:  op.Results.ItemsWritten,
+				events.Resources:     op.Results.ResourceOwners,
+				events.ExportID:      opStats.exportID,
+				events.Service:       op.Selectors.Service.String(),
+				events.StartTime:     dttm.Format(op.Results.StartedAt),
+				events.Status:        op.Status.String(),
+			})
+	}()
+
+	// -----
+	// Execution
+	// -----
+
+	expCollections, err := op.do(ctx, &opStats, sstore, start)
+	if err != nil {
+		// No return here!  We continue down to persistResults, even in case of failure.
+		logger.CtxErr(ctx, err).Error("running export")
+
+		if errors.Is(err, kopia.ErrNoRestorePath) {
+			op.Errors.Fail(clues.New("empty backup or unknown path provided"))
+		}
+
+		op.Errors.Fail(clues.Wrap(err, "running export"))
+	}
+
+	finalizeErrorHandling(ctx, op.Options, op.Errors, "running export")
+	LogFaultErrors(ctx, op.Errors.Errors(), "running export")
+
+	// -----
+	// Persistence
+	// -----
+
+	err = op.persistResults(ctx, start, &opStats)
+	if err != nil {
+		op.Errors.Fail(clues.Wrap(err, "persisting export results"))
+		return nil, op.Errors.Failure()
+	}
+
+	logger.Ctx(ctx).Infow("completed export", "results", op.Results)
+
+	return expCollections, nil
+}
+
+type zipExportCol struct {
+	reader io.ReadCloser
+}
+
+func (z zipExportCol) BasePath() string {
+	return ""
+}
+
+func (z zipExportCol) Items(ctx context.Context) <-chan export.Item {
+	rc := make(chan export.Item, 1)
+	defer close(rc)
+
+	rc <- export.Item{
+		Data: export.ItemData{
+			Name: "export.zip",
+			Body: z.reader,
+		},
+	}
+
+	return rc
+}
+
+// zipExportCollection takes a list of export collections and zips
+// them into a single collection.
+func zipExportCollection(
+	ctx context.Context,
+	expCollections []export.Collection,
+) (export.Collection, error) {
+	if len(expCollections) == 0 {
+		return nil, clues.New("no export collections provided")
+	}
+
+	reader, writer := io.Pipe()
+	wr := zip.NewWriter(writer)
+
+	go func() {
+		defer writer.Close()
+		defer wr.Close()
+
+		for _, ec := range expCollections {
+			folder := ec.BasePath()
+			items := ec.Items(ctx)
+
+			for item := range items {
+				err := item.Error
+				if err != nil {
+					writer.CloseWithError(clues.Wrap(err, "getting export item").With("id", item.ID))
+					return
+				}
+
+				name := item.Data.Name
+
+				f, err := wr.Create(folder + "/" + name)
+				if err != nil {
+					writer.CloseWithError(clues.Wrap(err, "creating zip entry").With("name", name).With("id", item.ID))
+					return
+				}
+
+				_, err = io.Copy(f, item.Data.Body)
+				if err != nil {
+					writer.CloseWithError(clues.Wrap(err, "writing zip entry").With("name", name).With("id", item.ID))
+					return
+				}
+			}
+		}
+	}()
+
+	return zipExportCol{reader}, nil
+}
+
+func (op *ExportOperation) do(
+	ctx context.Context,
+	opStats *exportStats,
+	detailsStore streamstore.Reader,
+	start time.Time,
+) ([]export.Collection, error) {
+	logger.Ctx(ctx).
+		With("control_options", op.Options, "selectors", op.Selectors).
+		Info("restoring selection")
+
+	bup, deets, err := getBackupAndDetailsFromID(
+		ctx,
+		op.BackupID,
+		op.store,
+		detailsStore,
+		op.Errors)
+	if err != nil {
+		return nil, clues.Wrap(err, "getting backup and details")
+	}
+
+	observe.Message(ctx, "Restoring", observe.Bullet, clues.Hide(bup.Selector.DiscreteOwner))
+
+	paths, err := formatDetailsForRestoration(ctx, bup.Version, op.Selectors, deets, op.Errors)
+	if err != nil {
+		return nil, clues.Wrap(err, "formatting paths from details")
+	}
+
+	ctx = clues.Add(
+		ctx,
+		"resource_owner_id", bup.Selector.ID(),
+		"resource_owner_name", clues.Hide(bup.Selector.Name()),
+		"details_entries", len(deets.Entries),
+		"details_paths", len(paths),
+		"backup_snapshot_id", bup.SnapshotID,
+		"backup_version", bup.Version)
+
+	op.bus.Event(
+		ctx,
+		events.ExportStart,
+		map[string]any{
+			events.StartTime:        start,
+			events.BackupID:         op.BackupID,
+			events.BackupCreateTime: bup.CreationTime,
+			events.ExportID:         opStats.exportID,
+		})
+
+	observe.Message(ctx, fmt.Sprintf("Discovered %d items in backup %s to export", len(paths), op.BackupID))
+
+	kopiaComplete := observe.MessageWithCompletion(ctx, "Enumerating items in repository")
+	defer close(kopiaComplete)
+
+	dcs, err := op.kopia.ProduceRestoreCollections(ctx, bup.SnapshotID, paths, opStats.bytesRead, op.Errors)
+	if err != nil {
+		return nil, clues.Wrap(err, "producing collections to export")
+	}
+
+	kopiaComplete <- struct{}{}
+
+	ctx = clues.Add(ctx, "coll_count", len(dcs))
+
+	// should always be 1, since backups are 1:1 with resourceOwners.
+	opStats.resourceCount = 1
+	opStats.cs = dcs
+
+	expCollections, err := exportRestoreCollections(
+		ctx,
+		op.ec,
+		bup.Version,
+		op.Selectors,
+		op.ExportCfg,
+		op.Options,
+		dcs,
+		op.Errors)
+	if err != nil {
+		return nil, clues.Wrap(err, "restoring collections")
+	}
+
+	opStats.ctrl = op.ec.Wait()
+
+	logger.Ctx(ctx).Debug(opStats.ctrl)
+
+	if op.ExportCfg.Archive {
+		zc, err := zipExportCollection(ctx, expCollections)
+		if err != nil {
+			return nil, clues.Wrap(err, "zipping export collections")
+		}
+
+		return []export.Collection{zc}, nil
+	}
+
+	return expCollections, nil
+}
+
+// persists details and statistics about the export operation.
+func (op *ExportOperation) persistResults(
+	ctx context.Context,
+	started time.Time,
+	opStats *exportStats,
+) error {
+	op.Results.StartedAt = started
+	op.Results.CompletedAt = time.Now()
+
+	op.Status = Completed
+
+	if op.Errors.Failure() != nil {
+		op.Status = Failed
+	}
+
+	op.Results.BytesRead = opStats.bytesRead.NumBytes
+	op.Results.ItemsRead = len(opStats.cs) // TODO: file count, not collection count
+	op.Results.ResourceOwners = opStats.resourceCount
+
+	if opStats.ctrl == nil {
+		op.Status = Failed
+		return clues.New("restoration never completed")
+	}
+
+	if op.Status != Failed && opStats.ctrl.IsZero() {
+		op.Status = NoData
+	}
+
+	// We don't have data on what all items were written
+	// op.Results.ItemsWritten = opStats.ctrl.Successes
+
+	return op.Errors.Failure()
+}
+
+// ---------------------------------------------------------------------------
+// Exportr funcs
+// ---------------------------------------------------------------------------
+
+func exportRestoreCollections(
+	ctx context.Context,
+	ec inject.ExportConsumer,
+	backupVersion int,
+	sel selectors.Selector,
+	exportCfg control.ExportConfig,
+	opts control.Options,
+	dcs []data.RestoreCollection,
+	errs *fault.Bus,
+) ([]export.Collection, error) {
+	complete := observe.MessageWithCompletion(ctx, "Preparing export")
+	defer func() {
+		complete <- struct{}{}
+		close(complete)
+	}()
+
+	expCollections, err := ec.ExportRestoreCollections(
+		ctx,
+		backupVersion,
+		sel,
+		exportCfg,
+		opts,
+		dcs,
+		errs)
+	if err != nil {
+		return nil, clues.Wrap(err, "exporting collections")
+	}
+
+	return expCollections, nil
+}

--- a/src/internal/operations/export.go
+++ b/src/internal/operations/export.go
@@ -299,7 +299,7 @@ func (op *ExportOperation) do(
 
 	observe.Message(ctx, "Exporting", observe.Bullet, clues.Hide(bup.Selector.DiscreteOwner))
 
-	paths, err := formatDetailsForRestoration(ctx, bup.Version, op.Selectors, deets, op.Errors)
+	paths, err := formatDetailsForRestoration(ctx, bup.Version, op.Selectors, deets, op.ec, op.Errors)
 	if err != nil {
 		return nil, clues.Wrap(err, "formatting paths from details")
 	}

--- a/src/internal/operations/export_test.go
+++ b/src/internal/operations/export_test.go
@@ -1,0 +1,267 @@
+package operations
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/alcionai/clues"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/data"
+	evmock "github.com/alcionai/corso/src/internal/events/mock"
+	"github.com/alcionai/corso/src/internal/kopia"
+	exchMock "github.com/alcionai/corso/src/internal/m365/exchange/mock"
+	"github.com/alcionai/corso/src/internal/m365/mock"
+	"github.com/alcionai/corso/src/internal/stats"
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/account"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/export"
+	"github.com/alcionai/corso/src/pkg/selectors"
+	"github.com/alcionai/corso/src/pkg/store"
+)
+
+type ExportOpSuite struct {
+	tester.Suite
+}
+
+func TestExportOpSuite(t *testing.T) {
+	suite.Run(t, &ExportOpSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *ExportOpSuite) TestExportOperation_PersistResults() {
+	var (
+		kw        = &kopia.Wrapper{}
+		sw        = &store.Wrapper{}
+		ctrl      = &mock.Controller{}
+		now       = time.Now()
+		exportCfg = control.DefaultExportConfig()
+	)
+
+	table := []struct {
+		expectStatus OpStatus
+		expectErr    assert.ErrorAssertionFunc
+		stats        exportStats
+		fail         error
+	}{
+		{
+			expectStatus: Completed,
+			expectErr:    assert.NoError,
+			stats: exportStats{
+				resourceCount: 1,
+				bytesRead: &stats.ByteCounter{
+					NumBytes: 42,
+				},
+				cs: []data.RestoreCollection{
+					data.NoFetchRestoreCollection{
+						Collection: &exchMock.DataCollection{},
+					},
+				},
+				ctrl: &data.CollectionStats{
+					Objects:   1,
+					Successes: 1,
+				},
+			},
+		},
+		{
+			expectStatus: Failed,
+			expectErr:    assert.Error,
+			fail:         assert.AnError,
+			stats: exportStats{
+				bytesRead: &stats.ByteCounter{},
+				ctrl:      &data.CollectionStats{},
+			},
+		},
+		{
+			expectStatus: NoData,
+			expectErr:    assert.NoError,
+			stats: exportStats{
+				bytesRead: &stats.ByteCounter{},
+				cs:        []data.RestoreCollection{},
+				ctrl:      &data.CollectionStats{},
+			},
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.expectStatus.String(), func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			op, err := NewExportOperation(
+				ctx,
+				control.Defaults(),
+				kw,
+				sw,
+				ctrl,
+				account.Account{},
+				"foo",
+				selectors.Selector{DiscreteOwner: "test"},
+				exportCfg,
+				evmock.NewBus())
+			require.NoError(t, err, clues.ToCore(err))
+
+			op.Errors.Fail(test.fail)
+
+			err = op.persistResults(ctx, now, &test.stats)
+			test.expectErr(t, err, clues.ToCore(err))
+
+			assert.Equal(t, test.expectStatus.String(), op.Status.String(), "status")
+			assert.Equal(t, len(test.stats.cs), op.Results.ItemsRead, "items read")
+			assert.Equal(t, test.stats.bytesRead.NumBytes, op.Results.BytesRead, "resource owners")
+			assert.Equal(t, test.stats.resourceCount, op.Results.ResourceOwners, "resource owners")
+			assert.Equal(t, now, op.Results.StartedAt, "started at")
+			assert.Less(t, now, op.Results.CompletedAt, "completed at")
+		})
+	}
+}
+
+type expCol struct {
+	base  string
+	items []export.Item
+}
+
+func (ec expCol) BasePath() string { return ec.base }
+func (ec expCol) Items(ctx context.Context) <-chan export.Item {
+	ch := make(chan export.Item)
+
+	go func() {
+		defer close(ch)
+
+		for _, item := range ec.items {
+			ch <- item
+		}
+	}()
+
+	return ch
+}
+
+func (suite *ExportOpSuite) TestZipExports() {
+	table := []struct {
+		name       string
+		collection []export.Collection
+		shouldErr  bool
+		readErr    bool
+	}{
+		{
+			name:       "nothing",
+			collection: []export.Collection{},
+			shouldErr:  true,
+		},
+		{
+			name: "empty",
+			collection: []export.Collection{
+				expCol{
+					base:  "",
+					items: []export.Item{},
+				},
+			},
+		},
+		{
+			name: "one item",
+			collection: []export.Collection{
+				expCol{
+					base: "",
+					items: []export.Item{
+						{
+							ID: "id1",
+							Data: export.ItemData{
+								Name: "test",
+								Body: io.NopCloser(bytes.NewBufferString("test")),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple items",
+			collection: []export.Collection{
+				expCol{
+					base: "",
+					items: []export.Item{
+						{
+							ID: "id1",
+							Data: export.ItemData{
+								Name: "test",
+								Body: io.NopCloser(bytes.NewBufferString("test")),
+							},
+						},
+					},
+				},
+				expCol{
+					base: "/fold",
+					items: []export.Item{
+						{
+							ID: "id2",
+							Data: export.ItemData{
+								Name: "test2",
+								Body: io.NopCloser(bytes.NewBufferString("test2")),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "one item with err",
+			collection: []export.Collection{
+				expCol{
+					base: "",
+					items: []export.Item{
+						{
+							ID:    "id3",
+							Error: assert.AnError,
+						},
+					},
+				},
+			},
+			readErr: true,
+		},
+	}
+
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			zc, err := zipExportCollection(ctx, test.collection)
+
+			if test.shouldErr {
+				assert.Error(t, err, "error")
+				return
+			}
+
+			require.NoError(t, err, "error")
+
+			assert.Empty(t, zc.BasePath(), "base path")
+
+			count := 0
+			for item := range zc.Items(ctx) {
+				assert.Equal(t, "export.zip", item.Data.Name, "name")
+
+				_, err := io.Copy(io.Discard, item.Data.Body)
+				if test.readErr {
+					assert.Error(t, err, "read error")
+					return
+				}
+
+				require.NoError(t, err, "read item")
+
+				item.Data.Body.Close()
+
+				count++
+			}
+
+			assert.Equal(t, 1, count, "single item")
+		})
+	}
+}

--- a/src/internal/operations/export_test.go
+++ b/src/internal/operations/export_test.go
@@ -109,7 +109,7 @@ func (suite *ExportOpSuite) TestExportOperation_PersistResults() {
 
 			op.Errors.Fail(test.fail)
 
-			err = op.persistResults(ctx, now, &test.stats)
+			err = op.finalizeMetrics(ctx, now, &test.stats)
 			test.expectErr(t, err, clues.ToCore(err))
 
 			assert.Equal(t, test.expectStatus.String(), op.Status.String(), "status")

--- a/src/internal/operations/inject/inject.go
+++ b/src/internal/operations/inject/inject.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/repository"
 	"github.com/alcionai/corso/src/pkg/count"
+	"github.com/alcionai/corso/src/pkg/export"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
@@ -57,6 +58,20 @@ type (
 		// Ex: pairing drive ids with drive names as they appeared at the time
 		// of backup.
 		CacheItemInfo(v details.ItemInfo)
+	}
+
+	ExportConsumer interface {
+		ExportRestoreCollections(
+			ctx context.Context,
+			backupVersion int,
+			selector selectors.Selector,
+			exportCfg control.ExportConfig,
+			opts control.Options,
+			dcs []data.RestoreCollection,
+			errs *fault.Bus,
+		) ([]export.Collection, error)
+
+		Wait() *data.CollectionStats
 	}
 
 	RepoMaintenancer interface {

--- a/src/internal/operations/inject/inject.go
+++ b/src/internal/operations/inject/inject.go
@@ -72,6 +72,8 @@ type (
 		) ([]export.Collection, error)
 
 		Wait() *data.CollectionStats
+
+		CacheItemInfoer
 	}
 
 	RepoMaintenancer interface {


### PR DESCRIPTION
This mostly mimics what we have for restore, just modified to call the
export consumer instead of the restore consumer.<!-- PR description-->

Prev: https://github.com/alcionai/corso/pull/3819
Next: https://github.com/alcionai/corso/pull/3821

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [x] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* https://github.com/alcionai/corso/pull/3797
* https://github.com/alcionai/corso/issues/3670

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
