### PR TITLE
[WIP] Support for restoring root group site

### DIFF
--- a/src/cli/restore/groups.go
+++ b/src/cli/restore/groups.go
@@ -5,8 +5,8 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/alcionai/corso/src/cli/flags"
-	. "github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/cli/utils"
+	"github.com/alcionai/corso/src/internal/common/dttm"
 )
 
 // called by restore.go to map subcommands to provider-specific handling.
@@ -77,5 +77,25 @@ func restoreGroupsCmd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	return Only(ctx, utils.ErrNotYetImplemented)
+	opts := utils.MakeGroupsOpts(cmd)
+	opts.RestoreCfg.DTTMFormat = dttm.HumanReadableDriveItem
+
+	if flags.RunModeFV == flags.RunModeFlagTest {
+		return nil
+	}
+
+	if err := utils.ValidateGroupsRestoreFlags(flags.BackupIDFV, opts); err != nil {
+		return err
+	}
+
+	sel := utils.IncludeGroupsRestoreDataSelectors(ctx, opts)
+	utils.FilterGroupsRestoreInfoSelectors(sel, opts)
+
+	return runRestore(
+		ctx,
+		cmd,
+		opts.RestoreCfg,
+		sel.Selector,
+		flags.BackupIDFV,
+		"Groups")
 }

--- a/src/cli/restore/groups_test.go
+++ b/src/cli/restore/groups_test.go
@@ -83,8 +83,7 @@ func (suite *GroupsUnitSuite) TestAddGroupsCommands() {
 			cmd.SetOut(new(bytes.Buffer)) // drop output
 			cmd.SetErr(new(bytes.Buffer)) // drop output
 			err := cmd.Execute()
-			// assert.NoError(t, err, clues.ToCore(err))
-			assert.ErrorIs(t, err, utils.ErrNotYetImplemented, clues.ToCore(err))
+			assert.NoError(t, err, clues.ToCore(err))
 
 			opts := utils.MakeGroupsOpts(cmd)
 			assert.Equal(t, testdata.BackupInput, flags.BackupIDFV)

--- a/src/cli/restore/restore.go
+++ b/src/cli/restore/restore.go
@@ -21,9 +21,6 @@ var restoreCommands = []func(cmd *cobra.Command) *cobra.Command{
 	addExchangeCommands,
 	addOneDriveCommands,
 	addSharePointCommands,
-	// awaiting release
-	// addGroupsCommands,
-	// addTeamsCommands,
 }
 
 // AddCommands attaches all `corso restore * *` commands to the parent.

--- a/src/internal/m365/collection/drive/group_handler.go
+++ b/src/internal/m365/collection/drive/group_handler.go
@@ -63,6 +63,11 @@ func (h groupBackupHandler) MetadataPathPrefix(tenantID string) (path.Path, erro
 		return nil, clues.Wrap(err, "making metadata path")
 	}
 
+	p, err = p.Append(false, odConsts.SitesPathDir, h.siteID)
+	if err != nil {
+		return nil, clues.Wrap(err, "appending sites to metadata path")
+	}
+
 	return p, nil
 }
 

--- a/src/internal/m365/collection/drive/group_handler_test.go
+++ b/src/internal/m365/collection/drive/group_handler_test.go
@@ -59,7 +59,7 @@ func (suite *GroupBackupHandlerUnitSuite) TestMetadataPathPrefix() {
 	}{
 		{
 			name:      "group",
-			expect:    "tenant/groupsMetadata/resourceOwner/libraries",
+			expect:    "tenant/groupsMetadata/resourceOwner/libraries/sites/site-id",
 			expectErr: assert.NoError,
 		},
 	}

