### PR TITLE
Handle groups without SharePoint sites 

### DIFF
--- a/src/internal/m365/service/groups/backup.go
+++ b/src/internal/m365/service/groups/backup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/alcionai/clues"
+	"golang.org/x/exp/slices"
 
 	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/common/prefixmatcher"
@@ -20,6 +21,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/backup/metadata"
 	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
@@ -50,6 +52,27 @@ func ProduceBackupCollections(
 		ctx,
 		"group_id", clues.Hide(bpc.ProtectedResource.ID()),
 		"group_name", clues.Hide(bpc.ProtectedResource.Name()))
+
+	resp, err := ac.Groups().GetByID(ctx, bpc.ProtectedResource.ID())
+	if err != nil {
+		return nil, nil, false, clues.Wrap(err, "getting group").WithClues(ctx)
+	}
+
+	// Not all groups will have associated SharePoint
+	// sites. Distribution channels and Security groups will not
+	// have one. This check is to skip those groups.
+	groupTypes := resp.GetGroupTypes()
+	hasSharePoint := slices.Contains(groupTypes, "Unified")
+
+	// If we don't have SharePoint site, there is nothing here to
+	// backup as of now.
+	if !hasSharePoint {
+		logger.Ctx(ctx).
+			With("group_id", bpc.ProtectedResource.ID()).
+			Infof("No SharePoint site found for group")
+
+		return nil, nil, false, clues.Stack(graph.ErrServiceNotEnabled, err).WithClues(ctx)
+	}
 
 	for _, scope := range b.Scopes() {
 		if el.Failure() != nil {


### PR DESCRIPTION
Security groups will not have an associated site. This avoids trying
to backup the site if we get an error that the site is not available.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* https://github.com/alcionai/corso/issues/3990

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
