### PR TITLE
Allow setting repo user and hostname

### DIFF
--- a/src/cli/config/config.go
+++ b/src/cli/config/config.go
@@ -10,7 +10,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/alcionai/corso/src/cli/flags"
 	. "github.com/alcionai/corso/src/cli/print"
+	"github.com/alcionai/corso/src/internal/common/str"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/storage"
@@ -38,6 +40,8 @@ const (
 
 	// Corso passphrase in config
 	CorsoPassphrase = "passphrase"
+	CorsoUser       = "corso_user"
+	CorsoHost       = "corso_host"
 )
 
 var (
@@ -50,9 +54,11 @@ var (
 // RepoDetails holds the repository configuration retrieved from
 // the .corso.toml configuration file.
 type RepoDetails struct {
-	Storage storage.Storage
-	Account account.Account
-	RepoID  string
+	Storage  storage.Storage
+	Account  account.Account
+	RepoID   string
+	RepoUser string
+	RepoHost string
 }
 
 // Attempts to set the default dir and config file path.
@@ -294,7 +300,18 @@ func getStorageAndAccountWithViper(
 		return config, clues.Wrap(err, "retrieving storage provider details")
 	}
 
+	config.RepoUser, config.RepoHost = getUserHost(vpr, readConfigFromViper)
+
 	return config, nil
+}
+
+func getUserHost(vpr *viper.Viper, readConfigFromViper bool) (string, string) {
+	user := str.First(flags.UserMaintenanceFV, vpr.GetString(CorsoUser))
+	host := str.First(flags.HostnameMaintenanceFV, vpr.GetString(CorsoHost))
+
+	// Fine if these are empty; later code will assign a meaningful default if
+	// needed.
+	return user, host
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli/flags/maintenance.go
+++ b/src/cli/flags/maintenance.go
@@ -7,13 +7,17 @@ import (
 )
 
 const (
-	MaintenanceModeFN  = "mode"
-	ForceMaintenanceFN = "force"
+	MaintenanceModeFN     = "mode"
+	ForceMaintenanceFN    = "force"
+	UserMaintenanceFN     = "user"
+	HostnameMaintenanceFN = "host"
 )
 
 var (
-	MaintenanceModeFV  string
-	ForceMaintenanceFV bool
+	MaintenanceModeFV     string
+	ForceMaintenanceFV    bool
+	UserMaintenanceFV     string
+	HostnameMaintenanceFV string
 )
 
 func AddMaintenanceModeFlag(cmd *cobra.Command) {
@@ -38,4 +42,22 @@ func AddForceMaintenanceFlag(cmd *cobra.Command) {
 		false,
 		"Force maintenance. Caution: user must ensure this is not run concurrently on a single repo")
 	cobra.CheckErr(fs.MarkHidden(ForceMaintenanceFN))
+}
+
+func AddMaintenanceUserFlag(cmd *cobra.Command) {
+	fs := cmd.Flags()
+	fs.StringVar(
+		&UserMaintenanceFV,
+		UserMaintenanceFN,
+		"",
+		"Attempt to run maintenance as the specified user for the repo owner user")
+}
+
+func AddMaintenanceHostnameFlag(cmd *cobra.Command) {
+	fs := cmd.Flags()
+	fs.StringVar(
+		&HostnameMaintenanceFV,
+		HostnameMaintenanceFN,
+		"",
+		"Attempt to run maintenance with the specified hostname for the repo owner hostname")
 }

--- a/src/cli/repo/repo.go
+++ b/src/cli/repo/repo.go
@@ -46,6 +46,8 @@ func AddCommands(cmd *cobra.Command) {
 		utils.MarkPreReleaseCommand())
 	flags.AddMaintenanceModeFlag(maintenanceCmd)
 	flags.AddForceMaintenanceFlag(maintenanceCmd)
+	flags.AddMaintenanceUserFlag(maintenanceCmd)
+	flags.AddMaintenanceHostnameFlag(maintenanceCmd)
 
 	for _, addRepoTo := range repoCommands {
 		addRepoTo(initCmd)

--- a/src/cli/repo/s3.go
+++ b/src/cli/repo/s3.go
@@ -130,6 +130,8 @@ func initS3Cmd(cmd *cobra.Command, args []string) error {
 		return Only(ctx, err)
 	}
 
+	opt := utils.ControlWithConfig(cfg)
+
 	// SendStartCorsoEvent uses distict ID as tenant ID because repoID is still not generated
 	utils.SendStartCorsoEvent(
 		ctx,
@@ -137,7 +139,7 @@ func initS3Cmd(cmd *cobra.Command, args []string) error {
 		cfg.Account.ID(),
 		map[string]any{"command": "init repo"},
 		cfg.Account.ID(),
-		utils.Control())
+		opt)
 
 	s3Cfg, err := cfg.Storage.S3Config()
 	if err != nil {
@@ -156,7 +158,7 @@ func initS3Cmd(cmd *cobra.Command, args []string) error {
 		return Only(ctx, clues.Wrap(err, "Failed to parse m365 account config"))
 	}
 
-	r, err := repository.Initialize(ctx, cfg.Account, cfg.Storage, utils.Control())
+	r, err := repository.Initialize(ctx, cfg.Account, cfg.Storage, opt)
 	if err != nil {
 		if succeedIfExists && errors.Is(err, repository.ErrorRepoAlreadyExists) {
 			return nil
@@ -226,7 +228,12 @@ func connectS3Cmd(cmd *cobra.Command, args []string) error {
 		return Only(ctx, clues.New(invalidEndpointErr))
 	}
 
-	r, err := repository.ConnectAndSendConnectEvent(ctx, cfg.Account, cfg.Storage, repoID, utils.Control())
+	r, err := repository.ConnectAndSendConnectEvent(
+		ctx,
+		cfg.Account,
+		cfg.Storage,
+		repoID,
+		utils.ControlWithConfig(cfg))
 	if err != nil {
 		return Only(ctx, clues.Wrap(err, "Failed to connect to the S3 repository"))
 	}

--- a/src/cli/utils/options.go
+++ b/src/cli/utils/options.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"github.com/alcionai/corso/src/cli/config"
 	"github.com/alcionai/corso/src/cli/flags"
 	"github.com/alcionai/corso/src/pkg/control"
 )
@@ -21,6 +22,15 @@ func Control() control.Options {
 	opt.ToggleFeatures.ExchangeImmutableIDs = flags.EnableImmutableIDFV
 	opt.ToggleFeatures.DisableConcurrencyLimiter = flags.DisableConcurrencyLimiterFV
 	opt.Parallelism.ItemFetch = flags.FetchParallelismFV
+
+	return opt
+}
+
+func ControlWithConfig(cfg config.RepoDetails) control.Options {
+	opt := Control()
+
+	opt.Repo.User = cfg.RepoUser
+	opt.Repo.Host = cfg.RepoHost
 
 	return opt
 }

--- a/src/cli/utils/utils.go
+++ b/src/cli/utils/utils.go
@@ -34,7 +34,7 @@ func GetAccountAndConnect(
 		repoID = events.RepoIDNotFound
 	}
 
-	r, err := repository.Connect(ctx, cfg.Account, cfg.Storage, repoID, Control())
+	r, err := repository.Connect(ctx, cfg.Account, cfg.Storage, repoID, ControlWithConfig(cfg))
 	if err != nil {
 		return nil, nil, nil, clues.Wrap(err, "connecting to the "+cfg.Storage.Provider.String()+" repository")
 	}


### PR DESCRIPTION
Allows sourcing info about repo user/hostname from
both the config file and flags for maintenance.
Since user/hostname mostly matters for maintenance
don't add the flags for all commands.

Do allow config file parameters for them since
that has a lot of repo-level information already.
Currently not setup to persist these values in the
config file

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [x] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3569

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
