### PR TITLE
First pass at documentation for maintenance

### DIFF
--- a/src/cli/flags/maintenance.go
+++ b/src/cli/flags/maintenance.go
@@ -27,7 +27,6 @@ func AddMaintenanceModeFlag(cmd *cobra.Command) {
 			"that does minimal clean-up and optimization. Pass '"+
 			repository.CompleteMaintenance.String()+"' to fully compact existing "+
 			"data and delete unused data.")
-	cobra.CheckErr(fs.MarkHidden(MaintenanceModeFN))
 }
 
 func AddForceMaintenanceFlag(cmd *cobra.Command) {

--- a/src/cli/flags/maintenance.go
+++ b/src/cli/flags/maintenance.go
@@ -26,11 +26,9 @@ func AddMaintenanceModeFlag(cmd *cobra.Command) {
 		&MaintenanceModeFV,
 		MaintenanceModeFN,
 		repository.CompleteMaintenance.String(),
-		"Type of maintenance operation to run. Pass '"+
-			repository.MetadataMaintenance.String()+"' to run a faster maintenance "+
-			"that does minimal clean-up and optimization. Pass '"+
-			repository.CompleteMaintenance.String()+"' to fully compact existing "+
-			"data and delete unused data.")
+		"Type of maintenance operation to run ('"+
+			repository.MetadataMaintenance.String()+"' | '"+
+			repository.CompleteMaintenance.String()+"' )")
 }
 
 func AddForceMaintenanceFlag(cmd *cobra.Command) {

--- a/src/cli/repo/repo.go
+++ b/src/cli/repo/repo.go
@@ -38,12 +38,8 @@ func AddCommands(cmd *cobra.Command) {
 	cmd.AddCommand(repoCmd)
 	repoCmd.AddCommand(initCmd)
 	repoCmd.AddCommand(connectCmd)
+	repoCmd.AddCommand(maintenanceCmd)
 
-	utils.AddCommand(
-		repoCmd,
-		maintenanceCmd,
-		utils.HideCommand(),
-		utils.MarkPreReleaseCommand())
 	flags.AddMaintenanceModeFlag(maintenanceCmd)
 	flags.AddForceMaintenanceFlag(maintenanceCmd)
 

--- a/website/docs/setup/maintenance.md
+++ b/website/docs/setup/maintenance.md
@@ -4,41 +4,41 @@ description: "Repository maintenance."
 
 # Repository maintenance
 
-Repository maintenance helps optimize the Corso repo as backups are created and
+Repository maintenance helps optimize the Corso repository as backups are created and
 possibly deleted by the user. Maintenance can also free up space by removing
 data no longer referenced by any backups from the repository.
 
-Maintenance helps support repo health by compacting existing data where
+Maintenance helps support repository health by compacting existing data where
 possible and removing unreferenced data from the repository. It's safe to run
 maintenance concurrently with backup, restore, and backup deletion operations.
 However, it's not safe to run maintenance operations concurrently on the same
-repository. Corso uses file locks and the idea of a repo owner to try to detect
+repository. Corso uses file locks and the idea of a repository owner to try to detect
 concurrent maintenance operations.
 
-## Repo owner
+## Repository owner
 
-The repo owner is set to the user and hostname of the machine that runs
+The repository owner is set to the user and hostname of the machine that runs
 maintenance on the repo the first time.
 
 If the user and hostname of the machine running maintenance can change, use
 either the `--force` flag or the `--user` and `--host` flags. The `--force` flag
 updates the repository owner and runs maintenance. The `--user` and `--host`
-flags act as if the given user/hostname owns the repo for the maintenance
+flags act as if the given user/hostname owns the repository for the maintenance
 operation but doesn't update repo owner info.
 
 *If any of these flags are passed the user must make sure no concurrent
-maintenance operations run on the same repo. Concurrent maintenance operations a
-repo may result in data loss.*
+maintenance operations run on the same repository. Concurrent maintenance operations a
+repository may result in data loss.*
 
 ## Maintenance types
 
 Corso allows for two different types of maintenance: `metadata` and `complete`.
 Metadata maintenance runs quickly and optimizes indexing data. Complete
 maintenance takes more time but compacts data in backups and removes
-unreferenced data from the repo.
+unreferenced data from the repository.
 
 As Corso allows concurrent backups during maintenance, running complete
 maintenance immediately after deleting a backup may not result in a reduction of
 objects in the storage service Corso is backing up to. Deletion of old objects
 in the storage service depends on both wall-clock time and running maintenance.
-Later maintenance runs on the repo will remove the data.
+Later maintenance runs on the repository will remove the data.

--- a/website/docs/setup/maintenance.md
+++ b/website/docs/setup/maintenance.md
@@ -4,41 +4,38 @@ description: "Repository maintenance."
 
 # Repository maintenance
 
-Repository maintenance helps optimize the Corso repository as backups are created and
-possibly deleted by the user. Maintenance can also free up space by removing
-data no longer referenced by any backups from the repository.
+Repository maintenance helps optimize the Corso repository as backups are created and possibly deleted by the user.  
+Maintenance can also free up space by removing data no longer referenced by any backups from the repository.
 
-Maintenance helps support repository health by compacting existing data where
-possible and removing unreferenced data from the repository. It's safe to run
-maintenance concurrently with backup, restore, and backup deletion operations.
-However, it's not safe to run maintenance operations concurrently on the same
-repository. Corso uses file locks and the idea of a repository owner to try to detect
-concurrent maintenance operations.
+It's safe to run maintenance concurrently with backup, restore, and backup deletion operations. However, it's not safe  
+to run maintenance operations concurrently on the same repository. Corso uses file locks and the idea of a repository  
+owner to try to detect concurrent maintenance operations.
 
 ## Repository owner
 
-The repository owner is set to the user and hostname of the machine that runs
-maintenance on the repo the first time.
+The repository owner is set to the user and hostname of the machine that runs maintenance on the repo the first time.  
 
-If the user and hostname of the machine running maintenance can change, use
-either the `--force` flag or the `--user` and `--host` flags. The `--force` flag
-updates the repository owner and runs maintenance. The `--user` and `--host`
-flags act as if the given user/hostname owns the repository for the maintenance
-operation but doesn't update repo owner info.
+If the user and hostname of the machine running maintenance can change, use either the `--force` flag or the `--user`  
+and `--host` flags.
 
-*If any of these flags are passed the user must make sure no concurrent
-maintenance operations run on the same repository. Concurrent maintenance operations a
-repository may result in data loss.*
+The `--force` flag updates the repository owner and runs maintenance.
+
+The `--user` and `--host` flags act as if the given user/hostname owns the repository for the maintenance operation  
+but doesn't update repo owner info.
+
+*If any of these flags are passed the user must make sure no concurrent maintenance operations run on the same  
+repository. Concurrent maintenance operations a repository may result in data loss.*
 
 ## Maintenance types
 
 Corso allows for two different types of maintenance: `metadata` and `complete`.
-Metadata maintenance runs quickly and optimizes indexing data. Complete
-maintenance takes more time but compacts data in backups and removes
-unreferenced data from the repository.
 
-As Corso allows concurrent backups during maintenance, running complete
-maintenance immediately after deleting a backup may not result in a reduction of
-objects in the storage service Corso is backing up to. Deletion of old objects
-in the storage service depends on both wall-clock time and running maintenance.
+Metadata maintenance runs quickly and optimizes indexing data. Complete maintenance takes more time but compacts data  
+in backups and removes unreferenced data from the repository.
+
+As Corso allows concurrent backups during maintenance, running complete maintenance immediately after deleting a  
+backup may not result in a reduction of objects in the storage service Corso is backing up to.  
+
+Deletion of old objects in the storage service depends on both wall-clock time and running maintenance.
+
 Later maintenance runs on the repository will remove the data.

--- a/website/docs/setup/maintenance.md
+++ b/website/docs/setup/maintenance.md
@@ -1,0 +1,44 @@
+---
+description: "Repository maintenance."
+---
+
+# Repository maintenance
+
+Repository maintenance helps optimize the Corso repo as backups are created and
+possibly deleted by the user. Maintenance can also free up space by removing
+data no longer referenced by any backups from the repository.
+
+Maintenance helps support repo health by compacting existing data where
+possible and removing unreferenced data from the repository. It's safe to run
+maintenance concurrently with backup, restore, and backup deletion operations.
+However, it's not safe to run maintenance operations concurrently on the same
+repository. Corso uses file locks and the idea of a repo owner to try to detect
+concurrent maintenance operations.
+
+## Repo owner
+
+The repo owner is set to the user and hostname of the machine that runs
+maintenance on the repo the first time.
+
+If the user and hostname of the machine running maintenance can change, use
+either the `--force` flag or the `--user` and `--host` flags. The `--force` flag
+updates the repository owner and runs maintenance. The `--user` and `--host`
+flags act as if the given user/hostname owns the repo for the maintenance
+operation but doesn't update repo owner info.
+
+*If any of these flags are passed the user must make sure no concurrent
+maintenance operations run on the same repo. Concurrent maintenance operations a
+repo may result in data loss.*
+
+## Maintenance types
+
+Corso allows for two different types of maintenance: `metadata` and `complete`.
+Metadata maintenance runs quickly and optimizes indexing data. Complete
+maintenance takes more time but compacts data in backups and removes
+unreferenced data from the repo.
+
+As Corso allows concurrent backups during maintenance, running complete
+maintenance immediately after deleting a backup may not result in a reduction of
+objects in the storage service Corso is backing up to. Deletion of old objects
+in the storage service depends on both wall-clock time and running maintenance.
+Later maintenance runs on the repo will remove the data.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -20,7 +20,15 @@ const sidebars = {
     {
       type: 'category',
       label: 'Usage',
-      items: ['setup/concepts', 'setup/download', 'setup/m365-access', 'setup/configuration', 'setup/repos', 'setup/fault-tolerance'],
+      items: [
+        'setup/concepts',
+        'setup/download',
+        'setup/m365-access',
+        'setup/configuration',
+        'setup/repos',
+        'setup/fault-tolerance',
+        'setup/maintenance'
+      ],
     },
     {
       type: 'category',

--- a/website/styles/Vocab/Base/accept.txt
+++ b/website/styles/Vocab/Base/accept.txt
@@ -58,3 +58,5 @@ deduplicating
 subtree
 subtrees
 anonymized
+unreferenced
+hostname


### PR DESCRIPTION
Assumes the addition of `--user` and `--hostname` flags

Also unhides the maintenance command and mode flag

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [x] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3569

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
