### PR TITLE
SDK option and logic to drop assist bases

### DIFF
--- a/src/internal/operations/manifests.go
+++ b/src/internal/operations/manifests.go
@@ -21,7 +21,7 @@ func produceManifestsAndMetadata(
 	rp inject.RestoreProducer,
 	reasons, fallbackReasons []kopia.Reasoner,
 	tenantID string,
-	getMetadata, getAssistBases bool,
+	getMetadata, dropAssistBases bool,
 ) (kopia.BackupBases, []data.RestoreCollection, bool, error) {
 	bb, meta, useMergeBases, err := getManifestsAndMetadata(
 		ctx,
@@ -32,7 +32,7 @@ func produceManifestsAndMetadata(
 		tenantID,
 		getMetadata)
 	if err != nil {
-		return nil, nil, false, clues.Stack(err).OrNil()
+		return nil, nil, false, clues.Stack(err)
 	}
 
 	if !useMergeBases || !getMetadata {
@@ -41,7 +41,7 @@ func produceManifestsAndMetadata(
 		bb.ClearMergeBases()
 	}
 
-	if !getAssistBases {
+	if dropAssistBases {
 		logger.Ctx(ctx).Debug("no caching requested, dropping assist bases")
 
 		bb.ClearAssistBases()

--- a/src/internal/operations/manifests.go
+++ b/src/internal/operations/manifests.go
@@ -25,7 +25,7 @@ func produceManifestsAndMetadata(
 	rp inject.RestoreProducer,
 	reasons, fallbackReasons []kopia.Reasoner,
 	tenantID string,
-	getMetadata bool,
+	getMetadata, getAssistBases bool,
 ) (kopia.BackupBases, []data.RestoreCollection, bool, error) {
 	var (
 		tags          = map[string]string{kopia.TagBackupCategory: ""}

--- a/src/internal/operations/manifests.go
+++ b/src/internal/operations/manifests.go
@@ -15,10 +15,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
-// calls kopia to retrieve prior backup manifests, metadata collections to supply backup heuristics.
-// TODO(ashmrtn): Make this a helper function that always returns as much as
-// possible and call in another function that drops metadata and/or
-// kopia-assisted incremental bases based on flag values.
 func produceManifestsAndMetadata(
 	ctx context.Context,
 	bf inject.BaseFinder,
@@ -26,6 +22,43 @@ func produceManifestsAndMetadata(
 	reasons, fallbackReasons []kopia.Reasoner,
 	tenantID string,
 	getMetadata, getAssistBases bool,
+) (kopia.BackupBases, []data.RestoreCollection, bool, error) {
+	bb, meta, useMergeBases, err := getManifestsAndMetadata(
+		ctx,
+		bf,
+		rp,
+		reasons,
+		fallbackReasons,
+		tenantID,
+		getMetadata)
+	if err != nil {
+		return nil, nil, false, clues.Stack(err).OrNil()
+	}
+
+	if !useMergeBases || !getMetadata {
+		logger.Ctx(ctx).Debug("full backup requested, dropping merge bases")
+
+		bb.ClearMergeBases()
+	}
+
+	if !getAssistBases {
+		logger.Ctx(ctx).Debug("no caching requested, dropping assist bases")
+
+		bb.ClearAssistBases()
+	}
+
+	return bb, meta, useMergeBases, nil
+}
+
+// getManifestsAndMetadata calls kopia to retrieve prior backup manifests,
+// metadata collections to supply backup heuristics.
+func getManifestsAndMetadata(
+	ctx context.Context,
+	bf inject.BaseFinder,
+	rp inject.RestoreProducer,
+	reasons, fallbackReasons []kopia.Reasoner,
+	tenantID string,
+	getMetadata bool,
 ) (kopia.BackupBases, []data.RestoreCollection, bool, error) {
 	var (
 		tags          = map[string]string{kopia.TagBackupCategory: ""}
@@ -52,12 +85,6 @@ func produceManifestsAndMetadata(
 		})
 
 	if !getMetadata {
-		logger.Ctx(ctx).Debug("full backup requested, dropping merge bases")
-
-		// TODO(ashmrtn): If this function is moved to be a helper function then
-		// move this change to the bases to the caller of this function.
-		bb.ClearMergeBases()
-
 		return bb, nil, false, nil
 	}
 

--- a/src/internal/operations/manifests_test.go
+++ b/src/internal/operations/manifests_test.go
@@ -254,7 +254,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 		rp          mockRestoreProducer
 		reasons     []kopia.Reasoner
 		getMeta     bool
-		getAssist   bool
+		dropAssist  bool
 		assertErr   assert.ErrorAssertionFunc
 		assertB     assert.BoolAssertionFunc
 		expectDCS   []mockColl
@@ -266,7 +266,6 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 			rp:         mockRestoreProducer{},
 			reasons:    []kopia.Reasoner{},
 			getMeta:    false,
-			getAssist:  true,
 			assertErr:  assert.NoError,
 			assertB:    assert.False,
 			expectDCS:  nil,
@@ -286,7 +285,6 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				kopia.NewReason("", ro, path.ExchangeService, path.EmailCategory),
 			},
 			getMeta:   false,
-			getAssist: true,
 			assertErr: assert.NoError,
 			assertB:   assert.False,
 			expectDCS: nil,
@@ -308,7 +306,6 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				kopia.NewReason("", ro, path.ExchangeService, path.EmailCategory),
 			},
 			getMeta:   true,
-			getAssist: true,
 			assertErr: assert.NoError,
 			// Doesn't matter if it's true or false as merge/assist bases are
 			// distinct. A future PR can go and remove the requirement to pass the
@@ -338,7 +335,6 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				kopia.NewReason("", ro, path.ExchangeService, path.ContactsCategory),
 			},
 			getMeta:   true,
-			getAssist: true,
 			assertErr: assert.NoError,
 			assertB:   assert.True,
 			expectDCS: []mockColl{{id: "id1"}},
@@ -386,7 +382,6 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				kopia.NewReason("", ro, path.ExchangeService, path.EmailCategory),
 			},
 			getMeta:   true,
-			getAssist: true,
 			assertErr: assert.NoError,
 			assertB:   assert.True,
 			expectDCS: []mockColl{{id: "id1"}},
@@ -416,11 +411,11 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 			reasons: []kopia.Reasoner{
 				kopia.NewReason("", ro, path.ExchangeService, path.EmailCategory),
 			},
-			getMeta:   true,
-			getAssist: false,
-			assertErr: assert.NoError,
-			assertB:   assert.True,
-			expectDCS: []mockColl{{id: "id1"}},
+			getMeta:    true,
+			dropAssist: true,
+			assertErr:  assert.NoError,
+			assertB:    assert.True,
+			expectDCS:  []mockColl{{id: "id1"}},
 			expectMans: kopia.NewMockBackupBases().WithMergeBases(
 				makeMan("id1", "", path.EmailCategory),
 			).
@@ -446,7 +441,6 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				kopia.NewReason("", ro, path.ExchangeService, path.EmailCategory),
 			},
 			getMeta:   true,
-			getAssist: true,
 			assertErr: assert.NoError,
 			assertB:   assert.True,
 			expectDCS: []mockColl{{id: "id1"}, {id: "id2"}},
@@ -469,7 +463,6 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				kopia.NewReason("", ro, path.ExchangeService, path.EmailCategory),
 			},
 			getMeta:    true,
-			getAssist:  true,
 			assertErr:  assert.Error,
 			assertB:    assert.False,
 			expectDCS:  nil,
@@ -491,7 +484,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				test.reasons, nil,
 				tid,
 				test.getMeta,
-				test.getAssist)
+				test.dropAssist)
 			test.assertErr(t, err, clues.ToCore(err))
 			test.assertB(t, b)
 
@@ -590,7 +583,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 		reasons         []kopia.Reasoner
 		fallbackReasons []kopia.Reasoner
 		getMeta         bool
-		getAssist       bool
+		dropAssist      bool
 		assertErr       assert.ErrorAssertionFunc
 		assertB         assert.BoolAssertionFunc
 		expectDCS       []mockColl
@@ -610,7 +603,6 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 			rp:              mockRestoreProducer{},
 			fallbackReasons: []kopia.Reasoner{fbEmailReason},
 			getMeta:         false,
-			getAssist:       true,
 			assertErr:       assert.NoError,
 			assertB:         assert.False,
 			expectDCS:       nil,
@@ -636,7 +628,6 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 			},
 			fallbackReasons: []kopia.Reasoner{fbEmailReason},
 			getMeta:         true,
