### PR TITLE
Print the point in time being used

### DIFF
--- a/src/cmd/longevity_test/longevity.go
+++ b/src/cmd/longevity_test/longevity.go
@@ -73,6 +73,12 @@ func pitrListBackups(
 	pitr time.Time,
 	backupIDs []string,
 ) error {
+	logAndPrint(
+		ctx,
+		"looking for %d backup(s) using timestamp %v\n",
+		len(backupIDs),
+		pitr)
+
 	if len(backupIDs) == 0 {
 		return nil
 	}


### PR DESCRIPTION
When looking for recently deleted backups, print the point in time that kopia will be opened at so that if we need to manually debug something the value is right there.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [x] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #4031

#### Test Plan

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
