### PR TITLE
Update backup details merge logic

### DIFF
--- a/src/internal/data/data_collection.go
+++ b/src/internal/data/data_collection.go
@@ -138,6 +138,9 @@ type StreamSize interface {
 }
 
 // StreamModTime is used to provide the modified time of the stream's data.
+//
+// If an item implements StreamModTime and StreamInfo it should return the same
+// value here as in item.Info().Modified().
 type StreamModTime interface {
 	ModTime() time.Time
 }

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -198,10 +198,7 @@ func (cp *corsoProgress) FinishedFile(relativePath string, err error) {
 
 	// These items were sourced from a base snapshot or were cached in kopia so we
 	// never had to materialize their details in-memory.
-	//
-	// TODO(ashmrtn): When we're ready to merge with cached items add cached as a
-	// condition here.
-	if d.info == nil {
+	if d.info == nil || d.cached {
 		if d.prevPath == nil {
 			cp.errs.AddRecoverable(cp.ctx, clues.New("item sourced from previous backup with no previous path").
 				With(

--- a/src/internal/kopia/upload_test.go
+++ b/src/internal/kopia/upload_test.go
@@ -468,10 +468,9 @@ func (suite *CorsoProgressUnitSuite) TestFinishedFile() {
 			cached: false,
 		},
 		{
-			name:   "all cached from assist base",
-			cached: true,
-			// TODO(ashmrtn): Update to true when we add cached items to toMerge.
-			expectToMergeEntries: false,
+			name:                 "all cached from assist base",
+			cached:               true,
+			expectToMergeEntries: true,
 		},
 		{
 			name:                 "all cached from merge base",

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -965,9 +965,11 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 			collections:           collections,
 			expectedUploadedFiles: 0,
 			expectedCachedFiles:   47,
-			deetsUpdated:          assert.False,
-			hashedBytesCheck:      assert.Zero,
-			uploadedBytes:         []int64{4000, 6000},
+			// Entries go to details merger since cached files are merged too.
+			expectMerge:      true,
+			deetsUpdated:     assert.False,
+			hashedBytesCheck: assert.Zero,
+			uploadedBytes:    []int64{4000, 6000},
 		},
 		{
 			name: "Kopia Assist And Merge No Files Changed",
@@ -999,6 +1001,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 			collections:           collections,
 			expectedUploadedFiles: 0,
 			expectedCachedFiles:   47,
+			expectMerge:           true,
 			deetsUpdated:          assert.False,
 			hashedBytesCheck:      assert.Zero,
 			uploadedBytes:         []int64{4000, 6000},

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -2,6 +2,7 @@ package operations
 
 import (
 	"context"
+	"encoding/json"
 	stdpath "path"
 	"testing"
 	"time"
@@ -1168,9 +1169,27 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 				return
 			}
 
-			assert.ElementsMatch(t, test.expectedEntries, deets.Details().Items())
+			// Check the JSON output format of things because for some reason it's not
+			// using the proper comparison for time.Time and failing due to that.
+			checkJSONOutputs(t, test.expectedEntries, deets.Details().Items())
 		})
 	}
+}
+
+func checkJSONOutputs(
+	t *testing.T,
+	expected []*details.Entry,
+	got []*details.Entry,
+) {
+	t.Helper()
+
+	expectedJSON, err := json.Marshal(expected)
+	require.NoError(t, err, "marshalling expected data")
+
+	gotJSON, err := json.Marshal(got)
+	require.NoError(t, err, "marshalling got data")
+
+	assert.JSONEq(t, string(expectedJSON), string(gotJSON))
 }
 
 func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsFolders() {

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -945,7 +945,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 			inputBackups: []kopia.BackupEntry{
 				{
 					Backup: &backup1,
-					Reasons: []kopia.Reasoner{
+					Reasons: []identity.Reasoner{
 						pathReason1,
 						pathReason3,
 					},
@@ -989,7 +989,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 			inputBackups: []kopia.BackupEntry{
 				{
 					Backup: &backup1,
-					Reasons: []kopia.Reasoner{
+					Reasons: []identity.Reasoner{
 						pathReason1,
 					},
 				},

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -137,9 +137,9 @@ func (mbu mockBackupConsumer) ConsumeBackupCollections(
 type mockDetailsMergeInfoer struct {
 	repoRefs map[string]path.Path
 	locs     map[string]*path.Builder
+	modTimes map[string]time.Time
 }
 
-// TODO(ashmrtn): Update this to take mod time?
 func (m *mockDetailsMergeInfoer) add(oldRef, newRef path.Path, newLoc *path.Builder) {
 	oldPB := oldRef.ToBuilder()
 	// Items are indexed individually.
@@ -149,11 +149,31 @@ func (m *mockDetailsMergeInfoer) add(oldRef, newRef path.Path, newLoc *path.Buil
 	m.locs[oldPB.ShortRef()] = newLoc
 }
 
+func (m *mockDetailsMergeInfoer) addWithModTime(
+	oldRef path.Path,
+	modTime time.Time,
+	newRef path.Path,
+	newLoc *path.Builder,
+) {
+	oldPB := oldRef.ToBuilder()
+	// Items are indexed individually.
+	m.repoRefs[oldPB.ShortRef()] = newRef
+	m.modTimes[oldPB.ShortRef()] = modTime
+
+	// Locations are indexed by directory.
+	m.locs[oldPB.ShortRef()] = newLoc
+}
+
 func (m *mockDetailsMergeInfoer) GetNewPathRefs(
 	oldRef *path.Builder,
-	_ time.Time,
+	modTime time.Time,
 	_ details.LocationIDer,
 ) (path.Path, *path.Builder, error) {
+	// Return no match if the modTime was set and it wasn't what was passed in.
+	if mt, ok := m.modTimes[oldRef.ShortRef()]; ok && !mt.Equal(modTime) {
+		return nil, nil, nil
+	}
+
 	return m.repoRefs[oldRef.ShortRef()], m.locs[oldRef.ShortRef()], nil
 }
 
@@ -169,6 +189,7 @@ func newMockDetailsMergeInfoer() *mockDetailsMergeInfoer {
 	return &mockDetailsMergeInfoer{
 		repoRefs: map[string]path.Path{},
 		locs:     map[string]*path.Builder{},
+		modTimes: map[string]time.Time{},
 	}
 }
 
@@ -290,6 +311,30 @@ func makeDetailsEntry(
 			t,
 			"service %s not supported in helper function",
 			p.Service().String())
+	}
+
+	return res
+}
+
+func makeDetailsEntryWithModTime(
+	t *testing.T,
+	p path.Path,
+	l *path.Builder,
+	size int,
+	updated bool,
+	modTime time.Time,
+) *details.Entry {
+	t.Helper()
+
+	res := makeDetailsEntry(t, p, l, size, updated)
+
+	switch {
+	case res.Exchange != nil:
+		res.Exchange.Modified = modTime
+	case res.OneDrive != nil:
+		res.OneDrive.Modified = modTime
+	case res.SharePoint != nil:
+		res.SharePoint.Modified = modTime
 	}
 
 	return res
@@ -548,6 +593,9 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 			itemPath3.ResourceOwner(),
 			itemPath3.Service(),
 			itemPath3.Category())
+
+		time1 = time.Now()
+		time2 = time1.Add(time.Hour)
 	)
 
 	itemParents1, err := path.GetDriveFolderPath(itemPath1)
@@ -556,10 +604,11 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 	itemParents1String := itemParents1.String()
 
 	table := []struct {
-		name             string
-		populatedDetails map[string]*details.Details
-		inputBackups     []kopia.BackupEntry
-		mdm              *mockDetailsMergeInfoer
+		name               string
+		populatedDetails   map[string]*details.Details
+		inputBackups       []kopia.BackupEntry
+		inputAssistBackups []kopia.BackupEntry
+		mdm                *mockDetailsMergeInfoer
 
 		errCheck        assert.ErrorAssertionFunc
 		expectedEntries []*details.Entry
@@ -610,39 +659,6 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 				return res
 			}(),
 			inputBackups: []kopia.BackupEntry{
-				{
-					Backup: &backup1,
-					Reasons: []identity.Reasoner{
-						pathReason1,
-					},
-				},
-			},
-			populatedDetails: map[string]*details.Details{
-				backup1.DetailsID: {
-					DetailsModel: details.DetailsModel{
-						Entries: []details.Entry{
-							*makeDetailsEntry(suite.T(), itemPath1, locationPath1, 42, false),
-						},
-					},
-				},
-			},
-			errCheck: assert.Error,
-		},
-		{
-			name: "TooManyItems",
-			mdm: func() *mockDetailsMergeInfoer {
-				res := newMockDetailsMergeInfoer()
-				res.add(itemPath1, itemPath1, locationPath1)
-
-				return res
-			}(),
-			inputBackups: []kopia.BackupEntry{
-				{
-					Backup: &backup1,
-					Reasons: []identity.Reasoner{
-						pathReason1,
-					},
-				},
 				{
 					Backup: &backup1,
 					Reasons: []identity.Reasoner{
@@ -916,6 +932,210 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 				makeDetailsEntry(suite.T(), itemPath3, locationPath3, 37, false),
 			},
 		},
+		{
+			name: "MergeAndAssistBases SameItems",
+			mdm: func() *mockDetailsMergeInfoer {
+				res := newMockDetailsMergeInfoer()
+				res.addWithModTime(itemPath1, time1, itemPath1, locationPath1)
+				res.addWithModTime(itemPath3, time2, itemPath3, locationPath3)
+
+				return res
+			}(),
+			inputBackups: []kopia.BackupEntry{
+				{
+					Backup: &backup1,
+					Reasons: []kopia.Reasoner{
+						pathReason1,
+						pathReason3,
+					},
+				},
+			},
+			inputAssistBackups: []kopia.BackupEntry{
+				{Backup: &backup2},
+			},
+			populatedDetails: map[string]*details.Details{
+				backup1.DetailsID: {
+					DetailsModel: details.DetailsModel{
+						Entries: []details.Entry{
+							*makeDetailsEntryWithModTime(suite.T(), itemPath1, locationPath1, 42, false, time1),
+							*makeDetailsEntryWithModTime(suite.T(), itemPath3, locationPath3, 37, false, time2),
+						},
+					},
+				},
+				backup2.DetailsID: {
+					DetailsModel: details.DetailsModel{
+						Entries: []details.Entry{
+							*makeDetailsEntryWithModTime(suite.T(), itemPath1, locationPath1, 42, false, time1),
+							*makeDetailsEntryWithModTime(suite.T(), itemPath3, locationPath3, 37, false, time2),
+						},
+					},
+				},
+			},
+			errCheck: assert.NoError,
+			expectedEntries: []*details.Entry{
+				makeDetailsEntryWithModTime(suite.T(), itemPath1, locationPath1, 42, false, time1),
+				makeDetailsEntryWithModTime(suite.T(), itemPath3, locationPath3, 37, false, time2),
+			},
+		},
+		{
+			name: "MergeAndAssistBases AssistBaseHasNewerItems",
+			mdm: func() *mockDetailsMergeInfoer {
+				res := newMockDetailsMergeInfoer()
+				res.addWithModTime(itemPath1, time2, itemPath1, locationPath1)
+
+				return res
+			}(),
+			inputBackups: []kopia.BackupEntry{
+				{
+					Backup: &backup1,
+					Reasons: []kopia.Reasoner{
+						pathReason1,
+					},
+				},
+			},
+			inputAssistBackups: []kopia.BackupEntry{
+				{Backup: &backup2},
+			},
+			populatedDetails: map[string]*details.Details{
+				backup1.DetailsID: {
+					DetailsModel: details.DetailsModel{
+						Entries: []details.Entry{
+							*makeDetailsEntryWithModTime(suite.T(), itemPath1, locationPath1, 42, false, time1),
+						},
+					},
+				},
+				backup2.DetailsID: {
+					DetailsModel: details.DetailsModel{
+						Entries: []details.Entry{
+							*makeDetailsEntryWithModTime(suite.T(), itemPath1, locationPath1, 84, false, time2),
+						},
+					},
+				},
+			},
+			errCheck: assert.NoError,
+			expectedEntries: []*details.Entry{
+				makeDetailsEntryWithModTime(suite.T(), itemPath1, locationPath1, 84, false, time2),
+			},
+		},
+		{
+			name: "AssistBases ConcurrentAssistBasesPicksMatchingVersion1",
+			mdm: func() *mockDetailsMergeInfoer {
+				res := newMockDetailsMergeInfoer()
+				res.addWithModTime(itemPath1, time2, itemPath1, locationPath1)
+
+				return res
+			}(),
+			inputAssistBackups: []kopia.BackupEntry{
+				{Backup: &backup1},
+				{Backup: &backup2},
+			},
+			populatedDetails: map[string]*details.Details{
+				backup1.DetailsID: {
+					DetailsModel: details.DetailsModel{
+						Entries: []details.Entry{
+							*makeDetailsEntryWithModTime(suite.T(), itemPath1, locationPath1, 42, false, time1),
+						},
+					},
+				},
+				backup2.DetailsID: {
+					DetailsModel: details.DetailsModel{
+						Entries: []details.Entry{
+							*makeDetailsEntryWithModTime(suite.T(), itemPath1, locationPath1, 84, false, time2),
+						},
+					},
+				},
+			},
+			errCheck: assert.NoError,
+			expectedEntries: []*details.Entry{
+				makeDetailsEntryWithModTime(suite.T(), itemPath1, locationPath1, 84, false, time2),
+			},
+		},
+		{
+			name: "AssistBases ConcurrentAssistBasesPicksMatchingVersion2",
+			mdm: func() *mockDetailsMergeInfoer {
+				res := newMockDetailsMergeInfoer()
+				res.addWithModTime(itemPath1, time1, itemPath1, locationPath1)
+
+				return res
+			}(),
+			inputAssistBackups: []kopia.BackupEntry{
+				{Backup: &backup1},
+				{Backup: &backup2},
+			},
+			populatedDetails: map[string]*details.Details{
+				backup1.DetailsID: {
+					DetailsModel: details.DetailsModel{
+						Entries: []details.Entry{
+							*makeDetailsEntryWithModTime(suite.T(), itemPath1, locationPath1, 42, false, time1),
+						},
+					},
+				},
+				backup2.DetailsID: {
+					DetailsModel: details.DetailsModel{
+						Entries: []details.Entry{
+							*makeDetailsEntryWithModTime(suite.T(), itemPath1, locationPath1, 84, false, time2),
+						},
+					},
+				},
+			},
+			errCheck: assert.NoError,
+			expectedEntries: []*details.Entry{
+				makeDetailsEntryWithModTime(suite.T(), itemPath1, locationPath1, 42, false, time1),
+			},
+		},
+		{
+			name: "AssistBases SameItemVersion",
+			mdm: func() *mockDetailsMergeInfoer {
+				res := newMockDetailsMergeInfoer()
+				res.addWithModTime(itemPath1, time1, itemPath1, locationPath1)
+
+				return res
+			}(),
+			inputAssistBackups: []kopia.BackupEntry{
+				{Backup: &backup1},
+				{Backup: &backup2},
+			},
+			populatedDetails: map[string]*details.Details{
+				backup1.DetailsID: {
+					DetailsModel: details.DetailsModel{
+						Entries: []details.Entry{
+							*makeDetailsEntryWithModTime(suite.T(), itemPath1, locationPath1, 42, false, time1),
+						},
+					},
+				},
+				backup2.DetailsID: {
+					DetailsModel: details.DetailsModel{
+						Entries: []details.Entry{
+							*makeDetailsEntryWithModTime(suite.T(), itemPath1, locationPath1, 42, false, time1),
+						},
+					},
+				},
+			},
+			errCheck: assert.NoError,
+			expectedEntries: []*details.Entry{
+				makeDetailsEntryWithModTime(suite.T(), itemPath1, locationPath1, 42, false, time1),
+			},
+		},
+		{
+			name: "AssistBase ItemDeleted",
+			mdm: func() *mockDetailsMergeInfoer {
+				return newMockDetailsMergeInfoer()
+			}(),
+			inputAssistBackups: []kopia.BackupEntry{
+				{Backup: &backup1},
+			},
+			populatedDetails: map[string]*details.Details{
+				backup1.DetailsID: {
+					DetailsModel: details.DetailsModel{
+						Entries: []details.Entry{
+							*makeDetailsEntryWithModTime(suite.T(), itemPath1, locationPath1, 42, false, time1),
+						},
+					},
+				},
+			},
+			errCheck:        assert.NoError,
+			expectedEntries: []*details.Entry{},
+		},
 	}
 
 	for _, test := range table {
@@ -929,10 +1149,14 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 			deets := details.Builder{}
 			writeStats := kopia.BackupStats{}
 
+			bb := kopia.NewMockBackupBases().
+				WithBackups(test.inputBackups...).
+				WithAssistBackups(test.inputAssistBackups...)
+
 			err := mergeDetails(
 				ctx,
 				mds,
-				test.inputBackups,
+				bb,
 				test.mdm,
 				&deets,
 				&writeStats,
@@ -1038,7 +1262,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsFolde
 	err := mergeDetails(
 		ctx,
 		mds,
-		[]kopia.BackupEntry{backup1},
+		kopia.NewMockBackupBases().WithBackups(backup1),
 		mdm,
 		&deets,
 		&writeStats,

--- a/src/internal/operations/test/onedrive_test.go
+++ b/src/internal/operations/test/onedrive_test.go
@@ -401,7 +401,7 @@ func runDriveIncrementalTest(
 			},
 			itemsRead:           1, // .data file for newitem
 			itemsWritten:        3, // .meta for newitem, .dirmeta for parent (.data is not written as it is not updated)
-			nonMetaItemsWritten: 1, // the file for which permission was updated
+			nonMetaItemsWritten: 0, // none because the file is considered cached instead of written.
 		},
 		{
 			name: "remove permission from new file",
@@ -419,7 +419,7 @@ func runDriveIncrementalTest(
 			},
 			itemsRead:           1, // .data file for newitem
 			itemsWritten:        3, // .meta for newitem, .dirmeta for parent (.data is not written as it is not updated)
-			nonMetaItemsWritten: 1, //.data file for newitem
+			nonMetaItemsWritten: 0, // none because the file is considered cached instead of written.
 		},
 		{
 			name: "add permission to container",
@@ -518,7 +518,7 @@ func runDriveIncrementalTest(
 			},
 			itemsRead:           1, // .data file for newitem
 			itemsWritten:        4, // .data and .meta for newitem, .dirmeta for parent
-			nonMetaItemsWritten: 1, // .data file for new item
+			nonMetaItemsWritten: 1, // .data file for moved item
 		},
 		{
 			name: "boomerang a file",
@@ -550,7 +550,7 @@ func runDriveIncrementalTest(
 			},
 			itemsRead:           1, // .data file for newitem
 			itemsWritten:        3, // .data and .meta for newitem, .dirmeta for parent
-			nonMetaItemsWritten: 1, // .data file for new item
+			nonMetaItemsWritten: 0, // non because the file is considered cached instead of written.
 		},
 		{
 			name: "delete file",


### PR DESCRIPTION
Update backup details merge logic to use assist
backup bases. As the modTime check is already in
DetailsMergeInfoer there's not much else to do
here besides wiring things up

Overall, this solution is an alternative to the
previous one. It works by placing all cached
items in the DetailsMergeInfoer instead of adding
them to details (assuming they had a details
entry)

During details merging, we can cycle through
all bases once and track only the items we've
added to details (so we don't duplicate things).
This works because we know precisely which items
we should be looking for

ModTime comparisons in the DetailsMergeInfoer
ensure we get the proper version of each item
details

**Note:** This requires a minor patch to how
we determine if it's safe to persist a backup
model because now backups won't produce details
entries for cached items until `mergeDetails`
runs

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
