### PR TITLE
Check for backups using PITR in corso

### DIFF
--- a/src/cmd/longevity_test/longevity.go
+++ b/src/cmd/longevity_test/longevity.go
@@ -67,9 +67,6 @@ func deleteBackups(
 // pitrListBackups connects to the repository at the given point in time and
 // lists the backups for service. It then checks the list of backups contains
 // the backups in backupIDs.
-//
-//nolint:unused
-//lint:ignore U1000 Waiting for full support.
 func pitrListBackups(
 	ctx context.Context,
 	service path.ServiceType,
@@ -153,9 +150,15 @@ func main() {
 		fatal(ctx, "invalid number of days provided", nil)
 	}
 
-	_, err = deleteBackups(ctx, service, days)
+	beforeDel := time.Now()
+
+	backups, err := deleteBackups(ctx, service, days)
 	if err != nil {
-		fatal(cc.Context(), "deleting backups", clues.Stack(err))
+		fatal(ctx, "deleting backups", clues.Stack(err))
+	}
+
+	if err := pitrListBackups(ctx, service, beforeDel, backups); err != nil {
+		fatal(ctx, "listing backups from point in time", clues.Stack(err))
 	}
 }
 


### PR DESCRIPTION
After we delete backups, make sure we can still open an old version of the repo and list them.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [x] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3799

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
