### PR TITLE
add cli flag for to-resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] (beta)
 
 ### Added
-- Restore commands now accept an optional resource override with the `--to-resource` flag.  This allows restores to recreate backup data witthin different mailboxes, sites, and users.  
+- Restore commands now accept an optional resource override with the `--to-resource` flag.  This allows restores to recreate backup data within different mailboxes, sites, and users.  
 
 ### Fixed
 - SharePoint document libraries deleted after the last backup can now be restored.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] (beta)
 
+### Added
+- Restore commands now accept an optional resource override with the `--to-resource` flag.  This allows restores to recreate backup data witthin different mailboxes, sites, and users.  
+
 ### Fixed
 - SharePoint document libraries deleted after the last backup can now be restored.
+- Restore requires the protected resource to have access to the service being restored.
 
 ## [v0.11.1] (beta) - 2023-07-20
 

--- a/src/cli/flags/restore_config.go
+++ b/src/cli/flags/restore_config.go
@@ -30,5 +30,5 @@ func AddRestoreConfigFlags(cmd *cobra.Command) {
 		"Overrides the folder where items get restored; '/' places items into their original location")
 	fs.StringVar(
 		&ToResourceFV, ToResourceFN, "",
-		"Overrides the protected resource (mailbox, site, etc) where data gets restored")
+		"Overrides the protected resource (mailbox, site, user, etc) where data gets restored")
 }

--- a/src/cli/flags/restore_config.go
+++ b/src/cli/flags/restore_config.go
@@ -9,11 +9,13 @@ import (
 const (
 	CollisionsFN  = "collisions"
 	DestinationFN = "destination"
+	ToResourceFN  = "to-resource"
 )
 
 var (
 	CollisionsFV  string
 	DestinationFV string
+	ToResourceFV  string
 )
 
 // AddRestoreConfigFlags adds the restore config flag set.
@@ -25,5 +27,8 @@ func AddRestoreConfigFlags(cmd *cobra.Command) {
 		"Sets the behavior for existing item collisions: "+string(control.Skip)+", "+string(control.Copy)+", or "+string(control.Replace))
 	fs.StringVar(
 		&DestinationFV, DestinationFN, "",
-		"Overrides the destination where items get restored; '/' places items into their original location")
+		"Overrides the folder where items get restored; '/' places items into their original location")
+	fs.StringVar(
+		&ToResourceFV, ToResourceFN, "",
+		"Overrides the protected resource (mailbox, site, etc) where data gets restored")
 }

--- a/src/cli/restore/exchange_test.go
+++ b/src/cli/restore/exchange_test.go
@@ -84,6 +84,7 @@ func (suite *ExchangeUnitSuite) TestAddExchangeCommands() {
 
 				"--" + flags.CollisionsFN, testdata.Collisions,
 				"--" + flags.DestinationFN, testdata.Destination,
+				"--" + flags.ToResourceFN, testdata.ToResource,
 
 				"--" + flags.AWSAccessKeyFN, testdata.AWSAccessKeyID,
 				"--" + flags.AWSSecretAccessKeyFN, testdata.AWSSecretAccessKey,
@@ -125,6 +126,7 @@ func (suite *ExchangeUnitSuite) TestAddExchangeCommands() {
 
 			assert.Equal(t, testdata.Collisions, opts.RestoreCfg.Collisions)
 			assert.Equal(t, testdata.Destination, opts.RestoreCfg.Destination)
+			assert.Equal(t, testdata.ToResource, opts.RestoreCfg.ProtectedResource)
 
 			assert.Equal(t, testdata.AWSAccessKeyID, flags.AWSAccessKeyFV)
 			assert.Equal(t, testdata.AWSSecretAccessKey, flags.AWSSecretAccessKeyFV)

--- a/src/cli/restore/onedrive_test.go
+++ b/src/cli/restore/onedrive_test.go
@@ -70,6 +70,7 @@ func (suite *OneDriveUnitSuite) TestAddOneDriveCommands() {
 
 				"--" + flags.CollisionsFN, testdata.Collisions,
 				"--" + flags.DestinationFN, testdata.Destination,
+				"--" + flags.ToResourceFN, testdata.ToResource,
 
 				"--" + flags.AWSAccessKeyFN, testdata.AWSAccessKeyID,
 				"--" + flags.AWSSecretAccessKeyFN, testdata.AWSSecretAccessKey,
@@ -80,6 +81,9 @@ func (suite *OneDriveUnitSuite) TestAddOneDriveCommands() {
 				"--" + flags.AzureClientSecretFN, testdata.AzureClientSecret,
 
 				"--" + flags.CorsoPassphraseFN, testdata.CorsoPassphrase,
+
+				// bool flags
+				"--" + flags.RestorePermissionsFN,
 			})
 
 			cmd.SetOut(new(bytes.Buffer)) // drop output
@@ -99,6 +103,7 @@ func (suite *OneDriveUnitSuite) TestAddOneDriveCommands() {
 
 			assert.Equal(t, testdata.Collisions, opts.RestoreCfg.Collisions)
 			assert.Equal(t, testdata.Destination, opts.RestoreCfg.Destination)
+			assert.Equal(t, testdata.ToResource, opts.RestoreCfg.ProtectedResource)
 
 			assert.Equal(t, testdata.AWSAccessKeyID, flags.AWSAccessKeyFV)
 			assert.Equal(t, testdata.AWSSecretAccessKey, flags.AWSSecretAccessKeyFV)
@@ -109,6 +114,7 @@ func (suite *OneDriveUnitSuite) TestAddOneDriveCommands() {
 			assert.Equal(t, testdata.AzureClientSecret, flags.AzureClientSecretFV)
 
 			assert.Equal(t, testdata.CorsoPassphrase, flags.CorsoPassphraseFV)
+			assert.True(t, flags.RestorePermissionsFV)
 		})
 	}
 }

