### PR TITLE
Switch bucket the test runs in

### DIFF
--- a/.github/workflows/longevity_test.yml
+++ b/.github/workflows/longevity_test.yml
@@ -28,8 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Need these in the local env so that corso can read them
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
       AZURE_CLIENT_ID: ${{ secrets[needs.SetM365App.outputs.client_id_env] }}
       AZURE_CLIENT_SECRET: ${{ secrets[needs.SetM365App.outputs.client_secret_env] }}
       AZURE_TENANT_ID: ${{ secrets.TENANT_ID }}
@@ -68,6 +66,15 @@ jobs:
       - run: go build -o corso
       
       - run: mkdir ${CORSO_LOG_DIR}
+
+        # Use shorter-lived credentials obtained from assume-role since these
+        # runs haven't been taking long.
+      - name: Configure AWS credentials from Test account
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          role-session-name: integration-testing
+          aws-region: us-east-1
 
 ##########################################################################################################################################
 

--- a/.github/workflows/longevity_test.yml
+++ b/.github/workflows/longevity_test.yml
@@ -86,7 +86,7 @@ jobs:
             --no-stats \
             --hide-progress \
             --prefix ${{ env.PREFIX }} \
-            --bucket ${{ secrets.CI_TESTS_S3_BUCKET }} \
+            --bucket ${{ secrets.CI_RETENTION_TESTS_S3_BUCKET }} \
             --succeed-if-exists \
             2>&1 | tee ${{ env.CORSO_LOG_DIR }}/gotest-repo-init.log
 
@@ -104,7 +104,7 @@ jobs:
             --no-stats \
             --hide-progress \
             --prefix ${{ env.PREFIX }} \
-            --bucket ${{ secrets.CI_TESTS_S3_BUCKET }} \
+            --bucket ${{ secrets.CI_RETENTION_TESTS_S3_BUCKET }} \
             2>&1 | tee ${{ env.CORSO_LOG_DIR }}/gotest-repo-connect.log
 
           if ! grep -q 'Connected to S3 bucket' ${{ env.CORSO_LOG_DIR }}/gotest-repo-connect.log


### PR DESCRIPTION
Switch to a bucket with versioning and
object locking so we can test that too.

Repo configured with retention out of band
since CLI flags for that won't be available
until next release at the earliest

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [x] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3799

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
