### PR TITLE
Use modTime in details merging

### DIFF
--- a/src/internal/kopia/merge_details.go
+++ b/src/internal/kopia/merge_details.go
@@ -1,6 +1,8 @@
 package kopia
 
 import (
+	"time"
+
 	"github.com/alcionai/clues"
 
 	"github.com/alcionai/corso/src/internal/common/prefixmatcher"
@@ -12,14 +14,11 @@ type DetailsMergeInfoer interface {
 	// ItemsToMerge returns the number of items that need to be merged.
 	ItemsToMerge() int
 	// GetNewPathRefs takes the old RepoRef and old LocationRef of an item and
-	// returns the new RepoRef, a prefix of the old LocationRef to replace, and
-	// the new LocationRefPrefix of the item if the item should be merged. If the
-	// item shouldn't be merged nils are returned.
-	//
-	// If the returned old LocationRef prefix is equal to the old LocationRef then
-	// the entire LocationRef should be replaced with the returned value.
+	// returns the new RepoRef, the new location of the item, and the mod time of
+	// the item if available. If the item shouldn't be merged nils are returned.
 	GetNewPathRefs(
 		oldRef *path.Builder,
+		modTime time.Time,
 		oldLoc details.LocationIDer,
 	) (path.Path, *path.Builder, error)
 }
@@ -27,6 +26,7 @@ type DetailsMergeInfoer interface {
 type prevRef struct {
 	repoRef path.Path
 	locRef  *path.Builder
+	modTime *time.Time
 }
 
 type mergeDetails struct {
@@ -44,6 +44,7 @@ func (m *mergeDetails) ItemsToMerge() int {
 
 func (m *mergeDetails) addRepoRef(
 	oldRef *path.Builder,
+	modTime *time.Time,
 	newRef path.Path,
 	newLocRef *path.Builder,
 ) error {
@@ -58,6 +59,7 @@ func (m *mergeDetails) addRepoRef(
 	pr := prevRef{
 		repoRef: newRef,
 		locRef:  newLocRef,
+		modTime: modTime,
 	}
 
 	m.repoRefs[oldRef.ShortRef()] = pr
@@ -67,10 +69,19 @@ func (m *mergeDetails) addRepoRef(
 
 func (m *mergeDetails) GetNewPathRefs(
 	oldRef *path.Builder,
+	modTime time.Time,
 	oldLoc details.LocationIDer,
 ) (path.Path, *path.Builder, error) {
 	pr, ok := m.repoRefs[oldRef.ShortRef()]
 	if !ok {
+		return nil, nil, nil
+	}
+
+	// ModTimes don't match which means we're attempting to merge a different
+	// version of the item (i.e. an older version from an assist base). We
+	// shouldn't return a match because it could cause us to source out-of-date
+	// details for the item.
+	if pr.modTime != nil && !pr.modTime.Equal(modTime) {
 		return nil, nil, nil
 	}
 

--- a/src/internal/kopia/merge_details.go
+++ b/src/internal/kopia/merge_details.go
@@ -14,8 +14,8 @@ type DetailsMergeInfoer interface {
 	// ItemsToMerge returns the number of items that need to be merged.
 	ItemsToMerge() int
 	// GetNewPathRefs takes the old RepoRef and old LocationRef of an item and
-	// returns the new RepoRef, the new location of the item, and the mod time of
-	// the item if available. If the item shouldn't be merged nils are returned.
+	// returns the new RepoRef and the new location of the item the item. If the
+	// item shouldn't be merged nils are returned.
 	GetNewPathRefs(
 		oldRef *path.Builder,
 		modTime time.Time,
@@ -42,6 +42,9 @@ func (m *mergeDetails) ItemsToMerge() int {
 	return len(m.repoRefs)
 }
 
+// addRepoRef adds an entry in mergeDetails that can be looked up later. If
+// modTime is non-nil then it's checked during lookup. If it is nil then the
+// mod time provided during lookup is ignored.
 func (m *mergeDetails) addRepoRef(
 	oldRef *path.Builder,
 	modTime *time.Time,

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -153,8 +153,8 @@ type corsoProgress struct {
 	// deets contains entries that are complete and don't need merged with base
 	// backup data at all.
 	deets *details.Builder
-	// toMerge represents items that we either don't have in-memory item info for
-	// or that need sourced from a base backup due to caching etc.
+	// toMerge represents items that we either don't have in-memory item info or
+	// that need sourced from a base backup due to caching etc.
 	toMerge    *mergeDetails
 	mu         sync.RWMutex
 	totalBytes int64

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/alcionai/corso/src/internal/common/prefixmatcher"
+	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/diagnostics"
 	"github.com/alcionai/corso/src/internal/m365/graph"
@@ -137,6 +138,7 @@ type itemDetails struct {
 	prevPath     path.Path
 	locationPath *path.Builder
 	cached       bool
+	modTime      *time.Time
 }
 
 type corsoProgress struct {
@@ -148,9 +150,11 @@ type corsoProgress struct {
 
 	snapshotfs.UploadProgress
 	pending map[string]*itemDetails
-	deets   *details.Builder
-	// toMerge represents items that we don't have in-memory item info for. The
-	// item info for these items should be sourced from a base snapshot later on.
+	// deets contains entries that are complete and don't need merged with base
+	// backup data at all.
+	deets *details.Builder
+	// toMerge represents items that we either don't have in-memory item info for
+	// or that need sourced from a base backup due to caching etc.
 	toMerge    *mergeDetails
 	mu         sync.RWMutex
 	totalBytes int64
@@ -194,6 +198,9 @@ func (cp *corsoProgress) FinishedFile(relativePath string, err error) {
 
 	// These items were sourced from a base snapshot or were cached in kopia so we
 	// never had to materialize their details in-memory.
+	//
+	// TODO(ashmrtn): When we're ready to merge with cached items add cached as a
+	// condition here.
 	if d.info == nil {
 		if d.prevPath == nil {
 			cp.errs.AddRecoverable(cp.ctx, clues.New("item sourced from previous backup with no previous path").
@@ -208,7 +215,11 @@ func (cp *corsoProgress) FinishedFile(relativePath string, err error) {
 		cp.mu.Lock()
 		defer cp.mu.Unlock()
 
-		err := cp.toMerge.addRepoRef(d.prevPath.ToBuilder(), d.repoPath, d.locationPath)
+		err := cp.toMerge.addRepoRef(
+			d.prevPath.ToBuilder(),
+			d.modTime,
+			d.repoPath,
+			d.locationPath)
 		if err != nil {
 			cp.errs.AddRecoverable(cp.ctx, clues.Wrap(err, "adding item to merge list").
 				With(
@@ -375,6 +386,11 @@ func collectionEntries(
 				continue
 			}
 
+			modTime := time.Now()
+			if smt, ok := e.(data.StreamModTime); ok {
+				modTime = smt.ModTime()
+			}
+
 			// Not all items implement StreamInfo. For example, the metadata files
 			// do not because they don't contain information directly backed up or
 			// used for restore. If progress does not contain information about a
@@ -391,16 +407,20 @@ func collectionEntries(
 				// info nil.
 				itemInfo := ei.Info()
 				d := &itemDetails{
-					info:         &itemInfo,
-					repoPath:     itemPath,
+					info:     &itemInfo,
+					repoPath: itemPath,
+					// Also use the current path as the previous path for this item. This
+					// is so that if the item is marked as cached and we need to merge
+					// details with an assist backup base which sourced the cached item we
+					// can find it with the lookup in DetailsMergeInfoer.
+					//
+					// This all works out because cached item checks in kopia are direct
+					// path + metadata comparisons.
+					prevPath:     itemPath,
 					locationPath: locationPath,
+					modTime:      &modTime,
 				}
 				progress.put(encodeAsPath(itemPath.PopFront().Elements()...), d)
-			}
-
-			modTime := time.Now()
-			if smt, ok := e.(data.StreamModTime); ok {
-				modTime = smt.ModTime()
 			}
 
 			entry := virtualfs.StreamingFileWithModTimeFromReader(
@@ -508,6 +528,7 @@ func streamBaseEntries(
 				repoPath:     itemPath,
 				prevPath:     prevItemPath,
 				locationPath: locationPath,
+				modTime:      ptr.To(entry.ModTime()),
 			}
 			progress.put(encodeAsPath(itemPath.PopFront().Elements()...), d)
 		}

--- a/src/internal/kopia/upload_test.go
+++ b/src/internal/kopia/upload_test.go
@@ -616,7 +616,10 @@ func (suite *CorsoProgressUnitSuite) TestFinishedFileBaseItemDoesntBuildHierarch
 	assert.Empty(t, cp.deets)
 
 	for _, expected := range expectedToMerge {
-		gotRef, _, _ := cp.toMerge.GetNewPathRefs(expected.oldRef, nil)
+		gotRef, _, _ := cp.toMerge.GetNewPathRefs(
+			expected.oldRef,
+			time.Now(),
+			nil)
 		if !assert.NotNil(t, gotRef) {
 			continue
 		}

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -532,7 +532,10 @@ func getNewPathRefs(
 	// able to assume we always have the location in the previous entry. We'll end
 	// up doing some extra parsing, but it will simplify this code.
 	if repoRef.Service() == path.ExchangeService {
-		newPath, newLoc, err := dataFromBackup.GetNewPathRefs(repoRef.ToBuilder(), nil)
+		newPath, newLoc, err := dataFromBackup.GetNewPathRefs(
+			repoRef.ToBuilder(),
+			entry.Modified(),
+			nil)
 		if err != nil {
 			return nil, nil, false, clues.Wrap(err, "getting new paths")
 		} else if newPath == nil {
@@ -565,7 +568,10 @@ func getNewPathRefs(
 		return nil, nil, false, clues.New("entry with empty LocationRef")
 	}
 
-	newPath, newLoc, err := dataFromBackup.GetNewPathRefs(repoRef.ToBuilder(), locRef)
+	newPath, newLoc, err := dataFromBackup.GetNewPathRefs(
+		repoRef.ToBuilder(),
+		entry.Modified(),
+		locRef)
 	if err != nil {
 		return nil, nil, false, clues.Wrap(err, "getting new paths with old location")
 	} else if newPath == nil {

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -138,6 +138,7 @@ type mockDetailsMergeInfoer struct {
 	locs     map[string]*path.Builder
 }
 
+// TODO(ashmrtn): Update this to take mod time?
 func (m *mockDetailsMergeInfoer) add(oldRef, newRef path.Path, newLoc *path.Builder) {
 	oldPB := oldRef.ToBuilder()
 	// Items are indexed individually.
@@ -149,6 +150,7 @@ func (m *mockDetailsMergeInfoer) add(oldRef, newRef path.Path, newLoc *path.Buil
 
 func (m *mockDetailsMergeInfoer) GetNewPathRefs(
 	oldRef *path.Builder,
+	_ time.Time,
 	_ details.LocationIDer,
 ) (path.Path, *path.Builder, error) {
 	return m.repoRefs[oldRef.ShortRef()], m.locs[oldRef.ShortRef()], nil


### PR DESCRIPTION
Add modTime as one of the things that the
DetailsMergeInfoer knows how to check against,
wire it into details merging, and populate it
during item upload

This will help merge assist backup base items
by allowing us to do a direct comparison on
modTimes if we add them to the
DetailsMergeInfoer during upload

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
