### PR TITLE
Retry unexpected EOF errors

### DIFF
--- a/src/internal/common/readers/retry_handler.go
+++ b/src/internal/common/readers/retry_handler.go
@@ -28,6 +28,7 @@ const (
 // between callers.
 var retryErrs = []error{
 	syscall.ECONNRESET,
+	io.ErrUnexpectedEOF,
 }
 
 type Getter interface {


### PR DESCRIPTION
<!-- PR description-->

Adds `io.ErrUnexpectedEOF` to the list of retriable errors looked up by retry handler. 

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
