### PR TITLE
Add some tests for extending object lock duration

### DIFF
--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -369,6 +369,25 @@ func checkRetentionParams(
 	expectExtend(t, params.ExtendObjectLocks, "extend object locks")
 }
 
+// mustReopen closes and reopens the connection that w uses. Assumes no other
+// structs besides w are holding a reference to the conn that w has.
+//
+//revive:disable-next-line:context-as-argument
+func mustReopen(t *testing.T, ctx context.Context, w *Wrapper) {
+	k := w.c
+
+	err := w.Close(ctx)
+	require.NoError(t, err, "closing wrapper: %v", clues.ToCore(err))
+
+	err = k.Close(ctx)
+	require.NoError(t, err, "closing conn: %v", clues.ToCore(err))
+
+	err = k.Connect(ctx, repository.Options{})
+	require.NoError(t, err, "reconnecting conn: %v", clues.ToCore(err))
+
+	w.c = k
+}
+
 type RetentionIntegrationSuite struct {
 	tester.Suite
 }
@@ -590,6 +609,129 @@ func (suite *RetentionIntegrationSuite) TestSetRetentionParameters_And_Maintenan
 		blob.RetentionMode(""),
 		0,
 		assert.False)
+}
+
+// Check that in the same connection we can create a repo, set and then update
+// the retention period, and run full maintenance to extend object locks.
+func (suite *RetentionIntegrationSuite) TestSetAndUpdateRetentionParameters_RunMaintenance() {
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	k, err := openKopiaRepo(t, ctx)
+	require.NoError(t, err, clues.ToCore(err))
+
+	w := &Wrapper{k}
+
+	mOpts := repository.Maintenance{
+		Safety: repository.FullMaintenanceSafety,
+		Type:   repository.CompleteMaintenance,
+	}
+
+	// This will set common maintenance config parameters. There's some interplay
+	// between the maintenance schedule and retention period that we want to check
+	// below.
+	err = w.RepoMaintenance(ctx, mOpts)
+	require.NoError(t, err, clues.ToCore(err))
+
+	// Enable retention.
+	err = w.SetRetentionParameters(ctx, repository.Retention{
+		Mode:     ptr.To(repository.GovernanceRetention),
+		Duration: ptr.To(time.Hour * 48),
+		Extend:   ptr.To(true),
+	})
+	require.NoError(t, err, clues.ToCore(err))
+
+	checkRetentionParams(
+		t,
+		ctx,
+		k,
+		blob.Governance,
+		time.Hour*48,
+		assert.True)
+
+	// Change retention duration without updating mode.
+	err = w.SetRetentionParameters(ctx, repository.Retention{
+		Duration: ptr.To(time.Hour * 96),
+	})
+	require.NoError(t, err, clues.ToCore(err))
+
+	checkRetentionParams(
+		t,
+		ctx,
+		k,
+		blob.Governance,
+		time.Hour*96,
+		assert.True)
+
+	// Run full maintenance again. This should extend object locks for things if
+	// they exist.
+	err = w.RepoMaintenance(ctx, mOpts)
+	require.NoError(t, err, clues.ToCore(err))
+}
+
+// Test that even if the retention configuration change is done from a different
+// repo connection that we still can extend the object locking duration and run
+// maintenance successfully.
+func (suite *RetentionIntegrationSuite) TestSetAndUpdateRetentionParameters_RunMaintenance2() {
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	k, err := openKopiaRepo(t, ctx)
+	require.NoError(t, err, clues.ToCore(err))
+
+	w := &Wrapper{k}
+
+	mOpts := repository.Maintenance{
+		Safety: repository.FullMaintenanceSafety,
+		Type:   repository.CompleteMaintenance,
+	}
+
+	// This will set common maintenance config parameters. There's some interplay
+	// between the maintenance schedule and retention period that we want to check
+	// below.
+	err = w.RepoMaintenance(ctx, mOpts)
+	require.NoError(t, err, clues.ToCore(err))
+
+	// Enable retention.
+	err = w.SetRetentionParameters(ctx, repository.Retention{
+		Mode:     ptr.To(repository.GovernanceRetention),
+		Duration: ptr.To(time.Hour * 48),
+		Extend:   ptr.To(true),
+	})
+	require.NoError(t, err, clues.ToCore(err))
+
+	checkRetentionParams(
+		t,
+		ctx,
+		k,
+		blob.Governance,
+		time.Hour*48,
+		assert.True)
+
+	mustReopen(t, ctx, w)
+
+	// Change retention duration without updating mode.
+	err = w.SetRetentionParameters(ctx, repository.Retention{
+		Duration: ptr.To(time.Hour * 96),
+	})
+	require.NoError(t, err, clues.ToCore(err))
+
+	checkRetentionParams(
+		t,
+		ctx,
+		k,
+		blob.Governance,
+		time.Hour*96,
+		assert.True)
+
+	// Run full maintenance again. This should extend object locks for things if
+	// they exist.
+	err = w.RepoMaintenance(ctx, mOpts)
+	require.NoError(t, err, clues.ToCore(err))
 }
 
 // ---------------


### PR DESCRIPTION
Make sure that we can successfully update the object lock duration and run full maintenance without having to close and reopen the repo.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3519

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
