### PR TITLE
Consolidate drive not found error messages

### DIFF
--- a/src/internal/m365/graph/errors.go
+++ b/src/internal/m365/graph/errors.go
@@ -65,12 +65,13 @@ const (
 	IOErrDuringRead   errorMessage = "IO error during request payload read"
 	MysiteURLNotFound errorMessage = "unable to retrieve user's mysite url"
 	MysiteNotFound    errorMessage = "user's mysite not found"
+	FileNotFound      errorMessage = "404 FILE NOT FOUND"
 	NoSPLicense       errorMessage = "Tenant does not have a SPO license"
 )
 
 const (
 	LabelsMalware             = "malware_detected"
-	LabelsMysiteNotFound      = "mysite_not_found"
+	LabelsDriveNotFound       = "drive_not_found"
 	LabelsNoSharePointLicense = "no_sharepoint_license"
 
 	// LabelsSkippable is used to determine if an error is skippable
@@ -316,7 +317,8 @@ func stackReq(
 }
 
 // Checks for the following conditions and labels the error accordingly:
-// * mysiteNotFound | mysiteURLNotFound
+// * MysiteNotFound | MysiteURLNotFound | FileNotFound
+// * NoSPLicense
 // * malware
 func setLabels(err *clues.Err, msg string) *clues.Err {
 	if err == nil {
@@ -326,8 +328,9 @@ func setLabels(err *clues.Err, msg string) *clues.Err {
 	f := filters.Contains([]string{msg})
 
 	if f.Compare(string(MysiteNotFound)) ||
-		f.Compare(string(MysiteURLNotFound)) {
-		err = err.Label(LabelsMysiteNotFound)
+		f.Compare(string(MysiteURLNotFound)) ||
+		f.Compare(string(FileNotFound)) {
+		err = err.Label(LabelsDriveNotFound)
 	}
 
 	if f.Compare(string(NoSPLicense)) {

--- a/src/internal/m365/graph/errors_test.go
+++ b/src/internal/m365/graph/errors_test.go
@@ -552,12 +552,17 @@ func (suite *GraphErrorsUnitSuite) TestGraphStack_labels() {
 		{
 			name:   "mysite not found",
 			err:    odErrMsg("code", string(MysiteNotFound)),
-			expect: []string{LabelsMysiteNotFound},
+			expect: []string{LabelsDriveNotFound},
 		},
 		{
 			name:   "mysite url not found",
 			err:    odErrMsg("code", string(MysiteURLNotFound)),
-			expect: []string{LabelsMysiteNotFound},
+			expect: []string{LabelsDriveNotFound},
+		},
+		{
+			name:   "404 file not found",
+			err:    odErrMsg("code", string(FileNotFound)),
+			expect: []string{LabelsDriveNotFound},
 		},
 		{
 			name:   "no sp license",

--- a/src/pkg/services/m365/api/drive_pager.go
+++ b/src/pkg/services/m365/api/drive_pager.go
@@ -398,7 +398,8 @@ func GetAllDrives(
 		for i := 0; i <= maxRetryCount; i++ {
 			page, err = pager.GetPage(ctx)
 			if err != nil {
-				if clues.HasLabel(err, graph.LabelsMysiteNotFound) || clues.HasLabel(err, graph.LabelsNoSharePointLicense) {
+				if clues.HasLabel(err, graph.LabelsDriveNotFound) ||
+					clues.HasLabel(err, graph.LabelsNoSharePointLicense) {
 					logger.CtxErr(ctx, err).Infof("resource owner does not have a drive")
 					return make([]models.Driveable, 0), nil // no license or drives.
 				}

--- a/src/pkg/services/m365/api/users.go
+++ b/src/pkg/services/m365/api/users.go
@@ -182,7 +182,7 @@ func (c Users) GetInfo(ctx context.Context, userID string) (*UserInfo, error) {
 	// check whether the user is able to access their onedrive drive.
 	// if they cannot, we can assume they are ineligible for onedrive backups.
 	if _, err := c.GetDefaultDrive(ctx, userID); err != nil {
-		if !clues.HasLabel(err, graph.LabelsMysiteNotFound) && !clues.HasLabel(err, graph.LabelsNoSharePointLicense) {
+		if !clues.HasLabel(err, graph.LabelsDriveNotFound) && !clues.HasLabel(err, graph.LabelsNoSharePointLicense) {
 			logger.CtxErr(ctx, err).Error("getting user's default drive")
 			return nil, graph.Wrap(ctx, err, "getting user's default drive info")
 		}

--- a/src/pkg/services/m365/m365.go
+++ b/src/pkg/services/m365/m365.go
@@ -107,7 +107,8 @@ func checkUserHasDrives(ctx context.Context, dgdd getDefaultDriver, userID strin
 	if err != nil {
 		// we consider this a non-error case, since it
 		// answers the question the caller is asking.
-		if clues.HasLabel(err, graph.LabelsMysiteNotFound) || clues.HasLabel(err, graph.LabelsNoSharePointLicense) {
+		if clues.HasLabel(err, graph.LabelsDriveNotFound) ||
+			clues.HasLabel(err, graph.LabelsNoSharePointLicense) {
 			return false, nil
 		}
 


### PR DESCRIPTION
<!-- PR description-->
For some users who do not have a onedrive, `GET https://graph.microsoft.com/v1.0/users/$(USER_ID)/drive` fails with `404 FILE NOT FOUND`. We expect graph to return `user's mysite not found` or `unable to retrieve user's mysite url` in this scenario. However, it appears that graph has introduced a new error message here. 

This PR handles the new error message & consolidates all drive not found error messages under a common label.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* https://github.com/alcionai/corso/issues/3846

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
