### PR TITLE
Batch deletion of individual backup components

### DIFF
--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -559,37 +559,6 @@ func (w Wrapper) ProduceRestoreCollections(
 	return res, el.Failure()
 }
 
-// DeleteSnapshot removes the provided manifest from kopia.
-func (w Wrapper) DeleteSnapshot(
-	ctx context.Context,
-	snapshotID string,
-) error {
-	mid := manifest.ID(snapshotID)
-	if len(mid) == 0 {
-		return clues.New("snapshot ID required for deletion").WithClues(ctx)
-	}
-
-	err := repo.WriteSession(
-		ctx,
-		w.c,
-		repo.WriteSessionOptions{Purpose: "KopiaWrapperBackupDeletion"},
-		func(innerCtx context.Context, rw repo.RepositoryWriter) error {
-			if err := rw.DeleteManifest(ctx, mid); err != nil {
-				return clues.Wrap(err, "deleting snapshot").WithClues(ctx)
-			}
-
-			return nil
-		},
-	)
-	// Telling kopia to always flush may hide other errors if it fails while
-	// flushing the write session (hence logging above).
-	if err != nil {
-		return clues.Wrap(err, "deleting backup manifest").WithClues(ctx)
-	}
-
-	return nil
-}
-
 func (w Wrapper) NewBaseFinder(bg store.BackupGetter) (*baseFinder, error) {
 	return newBaseFinder(w.c, bg)
 }

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/alcionai/clues"
-	"github.com/google/uuid"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/format"
@@ -2154,54 +2153,6 @@ func (suite *KopiaSimpleRepoIntegrationSuite) TestProduceRestoreCollections_Erro
 				fault.New(true))
 			assert.Error(t, err, clues.ToCore(err))
 			assert.Empty(t, c)
-		})
-	}
-}
-
-func (suite *KopiaSimpleRepoIntegrationSuite) TestDeleteSnapshot() {
-	t := suite.T()
-
-	err := suite.w.DeleteSnapshot(suite.ctx, string(suite.snapshotID))
-	assert.NoError(t, err, clues.ToCore(err))
-
-	// assert the deletion worked
-	itemPath := suite.files[suite.testPath1.String()][0].itemPath
-	ic := i64counter{}
-
-	c, err := suite.w.ProduceRestoreCollections(
-		suite.ctx,
-		string(suite.snapshotID),
-		toRestorePaths(t, itemPath),
-		&ic,
-		fault.New(true))
-	assert.Error(t, err, "snapshot should be deleted", clues.ToCore(err))
-	assert.Empty(t, c)
-	assert.Zero(t, ic.i)
-}
-
-func (suite *KopiaSimpleRepoIntegrationSuite) TestDeleteSnapshot_BadIDs() {
-	table := []struct {
-		name       string
-		snapshotID string
-		expect     assert.ErrorAssertionFunc
-	}{
-		{
-			name:       "no id",
-			snapshotID: "",
-			expect:     assert.Error,
-		},
-		{
-			name:       "unknown id",
-			snapshotID: uuid.NewString(),
-			expect:     assert.NoError,
-		},
-	}
-	for _, test := range table {
-		suite.Run(test.name, func() {
-			t := suite.T()
-
-			err := suite.w.DeleteSnapshot(suite.ctx, test.snapshotID)
-			test.expect(t, err, clues.ToCore(err))
 		})
 	}
 }

--- a/src/internal/streamstore/streamstore.go
+++ b/src/internal/streamstore/streamstore.go
@@ -79,16 +79,6 @@ func (ss *storeStreamer) Read(ctx context.Context, snapshotID string, col Collec
 	return nil
 }
 
-// Delete deletes a `details.Details` object from the kopia repository
-func (ss *storeStreamer) Delete(ctx context.Context, detailsID string) error {
-	err := ss.kw.DeleteSnapshot(ctx, detailsID)
-	if err != nil {
-		return clues.Wrap(err, "deleting snapshot in stream store")
-	}
-
-	return nil
-}
-
 // ---------------------------------------------------------------------------
 // interfaces
 // ---------------------------------------------------------------------------
