### PR TITLE
Add test to lookup deleted backup by opening old version of repo

### DIFF
--- a/src/cmd/longevity_test/longevity.go
+++ b/src/cmd/longevity_test/longevity.go
@@ -67,6 +67,9 @@ func deleteBackups(
 // pitrListBackups connects to the repository at the given point in time and
 // lists the backups for service. It then checks the list of backups contains
 // the backups in backupIDs.
+//
+//nolint:unused
+//lint:ignore U1000 Waiting for full support.
 func pitrListBackups(
 	ctx context.Context,
 	service path.ServiceType,
@@ -151,18 +154,8 @@ func main() {
 	}
 
 	_, err = deleteBackups(ctx, service, days)
-	// Get the time before we delete anything so we can open kopia at that time
-	// to ensure the PiTR function works.
-	beforeDel := time.Now()
-
-	deleted, err := deleteBackups(ctx, service, days)
 	if err != nil {
 		fatal(cc.Context(), "deleting backups", clues.Stack(err))
-	}
-
-	err = pitrListBackups(ctx, service, beforeDel, deleted)
-	if err != nil {
-		fatal(ctx, "looking for backups at previous point in time", err)
 	}
 }
 


### PR DESCRIPTION
Make helper function that allows
* opening the repo at a previous point in time
* listing backups
* searching the list for backups in a given set

This will allow us to open the repo just prior to
the point in time at which backups were deleted
so we can ensure PITR is working right

This PR does not enable this functionality in
CI, it only adds the code for it

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [x] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3799

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
