### PR TITLE
Sanity tests for SharePoint export

### DIFF
--- a/.github/actions/backup-restore-test/action.yml
+++ b/.github/actions/backup-restore-test/action.yml
@@ -89,7 +89,7 @@ runs:
       id: export
       shell: bash
       working-directory: src
-      if: ${{ inputs.service == 'onedrive' }} # Export only available for OneDrive
+      if: ${{ inputs.service == 'onedrive' || inputs.service == 'sharepoint' }}
       run: |
         set -euo pipefail
         CORSO_LOG_FILE=${{ inputs.log-dir }}/gotest-restore-${{ inputs.service }}-${{inputs.kind }}.log
@@ -105,7 +105,7 @@ runs:
     - name: Check export ${{ inputs.service }} ${{ inputs.kind }}
       shell: bash
       working-directory: src
-      if: ${{ inputs.service == 'onedrive' }}
+      if: ${{ inputs.service == 'onedrive' || inputs.service == 'sharepoint' }}
       env:
         SANITY_TEST_KIND: export
         SANITY_TEST_FOLDER: /tmp/export-${{ inputs.service }}-${{inputs.kind }}

--- a/src/cmd/sanity_test/export/sharepoint.go
+++ b/src/cmd/sanity_test/export/sharepoint.go
@@ -1,0 +1,88 @@
+package export
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/alcionai/clues"
+	msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
+
+	"github.com/alcionai/corso/src/cmd/sanity_test/common"
+	"github.com/alcionai/corso/src/cmd/sanity_test/restore"
+	"github.com/alcionai/corso/src/internal/common/ptr"
+)
+
+func CheckSharePointExport(
+	ctx context.Context,
+	client *msgraphsdk.GraphServiceClient,
+	siteID, folderName, dataFolder string,
+) {
+	drive, err := client.
+		Sites().
+		BySiteId(siteID).
+		Drive().
+		Get(ctx, nil)
+	if err != nil {
+		common.Fatal(ctx, "getting the drive:", err)
+	}
+
+	// map itemID -> item size
+	var (
+		fileSizes       = make(map[string]int64)
+		exportFileSizes = make(map[string]int64)
+		startTime       = time.Now()
+	)
+
+	err = filepath.Walk(folderName, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return clues.Stack(err)
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(folderName, path)
+		if err != nil {
+			return clues.Stack(err)
+		}
+
+		exportFileSizes[relPath] = info.Size()
+		if startTime.After(info.ModTime()) {
+			startTime = info.ModTime()
+		}
+
+		return nil
+	})
+	if err != nil {
+		fmt.Println("Error walking the path:", err)
+	}
+
+	_ = restore.PopulateDriveDetails(
+		ctx,
+		client,
+		ptr.Val(drive.GetId()),
+		folderName,
+		dataFolder,
+		fileSizes,
+		map[string][]common.PermissionInfo{},
+		startTime)
+
+	for fileName, expected := range fileSizes {
+		common.LogAndPrint(ctx, "checking for file: %s", fileName)
+
+		got := exportFileSizes[fileName]
+
+		common.Assert(
+			ctx,
+			func() bool { return expected == got },
+			fmt.Sprintf("different file size: %s", fileName),
+			expected,
+			got)
+	}
+
+	fmt.Println("Success")
+}

--- a/src/cmd/sanity_test/sanity_tests.go
+++ b/src/cmd/sanity_test/sanity_tests.go
@@ -77,6 +77,8 @@ func main() {
 		switch testService {
 		case "onedrive":
 			export.CheckOneDriveExport(ctx, client, testUser, folder, dataFolder)
+		case "sharepoint":
+			export.CheckSharePointExport(ctx, client, testSite, folder, dataFolder)
 		default:
 			common.Fatal(ctx, "unknown service for export sanity tests", nil)
 		}


### PR DESCRIPTION
This extends the existing export sanity tests to also cover SharePoint exports.

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* closes https://github.com/alcionai/corso/issues/3889

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
