### PR TITLE
Process assist backups first while merging details

### DIFF
--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -402,7 +402,6 @@ func (op *BackupOperation) do(
 		toMerge,
 		deets,
 		writeStats,
-		op.Selectors.PathService(),
 		op.Errors)
 	if err != nil {
 		return nil, clues.Wrap(err, "merging details")
@@ -639,7 +638,6 @@ func mergeDetailsFromAssistBackups(
 	detailsStore streamstore.Streamer,
 	deets *details.Builder,
 	assistBackups []kopia.BackupEntry,
-	serviceType path.ServiceType,
 	errs *fault.Bus,
 ) (map[string]details.Entry, error) {
 	// If the backup operation did not produce any new details, or if we don't
@@ -671,7 +669,7 @@ func mergeDetailsFromAssistBackups(
 			if err != nil {
 				return nil, clues.New("parsing base item info path").
 					WithClues(mctx).
-					With("repo_ref", path.NewElements(entry.RepoRef))
+					With("repo_ref", path.LoggableDir(entry.RepoRef))
 			}
 
 			// Although this assist base has an entry it may not be the most recent.
@@ -721,7 +719,6 @@ func mergeDetailsFromBaseBackups(
 	dataFromBackup kopia.DetailsMergeInfoer,
 	backups []kopia.BackupEntry,
 	repoRefToAssistDeets map[string]details.Entry,
-	serviceType path.ServiceType,
 	errs *fault.Bus,
 ) error {
 	// Don't bother loading any of the base details if there's nothing we need to merge.
@@ -765,16 +762,7 @@ func mergeDetailsFromBaseBackups(
 			}
 
 			mctx = clues.Add(mctx, "repo_ref", rr)
-			mctx = clues.Add(mctx, "repo_ref", rr)
 
-			newPath, newLoc, locUpdated, err := getNewPathRefs(
-				dataFromBackup,
-				entry,
-				rr,
-				baseBackup.Version)
-			if err != nil {
-				return clues.Wrap(err, "getting updated info for entry").WithClues(mctx)
-			}
 			newPath, newLoc, locUpdated, err := getNewPathRefs(
 				dataFromBackup,
 				entry,
@@ -853,7 +841,6 @@ func mergeDetails(
 	dataFromBackup kopia.DetailsMergeInfoer,
 	deets *details.Builder,
 	writeStats *kopia.BackupStats,
-	serviceType path.ServiceType,
 	errs *fault.Bus,
 ) error {
 	detailsModel := deets.Details().DetailsModel
@@ -871,7 +858,6 @@ func mergeDetails(
 		detailsStore,
 		deets,
 		assistBackups,
-		serviceType,
 		errs)
 	if err != nil {
 		return clues.Wrap(err, "merging details from assist backup")
@@ -889,7 +875,6 @@ func mergeDetails(
 		dataFromBackup,
 		backups,
 		repoRefToAssistDeets,
-		serviceType,
 		errs)
 	if err != nil {
 		return clues.Wrap(err, "merging details from base backup")

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -687,9 +687,10 @@ func mergeDetailsFromAssistBackups(
 
 	// Walk through new deets and update items from assist deets if needed.
 	// There are 2 possibilities here.
-	// 1. The item doesn't exist in assist deets. Do nothing.
+	// 1. The item didn't exist in assist deets. Do nothing.
 	// 2. The item existed in the assist deets. Source it from assist deets
-	// if mod time hasn't changed. Otherwise do nothing.
+	// if mod time hasn't changed. Otherwise current deets have the most
+	// recent info, do nothing.
 	for _, entry := range deets.Details().Items() {
 		assistDeets, ok := repoRefToAssistDeets[entry.RepoRef]
 		if !ok {
@@ -697,7 +698,7 @@ func mergeDetailsFromAssistBackups(
 		}
 
 		// If the mod time hasn't changed, use the item info from assist deets.
-		if entry.ItemInfo.Modified() == assistDeets.ItemInfo.Modified() {
+		if entry.ItemInfo.Modified().Equal(assistDeets.ItemInfo.Modified()) {
 			logger.Ctx(ctx).Infow("sourcing item info from assist backup",
 				"repo_ref", entry.RepoRef)
 
@@ -799,6 +800,10 @@ func mergeDetailsFromBaseBackups(
 				logger.Ctx(ctx).Infow("sourcing item info from assist backup",
 					"repo_ref", entry.RepoRef)
 
+				// If something is considered cached then we assume the mod time
+				// hasn’t changed. If the mod time hasn’t changed then we
+				// assume neither the item data nor metadata changed, hence it’s
+				// safe to source the item’s detail entry from assist deets.
 				item = assistDeets.ItemInfo
 			}
 

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -655,7 +655,7 @@ func mergeDetails(
 
 	var (
 		addedEntries int
-		excludeList  = make(map[path.Path]struct{})
+		excludeList  = make(map[string]struct{})
 	)
 
 	// Process partial backups first, as they are more recent
@@ -682,7 +682,7 @@ func mergeDetails(
 					With("repo_ref", path.NewElements(entry.RepoRef))
 			}
 
-			excludeList[rr] = struct{}{}
+			excludeList[rr.ShortRef()] = struct{}{}
 		}
 	}
 
@@ -722,7 +722,7 @@ func mergeDetailsFromBackup(
 	deets *details.Builder,
 	addedEntries *int,
 	errs *fault.Bus,
-	excludeList map[path.Path]struct{},
+	excludeList map[string]struct{},
 ) error {
 	var (
 		mctx                 = clues.Add(ctx, "base_backup_id", baseBackup.ID)
@@ -757,7 +757,7 @@ func mergeDetailsFromBackup(
 		}
 
 		// If we've already added this entry from a more recent backup, skip it.
-		if _, ok := excludeList[rr]; ok {
+		if _, ok := excludeList[rr.ShortRef()]; ok {
 			continue
 		}
 

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -930,10 +930,10 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 				ctx,
 				mds,
 				test.inputBackups,
+				nil,
 				test.mdm,
 				&deets,
 				&writeStats,
-				path.OneDriveService,
 				fault.New(true))
 			test.errCheck(t, err, clues.ToCore(err))
 
@@ -1036,10 +1036,10 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsFolde
 		ctx,
 		mds,
 		[]kopia.BackupEntry{backup1},
+		nil,
 		mdm,
 		&deets,
 		&writeStats,
-		path.ExchangeService,
 		fault.New(true))
 	assert.NoError(t, err, clues.ToCore(err))
 	compareDeetEntries(t, expectedEntries, deets.Details().Entries)


### PR DESCRIPTION
<!-- PR description-->

This PR introduces a few changes to `mergeDetails`.
1. We now merge newly produced deets with assist backups first.
2. We then source the existing deets from merge backups(`DetailsMergeInfoer`) as before. The only new change here is to update items which may have been modified during assist backup. 


---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
