### PR TITLE
Update test helpers for groups backup

### DIFF
--- a/src/internal/operations/test/group_test.go
+++ b/src/internal/operations/test/group_test.go
@@ -48,13 +48,13 @@ func (suite *GroupsBackupIntgSuite) TestBackup_Run_groupsBasic() {
 
 	var (
 		mb   = evmock.NewBus()
-		sel  = selectors.NewGroupsBackup([]string{suite.its.site.ID})
+		sel  = selectors.NewGroupsBackup([]string{suite.its.group.ID})
 		opts = control.DefaultOptions()
 	)
 
 	sel.Include(
 		selTD.GroupsBackupLibraryFolderScope(sel),
-		selTD.GroupsBackupChannelScope(sel))
+		selTD.GroupsBackupChannelScope(sel)) // FIXME: channel backups are not ready
 
 	bo, bod := prepNewTestBackupOp(t, ctx, mb, sel.Selector, opts, version.Backup)
 	defer bod.close(t, ctx)
@@ -79,7 +79,7 @@ func (suite *GroupsBackupIntgSuite) TestBackup_Run_groupsExtensions() {
 
 	var (
 		mb    = evmock.NewBus()
-		sel   = selectors.NewGroupsBackup([]string{suite.its.site.ID})
+		sel   = selectors.NewGroupsBackup([]string{suite.its.group.ID})
 		opts  = control.DefaultOptions()
 		tenID = tconfig.M365TenantID(t)
 		svc   = path.GroupsService

--- a/src/internal/operations/test/helper_test.go
+++ b/src/internal/operations/test/helper_test.go
@@ -582,10 +582,8 @@ type ids struct {
 }
 
 type gids struct {
-	ID                        string
-	RootSiteID                string
-	RootSiteDriveID           string
-	RootSiteDriveRootFolderID string
+	ID       string
+	RootSite ids
 }
 
 type intgTesterSetup struct {
@@ -674,17 +672,17 @@ func groupIDs(t *testing.T, id string, ac api.Client) gids {
 	site, err := ac.Groups().GetRootSite(ctx, id)
 	require.NoError(t, err, clues.ToCore(err))
 
-	r.RootSiteID = ptr.Val(site.GetId())
+	r.RootSite.ID = ptr.Val(site.GetId())
 
-	drive, err := ac.Sites().GetDefaultDrive(ctx, r.RootSiteID)
+	drive, err := ac.Sites().GetDefaultDrive(ctx, r.RootSite.ID)
 	require.NoError(t, err, clues.ToCore(err))
 
-	r.RootSiteDriveID = ptr.Val(drive.GetId())
+	r.RootSite.DriveID = ptr.Val(drive.GetId())
 
-	driveRootFolder, err := ac.Drives().GetRootFolder(ctx, r.RootSiteDriveID)
+	driveRootFolder, err := ac.Drives().GetRootFolder(ctx, r.RootSite.DriveID)
 	require.NoError(t, err, clues.ToCore(err))
 
-	r.RootSiteDriveRootFolderID = ptr.Val(driveRootFolder.GetId())
+	r.RootSite.DriveRootFolderID = ptr.Val(driveRootFolder.GetId())
 
 	return r
 }

--- a/src/internal/operations/test/restore_helper_test.go
+++ b/src/internal/operations/test/restore_helper_test.go
@@ -108,8 +108,12 @@ func prepNewTestRestoreOp(
 	rod.sw = store.NewWrapper(rod.kms)
 
 	connectorResource := resource.Users
-	if sel.Service == selectors.ServiceSharePoint {
+
+	switch sel.Service {
+	case selectors.ServiceSharePoint:
 		connectorResource = resource.Sites
+	case selectors.ServiceGroups:
+		connectorResource = resource.Groups
 	}
 
 	rod.ctrl, rod.sel = ControllerWithSelector(


### PR DESCRIPTION
This still is not complete, but this fixes a few places in the test suite helpers where we did not accommodate for groups.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* https://github.com/alcionai/corso/issues/3990

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
