### PR TITLE
enumerate ids, get messages in Items()

### DIFF
--- a/src/internal/common/str/str.go
+++ b/src/internal/common/str/str.go
@@ -56,3 +56,27 @@ func First(vs ...string) string {
 
 	return ""
 }
+
+// Preview reduces the string to the specified size.
+// If the string is longer than the size, the last three
+// characters are replaced with an ellipsis.  Size < 4
+// will default to 4.
+// ex:
+// Preview("123", 6) => "123"
+// Preview("1234567", 6) "123..."
+func Preview(s string, size int) string {
+	if size < 4 {
+		size = 4
+	}
+
+	if len(s) < size {
+		return s
+	}
+
+	ss := s[:size]
+	if len(s) > size {
+		ss = s[:size-3] + "..."
+	}
+
+	return ss
+}

--- a/src/internal/common/str/str_test.go
+++ b/src/internal/common/str/str_test.go
@@ -1,0 +1,53 @@
+package str
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// Warning: importing the corso tester.suite causes a circular import
+// ---------------------------------------------------------------------------
+
+func TestPreview(t *testing.T) {
+	table := []struct {
+		input  string
+		size   int
+		expect string
+	}{
+		{
+			input:  "",
+			size:   1,
+			expect: "",
+		},
+		{
+			input:  "yes",
+			size:   1,
+			expect: "yes",
+		},
+		{
+			input:  "yes!",
+			size:   5,
+			expect: "yes!",
+		},
+		{
+			input:  "however",
+			size:   6,
+			expect: "how...",
+		},
+		{
+			input:  "negative",
+			size:   -1,
+			expect: "n...",
+		},
+	}
+	for _, test := range table {
+		t.Run(test.input, func(t *testing.T) {
+			assert.Equal(
+				t,
+				test.expect,
+				Preview(test.input, test.size))
+		})
+	}
+}

--- a/src/internal/m365/collection/drive/handler_utils.go
+++ b/src/internal/m365/collection/drive/handler_utils.go
@@ -90,7 +90,6 @@ func augmentItemInfo(
 		}
 
 	case path.GroupsService:
-		// TODO: Add channel name and ID
 		dii.Groups = &details.GroupsInfo{
 			Created:    ptr.Val(item.GetCreatedDateTime()),
 			DriveID:    driveID,

--- a/src/internal/m365/collection/drive/restore.go
+++ b/src/internal/m365/collection/drive/restore.go
@@ -521,8 +521,6 @@ func restoreV6File(
 		return itemInfo, nil
 	}
 
-	fmt.Printf("\n-----\nrestorev6 %+v\n-----\n", rcc.RestoreConfig.IncludePermissions)
-
 	err = RestorePermissions(
 		ctx,
 		rh,
@@ -571,8 +569,6 @@ func CreateRestoreFolders(
 	if !restorePerms {
 		return id, nil
 	}
-
-	fmt.Printf("\n-----\ncreatefolders %+v\n-----\n", restorePerms)
 
 	err = RestorePermissions(
 		ctx,

--- a/src/internal/m365/collection/groups/backup.go
+++ b/src/internal/m365/collection/groups/backup.go
@@ -176,9 +176,7 @@ func populateCollections(
 			path.Builder{}.Append(cName),
 			qp.Category,
 			statusUpdater,
-			ctrlOpts,
-			cID,
-			cName)
+			ctrlOpts)
 
 		channelCollections[cID] = &edc
 

--- a/src/internal/m365/collection/groups/backup.go
+++ b/src/internal/m365/collection/groups/backup.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"golang.org/x/exp/maps"
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/data"
@@ -147,7 +148,7 @@ func populateCollections(
 
 		// ictx = clues.Add(ictx, "previous_path", prevPath)
 
-		items, _, err := bh.getChannelMessagesDelta(ctx, cID, "")
+		items, _, err := bh.getChannelMessageIDsDelta(ctx, cID, "")
 		if err != nil {
 			el.AddRecoverable(ctx, clues.Stack(err))
 			continue
@@ -168,6 +169,7 @@ func populateCollections(
 		}
 
 		edc := NewCollection(
+			bh,
 			qp.ProtectedResource.ID(),
 			currPath,
 			prevPath,
@@ -194,7 +196,7 @@ func populateCollections(
 		// currPaths[cID] = currPath.String()
 
 		// FIXME: normally this goes before removal, but the linters require no bottom comments
-		edc.added = append(edc.added, items...)
+		maps.Copy(edc.added, items)
 	}
 
 	// TODO: handle tombstones here

--- a/src/internal/m365/collection/groups/channel_handler.go
+++ b/src/internal/m365/collection/groups/channel_handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
+	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
@@ -35,11 +36,11 @@ func (bh channelsBackupHandler) getChannels(
 	return bh.ac.GetChannels(ctx, bh.protectedResource)
 }
 
-func (bh channelsBackupHandler) getChannelMessagesDelta(
+func (bh channelsBackupHandler) getChannelMessageIDsDelta(
 	ctx context.Context,
 	channelID, prevDelta string,
-) ([]models.ChatMessageable, api.DeltaUpdate, error) {
-	return bh.ac.GetChannelMessagesDelta(ctx, bh.protectedResource, channelID, prevDelta)
+) (map[string]struct{}, api.DeltaUpdate, error) {
+	return bh.ac.GetChannelMessageIDsDelta(ctx, bh.protectedResource, channelID, prevDelta)
 }
 
 func (bh channelsBackupHandler) includeContainer(
@@ -62,4 +63,11 @@ func (bh channelsBackupHandler) canonicalPath(
 			path.GroupsService,
 			path.ChannelMessagesCategory,
 			false)
+}
+
+func (bh channelsBackupHandler) getChannelMessage(
+	ctx context.Context,
+	teamID, channelID, itemID string,
+) (models.ChatMessageable, *details.GroupsInfo, error) {
+	return bh.ac.GetChannelMessage(ctx, teamID, channelID, itemID)
 }

--- a/src/internal/m365/collection/groups/collection.go
+++ b/src/internal/m365/collection/groups/collection.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/alcionai/clues"
 	kjson "github.com/microsoft/kiota-serialization-json-go"
-	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/data"
@@ -21,7 +20,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
-	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 var (
@@ -45,11 +43,11 @@ type Collection struct {
 	stream            chan data.Item
 
 	// added is a list of existing item IDs that were added to a container
-	added []models.ChatMessageable
+	added map[string]struct{}
 	// removed is a list of item IDs that were deleted from, or moved out, of a container
 	removed map[string]struct{}
 
-	// getter itemGetter
+	getter getChannelMessager
 
 	category      path.CategoryType
 	statusUpdater support.StatusUpdater
@@ -80,6 +78,7 @@ type Collection struct {
 // If both are populated, then state is either moved (if they differ),
 // or notMoved (if they match).
 func NewCollection(
+	getter getChannelMessager,
 	protectedResource string,
 	curr, prev path.Path,
 	location *path.Builder,
@@ -92,17 +91,18 @@ func NewCollection(
 	collection := Collection{
 		chanID:   chanID,
 		chanName: chanName,
-		added:    make([]models.ChatMessageable, 0),
+		added:    map[string]struct{}{},
 		category: category,
 		ctrl:     ctrlOpts,
-		stream:   make(chan data.Item, collectionChannelBufferSize),
 		// doNotMergeItems:   doNotMergeItems,
 		fullPath:          curr,
+		getter:            getter,
 		locationPath:      location,
 		prevPath:          prev,
 		removed:           make(map[string]struct{}, 0),
 		state:             data.StateOf(prev, curr),
 		statusUpdater:     statusUpdater,
+		stream:            make(chan data.Item, collectionChannelBufferSize),
 		protectedResource: protectedResource,
 	}
 
@@ -206,6 +206,7 @@ func (col *Collection) streamItems(ctx context.Context, errs *fault.Bus) {
 		totalBytes    int64
 		wg            sync.WaitGroup
 		colProgress   chan<- struct{}
+		el            = errs.Local()
 	)
 
 	ctx = clues.Add(ctx, "category", col.category.String())
@@ -252,20 +253,30 @@ func (col *Collection) streamItems(ctx context.Context, errs *fault.Bus) {
 	// }
 
 	// add any new items
-	for _, item := range col.added {
-		if errs.Failure() != nil {
+	for id := range col.added {
+		if el.Failure() != nil {
 			break
 		}
 
 		wg.Add(1)
 		semaphoreCh <- struct{}{}
 
-		go func(item models.ChatMessageable) {
+		go func(id string) {
 			defer wg.Done()
 			defer func() { <-semaphoreCh }()
 
 			writer := kjson.NewJsonSerializationWriter()
 			defer writer.Close()
+
+			item, info, err := col.getter.getChannelMessage(
+				ctx,
+				col.protectedResource,
+				col.chanID,
+				id)
+			if err != nil {
+				logger.CtxErr(ctx, err).Info("writing channel message to serializer")
+				return
+			}
 
 			if err := writer.WriteObjectValue("", item); err != nil {
 				logger.CtxErr(ctx, err).Info("writing channel message to serializer")
@@ -280,7 +291,8 @@ func (col *Collection) streamItems(ctx context.Context, errs *fault.Bus) {
 
 			// TODO: the item getter should provide this func when we switch
 			// to a lookup-id-then-item pattern.
-			info := api.ChannelMessageInfo(item, int64(len(data)), col.chanID, col.chanName)
+			info.ChannelID = col.chanID
+			info.ChannelName = col.chanName
 			info.ParentPath = col.LocationPath().String()
 
 			col.stream <- &Item{
@@ -296,7 +308,7 @@ func (col *Collection) streamItems(ctx context.Context, errs *fault.Bus) {
 			if colProgress != nil {
 				colProgress <- struct{}{}
 			}
-		}(item)
+		}(id)
 	}
 
 	wg.Wait()

--- a/src/internal/m365/collection/groups/collection_test.go
+++ b/src/internal/m365/collection/groups/collection_test.go
@@ -125,9 +125,7 @@ func (suite *CollectionSuite) TestNewCollection_state() {
 				test.curr, test.prev, test.loc,
 				0,
 				nil,
-				control.DefaultOptions(),
-				"chanID",
-				"chanName")
+				control.DefaultOptions())
 			assert.Equal(t, test.expect, c.State(), "collection state")
 			assert.Equal(t, test.curr, c.fullPath, "full path")
 			assert.Equal(t, test.prev, c.prevPath, "prev path")

--- a/src/internal/m365/collection/groups/collection_test.go
+++ b/src/internal/m365/collection/groups/collection_test.go
@@ -120,6 +120,7 @@ func (suite *CollectionSuite) TestNewCollection_state() {
 			t := suite.T()
 
 			c := NewCollection(
+				nil,
 				"g",
 				test.curr, test.prev, test.loc,
 				0,

--- a/src/internal/m365/collection/groups/handlers.go
+++ b/src/internal/m365/collection/groups/handlers.go
@@ -6,22 +6,25 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
 	"github.com/alcionai/corso/src/internal/m365/graph"
+	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type backupHandler interface {
+	getChannelMessager
+
 	// gets all channels for the group
 	getChannels(
 		ctx context.Context,
 	) ([]models.Channelable, error)
 
-	// gets all messages by delta in the channel.
-	getChannelMessagesDelta(
+	// gets all message IDs by delta in the channel
+	getChannelMessageIDsDelta(
 		ctx context.Context,
 		channelID, prevDelta string,
-	) ([]models.ChatMessageable, api.DeltaUpdate, error)
+	) (map[string]struct{}, api.DeltaUpdate, error)
 
 	// includeContainer evaluates whether the channel is included
 	// in the provided scope.
@@ -38,4 +41,11 @@ type backupHandler interface {
 		folders *path.Builder,
 		tenantID string,
 	) (path.Path, error)
+}
+
+type getChannelMessager interface {
+	getChannelMessage(
+		ctx context.Context,
+		teamID, channelID, itemID string,
+	) (models.ChatMessageable, *details.GroupsInfo, error)
 }

--- a/src/internal/m365/onedrive_test.go
+++ b/src/internal/m365/onedrive_test.go
@@ -861,8 +861,6 @@ func testRestoreNoPermissionsAndBackup(suite oneDriveSuite, startVersion int) {
 			restoreCfg.OnCollision = control.Replace
 			restoreCfg.IncludePermissions = false
 
-			fmt.Printf("\n-----\nrcfg %+v\n-----\n", restoreCfg.IncludePermissions)
-
 			runRestoreBackupTestVersions(
 				t,
 				testData,

--- a/src/internal/operations/test/group_test.go
+++ b/src/internal/operations/test/group_test.go
@@ -47,14 +47,16 @@ func (suite *GroupsBackupIntgSuite) TestBackup_Run_groupsBasic() {
 	defer flush()
 
 	var (
-		mb   = evmock.NewBus()
-		sel  = selectors.NewGroupsBackup([]string{suite.its.group.ID})
-		opts = control.DefaultOptions()
+		mb      = evmock.NewBus()
+		sel     = selectors.NewGroupsBackup([]string{suite.its.group.ID})
+		opts    = control.DefaultOptions()
+		whatSet = deeTD.CategoryFromRepoRef
 	)
 
 	sel.Include(
-		selTD.GroupsBackupLibraryFolderScope(sel),
-		selTD.GroupsBackupChannelScope(sel)) // FIXME: channel backups are not ready
+		// TODO(abin): ensure implementation succeeds
+		// selTD.GroupsBackupLibraryFolderScope(sel),
+		selTD.GroupsBackupChannelScope(sel))
 
 	bo, bod := prepNewTestBackupOp(t, ctx, mb, sel.Selector, opts, version.Backup)
 	defer bod.close(t, ctx)
@@ -68,7 +70,27 @@ func (suite *GroupsBackupIntgSuite) TestBackup_Run_groupsBasic() {
 		&bo,
 		bod.sel,
 		bod.sel.ID(),
-		path.LibrariesCategory)
+		path.ChannelMessagesCategory)
+
+	_, expectDeets := deeTD.GetDeetsInBackup(
+		t,
+		ctx,
+		bo.Results.BackupID,
+		bod.acct.ID(),
+		bod.sel.ID(),
+		path.GroupsService,
+		whatSet,
+		bod.kms,
+		bod.sss)
+	deeTD.CheckBackupDetails(
+		t,
+		ctx,
+		bo.Results.BackupID,
+		whatSet,
+		bod.kms,
+		bod.sss,
+		expectDeets,
+		false)
 }
 
 func (suite *GroupsBackupIntgSuite) TestBackup_Run_groupsExtensions() {

--- a/src/internal/operations/test/helper_test.go
+++ b/src/internal/operations/test/helper_test.go
@@ -132,22 +132,22 @@ func prepNewTestBackupOp(
 
 	bod.sw = store.NewWrapper(bod.kms)
 
-	connectorResource := resource.Users
+	var connectorResource resource.Category
 
-	switch sel.Service {
-	case selectors.ServiceSharePoint:
+	switch sel.PathService() {
+	case path.SharePointService:
 		connectorResource = resource.Sites
-	case selectors.ServiceGroups:
+	case path.GroupsService:
 		connectorResource = resource.Groups
+	default:
+		connectorResource = resource.Users
 	}
 
 	bod.ctrl, bod.sel = ControllerWithSelector(
 		t,
 		ctx,
 		bod.acct,
-		connectorResource,
-		sel,
-		nil,
+		connectorResource, sel, nil,
 		bod.close)
 
 	bo := newTestBackupOp(
@@ -543,12 +543,12 @@ func ControllerWithSelector(
 	t *testing.T,
 	ctx context.Context, //revive:disable-line:context-as-argument
 	acct account.Account,
-	cr resource.Category,
+	rc resource.Category,
 	sel selectors.Selector,
 	ins idname.Cacher,
 	onFail func(*testing.T, context.Context),
 ) (*m365.Controller, selectors.Selector) {
-	ctrl, err := m365.NewController(ctx, acct, cr, sel.PathService(), control.DefaultOptions())
+	ctrl, err := m365.NewController(ctx, acct, rc, sel.PathService(), control.DefaultOptions())
 	if !assert.NoError(t, err, clues.ToCore(err)) {
 		if onFail != nil {
 			onFail(t, ctx)

--- a/src/pkg/backup/details/groups.go
+++ b/src/pkg/backup/details/groups.go
@@ -47,8 +47,6 @@ type GroupsInfo struct {
 	Size       int64     `json:"size,omitempty"`
 
 	// Channels Specific
-	ChannelName    string    `json:"channelName,omitempty"`
-	ChannelID      string    `json:"channelID,omitempty"`
 	LastReplyAt    time.Time `json:"lastResponseAt,omitempty"`
 	MessageCreator string    `json:"messageCreator,omitempty"`
 	MessagePreview string    `json:"messagePreview,omitempty"`
@@ -91,7 +89,7 @@ func (i GroupsInfo) Values() []string {
 	case GroupsChannelMessage:
 		return []string{
 			i.MessagePreview,
-			i.ChannelName,
+			i.ParentPath,
 			strconv.Itoa(i.ReplyCount),
 			i.MessageCreator,
 			dttm.FormatToTabularDisplay(i.Created),
@@ -103,33 +101,24 @@ func (i GroupsInfo) Values() []string {
 }
 
 func (i *GroupsInfo) UpdateParentPath(newLocPath *path.Builder) {
-	i.ParentPath = newLocPath.PopFront().String()
+	i.ParentPath = newLocPath.String()
 }
 
 func (i *GroupsInfo) uniqueLocation(baseLoc *path.Builder) (*uniqueLoc, error) {
 	var (
-		category path.CategoryType
-		loc      uniqueLoc
-		err      error
+		loc uniqueLoc
+		err error
 	)
 
 	switch i.ItemType {
 	case SharePointLibrary:
-		category = path.LibrariesCategory
-
 		if len(i.DriveID) == 0 {
 			return nil, clues.New("empty drive ID")
 		}
 
-		loc, err = NewGroupsLocationIDer(category, i.DriveID, baseLoc.Elements()...)
+		loc, err = NewGroupsLocationIDer(path.LibrariesCategory, i.DriveID, baseLoc.Elements()...)
 	case GroupsChannelMessage:
-		category = path.ChannelMessagesCategory
-
-		if len(i.ChannelID) == 0 {
-			return nil, clues.New("empty channel ID")
-		}
-
-		loc, err = NewGroupsLocationIDer(category, "", baseLoc.Elements()...)
+		loc, err = NewGroupsLocationIDer(path.ChannelMessagesCategory, "", baseLoc.Elements()...)
 	}
 
 	return &loc, err

--- a/src/pkg/selectors/groups.go
+++ b/src/pkg/selectors/groups.go
@@ -409,7 +409,6 @@ const (
 
 	// channel and drive selection
 	GroupsInfoSiteLibraryDrive groupsCategory = "GroupsInfoSiteLibraryDrive"
-	GroupsInfoChannel          groupsCategory = "GroupsInfoChannel"
 
 	// data contained within details.ItemInfo
 	GroupsInfoChannelMessageCreatedAfter    groupsCategory = "GroupsInfoChannelMessageCreatedAfter"
@@ -672,18 +671,6 @@ func (s GroupsScope) matchesInfo(dii details.ItemInfo) bool {
 		}
 
 		return matchesAny(s, GroupsInfoSiteLibraryDrive, ds)
-	case GroupsInfoChannel:
-		ds := []string{}
-
-		if len(info.ChannelID) > 0 {
-			ds = append(ds, info.ChannelID)
-		}
-
-		if len(info.ChannelName) > 0 {
-			ds = append(ds, info.ChannelName)
-		}
-
-		return matchesAny(s, GroupsInfoChannel, ds)
 	case GroupsInfoChannelMessageCreator:
 		i = info.MessageCreator
 	case GroupsInfoChannelMessageCreatedAfter, GroupsInfoChannelMessageCreatedBefore:

--- a/src/pkg/services/m365/api/channels.go
+++ b/src/pkg/services/m365/api/channels.go
@@ -12,7 +12,6 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/pkg/backup/details"
-	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
 )
 
@@ -104,12 +103,10 @@ func (c Channels) GetChannelByName(
 // message
 // ---------------------------------------------------------------------------
 
-// GetMessage retrieves a ChannelMessage item.
-func (c Channels) GetMessage(
+func (c Channels) GetChannelMessage(
 	ctx context.Context,
 	teamID, channelID, itemID string,
-	errs *fault.Bus,
-) (serialization.Parsable, *details.GroupsInfo, error) {
+) (models.ChatMessageable, *details.GroupsInfo, error) {
 	var size int64
 
 	message, err := c.Stable.

--- a/src/pkg/services/m365/api/channels_pager_test.go
+++ b/src/pkg/services/m365/api/channels_pager_test.go
@@ -51,23 +51,32 @@ func (suite *ChannelsPagerIntgSuite) TestEnumerateChannelMessages() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	msgs, du, err := ac.GetChannelMessagesDelta(
+	msgIDs, du, err := ac.GetChannelMessageIDsDelta(
 		ctx,
 		suite.its.group.id,
 		suite.its.group.testContainerID,
 		"")
 	require.NoError(t, err, clues.ToCore(err))
-	require.NotEmpty(t, msgs)
+	require.NotEmpty(t, msgIDs)
 	require.NotZero(t, du.URL, "delta link")
 	require.True(t, du.Reset, "reset due to empty prev delta link")
 
-	msgs, du, err = ac.GetChannelMessagesDelta(
+	msgIDs, du, err = ac.GetChannelMessageIDsDelta(
 		ctx,
 		suite.its.group.id,
 		suite.its.group.testContainerID,
 		du.URL)
 	require.NoError(t, err, clues.ToCore(err))
-	require.Empty(t, msgs, "should have no new messages from delta")
+	require.Empty(t, msgIDs, "should have no new messages from delta")
 	require.NotZero(t, du.URL, "delta link")
 	require.False(t, du.Reset, "prev delta link should be valid")
+
+	for id := range msgIDs {
+		_, _, err := ac.GetChannelMessage(
+			ctx,
+			suite.its.group.id,
+			suite.its.group.testContainerID,
+			id)
+		require.NoError(t, err, clues.ToCore(err))
+	}
 }

--- a/src/pkg/services/m365/api/channels_pager_test.go
+++ b/src/pkg/services/m365/api/channels_pager_test.go
@@ -2,13 +2,18 @@ package api_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/alcionai/clues"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/internal/common/str"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type ChannelsPagerIntgSuite struct {
@@ -72,11 +77,58 @@ func (suite *ChannelsPagerIntgSuite) TestEnumerateChannelMessages() {
 	require.False(t, du.Reset, "prev delta link should be valid")
 
 	for id := range msgIDs {
-		_, _, err := ac.GetChannelMessage(
-			ctx,
-			suite.its.group.id,
-			suite.its.group.testContainerID,
-			id)
-		require.NoError(t, err, clues.ToCore(err))
+		suite.Run(id+"-replies", func() {
+			testEnumerateChannelMessageReplies(
+				suite.T(),
+				suite.its.ac.Channels(),
+				suite.its.group.id,
+				suite.its.group.testContainerID,
+				id)
+		})
 	}
+}
+
+func testEnumerateChannelMessageReplies(
+	t *testing.T,
+	ac api.Channels,
+	groupID, channelID, messageID string,
+) {
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	msg, info, err := ac.GetChannelMessage(ctx, groupID, channelID, messageID)
+	require.NoError(t, err, clues.ToCore(err))
+
+	replies, err := ac.GetChannelMessageReplies(ctx, groupID, channelID, messageID)
+	require.NoError(t, err, clues.ToCore(err))
+
+	var (
+		lastReply time.Time
+		replyIDs  = map[string]struct{}{}
+	)
+
+	for _, r := range replies {
+		cdt := ptr.Val(r.GetCreatedDateTime())
+		if cdt.After(lastReply) {
+			lastReply = cdt
+		}
+
+		replyIDs[ptr.Val(r.GetId())] = struct{}{}
+	}
+
+	assert.Equal(t, messageID, ptr.Val(msg.GetId()))
+	assert.Equal(t, channelID, ptr.Val(msg.GetChannelIdentity().GetChannelId()))
+	assert.Equal(t, groupID, ptr.Val(msg.GetChannelIdentity().GetTeamId()))
+	assert.Equal(t, len(replies), info.ReplyCount)
+	assert.Equal(t, msg.GetFrom().GetUser().GetDisplayName(), info.MessageCreator)
+	assert.Equal(t, lastReply, info.LastReplyAt)
+	assert.Equal(t, str.Preview(ptr.Val(msg.GetBody().GetContent()), 16), info.MessagePreview)
+
+	msgReplyIDs := map[string]struct{}{}
+
+	for _, reply := range msg.GetReplies() {
+		msgReplyIDs[ptr.Val(reply.GetId())] = struct{}{}
+	}
+
+	assert.Equal(t, replyIDs, msgReplyIDs)
 }

--- a/src/pkg/services/m365/api/config.go
+++ b/src/pkg/services/m365/api/config.go
@@ -87,7 +87,13 @@ func newEventualConsistencyHeaders() *abstractions.RequestHeaders {
 
 // makes a slice with []string{"id", s...}
 func idAnd(ss ...string) []string {
-	return append([]string{"id"}, ss...)
+	id := []string{"id"}
+
+	if len(ss) == 0 {
+		return id
+	}
+
+	return append(id, ss...)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/services/m365/api/events.go
+++ b/src/pkg/services/m365/api/events.go
@@ -212,9 +212,10 @@ func (c Events) GetItem(
 	// cancelledOccurrences end up in AdditionalData
 	// https://learn.microsoft.com/en-us/graph/api/resources/event?view=graph-rest-beta#properties
 	rawURL := fmt.Sprintf(eventExceptionsBetaURLTemplate, userID, itemID)
-	builder := users.NewItemEventsEventItemRequestBuilder(rawURL, c.Stable.Adapter())
 
-	event, err = builder.Get(ctx, config)
+	event, err = users.
+		NewItemEventsEventItemRequestBuilder(rawURL, c.Stable.Adapter()).
+		Get(ctx, config)
 	if err != nil {
 		return nil, nil, graph.Stack(ctx, err)
 	}


### PR DESCRIPTION
delays getting the full channel message data until we iterate over each message in the collection's Items() stream. The initial enumeration has had its footprint reduced to only ids. Also fixes up the failing operations backup test.

Follow up PRs still need to:
* populate each message with all its replies on the get-later
* turn on other integration testing at the operations and ci layers

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #3989

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
