### PR TITLE
first pass on ServiceResource tuple compliance

### DIFF
--- a/src/cmd/factory/impl/common.go
+++ b/src/cmd/factory/impl/common.go
@@ -177,7 +177,7 @@ type collection struct {
 
 func buildCollections(
 	service path.ServiceType,
-	tenant, user string,
+	tenant, protectedResource string,
 	restoreCfg control.RestoreConfig,
 	colls []collection,
 ) ([]data.RestoreCollection, error) {
@@ -186,8 +186,10 @@ func buildCollections(
 	for _, c := range colls {
 		pth, err := path.Build(
 			tenant,
-			user,
-			service,
+			[]path.ServiceResource{{
+				Service:           service,
+				ProtectedResource: protectedResource,
+			}},
 			c.category,
 			false,
 			c.PathElements...)

--- a/src/internal/data/data_collection_test.go
+++ b/src/internal/data/data_collection_test.go
@@ -21,11 +21,35 @@ func TestDataCollectionSuite(t *testing.T) {
 }
 
 func (suite *DataCollectionSuite) TestStateOf() {
-	fooP, err := path.Build("t", "u", path.ExchangeService, path.EmailCategory, false, "foo")
+	fooP, err := path.Build(
+		"t",
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: "u",
+		}},
+		path.EmailCategory,
+		false,
+		"foo")
 	require.NoError(suite.T(), err, clues.ToCore(err))
-	barP, err := path.Build("t", "u", path.ExchangeService, path.EmailCategory, false, "bar")
+	barP, err := path.Build(
+		"t",
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: "u",
+		}},
+		path.EmailCategory,
+		false,
+		"bar")
 	require.NoError(suite.T(), err, clues.ToCore(err))
-	preP, err := path.Build("_t", "_u", path.ExchangeService, path.EmailCategory, false, "foo")
+	preP, err := path.Build(
+		"_t",
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: "u",
+		}},
+		path.EmailCategory,
+		false,
+		"foo")
 	require.NoError(suite.T(), err, clues.ToCore(err))
 
 	table := []struct {

--- a/src/internal/kopia/data_collection_test.go
+++ b/src/internal/kopia/data_collection_test.go
@@ -78,8 +78,10 @@ func (suite *KopiaDataCollectionUnitSuite) TestReturnsPath() {
 
 	pth, err := path.Build(
 		"a-tenant",
-		"a-user",
-		path.ExchangeService,
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: "a-user",
+		}},
 		path.EmailCategory,
 		false,
 		"some", "path", "for", "data")
@@ -330,8 +332,10 @@ func (suite *KopiaDataCollectionUnitSuite) TestFetchItemByName() {
 
 	pth, err := path.Build(
 		tenant,
-		user,
-		path.ExchangeService,
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: user,
+		}},
 		category,
 		false,
 		folder1, folder2)

--- a/src/internal/kopia/merge_collection_test.go
+++ b/src/internal/kopia/merge_collection_test.go
@@ -32,8 +32,10 @@ func (suite *MergeCollectionUnitSuite) TestReturnsPath() {
 
 	pth, err := path.Build(
 		"a-tenant",
-		"a-user",
-		path.ExchangeService,
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: "a-user",
+		}},
 		path.EmailCategory,
 		false,
 		"some", "path", "for", "data")
@@ -61,8 +63,10 @@ func (suite *MergeCollectionUnitSuite) TestItems() {
 
 	pth, err := path.Build(
 		"a-tenant",
-		"a-user",
-		path.ExchangeService,
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: "a-user",
+		}},
 		path.EmailCategory,
 		false,
 		"some", "path", "for", "data")
@@ -101,8 +105,10 @@ func (suite *MergeCollectionUnitSuite) TestAddCollection_DifferentPathFails() {
 
 	pth1, err := path.Build(
 		"a-tenant",
-		"a-user",
-		path.ExchangeService,
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: "a-user",
+		}},
 		path.EmailCategory,
 		false,
 		"some", "path", "for", "data")
@@ -110,8 +116,10 @@ func (suite *MergeCollectionUnitSuite) TestAddCollection_DifferentPathFails() {
 
 	pth2, err := path.Build(
 		"a-tenant",
-		"a-user",
-		path.ExchangeService,
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: "a-user",
+		}},
 		path.EmailCategory,
 		false,
 		"some", "path", "for", "data2")
@@ -142,8 +150,10 @@ func (suite *MergeCollectionUnitSuite) TestFetchItemByName() {
 
 	pth, err := path.Build(
 		"a-tenant",
-		"a-user",
-		path.ExchangeService,
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: "a-user",
+		}},
 		path.EmailCategory,
 		false,
 		"some", "path", "for", "data")

--- a/src/internal/kopia/upload_test.go
+++ b/src/internal/kopia/upload_test.go
@@ -364,8 +364,10 @@ func TestCorsoProgressUnitSuite(t *testing.T) {
 func (suite *CorsoProgressUnitSuite) SetupSuite() {
 	p, err := path.Build(
 		testTenant,
-		testUser,
-		path.ExchangeService,
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: testUser,
+		}},
 		path.EmailCategory,
 		true,
 		testInboxDir, "testFile")
