### PR TITLE
Add S3 retention checker to longevity test

### DIFF
--- a/.github/workflows/longevity_test.yml
+++ b/.github/workflows/longevity_test.yml
@@ -38,6 +38,11 @@ jobs:
       RESTORE_DEST_PFX: Corso_Test_Longevity_
       TEST_USER: ${{ github.event.inputs.user != '' && github.event.inputs.user || secrets.CORSO_M365_TEST_USER_ID }}
       PREFIX: 'longevity'
+
+      # Options for retention.
+      RETENTION_MODE: GOVERNANCE
+      # Time to retain blobs for in hours.
+      RETENTION_DURATION: 216
     defaults:
       run:
         working-directory: src
@@ -54,7 +59,9 @@ jobs:
         with:
           go-version-file: src/go.mod
 
-      - run: go build -o longevity-test ./cmd/longevity_test
+      - run: |
+          go build -o longevity-test ./cmd/longevity_test
+          go build -o s3checker ./cmd/s3checker
 
       - name: Get version string
         id: version
@@ -319,7 +326,6 @@ jobs:
       - name: Maintenance test Weekly
         id: maintenance-test-weekly
         run: |
-
           if [[ $(date +%A) == "Saturday" ]]; then
             set -euo pipefail
             echo -e "\n Maintenance test Weekly\n" >> ${CORSO_LOG_FILE}
@@ -330,6 +336,29 @@ jobs:
             --force \
             --json \
             2>&1 | tee ${{ env.CORSO_LOG_DIR }}/maintenance_complete.txt 
+
+            # TODO(ashmrtn): We can also check that non-current versions of
+            # blobs don't have their retention extended if we want.
+            #
+            # Objects in S3 should have longer locking retention times now that
+            # we can explicitly check for.
+            #
+            # Blob prefixes are as follows:
+            #   - kopia.blobcfg - repo-wide config
+            #   - kopia.repository - repo-wide config
+            #   - p - data pack blobs (i.e. file data)
+            #   - q - metadata pack blobs (i.e. manifests, directory listings, etc)
+            #   - x - index blobs
+            ./s3checker \
+              --bucket ${{ secrets.CI_RETENTION_TESTS_S3_BUCKET }} \
+              --bucket-prefix ${{ env.PREFIX }} \
+              --retention-mode ${{ env.RETENTION_MODE }} \
+              --live-retention-duration "$((${{ env.RETENTION_DURATION}}-1))h" \
+              --prefix "kopia.blobcfg" \
+              --prefix "kopia.repository" \
+              --prefix "p" \
+              --prefix "q" \
+              --prefix "x"
           fi
 
 ##########################################################################################################################################

--- a/.github/workflows/longevity_test.yml
+++ b/.github/workflows/longevity_test.yml
@@ -340,8 +340,15 @@ jobs:
             # TODO(ashmrtn): We can also check that non-current versions of
             # blobs don't have their retention extended if we want.
             #
-            # Objects in S3 should have longer locking retention times now that
-            # we can explicitly check for.
+            # Assuming no failures during full maintenance, current versions of
+            # objects with the below versions should have retention times that
+            # are roughly (now + RETENTION_DURATION). We can explicitly check
+            # for this, but leave a little breathing room since maintenance may
+            # take some time to run.
+            #
+            # If we pick a live-retention-duration that is too small then we'll
+            # start seeing failures. The check for live objects is a lower bound
+            # check.
             #
             # Blob prefixes are as follows:
             #   - kopia.blobcfg - repo-wide config

--- a/.github/workflows/longevity_test.yml
+++ b/.github/workflows/longevity_test.yml
@@ -250,6 +250,33 @@ jobs:
 
 ##########################################################################################################################################
 
