### PR TITLE
fixing up selectors

### DIFF
--- a/src/pkg/path/path.go
+++ b/src/pkg/path/path.go
@@ -186,7 +186,7 @@ func FromDataLayerPath(p string, isItem bool) (Path, error) {
 		return nil, clues.New("path has too few segments").With("path_string", p)
 	}
 
-	srs, catIdx, err := ElementsToServiceResources(pb.elements[1:])
+	srs, catIdx, err := elementsToServiceResources(pb.elements[1:])
 	if err != nil {
 		return nil, clues.Stack(err)
 	}

--- a/src/pkg/path/resource_path.go
+++ b/src/pkg/path/resource_path.go
@@ -31,7 +31,7 @@ func newDataLayerResourcePath(
 	cat CategoryType,
 	isItem bool,
 ) dataLayerResourcePath {
-	pfx := append([]string{tenant}, ServiceResourcesToElements(srs)...)
+	pfx := append([]string{tenant}, serviceResourcesToElements(srs)...)
 	pfx = append(pfx, cat.String())
 
 	return dataLayerResourcePath{

--- a/src/pkg/path/service_resource.go
+++ b/src/pkg/path/service_resource.go
@@ -37,7 +37,7 @@ func (sr ServiceResource) validate() error {
 }
 
 // ---------------------------------------------------------------------------
-// Collection
+// Exported Helpers
 // ---------------------------------------------------------------------------
 
 // NewServiceResources is a lenient constructor for building a
@@ -74,7 +74,21 @@ func NewServiceResources(elems ...any) ([]ServiceResource, error) {
 	return srs, nil
 }
 
-func ServiceResourcesToElements(srs []ServiceResource) Elements {
+func ServiceResourcesToResources(srs []ServiceResource) []string {
+	prs := make([]string, len(srs))
+
+	for i := range srs {
+		prs[i] = srs[i].ProtectedResource
+	}
+
+	return prs
+}
+
+// ---------------------------------------------------------------------------
+// Unexported Helpers
+// ---------------------------------------------------------------------------
+
+func serviceResourcesToElements(srs []ServiceResource) Elements {
 	es := make(Elements, 0, len(srs)*2)
 
 	for _, tuple := range srs {
@@ -85,7 +99,7 @@ func ServiceResourcesToElements(srs []ServiceResource) Elements {
 	return es
 }
 
-// ElementsToServiceResources turns as many pairs of elems as possible
+// elementsToServiceResources turns as many pairs of elems as possible
 // into ServiceResource tuples.  Elems must begin with a service, but
 // may contain more entries than there are service/resource pairs.
 // This transformer will continue consuming elements until it finds an
@@ -93,7 +107,7 @@ func ServiceResourcesToElements(srs []ServiceResource) Elements {
 // Returns the serviceResource pairs, the first index containing element
 // that is not part of a service/resource pair, and an error if elems is
 // len==0 or contains no services.
-func ElementsToServiceResources(elems Elements) ([]ServiceResource, int, error) {
+func elementsToServiceResources(elems Elements) ([]ServiceResource, int, error) {
 	if len(elems) == 0 {
 		return nil, -1, clues.Wrap(errMissingSegment, "service")
 	}

--- a/src/pkg/path/service_resource_test.go
+++ b/src/pkg/path/service_resource_test.go
@@ -157,7 +157,7 @@ func (suite *ServiceResourceUnitSuite) TestServiceResourceToElements() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			result := ServiceResourcesToElements(test.srs)
+			result := serviceResourcesToElements(test.srs)
 
 			// not ElementsMatch, order matters
 			assert.Equal(t, test.expect, result)
@@ -234,7 +234,7 @@ func (suite *ServiceResourceUnitSuite) TestElementsToServiceResource() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			srs, idx, err := ElementsToServiceResources(test.elems)
+			srs, idx, err := elementsToServiceResources(test.elems)
 			test.expectErr(t, err, clues.ToCore(err))
 			assert.Equal(t, test.expectIdx, idx)
 			assert.Equal(t, test.expectSRS, srs)

--- a/src/pkg/selectors/exchange_test.go
+++ b/src/pkg/selectors/exchange_test.go
@@ -815,10 +815,12 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 		}
 
 		joinedFldrs := strings.Join(newElems, "/")
-
-		sr0 := p.ServiceResources()[0]
-
-		return stubRepoRef(sr0.Service, p.Category(), sr0.ProtectedResource, joinedFldrs, p.Item())
+		return stubRepoRef(
+			suite.T(),
+			p.ServiceResources(),
+			p.Category(),
+			joinedFldrs,
+			p.Item())
 	}
 
 	makeDeets := func(refs ...path.Path) *details.Details {
@@ -1060,12 +1062,36 @@ func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce() {
 
 func (suite *ExchangeSelectorSuite) TestExchangeRestore_Reduce_locationRef() {
 	var (
-		contact         = stubRepoRef(path.ExchangeService, path.ContactsCategory, "uid", "id5/id6", "cid")
 		contactLocation = "conts/my_cont"
-		event           = stubRepoRef(path.ExchangeService, path.EventsCategory, "uid", "id1/id2", "eid")
 		eventLocation   = "cal/my_cal"
-		mail            = stubRepoRef(path.ExchangeService, path.EmailCategory, "uid", "id3/id4", "mid")
 		mailLocation    = "inbx/my_mail"
+		contact         = stubRepoRef(
+			suite.T(),
+			[]path.ServiceResource{{
+				Service:           path.ExchangeService,
+				ProtectedResource: "uid",
+			}},
+			path.ContactsCategory,
+			"id5/id6",
+			"cid")
+		event = stubRepoRef(
+			suite.T(),
+			[]path.ServiceResource{{
+				Service:           path.ExchangeService,
+				ProtectedResource: "uid",
+			}},
+			path.EventsCategory,
+			"id1/id2",
+			"eid")
+		mail = stubRepoRef(
+			suite.T(),
+			[]path.ServiceResource{{
+				Service:           path.ExchangeService,
+				ProtectedResource: "uid",
+			}},
+			path.EmailCategory,
+			"id3/id4",
+			"mid")
 	)
 
 	makeDeets := func(refs ...string) *details.Details {

--- a/src/pkg/selectors/helpers_test.go
+++ b/src/pkg/selectors/helpers_test.go
@@ -2,7 +2,6 @@ package selectors
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/alcionai/clues"
@@ -229,6 +228,22 @@ func stubPath(t *testing.T, user string, s []string, cat path.CategoryType) path
 
 // stubRepoRef ensures test path production matches that of repoRef design,
 // stubbing out static values where necessary.
-func stubRepoRef(service path.ServiceType, data path.CategoryType, resourceOwner, folders, item string) string {
-	return strings.Join([]string{"tid", service.String(), resourceOwner, data.String(), folders, item}, "/")
+func stubRepoRef(
+	t *testing.T,
+	srs []path.ServiceResource,
+	cat path.CategoryType,
+	folders, item string,
+) string {
+	fs := path.Split(folders)
+	fs = append(fs, item)
+
+	pb, err := path.Build(
+		"tid",
+		srs,
+		cat,
+		true,
+		fs...)
+	require.NoError(t, err, clues.ToCore(err))
+
+	return pb.String()
 }

--- a/src/pkg/selectors/onedrive_test.go
+++ b/src/pkg/selectors/onedrive_test.go
@@ -161,23 +161,32 @@ func (suite *OneDriveSelectorSuite) TestToOneDriveRestore() {
 func (suite *OneDriveSelectorSuite) TestOneDriveRestore_Reduce() {
 	var (
 		file = stubRepoRef(
-			path.OneDriveService,
+			suite.T(),
+			[]path.ServiceResource{{
+				Service:           path.OneDriveService,
+				ProtectedResource: "uid",
+			}},
 			path.FilesCategory,
-			"uid",
 			"drive/driveID/root:/folderA.d/folderB.d",
 			"file")
 		fileParent = "folderA/folderB"
 		file2      = stubRepoRef(
-			path.OneDriveService,
+			suite.T(),
+			[]path.ServiceResource{{
+				Service:           path.OneDriveService,
+				ProtectedResource: "uid",
+			}},
 			path.FilesCategory,
-			"uid",
 			"drive/driveID/root:/folderA.d/folderC.d",
 			"file2")
 		fileParent2 = "folderA/folderC"
 		file3       = stubRepoRef(
-			path.OneDriveService,
+			suite.T(),
+			[]path.ServiceResource{{
+				Service:           path.OneDriveService,
+				ProtectedResource: "uid",
+			}},
 			path.FilesCategory,
-			"uid",
 			"drive/driveID/root:/folderD.d/folderE.d",
 			"file3")
 		fileParent3 = "folderD/folderE"

--- a/src/pkg/selectors/scopes.go
+++ b/src/pkg/selectors/scopes.go
@@ -544,8 +544,11 @@ func reduce[T scopeT, C categoryT](
 			continue
 		}
 
-		// first check, every entry needs to match the selector's resource owners.
-		if !matchesResourceOwner.Compare(repoPath.ResourceOwner()) {
+		// first check, every entry needs to have at least one protected resource
+		// that matches the selector's protected resources.
+		if !matchesResourceOwner.CompareAny(
+			path.ServiceResourcesToResources(
+				repoPath.ServiceResources())...) {
 			continue
 		}
 

--- a/src/pkg/selectors/sharepoint_test.go
+++ b/src/pkg/selectors/sharepoint_test.go
@@ -155,9 +155,12 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 		}
 
 		return stubRepoRef(
-			path.SharePointService,
+			suite.T(),
+			[]path.ServiceResource{{
+				Service:           path.SharePointService,
+				ProtectedResource: siteID,
+			}},
 			cat,
-			siteID,
 			strings.Join(folderElems, "/"),
 			item)
 	}
@@ -188,8 +191,24 @@ func (suite *SharePointSelectorSuite) TestSharePointRestore_Reduce() {
 			"sid",
 			append(slices.Clone(prefixElems), itemElems3...),
 			"item3")
-		item4 = stubRepoRef(path.SharePointService, path.PagesCategory, "sid", pairGH, "item4")
-		item5 = stubRepoRef(path.SharePointService, path.PagesCategory, "sid", pairGH, "item5")
+		item4 = stubRepoRef(
+			suite.T(),
+			[]path.ServiceResource{{
+				Service:           path.SharePointService,
+				ProtectedResource: "sid",
+			}},
+			path.PagesCategory,
+			pairGH,
+			"item4")
+		item5 = stubRepoRef(
+			suite.T(),
+			[]path.ServiceResource{{
+				Service:           path.SharePointService,
+				ProtectedResource: "sid",
+			}},
+			path.PagesCategory,
+			pairGH,
+			"item5")
 	)
 
 	deets := &details.Details{


### PR DESCRIPTION
adds a set of fixes targeted at the selectors package.  Largely updates testing code.  But also updates the resource check at the beginning of the Reduce flow to check for a match on any of the resources in the ServiceResources slice.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #3993

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