--- a/src/cli/restore/sharepoint_test.go
+++ b/src/cli/restore/sharepoint_test.go
@@ -75,6 +75,7 @@ func (suite *SharePointUnitSuite) TestAddSharePointCommands() {
 
 				"--" + flags.CollisionsFN, testdata.Collisions,
 				"--" + flags.DestinationFN, testdata.Destination,
+				"--" + flags.ToResourceFN, testdata.ToResource,
 
 				"--" + flags.AWSAccessKeyFN, testdata.AWSAccessKeyID,
 				"--" + flags.AWSSecretAccessKeyFN, testdata.AWSSecretAccessKey,
@@ -85,6 +86,9 @@ func (suite *SharePointUnitSuite) TestAddSharePointCommands() {
 				"--" + flags.AzureClientSecretFN, testdata.AzureClientSecret,
 
 				"--" + flags.CorsoPassphraseFN, testdata.CorsoPassphrase,
+
+				// bool flags
+				"--" + flags.RestorePermissionsFN,
 			})
 
 			cmd.SetOut(new(bytes.Buffer)) // drop output
@@ -111,6 +115,7 @@ func (suite *SharePointUnitSuite) TestAddSharePointCommands() {
 
 			assert.Equal(t, testdata.Collisions, opts.RestoreCfg.Collisions)
 			assert.Equal(t, testdata.Destination, opts.RestoreCfg.Destination)
+			assert.Equal(t, testdata.ToResource, opts.RestoreCfg.ProtectedResource)
 
 			assert.Equal(t, testdata.AWSAccessKeyID, flags.AWSAccessKeyFV)
 			assert.Equal(t, testdata.AWSSecretAccessKey, flags.AWSSecretAccessKeyFV)
@@ -121,6 +126,9 @@ func (suite *SharePointUnitSuite) TestAddSharePointCommands() {
 			assert.Equal(t, testdata.AzureClientSecret, flags.AzureClientSecretFV)
 
 			assert.Equal(t, testdata.CorsoPassphrase, flags.CorsoPassphraseFV)
+
+			// bool flags
+			assert.True(t, flags.RestorePermissionsFV)
 		})
 	}
 }

