### PR TITLE
Common structs/mocks/consts for assist backups

### DIFF
--- a/src/internal/kopia/backup_bases.go
+++ b/src/internal/kopia/backup_bases.go
@@ -16,6 +16,7 @@ import (
 type BackupBases interface {
 	RemoveMergeBaseByManifestID(manifestID manifest.ID)
 	Backups() []BackupEntry
+	AssistBackups() []BackupEntry
 	MinBackupVersion() int
 	MergeBases() []ManifestEntry
 	ClearMergeBases()
@@ -31,9 +32,10 @@ type BackupBases interface {
 type backupBases struct {
 	// backups and mergeBases should be modified together as they relate similar
 	// data.
-	backups     []BackupEntry
-	mergeBases  []ManifestEntry
-	assistBases []ManifestEntry
+	backups       []BackupEntry
+	mergeBases    []ManifestEntry
+	assistBases   []ManifestEntry
+	assistBackups []BackupEntry
 }
 
 func (bb *backupBases) RemoveMergeBaseByManifestID(manifestID manifest.ID) {
@@ -69,6 +71,10 @@ func (bb *backupBases) RemoveMergeBaseByManifestID(manifestID manifest.ID) {
 
 func (bb backupBases) Backups() []BackupEntry {
 	return slices.Clone(bb.backups)
+}
+
+func (bb backupBases) AssistBackups() []BackupEntry {
+	return slices.Clone(bb.assistBackups)
 }
 
 func (bb *backupBases) MinBackupVersion() int {

--- a/src/internal/kopia/mock_backup_base.go
+++ b/src/internal/kopia/mock_backup_base.go
@@ -14,13 +14,17 @@ func AssertBackupBasesEqual(t *testing.T, expect, got BackupBases) {
 	if expect == nil {
 		assert.Empty(t, got.Backups(), "backups")
 		assert.Empty(t, got.MergeBases(), "merge bases")
+		assert.Empty(t, got.AssistBackups(), "assist backups")
 		assert.Empty(t, got.AssistBases(), "assist bases")
 
 		return
 	}
 
 	if got == nil {
-		if len(expect.Backups()) > 0 && len(expect.MergeBases()) > 0 && len(expect.AssistBases()) > 0 {
+		if len(expect.Backups()) > 0 &&
+			len(expect.MergeBases()) > 0 &&
+			len(expect.AssistBackups()) > 0 &&
+			len(expect.AssistBases()) > 0 {
 			assert.Fail(t, "got was nil but expected non-nil result %v", expect)
 		}
 
@@ -29,6 +33,7 @@ func AssertBackupBasesEqual(t *testing.T, expect, got BackupBases) {
 
 	assert.ElementsMatch(t, expect.Backups(), got.Backups(), "backups")
 	assert.ElementsMatch(t, expect.MergeBases(), got.MergeBases(), "merge bases")
+	assert.ElementsMatch(t, expect.AssistBackups(), got.AssistBackups(), "assist backups")
 	assert.ElementsMatch(t, expect.AssistBases(), got.AssistBases(), "assist bases")
 }
 
@@ -49,6 +54,11 @@ func (bb *MockBackupBases) WithMergeBases(m ...ManifestEntry) *MockBackupBases {
 	bb.backupBases.mergeBases = append(bb.MergeBases(), m...)
 	bb.backupBases.assistBases = append(bb.AssistBases(), m...)
 
+	return bb
+}
+
+func (bb *MockBackupBases) WithAssistBackups(b ...BackupEntry) *MockBackupBases {
+	bb.backupBases.assistBackups = append(bb.AssistBackups(), b...)
 	return bb
 }
 

--- a/src/internal/model/model.go
+++ b/src/internal/model/model.go
@@ -32,7 +32,10 @@ const (
 
 // common tags for filtering
 const (
-	ServiceTag = "service"
+	ServiceTag    = "service"
+	BackupTypeTag = "backup-type"
+	AssistBackup  = "assist-backup"
+	MergeBackup   = "merge-backup"
 )
 
 // Valid returns true if the ModelType value fits within the iota range.


### PR DESCRIPTION
Pull into separate PR so we can start merging things separately.

`BackupBases` sourced from branch `backup_bases_changes`
`model.go` sourced from branch `partial_bup`
mock backup bases sourced from branch `backup-details-merge`

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
