### PR TITLE
distrubutes ServiceResource throughout path

### DIFF
--- a/src/pkg/path/builder.go
+++ b/src/pkg/path/builder.go
@@ -203,28 +203,30 @@ func (pb Builder) withPrefix(elements ...string) *Builder {
 
 // verifyPrefix ensures that the tenant and resourceOwner are valid
 // values, and that the builder has some directory structure.
-func (pb Builder) verifyPrefix(tenant, resourceOwner string) error {
-	if err := verifyInputValues(tenant, resourceOwner); err != nil {
-		return err
-	}
+// func (pb Builder) verifyPrefix(tenant, resourceOwner string) error {
+// 	if err := verifyPrefixValues(tenant, resourceOwner); err != nil {
+// 		return err
+// 	}
 
-	if len(pb.elements) == 0 {
-		return clues.New("missing path beyond prefix")
-	}
+// 	if len(pb.elements) == 0 {
+// 		return clues.New("missing path beyond prefix")
+// 	}
 
-	return nil
-}
+// 	return nil
+// }
 
 // ---------------------------------------------------------------------------
 // Data Layer Path Transformers
 // ---------------------------------------------------------------------------
 
 func (pb Builder) ToStreamStorePath(
-	tenant, purpose string,
-	service ServiceType,
+	tenant string,
+	srs []ServiceResource,
 	isItem bool,
 ) (Path, error) {
-	if err := verifyInputValues(tenant, purpose); err != nil {
+	cat := DetailsCategory
+
+	if err := verifyPrefixValues(tenant, srs, cat); err != nil {
 		return nil, err
 	}
 
@@ -232,40 +234,18 @@ func (pb Builder) ToStreamStorePath(
 		return nil, clues.New("missing path beyond prefix")
 	}
 
-	metadataService := UnknownService
+	dlrp := newDataLayerResourcePath(pb, tenant, toMetadataServices(srs), cat, isItem)
 
-	switch service {
-	case ExchangeService:
-		metadataService = ExchangeMetadataService
-	case OneDriveService:
-		metadataService = OneDriveMetadataService
-	case SharePointService:
-		metadataService = SharePointMetadataService
-	}
-
-	return &dataLayerResourcePath{
-		Builder: *pb.withPrefix(
-			tenant,
-			metadataService.String(),
-			purpose,
-			DetailsCategory.String()),
-		service:  metadataService,
-		category: DetailsCategory,
-		hasItem:  isItem,
-	}, nil
+	return &dlrp, nil
 }
 
 func (pb Builder) ToServiceCategoryMetadataPath(
-	tenant, user string,
-	service ServiceType,
-	category CategoryType,
+	tenant string,
+	srs []ServiceResource,
+	cat CategoryType,
 	isItem bool,
 ) (Path, error) {
-	if err := ValidateServiceAndCategory(service, category); err != nil {
-		return nil, err
-	}
-
-	if err := verifyInputValues(tenant, user); err != nil {
+	if err := verifyPrefixValues(tenant, srs, cat); err != nil {
 		return nil, err
 	}
 
@@ -273,78 +253,65 @@ func (pb Builder) ToServiceCategoryMetadataPath(
 		return nil, clues.New("missing path beyond prefix")
 	}
 
-	metadataService := UnknownService
+	dlrp := newDataLayerResourcePath(pb, tenant, toMetadataServices(srs), cat, isItem)
 
-	switch service {
-	case ExchangeService:
-		metadataService = ExchangeMetadataService
-	case OneDriveService:
-		metadataService = OneDriveMetadataService
-	case SharePointService:
-		metadataService = SharePointMetadataService
-	}
-
-	return &dataLayerResourcePath{
-		Builder: *pb.withPrefix(
-			tenant,
-			metadataService.String(),
-			user,
-			category.String(),
-		),
-		service:  metadataService,
-		category: category,
-		hasItem:  isItem,
-	}, nil
+	return &dlrp, nil
 }
 
 func (pb Builder) ToDataLayerPath(
-	tenant, user string,
-	service ServiceType,
-	category CategoryType,
+	tenant string,
+	srs []ServiceResource,
+	cat CategoryType,
 	isItem bool,
 ) (Path, error) {
-	if err := ValidateServiceAndCategory(service, category); err != nil {
+	if err := verifyPrefixValues(tenant, srs, cat); err != nil {
 		return nil, err
 	}
 
-	if err := pb.verifyPrefix(tenant, user); err != nil {
-		return nil, err
-	}
+	dlrp := newDataLayerResourcePath(pb, tenant, srs, cat, isItem)
 
-	return &dataLayerResourcePath{
-		Builder: *pb.withPrefix(
-			tenant,
-			service.String(),
-			user,
-			category.String()),
-		service:  service,
-		category: category,
-		hasItem:  isItem,
-	}, nil
+	return &dlrp, nil
 }
 
 func (pb Builder) ToDataLayerExchangePathForCategory(
-	tenant, user string,
+	tenant, mailboxID string,
 	category CategoryType,
 	isItem bool,
 ) (Path, error) {
-	return pb.ToDataLayerPath(tenant, user, ExchangeService, category, isItem)
+	srs, err := NewServiceResources(ExchangeService, mailboxID)
+	if err != nil {
+		return nil, err
+	}
+
+	return pb.ToDataLayerPath(tenant, srs, category, isItem)
 }
 
 func (pb Builder) ToDataLayerOneDrivePath(
-	tenant, user string,
+	tenant, userID string,
 	isItem bool,
 ) (Path, error) {
-	return pb.ToDataLayerPath(tenant, user, OneDriveService, FilesCategory, isItem)
+	srs, err := NewServiceResources(OneDriveService, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	return pb.ToDataLayerPath(tenant, srs, FilesCategory, isItem)
 }
 
 func (pb Builder) ToDataLayerSharePointPath(
-	tenant, site string,
+	tenant, siteID string,
 	category CategoryType,
 	isItem bool,
 ) (Path, error) {
-	return pb.ToDataLayerPath(tenant, site, SharePointService, category, isItem)
+	srs, err := NewServiceResources(SharePointService, siteID)
+	if err != nil {
+		return nil, err
+	}
+
+	return pb.ToDataLayerPath(tenant, srs, category, isItem)
 }
+
+// TODO: ToDataLayerGroupsPath()
 
 // ---------------------------------------------------------------------------
 // Stringers and PII Concealer Compliance

--- a/src/pkg/path/builder_test.go
+++ b/src/pkg/path/builder_test.go
@@ -46,7 +46,10 @@ func (suite *BuilderUnitSuite) TestAppend() {
 func (suite *BuilderUnitSuite) TestAppendItem() {
 	t := suite.T()
 
-	p, err := Build("t", "ro", ExchangeService, EmailCategory, false, "foo", "bar")
+	srs, err := NewServiceResources(ExchangeService, "ro")
+	require.NoError(t, err, clues.ToCore(err))
+
+	p, err := Build("t", srs, EmailCategory, false, "foo", "bar")
 	require.NoError(t, err, clues.ToCore(err))
 
 	pb := p.ToBuilder()
@@ -339,8 +342,13 @@ func (suite *BuilderUnitSuite) TestFolder() {
 }
 
 func (suite *BuilderUnitSuite) TestPIIHandling() {
-	p, err := Build("t", "ro", ExchangeService, EventsCategory, true, "dir", "item")
-	require.NoError(suite.T(), err)
+	t := suite.T()
+
+	srs, err := NewServiceResources(ExchangeService, "ro")
+	require.NoError(t, err, clues.ToCore(err))
+
+	p, err := Build("t", srs, EventsCategory, true, "dir", "item")
+	require.NoError(t, err)
 
 	table := []struct {
 		name        string

--- a/src/pkg/path/category_type.go
+++ b/src/pkg/path/category_type.go
@@ -75,24 +75,6 @@ var serviceCategories = map[ServiceType]map[CategoryType]struct{}{
 	},
 }
 
-func validateServiceAndCategoryStrings(s, c string) (ServiceType, CategoryType, error) {
-	service := toServiceType(s)
-	if service == UnknownService {
-		return UnknownService, UnknownCategory, clues.Stack(ErrorUnknownService).With("service", fmt.Sprintf("%q", s))
-	}
-
-	category := ToCategoryType(c)
-	if category == UnknownCategory {
-		return UnknownService, UnknownCategory, clues.Stack(ErrorUnknownService).With("category", fmt.Sprintf("%q", c))
-	}
-
-	if err := ValidateServiceAndCategory(service, category); err != nil {
-		return UnknownService, UnknownCategory, err
-	}
-
-	return service, category, nil
-}
-
 func ValidateServiceAndCategory(service ServiceType, category CategoryType) error {
 	cats, ok := serviceCategories[service]
 	if !ok {

--- a/src/pkg/path/drive_test.go
+++ b/src/pkg/path/drive_test.go
@@ -59,7 +59,10 @@ func (suite *OneDrivePathSuite) Test_ToOneDrivePath() {
 		suite.Run(tt.name, func() {
 			t := suite.T()
 
-			p, err := path.Build("tenant", "user", path.OneDriveService, path.FilesCategory, false, tt.pathElements...)
+			srs, err := path.NewServiceResources(path.OneDriveService, "user")
+			require.NoError(t, err, clues.ToCore(err))
+
+			p, err := path.Build("tenant", srs, path.FilesCategory, false, tt.pathElements...)
 			require.NoError(suite.T(), err, clues.ToCore(err))
 
 			got, err := path.ToDrivePath(p)

--- a/src/pkg/path/service_category_test.go
+++ b/src/pkg/path/service_category_test.go
@@ -20,118 +20,76 @@ func TestServiceCategoryUnitSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
-func (suite *ServiceCategoryUnitSuite) TestValidateServiceAndCategoryBadStringErrors() {
+func (suite *ServiceCategoryUnitSuite) TestVerifyPrefixValues() {
 	table := []struct {
 		name     string
-		service  string
-		category string
-	}{
-		{
-			name:     "Service",
-			service:  "foo",
-			category: EmailCategory.String(),
-		},
-		{
-			name:     "Category",
-			service:  ExchangeService.String(),
-			category: "foo",
-		},
-	}
-	for _, test := range table {
-		suite.Run(test.name, func() {
-			_, _, err := validateServiceAndCategoryStrings(test.service, test.category)
-			assert.Error(suite.T(), err)
-		})
-	}
-}
-
-func (suite *ServiceCategoryUnitSuite) TestValidateServiceAndCategory() {
-	table := []struct {
-		name             string
-		service          string
-		category         string
-		expectedService  ServiceType
-		expectedCategory CategoryType
-		check            assert.ErrorAssertionFunc
+		service  ServiceType
+		category CategoryType
+		check    assert.ErrorAssertionFunc
 	}{
 		{
 			name:     "UnknownService",
-			service:  UnknownService.String(),
-			category: EmailCategory.String(),
+			service:  UnknownService,
+			category: EmailCategory,
 			check:    assert.Error,
 		},
 		{
 			name:     "UnknownCategory",
-			service:  ExchangeService.String(),
-			category: UnknownCategory.String(),
+			service:  ExchangeService,
+			category: UnknownCategory,
 			check:    assert.Error,
 		},
 		{
-			name:     "BadServiceString",
-			service:  "foo",
-			category: EmailCategory.String(),
+			name:     "BadServiceType",
+			service:  ServiceType(-1),
+			category: EmailCategory,
 			check:    assert.Error,
 		},
 		{
-			name:     "BadCategoryString",
-			service:  ExchangeService.String(),
-			category: "foo",
+			name:     "BadCategoryType",
+			service:  ExchangeService,
+			category: CategoryType(-1),
 			check:    assert.Error,
 		},
 		{
-			name:             "ExchangeEmail",
-			service:          ExchangeService.String(),
-			category:         EmailCategory.String(),
-			expectedService:  ExchangeService,
-			expectedCategory: EmailCategory,
-			check:            assert.NoError,
+			name:     "ExchangeEmail",
+			service:  ExchangeService,
+			category: EmailCategory,
+			check:    assert.NoError,
 		},
 		{
-			name:             "ExchangeContacts",
-			service:          ExchangeService.String(),
-			category:         ContactsCategory.String(),
-			expectedService:  ExchangeService,
-			expectedCategory: ContactsCategory,
-			check:            assert.NoError,
+			name:     "ExchangeContacts",
+			service:  ExchangeService,
+			category: ContactsCategory,
+			check:    assert.NoError,
 		},
 		{
-			name:             "ExchangeEvents",
-			service:          ExchangeService.String(),
-			category:         EventsCategory.String(),
-			expectedService:  ExchangeService,
-			expectedCategory: EventsCategory,
-			check:            assert.NoError,
+			name:     "ExchangeEvents",
+			service:  ExchangeService,
+			category: EventsCategory,
+			check:    assert.NoError,
 		},
 		{
-			name:             "OneDriveFiles",
-			service:          OneDriveService.String(),
-			category:         FilesCategory.String(),
-			expectedService:  OneDriveService,
-			expectedCategory: FilesCategory,
-			check:            assert.NoError,
+			name:     "OneDriveFiles",
+			service:  OneDriveService,
+			category: FilesCategory,
+			check:    assert.NoError,
 		},
 		{
-			name:             "SharePointLibraries",
-			service:          SharePointService.String(),
-			category:         LibrariesCategory.String(),
-			expectedService:  SharePointService,
-			expectedCategory: LibrariesCategory,
-			check:            assert.NoError,
+			name:     "SharePointLibraries",
+			service:  SharePointService,
+			category: LibrariesCategory,
+			check:    assert.NoError,
 		},
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			s, c, err := validateServiceAndCategoryStrings(test.service, test.category)
+			srs := []ServiceResource{{test.service, "resource"}}
+
+			err := verifyPrefixValues("tid", srs, test.category)
 			test.check(t, err, clues.ToCore(err))
-
-			if err != nil {
-				return
-			}
-
-			assert.Equal(t, test.expectedService, s)
-			assert.Equal(t, test.expectedCategory, c)
 		})
 	}
 }


### PR DESCRIPTION
Adds utilization of the ServiceResource struct to all of
the path package functionality.  In general, this takes
most instances where a service and resource
are requested, and replaces those values with a
slice of ServiceResource tuples.

To keep the review smaller, this change does not update
any packages outside of path.  Therefore the tests and
build are guaranteed to fail.  The next PR, which
updates all other packages with the changes, is
necessary for both PRs to move forward.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #3993

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