@@ -2867,16 +2869,40 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSelectsMigrateSubt
 		migratedUser = "user_migrate"
 	)
 
-	oldPrefixPathEmail, err := path.BuildPrefix(testTenant, testUser, path.ExchangeService, path.EmailCategory)
+	oldPrefixPathEmail, err := path.BuildPrefix(
+		testTenant,
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: testUser,
+		}},
+		path.EmailCategory)
 	require.NoError(t, err, clues.ToCore(err))
 
-	newPrefixPathEmail, err := path.BuildPrefix(testTenant, migratedUser, path.ExchangeService, path.EmailCategory)
+	newPrefixPathEmail, err := path.BuildPrefix(
+		testTenant,
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: migratedUser,
+		}},
+		path.EmailCategory)
 	require.NoError(t, err, clues.ToCore(err))
 
-	oldPrefixPathCont, err := path.BuildPrefix(testTenant, testUser, path.ExchangeService, path.ContactsCategory)
+	oldPrefixPathCont, err := path.BuildPrefix(
+		testTenant,
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: testUser,
+		}},
+		path.ContactsCategory)
 	require.NoError(t, err, clues.ToCore(err))
 
-	newPrefixPathCont, err := path.BuildPrefix(testTenant, migratedUser, path.ExchangeService, path.ContactsCategory)
+	newPrefixPathCont, err := path.BuildPrefix(
+		testTenant,
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: migratedUser,
+		}},
+		path.ContactsCategory)
 	require.NoError(t, err, clues.ToCore(err))
 
 	var (

--- a/src/internal/m365/collection/drive/collections_test.go
+++ b/src/internal/m365/collection/drive/collections_test.go
@@ -1248,8 +1248,10 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 
 	metadataPath, err := path.Builder{}.ToServiceCategoryMetadataPath(
 		tenant,
-		user,
-		path.OneDriveService,
+		[]path.ServiceResource{{
+			Service:           path.OneDriveService,
+			ProtectedResource: user,
+		}},
 		path.FilesCategory,
 		false)
 	require.NoError(suite.T(), err, "making metadata path", clues.ToCore(err))

--- a/src/internal/m365/collection/drive/item_handler.go
+++ b/src/internal/m365/collection/drive/item_handler.go
@@ -46,8 +46,10 @@ func (h itemBackupHandler) PathPrefix(
 ) (path.Path, error) {
 	return path.Build(
 		tenantID,
-		resourceOwner,
-		path.OneDriveService,
+		[]path.ServiceResource{{
+			Service:           path.OneDriveService,
+			ProtectedResource: resourceOwner,
+		}},
 		path.FilesCategory,
 		false,
 		odConsts.DrivesPathDir,

--- a/src/internal/m365/collection/drive/library_handler.go
+++ b/src/internal/m365/collection/drive/library_handler.go
@@ -41,8 +41,10 @@ func (h libraryBackupHandler) PathPrefix(
 ) (path.Path, error) {
 	return path.Build(
 		tenantID,
-		resourceOwner,
-		path.SharePointService,
+		[]path.ServiceResource{{
+			Service:           path.SharePointService,
+			ProtectedResource: resourceOwner,
+		}},
 		path.LibrariesCategory,
 		false,
 		odConsts.DrivesPathDir,

--- a/src/internal/m365/collection/drive/permission_test.go
+++ b/src/internal/m365/collection/drive/permission_test.go
@@ -42,8 +42,10 @@ func runComputeParentPermissionsTest(
 
 	entry, err := path.Build(
 		"tenant",
-		resourceOwner,
-		service,
+		[]path.ServiceResource{{
+			Service:           service,
+			ProtectedResource: resourceOwner,
+		}},
 		category,
 		false,
 		strings.Split(entryPath, "/")...)
@@ -51,8 +53,10 @@ func runComputeParentPermissionsTest(
 
 	rootEntry, err := path.Build(
 		"tenant",
-		resourceOwner,
-		service,
+		[]path.ServiceResource{{
+			Service:           service,
+			ProtectedResource: resourceOwner,
+		}},
 		category,
 		false,
 		strings.Split(rootEntryPath, "/")...)

--- a/src/internal/m365/collection/site/backup.go
+++ b/src/internal/m365/collection/site/backup.go
@@ -93,8 +93,10 @@ func CollectPages(
 
 		dir, err := path.Build(
 			creds.AzureTenantID,
-			bpc.ProtectedResource.ID(),
-			path.SharePointService,
+			[]path.ServiceResource{{
+				Service:           path.SharePointService,
+				ProtectedResource: bpc.ProtectedResource.ID(),
+			}},
 			path.PagesCategory,
 			false,
 			tuple.Name)
@@ -144,8 +146,10 @@ func CollectLists(
 
 		dir, err := path.Build(
 			tenantID,
-			bpc.ProtectedResource.ID(),
-			path.SharePointService,
+			[]path.ServiceResource{{
+				Service:           path.SharePointService,
+				ProtectedResource: bpc.ProtectedResource.ID(),
+			}},
 			path.ListsCategory,
 			false,
 			tuple.Name)

--- a/src/internal/m365/collection/site/collection_test.go
+++ b/src/internal/m365/collection/site/collection_test.go
@@ -95,8 +95,10 @@ func (suite *SharePointCollectionSuite) TestCollection_Items() {
 			getDir: func(t *testing.T) path.Path {
 				dir, err := path.Build(
 					tenant,
-					user,
-					path.SharePointService,
+					[]path.ServiceResource{{
+						Service:           path.SharePointService,
+						ProtectedResource: user,
+					}},
 					path.ListsCategory,
 					false,
 					dirRoot)
@@ -131,8 +133,10 @@ func (suite *SharePointCollectionSuite) TestCollection_Items() {
 			getDir: func(t *testing.T) path.Path {
 				dir, err := path.Build(
 					tenant,
-					user,
-					path.SharePointService,
+					[]path.ServiceResource{{
+						Service:           path.SharePointService,
+						ProtectedResource: user,
+					}},
 					path.PagesCategory,
 					false,
 					dirRoot)

--- a/src/internal/m365/controller_test.go
+++ b/src/internal/m365/controller_test.go
@@ -1111,9 +1111,11 @@ func (suite *ControllerIntegrationSuite) TestMultiFolderBackupDifferentNames() {
 				})
 
 				totalItems, _, collections, expectedData, err := stub.CollectionsForInfo(
-					test.service,
 					suite.ctrl.tenant,
-					suite.user,
+					[]path.ServiceResource{{
+						Service:           test.service,
+						ProtectedResource: suite.user,
+					}},
 					restoreCfg,
 					[]stub.ColInfo{collection},
 					version.Backup,

--- a/src/internal/m365/graph/collections.go
+++ b/src/internal/m365/graph/collections.go
@@ -79,7 +79,13 @@ func BaseCollections(
 	for cat := range categories {
 		ictx := clues.Add(ctx, "base_service", service, "base_category", cat)
 
-		full, err := path.BuildPrefix(tenant, rOwner, service, cat)
+		full, err := path.BuildPrefix(
+			tenant,
+			[]path.ServiceResource{{
+				Service:           service,
+				ProtectedResource: rOwner,
+			}},
+			cat)
 		if err != nil {
 			// Shouldn't happen.
 			err = clues.Wrap(err, "making path").WithClues(ictx)

--- a/src/internal/m365/graph/collections_test.go
+++ b/src/internal/m365/graph/collections_test.go
@@ -24,16 +24,44 @@ func (suite *CollectionsUnitSuite) TestNewPrefixCollection() {
 	serv := path.OneDriveService
 	cat := path.FilesCategory
 
-	p1, err := path.BuildPrefix("t", "ro1", serv, cat)
+	p1, err := path.BuildPrefix(
+		"t",
+		[]path.ServiceResource{{
+			Service:           serv,
+			ProtectedResource: "ro1",
+		}},
+		cat)
 	require.NoError(t, err, clues.ToCore(err))
 
-	p2, err := path.BuildPrefix("t", "ro2", serv, cat)
+	p2, err := path.BuildPrefix(
+		"t",
+		[]path.ServiceResource{{
+			Service:           serv,
+			ProtectedResource: "ro2",
+		}},
+		cat)
 	require.NoError(t, err, clues.ToCore(err))
 
-	items, err := path.Build("t", "ro", serv, cat, true, "fld", "itm")
+	items, err := path.Build(
+		"t",
+		[]path.ServiceResource{{
+			Service:           serv,
+			ProtectedResource: "ro",
+		}},
+		cat,
+		true,
+		"fld", "itm")
 	require.NoError(t, err, clues.ToCore(err))
 
-	folders, err := path.Build("t", "ro", serv, cat, false, "fld")
+	folders, err := path.Build(
+		"t",
+		[]path.ServiceResource{{
+			Service:           serv,
+			ProtectedResource: "ro",
+		}},
+		cat,
+		false,
+		"fld")
 	require.NoError(t, err, clues.ToCore(err))
 
 	table := []struct {

--- a/src/internal/m365/graph/metadata/metadata_test.go
+++ b/src/internal/m365/graph/metadata/metadata_test.go
@@ -92,8 +92,10 @@ func (suite *MetadataUnitSuite) TestIsMetadataFile_Files_MetaSuffixes() {
 
 				p, err := path.Build(
 					tenant,
-					user,
-					test.service,
+					[]path.ServiceResource{{
+						Service:           test.service,
+						ProtectedResource: user,
+					}},
 					test.category,
 					true,
 					"file"+ext)
@@ -113,8 +115,10 @@ func (suite *MetadataUnitSuite) TestIsMetadataFile_Files_NotMetaSuffixes() {
 
 				p, err := path.Build(
 					tenant,
-					user,
-					test.service,
+					[]path.ServiceResource{{
+						Service:           test.service,
+						ProtectedResource: user,
+					}},
 					test.category,
 					true,
 					"file"+ext)
@@ -136,8 +140,10 @@ func (suite *MetadataUnitSuite) TestIsMetadataFile_Directories() {
 
 				p, err := path.Build(
 					tenant,
-					user,
-					test.service,
+					[]path.ServiceResource{{
+						Service:           test.service,
+						ProtectedResource: user,
+					}},
 					test.category,
 					false,
 					"file"+ext)

--- a/src/internal/m365/graph/metadata_collection.go
+++ b/src/internal/m365/graph/metadata_collection.go
@@ -75,8 +75,10 @@ func MakeMetadataCollection(
 
 	p, err := path.Builder{}.ToServiceCategoryMetadataPath(
 		tenant,
-		resourceOwner,
-		service,
+		[]path.ServiceResource{{
+			Service:           service,
+			ProtectedResource: resourceOwner,
+		}},
 		cat,
 		false)
 	if err != nil {

--- a/src/internal/m365/graph/metadata_collection_test.go
+++ b/src/internal/m365/graph/metadata_collection_test.go
@@ -30,8 +30,10 @@ func (suite *MetadataCollectionUnitSuite) TestFullPath() {
 
 	p, err := path.Build(
 		"a-tenant",
-		"a-user",
-		path.ExchangeService,
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: "a-user",
+		}},
 		path.EmailCategory,
 		false,
 		"foo")
@@ -72,8 +74,10 @@ func (suite *MetadataCollectionUnitSuite) TestItems() {
 
 	p, err := path.Build(
 		"a-tenant",
-		"a-user",
-		path.ExchangeService,
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: "a-user",
+		}},
 		path.EmailCategory,
 		false,
 		"foo")

--- a/src/internal/m365/helper_test.go
+++ b/src/internal/m365/helper_test.go
@@ -942,8 +942,7 @@ func checkHasCollections(
 
 		p, err := loc.ToDataLayerPath(
 			fp.Tenant(),
-			fp.ResourceOwner(),
-			fp.Service(),
+			fp.ServiceResources(),
 			fp.Category(),
 			false)
 		if !assert.NoError(t, err, clues.ToCore(err)) {

--- a/src/internal/m365/service/exchange/backup_test.go
+++ b/src/internal/m365/service/exchange/backup_test.go
@@ -343,8 +343,10 @@ func (f failingColl) Items(ctx context.Context, errs *fault.Bus) <-chan data.Str
 func (f failingColl) FullPath() path.Path {
 	tmp, err := path.Build(
 		"tenant",
-		"user",
-		path.ExchangeService,
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: "user",
+		}},
 		path.EmailCategory,
 		false,
 		"inbox")
@@ -1267,8 +1269,10 @@ func (suite *CollectionPopulationSuite) TestFilterContainersAndFillCollections_D
 	oldPath1 := func(t *testing.T, cat path.CategoryType) path.Path {
 		res, err := location.Append("1").ToDataLayerPath(
 			suite.creds.AzureTenantID,
-			qp.ProtectedResource.ID(),
-			path.ExchangeService,
+			[]path.ServiceResource{{
+				Service:           path.ExchangeService,
+				ProtectedResource: qp.ProtectedResource.ID(),
+			}},
 			cat,
 			false)
 		require.NoError(t, err, clues.ToCore(err))
@@ -1279,8 +1283,10 @@ func (suite *CollectionPopulationSuite) TestFilterContainersAndFillCollections_D
 	oldPath2 := func(t *testing.T, cat path.CategoryType) path.Path {
 		res, err := location.Append("2").ToDataLayerPath(
 			suite.creds.AzureTenantID,
-			qp.ProtectedResource.ID(),
-			path.ExchangeService,
+			[]path.ServiceResource{{
+				Service:           path.ExchangeService,
+				ProtectedResource: qp.ProtectedResource.ID(),
+			}},
 			cat,
 			false)
 		require.NoError(t, err, clues.ToCore(err))
@@ -1291,8 +1297,10 @@ func (suite *CollectionPopulationSuite) TestFilterContainersAndFillCollections_D
 	idPath1 := func(t *testing.T, cat path.CategoryType) path.Path {
 		res, err := path.Builder{}.Append("1").ToDataLayerPath(
 			suite.creds.AzureTenantID,
-			qp.ProtectedResource.ID(),
-			path.ExchangeService,
+			[]path.ServiceResource{{
+				Service:           path.ExchangeService,
+				ProtectedResource: qp.ProtectedResource.ID(),
+			}},
 			cat,
 			false)
 		require.NoError(t, err, clues.ToCore(err))
@@ -1303,8 +1311,10 @@ func (suite *CollectionPopulationSuite) TestFilterContainersAndFillCollections_D
 	idPath2 := func(t *testing.T, cat path.CategoryType) path.Path {
 		res, err := path.Builder{}.Append("2").ToDataLayerPath(
 			suite.creds.AzureTenantID,
-			qp.ProtectedResource.ID(),
-			path.ExchangeService,
+			[]path.ServiceResource{{
+				Service:           path.ExchangeService,
+				ProtectedResource: qp.ProtectedResource.ID(),
+			}},
 			cat,
 			false)
 		require.NoError(t, err, clues.ToCore(err))
@@ -1706,7 +1716,15 @@ func (suite *CollectionPopulationSuite) TestFilterContainersAndFillCollections_i
 	)
 
 	prevPath := func(t *testing.T, at ...string) path.Path {
-		p, err := path.Build(tenantID, userID, path.ExchangeService, cat, false, at...)
+		p, err := path.Build(
+			tenantID,
+			[]path.ServiceResource{{
+				Service:           path.ExchangeService,
+				ProtectedResource: userID,
+			}},
+			cat,
+			false,
+			at...)
 		require.NoError(t, err, clues.ToCore(err))
 
 		return p

--- a/src/internal/m365/service/exchange/collection_test.go
+++ b/src/internal/m365/service/exchange/collection_test.go
@@ -89,8 +89,10 @@ func (suite *CollectionSuite) TestColleciton_FullPath() {
 
 	fullPath, err := path.Build(
 		tenant,
-		user,
-		path.ExchangeService,
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: user,
+		}},
 		path.EmailCategory,
 		false,
 		folder)
@@ -113,8 +115,10 @@ func (suite *CollectionSuite) TestCollection_NewCollection() {
 
 	fullPath, err := path.Build(
 		tenant,
-		user,
-		path.ExchangeService,
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: user,
+		}},
 		path.EmailCategory,
 		false,
 		folder)
@@ -129,9 +133,25 @@ func (suite *CollectionSuite) TestCollection_NewCollection() {
 }
 
 func (suite *CollectionSuite) TestNewCollection_state() {
-	fooP, err := path.Build("t", "u", path.ExchangeService, path.EmailCategory, false, "foo")
+	fooP, err := path.Build(
+		"t",
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: "u",
+		}},
+		path.EmailCategory,
+		false,
+		"foo")
 	require.NoError(suite.T(), err, clues.ToCore(err))
-	barP, err := path.Build("t", "u", path.ExchangeService, path.EmailCategory, false, "bar")
+	barP, err := path.Build(
+		"t",
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: "u",
+		}},
+		path.EmailCategory,
+		false,
+		"bar")
 	require.NoError(suite.T(), err, clues.ToCore(err))
 
 	locPB := path.Builder{}.Append("human-readable")

--- a/src/internal/m365/service/exchange/container_resolver_test.go
+++ b/src/internal/m365/service/exchange/container_resolver_test.go
@@ -812,8 +812,10 @@ func runCreateDestinationTest(
 
 	path1, err := path.Build(
 		tenantID,
-		userID,
-		svc,
+		[]path.ServiceResource{{
+			Service:           svc,
+			ProtectedResource: userID,
+		}},
 		category,
 		false,
 		containerNames1...)
@@ -833,8 +835,10 @@ func runCreateDestinationTest(
 
 	path2, err := path.Build(
 		tenantID,
-		userID,
-		svc,
+		[]path.ServiceResource{{
+			Service:           svc,
+			ProtectedResource: userID,
+		}},
 		category,
 		false,
 		containerNames2...)

--- a/src/internal/m365/service/onedrive/backup.go
+++ b/src/internal/m365/service/onedrive/backup.go
@@ -111,8 +111,10 @@ func migrationCollections(
 	// backup, onedrive needs to force the owner PN -> ID migration
 	mc, err := path.BuildPrefix(
 		tenant,
-		bpc.ProtectedResource.ID(),
-		path.OneDriveService,
+		[]path.ServiceResource{{
+			Service:           path.OneDriveService,
+			ProtectedResource: bpc.ProtectedResource.ID(),
+		}},
 		path.FilesCategory)
 	if err != nil {
 		return nil, clues.Wrap(err, "creating user id migration path")
@@ -120,8 +122,10 @@ func migrationCollections(
 
 	mpc, err := path.BuildPrefix(
 		tenant,
-		bpc.ProtectedResource.Name(),
-		path.OneDriveService,
+		[]path.ServiceResource{{
+			Service:           path.OneDriveService,
+			ProtectedResource: bpc.ProtectedResource.Name(),
+		}},
 		path.FilesCategory)
 	if err != nil {
 		return nil, clues.Wrap(err, "creating user name migration path")

--- a/src/internal/m365/service/onedrive/mock/handlers.go
+++ b/src/internal/m365/service/onedrive/mock/handlers.go
@@ -161,8 +161,10 @@ type pathPrefixer func(tID, ro, driveID string) (path.Path, error)
 var defaultOneDrivePathPrefixer = func(tID, ro, driveID string) (path.Path, error) {
 	return path.Build(
 		tID,
-		ro,
-		path.OneDriveService,
+		[]path.ServiceResource{{
+			Service:           path.OneDriveService,
+			ProtectedResource: ro,
+		}},
 		path.FilesCategory,
 		false,
 		odConsts.DrivesPathDir,
@@ -173,8 +175,10 @@ var defaultOneDrivePathPrefixer = func(tID, ro, driveID string) (path.Path, erro
 var defaultSharePointPathPrefixer = func(tID, ro, driveID string) (path.Path, error) {
 	return path.Build(
 		tID,
-		ro,
-		path.SharePointService,
+		[]path.ServiceResource{{
+			Service:           path.SharePointService,
+			ProtectedResource: ro,
+		}},
 		path.LibrariesCategory,
 		false,
 		odConsts.DrivesPathDir,

--- a/src/internal/m365/stub/stub.go
+++ b/src/internal/m365/stub/stub.go
@@ -84,8 +84,8 @@ func GetCollectionsAndExpected(
 }
 
 func CollectionsForInfo(
-	service path.ServiceType,
-	tenant, user string,
+	tenant string,
+	srs []path.ServiceResource,
 	restoreCfg control.RestoreConfig,
 	allInfo []ColInfo,
 	backupVersion int,
@@ -100,8 +100,7 @@ func CollectionsForInfo(
 	for _, info := range allInfo {
 		pth, err := path.Build(
 			tenant,
-			user,
-			service,
+			srs,
 			info.Category,
 			false,
 			info.PathElements...)

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -218,8 +218,10 @@ func makeMetadataBasePath(
 
 	p, err := path.Builder{}.ToServiceCategoryMetadataPath(
 		tenant,
-		resourceOwner,
-		service,
+		[]path.ServiceResource{{
+			Service:           service,
+			ProtectedResource: resourceOwner,
+		}},
 		category,
 		false)
 	require.NoError(t, err, clues.ToCore(err))
@@ -1635,7 +1637,15 @@ func (suite *AssistBackupIntegrationSuite) TestBackupTypesForFailureModes() {
 
 	pathElements := []string{odConsts.DrivesPathDir, "drive-id", odConsts.RootPathDir, folderID}
 
-	tmp, err := path.Build(tenantID, userID, path.OneDriveService, path.FilesCategory, false, pathElements...)
+	tmp, err := path.Build(
+		tenantID,
+		[]path.ServiceResource{{
+			Service:           path.OneDriveService,
+			ProtectedResource: userID,
+		}},
+		path.FilesCategory,
+		false,
+		pathElements...)
 	require.NoError(suite.T(), err, clues.ToCore(err))
 
 	locPath := path.Builder{}.Append(tmp.Folders()...)
@@ -1916,7 +1926,15 @@ func (suite *AssistBackupIntegrationSuite) TestExtensionsIncrementals() {
 
 	pathElements := []string{odConsts.DrivesPathDir, "drive-id", odConsts.RootPathDir, folderID}
 
-	tmp, err := path.Build(tenantID, userID, path.OneDriveService, path.FilesCategory, false, pathElements...)
+	tmp, err := path.Build(
+		tenantID,
+		[]path.ServiceResource{{
+			Service:           path.OneDriveService,
+			ProtectedResource: userID,
+		}},
+		path.FilesCategory,
+		false,
+		pathElements...)
 	require.NoError(suite.T(), err, clues.ToCore(err))
 
 	locPath := path.Builder{}.Append(tmp.Folders()...)

--- a/src/internal/operations/manifests_test.go
+++ b/src/internal/operations/manifests_test.go
@@ -344,7 +344,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 					assert.Equal(
 						t,
 						path.ExchangeMetadataService,
-						p.Service(),
+						p.ServiceResources()[0].Service,
 						"read data service")
 
 					assert.Contains(
@@ -354,8 +354,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 							path.ContactsCategory,
 						},
 						p.Category(),
-						"read data category doesn't match a given reason",
-					)
+						"read data category doesn't match a given reason")
 				}
 			},
 			expectMans: kopia.NewMockBackupBases().WithMergeBases(

--- a/src/internal/operations/pathtransformer/restore_path_transformer.go
+++ b/src/internal/operations/pathtransformer/restore_path_transformer.go
@@ -44,8 +44,7 @@ func basicLocationPath(repoRef path.Path, locRef *path.Builder) (path.Path, erro
 	if len(locRef.Elements()) == 0 {
 		res, err := path.BuildPrefix(
 			repoRef.Tenant(),
-			repoRef.ResourceOwner(),
-			repoRef.Service(),
+			repoRef.ServiceResources(),
 			repoRef.Category())
 		if err != nil {
 			return nil, clues.Wrap(err, "getting prefix for empty location")
@@ -56,8 +55,7 @@ func basicLocationPath(repoRef path.Path, locRef *path.Builder) (path.Path, erro
 
 	return locRef.ToDataLayerPath(
 		repoRef.Tenant(),
-		repoRef.ResourceOwner(),
-		repoRef.Service(),
+		repoRef.ServiceResources(),
 		repoRef.Category(),
 		false)
 }

--- a/src/internal/operations/test/exchange_test.go
+++ b/src/internal/operations/test/exchange_test.go
@@ -347,7 +347,13 @@ func testExchangeContinuousBackups(suite *ExchangeBackupIntgSuite, toggles contr
 		// },
 	}
 
-	rrPfx, err := path.BuildPrefix(acct.ID(), uidn.ID(), service, path.EmailCategory)
+	rrPfx, err := path.BuildPrefix(
+		acct.ID(),
+		[]path.ServiceResource{{
+			Service:           service,
+			ProtectedResource: uidn.ID(),
+		}},
+		path.EmailCategory)
 	require.NoError(t, err, clues.ToCore(err))
 
 	// strip the category from the prefix; we primarily want the tenant and resource owner.

--- a/src/internal/operations/test/helper_test.go
+++ b/src/internal/operations/test/helper_test.go
@@ -291,11 +291,15 @@ func checkMetadataFilesExist(
 
 			paths := []path.RestorePaths{}
 			pathsByRef := map[string][]string{}
+			srs := []path.ServiceResource{{
+				Service:           service,
+				ProtectedResource: resourceOwner,
+			}}
 
 			for _, fName := range files {
 				p, err := path.Builder{}.
 					Append(fName).
-					ToServiceCategoryMetadataPath(tenant, resourceOwner, service, category, true)
+					ToServiceCategoryMetadataPath(tenant, srs, category, true)
 				if !assert.NoError(t, err, "bad metadata path", clues.ToCore(err)) {
 					continue
 				}

--- a/src/internal/operations/test/onedrive_test.go
+++ b/src/internal/operations/test/onedrive_test.go
@@ -213,7 +213,13 @@ func runDriveIncrementalTest(
 		}
 	)
 
-	rrPfx, err := path.BuildPrefix(atid, roidn.ID(), service, category)
+	rrPfx, err := path.BuildPrefix(
+		atid,
+		[]path.ServiceResource{{
+			Service:           service,
+			ProtectedResource: roidn.ID(),
+		}},
+		category)
 	require.NoError(t, err, clues.ToCore(err))
 
 	// strip the category from the prefix; we primarily want the tenant and resource owner.

--- a/src/pkg/backup/details/details_test.go
+++ b/src/pkg/backup/details/details_test.go
@@ -1122,8 +1122,10 @@ func makeItemPath(
 
 	p, err := path.Build(
 		tenant,
-		resourceOwner,
-		service,
+		[]path.ServiceResource{{
+			Service:           service,
+			ProtectedResource: resourceOwner,
+		}},
 		category,
 		true,
 		elems...)

--- a/src/pkg/control/restore_test.go
+++ b/src/pkg/control/restore_test.go
@@ -104,7 +104,17 @@ func (suite *RestoreUnitSuite) TestEnsureRestoreConfigDefaults() {
 }
 
 func (suite *RestoreUnitSuite) TestRestoreConfig_piiHandling() {
-	p, err := path.Build("tid", "ro", path.ExchangeService, path.EmailCategory, true, "foo", "bar", "baz")
+	p, err := path.Build(
+		"tid",
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: "ro",
+		}},
+		path.EmailCategory,
+		true,
+		"foo",
+		"bar",
+		"baz")
 	require.NoError(suite.T(), err, clues.ToCore(err))
 
 	cdrc := control.DefaultRestoreConfig(dttm.HumanReadable)

--- a/src/pkg/logger/example_logger_test.go
+++ b/src/pkg/logger/example_logger_test.go
@@ -19,7 +19,15 @@ const itemID = "item_id"
 
 var (
 	err         error
-	itemPath, _ = path.Build("tid", "own", path.ExchangeService, path.ContactsCategory, false, "foo")
+	itemPath, _ = path.Build(
+		"tid",
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: "own",
+		}},
+		path.ContactsCategory,
+		false,
+		"foo")
 )
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/path/path_test.go
+++ b/src/pkg/path/path_test.go
@@ -387,12 +387,9 @@ func (suite *PathUnitSuite) TestFromDataLayerPath() {
 	}
 
 	for service, cats := range serviceCategories {
-
 		for cat := range cats {
-
 			for _, item := range isItem {
 				suite.Run(fmt.Sprintf("%s-%s-%s", service, cat, item.name), func() {
-
 					for _, test := range table {
 						suite.Run(test.name, func() {
 							var (
@@ -461,7 +458,8 @@ func (suite *PathUnitSuite) TestBuildPrefix() {
 				"t",
 				GroupsService.String(), "roo",
 				SharePointService.String(), "oor",
-				LibrariesCategory.String()}),
+				LibrariesCategory.String(),
+			}),
 			expectErr: require.NoError,
 		},
 		{

--- a/src/pkg/path/service_resource.go
+++ b/src/pkg/path/service_resource.go
@@ -157,13 +157,13 @@ func toMetadataServices(srs []ServiceResource) []ServiceResource {
 		metadataService := UnknownService
 
 		switch sr.Service {
+		// TODO: add groups
 		case ExchangeService:
 			metadataService = ExchangeMetadataService
 		case OneDriveService:
 			metadataService = OneDriveMetadataService
 		case SharePointService:
 			metadataService = SharePointMetadataService
-			// TODO: add groups
 		}
 
 		msr.Service = metadataService

--- a/src/pkg/path/service_resource_test.go
+++ b/src/pkg/path/service_resource_test.go
@@ -3,10 +3,10 @@ package path
 import (
 	"testing"
 
+	"github.com/alcionai/clues"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/alcionai/clues"
 	"github.com/alcionai/corso/src/internal/tester"
 )
 

--- a/src/pkg/path/service_type_test.go
+++ b/src/pkg/path/service_type_test.go
@@ -3,10 +3,10 @@ package path
 import (
 	"testing"
 
+	"github.com/alcionai/clues"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/alcionai/clues"
 	"github.com/alcionai/corso/src/internal/tester"
 )
 

--- a/src/pkg/repository/loadtest/repository_load_test.go
+++ b/src/pkg/repository/loadtest/repository_load_test.go
@@ -348,7 +348,7 @@ func ensureAllUsersInDetails(
 				continue
 			}
 
-			ro := p.ResourceOwner()
+			ro := p.ServiceResources()[0].ProtectedResource
 			if !assert.NotEmpty(t, ro, "resource owner in path: "+rr) {
 				continue
 			}

--- a/src/pkg/selectors/exchange_test.go
+++ b/src/pkg/selectors/exchange_test.go
@@ -816,7 +816,9 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 
 		joinedFldrs := strings.Join(newElems, "/")
 
-		return stubRepoRef(p.Service(), p.Category(), p.ResourceOwner(), joinedFldrs, p.Item())
+		sr0 := p.ServiceResources()[0]
+
+		return stubRepoRef(sr0.Service, p.Category(), sr0.ProtectedResource, joinedFldrs, p.Item())
 	}
 
 	makeDeets := func(refs ...path.Path) *details.Details {

--- a/src/pkg/selectors/helpers_test.go
+++ b/src/pkg/selectors/helpers_test.go
@@ -213,7 +213,15 @@ func scopeMustHave[T scopeT](t *testing.T, sc T, m map[categorizer][]string) {
 // stubPath ensures test path production matches that of fullPath design,
 // stubbing out static values where necessary.
 func stubPath(t *testing.T, user string, s []string, cat path.CategoryType) path.Path {
-	pth, err := path.Build("tid", user, path.ExchangeService, cat, true, s...)
+	pth, err := path.Build(
+		"tid",
+		[]path.ServiceResource{{
+			Service:           path.ExchangeService,
+			ProtectedResource: user,
+		}},
+		cat,
+		true,
+		s...)
 	require.NoError(t, err, clues.ToCore(err))
 
 	return pth

--- a/src/pkg/selectors/onedrive_test.go
+++ b/src/pkg/selectors/onedrive_test.go
@@ -314,7 +314,15 @@ func (suite *OneDriveSelectorSuite) TestOneDriveCategory_PathValues() {
 	shortRef := "short"
 	elems := []string{odConsts.DrivesPathDir, "driveID", odConsts.RootPathDir, "dir1.d", "dir2.d", fileID}
 
-	filePath, err := path.Build("tenant", "user", path.OneDriveService, path.FilesCategory, true, elems...)
+	filePath, err := path.Build(
+		"tenant",
+		[]path.ServiceResource{{
+			Service:           path.OneDriveService,
+			ProtectedResource: "user",
+		}},
+		path.FilesCategory,
+		true,
+		elems...)
 	require.NoError(t, err, clues.ToCore(err))
 
 	fileLoc := path.Builder{}.Append("dir1", "dir2")
@@ -351,8 +359,10 @@ func (suite *OneDriveSelectorSuite) TestOneDriveCategory_PathValues() {
 
 			itemPath, err := path.Build(
 				"tenant",
-				"site",
-				path.OneDriveService,
+				[]path.ServiceResource{{
+					Service:           path.OneDriveService,
+					ProtectedResource: "site",
+				}},
 				path.FilesCategory,
 				true,
 				test.pathElems...)

--- a/src/pkg/selectors/sharepoint_test.go
+++ b/src/pkg/selectors/sharepoint_test.go
@@ -417,10 +417,12 @@ func (suite *SharePointSelectorSuite) TestSharePointCategory_PathValues() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
+			srs, err := path.NewServiceResources(path.SharePointService, "site")
+			require.NoError(t, err, clues.ToCore(err))
+
 			itemPath, err := path.Build(
 				"tenant",
-				"site",
-				path.SharePointService,
+				srs,
 				test.sc.PathType(),
 				true,
 				test.pathElems...)


### PR DESCRIPTION
First pass for updating code outside of the path package to comply with ServiceResource tuple slices.  Compliance is still incomplete, so the build and tests
will still fail.  Changes
in this PR are focused on the easier-to-make changes, mostly generating ServiceResources where there were
previously manual declarations of service and resource.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #3993

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