+        # TODO(ashmrtn) Testing only, remove before merging.
+      - name: S3 retention check
+        id: s3-retention-check
+        run: |
+          # TODO(ashmrtn): We can also check that non-current versions of
+          # blobs don't have their retention extended if we want.
+          #
+          # Objects in S3 should have longer locking retention times now that
+          # we can explicitly check for.
+          #
+          # Blob prefixes are as follows:
+          #   - kopia.blobcfg - repo-wide config
+          #   - kopia.repository - repo-wide config
+          #   - p - data pack blobs (i.e. file data)
+          #   - q - metadata pack blobs (i.e. manifests, directory listings, etc)
+          #   - x - index blobs
+          ./s3checker \
+            --bucket ${{ secrets.CI_RETENTION_TESTS_S3_BUCKET }} \
+            --bucket-prefix ${{ env.PREFIX }} \
+            --retention-mode ${{ env.RETENTION_MODE }} \
+            --live-retention-duration "$((${{ env.RETENTION_DURATION}}-1))h" \
+            --prefix "kopia.blobcfg" \
+            --prefix "kopia.repository" \
+            --prefix "p" \
+            --prefix "q" \
+            --prefix "x"
+
 # Export OneDrive Test
       - name: OneDrive Export test
         run: |
@@ -360,33 +387,6 @@ jobs:
               --prefix "q" \
               --prefix "x"
           fi
-
-        # TODO(ashmrtn) Testing only, remove before merging.
-      - name: S3 retention check
-        id: s3-retention-check
-        run: |
-          # TODO(ashmrtn): We can also check that non-current versions of
-          # blobs don't have their retention extended if we want.
-          #
-          # Objects in S3 should have longer locking retention times now that
-          # we can explicitly check for.
-          #
-          # Blob prefixes are as follows:
-          #   - kopia.blobcfg - repo-wide config
-          #   - kopia.repository - repo-wide config
-          #   - p - data pack blobs (i.e. file data)
-          #   - q - metadata pack blobs (i.e. manifests, directory listings, etc)
-          #   - x - index blobs
-          ./s3checker \
-            --bucket ${{ secrets.CI_RETENTION_TESTS_S3_BUCKET }} \
-            --bucket-prefix ${{ env.PREFIX }} \
-            --retention-mode ${{ env.RETENTION_MODE }} \
-            --live-retention-duration "$((${{ env.RETENTION_DURATION}}-1))h" \
-            --prefix "kopia.blobcfg" \
-            --prefix "kopia.repository" \
-            --prefix "p" \
-            --prefix "q" \
-            --prefix "x"
 
 ##########################################################################################################################################
 

--- a/.github/workflows/longevity_test.yml
+++ b/.github/workflows/longevity_test.yml
@@ -42,7 +42,7 @@ jobs:
       # Options for retention.
       RETENTION_MODE: GOVERNANCE
       # Time to retain blobs for in hours.
-      RETENTION_DURATION: 216
+      RETENTION_DURATION: 168
     defaults:
       run:
         working-directory: src
@@ -360,6 +360,33 @@ jobs:
               --prefix "q" \
               --prefix "x"
           fi
+
+        # TODO(ashmrtn) Testing only, remove before merging.
+      - name: S3 retention check
+        id: s3-retention-check
+        run: |
+          # TODO(ashmrtn): We can also check that non-current versions of
+          # blobs don't have their retention extended if we want.
+          #
+          # Objects in S3 should have longer locking retention times now that
+          # we can explicitly check for.
+          #
+          # Blob prefixes are as follows:
+          #   - kopia.blobcfg - repo-wide config
+          #   - kopia.repository - repo-wide config
+          #   - p - data pack blobs (i.e. file data)
+          #   - q - metadata pack blobs (i.e. manifests, directory listings, etc)
+          #   - x - index blobs
+          ./s3checker \
+            --bucket ${{ secrets.CI_RETENTION_TESTS_S3_BUCKET }} \
+            --bucket-prefix ${{ env.PREFIX }} \
+            --retention-mode ${{ env.RETENTION_MODE }} \
+            --live-retention-duration "$((${{ env.RETENTION_DURATION}}-1))h" \
+            --prefix "kopia.blobcfg" \
+            --prefix "kopia.repository" \
+            --prefix "p" \
+            --prefix "q" \
+            --prefix "x"
 
 ##########################################################################################################################################
 

