### PR TITLE
threadsafe maps in restore caches

### DIFF
--- a/src/internal/m365/onedrive/item_collector_test.go
+++ b/src/internal/m365/onedrive/item_collector_test.go
@@ -362,7 +362,7 @@ func (suite *OneDriveIntgSuite) TestCreateGetDeleteFolder() {
 	}
 
 	caches := NewRestoreCaches(nil)
-	caches.DriveIDToDriveInfo[driveID] = driveInfo{rootFolderID: ptr.Val(rootFolder.GetId())}
+	caches.DriveIDToDriveInfo.Store(driveID, driveInfo{rootFolderID: ptr.Val(rootFolder.GetId())})
 
 	rh := NewRestoreHandler(suite.ac)
 

--- a/src/internal/m365/onedrive/permission_test.go
+++ b/src/internal/m365/onedrive/permission_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/puzpuzpuz/xsync/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -156,7 +157,12 @@ func runComputeParentPermissionsTest(
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			m, err := computePreviousMetadata(ctx, test.item, test.parentPerms)
+			input := xsync.NewMapOf[metadata.Metadata]()
+			for k, v := range test.parentPerms {
+				input.Store(k, v)
+			}
+
+			m, err := computePreviousMetadata(ctx, test.item, input)
 			require.NoError(t, err, "compute permissions")
 
 			assert.Equal(t, m, test.meta)

--- a/src/internal/m365/onedrive/restore_test.go
+++ b/src/internal/m365/onedrive/restore_test.go
@@ -682,12 +682,12 @@ func (suite *RestoreUnitSuite) TestRestoreCaches_AddDrive() {
 			test.expectErr(t, err, clues.ToCore(err))
 
 			if test.checkValues {
-				idResult := rc.DriveIDToDriveInfo[driveID]
+				idResult, _ := rc.DriveIDToDriveInfo.Load(driveID)
 				assert.Equal(t, driveID, idResult.id, "drive id")
 				assert.Equal(t, name, idResult.name, "drive name")
 				assert.Equal(t, test.expectID, idResult.rootFolderID, "root folder id")
 
-				nameResult := rc.DriveNameToDriveInfo[name]
+				nameResult, _ := rc.DriveNameToDriveInfo.Load(name)
 				assert.Equal(t, driveID, nameResult.id, "drive id")
 				assert.Equal(t, name, nameResult.name, "drive name")
 				assert.Equal(t, test.expectID, nameResult.rootFolderID, "root folder id")
@@ -787,12 +787,12 @@ func (suite *RestoreUnitSuite) TestRestoreCaches_Populate() {
 			assert.Len(t, rc.DriveNameToDriveInfo, test.expectLen)
 
 			if test.checkValues {
-				idResult := rc.DriveIDToDriveInfo[driveID]
+				idResult, _ := rc.DriveIDToDriveInfo.Load(driveID)
 				assert.Equal(t, driveID, idResult.id, "drive id")
 				assert.Equal(t, name, idResult.name, "drive name")
 				assert.Equal(t, rfID, idResult.rootFolderID, "root folder id")
 
-				nameResult := rc.DriveNameToDriveInfo[name]
+				nameResult, _ := rc.DriveNameToDriveInfo.Load(name)
 				assert.Equal(t, driveID, nameResult.id, "drive id")
 				assert.Equal(t, name, nameResult.name, "drive name")
 				assert.Equal(t, rfID, nameResult.rootFolderID, "root folder id")
@@ -868,8 +868,8 @@ func (suite *RestoreUnitSuite) TestEnsureDriveExists() {
 			id:   id,
 			name: name,
 		}
-		rc.DriveIDToDriveInfo[id] = di
-		rc.DriveNameToDriveInfo[name] = di
+		rc.DriveIDToDriveInfo.Store(id, di)
+		rc.DriveNameToDriveInfo.Store(name, di)
 
 		return rc
 	}
@@ -883,8 +883,8 @@ func (suite *RestoreUnitSuite) TestEnsureDriveExists() {
 			id:   "diff",
 			name: name,
 		}
-		rc.DriveIDToDriveInfo["diff"] = di
-		rc.DriveNameToDriveInfo[name] = di
+		rc.DriveIDToDriveInfo.Store("diff", di)
+		rc.DriveNameToDriveInfo.Store(name, di)
 
 		return rc
 	}
@@ -1050,7 +1050,7 @@ func (suite *RestoreUnitSuite) TestEnsureDriveExists() {
 				assert.Equal(t, test.expectName, di.name, "ensured drive has expected name")
 				assert.Equal(t, test.expectID, di.id, "ensured drive has expected id")
 
-				nameResult := rc.DriveNameToDriveInfo[test.expectName]
+				nameResult, _ := rc.DriveNameToDriveInfo.Load(test.expectName)
 				assert.Equal(t, test.expectName, nameResult.name, "found drive entry with expected name")
 			}
 		})

--- a/src/internal/m365/onedrive/restore_test.go
+++ b/src/internal/m365/onedrive/restore_test.go
@@ -783,8 +783,8 @@ func (suite *RestoreUnitSuite) TestRestoreCaches_Populate() {
 			err := rc.Populate(ctx, gdparf, "shmoo")
 			test.expectErr(t, err, clues.ToCore(err))
 
-			assert.Len(t, rc.DriveIDToDriveInfo, test.expectLen)
-			assert.Len(t, rc.DriveNameToDriveInfo, test.expectLen)
+			assert.Equal(t, rc.DriveIDToDriveInfo.Size(), test.expectLen)
+			assert.Equal(t, rc.DriveNameToDriveInfo.Size(), test.expectLen)
 
 			if test.checkValues {
 				idResult, _ := rc.DriveIDToDriveInfo.Load(driveID)

--- a/src/internal/operations/test/onedrive_test.go
+++ b/src/internal/operations/test/onedrive_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/drives"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/puzpuzpuz/xsync/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -334,7 +335,7 @@ func runDriveIncrementalTest(
 		newFileName = "new_file.txt"
 		newFileID   string
 
-		permissionIDMappings = map[string]string{}
+		permissionIDMappings = xsync.NewMapOf[string]()
 		writePerm            = metadata.Permission{
 			ID:       "perm-id",
 			Roles:    []string{"write"},


### PR DESCRIPTION
replaces the restore cache maps with threadsafe maps.

Onedrive restores would rarely fail due to concurrent
map writes against the restore cache maps.  This change
should protect against failure in those conditions.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