--- a/src/cli/utils/restore_config.go
+++ b/src/cli/utils/restore_config.go
@@ -19,6 +19,7 @@ type RestoreCfgOpts struct {
 	// to the default folder name.  Defaults to
 	// dttm.HumanReadable.
 	DTTMFormat         dttm.TimeFormat
+	ProtectedResource  string
 	RestorePermissions bool
 
 	Populated flags.PopulatedFlags
@@ -29,6 +30,7 @@ func makeRestoreCfgOpts(cmd *cobra.Command) RestoreCfgOpts {
 		Collisions:         flags.CollisionsFV,
 		Destination:        flags.DestinationFV,
 		DTTMFormat:         dttm.HumanReadable,
+		ProtectedResource:  flags.ToResourceFV,
 		RestorePermissions: flags.RestorePermissionsFV,
 
 		// populated contains the list of flags that appear in the
@@ -69,6 +71,7 @@ func MakeRestoreConfig(
 		restoreCfg.Location = opts.Destination
 	}
 
+	restoreCfg.ProtectedResource = opts.ProtectedResource
 	restoreCfg.IncludePermissions = opts.RestorePermissions
 
 	Infof(ctx, "Restoring to folder %s", restoreCfg.Location)

--- a/src/cli/utils/testdata/flags.go
+++ b/src/cli/utils/testdata/flags.go
@@ -46,6 +46,7 @@ var (
 
 	Collisions         = "collisions"
 	Destination        = "destination"
+	ToResource         = "toResource"
 	RestorePermissions = true
 
 	AzureClientID     = "testAzureClientId"

--- a/src/internal/m365/onedrive/restore.go
+++ b/src/internal/m365/onedrive/restore.go
@@ -51,16 +51,15 @@ func ConsumeRestoreCollections(
 	ctr *count.Bus,
 ) (*support.ControllerOperationStatus, error) {
 	var (
-		restoreMetrics      support.CollectionMetrics
-		el                  = errs.Local()
-		caches              = NewRestoreCaches(backupDriveIDNames)
-		protectedResourceID = rcc.ProtectedResource.ID()
-		fallbackDriveName   = rcc.RestoreConfig.Location
+		restoreMetrics    support.CollectionMetrics
+		el                = errs.Local()
+		caches            = NewRestoreCaches(backupDriveIDNames)
+		fallbackDriveName = rcc.RestoreConfig.Location
 	)
 
 	ctx = clues.Add(ctx, "backup_version", rcc.BackupVersion)
 
-	err := caches.Populate(ctx, rh, protectedResourceID)
+	err := caches.Populate(ctx, rh, rcc.ProtectedResource.ID())
 	if err != nil {
 		return nil, clues.Wrap(err, "initializing restore caches")
 	}
@@ -132,15 +131,14 @@ func RestoreCollection(
 	ctr *count.Bus,
 ) (support.CollectionMetrics, error) {
 	var (
-		metrics             = support.CollectionMetrics{}
-		directory           = dc.FullPath()
-		protectedResourceID = directory.ResourceOwner()
-		el                  = errs.Local()
-		metricsObjects      int64
-		metricsBytes        int64
-		metricsSuccess      int64
-		wg                  sync.WaitGroup
-		complete            bool
+		metrics        = support.CollectionMetrics{}
+		directory      = dc.FullPath()
+		el             = errs.Local()
+		metricsObjects int64
+		metricsBytes   int64
+		metricsSuccess int64
+		wg             sync.WaitGroup
+		complete       bool
 	)
 
 	ctx, end := diagnostics.Span(ctx, "gc:drive:restoreCollection", diagnostics.Label("path", directory))
@@ -156,7 +154,7 @@ func RestoreCollection(
 		rh,
 		caches,
 		drivePath,
-		protectedResourceID,
+		rcc.ProtectedResource.ID(),
 		fallbackDriveName)
 	if err != nil {
 		return metrics, clues.Wrap(err, "ensuring drive exists")

--- a/src/internal/m365/sharepoint/restore.go
+++ b/src/internal/m365/sharepoint/restore.go
@@ -41,14 +41,13 @@ func ConsumeRestoreCollections(
 	ctr *count.Bus,
 ) (*support.ControllerOperationStatus, error) {
 	var (
-		lrh                 = libraryRestoreHandler{ac}
-		protectedResourceID = dcs[0].FullPath().ResourceOwner()
-		restoreMetrics      support.CollectionMetrics
-		caches              = onedrive.NewRestoreCaches(backupDriveIDNames)
-		el                  = errs.Local()
+		lrh            = libraryRestoreHandler{ac}
+		restoreMetrics support.CollectionMetrics
+		caches         = onedrive.NewRestoreCaches(backupDriveIDNames)
+		el             = errs.Local()
 	)
 
-	err := caches.Populate(ctx, lrh, protectedResourceID)
+	err := caches.Populate(ctx, lrh, rcc.ProtectedResource.ID())
 	if err != nil {
 		return nil, clues.Wrap(err, "initializing restore caches")
 	}
@@ -69,7 +68,7 @@ func ConsumeRestoreCollections(
 			metrics  support.CollectionMetrics
 			ictx     = clues.Add(ctx,
 				"category", category,
-				"restore_location", rcc.RestoreConfig.Location,
+				"restore_location", clues.Hide(rcc.RestoreConfig.Location),
 				"resource_owner", clues.Hide(dc.FullPath().ResourceOwner()),
 				"full_path", dc.FullPath())
 		)

--- a/website/docs/setup/restore-options.md
+++ b/website/docs/setup/restore-options.md
@@ -108,3 +108,18 @@ the copy of`reports.txt` is named `reports 1.txt`.
 Collisions will entirely replace the current version of the item with the backup
 version. If multiple existing items collide with the backup item, only one of the
 existing items is replaced.
+
+## To resource
+
+The `--to-resource` flag lets you select which resource will receive the restored data.
+A resource can be a mailbox, user, or sharepoint site.  
+
+<CodeBlock language="bash">{
+    `corso restore onedrive --backup abcd --to-resource adelev@alcion.ai`
+}</CodeBlock>
+
+### Limitations
+
+* The resource must exist.  Corso will not create new mailboxes, users, or sites.
+* The resource must have access to the service being restored.  No restore will be
+performed for an unlicensed resource.

--- a/website/docs/setup/restore-options.md
+++ b/website/docs/setup/restore-options.md
@@ -10,7 +10,7 @@ manner to a new folder. When you need more control over the results you can
 use the advanced configuration options to change where and how your data
 gets restored.
 
-## Restore folder target
+## Restore to target folder
 
 The `--destination` flag lets you select the top-level folder where Corso will
 write all of the restored data.
@@ -109,7 +109,7 @@ Collisions will entirely replace the current version of the item with the backup
 version. If multiple existing items collide with the backup item, only one of the
 existing items is replaced.
 
-## Restore resource target
+## Restore to target resource
 
 The `--to-resource` flag lets you select which resource will receive the restored data.
 A resource can be a mailbox, user, sharepoint site, or other owner of data.

--- a/website/docs/setup/restore-options.md
+++ b/website/docs/setup/restore-options.md
@@ -10,7 +10,7 @@ manner to a new folder. When you need more control over the results you can
 use the advanced configuration options to change where and how your data
 gets restored.
 
-## Destination
+## Restore folder target
 
 The `--destination` flag lets you select the top-level folder where Corso will
 write all of the restored data.
@@ -18,7 +18,7 @@ write all of the restored data.
 ### The default destination
 
 <CodeBlock language="bash">{
-    `corso restore onedrive --backup abcd`
+    `corso restore onedrive --backup a422895c-c20c-4b06-883d-b866db9f86ef`
 }</CodeBlock>
 
 If the flag isn't provided, Corso will create a new folder with a standard name:
@@ -29,7 +29,7 @@ data integrity then this is always the safest option.
 ### An alternate destination
 
 <CodeBlock language="bash">{
-    `corso restore onedrive --backup abcd --destination /my-latest-restore`
+    `corso restore onedrive --destination /my-latest-restore --backup a422895c-c20c-4b06-883d-b866db9f86ef`
 }</CodeBlock>
 
 When a destination is manually specified, all restored will appear in that top-level
@@ -41,7 +41,7 @@ folder multiple times.
 ### The original location
 
 <CodeBlock language="bash">{
-    `corso restore onedrive --backup abcd --destination /`
+    `corso restore onedrive --destination / --backup a422895c-c20c-4b06-883d-b866db9f86ef`
 }</CodeBlock>
 
 You can restore items back to their original location by setting the destination
@@ -79,19 +79,19 @@ it still collides.
 Collisions can be handled with three different configurations: `Skip`, `Copy`,
 and `Replace`.
 
-## Skip (default)
+### Skip (default)
 
 <CodeBlock language="bash">{
-    `corso restore onedrive --backup abcd --collisions skip --destination /`
+    `corso restore onedrive --collisions skip --destination / --backup a422895c-c20c-4b06-883d-b866db9f86ef`
 }</CodeBlock>
 
 When a collision is identified, the item is skipped and
 no restore is attempted.
 
-## Copy
+### Copy
 
 <CodeBlock language="bash">{
-    `corso restore onedrive --backup abcd --collisions copy --destination /my-latest-restore`
+    `corso restore onedrive --collisions copy --destination /my-latest-restore --backup a422895c-c20c-4b06-883d-b866db9f86ef`
 }</CodeBlock>
 
 Item collisions create a copy of the item in the backup. The copy holds the backup
@@ -99,23 +99,27 @@ version of the item, leaving the current version unchanged. If necessary, change
 item properties (such as filenames) to avoid additional collisions. Eg:
 the copy of`reports.txt` is named `reports 1.txt`.
 
-## Replace
+### Replace
 
 <CodeBlock language="bash">{
-    `corso restore onedrive --backup abcd --collisions replace --destination /`
+    `corso restore onedrive --collisions replace --destination / --backup a422895c-c20c-4b06-883d-b866db9f86ef`
 }</CodeBlock>
 
 Collisions will entirely replace the current version of the item with the backup
 version. If multiple existing items collide with the backup item, only one of the
 existing items is replaced.
 
-## To resource
+## Restore resource target
 
 The `--to-resource` flag lets you select which resource will receive the restored data.
-A resource can be a mailbox, user, or sharepoint site.  
+A resource can be a mailbox, user, sharepoint site, or other owner of data.
+
+When restoring to a target resource, all other restore configuration behaves normally.
+Data is restored into the default folder: `Corso_Restore_<current-date-time>` (unless a
+`--destination` flag is added).  When restoring in-place, collision policies are followed.
 
 <CodeBlock language="bash">{
-    `corso restore onedrive --backup abcd --to-resource adelev@alcion.ai`
+    `corso restore onedrive --to-resource adelev@alcion.ai --backup a422895c-c20c-4b06-883d-b866db9f86ef`
 }</CodeBlock>
 
 ### Limitations


### PR DESCRIPTION
adds a cli flag for restoring to a different resource (mailbox, user, site) from the one stored in the
backup.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #3562

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