--- a/src/internal/m365/controller.go
+++ b/src/internal/m365/controller.go
@@ -151,6 +151,10 @@ func (ctrl *Controller) incrementAwaitingMessages() {
 }
 
 func (ctrl *Controller) CacheItemInfo(dii details.ItemInfo) {
+	if dii.Groups != nil {
+		ctrl.backupDriveIDNames.Add(dii.Groups.DriveID, dii.Groups.DriveName)
+	}
+
 	if dii.SharePoint != nil {
 		ctrl.backupDriveIDNames.Add(dii.SharePoint.DriveID, dii.SharePoint.DriveName)
 	}

--- a/src/internal/m365/restore.go
+++ b/src/internal/m365/restore.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/collection/drive"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/m365/service/exchange"
+	"github.com/alcionai/corso/src/internal/m365/service/groups"
 	"github.com/alcionai/corso/src/internal/m365/service/onedrive"
 	"github.com/alcionai/corso/src/internal/m365/service/sharepoint"
 	"github.com/alcionai/corso/src/internal/m365/support"
@@ -81,6 +82,16 @@ func (ctrl *Controller) ConsumeRestoreCollections(
 			ctr)
 	case path.SharePointService:
 		status, err = sharepoint.ConsumeRestoreCollections(
+			ctx,
+			rcc,
+			ctrl.AC,
+			ctrl.backupDriveIDNames,
+			dcs,
+			deets,
+			errs,
+			ctr)
+	case path.GroupsService:
+		status, err = groups.ConsumeRestoreCollections(
 			ctx,
 			rcc,
 			ctrl.AC,

--- a/src/internal/m365/service/groups/backup.go
+++ b/src/internal/m365/service/groups/backup.go
@@ -74,7 +74,7 @@ func ProduceBackupCollections(
 				LastBackupVersion: bpc.LastBackupVersion,
 				Options:           bpc.Options,
 				ProtectedResource: pr,
-				Selector:          bpc.Selector,
+				Selector:          bpc.Selector, // TODO(meain): add metadata collections
 			}
 
 			dbcs, canUsePreviousBackup, err = site.CollectLibraries(

--- a/src/internal/operations/pathtransformer/restore_path_transformer.go
+++ b/src/internal/operations/pathtransformer/restore_path_transformer.go
@@ -135,7 +135,8 @@ func makeRestorePathsForEntry(
 		res.RestorePath, err = basicLocationPath(repoRef, locRef)
 	case ent.OneDrive != nil ||
 		(ent.SharePoint != nil && ent.SharePoint.ItemType == details.SharePointLibrary) ||
-		(ent.SharePoint != nil && ent.SharePoint.ItemType == details.OneDriveItem):
+		(ent.SharePoint != nil && ent.SharePoint.ItemType == details.OneDriveItem) ||
+		(ent.Groups != nil && ent.Groups.ItemType == details.SharePointLibrary):
 		res.RestorePath, err = drivePathMerge(ent, repoRef, locRef)
 	default:
 		return res, clues.New("unknown entry type").WithClues(ctx)

--- a/src/internal/operations/pathtransformer/restore_path_transformer.go
+++ b/src/internal/operations/pathtransformer/restore_path_transformer.go
@@ -2,6 +2,7 @@ package pathtransformer
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/alcionai/clues"
 
@@ -26,7 +27,8 @@ func locationRef(
 
 	// We could get an empty LocationRef either because it wasn't populated or it
 	// was in the root of the data type.
-	elems := repoRef.Folders()
+	elems := repoRef.Folders() // TODO(meain): problem here?
+	fmt.Println("restore_path_transformer.go:30 elems:", elems)
 
 	if ent.OneDrive != nil || ent.SharePoint != nil {
 		dp, err := path.ToDrivePath(repoRef)
@@ -73,6 +75,8 @@ func drivePathMerge(
 
 	if ent.SharePoint != nil {
 		driveID = ent.SharePoint.DriveID
+	} else if ent.Groups != nil {
+		driveID = ent.Groups.DriveID
 	} else if ent.OneDrive != nil {
 		driveID = ent.OneDrive.DriveID
 	}

--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -412,7 +412,9 @@ func formatDetailsForRestoration(
 		return nil, clues.Wrap(err, "getting restore paths")
 	}
 
-	if sel.Service == selectors.ServiceOneDrive || sel.Service == selectors.ServiceSharePoint {
+	if sel.Service == selectors.ServiceOneDrive ||
+		sel.Service == selectors.ServiceSharePoint ||
+		sel.Service == selectors.ServiceGroups {
 		paths, err = onedrive.AugmentRestorePaths(backupVersion, paths)
 		if err != nil {
 			return nil, clues.Wrap(err, "augmenting paths")


### PR DESCRIPTION
This adds initial support for restoring group sites. It restores the root group site to the current root site of the group.

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [x] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* https://github.com/alcionai/corso/issues/3992

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
