### PR TITLE
return path service and resource

### DIFF
--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -724,8 +724,10 @@ func TestKopiaIntegrationSuite(t *testing.T) {
 func (suite *KopiaIntegrationSuite) SetupSuite() {
 	tmp, err := path.Build(
 		testTenant,
-		testUser,
-		path.ExchangeService,
+		[]path.ServiceResource{{
+			ProtectedResource: testUser,
+			Service:           path.ExchangeService,
+		}},
 		path.EmailCategory,
 		false,
 		testInboxDir)
@@ -736,8 +738,10 @@ func (suite *KopiaIntegrationSuite) SetupSuite() {
 
 	tmp, err = path.Build(
 		testTenant,
-		testUser,
-		path.ExchangeService,
+		[]path.ServiceResource{{
+			ProtectedResource: testUser,
+			Service:           path.ExchangeService,
+		}},
 		path.EmailCategory,
 		false,
 		testArchiveDir)
@@ -804,14 +808,14 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 	reasons := []identity.Reasoner{
 		NewReason(
 			testTenant,
-			suite.storePath1.ResourceOwner(),
-			suite.storePath1.Service(),
+			suite.storePath1.PrimaryProtectedResource(),
+			suite.storePath1.PrimaryService(),
 			suite.storePath1.Category(),
 		),
 		NewReason(
 			testTenant,
-			suite.storePath2.ResourceOwner(),
-			suite.storePath2.Service(),
+			suite.storePath2.PrimaryProtectedResource(),
+			suite.storePath2.PrimaryService(),
 			suite.storePath2.Category(),
 		),
 	}
@@ -1052,8 +1056,10 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 func (suite *KopiaIntegrationSuite) TestBackupCollections_NoDetailsForMeta() {
 	tmp, err := path.Build(
 		testTenant,
-		testUser,
-		path.OneDriveService,
+		[]path.ServiceResource{{
+			ProtectedResource: testUser,
+			Service:           path.OneDriveService,
+		}},
 		path.FilesCategory,
 		false,
 		testInboxDir)
@@ -1079,8 +1085,8 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_NoDetailsForMeta() {
 	reasons := []identity.Reasoner{
 		NewReason(
 			testTenant,
-			storePath.ResourceOwner(),
-			storePath.Service(),
+			storePath.PrimaryProtectedResource(),
+			storePath.PrimaryService(),
 			storePath.Category()),
 	}
 
@@ -1507,8 +1513,10 @@ func TestKopiaSimpleRepoIntegrationSuite(t *testing.T) {
 func (suite *KopiaSimpleRepoIntegrationSuite) SetupSuite() {
 	tmp, err := path.Build(
 		testTenant,
-		testUser,
-		path.ExchangeService,
+		[]path.ServiceResource{{
+			ProtectedResource: testUser,
+			Service:           path.ExchangeService,
+		}},
 		path.EmailCategory,
 		false,
 		testInboxDir)
@@ -1518,8 +1526,10 @@ func (suite *KopiaSimpleRepoIntegrationSuite) SetupSuite() {
 
 	tmp, err = path.Build(
 		testTenant,
-		testUser,
-		path.ExchangeService,
+		[]path.ServiceResource{{
+			ProtectedResource: testUser,
+			Service:           path.ExchangeService,
+		}},
 		path.EmailCategory,
 		false,
 		testArchiveDir)
@@ -1800,8 +1810,10 @@ func (suite *KopiaSimpleRepoIntegrationSuite) TestBackupExcludeItem() {
 func (suite *KopiaSimpleRepoIntegrationSuite) TestProduceRestoreCollections() {
 	doesntExist, err := path.Build(
 		testTenant,
-		testUser,
-		path.ExchangeService,
+		[]path.ServiceResource{{
+			ProtectedResource: testUser,
+			Service:           path.ExchangeService,
+		}},
 		path.EmailCategory,
 		true,
 		"subdir", "foo")
@@ -1934,8 +1946,10 @@ func (suite *KopiaSimpleRepoIntegrationSuite) TestProduceRestoreCollections() {
 func (suite *KopiaSimpleRepoIntegrationSuite) TestProduceRestoreCollections_PathChanges() {
 	rp1, err := path.Build(
 		testTenant,
-		testUser,
-		path.ExchangeService,
+		[]path.ServiceResource{{
+			ProtectedResource: testUser,
+			Service:           path.ExchangeService,
+		}},
 		path.EmailCategory,
 		false,
 		"corso_restore", "Inbox")
@@ -1943,8 +1957,10 @@ func (suite *KopiaSimpleRepoIntegrationSuite) TestProduceRestoreCollections_Path
 
 	rp2, err := path.Build(
 		testTenant,
-		testUser,
-		path.ExchangeService,
+		[]path.ServiceResource{{
+			ProtectedResource: testUser,
+			Service:           path.ExchangeService,
+		}},
 		path.EmailCategory,
 		false,
 		"corso_restore", "Archive")
@@ -2057,8 +2073,10 @@ func (suite *KopiaSimpleRepoIntegrationSuite) TestProduceRestoreCollections_Fetc
 
 	rp1, err := path.Build(
 		testTenant,
-		testUser,
-		path.ExchangeService,
+		[]path.ServiceResource{{
+			ProtectedResource: testUser,
+			Service:           path.ExchangeService,
+		}},
 		path.EmailCategory,
 		false,
 		"corso_restore", "Inbox")

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -538,8 +538,8 @@ func consumeBackupCollections(
 
 func matchesReason(reasons []identity.Reasoner, p path.Path) bool {
 	for _, reason := range reasons {
-		if p.ResourceOwner() == reason.ProtectedResource() &&
-			p.Service() == reason.Service() &&
+		if p.PrimaryProtectedResource() == reason.ProtectedResource() &&
+			p.PrimaryService() == reason.Service() &&
 			p.Category() == reason.Category() {
 			return true
 		}

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -617,13 +617,13 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 
 		pathReason1 = kopia.NewReason(
 			"",
-			itemPath1.ResourceOwner(),
-			itemPath1.Service(),
+			itemPath1.PrimaryProtectedResource(),
+			itemPath1.PrimaryService(),
 			itemPath1.Category())
 		pathReason3 = kopia.NewReason(
 			"",
-			itemPath3.ResourceOwner(),
-			itemPath3.Service(),
+			itemPath3.PrimaryProtectedResource(),
+			itemPath3.PrimaryService(),
 			itemPath3.Category())
 
 		time1 = time.Now()
@@ -1240,8 +1240,8 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsFolde
 
 		pathReason1 = kopia.NewReason(
 			"",
-			itemPath1.ResourceOwner(),
-			itemPath1.Service(),
+			itemPath1.PrimaryProtectedResource(),
+			itemPath1.PrimaryService(),
 			itemPath1.Category())
 
 		backup1 = kopia.BackupEntry{

--- a/src/pkg/path/path.go
+++ b/src/pkg/path/path.go
@@ -78,47 +78,58 @@ var (
 // Resources that don't have the requested information should return an empty
 // string.
 type Path interface {
-	String() string
+	// parts
+
+	Tenant() string
 	// ServiceResources produces all of the services and subservices, along with
 	// the protected resource paired with the service, as contained in the path,
 	// in their order of appearance.
 	ServiceResources() []ServiceResource
+	// PrimaryService is the first service in ServiceResources()
+	PrimaryService() ServiceType
+	// PrimaryProtectedResource is the first ProtectedResource in ServiceResources()
+	PrimaryProtectedResource() string
 	Category() CategoryType
-	Tenant() string
 	Folder(escaped bool) string
 	Folders() Elements
 	Item() string
-	// UpdateParent updates parent from old to new if the item/folder was
-	// parented by old path
-	UpdateParent(prev, cur Path) bool
-	// PopFront returns a Builder object with the first element (left-side)
-	// removed. As the resulting set of elements is no longer a valid resource
-	// path a Builder is returned instead.
-	PopFront() *Builder
-	// Dir returns a Path object with the right-most element removed if possible.
-	// If removing the right-most element would discard one of the required prefix
-	// elements then an error is returned.
-	Dir() (Path, error)
+
+	// type transformations
+
+	// ToBuilder returns a Builder instance that represents the current Path.
+	ToBuilder() *Builder
 	// Elements returns all the elements in the path. This is a temporary function
 	// and will likely be updated to handle encoded elements instead of clear-text
 	// elements in the future.
 	Elements() Elements
+	// Halves breaks the path into its prefix (tenant, services, resources, category)
+	// and suffix (all parts after the prefix).  If either half is empty, that half
+	// returns an empty, non-nil, value.
+	Halves() (*Builder, Elements)
+	// ShortRef returns a short reference representing this path. The short
+	// reference is guaranteed to be unique. No guarantees are made about whether
+	// a short reference can be converted back into the Path that generated it.
+	ShortRef() string
+
+	// mutators
+
 	// Append returns a new Path object with the given element added to the end of
 	// the old Path if possible. If the old Path is an item Path then Append
 	// returns an error.
 	Append(isItem bool, elems ...string) (Path, error)
 	// AppendItem is a shorthand for Append(true, someItem)
 	AppendItem(item string) (Path, error)
-	// ShortRef returns a short reference representing this path. The short
-	// reference is guaranteed to be unique. No guarantees are made about whether
-	// a short reference can be converted back into the Path that generated it.
-	ShortRef() string
-	// ToBuilder returns a Builder instance that represents the current Path.
-	ToBuilder() *Builder
-	// Halves breaks the path into its prefix (tenant, services, resources, category)
-	// and suffix (all parts after the prefix).  If either half is empty, that half
-	// returns an empty, non-nil, value.
-	Halves() (*Builder, Elements)
+	// Dir returns a Path object with the right-most element removed if possible.
+	// If removing the right-most element would discard one of the required prefix
+	// elements then an error is returned.
+	Dir() (Path, error)
+	// PopFront returns a Builder object with the first element (left-side)
+	// removed. As the resulting set of elements is no longer a valid resource
+	// path a Builder is returned instead.
+	PopFront() *Builder
+	// UpdateParent updates parent from old to new if the item/folder was
+	// parented by old path
+	UpdateParent(prev, cur Path) bool
 
 	// Every path needs to comply with these funcs to ensure that PII
 	// is appropriately hidden from logging, errors, and other outputs.

--- a/src/pkg/path/resource_path.go
+++ b/src/pkg/path/resource_path.go
@@ -51,6 +51,26 @@ func (rp dataLayerResourcePath) ServiceResources() []ServiceResource {
 	return rp.serviceResources
 }
 
+func (rp dataLayerResourcePath) PrimaryService() ServiceType {
+	srs := rp.serviceResources
+
+	if len(srs) == 0 {
+		return UnknownService
+	}
+
+	return srs[0].Service
+}
+
+func (rp dataLayerResourcePath) PrimaryProtectedResource() string {
+	srs := rp.serviceResources
+
+	if len(srs) == 0 {
+		return ""
+	}
+
+	return srs[0].ProtectedResource
+}
+
 // Category returns the CategoryType embedded in the dataLayerResourcePath.
 func (rp dataLayerResourcePath) Category() CategoryType {
 	return rp.category
@@ -72,10 +92,16 @@ func (rp dataLayerResourcePath) lastFolderIdx() int {
 	return endIdx
 }
 
+func (rp dataLayerResourcePath) prefixLen() int {
+	return 2 + 2*len(rp.serviceResources)
+}
+
 // Folder returns the folder segment embedded in the dataLayerResourcePath.
 func (rp dataLayerResourcePath) Folder(escape bool) string {
 	endIdx := rp.lastFolderIdx()
-	if endIdx == 4 {
+	pfxLen := rp.prefixLen()
+
+	if endIdx == pfxLen {
 		return ""
 	}
 
@@ -93,11 +119,14 @@ func (rp dataLayerResourcePath) Folder(escape bool) string {
 // dataLayerResourcePath.
 func (rp dataLayerResourcePath) Folders() Elements {
 	endIdx := rp.lastFolderIdx()
-	if endIdx == 4 {
+	pfxLen := rp.prefixLen()
+
+	// if endIdx == prefix length, there are no folders
+	if endIdx == pfxLen {
 		return nil
 	}
 
-	return append([]string{}, rp.elements[4:endIdx]...)
+	return append([]string{}, rp.elements[pfxLen:endIdx]...)
 }
 
 // Item returns the item embedded in the dataLayerResourcePath if the path


### PR DESCRIPTION
Returns the path interface funcs for Service and Resource, this time as "primaryFoo" funcs, to indicate that these are the primary service and resource values.  This functionality is mostly for quality of life.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #3993

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
