### PR TITLE
Exclude recently created models from garbage collection

### DIFF
--- a/src/internal/kopia/cleanup_backups.go
+++ b/src/internal/kopia/cleanup_backups.go
@@ -28,14 +28,9 @@ import (
 // if this is run concurrently with a backup it's not likely to delete models
 // just being created. For example, if there was no buffer period and this is
 // run when another corso instance has created an item data snapshot but hasn't
-// yet created the details snapshot or the backup model would result in this
+// yet created the details snapshot or the backup model it would result in this
 // instance of corso marking the newly created item data snapshot for deletion
 // because it appears orphaned.
-//
-// For simplicity, we exclude all items younger than the cutoff. It's possible
-// to exclude only snapshots and details models since the backup model is the
-// last thing persisted for a backup. However, If we selectively exclude things
-// then changes to the order of persistence may require changes here too.
 //
 // The buffer duration should be longer than the difference in creation times
 // between the first item data snapshot/details/backup model made during a
@@ -178,7 +173,7 @@ func cleanupOrphanedData(
 		}
 	}
 
-	logger.Ctx(ctx).Debugw(
+	logger.Ctx(ctx).Infow(
 		"garbage collecting orphaned items",
 		"num_items", len(toDelete),
 		"kopia_ids", maps.Keys(toDelete))


### PR DESCRIPTION
Exclude models that have been created within the
buffer period from garbage collection/orphaned
checks so that we don't accidentally delete
models for backups that are running concurrently
with the garbage collection task

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [x] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3217

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