@@ -99,7 +89,6 @@ type Streamer interface {
 	Collector
 	Writer
 	Reader
-	Delete(context.Context, string) error
 }
 
 type CollectorWriter interface {

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/alcionai/clues"
 	"github.com/google/uuid"
+	"github.com/kopia/kopia/repo/manifest"
 	"github.com/pkg/errors"
 
 	"github.com/alcionai/corso/src/internal/common/crash"
@@ -635,25 +636,29 @@ type snapshotDeleter interface {
 
 // DeleteBackup removes the backup from both the model store and the backup storage.
 func (r repository) DeleteBackup(ctx context.Context, id string) error {
-	return deleteBackup(ctx, id, r.dataLayer, store.NewWrapper(r.modelStore))
+	return deleteBackup(ctx, id, store.NewWrapper(r.modelStore))
 }
 
 // deleteBackup handles the processing for Backup.
 func deleteBackup(
 	ctx context.Context,
 	id string,
-	kw snapshotDeleter,
-	sw store.BackupGetterDeleter,
+	sw store.BackupGetterModelDeleter,
 ) error {
 	b, err := sw.GetBackup(ctx, model.StableID(id))
 	if err != nil {
-		return errWrapper(err)
+		return clues.Stack(errWrapper(err)).WithClues(ctx)
 	}
 
+	// Although we haven't explicitly stated it, snapshots are technically
+	// manifests in kopia. This means we can use the same delete API to remove
+	// them and backup models. Deleting all of them together gives us both
+	// atomicity guarantees (around when data will be flushed) and helps reduce
+	// the number of manifest blobs that kopia will create.
+	toDelete := []manifest.ID{manifest.ID(b.ModelStoreID)}
+
 	if len(b.SnapshotID) > 0 {
-		if err := kw.DeleteSnapshot(ctx, b.SnapshotID); err != nil {
-			return err
-		}
+		toDelete = append(toDelete, manifest.ID(b.SnapshotID))
 	}
 
 	ssid := b.StreamStoreID
@@ -662,12 +667,10 @@ func deleteBackup(
 	}
 
 	if len(ssid) > 0 {
-		if err := kw.DeleteSnapshot(ctx, ssid); err != nil {
-			return err
-		}
+		toDelete = append(toDelete, manifest.ID(ssid))
 	}
 
-	return sw.DeleteBackup(ctx, model.StableID(id))
+	return sw.DeleteWithModelStoreIDs(ctx, toDelete...)
 }
 
 func (r repository) ConnectToM365(

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -630,10 +630,6 @@ func getBackupErrors(
 	return &fe, b, nil
 }
 
-type snapshotDeleter interface {
-	DeleteSnapshot(ctx context.Context, snapshotID string) error
-}
-
 // DeleteBackup removes the backup from both the model store and the backup storage.
 func (r repository) DeleteBackup(ctx context.Context, id string) error {
 	return deleteBackup(ctx, id, store.NewWrapper(r.modelStore))

--- a/src/pkg/store/backup.go
+++ b/src/pkg/store/backup.go
@@ -59,14 +59,23 @@ type (
 		DeleteBackup(ctx context.Context, backupID model.StableID) error
 	}
 
+	ModelDeleter interface {
+		DeleteWithModelStoreIDs(ctx context.Context, ids ...manifest.ID) error
+	}
+
+	BackupGetterModelDeleter interface {
+		BackupGetter
+		ModelDeleter
+	}
+
 	Storer interface {
 		Delete(ctx context.Context, s model.Schema, id model.StableID) error
-		DeleteWithModelStoreIDs(ctx context.Context, ids ...manifest.ID) error
 		Get(ctx context.Context, s model.Schema, id model.StableID, data model.Model) error
 		GetIDsForType(ctx context.Context, s model.Schema, tags map[string]string) ([]*model.BaseModel, error)
 		GetWithModelStoreID(ctx context.Context, s model.Schema, id manifest.ID, data model.Model) error
 		Put(ctx context.Context, s model.Schema, m model.Model) error
 		Update(ctx context.Context, s model.Schema, m model.Model) error
+		ModelDeleter
 	}
 
 	BackupStorer interface {

--- a/src/pkg/store/mock/wrapper.go
+++ b/src/pkg/store/mock/wrapper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/alcionai/clues"
+	"github.com/kopia/kopia/repo/manifest"
 
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/pkg/backup"
@@ -22,14 +23,14 @@ func (bw BackupWrapper) GetBackup(
 ) (*backup.Backup, error) {
 	bw.Backup.SnapshotID = bw.Backup.ID.String()
 
-	return bw.Backup, bw.GetErr
+	return bw.Backup, clues.Stack(bw.GetErr).OrNil()
 }
 
 func (bw BackupWrapper) DeleteBackup(
 	ctx context.Context,
 	backupID model.StableID,
 ) error {
-	return bw.DeleteErr
+	return clues.Stack(bw.DeleteErr).OrNil()
 }
 
 func (bw BackupWrapper) GetBackups(
@@ -37,4 +38,11 @@ func (bw BackupWrapper) GetBackups(
 	filters ...store.FilterOption,
 ) ([]*backup.Backup, error) {
 	return nil, clues.New("GetBackups mock not implemented yet")
+}
+
+func (bw BackupWrapper) DeleteWithModelStoreIDs(
+	ctx context.Context,
+	ids ...manifest.ID,
+) error {
+	return clues.Stack(bw.DeleteErr).OrNil()
 }


### PR DESCRIPTION
Reduce the number of kopia manifest blobs
created during backup deletion by batching
the deletion of snapshots and the backup
model into a single kopia operation

Also reorangizes/updates test code for
backup deletion

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #4019

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
