### PR TITLE
Fix path for group metadata

### DIFF
--- a/src/internal/m365/collection/drive/collections_test.go
+++ b/src/internal/m365/collection/drive/collections_test.go
@@ -747,6 +747,7 @@ func (suite *OneDriveCollectionsUnitSuite) TestUpdateCollections() {
 				&itemBackupHandler{api.Drives{}, tt.scope},
 				tenant,
 				user,
+				user,
 				nil,
 				control.Options{ToggleFeatures: control.Toggles{}})
 
@@ -2344,6 +2345,7 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 				mbh,
 				tenant,
 				user,
+				user,
 				func(*support.ControllerOperationStatus) {},
 				control.Options{ToggleFeatures: control.Toggles{}})
 
@@ -2713,6 +2715,7 @@ func (suite *OneDriveCollectionsUnitSuite) TestAddURLCacheToDriveCollections() {
 			c := NewCollections(
 				mbh,
 				"test-tenant",
+				"test-user",
 				"test-user",
 				nil,
 				control.Options{ToggleFeatures: control.Toggles{}})

--- a/src/internal/m365/collection/drive/item_collector_test.go
+++ b/src/internal/m365/collection/drive/item_collector_test.go
@@ -347,6 +347,7 @@ func (suite *OneDriveIntgSuite) TestOneDriveNewCollections() {
 				&itemBackupHandler{suite.ac.Drives(), scope},
 				creds.AzureTenantID,
 				test.user,
+				test.user,
 				service.updateStatus,
 				control.Options{
 					ToggleFeatures: control.Toggles{},

--- a/src/internal/m365/collection/site/backup.go
+++ b/src/internal/m365/collection/site/backup.go
@@ -27,6 +27,7 @@ func CollectLibraries(
 	bpc inject.BackupProducerConfig,
 	bh drive.BackupHandler,
 	tenantID string,
+	resourceOwner string,
 	ssmb *prefixmatcher.StringSetMatchBuilder,
 	su support.StatusUpdater,
 	errs *fault.Bus,
@@ -38,14 +39,12 @@ func CollectLibraries(
 		colls       = drive.NewCollections(
 			bh,
 			tenantID,
+			resourceOwner,
 			bpc.ProtectedResource.ID(),
 			su,
 			bpc.Options)
 	)
 
-	// TODO(meain): backup resource owner should be group id in case
-	// of group sharepoint site backup. As of now, we always use
-	// sharepoint site ids.
 	odcs, canUsePreviousBackup, err := colls.Get(ctx, bpc.MetadataCollections, ssmb, errs)
 	if err != nil {
 		return nil, false, graph.Wrap(ctx, err, "getting library")

--- a/src/internal/m365/service/groups/backup.go
+++ b/src/internal/m365/service/groups/backup.go
@@ -71,17 +71,23 @@ func ProduceBackupCollections(
 
 			pr := idname.NewProvider(ptr.Val(resp.GetId()), ptr.Val(resp.GetName()))
 			sbpc := inject.BackupProducerConfig{
-				LastBackupVersion: bpc.LastBackupVersion,
-				Options:           bpc.Options,
-				ProtectedResource: pr,
-				Selector:          bpc.Selector,
+				LastBackupVersion:   bpc.LastBackupVersion,
+				Options:             bpc.Options,
+				ProtectedResource:   pr,
+				Selector:            bpc.Selector,
+				MetadataCollections: bpc.MetadataCollections,
 			}
+
+			// NOTE: MetadataCollections are empty as some(channel
+			// messages) don't have metadata and that causes the
+			// entire metadata fetch to fail.
 
 			dbcs, canUsePreviousBackup, err = site.CollectLibraries(
 				ctx,
 				sbpc,
 				drive.NewGroupBackupHandler(bpc.ProtectedResource.ID(), ac.Drives(), scope),
 				creds.AzureTenantID,
+				bpc.ProtectedResource.ID(),
 				ssmb,
 				su,
 				errs)

--- a/src/internal/m365/service/onedrive/backup.go
+++ b/src/internal/m365/service/onedrive/backup.go
@@ -52,6 +52,7 @@ func ProduceBackupCollections(
 			drive.NewItemBackupHandler(ac.Drives(), scope),
 			tenant,
 			bpc.ProtectedResource.ID(),
+			bpc.ProtectedResource.ID(),
 			su,
 			bpc.Options)
 

--- a/src/internal/m365/service/sharepoint/backup.go
+++ b/src/internal/m365/service/sharepoint/backup.go
@@ -82,6 +82,7 @@ func ProduceBackupCollections(
 				bpc,
 				drive.NewLibraryBackupHandler(ac.Drives(), scope, bpc.Selector.PathService()),
 				creds.AzureTenantID,
+				bpc.ProtectedResource.ID(),
 				ssmb,
 				su,
 				errs)

--- a/src/internal/m365/service/sharepoint/backup_test.go
+++ b/src/internal/m365/service/sharepoint/backup_test.go
@@ -104,6 +104,7 @@ func (suite *LibrariesBackupUnitSuite) TestUpdateCollections() {
 				drive.NewLibraryBackupHandler(api.Drives{}, test.scope, path.SharePointService),
 				tenantID,
 				siteID,
+				siteID,
 				nil,
 				control.DefaultOptions())
 


### PR DESCRIPTION
Previously we were using sharepoint site id.

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [x] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* https://github.com/alcionai/corso/issues/3990

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
