### PR TITLE
all non-resourcer compliance

### DIFF
--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -515,7 +515,7 @@ func streamBaseEntries(
 		// TODO(ashmrtn): We may eventually want to make this a function that is
 		// passed in so that we can more easily switch it between different external
 		// service provider implementations.
-		if !metadata.IsMetadataFile(itemPath) {
+		if !metadata.IsMetadataFilePath(itemPath) {
 			// All items have item info in the base backup. However, we need to make
 			// sure we have enough metadata to find those entries. To do that we add
 			// the item to progress and having progress aggregate everything for

--- a/src/internal/m365/backup_test.go
+++ b/src/internal/m365/backup_test.go
@@ -403,17 +403,19 @@ func (suite *SPCollectionIntgSuite) TestCreateSharePointCollection_Libraries() {
 	// No excludes yet as this isn't an incremental backup.
 	assert.True(t, excludes.Empty())
 
+	// assume the last service in the path is sharepoint.
+	srs := cols[0].FullPath().ServiceResources()
+	service := srs[len(srs)-1].Service
+
 	t.Logf("cols[0] Path: %s\n", cols[0].FullPath().String())
-	assert.Equal(
-		t,
-		path.SharePointMetadataService.String(),
-		cols[0].FullPath().Service().String())
+	assert.Equal(t, path.SharePointMetadataService, service)
+
+	// assume the last service in the path is sharepoint.
+	srs = cols[1].FullPath().ServiceResources()
+	service = srs[len(srs)-1].Service
 
 	t.Logf("cols[1] Path: %s\n", cols[1].FullPath().String())
-	assert.Equal(
-		t,
-		path.SharePointService.String(),
-		cols[1].FullPath().Service().String())
+	assert.Equal(t, path.SharePointService, service)
 }
 
 func (suite *SPCollectionIntgSuite) TestCreateSharePointCollection_Lists() {

--- a/src/internal/m365/collection/site/collection.go
+++ b/src/internal/m365/collection/site/collection.go
@@ -218,12 +218,16 @@ func (sc *Collection) retrieveLists(
 	var (
 		metrics support.CollectionMetrics
 		el      = errs.Local()
+		// todo: pass in the resourceOwner as an idname.Provider
+		srs = sc.fullPath.ServiceResources()
+		// take the last resource in srs, since that should be the data owner
+		protectedResource = srs[len(srs)-1].ProtectedResource
 	)
 
 	lists, err := loadSiteLists(
 		ctx,
 		sc.client.Stable,
-		sc.fullPath.ResourceOwner(),
+		protectedResource,
 		sc.jobs,
 		errs)
 	if err != nil {
@@ -279,6 +283,10 @@ func (sc *Collection) retrievePages(
 	var (
 		metrics support.CollectionMetrics
 		el      = errs.Local()
+		// todo: pass in the resourceOwner as an idname.Provider
+		srs = sc.fullPath.ServiceResources()
+		// take the last resource in srs, since that should be the data owner
+		protectedResource = srs[len(srs)-1].ProtectedResource
 	)
 
 	betaService := sc.betaService
@@ -286,14 +294,14 @@ func (sc *Collection) retrievePages(
 		return metrics, clues.New("beta service required").WithClues(ctx)
 	}
 
-	parent, err := as.GetByID(ctx, sc.fullPath.ResourceOwner())
+	parent, err := as.GetByID(ctx, protectedResource)
 	if err != nil {
 		return metrics, err
 	}
 
 	root := ptr.Val(parent.GetWebUrl())
 
-	pages, err := betaAPI.GetSitePages(ctx, betaService, sc.fullPath.ResourceOwner(), sc.jobs, errs)
+	pages, err := betaAPI.GetSitePages(ctx, betaService, protectedResource, sc.jobs, errs)
 	if err != nil {
 		return metrics, err
 	}

--- a/src/internal/m365/collection/site/restore.go
+++ b/src/internal/m365/collection/site/restore.go
@@ -69,7 +69,9 @@ func ConsumeRestoreCollections(
 			ictx     = clues.Add(ctx,
 				"category", category,
 				"restore_location", clues.Hide(rcc.RestoreConfig.Location),
-				"resource_owner", clues.Hide(dc.FullPath().ResourceOwner()),
+				"resource_owners", clues.Hide(
+					path.ServiceResourcesToResources(
+						dc.FullPath().ServiceResources())),
 				"full_path", dc.FullPath())
 		)
 
@@ -219,9 +221,12 @@ func RestoreListCollection(
 	var (
 		metrics   = support.CollectionMetrics{}
 		directory = dc.FullPath()
-		siteID    = directory.ResourceOwner()
 		items     = dc.Items(ctx, errs)
 		el        = errs.Local()
+		// todo: pass in the resourceOwner as an idname.Provider
+		srs = directory.ServiceResources()
+		// take the last resource in srs, since that should be the data owner
+		protectedResource = srs[len(srs)-1].ProtectedResource
 	)
 
 	trace.Log(ctx, "m365:sharepoint:restoreListCollection", directory.String())
@@ -245,7 +250,7 @@ func RestoreListCollection(
 				ctx,
 				service,
 				itemData,
-				siteID,
+				protectedResource,
 				restoreContainerName)
 			if err != nil {
 				el.AddRecoverable(ctx, err)
@@ -292,7 +297,10 @@ func RestorePageCollection(
 	var (
 		metrics   = support.CollectionMetrics{}
 		directory = dc.FullPath()
-		siteID    = directory.ResourceOwner()
+		// todo: pass in the resourceOwner as an idname.Provider
+		srs = directory.ServiceResources()
+		// take the last resource in srs, since that should be the data owner
+		protectedResource = srs[len(srs)-1].ProtectedResource
 	)
 
 	trace.Log(ctx, "m365:sharepoint:restorePageCollection", directory.String())
@@ -325,7 +333,7 @@ func RestorePageCollection(
 				ctx,
 				service,
 				itemData,
-				siteID,
+				protectedResource,
 				restoreContainerName)
 			if err != nil {
 				el.AddRecoverable(ctx, err)

--- a/src/internal/m365/controller_test.go
+++ b/src/internal/m365/controller_test.go
@@ -1249,11 +1249,11 @@ func (suite *ControllerIntegrationSuite) TestRestoreAndBackup_largeMailAttachmen
 
 func (suite *ControllerIntegrationSuite) TestBackup_CreatesPrefixCollections() {
 	table := []struct {
-		name         string
-		resourceCat  resource.Category
-		selectorFunc func(t *testing.T) selectors.Selector
-		service      path.ServiceType
-		categories   []string
+		name             string
+		resourceCat      resource.Category
+		selectorFunc     func(t *testing.T) selectors.Selector
+		metadataServices []path.ServiceType
+		categories       []string
 	}{
 		{
 			name:        "Exchange",
@@ -1267,7 +1267,7 @@ func (suite *ControllerIntegrationSuite) TestBackup_CreatesPrefixCollections() {
 
 				return sel.Selector
 			},
-			service: path.ExchangeService,
+			metadataServices: []path.ServiceType{path.ExchangeMetadataService},
 			categories: []string{
 				path.EmailCategory.String(),
 				path.ContactsCategory.String(),
@@ -1283,7 +1283,7 @@ func (suite *ControllerIntegrationSuite) TestBackup_CreatesPrefixCollections() {
 
 				return sel.Selector
 			},
-			service: path.OneDriveService,
+			metadataServices: []path.ServiceType{path.OneDriveMetadataService},
 			categories: []string{
 				path.FilesCategory.String(),
 			},
@@ -1302,7 +1302,7 @@ func (suite *ControllerIntegrationSuite) TestBackup_CreatesPrefixCollections() {
 
 				return sel.Selector
 			},
-			service: path.SharePointService,
+			metadataServices: []path.ServiceType{path.SharePointMetadataService},
 			categories: []string{
 				path.LibrariesCategory.String(),
 				// not yet in use
@@ -1365,7 +1365,7 @@ func (suite *ControllerIntegrationSuite) TestBackup_CreatesPrefixCollections() {
 
 				// Ignore metadata collections.
 				fullPath := col.FullPath()
-				if fullPath.Service() != test.service {
+				if path.ServiceResourcesMatchServices(fullPath.ServiceResources(), test.metadataServices) {
 					continue
 				}
 

--- a/src/internal/m365/graph/metadata/metadata.go
+++ b/src/internal/m365/graph/metadata/metadata.go
@@ -5,13 +5,30 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
-func IsMetadataFile(p path.Path) bool {
-	switch p.Service() {
+// IsMetadataFilePath checks whether the LAST service in the path
+// supports metadata file types and, if so, whether the item has
+// a meta suffix.
+func IsMetadataFilePath(p path.Path) bool {
+	return IsMetadataFile(
+		p.ServiceResources(),
+		p.Category(),
+		p.Item())
+}
+
+// IsMetadataFile accepts the ServiceResources, cat, and Item values from
+// a path (or equivalent representation) and returns true if the item
+// is a Metadata entry.
+func IsMetadataFile(
+	srs []path.ServiceResource,
+	cat path.CategoryType,
+	itemID string,
+) bool {
+	switch srs[len(srs)-1].Service {
 	case path.OneDriveService:
-		return metadata.HasMetaSuffix(p.Item())
+		return metadata.HasMetaSuffix(itemID)
 
 	case path.SharePointService:
-		return p.Category() == path.LibrariesCategory && metadata.HasMetaSuffix(p.Item())
+		return cat == path.LibrariesCategory && metadata.HasMetaSuffix(itemID)
 
 	default:
 		return false

--- a/src/internal/m365/service/exchange/backup_test.go
+++ b/src/internal/m365/service/exchange/backup_test.go
@@ -491,7 +491,9 @@ func (suite *BackupIntgSuite) TestMailFetch() {
 			require.NoError(t, err, clues.ToCore(err))
 
 			for _, c := range collections {
-				if c.FullPath().Service() == path.ExchangeMetadataService {
+				if path.ServiceResourcesMatchServices(
+					c.FullPath().ServiceResources(),
+					[]path.ServiceType{path.ExchangeMetadataService}) {
 					continue
 				}
 
@@ -577,7 +579,9 @@ func (suite *BackupIntgSuite) TestDelta() {
 			var metadata data.BackupCollection
 
 			for _, coll := range collections {
-				if coll.FullPath().Service() == path.ExchangeMetadataService {
+				if path.ServiceResourcesMatchServices(
+					coll.FullPath().ServiceResources(),
+					[]path.ServiceType{path.ExchangeMetadataService}) {
 					metadata = coll
 				}
 			}
@@ -611,7 +615,9 @@ func (suite *BackupIntgSuite) TestDelta() {
 			// Delta usage is commented out at the moment, anyway.  So this is currently
 			// a sanity check that the minimum behavior won't break.
 			for _, coll := range collections {
-				if coll.FullPath().Service() != path.ExchangeMetadataService {
+				if !path.ServiceResourcesMatchServices(
+					coll.FullPath().ServiceResources(),
+					[]path.ServiceType{path.ExchangeMetadataService}) {
 					ec, ok := coll.(*Collection)
 					require.True(t, ok, "collection is *Collection")
 					assert.NotNil(t, ec)
@@ -666,7 +672,9 @@ func (suite *BackupIntgSuite) TestMailSerializationRegression() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			isMetadata := edc.FullPath().Service() == path.ExchangeMetadataService
+			isMetadata := path.ServiceResourcesMatchServices(
+				edc.FullPath().ServiceResources(),
+				[]path.ServiceType{path.ExchangeMetadataService})
 			streamChannel := edc.Items(ctx, fault.New(true))
 
 			// Verify that each message can be restored
@@ -744,7 +752,9 @@ func (suite *BackupIntgSuite) TestContactSerializationRegression() {
 			require.GreaterOrEqual(t, 2, len(edcs), "expected 1 <= num collections <= 2")
 
 			for _, edc := range edcs {
-				isMetadata := edc.FullPath().Service() == path.ExchangeMetadataService
+				isMetadata := path.ServiceResourcesMatchServices(
+					edc.FullPath().ServiceResources(),
+					[]path.ServiceType{path.ExchangeMetadataService})
 				count := 0
 
 				for stream := range edc.Items(ctx, fault.New(true)) {
@@ -874,7 +884,10 @@ func (suite *BackupIntgSuite) TestEventsSerializationRegression() {
 			for _, edc := range collections {
 				var isMetadata bool
 
-				if edc.FullPath().Service() != path.ExchangeMetadataService {
+				// FIXME: this doesn't seem right, it's saying "if not metadata, isMetadata = true"
+				if !path.ServiceResourcesMatchServices(
+					edc.FullPath().ServiceResources(),
+					[]path.ServiceType{path.ExchangeMetadataService}) {
 					isMetadata = true
 					assert.Equal(t, test.expected, edc.FullPath().Folder(false))
 				} else {
@@ -1140,7 +1153,9 @@ func (suite *CollectionPopulationSuite) TestPopulateCollections() {
 
 				deleteds, news, metadatas, doNotMerges := 0, 0, 0, 0
 				for _, c := range collections {
-					if c.FullPath().Service() == path.ExchangeMetadataService {
+					if path.ServiceResourcesMatchServices(
+						c.FullPath().ServiceResources(),
+						[]path.ServiceType{path.ExchangeMetadataService}) {
 						metadatas++
 						continue
 					}
@@ -1491,7 +1506,9 @@ func (suite *CollectionPopulationSuite) TestFilterContainersAndFillCollections_D
 							continue
 						}
 
-						if c.FullPath().Service() == path.ExchangeMetadataService {
+						if path.ServiceResourcesMatchServices(
+							c.FullPath().ServiceResources(),
+							[]path.ServiceType{path.ExchangeMetadataService}) {
 							metadatas++
 							checkMetadata(t, ctx, qp.Category, test.expectMetadata(t, qp.Category), c)
 							continue
@@ -1650,7 +1667,9 @@ func (suite *CollectionPopulationSuite) TestFilterContainersAndFillCollections_r
 
 			deleteds, news, metadatas, doNotMerges := 0, 0, 0, 0
 			for _, c := range collections {
-				if c.FullPath().Service() == path.ExchangeMetadataService {
+				if path.ServiceResourcesMatchServices(
+					c.FullPath().ServiceResources(),
+					[]path.ServiceType{path.ExchangeMetadataService}) {
 					metadatas++
 					continue
 				}
@@ -2082,7 +2101,9 @@ func (suite *CollectionPopulationSuite) TestFilterContainersAndFillCollections_i
 
 						require.NotNil(t, p)
 
-						if p.Service() == path.ExchangeMetadataService {
+						if path.ServiceResourcesMatchServices(
+							c.FullPath().ServiceResources(),
+							[]path.ServiceType{path.ExchangeMetadataService}) {
 							metadatas++
 							continue
 						}

--- a/src/internal/m365/service/groups/restore.go
+++ b/src/internal/m365/service/groups/restore.go
@@ -57,7 +57,9 @@ func ConsumeRestoreCollections(
 			ictx     = clues.Add(ctx,
 				"category", category,
 				"restore_location", clues.Hide(rcc.RestoreConfig.Location),
-				"protected_resource", clues.Hide(dc.FullPath().ResourceOwner()),
+				"resource_owners", clues.Hide(
+					path.ServiceResourcesToResources(
+						dc.FullPath().ServiceResources())),
 				"full_path", dc.FullPath())
 		)
 

--- a/src/internal/m365/service/sharepoint/restore.go
+++ b/src/internal/m365/service/sharepoint/restore.go
@@ -61,7 +61,9 @@ func ConsumeRestoreCollections(
 			ictx     = clues.Add(ctx,
 				"category", category,
 				"restore_location", clues.Hide(rcc.RestoreConfig.Location),
-				"resource_owner", clues.Hide(dc.FullPath().ResourceOwner()),
+				"resource_owners", clues.Hide(
+					path.ServiceResourcesToResources(
+						dc.FullPath().ServiceResources())),
 				"full_path", dc.FullPath())
 		)
 

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -566,7 +566,10 @@ func getNewPathRefs(
 	// TODO(ashmrtn): In the future we can remove this first check as we'll be
 	// able to assume we always have the location in the previous entry. We'll end
 	// up doing some extra parsing, but it will simplify this code.
-	if repoRef.Service() == path.ExchangeService {
+	//
+	// Currently safe to check only the 0th SR, since exchange had no subservices
+	// at the time of the locations addition.
+	if repoRef.ServiceResources()[0].Service == path.ExchangeService {
 		newPath, newLoc, err := dataFromBackup.GetNewPathRefs(
 			repoRef.ToBuilder(),
 			entry.Modified(),

--- a/src/internal/streamstore/streamstore.go
+++ b/src/internal/streamstore/streamstore.go
@@ -198,8 +198,13 @@ func collect(
 	service path.ServiceType,
 	col Collectable,
 ) (data.BackupCollection, error) {
+	srs := []path.ServiceResource{{
+		Service:           service,
+		ProtectedResource: col.purpose,
+	}}
+
 	// construct the path of the container
-	p, err := path.Builder{}.ToStreamStorePath(tenantID, col.purpose, service, false)
+	p, err := path.Builder{}.ToStreamStorePath(tenantID, srs, false)
 	if err != nil {
 		return nil, clues.Stack(err).WithClues(ctx)
 	}
@@ -257,10 +262,15 @@ func read(
 	rer inject.RestoreProducer,
 	errs *fault.Bus,
 ) error {
+	srs := []path.ServiceResource{{
+		Service:           service,
+		ProtectedResource: col.purpose,
+	}}
+
 	// construct the path of the container
 	p, err := path.Builder{}.
 		Append(col.itemName).
-		ToStreamStorePath(tenantID, col.purpose, service, true)
+		ToStreamStorePath(tenantID, srs, true)
 	if err != nil {
 		return clues.Stack(err).WithClues(ctx)
 	}

--- a/src/pkg/path/resource_path.go
+++ b/src/pkg/path/resource_path.go
@@ -31,7 +31,7 @@ func newDataLayerResourcePath(
 	cat CategoryType,
 	isItem bool,
 ) dataLayerResourcePath {
-	pfx := append([]string{tenant}, serviceResourcesToElements(srs)...)
+	pfx := append([]string{tenant}, ServiceResourcesToElements(srs)...)
 	pfx = append(pfx, cat.String())
 
 	return dataLayerResourcePath{

--- a/src/pkg/path/service_resource.go
+++ b/src/pkg/path/service_resource.go
@@ -2,6 +2,7 @@ package path
 
 import (
 	"github.com/alcionai/clues"
+	"golang.org/x/exp/slices"
 
 	"github.com/alcionai/corso/src/internal/common/str"
 	"github.com/alcionai/corso/src/internal/common/tform"
@@ -84,11 +85,13 @@ func ServiceResourcesToResources(srs []ServiceResource) []string {
 	return prs
 }
 
-// ---------------------------------------------------------------------------
-// Unexported Helpers
-// ---------------------------------------------------------------------------
+func ServiceResourcesMatchServices(srs []ServiceResource, sts []ServiceType) bool {
+	return slices.EqualFunc(srs, sts, func(sr ServiceResource, st ServiceType) bool {
+		return sr.Service == st
+	})
+}
 
-func serviceResourcesToElements(srs []ServiceResource) Elements {
+func ServiceResourcesToElements(srs []ServiceResource) Elements {
 	es := make(Elements, 0, len(srs)*2)
 
 	for _, tuple := range srs {
@@ -98,6 +101,10 @@ func serviceResourcesToElements(srs []ServiceResource) Elements {
 
 	return es
 }
+
+// ---------------------------------------------------------------------------
+// Unexported Helpers
+// ---------------------------------------------------------------------------
 
 // elementsToServiceResources turns as many pairs of elems as possible
 // into ServiceResource tuples.  Elems must begin with a service, but

--- a/src/pkg/path/service_resource_test.go
+++ b/src/pkg/path/service_resource_test.go
@@ -157,7 +157,7 @@ func (suite *ServiceResourceUnitSuite) TestServiceResourceToElements() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			result := serviceResourcesToElements(test.srs)
+			result := ServiceResourcesToElements(test.srs)
 
 			// not ElementsMatch, order matters
 			assert.Equal(t, test.expect, result)


### PR DESCRIPTION
Updates all path package uses that does not involve a Resourcer.  Third to last step to wrapping up compliance. Second step is to update the Resourcer interface to comply with ServiceResources.  Last step is to clean up any lingering linters, bugs, tests, and other things needed to make the build green.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #3993

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
