### PR TITLE
Add and populate mod time for BaseModel

### DIFF
--- a/src/internal/kopia/model_store.go
+++ b/src/internal/kopia/model_store.go
@@ -210,6 +210,7 @@ func (ms ModelStore) populateBaseModelFromMetadata(
 	base.ID = model.StableID(id)
 	base.ModelVersion = v
 	base.Tags = m.Labels
+	base.ModTime = m.ModTime
 
 	stripHiddenTags(base.Tags)
 

--- a/src/internal/model/model.go
+++ b/src/internal/model/model.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"time"
+
 	"github.com/kopia/kopia/repo/manifest"
 )
 
@@ -68,7 +70,8 @@ type BaseModel struct {
 	// Tags associated with this model in the store to facilitate lookup. Tags in
 	// the struct are not serialized directly into the stored model, but are part
 	// of the metadata for the model.
-	Tags map[string]string `json:"-"`
+	Tags    map[string]string `json:"-"`
+	ModTime time.Time         `json:"-"`
 }
 
 func (bm *BaseModel) Base() *BaseModel {


### PR DESCRIPTION
Get the last time a model was modified and return it in BaseModel. This will help with discovering what items can be garbage collected during incomplete backup cleanup as we don't want to accidentally delete in-flight backups.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3217

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