--- a/.github/workflows/longevity_test.yml
+++ b/.github/workflows/longevity_test.yml
@@ -42,7 +42,7 @@ jobs:
       # Options for retention.
       RETENTION_MODE: GOVERNANCE
       # Time to retain blobs for in hours.
-      RETENTION_DURATION: 168
+      RETENTION_DURATION: 216
     defaults:
       run:
         working-directory: src
@@ -249,33 +249,6 @@ jobs:
           ./longevity-test
 
 ##########################################################################################################################################
-
-        # TODO(ashmrtn) Testing only, remove before merging.
-      - name: S3 retention check
-        id: s3-retention-check
-        run: |
-          # TODO(ashmrtn): We can also check that non-current versions of
-          # blobs don't have their retention extended if we want.
-          #
-          # Objects in S3 should have longer locking retention times now that
-          # we can explicitly check for.
-          #
-          # Blob prefixes are as follows:
-          #   - kopia.blobcfg - repo-wide config
-          #   - kopia.repository - repo-wide config
-          #   - p - data pack blobs (i.e. file data)
-          #   - q - metadata pack blobs (i.e. manifests, directory listings, etc)
-          #   - x - index blobs
-          ./s3checker \
-            --bucket ${{ secrets.CI_RETENTION_TESTS_S3_BUCKET }} \
-            --bucket-prefix ${{ env.PREFIX }} \
-            --retention-mode ${{ env.RETENTION_MODE }} \
-            --live-retention-duration "$((${{ env.RETENTION_DURATION}}-1))h" \
-            --prefix "kopia.blobcfg" \
-            --prefix "kopia.repository" \
-            --prefix "p" \
-            --prefix "q" \
-            --prefix "x"
 
 # Export OneDrive Test
       - name: OneDrive Export test

--- a/src/cmd/longevity_test/longevity.go
+++ b/src/cmd/longevity_test/longevity.go
@@ -67,6 +67,9 @@ func deleteBackups(
 // pitrListBackups connects to the repository at the given point in time and
 // lists the backups for service. It then checks the list of backups contains
 // the backups in backupIDs.
+//
+//nolint:unused
+//lint:ignore U1000 Waiting for full support.
 func pitrListBackups(
 	ctx context.Context,
 	service path.ServiceType,
@@ -150,15 +153,9 @@ func main() {
 		fatal(ctx, "invalid number of days provided", nil)
 	}
 
-	beforeDel := time.Now()
-
-	backups, err := deleteBackups(ctx, service, days)
+	_, err = deleteBackups(ctx, service, days)
 	if err != nil {
-		fatal(ctx, "deleting backups", clues.Stack(err))
-	}
-
-	if err := pitrListBackups(ctx, service, beforeDel, backups); err != nil {
-		fatal(ctx, "listing backups from point in time", clues.Stack(err))
+		fatal(cc.Context(), "deleting backups", clues.Stack(err))
 	}
 }
 

--- a/src/cmd/longevity_test/longevity.go
+++ b/src/cmd/longevity_test/longevity.go
@@ -67,9 +67,6 @@ func deleteBackups(
 // pitrListBackups connects to the repository at the given point in time and
 // lists the backups for service. It then checks the list of backups contains
 // the backups in backupIDs.
-//
-//nolint:unused
-//lint:ignore U1000 Waiting for full support.
 func pitrListBackups(
 	ctx context.Context,
 	service path.ServiceType,
@@ -153,9 +150,15 @@ func main() {
 		fatal(ctx, "invalid number of days provided", nil)
 	}
 
-	_, err = deleteBackups(ctx, service, days)
+	beforeDel := time.Now()
+
+	backups, err := deleteBackups(ctx, service, days)
 	if err != nil {
-		fatal(cc.Context(), "deleting backups", clues.Stack(err))
+		fatal(ctx, "deleting backups", clues.Stack(err))
+	}
+
+	if err := pitrListBackups(ctx, service, beforeDel, backups); err != nil {
+		fatal(ctx, "listing backups from point in time", clues.Stack(err))
 	}
 }
 


### PR DESCRIPTION
After maintenance runs, check that the
retention time on blobs has been extended
as expected

Currently only checking live blobs

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [x] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* closes #3799

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