-			getAssist:       true,
 			assertErr:       assert.NoError,
 			assertB:         assert.True,
 			expectDCS:       []mockColl{{id: "fb_id1"}},
@@ -664,7 +655,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 			},
 			fallbackReasons: []kopia.Reasoner{fbEmailReason},
 			getMeta:         true,
-			getAssist:       false,
+			dropAssist:      true,
 			assertErr:       assert.NoError,
 			assertB:         assert.True,
 			expectDCS:       []mockColl{{id: "fb_id1"}},
@@ -698,7 +689,6 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 			reasons:         []kopia.Reasoner{emailReason},
 			fallbackReasons: []kopia.Reasoner{fbEmailReason},
 			getMeta:         true,
-			getAssist:       true,
 			assertErr:       assert.NoError,
 			assertB:         assert.True,
 			expectDCS:       []mockColl{{id: "id1"}},
@@ -727,7 +717,6 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 			reasons:         []kopia.Reasoner{emailReason},
 			fallbackReasons: []kopia.Reasoner{fbEmailReason},
 			getMeta:         true,
-			getAssist:       true,
 			assertErr:       assert.NoError,
 			assertB:         assert.True,
 			expectDCS:       nil,
@@ -764,7 +753,6 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 			reasons:         []kopia.Reasoner{emailReason},
 			fallbackReasons: []kopia.Reasoner{fbEmailReason},
 			getMeta:         true,
