### PR TITLE
Fix data clobbering issue when getting Quota Exceeded status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] (beta)
 
+### Fixed
+- Exchange backups would fail attemptting to use delta tokens even if the user was over quota
+
 ## [v0.12.0] (beta) - 2023-08-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] (beta)
 
 ### Fixed
-- Exchange backups would fail attemptting to use delta tokens even if the user was over quota
+- Exchange backups would fail attempting to use delta tokens even if the user was over quota
 
 ## [v0.12.0] (beta) - 2023-08-28
 

--- a/src/pkg/services/m365/api/users.go
+++ b/src/pkg/services/m365/api/users.go
@@ -238,7 +238,7 @@ func (c Users) GetInfo(ctx context.Context, userID string) (*UserInfo, error) {
 			return nil, clues.Stack(err)
 		}
 
-		userInfo.Mailbox.QuotaExceeded = graph.IsErrQuotaExceeded(err)
+		mi.QuotaExceeded = graph.IsErrQuotaExceeded(err)
 	}
 
 	userInfo.Mailbox = mi

--- a/src/pkg/services/m365/api/users_test.go
+++ b/src/pkg/services/m365/api/users_test.go
@@ -252,7 +252,7 @@ func (suite *UsersIntgSuite) TestUsers_GetInfo_errors() {
 	}
 }
 
-func (suite *UsersIntgSuite) TestUsers_GetInfo_QuotaExceeded() {
+func (suite *UsersIntgSuite) TestUsers_GetInfo_quotaExceeded() {
 	t := suite.T()
 	ctx, flush := tester.NewContext(t)
 


### PR DESCRIPTION
Don't clobber the Quota Exceeded status once we get it

Add unit test to make sure this doesn't happen

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
