### PR TITLE
Remove call to PITR backup check

### DIFF
--- a/src/cmd/longevity_test/longevity.go
+++ b/src/cmd/longevity_test/longevity.go
@@ -67,6 +67,9 @@ func deleteBackups(
 // pitrListBackups connects to the repository at the given point in time and
 // lists the backups for service. It then checks the list of backups contains
 // the backups in backupIDs.
+//
+//nolint:unused
+//lint:ignore U1000 Waiting for upstream fix tracked by 4031
 func pitrListBackups(
 	ctx context.Context,
 	service path.ServiceType,
@@ -156,15 +159,9 @@ func main() {
 		fatal(ctx, "invalid number of days provided", nil)
 	}
 
-	beforeDel := time.Now()
-
-	backups, err := deleteBackups(ctx, service, days)
+	_, err = deleteBackups(ctx, service, days)
 	if err != nil {
 		fatal(ctx, "deleting backups", clues.Stack(err))
-	}
-
-	if err := pitrListBackups(ctx, service, beforeDel, backups); err != nil {
-		fatal(ctx, "listing backups from point in time", clues.Stack(err))
 	}
 }
 


### PR DESCRIPTION
Currently failing due to minor upstream bugs. Disable until we can get upstream fixes in.

Revert this merge once upstream issues are fixed

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [x] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #4031

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