-			getAssist:       true,
 			assertErr:       assert.NoError,
 			assertB:         assert.True,
 			expectDCS:       []mockColl{{id: "id1"}},
@@ -797,7 +785,6 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 			reasons:         []kopia.Reasoner{emailReason},
 			fallbackReasons: []kopia.Reasoner{fbEmailReason},
 			getMeta:         true,
-			getAssist:       true,
 			assertErr:       assert.NoError,
 			assertB:         assert.True,
 			expectDCS:       []mockColl{{id: "fb_id1"}},
@@ -832,7 +819,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 			reasons:         []kopia.Reasoner{emailReason},
 			fallbackReasons: []kopia.Reasoner{fbEmailReason},
 			getMeta:         true,
-			getAssist:       false,
+			dropAssist:      true,
 			assertErr:       assert.NoError,
 			assertB:         assert.True,
 			expectDCS:       []mockColl{{id: "fb_id1"}},
@@ -864,7 +851,6 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 			reasons:         []kopia.Reasoner{emailReason},
 			fallbackReasons: []kopia.Reasoner{fbEmailReason},
 			getMeta:         true,
-			getAssist:       true,
 			assertErr:       assert.NoError,
 			assertB:         assert.True,
 			expectDCS:       []mockColl{{id: "id1"}},
@@ -901,7 +887,6 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 				kopia.NewReason("", fbro, path.ExchangeService, path.ContactsCategory),
 			},
 			getMeta:   true,
-			getAssist: true,
 			assertErr: assert.NoError,
 			assertB:   assert.True,
 			expectDCS: []mockColl{{id: "id1"}},
@@ -934,7 +919,6 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 				kopia.NewReason("", fbro, path.ExchangeService, path.ContactsCategory),
 			},
 			getMeta:   true,
-			getAssist: true,
 			assertErr: assert.NoError,
 			assertB:   assert.True,
 			expectDCS: []mockColl{{id: "id1"}, {id: "fb_id1"}},
@@ -974,7 +958,6 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 				kopia.NewReason("", fbro, path.ExchangeService, path.ContactsCategory),
 			},
 			getMeta:   true,
-			getAssist: true,
 			assertErr: assert.NoError,
 			assertB:   assert.True,
 			expectDCS: []mockColl{{id: "id1"}, {id: "fb_id1"}},
@@ -1001,7 +984,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 				test.reasons, test.fallbackReasons,
 				tid,
 				test.getMeta,
-				test.getAssist)
+				test.dropAssist)
 			test.assertErr(t, err, clues.ToCore(err))
 			test.assertB(t, b)
 

--- a/src/pkg/control/options.go
+++ b/src/pkg/control/options.go
@@ -62,6 +62,10 @@ type Toggles struct {
 	// DisableIncrementals prevents backups from using incremental lookups,
 	// forcing a new, complete backup of all data regardless of prior state.
 	DisableIncrementals bool `json:"exchangeIncrementals,omitempty"`
+	// DisableAssistCaching disables finding cached items in previous failed
+	// backups (i.e. kopia-assisted incrementals). Data dedupe will still occur
+	// since that is based on content hashes.
+	DisableAssistCaching bool `json:"disableAssistCaching,omitempty"`
 	// DisableDelta prevents backups from using delta based lookups,
 	// forcing a backup by enumerating all items. This is different
 	// from DisableIncrementals in that this does not even makes use of

--- a/src/pkg/control/options.go
+++ b/src/pkg/control/options.go
@@ -62,10 +62,12 @@ type Toggles struct {
 	// DisableIncrementals prevents backups from using incremental lookups,
 	// forcing a new, complete backup of all data regardless of prior state.
 	DisableIncrementals bool `json:"exchangeIncrementals,omitempty"`
-	// DisableAssistCaching disables finding cached items in previous failed
+	// ForceItemDataDownload disables finding cached items in previous failed
 	// backups (i.e. kopia-assisted incrementals). Data dedupe will still occur
-	// since that is based on content hashes.
-	DisableAssistCaching bool `json:"disableAssistCaching,omitempty"`
+	// since that is based on content hashes. Items that have not changed since
+	// the previous backup (i.e. in the merge base) will not be redownloaded. Use
+	// DisableIncrementals to control that behavior.
+	ForceItemDataDownload bool `json:"forceItemDataDownload,omitempty"`
 	// DisableDelta prevents backups from using delta based lookups,
 	// forcing a backup by enumerating all items. This is different
 	// from DisableIncrementals in that this does not even makes use of


### PR DESCRIPTION
Add a way for SDK users to drop
kopia-assisted incremental bases
thus forcing item data redownload
if the item wasn't sourced from
a merge base

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #2360

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
