### PR TITLE
add groups operations v0 backup test

### DIFF
--- a/src/internal/operations/test/group_test.go
+++ b/src/internal/operations/test/group_test.go
@@ -1,0 +1,136 @@
+package test_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	evmock "github.com/alcionai/corso/src/internal/events/mock"
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
+	"github.com/alcionai/corso/src/internal/version"
+	deeTD "github.com/alcionai/corso/src/pkg/backup/details/testdata"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/selectors"
+	selTD "github.com/alcionai/corso/src/pkg/selectors/testdata"
+	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
+)
+
+type GroupsBackupIntgSuite struct {
+	tester.Suite
+	its intgTesterSetup
+}
+
+func TestGroupsBackupIntgSuite(t *testing.T) {
+	t.Skip("enable when groups e2e v0 backup is complete")
+
+	suite.Run(t, &GroupsBackupIntgSuite{
+		Suite: tester.NewIntegrationSuite(
+			t,
+			[][]string{tconfig.M365AcctCredEnvs, storeTD.AWSStorageCredEnvs}),
+	})
+}
+
+func (suite *GroupsBackupIntgSuite) SetupSuite() {
+	suite.its = newIntegrationTesterSetup(suite.T())
+}
+
+// TODO(v1 backup): Incremental backup
+// TODO(v0,v1 restore): Library restore
+// TODO(v0 export): Channels export
+
+func (suite *GroupsBackupIntgSuite) TestBackup_Run_groupsBasic() {
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	var (
+		mb   = evmock.NewBus()
+		sel  = selectors.NewGroupsBackup([]string{suite.its.site.ID})
+		opts = control.DefaultOptions()
+	)
+
+	sel.Include(
+		selTD.GroupsBackupLibraryFolderScope(sel),
+		selTD.GroupsBackupChannelScope(sel))
+
+	bo, bod := prepNewTestBackupOp(t, ctx, mb, sel.Selector, opts, version.Backup)
+	defer bod.close(t, ctx)
+
+	runAndCheckBackup(t, ctx, &bo, mb, false)
+	checkBackupIsInManifests(
+		t,
+		ctx,
+		bod.kw,
+		bod.sw,
+		&bo,
+		bod.sel,
+		bod.sel.ID(),
+		path.LibrariesCategory)
+}
+
+func (suite *GroupsBackupIntgSuite) TestBackup_Run_groupsExtensions() {
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	var (
+		mb    = evmock.NewBus()
+		sel   = selectors.NewGroupsBackup([]string{suite.its.site.ID})
+		opts  = control.DefaultOptions()
+		tenID = tconfig.M365TenantID(t)
+		svc   = path.GroupsService
+		ws    = deeTD.DriveIDFromRepoRef
+	)
+
+	opts.ItemExtensionFactory = getTestExtensionFactories()
+
+	// does not apply to channel messages
+	sel.Include(selTD.GroupsBackupLibraryFolderScope(sel))
+
+	bo, bod := prepNewTestBackupOp(t, ctx, mb, sel.Selector, opts, version.Backup)
+	defer bod.close(t, ctx)
+
+	runAndCheckBackup(t, ctx, &bo, mb, false)
+	checkBackupIsInManifests(
+		t,
+		ctx,
+		bod.kw,
+		bod.sw,
+		&bo,
+		bod.sel,
+		bod.sel.ID(),
+		path.LibrariesCategory)
+
+	bID := bo.Results.BackupID
+
+	deets, expectDeets := deeTD.GetDeetsInBackup(
+		t,
+		ctx,
+		bID,
+		tenID,
+		bod.sel.ID(),
+		svc,
+		ws,
+		bod.kms,
+		bod.sss)
+	deeTD.CheckBackupDetails(
+		t,
+		ctx,
+		bID,
+		ws,
+		bod.kms,
+		bod.sss,
+		expectDeets,
+		false)
+
+	// Check that the extensions are in the backup
+	for _, ent := range deets.Entries {
+		if ent.Folder == nil {
+			verifyExtensionData(t, ent.ItemInfo, path.GroupsService)
+		}
+	}
+}

--- a/src/internal/operations/test/helper_test.go
+++ b/src/internal/operations/test/helper_test.go
@@ -582,6 +582,7 @@ type intgTesterSetup struct {
 	secondaryUser ids
 	site          ids
 	secondarySite ids
+	group         ids
 }
 
 func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
@@ -606,6 +607,9 @@ func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
 	its.secondaryUser = userIDs(t, tconfig.SecondaryM365UserID(t), its.ac)
 	its.site = siteIDs(t, tconfig.M365SiteID(t), its.ac)
 	its.secondarySite = siteIDs(t, tconfig.SecondaryM365SiteID(t), its.ac)
+	// teamID is used here intentionally.  We want the group
+	// to have access to teams data
+	its.group = groupIDs(t, tconfig.M365TeamID(t), its.ac)
 
 	return its
 }
@@ -644,6 +648,26 @@ func siteIDs(t *testing.T, id string, ac api.Client) ids {
 	require.NoError(t, err, clues.ToCore(err))
 
 	r.DriveRootFolderID = ptr.Val(driveRootFolder.GetId())
+
+	return r
+}
+
+func groupIDs(t *testing.T, id string, ac api.Client) ids {
+	r := ids{ID: id}
+
+	// ctx, flush := tester.NewContext(t)
+	// defer flush()
+
+	// TODO: get default site drive info
+	// drive, err := ac.Groups().GetDefaultDrive(ctx, id)
+	// require.NoError(t, err, clues.ToCore(err))
+
+	// r.DriveID = ptr.Val(drive.GetId())
+
+	// driveRootFolder, err := ac.Drives().GetRootFolder(ctx, r.DriveID)
+	// require.NoError(t, err, clues.ToCore(err))
+
+	// r.DriveRootFolderID = ptr.Val(driveRootFolder.GetId())
 
 	return r
 }

--- a/src/pkg/selectors/testdata/groups.go
+++ b/src/pkg/selectors/testdata/groups.go
@@ -1,0 +1,19 @@
+package testdata
+
+import (
+	"github.com/alcionai/corso/src/pkg/selectors"
+)
+
+const TestChannelName = "test"
+
+// GroupsBackupFolderScope is the standard folder scope that should be used
+// in integration backups with groups when interacting with libraries.
+func GroupsBackupLibraryFolderScope(sel *selectors.GroupsBackup) []selectors.GroupsScope {
+	return sel.LibraryFolders([]string{TestFolderName}, selectors.PrefixMatch())
+}
+
+// GroupsBackupChannelScope is the standard folder scope that should be used
+// in integration backups with groups when interacting with channels.
+func GroupsBackupChannelScope(sel *selectors.GroupsBackup) []selectors.GroupsScope {
+	return sel.Channel(TestChannelName)
+}


### PR DESCRIPTION
adds basic backup integration tests for groups in the operations testing package.
currently skipped and awaiting full v0 backup implementation.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Supportability/Tests

#### Issue(s)

* #3988

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
