### PR TITLE
Do not print completed header if no backups

### DIFF
--- a/src/cli/backup/backup.go
+++ b/src/cli/backup/backup.go
@@ -255,7 +255,10 @@ func runBackups(
 		return Only(ctx, clues.Wrap(berrs.Failure(), "Unable to retrieve backup results from storage"))
 	}
 
-	Info(ctx, "Completed Backups:")
+	if len(bups) > 0 {
+		Info(ctx, "Completed Backups:")
+	}
+
 	backup.PrintAll(ctx, bups)
 
 	if len(errs) > 0 {


### PR DESCRIPTION
Before:

```
Logging to file: /home/meain/.cache/corso/logs/2023-08-28T07-18-24Z.log
Connecting to repository:      1s done
Connecting to M365:      0s done
Backing Up ∙ Security Group
Discovering items to backup:      2s done
Completed Backups:													# <--- Unnecessary
No backups available
```

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
