### PR TITLE
move kopia.Reasoner to new package

### DIFF
--- a/src/internal/kopia/backup_bases.go
+++ b/src/internal/kopia/backup_bases.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/alcionai/corso/src/internal/version"
+	"github.com/alcionai/corso/src/pkg/backup/identity"
 	"github.com/alcionai/corso/src/pkg/logger"
 )
 
@@ -25,7 +26,7 @@ type BackupBases interface {
 	MergeBackupBases(
 		ctx context.Context,
 		other BackupBases,
-		reasonToKey func(Reasoner) string,
+		reasonToKey func(identity.Reasoner) string,
 	) BackupBases
 }
 
@@ -131,7 +132,7 @@ func (bb *backupBases) ClearAssistBases() {
 func (bb *backupBases) MergeBackupBases(
 	ctx context.Context,
 	other BackupBases,
-	reasonToKey func(reason Reasoner) string,
+	reasonToKey func(reason identity.Reasoner) string,
 ) BackupBases {
 	if other == nil || (len(other.MergeBases()) == 0 && len(other.AssistBases()) == 0) {
 		return bb
@@ -165,7 +166,7 @@ func (bb *backupBases) MergeBackupBases(
 
 	// Calculate the set of mergeBases to pull from other into this one.
 	for _, m := range other.MergeBases() {
-		useReasons := []Reasoner{}
+		useReasons := []identity.Reasoner{}
 
 		for _, r := range m.Reasons {
 			k := reasonToKey(r)

--- a/src/internal/kopia/backup_bases_test.go
+++ b/src/internal/kopia/backup_bases_test.go
@@ -13,10 +13,11 @@ import (
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/backup"
+	"github.com/alcionai/corso/src/pkg/backup/identity"
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
-func makeManifest(id, incmpl, bID string, reasons ...Reasoner) ManifestEntry {
+func makeManifest(id, incmpl, bID string, reasons ...identity.Reasoner) ManifestEntry {
 	bIDKey, _ := makeTagKV(TagBackupID)
 
 	return ManifestEntry{
@@ -216,7 +217,7 @@ func (suite *BackupBasesUnitSuite) TestMergeBackupBases() {
 
 		for _, i := range mergeInputs {
 			baseID := fmt.Sprintf("id%d", i.id)
-			reasons := make([]Reasoner, 0, len(i.cat))
+			reasons := make([]identity.Reasoner, 0, len(i.cat))
 
 			for _, c := range i.cat {
 				reasons = append(reasons, NewReason("", ro, path.ExchangeService, c))
@@ -241,7 +242,7 @@ func (suite *BackupBasesUnitSuite) TestMergeBackupBases() {
 		for _, i := range assistInputs {
 			baseID := fmt.Sprintf("id%d", i.id)
 
-			reasons := make([]Reasoner, 0, len(i.cat))
+			reasons := make([]identity.Reasoner, 0, len(i.cat))
 
 			for _, c := range i.cat {
 				reasons = append(reasons, NewReason("", ro, path.ExchangeService, c))
@@ -467,7 +468,7 @@ func (suite *BackupBasesUnitSuite) TestMergeBackupBases() {
 			got := bb.MergeBackupBases(
 				ctx,
 				other,
-				func(r Reasoner) string {
+				func(r identity.Reasoner) string {
 					return r.Service().String() + r.Category().String()
 				})
 			AssertBackupBasesEqual(t, expected, got)

--- a/src/internal/kopia/base_finder.go
+++ b/src/internal/kopia/base_finder.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/internal/operations/inject"
 	"github.com/alcionai/corso/src/pkg/backup"
+	"github.com/alcionai/corso/src/pkg/backup/identity"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
 )
@@ -29,23 +30,11 @@ const (
 	userTagPrefix = "tag:"
 )
 
-// TODO(ashmrtn): Move this into some inject package. Here to avoid import
-// cycles.
-type Reasoner interface {
-	Tenant() string
-	ProtectedResource() string
-	Service() path.ServiceType
-	Category() path.CategoryType
-	// SubtreePath returns the path prefix for data in existing backups that have
-	// parameters (tenant, protected resourced, etc) that match this Reasoner.
-	SubtreePath() (path.Path, error)
-}
-
 func NewReason(
 	tenant, resource string,
 	service path.ServiceType,
 	category path.CategoryType,
-) Reasoner {
+) identity.Reasoner {
 	return reason{
 		tenant:   tenant,
 		resource: resource,
@@ -90,7 +79,7 @@ func (r reason) SubtreePath() (path.Path, error) {
 	return p, clues.Wrap(err, "building path").OrNil()
 }
 
-func tagKeys(r Reasoner) []string {
+func tagKeys(r identity.Reasoner) []string {
 	return []string{
 		r.ProtectedResource(),
 		serviceCatString(r.Service(), r.Category()),
@@ -98,13 +87,13 @@ func tagKeys(r Reasoner) []string {
 }
 
 // reasonKey returns the concatenation of the ProtectedResource, Service, and Category.
-func reasonKey(r Reasoner) string {
+func reasonKey(r identity.Reasoner) string {
 	return r.ProtectedResource() + r.Service().String() + r.Category().String()
 }
 
 type BackupEntry struct {
 	*backup.Backup
-	Reasons []Reasoner
+	Reasons []identity.Reasoner
 }
 
 type ManifestEntry struct {
@@ -116,7 +105,7 @@ type ManifestEntry struct {
 	// 1. backup user1 email,contacts -> B1
 	// 2. backup user1 contacts -> B2 (uses B1 as base)
 	// 3. backup user1 email,contacts,events (uses B1 for email, B2 for contacts)
-	Reasons []Reasoner
+	Reasons []identity.Reasoner
 }
 
 func (me ManifestEntry) GetTag(key string) (string, bool) {
@@ -215,7 +204,7 @@ type backupBase struct {
 // are associated with an assist backup or merge backup.
 func (b *baseFinder) findBasesInSet(
 	ctx context.Context,
-	reason Reasoner,
+	reason identity.Reasoner,
 	metas []*manifest.EntryMetadata,
 ) (*backupBase, *backupBase, error) {
 	// Sort manifests by time so we can go through them sequentially. The code in
@@ -288,11 +277,11 @@ func (b *baseFinder) findBasesInSet(
 			if assistBase == nil {
 				assistModel := BackupEntry{
 					Backup:  bup,
-					Reasons: []Reasoner{reason},
+					Reasons: []identity.Reasoner{reason},
 				}
 				assistSnap := ManifestEntry{
 					Manifest: man,
-					Reasons:  []Reasoner{reason},
+					Reasons:  []identity.Reasoner{reason},
 				}
 
 				assistBase = &backupBase{
@@ -318,11 +307,12 @@ func (b *baseFinder) findBasesInSet(
 
 		mergeSnap := ManifestEntry{
 			Manifest: man,
-			Reasons:  []Reasoner{reason},
+			Reasons:  []identity.Reasoner{reason},
 		}
+
 		mergeModel := BackupEntry{
 			Backup:  bup,
-			Reasons: []Reasoner{reason},
+			Reasons: []identity.Reasoner{reason},
 		}
 
 		mergeBase = &backupBase{
@@ -378,7 +368,7 @@ func (b *baseFinder) isAssistBackupModel(
 
 func (b *baseFinder) getBase(
 	ctx context.Context,
-	r Reasoner,
+	r identity.Reasoner,
 	tags map[string]string,
 ) (*backupBase, *backupBase, error) {
 	allTags := map[string]string{}
@@ -405,7 +395,7 @@ func (b *baseFinder) getBase(
 
 func (b *baseFinder) FindBases(
 	ctx context.Context,
-	reasons []Reasoner,
+	reasons []identity.Reasoner,
 	tags map[string]string,
 ) BackupBases {
 	var (

--- a/src/internal/kopia/base_finder_test.go
+++ b/src/internal/kopia/base_finder_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/backup"
+	"github.com/alcionai/corso/src/pkg/backup/identity"
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
@@ -44,7 +45,7 @@ var (
 	testUser2 = "user2"
 	testUser3 = "user3"
 
-	testAllUsersAllCats = []Reasoner{
+	testAllUsersAllCats = []identity.Reasoner{
 		// User1 email and events.
 		NewReason("", testUser1, path.ExchangeService, path.EmailCategory),
 		NewReason("", testUser1, path.ExchangeService, path.EventsCategory),
@@ -55,12 +56,12 @@ var (
 		NewReason("", testUser3, path.ExchangeService, path.EmailCategory),
 		NewReason("", testUser3, path.ExchangeService, path.EventsCategory),
 	}
-	testAllUsersMail = []Reasoner{
+	testAllUsersMail = []identity.Reasoner{
 		NewReason("", testUser1, path.ExchangeService, path.EmailCategory),
 		NewReason("", testUser2, path.ExchangeService, path.EmailCategory),
 		NewReason("", testUser3, path.ExchangeService, path.EmailCategory),
 	}
-	testUser1Mail = []Reasoner{
+	testUser1Mail = []identity.Reasoner{
 		NewReason("", testUser1, path.ExchangeService, path.EmailCategory),
 	}
 )
@@ -292,7 +293,7 @@ func (suite *BaseFinderUnitSuite) TestNoResult_NoBackupsOrSnapshots() {
 		sm: mockEmptySnapshotManager{},
 		bg: mockEmptyModelGetter{},
 	}
-	reasons := []Reasoner{
+	reasons := []identity.Reasoner{
 		NewReason("", "a-user", path.ExchangeService, path.EmailCategory),
 	}
 
@@ -311,7 +312,7 @@ func (suite *BaseFinderUnitSuite) TestNoResult_ErrorListingSnapshots() {
 		sm: &mockSnapshotManager{findErr: assert.AnError},
 		bg: mockEmptyModelGetter{},
 	}
-	reasons := []Reasoner{
+	reasons := []identity.Reasoner{
 		NewReason("", "a-user", path.ExchangeService, path.EmailCategory),
 	}
 
@@ -323,17 +324,17 @@ func (suite *BaseFinderUnitSuite) TestNoResult_ErrorListingSnapshots() {
 func (suite *BaseFinderUnitSuite) TestGetBases() {
 	table := []struct {
 		name         string
-		input        []Reasoner
+		input        []identity.Reasoner
 		manifestData []manifestInfo
 		// Use this to denote the Reasons a base backup or base manifest is
 		// selected. The int maps to the index of the backup or manifest in data.
-		expectedBaseReasons map[int][]Reasoner
+		expectedBaseReasons map[int][]identity.Reasoner
 		// Use this to denote the Reasons a kopia assised incrementals manifest is
 		// selected. The int maps to the index of the manifest in data.
 		// TODO(pandeyabs): Remove this once we have 1:1 mapping between snapshots
 		// and backup models.
-		expectedAssistManifestReasons map[int][]Reasoner
-		expectedAssistReasons         map[int][]Reasoner
+		expectedAssistManifestReasons map[int][]identity.Reasoner
+		expectedAssistReasons         map[int][]identity.Reasoner
 		backupData                    []backupInfo
 	}{
 		{
@@ -359,13 +360,13 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					testUser1,
 				),
 			},
-			expectedBaseReasons: map[int][]Reasoner{
+			expectedBaseReasons: map[int][]identity.Reasoner{
 				1: testUser1Mail,
 			},
-			expectedAssistManifestReasons: map[int][]Reasoner{
+			expectedAssistManifestReasons: map[int][]identity.Reasoner{
 				1: testUser1Mail,
 			},
-			expectedAssistReasons: map[int][]Reasoner{},
+			expectedAssistReasons: map[int][]identity.Reasoner{},
 			backupData: []backupInfo{
 				newBackupModel(testBackup2, true, true, false, nil, nil),
 				newBackupModel(testBackup1, true, true, false, nil, nil),
@@ -394,11 +395,11 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					testUser1,
 				),
 			},
-			expectedBaseReasons: map[int][]Reasoner{},
-			expectedAssistManifestReasons: map[int][]Reasoner{
+			expectedBaseReasons: map[int][]identity.Reasoner{},
+			expectedAssistManifestReasons: map[int][]identity.Reasoner{
 				1: testUser1Mail,
 			},
-			expectedAssistReasons: map[int][]Reasoner{
+			expectedAssistReasons: map[int][]identity.Reasoner{
 				1: testUser1Mail,
 			},
 			backupData: []backupInfo{
@@ -435,10 +436,10 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					testUser1,
 				),
 			},
-			expectedBaseReasons: map[int][]Reasoner{
+			expectedBaseReasons: map[int][]identity.Reasoner{
 				1: testUser1Mail,
 			},
-			expectedAssistManifestReasons: map[int][]Reasoner{
+			expectedAssistManifestReasons: map[int][]identity.Reasoner{
 				1: testUser1Mail,
 			},
 			backupData: []backupInfo{
@@ -469,13 +470,13 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					testUser1,
 				),
 			},
-			expectedBaseReasons: map[int][]Reasoner{
+			expectedBaseReasons: map[int][]identity.Reasoner{
 				1: testUser1Mail,
 			},
-			expectedAssistManifestReasons: map[int][]Reasoner{
+			expectedAssistManifestReasons: map[int][]identity.Reasoner{
 				1: testUser1Mail,
 			},
-			expectedAssistReasons: map[int][]Reasoner{},
+			expectedAssistReasons: map[int][]identity.Reasoner{},
 			backupData: []backupInfo{
 				newBackupModel(testBackup2, true, false, false, nil, nil),
 				newBackupModel(testBackup1, true, true, false, nil, nil),
@@ -498,13 +499,13 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					testUser3,
 				),
 			},
-			expectedBaseReasons: map[int][]Reasoner{
+			expectedBaseReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
-			expectedAssistManifestReasons: map[int][]Reasoner{
+			expectedAssistManifestReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
-			expectedAssistReasons: map[int][]Reasoner{},
+			expectedAssistReasons: map[int][]identity.Reasoner{},
 			backupData: []backupInfo{
 				newBackupModel(testBackup1, true, true, true, nil, nil),
 			},
@@ -526,13 +527,13 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					testUser3,
 				),
 			},
-			expectedBaseReasons: map[int][]Reasoner{
+			expectedBaseReasons: map[int][]identity.Reasoner{
 				0: testAllUsersAllCats,
 			},
-			expectedAssistManifestReasons: map[int][]Reasoner{
+			expectedAssistManifestReasons: map[int][]identity.Reasoner{
 				0: testAllUsersAllCats,
 			},
-			expectedAssistReasons: map[int][]Reasoner{},
+			expectedAssistReasons: map[int][]identity.Reasoner{},
 			backupData: []backupInfo{
 				newBackupModel(testBackup1, true, true, false, nil, nil),
 			},
@@ -554,11 +555,11 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					testUser3,
 				),
 			},
-			expectedBaseReasons: map[int][]Reasoner{},
-			expectedAssistManifestReasons: map[int][]Reasoner{
+			expectedBaseReasons: map[int][]identity.Reasoner{},
+			expectedAssistManifestReasons: map[int][]identity.Reasoner{
 				0: testAllUsersAllCats,
 			},
-			expectedAssistReasons: map[int][]Reasoner{
+			expectedAssistReasons: map[int][]identity.Reasoner{
 				0: testAllUsersAllCats,
 			},
 			backupData: []backupInfo{
@@ -599,7 +600,7 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					testUser3,
 				),
 			},
-			expectedBaseReasons: map[int][]Reasoner{
+			expectedBaseReasons: map[int][]identity.Reasoner{
 				0: {
 					NewReason("", testUser1, path.ExchangeService, path.EmailCategory),
 					NewReason("", testUser2, path.ExchangeService, path.EmailCategory),
@@ -611,7 +612,7 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					NewReason("", testUser3, path.ExchangeService, path.EventsCategory),
 				},
 			},
-			expectedAssistManifestReasons: map[int][]Reasoner{
+			expectedAssistManifestReasons: map[int][]identity.Reasoner{
 				0: {
 					NewReason("", testUser1, path.ExchangeService, path.EmailCategory),
 					NewReason("", testUser2, path.ExchangeService, path.EmailCategory),
@@ -664,7 +665,7 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					testUser2,
 				),
 			},
-			expectedBaseReasons: map[int][]Reasoner{
+			expectedBaseReasons: map[int][]identity.Reasoner{
 				2: {
 					NewReason("", testUser1, path.ExchangeService, path.EmailCategory),
 					NewReason("", testUser2, path.ExchangeService, path.EmailCategory),
@@ -672,7 +673,7 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					NewReason("", testUser2, path.ExchangeService, path.EventsCategory),
 				},
 			},
-			expectedAssistManifestReasons: map[int][]Reasoner{
+			expectedAssistManifestReasons: map[int][]identity.Reasoner{
 				0: {
 					NewReason("", testUser1, path.ExchangeService, path.EventsCategory),
 					NewReason("", testUser2, path.ExchangeService, path.EventsCategory),
@@ -688,7 +689,7 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					NewReason("", testUser2, path.ExchangeService, path.EventsCategory),
 				},
 			},
-			expectedAssistReasons: map[int][]Reasoner{
+			expectedAssistReasons: map[int][]identity.Reasoner{
 				0: {
 					NewReason("", testUser1, path.ExchangeService, path.EventsCategory),
 					NewReason("", testUser2, path.ExchangeService, path.EventsCategory),
@@ -739,10 +740,10 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					testUser1,
 				),
 			},
-			expectedBaseReasons: map[int][]Reasoner{
+			expectedBaseReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
-			expectedAssistManifestReasons: map[int][]Reasoner{
+			expectedAssistManifestReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
 			backupData: []backupInfo{
@@ -774,10 +775,10 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					testUser1,
 				),
 			},
-			expectedBaseReasons: map[int][]Reasoner{
+			expectedBaseReasons: map[int][]identity.Reasoner{
 				1: testUser1Mail,
 			},
-			expectedAssistManifestReasons: map[int][]Reasoner{
+			expectedAssistManifestReasons: map[int][]identity.Reasoner{
 				1: testUser1Mail,
 			},
 			backupData: []backupInfo{
@@ -809,8 +810,8 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					testUser1,
 				),
 			},
-			expectedBaseReasons:           map[int][]Reasoner{},
-			expectedAssistManifestReasons: map[int][]Reasoner{},
+			expectedBaseReasons:           map[int][]identity.Reasoner{},
+			expectedAssistManifestReasons: map[int][]identity.Reasoner{},
 			backupData: []backupInfo{
 				// Shouldn't be returned but have here just so we can see.
 				newBackupModel(testBackup1, true, true, false, nil, nil),
@@ -831,10 +832,10 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					testUser1,
 				),
 			},
-			expectedBaseReasons: map[int][]Reasoner{
+			expectedBaseReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
-			expectedAssistManifestReasons: map[int][]Reasoner{
+			expectedAssistManifestReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
 			backupData: []backupInfo{
@@ -866,10 +867,10 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					testUser1,
 				),
 			},
-			expectedBaseReasons: map[int][]Reasoner{
+			expectedBaseReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
-			expectedAssistManifestReasons: map[int][]Reasoner{
+			expectedAssistManifestReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
 			backupData: []backupInfo{
@@ -919,14 +920,14 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					testUser1,
 				),
 			},
-			expectedBaseReasons: map[int][]Reasoner{
+			expectedBaseReasons: map[int][]identity.Reasoner{
 				2: testUser1Mail,
 			},
-			expectedAssistManifestReasons: map[int][]Reasoner{
+			expectedAssistManifestReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 				2: testUser1Mail,
 			},
-			expectedAssistReasons: map[int][]Reasoner{
+			expectedAssistReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
 			backupData: []backupInfo{
@@ -971,13 +972,13 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					testUser1,
 				),
 			},
-			expectedBaseReasons: map[int][]Reasoner{
+			expectedBaseReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
-			expectedAssistManifestReasons: map[int][]Reasoner{
+			expectedAssistManifestReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
-			expectedAssistReasons: map[int][]Reasoner{},
+			expectedAssistReasons: map[int][]identity.Reasoner{},
 			backupData: []backupInfo{
 				newBackupModel(testBackup2, true, true, false, nil, nil),
 				newBackupModel(
@@ -1012,11 +1013,11 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					testUser1,
 				),
 			},
-			expectedBaseReasons: map[int][]Reasoner{},
-			expectedAssistManifestReasons: map[int][]Reasoner{
+			expectedBaseReasons: map[int][]identity.Reasoner{},
+			expectedAssistManifestReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
-			expectedAssistReasons: map[int][]Reasoner{
+			expectedAssistReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
 			backupData: []backupInfo{
@@ -1050,13 +1051,13 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					testUser1,
 				),
 			},
-			expectedBaseReasons: map[int][]Reasoner{
+			expectedBaseReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
-			expectedAssistManifestReasons: map[int][]Reasoner{
+			expectedAssistManifestReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
-			expectedAssistReasons: map[int][]Reasoner{},
+			expectedAssistReasons: map[int][]identity.Reasoner{},
 			backupData: []backupInfo{
 				newBackupModel(testBackup2, true, true, false, nil, nil),
 				newBackupModel(
@@ -1132,17 +1133,17 @@ func (suite *BaseFinderUnitSuite) TestFindBases_CustomTags() {
 
 	table := []struct {
 		name  string
-		input []Reasoner
+		input []identity.Reasoner
 		tags  map[string]string
 		// Use this to denote which manifests in data should be expected. Allows
 		// defining data in a table while not repeating things between data and
 		// expected.
-		expectedIdxs map[int][]Reasoner
+		expectedIdxs map[int][]identity.Reasoner
 	}{
 		{
 			name: "no tags specified",
 			tags: nil,
-			expectedIdxs: map[int][]Reasoner{
+			expectedIdxs: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
 		},
@@ -1152,14 +1153,14 @@ func (suite *BaseFinderUnitSuite) TestFindBases_CustomTags() {
 				"fnords": "",
 				"smarf":  "",
 			},
-			expectedIdxs: map[int][]Reasoner{
+			expectedIdxs: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
 		},
 		{
 			name: "subset of custom tags",
 			tags: map[string]string{"fnords": ""},
-			expectedIdxs: map[int][]Reasoner{
+			expectedIdxs: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
 		},
@@ -1200,7 +1201,7 @@ func checkManifestEntriesMatch(
 	t *testing.T,
 	retSnaps []ManifestEntry,
 	allExpected []manifestInfo,
-	expectedIdxsAndReasons map[int][]Reasoner,
+	expectedIdxsAndReasons map[int][]identity.Reasoner,
 ) {
 	// Check the proper snapshot manifests were returned.
 	expected := make([]*snapshot.Manifest, 0, len(expectedIdxsAndReasons))
@@ -1216,7 +1217,7 @@ func checkManifestEntriesMatch(
 	assert.ElementsMatch(t, expected, got)
 
 	// Check the reasons for selecting each manifest are correct.
-	expectedReasons := make(map[manifest.ID][]Reasoner, len(expectedIdxsAndReasons))
+	expectedReasons := make(map[manifest.ID][]identity.Reasoner, len(expectedIdxsAndReasons))
 	for idx, reasons := range expectedIdxsAndReasons {
 		expectedReasons[allExpected[idx].man.ID] = reasons
 	}
@@ -1242,7 +1243,7 @@ func checkBackupEntriesMatch(
 	t *testing.T,
 	retBups []BackupEntry,
 	allExpected []backupInfo,
-	expectedIdxsAndReasons map[int][]Reasoner,
+	expectedIdxsAndReasons map[int][]identity.Reasoner,
 ) {
 	// Check the proper snapshot manifests were returned.
 	expected := make([]*backup.Backup, 0, len(expectedIdxsAndReasons))
@@ -1258,7 +1259,7 @@ func checkBackupEntriesMatch(
 	assert.ElementsMatch(t, expected, got)
 
 	// Check the reasons for selecting each manifest are correct.
-	expectedReasons := make(map[model.StableID][]Reasoner, len(expectedIdxsAndReasons))
+	expectedReasons := make(map[model.StableID][]identity.Reasoner, len(expectedIdxsAndReasons))
 	for idx, reasons := range expectedIdxsAndReasons {
 		expectedReasons[allExpected[idx].b.ID] = reasons
 	}

--- a/src/internal/kopia/inject/inject.go
+++ b/src/internal/kopia/inject/inject.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/kopia"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/backup/identity"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 )
@@ -15,7 +16,7 @@ type (
 	BackupConsumer interface {
 		ConsumeBackupCollections(
 			ctx context.Context,
-			backupReasons []kopia.Reasoner,
+			backupReasons []identity.Reasoner,
 			bases kopia.BackupBases,
 			cs []data.BackupCollection,
 			pmr prefixmatcher.StringSetReader,
@@ -38,7 +39,7 @@ type (
 	BaseFinder interface {
 		FindBases(
 			ctx context.Context,
-			reasons []kopia.Reasoner,
+			reasons []identity.Reasoner,
 			tags map[string]string,
 		) kopia.BackupBases
 	}

--- a/src/internal/kopia/upload_test.go
+++ b/src/internal/kopia/upload_test.go
@@ -24,6 +24,7 @@ import (
 	exchMock "github.com/alcionai/corso/src/internal/m365/exchange/mock"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/backup/identity"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 )
@@ -1011,7 +1012,7 @@ func makeManifestEntry(
 	service path.ServiceType,
 	categories ...path.CategoryType,
 ) ManifestEntry {
-	var reasons []Reasoner
+	var reasons []identity.Reasoner
 
 	for _, c := range categories {
 		reasons = append(reasons, NewReason(tenant, resourceOwner, service, c))

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -23,6 +23,7 @@ import (
 	"github.com/alcionai/corso/src/internal/operations/inject"
 	"github.com/alcionai/corso/src/internal/stats"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/backup/identity"
 	"github.com/alcionai/corso/src/pkg/control/repository"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
@@ -137,7 +138,7 @@ func (w *Wrapper) Close(ctx context.Context) error {
 // complete backup of all data.
 func (w Wrapper) ConsumeBackupCollections(
 	ctx context.Context,
-	backupReasons []Reasoner,
+	backupReasons []identity.Reasoner,
 	bases BackupBases,
 	collections []data.BackupCollection,
 	globalExcludeSet prefixmatcher.StringSetReader,

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/onedrive/metadata"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/backup/identity"
 	"github.com/alcionai/corso/src/pkg/control/repository"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
@@ -800,7 +801,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 		"brunhilda": "",
 	}
 
-	reasons := []Reasoner{
+	reasons := []identity.Reasoner{
 		NewReason(
 			testTenant,
 			suite.storePath1.ResourceOwner(),
@@ -1072,7 +1073,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_NoDetailsForMeta() {
 		"brunhilda": "",
 	}
 
-	reasons := []Reasoner{
+	reasons := []identity.Reasoner{
 		NewReason(
 			testTenant,
 			storePath.ResourceOwner(),
@@ -1267,7 +1268,7 @@ func (suite *KopiaIntegrationSuite) TestRestoreAfterCompressionChange() {
 
 	stats, _, _, err := w.ConsumeBackupCollections(
 		ctx,
-		[]Reasoner{r},
+		[]identity.Reasoner{r},
 		nil,
 		[]data.BackupCollection{dc1, dc2},
 		nil,
@@ -1385,7 +1386,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_ReaderError() {
 
 	stats, deets, _, err := suite.w.ConsumeBackupCollections(
 		suite.ctx,
-		[]Reasoner{r},
+		[]identity.Reasoner{r},
 		nil,
 		collections,
 		nil,
@@ -1618,7 +1619,7 @@ func (suite *KopiaSimpleRepoIntegrationSuite) SetupTest() {
 
 	stats, deets, _, err := suite.w.ConsumeBackupCollections(
 		suite.ctx,
-		[]Reasoner{r},
+		[]identity.Reasoner{r},
 		nil,
 		collections,
 		nil,
@@ -1745,11 +1746,11 @@ func (suite *KopiaSimpleRepoIntegrationSuite) TestBackupExcludeItem() {
 
 			stats, _, _, err := suite.w.ConsumeBackupCollections(
 				suite.ctx,
-				[]Reasoner{r},
+				[]identity.Reasoner{r},
 				NewMockBackupBases().WithMergeBases(
 					ManifestEntry{
 						Manifest: man,
-						Reasons:  []Reasoner{r},
+						Reasons:  []identity.Reasoner{r},
 					},
 				),
 				test.cols(),

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -26,6 +26,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/backup/identity"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/count"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -377,7 +378,7 @@ func (op *BackupOperation) do(
 	return deets, nil
 }
 
-func makeFallbackReasons(tenant string, sel selectors.Selector) []kopia.Reasoner {
+func makeFallbackReasons(tenant string, sel selectors.Selector) []identity.Reasoner {
 	if sel.PathService() != path.SharePointService &&
 		sel.DiscreteOwner != sel.DiscreteOwnerName {
 		return selectorToReasons(tenant, sel, true)
@@ -429,9 +430,9 @@ func selectorToReasons(
 	tenant string,
 	sel selectors.Selector,
 	useOwnerNameForID bool,
-) []kopia.Reasoner {
+) []identity.Reasoner {
 	service := sel.PathService()
-	reasons := []kopia.Reasoner{}
+	reasons := []identity.Reasoner{}
 
 	pcs, err := sel.PathCategories()
 	if err != nil {
@@ -459,7 +460,7 @@ func consumeBackupCollections(
 	ctx context.Context,
 	bc kinject.BackupConsumer,
 	tenantID string,
-	reasons []kopia.Reasoner,
+	reasons []identity.Reasoner,
 	bbs kopia.BackupBases,
 	cs []data.BackupCollection,
 	pmr prefixmatcher.StringSetReader,
@@ -511,7 +512,7 @@ func consumeBackupCollections(
 	return kopiaStats, deets, itemsSourcedFromBase, err
 }
 
-func matchesReason(reasons []kopia.Reasoner, p path.Path) bool {
+func matchesReason(reasons []identity.Reasoner, p path.Path) bool {
 	for _, reason := range reasons {
 		if p.ResourceOwner() == reason.ProtectedResource() &&
 			p.Service() == reason.Service() &&

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/backup/identity"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -107,7 +108,7 @@ func checkPaths(t *testing.T, expected, got []path.Path) {
 
 type mockBackupConsumer struct {
 	checkFunc func(
-		backupReasons []kopia.Reasoner,
+		backupReasons []identity.Reasoner,
 		bases kopia.BackupBases,
 		cs []data.BackupCollection,
 		tags map[string]string,
@@ -116,7 +117,7 @@ type mockBackupConsumer struct {
 
 func (mbu mockBackupConsumer) ConsumeBackupCollections(
 	ctx context.Context,
-	backupReasons []kopia.Reasoner,
+	backupReasons []identity.Reasoner,
 	bases kopia.BackupBases,
 	cs []data.BackupCollection,
 	excluded prefixmatcher.StringSetReader,
@@ -408,7 +409,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_ConsumeBackupDataCollections
 			path.ExchangeService,
 			path.ContactsCategory)
 
-		reasons = []kopia.Reasoner{
+		reasons = []identity.Reasoner{
 			emailReason,
 			contactsReason,
 		}
@@ -423,13 +424,13 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_ConsumeBackupDataCollections
 		bases = kopia.NewMockBackupBases().WithMergeBases(
 			kopia.ManifestEntry{
 				Manifest: manifest1,
-				Reasons: []kopia.Reasoner{
+				Reasons: []identity.Reasoner{
 					emailReason,
 				},
 			}).WithAssistBases(
 			kopia.ManifestEntry{
 				Manifest: manifest2,
-				Reasons: []kopia.Reasoner{
+				Reasons: []identity.Reasoner{
 					contactsReason,
 				},
 			})
@@ -443,7 +444,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_ConsumeBackupDataCollections
 
 	mbu := &mockBackupConsumer{
 		checkFunc: func(
-			backupReasons []kopia.Reasoner,
+			backupReasons []identity.Reasoner,
 			gotBases kopia.BackupBases,
 			cs []data.BackupCollection,
 			gotTags map[string]string,
@@ -592,7 +593,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 						},
 						DetailsID: "foo",
 					},
-					Reasons: []kopia.Reasoner{
+					Reasons: []identity.Reasoner{
 						pathReason1,
 					},
 				},
@@ -611,7 +612,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 			inputBackups: []kopia.BackupEntry{
 				{
 					Backup: &backup1,
-					Reasons: []kopia.Reasoner{
+					Reasons: []identity.Reasoner{
 						pathReason1,
 					},
 				},
@@ -638,13 +639,13 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 			inputBackups: []kopia.BackupEntry{
 				{
 					Backup: &backup1,
-					Reasons: []kopia.Reasoner{
+					Reasons: []identity.Reasoner{
 						pathReason1,
 					},
 				},
 				{
 					Backup: &backup1,
-					Reasons: []kopia.Reasoner{
+					Reasons: []identity.Reasoner{
 						pathReason1,
 					},
 				},
@@ -671,7 +672,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 			inputBackups: []kopia.BackupEntry{
 				{
 					Backup: &backup1,
-					Reasons: []kopia.Reasoner{
+					Reasons: []identity.Reasoner{
 						pathReason1,
 					},
 				},
@@ -730,7 +731,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 			inputBackups: []kopia.BackupEntry{
 				{
 					Backup: &backup1,
-					Reasons: []kopia.Reasoner{
+					Reasons: []identity.Reasoner{
 						pathReason1,
 					},
 				},
@@ -757,7 +758,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 			inputBackups: []kopia.BackupEntry{
 				{
 					Backup: &backup1,
-					Reasons: []kopia.Reasoner{
+					Reasons: []identity.Reasoner{
 						pathReason1,
 					},
 				},
@@ -787,7 +788,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 			inputBackups: []kopia.BackupEntry{
 				{
 					Backup: &backup1,
-					Reasons: []kopia.Reasoner{
+					Reasons: []identity.Reasoner{
 						pathReason1,
 					},
 				},
@@ -817,7 +818,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 			inputBackups: []kopia.BackupEntry{
 				{
 					Backup: &backup1,
-					Reasons: []kopia.Reasoner{
+					Reasons: []identity.Reasoner{
 						pathReason1,
 					},
 				},
@@ -848,7 +849,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 			inputBackups: []kopia.BackupEntry{
 				{
 					Backup: &backup1,
-					Reasons: []kopia.Reasoner{
+					Reasons: []identity.Reasoner{
 						pathReason1,
 					},
 				},
@@ -879,13 +880,13 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 			inputBackups: []kopia.BackupEntry{
 				{
 					Backup: &backup1,
-					Reasons: []kopia.Reasoner{
+					Reasons: []identity.Reasoner{
 						pathReason1,
 					},
 				},
 				{
 					Backup: &backup2,
-					Reasons: []kopia.Reasoner{
+					Reasons: []identity.Reasoner{
 						pathReason3,
 					},
 				},
@@ -985,7 +986,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsFolde
 				},
 				DetailsID: "did1",
 			},
-			Reasons: []kopia.Reasoner{
+			Reasons: []identity.Reasoner{
 				pathReason1,
 			},
 		}

--- a/src/internal/operations/manifests.go
+++ b/src/internal/operations/manifests.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alcionai/corso/src/internal/kopia"
 	"github.com/alcionai/corso/src/internal/kopia/inject"
 	"github.com/alcionai/corso/src/internal/m365/graph"
+	"github.com/alcionai/corso/src/pkg/backup/identity"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -19,7 +20,7 @@ func produceManifestsAndMetadata(
 	ctx context.Context,
 	bf inject.BaseFinder,
 	rp inject.RestoreProducer,
-	reasons, fallbackReasons []kopia.Reasoner,
+	reasons, fallbackReasons []identity.Reasoner,
 	tenantID string,
 	getMetadata, dropAssistBases bool,
 ) (kopia.BackupBases, []data.RestoreCollection, bool, error) {
@@ -56,7 +57,7 @@ func getManifestsAndMetadata(
 	ctx context.Context,
 	bf inject.BaseFinder,
 	rp inject.RestoreProducer,
-	reasons, fallbackReasons []kopia.Reasoner,
+	reasons, fallbackReasons []identity.Reasoner,
 	tenantID string,
 	getMetadata bool,
 ) (kopia.BackupBases, []data.RestoreCollection, bool, error) {
@@ -82,7 +83,7 @@ func getManifestsAndMetadata(
 	bb = bb.MergeBackupBases(
 		ctx,
 		fbb,
-		func(r kopia.Reasoner) string {
+		func(r identity.Reasoner) string {
 			return r.Service().String() + r.Category().String()
 		})
 

--- a/src/internal/operations/manifests_test.go
+++ b/src/internal/operations/manifests_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/backup"
+	"github.com/alcionai/corso/src/pkg/backup/identity"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 )
@@ -47,7 +48,7 @@ type mockBackupFinder struct {
 
 func (bf *mockBackupFinder) FindBases(
 	_ context.Context,
-	reasons []kopia.Reasoner,
+	reasons []identity.Reasoner,
 	_ map[string]string,
 ) kopia.BackupBases {
 	if len(reasons) == 0 {
@@ -102,7 +103,7 @@ func (suite *OperationsManifestsUnitSuite) TestCollectMetadata() {
 	table := []struct {
 		name        string
 		manID       string
-		reasons     []kopia.Reasoner
+		reasons     []identity.Reasoner
 		fileNames   []string
 		expectPaths func(*testing.T, []string) []path.Path
 		expectErr   error
@@ -110,7 +111,7 @@ func (suite *OperationsManifestsUnitSuite) TestCollectMetadata() {
 		{
 			name:  "single reason, single file",
 			manID: "single single",
-			reasons: []kopia.Reasoner{
+			reasons: []identity.Reasoner{
 				kopia.NewReason(tid, ro, path.ExchangeService, path.EmailCategory),
 			},
 			expectPaths: func(t *testing.T, files []string) []path.Path {
@@ -129,7 +130,7 @@ func (suite *OperationsManifestsUnitSuite) TestCollectMetadata() {
 		{
 			name:  "single reason, multiple files",
 			manID: "single multi",
-			reasons: []kopia.Reasoner{
+			reasons: []identity.Reasoner{
 				kopia.NewReason(tid, ro, path.ExchangeService, path.EmailCategory),
 			},
 			expectPaths: func(t *testing.T, files []string) []path.Path {
@@ -148,7 +149,7 @@ func (suite *OperationsManifestsUnitSuite) TestCollectMetadata() {
 		{
 			name:  "multiple reasons, single file",
 			manID: "multi single",
-			reasons: []kopia.Reasoner{
+			reasons: []identity.Reasoner{
 				kopia.NewReason(tid, ro, path.ExchangeService, path.EmailCategory),
 				kopia.NewReason(tid, ro, path.ExchangeService, path.ContactsCategory),
 			},
@@ -171,7 +172,7 @@ func (suite *OperationsManifestsUnitSuite) TestCollectMetadata() {
 		{
 			name:  "multiple reasons, multiple file",
 			manID: "multi multi",
-			reasons: []kopia.Reasoner{
+			reasons: []identity.Reasoner{
 				kopia.NewReason(tid, ro, path.ExchangeService, path.EmailCategory),
 				kopia.NewReason(tid, ro, path.ExchangeService, path.ContactsCategory),
 			},
@@ -219,8 +220,8 @@ func buildReasons(
 	ro string,
 	service path.ServiceType,
 	cats ...path.CategoryType,
-) []kopia.Reasoner {
-	var reasons []kopia.Reasoner
+) []identity.Reasoner {
+	var reasons []identity.Reasoner
 
 	for _, cat := range cats {
 		reasons = append(
@@ -252,7 +253,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 		name        string
 		bf          *mockBackupFinder
 		rp          mockRestoreProducer
-		reasons     []kopia.Reasoner
+		reasons     []identity.Reasoner
 		getMeta     bool
 		dropAssist  bool
 		assertErr   assert.ErrorAssertionFunc
@@ -264,7 +265,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 		{
 			name:       "don't get metadata, no mans",
 			rp:         mockRestoreProducer{},
-			reasons:    []kopia.Reasoner{},
+			reasons:    []identity.Reasoner{},
 			getMeta:    false,
 			assertErr:  assert.NoError,
 			assertB:    assert.False,
@@ -281,7 +282,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				},
 			},
 			rp: mockRestoreProducer{},
-			reasons: []kopia.Reasoner{
+			reasons: []identity.Reasoner{
 				kopia.NewReason("", ro, path.ExchangeService, path.EmailCategory),
 			},
 			getMeta:   false,
@@ -302,7 +303,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				},
 			},
 			rp: mockRestoreProducer{},
-			reasons: []kopia.Reasoner{
+			reasons: []identity.Reasoner{
 				kopia.NewReason("", ro, path.ExchangeService, path.EmailCategory),
 			},
 			getMeta:   true,
@@ -330,7 +331,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 					"id1": {data.NoFetchRestoreCollection{Collection: mockColl{id: "id1"}}},
 				},
 			},
-			reasons: []kopia.Reasoner{
+			reasons: []identity.Reasoner{
 				kopia.NewReason("", ro, path.ExchangeService, path.EmailCategory),
 				kopia.NewReason("", ro, path.ExchangeService, path.ContactsCategory),
 			},
@@ -378,7 +379,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 					"id2": {data.NoFetchRestoreCollection{Collection: mockColl{id: "id2"}}},
 				},
 			},
-			reasons: []kopia.Reasoner{
+			reasons: []identity.Reasoner{
 				kopia.NewReason("", ro, path.ExchangeService, path.EmailCategory),
 			},
 			getMeta:   true,
@@ -408,7 +409,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 					"id2": {data.NoFetchRestoreCollection{Collection: mockColl{id: "id2"}}},
 				},
 			},
-			reasons: []kopia.Reasoner{
+			reasons: []identity.Reasoner{
 				kopia.NewReason("", ro, path.ExchangeService, path.EmailCategory),
 			},
 			getMeta:    true,
@@ -437,7 +438,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 					"id2": {data.NoFetchRestoreCollection{Collection: mockColl{id: "id2"}}},
 				},
 			},
-			reasons: []kopia.Reasoner{
+			reasons: []identity.Reasoner{
 				kopia.NewReason("", ro, path.ExchangeService, path.EmailCategory),
 			},
 			getMeta:   true,
@@ -459,7 +460,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				},
 			},
 			rp: mockRestoreProducer{err: assert.AnError},
-			reasons: []kopia.Reasoner{
+			reasons: []identity.Reasoner{
 				kopia.NewReason("", ro, path.ExchangeService, path.EmailCategory),
 			},
 			getMeta:    true,
@@ -580,8 +581,8 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 		name            string
 		bf              *mockBackupFinder
 		rp              mockRestoreProducer
-		reasons         []kopia.Reasoner
-		fallbackReasons []kopia.Reasoner
+		reasons         []identity.Reasoner
+		fallbackReasons []identity.Reasoner
 		getMeta         bool
 		dropAssist      bool
 		assertErr       assert.ErrorAssertionFunc
@@ -601,7 +602,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 				},
 			},
 			rp:              mockRestoreProducer{},
-			fallbackReasons: []kopia.Reasoner{fbEmailReason},
+			fallbackReasons: []identity.Reasoner{fbEmailReason},
 			getMeta:         false,
 			assertErr:       assert.NoError,
 			assertB:         assert.False,
@@ -626,7 +627,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 					"fb_id1": {data.NoFetchRestoreCollection{Collection: mockColl{id: "fb_id1"}}},
 				},
 			},
-			fallbackReasons: []kopia.Reasoner{fbEmailReason},
+			fallbackReasons: []identity.Reasoner{fbEmailReason},
 			getMeta:         true,
 			assertErr:       assert.NoError,
 			assertB:         assert.True,
@@ -653,7 +654,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 					"fb_id1": {data.NoFetchRestoreCollection{Collection: mockColl{id: "fb_id1"}}},
 				},
 			},
-			fallbackReasons: []kopia.Reasoner{fbEmailReason},
+			fallbackReasons: []identity.Reasoner{fbEmailReason},
 			getMeta:         true,
 			dropAssist:      true,
 			assertErr:       assert.NoError,
@@ -686,8 +687,8 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 					"fb_id1": {data.NoFetchRestoreCollection{Collection: mockColl{id: "fb_id1"}}},
 				},
 			},
-			reasons:         []kopia.Reasoner{emailReason},
-			fallbackReasons: []kopia.Reasoner{fbEmailReason},
+			reasons:         []identity.Reasoner{emailReason},
+			fallbackReasons: []identity.Reasoner{fbEmailReason},
 			getMeta:         true,
 			assertErr:       assert.NoError,
 			assertB:         assert.True,
@@ -714,8 +715,8 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 					"fb_id2": {data.NoFetchRestoreCollection{Collection: mockColl{id: "fb_id2"}}},
 				},
 			},
-			reasons:         []kopia.Reasoner{emailReason},
-			fallbackReasons: []kopia.Reasoner{fbEmailReason},
+			reasons:         []identity.Reasoner{emailReason},
+			fallbackReasons: []identity.Reasoner{fbEmailReason},
 			getMeta:         true,
 			assertErr:       assert.NoError,
 			assertB:         assert.True,
@@ -750,8 +751,8 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 					"fb_id2": {data.NoFetchRestoreCollection{Collection: mockColl{id: "fb_id2"}}},
 				},
 			},
-			reasons:         []kopia.Reasoner{emailReason},
-			fallbackReasons: []kopia.Reasoner{fbEmailReason},
+			reasons:         []identity.Reasoner{emailReason},
+			fallbackReasons: []identity.Reasoner{fbEmailReason},
 			getMeta:         true,
 			assertErr:       assert.NoError,
 			assertB:         assert.True,
@@ -782,8 +783,8 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 					"fb_id1": {data.NoFetchRestoreCollection{Collection: mockColl{id: "fb_id1"}}},
 				},
 			},
-			reasons:         []kopia.Reasoner{emailReason},
-			fallbackReasons: []kopia.Reasoner{fbEmailReason},
+			reasons:         []identity.Reasoner{emailReason},
+			fallbackReasons: []identity.Reasoner{fbEmailReason},
 			getMeta:         true,
 			assertErr:       assert.NoError,
 			assertB:         assert.True,
@@ -816,8 +817,8 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 					"fb_id1": {data.NoFetchRestoreCollection{Collection: mockColl{id: "fb_id1"}}},
 				},
 			},
-			reasons:         []kopia.Reasoner{emailReason},
-			fallbackReasons: []kopia.Reasoner{fbEmailReason},
+			reasons:         []identity.Reasoner{emailReason},
+			fallbackReasons: []identity.Reasoner{fbEmailReason},
 			getMeta:         true,
 			dropAssist:      true,
 			assertErr:       assert.NoError,
@@ -848,8 +849,8 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 					"fb_id2": {data.NoFetchRestoreCollection{Collection: mockColl{id: "fb_id2"}}},
 				},
 			},
-			reasons:         []kopia.Reasoner{emailReason},
-			fallbackReasons: []kopia.Reasoner{fbEmailReason},
+			reasons:         []identity.Reasoner{emailReason},
+			fallbackReasons: []identity.Reasoner{fbEmailReason},
 			getMeta:         true,
 			assertErr:       assert.NoError,
 			assertB:         assert.True,
@@ -878,11 +879,11 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 					"fb_id1": {data.NoFetchRestoreCollection{Collection: mockColl{id: "fb_id1"}}},
 				},
 			},
-			reasons: []kopia.Reasoner{
+			reasons: []identity.Reasoner{
 				emailReason,
 				kopia.NewReason("", ro, path.ExchangeService, path.ContactsCategory),
 			},
-			fallbackReasons: []kopia.Reasoner{
+			fallbackReasons: []identity.Reasoner{
 				fbEmailReason,
 				kopia.NewReason("", fbro, path.ExchangeService, path.ContactsCategory),
 			},
@@ -914,8 +915,8 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 					"fb_id1": {data.NoFetchRestoreCollection{Collection: mockColl{id: "fb_id1"}}},
 				},
 			},
-			reasons: []kopia.Reasoner{emailReason},
-			fallbackReasons: []kopia.Reasoner{
+			reasons: []identity.Reasoner{emailReason},
+			fallbackReasons: []identity.Reasoner{
 				kopia.NewReason("", fbro, path.ExchangeService, path.ContactsCategory),
 			},
 			getMeta:   true,
@@ -949,11 +950,11 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 					"fb_id1": {data.NoFetchRestoreCollection{Collection: mockColl{id: "fb_id1"}}},
 				},
 			},
-			reasons: []kopia.Reasoner{
+			reasons: []identity.Reasoner{
 				emailReason,
 				kopia.NewReason("", ro, path.ExchangeService, path.ContactsCategory),
 			},
-			fallbackReasons: []kopia.Reasoner{
+			fallbackReasons: []identity.Reasoner{
 				fbEmailReason,
 				kopia.NewReason("", fbro, path.ExchangeService, path.ContactsCategory),
 			},

--- a/src/internal/operations/test/helper_test.go
+++ b/src/internal/operations/test/helper_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/backup/identity"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/repository"
 	"github.com/alcionai/corso/src/pkg/count"
@@ -251,7 +252,7 @@ func checkBackupIsInManifests(
 			bf, err := kw.NewBaseFinder(sw)
 			require.NoError(t, err, clues.ToCore(err))
 
-			mans := bf.FindBases(ctx, []kopia.Reasoner{r}, tags)
+			mans := bf.FindBases(ctx, []identity.Reasoner{r}, tags)
 			for _, man := range mans.MergeBases() {
 				bID, ok := man.GetTag(kopia.TagBackupID)
 				if !assert.Truef(t, ok, "snapshot manifest %s missing backup ID tag", man.ID) {

--- a/src/pkg/backup/identity/identity.go
+++ b/src/pkg/backup/identity/identity.go
@@ -1,0 +1,16 @@
+package identity
+
+import "github.com/alcionai/corso/src/pkg/path"
+
+// Reasoner describes the parts of the backup that make up its
+// data identity: the tenant, protected resources, services, and
+// categories which are held within the backup.
+type Reasoner interface {
+	Tenant() string
+	ProtectedResource() string
+	Service() path.ServiceType
+	Category() path.CategoryType
+	// SubtreePath returns the path prefix for data in existing backups that have
+	// parameters (tenant, protected resourced, etc) that match this Reasoner.
+	SubtreePath() (path.Path, error)
+}


### PR DESCRIPTION
Moves the kopia.Reasoner interface out of the
kopia package and into pkg/backup/identity.

No logical changes here, just renaming and movement.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3993

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
