### PR TITLE
observe refactoring

### DIFF
--- a/src/cli/backup/backup.go
+++ b/src/cli/backup/backup.go
@@ -230,6 +230,9 @@ func runBackups(
 			continue
 		}
 
+		// // observe bars needs to be flushed before printing
+		// ctx = observe.Flush(ctx)
+
 		bIDs = append(bIDs, string(bo.Results.BackupID))
 
 		if !DisplayJSONFormat() {

--- a/src/cli/backup/backup.go
+++ b/src/cli/backup/backup.go
@@ -230,9 +230,6 @@ func runBackups(
 			continue
 		}
 
-		// // observe bars needs to be flushed before printing
-		// ctx = observe.Flush(ctx)
-
 		bIDs = append(bIDs, string(bo.Results.BackupID))
 
 		if !DisplayJSONFormat() {

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -161,16 +161,15 @@ func BuildCommandTree(cmd *cobra.Command) {
 func Handle() {
 	//nolint:forbidigo
 	ctx := config.Seed(context.Background())
+	ctx, log := logger.Seed(ctx, logger.PreloadLoggingFlags(os.Args[1:]))
 	ctx = print.SetRootCmd(ctx, corsoCmd)
-
-	observe.SeedWriter(ctx, print.StderrWriter(ctx), observe.PreloadFlags())
+	ctx = observe.SeedObserver(ctx, print.StderrWriter(ctx), observe.PreloadFlags())
 
 	BuildCommandTree(corsoCmd)
 
-	ctx, log := logger.Seed(ctx, logger.PreloadLoggingFlags(os.Args[1:]))
-
 	defer func() {
-		_ = log.Sync() // flush all logs in the buffer
+		observe.Flush(ctx) // flush the progress bars
+		_ = log.Sync()     // flush all logs in the buffer
 	}()
 
 	if err := corsoCmd.ExecuteContext(ctx); err != nil {

--- a/src/cli/print/print.go
+++ b/src/cli/print/print.go
@@ -9,6 +9,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tidwall/pretty"
 	"github.com/tomlazar/table"
+
+	"github.com/alcionai/corso/src/internal/observe"
 )
 
 var (
@@ -83,38 +85,38 @@ func Only(ctx context.Context, e error) error {
 // if s is nil, prints nothing.
 // Prepends the message with "Error: "
 func Err(ctx context.Context, s ...any) {
-	out(getRootCmd(ctx).ErrOrStderr(), s...)
+	out(ctx, getRootCmd(ctx).ErrOrStderr(), s...)
 }
 
 // Errf prints the params to cobra's error writer (stdErr by default)
 // if s is nil, prints nothing.
 // Prepends the message with "Error: "
 func Errf(ctx context.Context, tmpl string, s ...any) {
-	outf(getRootCmd(ctx).ErrOrStderr(), "\nError: \n\t"+tmpl+"\n", s...)
+	outf(ctx, getRootCmd(ctx).ErrOrStderr(), "\nError: \n\t"+tmpl+"\n", s...)
 }
 
 // Out prints the params to cobra's output writer (stdOut by default)
 // if s is nil, prints nothing.
 func Out(ctx context.Context, s ...any) {
-	out(getRootCmd(ctx).OutOrStdout(), s...)
+	out(ctx, getRootCmd(ctx).OutOrStdout(), s...)
 }
 
 // Out prints the formatted strings to cobra's output writer (stdOut by default)
 // if t is empty, prints nothing.
 func Outf(ctx context.Context, t string, s ...any) {
-	outf(getRootCmd(ctx).OutOrStdout(), t, s...)
+	outf(ctx, getRootCmd(ctx).OutOrStdout(), t, s...)
 }
 
 // Info prints the params to cobra's error writer (stdErr by default)
 // if s is nil, prints nothing.
 func Info(ctx context.Context, s ...any) {
-	out(getRootCmd(ctx).ErrOrStderr(), s...)
+	out(ctx, getRootCmd(ctx).ErrOrStderr(), s...)
 }
 
 // Info prints the formatted strings to cobra's error writer (stdErr by default)
 // if t is empty, prints nothing.
 func Infof(ctx context.Context, t string, s ...any) {
-	outf(getRootCmd(ctx).ErrOrStderr(), t, s...)
+	outf(ctx, getRootCmd(ctx).ErrOrStderr(), t, s...)
 }
 
 // PrettyJSON prettifies and prints the value.
@@ -127,20 +129,26 @@ func PrettyJSON(ctx context.Context, p minimumPrintabler) {
 }
 
 // out is the testable core of exported print funcs
-func out(w io.Writer, s ...any) {
+func out(ctx context.Context, w io.Writer, s ...any) {
 	if len(s) == 0 {
 		return
 	}
+
+	// observe bars needs to be flushed before printing
+	observe.Flush(ctx)
 
 	fmt.Fprint(w, s...)
 	fmt.Fprintf(w, "\n")
 }
 
 // outf is the testable core of exported print funcs
-func outf(w io.Writer, t string, s ...any) {
+func outf(ctx context.Context, w io.Writer, t string, s ...any) {
 	if len(t) == 0 {
 		return
 	}
+
+	// observe bars needs to be flushed before printing
+	observe.Flush(ctx)
 
 	fmt.Fprintf(w, t, s...)
 	fmt.Fprintf(w, "\n")

--- a/src/cli/print/print_test.go
+++ b/src/cli/print/print_test.go
@@ -36,20 +36,28 @@ func (suite *PrintUnitSuite) TestOnly() {
 
 func (suite *PrintUnitSuite) TestOut() {
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
 	b := bytes.Buffer{}
 	msg := "I have seen the fnords!"
 
-	out(&b, msg)
+	out(ctx, &b, msg)
 	assert.Contains(t, b.String(), msg)
 }
 
 func (suite *PrintUnitSuite) TestOutf() {
 	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
 	b := bytes.Buffer{}
 	msg := "I have seen the fnords!"
 	msg2 := "smarf"
 
-	outf(&b, msg, msg2)
+	outf(ctx, &b, msg, msg2)
 	bs := b.String()
 	assert.Contains(t, bs, msg)
 	assert.Contains(t, bs, msg2)

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -73,16 +73,16 @@ func (rw *backupStreamReader) Close() error {
 
 	rw.combined = nil
 
-	var outerErr error
+	var errs *clues.Err
 
 	for _, r := range rw.readers {
 		err := r.Close()
 		if err != nil {
-			outerErr = clues.Stack(err, clues.New("closing reader"))
+			errs = clues.Stack(clues.Wrap(err, "closing reader"), errs)
 		}
 	}
 
-	return outerErr
+	return errs.OrNil()
 }
 
 // restoreStreamReader is a wrapper around the io.Reader that kopia returns when

--- a/src/internal/m365/exchange/backup.go
+++ b/src/internal/m365/exchange/backup.go
@@ -287,10 +287,10 @@ func createCollections(
 		return nil, clues.New("unsupported backup category type").WithClues(ctx)
 	}
 
-	foldersComplete := observe.MessageWithCompletion(
+	progressBar := observe.MessageWithCompletion(
 		ctx,
 		observe.Bulletf("%s", qp.Category))
-	defer close(foldersComplete)
+	defer close(progressBar)
 
 	rootFolder, cc := handler.NewContainerCache(user.ID())
 
@@ -311,8 +311,6 @@ func createCollections(
 	if err != nil {
 		return nil, clues.Wrap(err, "filling collections")
 	}
-
-	foldersComplete <- struct{}{}
 
 	for _, coll := range collections {
 		allCollections = append(allCollections, coll)

--- a/src/internal/m365/exchange/collection.go
+++ b/src/internal/m365/exchange/collection.go
@@ -167,10 +167,7 @@ func (col *Collection) streamItems(ctx context.Context, errs *fault.Bus) {
 			ctx,
 			col.fullPath.Category().String(),
 			col.LocationPath().Elements())
-
-		defer func() {
-			close(colProgress)
-		}()
+		defer close(colProgress)
 	}
 
 	semaphoreCh := make(chan struct{}, col.ctrl.Parallelism.ItemFetch)

--- a/src/internal/m365/onedrive/collections.go
+++ b/src/internal/m365/onedrive/collections.go
@@ -242,8 +242,8 @@ func (c *Collections) Get(
 		driveTombstones[driveID] = struct{}{}
 	}
 
-	driveComplete := observe.MessageWithCompletion(ctx, observe.Bulletf("files"))
-	defer close(driveComplete)
+	progressBar := observe.MessageWithCompletion(ctx, observe.Bulletf("files"))
+	defer close(progressBar)
 
 	// Enumerate drives for the specified resourceOwner
 	pager := c.handler.NewDrivePager(c.resourceOwner, nil)

--- a/src/internal/m365/onedrive/restore.go
+++ b/src/internal/m365/onedrive/restore.go
@@ -976,7 +976,11 @@ func restoreFile(
 		return "", details.ItemInfo{}, clues.Wrap(err, "get item upload session")
 	}
 
-	var written int64
+	var (
+		written          int64
+		progReader       io.ReadCloser
+		closeProgressBar func()
+	)
 
 	// This is just to retry file upload, the uploadSession creation is
 	// not retried here We need extra logic to retry file upload as we
@@ -1002,7 +1006,7 @@ func restoreFile(
 			iReader = itemData.ToReader()
 		}
 
-		progReader, abort := observe.ItemProgress(
+		progReader, closeProgressBar = observe.ItemProgress(
 			ctx,
 			iReader,
 			observe.ItemRestoreMsg,
@@ -1015,8 +1019,8 @@ func restoreFile(
 			break
 		}
 
-		// clear out the bar if err
-		abort()
+		// clear out the progress bar immediately on error
+		closeProgressBar()
 
 		// refresh the io.Writer to restart the upload
 		// TODO: @vkamra verify if var session is the desired input
@@ -1026,6 +1030,8 @@ func restoreFile(
 	if err != nil {
 		return "", details.ItemInfo{}, clues.Wrap(err, "uploading file")
 	}
+
+	defer closeProgressBar()
 
 	dii := ir.AugmentItemInfo(details.ItemInfo{}, newItem, written, nil)
 

--- a/src/internal/m365/sharepoint/backup.go
+++ b/src/internal/m365/sharepoint/backup.go
@@ -62,10 +62,10 @@ func ProduceBackupCollections(
 			break
 		}
 
-		foldersComplete := observe.MessageWithCompletion(
+		progressBar := observe.MessageWithCompletion(
 			ctx,
 			observe.Bulletf("%s", scope.Category().PathType()))
-		defer close(foldersComplete)
+		defer close(progressBar)
 
 		var spcs []data.BackupCollection
 
@@ -125,7 +125,6 @@ func ProduceBackupCollections(
 		}
 
 		collections = append(collections, spcs...)
-		foldersComplete <- struct{}{}
 
 		categories[scope.Category().PathType()] = struct{}{}
 	}

--- a/src/internal/m365/sharepoint/collection.go
+++ b/src/internal/m365/sharepoint/collection.go
@@ -190,10 +190,7 @@ func (sc *Collection) runPopulate(
 		ctx,
 		sc.fullPath.Category().String(),
 		sc.fullPath.Folders())
-
-	defer func() {
-		close(colProgress)
-	}()
+	defer close(colProgress)
 
 	// Switch retrieval function based on category
 	switch sc.category {

--- a/src/internal/observe/observe.go
+++ b/src/internal/observe/observe.go
@@ -279,6 +279,8 @@ func (ac *autoCloser) Close() error {
 // ItemProgress tracks the display of an item in a folder by counting the bytes
 // read through the provided readcloser, up until the byte count matches
 // the totalBytes.
+// The progress bar will close automatically when the reader closes.  If an early
+// close is needed due to abort or other issue, the returned func can be used.
 func ItemProgress(
 	ctx context.Context,
 	rc io.ReadCloser,

--- a/src/internal/observe/observe.go
+++ b/src/internal/observe/observe.go
@@ -80,8 +80,12 @@ func PreloadFlags() config {
 
 // config handles observer configuration
 type config struct {
-	doNotDisplay          bool
+	// under certain conditions (ex: testing) we aren't outputting
+	// to a terminal.  When this happens the observe bars need to be
+	// given a specific optional value or they'll never flush the
+	// writer.
 	displayIsTerminal     bool
+	doNotDisplay          bool
 	keepBarsAfterComplete bool
 }
 
@@ -100,7 +104,7 @@ func (o observer) hidden() bool {
 	return o.cfg.doNotDisplay || o.w == nil
 }
 
-func (o *observer) cycleWriter(ctx context.Context) {
+func (o *observer) resetWriter(ctx context.Context) {
 	opts := []mpb.ContainerOption{
 		mpb.WithWidth(progressBarWidth),
 		mpb.WithWaitGroup(o.wg),
@@ -124,7 +128,7 @@ func SeedObserver(ctx context.Context, w io.Writer, cfg config) context.Context 
 		wg:  &sync.WaitGroup{},
 	}
 
-	obs.cycleWriter(ctx)
+	obs.resetWriter(ctx)
 
 	return setObserver(ctx, obs)
 }
@@ -151,7 +155,7 @@ func Flush(ctx context.Context) {
 		obs.mp.Wait()
 	}
 
-	obs.cycleWriter(ctx)
+	obs.resetWriter(ctx)
 }
 
 const (

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -137,8 +137,6 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 	ctx, end := diagnostics.Span(ctx, "operations:backup:run")
 	defer func() {
 		end()
-		// wait for the progress display to clean up
-		observe.Complete()
 	}()
 
 	ctx, flushMetrics := events.NewMetrics(ctx, logger.Writer{Ctx: ctx})
@@ -399,11 +397,8 @@ func produceBackupDataCollections(
 	ctrlOpts control.Options,
 	errs *fault.Bus,
 ) ([]data.BackupCollection, prefixmatcher.StringSetReader, bool, error) {
-	complete := observe.MessageWithCompletion(ctx, "Discovering items to backup")
-	defer func() {
-		complete <- struct{}{}
-		close(complete)
-	}()
+	progressBar := observe.MessageWithCompletion(ctx, "Discovering items to backup")
+	defer close(progressBar)
 
 	return bp.ProduceBackupCollections(
 		ctx,
@@ -463,11 +458,8 @@ func consumeBackupCollections(
 ) (*kopia.BackupStats, *details.Builder, kopia.DetailsMergeInfoer, error) {
 	ctx = clues.Add(ctx, "collection_source", "operations")
 
-	complete := observe.MessageWithCompletion(ctx, "Backing up data")
-	defer func() {
-		complete <- struct{}{}
-		close(complete)
-	}()
+	progressBar := observe.MessageWithCompletion(ctx, "Backing up data")
+	defer close(progressBar)
 
 	tags := map[string]string{
 		kopia.TagBackupID:       string(backupID),

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -208,12 +208,8 @@ func Connect(
 		}
 	}()
 
-	// Close/Reset the progress bar. This ensures callers don't have to worry about
-	// their output getting clobbered (#1720)
-	defer observe.Complete()
-
-	complete := observe.MessageWithCompletion(ctx, "Connecting to repository")
-	defer close(complete)
+	progressBar := observe.MessageWithCompletion(ctx, "Connecting to repository")
+	defer close(progressBar)
 
 	kopiaRef := kopia.NewConn(s)
 	if err := kopiaRef.Connect(ctx, opts.Repo); err != nil {
@@ -251,8 +247,6 @@ func Connect(
 	if !opts.DisableMetrics {
 		bus.SetRepoID(repoid)
 	}
-
-	complete <- struct{}{}
 
 	// todo: ID and CreatedAt should get retrieved from a stored kopia config.
 	return &repository{
@@ -654,17 +648,20 @@ func newRepoID(s storage.Storage) string {
 // helpers
 // ---------------------------------------------------------------------------
 
+var m365nonce bool
+
 func connectToM365(
 	ctx context.Context,
 	pst path.ServiceType,
 	acct account.Account,
 	co control.Options,
 ) (*m365.Controller, error) {
-	complete := observe.MessageWithCompletion(ctx, "Connecting to M365")
-	defer func() {
-		complete <- struct{}{}
-		close(complete)
-	}()
+	if !m365nonce {
+		m365nonce = true
+
+		progressBar := observe.MessageWithCompletion(ctx, "Connecting to M365")
+		defer close(progressBar)
+	}
 
 	// retrieve data from the producer
 	rc := resource.Users


### PR DESCRIPTION
minor refactor to the observe package to ensure
good behavior from our progress bars.  This refactor has the following goals:

1. get unit tests working with latest version (allows version upgrade after breaking changes)
2. transition the observe writer away from a global and into a context.
3. clean up the pattern of behavior around closing some bars.
4. clean up progress bars that weren't geting closed due to async issues.
5. Generally improve resource control by automating and centralizing some closing and flushing.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
