### PR TITLE
Export data from OD/SP in logevity tests

### DIFF
--- a/.github/workflows/longevity_test.yml
+++ b/.github/workflows/longevity_test.yml
@@ -230,6 +230,62 @@ jobs:
 
 ##########################################################################################################################################
 
+# Export OneDrive Test
+      - name: OneDrive Export test
+        run: |
+          set -euo pipefail
+          echo -e "\Export OneDrive test\n" >> ${CORSO_LOG_FILE}
+
+          echo -e "\Export OneDrive test - first entry\n" >> ${CORSO_LOG_FILE}
+          ./corso backup list onedrive 2>/dev/null | tail -n+2 | head -n1 | awk '{print $1}' |
+              while read -r line; do
+                  ./corso export onedrive \
+                    "/tmp/corso-export--$line" \
+                    --no-stats \
+                    --backup "$line" \
+                    2>&1 | tee ${{ env.CORSO_LOG_DIR }}/export_onedrive.txt
+              done
+
+          echo -e "\Export OneDrive test - last entry\n" >> ${CORSO_LOG_FILE}
+          ./corso backup list onedrive 2>/dev/null | tail -n1 | awk '{print $1}' |
+              while read -r line; do
+                  ./corso export onedrive \
+                    "/tmp/corso-export--$line" \
+                    --no-stats \
+                    --backup "$line" \
+                    2>&1 | tee ${{ env.CORSO_LOG_DIR }}/export_onedrive.txt
+              done
+
+##########################################################################################################################################
+
+# Export SharePoint Test
+      - name: SharePoint Export test
+        run: |
+          set -euo pipefail
+          echo -e "\Export SharePoint test\n" >> ${CORSO_LOG_FILE}
+
+          echo -e "\Export SharePoint test - first entry\n" >> ${CORSO_LOG_FILE}
+          ./corso backup list sharepoint 2>/dev/null | tail -n+2 | head -n1 | awk '{print $1}' |
+              while read -r line; do
+                  ./corso export sharepoint \
+                    "/tmp/corso-export--$line" \
+                    --no-stats \
+                    --backup "$line" \
+                    2>&1 | tee ${{ env.CORSO_LOG_DIR }}/export_sharepoint.txt
+              done
+
+          echo -e "\Export SharePoint test - last entry\n" >> ${CORSO_LOG_FILE}
+          ./corso backup list sharepoint 2>/dev/null | tail -n1 | awk '{print $1}' |
+              while read -r line; do
+                  ./corso export sharepoint \
+                    "/tmp/corso-export--$line" \
+                    --no-stats \
+                    --backup "$line" \
+                    2>&1 | tee ${{ env.CORSO_LOG_DIR }}/export_sharepoint.txt
+              done
+
+##########################################################################################################################################
+
 # Maintenance test
       - name: Maintenance test Daily
         id: maintenance-test-daily

--- a/.github/workflows/longevity_test.yml
+++ b/.github/workflows/longevity_test.yml
@@ -243,7 +243,7 @@ jobs:
                     "/tmp/corso-export--$line" \
                     --no-stats \
                     --backup "$line" \
-                    2>&1 | tee ${{ env.CORSO_LOG_DIR }}/export_onedrive.txt
+                    2>&1 | tee ${{ env.CORSO_LOG_DIR }}/export_onedrive_first.txt
               done
 
           echo -e "\Export OneDrive test - last entry\n" >> ${CORSO_LOG_FILE}
@@ -253,7 +253,7 @@ jobs:
                     "/tmp/corso-export--$line" \
                     --no-stats \
                     --backup "$line" \
-                    2>&1 | tee ${{ env.CORSO_LOG_DIR }}/export_onedrive.txt
+                    2>&1 | tee ${{ env.CORSO_LOG_DIR }}/export_onedrive_last.txt
               done
 
 ##########################################################################################################################################
@@ -271,7 +271,7 @@ jobs:
                     "/tmp/corso-export--$line" \
                     --no-stats \
                     --backup "$line" \
-                    2>&1 | tee ${{ env.CORSO_LOG_DIR }}/export_sharepoint.txt
+                    2>&1 | tee ${{ env.CORSO_LOG_DIR }}/export_sharepoint_first.txt
               done
 
           echo -e "\Export SharePoint test - last entry\n" >> ${CORSO_LOG_FILE}
@@ -281,7 +281,7 @@ jobs:
                     "/tmp/corso-export--$line" \
                     --no-stats \
                     --backup "$line" \
-                    2>&1 | tee ${{ env.CORSO_LOG_DIR }}/export_sharepoint.txt
+                    2>&1 | tee ${{ env.CORSO_LOG_DIR }}/export_sharepoint_last.txt
               done
 
 ##########################################################################################################################################


### PR DESCRIPTION
~This tries to export all the backup that is available in the logevity test repo. This should warn us in case we are not able to export any older versions.~ Had a discussion and decided it would be better to export just two items and thought we could start with trying to export the first and the last item.

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* closes https://github.com/alcionai/corso/issues/3920

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
