### PR TITLE
check service enabled on restore

### DIFF
--- a/src/internal/m365/backup.go
+++ b/src/internal/m365/backup.go
@@ -61,7 +61,7 @@ func (ctrl *Controller) ProduceBackupCollections(
 	serviceEnabled, canMakeDeltaQueries, err := checkServiceEnabled(
 		ctx,
 		ctrl.AC.Users(),
-		path.ServiceType(sels.Service),
+		sels.PathService(),
 		sels.DiscreteOwner)
 	if err != nil {
 		return nil, nil, false, err

--- a/src/internal/m365/restore.go
+++ b/src/internal/m365/restore.go
@@ -39,11 +39,23 @@ func (ctrl *Controller) ConsumeRestoreCollections(
 		return nil, clues.New("no data collections to restore")
 	}
 
+	serviceEnabled, _, err := checkServiceEnabled(
+		ctx,
+		ctrl.AC.Users(),
+		rcc.Selector.PathService(),
+		rcc.ProtectedResource.ID())
+	if err != nil {
+		return nil, err
+	}
+
+	if !serviceEnabled {
+		return nil, clues.Stack(graph.ErrServiceNotEnabled).WithClues(ctx)
+	}
+
 	var (
 		service = rcc.Selector.PathService()
 		status  *support.ControllerOperationStatus
 		deets   = &details.Builder{}
-		err     error
 	)
 
 	switch service {


### PR DESCRIPTION
Now that restore can target a user who is different from the backup user, the ConsumeRestoreCollections call in m365 also needs to check whether the protectedResource targeted for restore has their services enabled.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #3562

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
