### PR TITLE
utilize old drive name when restoring

### DIFF
--- a/src/internal/common/idname/idname.go
+++ b/src/internal/common/idname/idname.go
@@ -73,8 +73,8 @@ func NewCache(idToName map[string]string) *cache {
 }
 
 func (c *cache) Add(id, name string) {
-	c.idToName[id] = name
-	c.nameToID[name] = id
+	c.idToName[strings.ToLower(id)] = name
+	c.nameToID[strings.ToLower(name)] = id
 }
 
 // IDOf returns the id associated with the given name.


### PR DESCRIPTION
utilizes the old drive name in case the drive
was deleted between backup and restore.
Priority is first to use drives whose ids match the backup id; second, to use drives whose names
match the backup drive name; third, to fall
back to a new, arbitrary name.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #3562

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
