### PR TITLE
Persist repo owner info in config

### DIFF
--- a/src/cli/backup/backup.go
+++ b/src/cli/backup/backup.go
@@ -276,7 +276,7 @@ func genericDeleteCommand(
 
 	ctx := clues.Add(cmd.Context(), "delete_backup_id", bID)
 
-	r, _, _, err := utils.GetAccountAndConnect(ctx, pst, repo.S3Overrides(cmd))
+	r, _, _, _, err := utils.GetAccountAndConnect(ctx, pst, repo.S3Overrides(cmd))
 	if err != nil {
 		return Only(ctx, err)
 	}
@@ -302,7 +302,7 @@ func genericListCommand(
 ) error {
 	ctx := cmd.Context()
 
-	r, _, _, err := utils.GetAccountAndConnect(ctx, service, repo.S3Overrides(cmd))
+	r, _, _, _, err := utils.GetAccountAndConnect(ctx, service, repo.S3Overrides(cmd))
 	if err != nil {
 		return Only(ctx, err)
 	}

--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -275,14 +275,12 @@ func detailsExchangeCmd(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	opts := utils.MakeExchangeOpts(cmd)
 
-	r, _, _, err := utils.GetAccountAndConnect(ctx, path.ExchangeService, repo.S3Overrides(cmd))
+	r, _, _, ctrlOpts, err := utils.GetAccountAndConnect(ctx, path.ExchangeService, repo.S3Overrides(cmd))
 	if err != nil {
 		return Only(ctx, err)
 	}
 
 	defer utils.CloseRepo(ctx, r)
-
-	ctrlOpts := utils.Control()
 
 	ds, err := runDetailsExchangeCmd(ctx, r, flags.BackupIDFV, opts, ctrlOpts.SkipReduce)
 	if err != nil {

--- a/src/cli/backup/onedrive.go
+++ b/src/cli/backup/onedrive.go
@@ -234,14 +234,12 @@ func detailsOneDriveCmd(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	opts := utils.MakeOneDriveOpts(cmd)
 
-	r, _, _, err := utils.GetAccountAndConnect(ctx, path.OneDriveService, repo.S3Overrides(cmd))
+	r, _, _, ctrlOpts, err := utils.GetAccountAndConnect(ctx, path.OneDriveService, repo.S3Overrides(cmd))
 	if err != nil {
 		return Only(ctx, err)
 	}
 
 	defer utils.CloseRepo(ctx, r)
-
-	ctrlOpts := utils.Control()
 
 	ds, err := runDetailsOneDriveCmd(ctx, r, flags.BackupIDFV, opts, ctrlOpts.SkipReduce)
 	if err != nil {

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -325,14 +325,12 @@ func detailsSharePointCmd(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	opts := utils.MakeSharePointOpts(cmd)
 
-	r, _, _, err := utils.GetAccountAndConnect(ctx, path.SharePointService, repo.S3Overrides(cmd))
+	r, _, _, ctrlOpts, err := utils.GetAccountAndConnect(ctx, path.SharePointService, repo.S3Overrides(cmd))
 	if err != nil {
 		return Only(ctx, err)
 	}
 
 	defer utils.CloseRepo(ctx, r)
-
-	ctrlOpts := utils.Control()
 
 	ds, err := runDetailsSharePointCmd(ctx, r, flags.BackupIDFV, opts, ctrlOpts.SkipReduce)
 	if err != nil {

--- a/src/cli/config/config.go
+++ b/src/cli/config/config.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/internal/common/str"
 	"github.com/alcionai/corso/src/pkg/account"
+	"github.com/alcionai/corso/src/pkg/control/repository"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/storage"
 )
@@ -204,9 +205,15 @@ func WriteRepoConfig(
 	ctx context.Context,
 	s3Config storage.S3Config,
 	m365Config account.M365Config,
+	repoOpts repository.Options,
 	repoID string,
 ) error {
-	return writeRepoConfigWithViper(GetViper(ctx), s3Config, m365Config, repoID)
+	return writeRepoConfigWithViper(
+		GetViper(ctx),
+		s3Config,
+		m365Config,
+		repoOpts,
+		repoID)
 }
 
 // writeRepoConfigWithViper implements WriteRepoConfig, but takes in a viper
@@ -215,6 +222,7 @@ func writeRepoConfigWithViper(
 	vpr *viper.Viper,
 	s3Config storage.S3Config,
 	m365Config account.M365Config,
+	repoOpts repository.Options,
 	repoID string,
 ) error {
 	s3Config = s3Config.Normalize()
@@ -227,6 +235,15 @@ func writeRepoConfigWithViper(
 	vpr.Set(DisableTLSKey, s3Config.DoNotUseTLS)
 	vpr.Set(DisableTLSVerificationKey, s3Config.DoNotVerifyTLS)
 	vpr.Set(RepoID, repoID)
+
+	// Need if-checks as Viper will write empty values otherwise.
+	if len(repoOpts.User) > 0 {
+		vpr.Set(CorsoUser, repoOpts.User)
+	}
+
+	if len(repoOpts.Host) > 0 {
+		vpr.Set(CorsoHost, repoOpts.Host)
+	}
 
 	vpr.Set(AccountProviderTypeKey, account.ProviderM365.String())
 	vpr.Set(AzureTenantIDKey, m365Config.AzureTenantID)

--- a/src/cli/repo/repo.go
+++ b/src/cli/repo/repo.go
@@ -121,7 +121,7 @@ func handleMaintenanceCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	r, _, _, err := utils.GetAccountAndConnect(ctx, path.UnknownService, S3Overrides(cmd))
+	r, _, err := utils.AccountConnectAndWriteRepoConfig(ctx, path.UnknownService, S3Overrides(cmd))
 	if err != nil {
 		return print.Only(ctx, err)
 	}

--- a/src/cli/repo/s3.go
+++ b/src/cli/repo/s3.go
@@ -171,7 +171,7 @@ func initS3Cmd(cmd *cobra.Command, args []string) error {
 
 	Infof(ctx, "Initialized a S3 repository within bucket %s.", s3Cfg.Bucket)
 
-	if err = config.WriteRepoConfig(ctx, s3Cfg, m365, r.GetID()); err != nil {
+	if err = config.WriteRepoConfig(ctx, s3Cfg, m365, opt.Repo, r.GetID()); err != nil {
 		return Only(ctx, clues.Wrap(err, "Failed to write repository configuration"))
 	}
 
@@ -228,12 +228,14 @@ func connectS3Cmd(cmd *cobra.Command, args []string) error {
 		return Only(ctx, clues.New(invalidEndpointErr))
 	}
 
+	opts := utils.ControlWithConfig(cfg)
+
 	r, err := repository.ConnectAndSendConnectEvent(
 		ctx,
 		cfg.Account,
 		cfg.Storage,
 		repoID,
-		utils.ControlWithConfig(cfg))
+		opts)
 	if err != nil {
 		return Only(ctx, clues.Wrap(err, "Failed to connect to the S3 repository"))
 	}
@@ -242,7 +244,7 @@ func connectS3Cmd(cmd *cobra.Command, args []string) error {
 
 	Infof(ctx, "Connected to S3 bucket %s.", s3Cfg.Bucket)
 
-	if err = config.WriteRepoConfig(ctx, s3Cfg, m365, r.GetID()); err != nil {
+	if err = config.WriteRepoConfig(ctx, s3Cfg, m365, opts.Repo, r.GetID()); err != nil {
 		return Only(ctx, clues.Wrap(err, "Failed to write repository configuration"))
 	}
 

--- a/src/cli/restore/restore.go
+++ b/src/cli/restore/restore.go
@@ -94,7 +94,7 @@ func runRestore(
 	sel selectors.Selector,
 	backupID, serviceName string,
 ) error {
-	r, _, _, err := utils.GetAccountAndConnect(ctx, sel.PathService(), repo.S3Overrides(cmd))
+	r, _, _, _, err := utils.GetAccountAndConnect(ctx, sel.PathService(), repo.S3Overrides(cmd))
 	if err != nil {
 		return Only(ctx, err)
 	}

--- a/src/cli/utils/utils.go
+++ b/src/cli/utils/utils.go
@@ -55,7 +55,7 @@ func AccountConnectAndWriteRepoConfig(
 	pst path.ServiceType,
 	overrides map[string]string,
 ) (repository.Repository, *account.Account, error) {
-	r, stg, acc, _, err := GetAccountAndConnect(ctx, pst, overrides)
+	r, stg, acc, opts, err := GetAccountAndConnect(ctx, pst, overrides)
 	if err != nil {
 		logger.CtxErr(ctx, err).Info("getting and connecting account")
 		return nil, nil, err
@@ -75,7 +75,7 @@ func AccountConnectAndWriteRepoConfig(
 
 	// repo config gets set during repo connect and init.
 	// This call confirms we have the correct values.
-	err = config.WriteRepoConfig(ctx, s3Config, m365Config, r.GetID())
+	err = config.WriteRepoConfig(ctx, s3Config, m365Config, opts.Repo, r.GetID())
 	if err != nil {
 		logger.CtxErr(ctx, err).Info("writing to repository configuration")
 		return nil, nil, err

--- a/src/cmd/longevity_test/longevity.go
+++ b/src/cmd/longevity_test/longevity.go
@@ -39,7 +39,7 @@ func main() {
 		fatal(cc.Context(), "unknown service", nil)
 	}
 
-	r, _, _, err := utils.GetAccountAndConnect(cc.Context(), service, nil)
+	r, _, _, _, err := utils.GetAccountAndConnect(cc.Context(), service, nil)
 	if err != nil {
 		fatal(cc.Context(), "unable to connect account", err)
 	}


### PR DESCRIPTION
If repo owner info is set then persist those values
in the config file. This is expected to apply only
to maintenance commands right now

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3569

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
