### PR TITLE
Don't fail deletion on missing backups

### DIFF
--- a/src/cli/backup/backup.go
+++ b/src/cli/backup/backup.go
@@ -283,7 +283,7 @@ func genericDeleteCommand(
 
 	defer utils.CloseRepo(ctx, r)
 
-	if err := r.DeleteBackups(ctx, bID); err != nil {
+	if err := r.DeleteBackups(ctx, true, bID); err != nil {
 		return Only(ctx, clues.Wrap(err, "Deleting backup "+bID))
 	}
 

--- a/src/cmd/longevity_test/longevity.go
+++ b/src/cmd/longevity_test/longevity.go
@@ -48,7 +48,7 @@ func deleteBackups(
 
 	for _, backup := range backups {
 		if backup.StartAndEndTime.CompletedAt.Before(cutoff) {
-			if err := r.DeleteBackups(ctx, backup.ID.String()); err != nil {
+			if err := r.DeleteBackups(ctx, true, backup.ID.String()); err != nil {
 				return nil, clues.Wrap(
 					err,
 					"deleting backup").

--- a/src/pkg/repository/repository_test.go
+++ b/src/pkg/repository/repository_test.go
@@ -322,7 +322,7 @@ func (suite *RepositoryIntegrationSuite) TestNewBackupAndDelete() {
 
 	backupID := string(bo.Results.BackupID)
 
-	err = r.DeleteBackups(ctx, backupID)
+	err = r.DeleteBackups(ctx, true, backupID)
 	require.NoError(t, err, "deleting backup: %v", clues.ToCore(err))
 
 	// This operation should fail since the backup doesn't exist anymore.

--- a/src/pkg/repository/repository_unexported_test.go
+++ b/src/pkg/repository/repository_unexported_test.go
@@ -373,36 +373,36 @@ func (m *mockBackupGetterModelDeleter) DeleteWithModelStoreIDs(
 func (suite *RepositoryBackupsUnitSuite) TestDeleteBackups() {
 	bup := &backup.Backup{
 		BaseModel: model.BaseModel{
-			ID:           model.StableID(uuid.NewString()),
-			ModelStoreID: manifest.ID(uuid.NewString()),
+			ID:           model.StableID("current-bup-id"),
+			ModelStoreID: manifest.ID("current-bup-msid"),
 		},
-		SnapshotID:    uuid.NewString(),
-		StreamStoreID: uuid.NewString(),
+		SnapshotID:    "current-bup-dsid",
+		StreamStoreID: "current-bup-ssid",
 	}
 
 	bupLegacy := &backup.Backup{
 		BaseModel: model.BaseModel{
-			ID:           model.StableID(uuid.NewString()),
-			ModelStoreID: manifest.ID(uuid.NewString()),
+			ID:           model.StableID("legacy-bup-id"),
+			ModelStoreID: manifest.ID("legacy-bup-msid"),
 		},
-		SnapshotID: uuid.NewString(),
-		DetailsID:  uuid.NewString(),
+		SnapshotID: "legacy-bup-dsid",
+		DetailsID:  "legacy-bup-did",
 	}
 
 	bupNoSnapshot := &backup.Backup{
 		BaseModel: model.BaseModel{
-			ID:           model.StableID(uuid.NewString()),
-			ModelStoreID: manifest.ID(uuid.NewString()),
+			ID:           model.StableID("ns-bup-id"),
+			ModelStoreID: manifest.ID("ns-bup-id-msid"),
 		},
-		StreamStoreID: uuid.NewString(),
+		StreamStoreID: "ns-bup-ssid",
 	}
 
 	bupNoDetails := &backup.Backup{
 		BaseModel: model.BaseModel{
-			ID:           model.StableID(uuid.NewString()),
-			ModelStoreID: manifest.ID(uuid.NewString()),
+			ID:           model.StableID("nssid-bup-id"),
+			ModelStoreID: manifest.ID("nssid-bup-msid"),
 		},
-		SnapshotID: uuid.NewString(),
+		SnapshotID: "nssid-bup-dsid",
 	}
 
 	table := []struct {

--- a/src/pkg/repository/repository_unexported_test.go
+++ b/src/pkg/repository/repository_unexported_test.go
@@ -450,9 +450,10 @@ func (suite *RepositoryBackupsUnitSuite) TestDeleteBackups() {
 			expectGets: []model.StableID{
 				bup.ID,
 			},
+			dels:       []error{nil},
+			expectDels: [][]string{nil},
 			expectErr: func(t *testing.T, result error) {
-				assert.ErrorIs(t, result, data.ErrNotFound, clues.ToCore(result))
-				assert.ErrorIs(t, result, ErrorBackupNotFound, clues.ToCore(result))
+				assert.NoError(t, result, clues.ToCore(result))
 			},
 		},
 		{
@@ -585,7 +586,7 @@ func (suite *RepositoryBackupsUnitSuite) TestDeleteBackups() {
 			},
 		},
 		{
-			name: "MultipleBackups GetError",
+			name: "MultipleBackups GetError NoFailOnMissing",
 			inputIDs: []model.StableID{
 				bup.ID,
 				bupLegacy.ID,
@@ -594,9 +595,9 @@ func (suite *RepositoryBackupsUnitSuite) TestDeleteBackups() {
 			},
 			gets: []getRes{
 				{bup: bup},
-				{bup: bupLegacy},
-				{bup: bupNoSnapshot},
 				{err: data.ErrNotFound},
+				{bup: bupNoSnapshot},
+				{bup: bupNoDetails},
 			},
 			expectGets: []model.StableID{
 				bup.ID,
@@ -604,9 +605,20 @@ func (suite *RepositoryBackupsUnitSuite) TestDeleteBackups() {
 				bupNoSnapshot.ID,
 				bupNoDetails.ID,
 			},
+			dels: []error{nil},
+			expectDels: [][]string{
+				{
+					string(bup.ModelStoreID),
+					bup.SnapshotID,
+					bup.StreamStoreID,
+					string(bupNoSnapshot.ModelStoreID),
+					bupNoSnapshot.StreamStoreID,
+					string(bupNoDetails.ModelStoreID),
+					bupNoDetails.SnapshotID,
+				},
+			},
 			expectErr: func(t *testing.T, result error) {
-				assert.ErrorIs(t, result, data.ErrNotFound, clues.ToCore(result))
-				assert.ErrorIs(t, result, ErrorBackupNotFound, clues.ToCore(result))
+				assert.NoError(t, result, clues.ToCore(result))
 			},
 		},
 	}


### PR DESCRIPTION
Allows ignoring missing backups during deletion by
passing in an addition bool param.

Since this changes the API, we can remove the final
commit to make ignoring missing backups the
default behavior. This will change CLI behavior
though

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #4019

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
