### PR TITLE
gather replies when streaming message items

### DIFF
--- a/src/internal/common/str/str.go
+++ b/src/internal/common/str/str.go
@@ -56,3 +56,27 @@ func First(vs ...string) string {
 
 	return ""
 }
+
+// Preview reduces the string to the specified size.
+// If the string is longer than the size, the last three
+// characters are replaced with an ellipsis.  Size < 4
+// will default to 4.
+// ex:
+// Preview("123", 6) => "123"
+// Preview("1234567", 6) "123..."
+func Preview(s string, size int) string {
+	if size < 4 {
+		size = 4
+	}
+
+	if len(s) < size {
+		return s
+	}
+
+	ss := s[:size]
+	if len(s) > size {
+		ss = s[:size-3] + "..."
+	}
+
+	return ss
+}

--- a/src/internal/common/str/str_test.go
+++ b/src/internal/common/str/str_test.go
@@ -1,0 +1,53 @@
+package str
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// Warning: importing the corso tester.suite causes a circular import
+// ---------------------------------------------------------------------------
+
+func TestPreview(t *testing.T) {
+	table := []struct {
+		input  string
+		size   int
+		expect string
+	}{
+		{
+			input:  "",
+			size:   1,
+			expect: "",
+		},
+		{
+			input:  "yes",
+			size:   1,
+			expect: "yes",
+		},
+		{
+			input:  "yes!",
+			size:   5,
+			expect: "yes!",
+		},
+		{
+			input:  "however",
+			size:   6,
+			expect: "how...",
+		},
+		{
+			input:  "negative",
+			size:   -1,
+			expect: "n...",
+		},
+	}
+	for _, test := range table {
+		t.Run(test.input, func(t *testing.T) {
+			assert.Equal(
+				t,
+				test.expect,
+				Preview(test.input, test.size))
+		})
+	}
+}

--- a/src/internal/m365/collection/drive/handler_utils.go
+++ b/src/internal/m365/collection/drive/handler_utils.go
@@ -90,7 +90,6 @@ func augmentItemInfo(
 		}
 
 	case path.GroupsService:
-		// TODO: Add channel name and ID
 		dii.Groups = &details.GroupsInfo{
 			Created:    ptr.Val(item.GetCreatedDateTime()),
 			DriveID:    driveID,

--- a/src/internal/m365/collection/groups/backup.go
+++ b/src/internal/m365/collection/groups/backup.go
@@ -176,9 +176,7 @@ func populateCollections(
 			path.Builder{}.Append(cName),
 			qp.Category,
 			statusUpdater,
-			ctrlOpts,
-			cID,
-			cName)
+			ctrlOpts)
 
 		channelCollections[cID] = &edc
 

--- a/src/internal/m365/collection/groups/collection_test.go
+++ b/src/internal/m365/collection/groups/collection_test.go
@@ -125,9 +125,7 @@ func (suite *CollectionSuite) TestNewCollection_state() {
 				test.curr, test.prev, test.loc,
 				0,
 				nil,
-				control.DefaultOptions(),
-				"chanID",
-				"chanName")
+				control.DefaultOptions())
 			assert.Equal(t, test.expect, c.State(), "collection state")
 			assert.Equal(t, test.curr, c.fullPath, "full path")
 			assert.Equal(t, test.prev, c.prevPath, "prev path")

--- a/src/pkg/backup/details/groups.go
+++ b/src/pkg/backup/details/groups.go
@@ -47,8 +47,6 @@ type GroupsInfo struct {
 	Size       int64     `json:"size,omitempty"`
 
 	// Channels Specific
-	ChannelName    string    `json:"channelName,omitempty"`
-	ChannelID      string    `json:"channelID,omitempty"`
 	LastReplyAt    time.Time `json:"lastResponseAt,omitempty"`
 	MessageCreator string    `json:"messageCreator,omitempty"`
 	MessagePreview string    `json:"messagePreview,omitempty"`
@@ -91,7 +89,7 @@ func (i GroupsInfo) Values() []string {
 	case GroupsChannelMessage:
 		return []string{
 			i.MessagePreview,
-			i.ChannelName,
+			i.ParentPath,
 			strconv.Itoa(i.ReplyCount),
 			i.MessageCreator,
 			dttm.FormatToTabularDisplay(i.Created),
@@ -103,33 +101,24 @@ func (i GroupsInfo) Values() []string {
 }
 
 func (i *GroupsInfo) UpdateParentPath(newLocPath *path.Builder) {
-	i.ParentPath = newLocPath.PopFront().String()
+	i.ParentPath = newLocPath.String()
 }
 
 func (i *GroupsInfo) uniqueLocation(baseLoc *path.Builder) (*uniqueLoc, error) {
 	var (
-		category path.CategoryType
-		loc      uniqueLoc
-		err      error
+		loc uniqueLoc
+		err error
 	)
 
 	switch i.ItemType {
 	case SharePointLibrary:
-		category = path.LibrariesCategory
-
 		if len(i.DriveID) == 0 {
 			return nil, clues.New("empty drive ID")
 		}
 
-		loc, err = NewGroupsLocationIDer(category, i.DriveID, baseLoc.Elements()...)
+		loc, err = NewGroupsLocationIDer(path.LibrariesCategory, i.DriveID, baseLoc.Elements()...)
 	case GroupsChannelMessage:
-		category = path.ChannelMessagesCategory
-
-		if len(i.ChannelID) == 0 {
-			return nil, clues.New("empty channel ID")
-		}
-
-		loc, err = NewGroupsLocationIDer(category, "", baseLoc.Elements()...)
+		loc, err = NewGroupsLocationIDer(path.ChannelMessagesCategory, "", baseLoc.Elements()...)
 	}
 
 	return &loc, err

--- a/src/pkg/selectors/groups.go
+++ b/src/pkg/selectors/groups.go
@@ -409,7 +409,6 @@ const (
 
 	// channel and drive selection
 	GroupsInfoSiteLibraryDrive groupsCategory = "GroupsInfoSiteLibraryDrive"
-	GroupsInfoChannel          groupsCategory = "GroupsInfoChannel"
 
 	// data contained within details.ItemInfo
 	GroupsInfoChannelMessageCreatedAfter    groupsCategory = "GroupsInfoChannelMessageCreatedAfter"
@@ -672,18 +671,6 @@ func (s GroupsScope) matchesInfo(dii details.ItemInfo) bool {
 		}
 
 		return matchesAny(s, GroupsInfoSiteLibraryDrive, ds)
-	case GroupsInfoChannel:
-		ds := []string{}
-
-		if len(info.ChannelID) > 0 {
-			ds = append(ds, info.ChannelID)
-		}
-
-		if len(info.ChannelName) > 0 {
-			ds = append(ds, info.ChannelName)
-		}
-
-		return matchesAny(s, GroupsInfoChannel, ds)
 	case GroupsInfoChannelMessageCreator:
 		i = info.MessageCreator
 	case GroupsInfoChannelMessageCreatedAfter, GroupsInfoChannelMessageCreatedBefore:

--- a/src/pkg/services/m365/api/channels_pager_test.go
+++ b/src/pkg/services/m365/api/channels_pager_test.go
@@ -2,13 +2,18 @@ package api_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/alcionai/clues"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/internal/common/str"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type ChannelsPagerIntgSuite struct {
@@ -72,11 +77,58 @@ func (suite *ChannelsPagerIntgSuite) TestEnumerateChannelMessages() {
 	require.False(t, du.Reset, "prev delta link should be valid")
 
 	for id := range msgIDs {
-		_, _, err := ac.GetChannelMessage(
-			ctx,
-			suite.its.group.id,
-			suite.its.group.testContainerID,
-			id)
-		require.NoError(t, err, clues.ToCore(err))
+		suite.Run(id+"-replies", func() {
+			testEnumerateChannelMessageReplies(
+				suite.T(),
+				suite.its.ac.Channels(),
+				suite.its.group.id,
+				suite.its.group.testContainerID,
+				id)
+		})
 	}
+}
+
+func testEnumerateChannelMessageReplies(
+	t *testing.T,
+	ac api.Channels,
+	groupID, channelID, messageID string,
+) {
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	msg, info, err := ac.GetChannelMessage(ctx, groupID, channelID, messageID)
+	require.NoError(t, err, clues.ToCore(err))
+
+	replies, err := ac.GetChannelMessageReplies(ctx, groupID, channelID, messageID)
+	require.NoError(t, err, clues.ToCore(err))
+
+	var (
+		lastReply time.Time
+		replyIDs  = map[string]struct{}{}
+	)
+
+	for _, r := range replies {
+		cdt := ptr.Val(r.GetCreatedDateTime())
+		if cdt.After(lastReply) {
+			lastReply = cdt
+		}
+
+		replyIDs[ptr.Val(r.GetId())] = struct{}{}
+	}
+
+	assert.Equal(t, messageID, ptr.Val(msg.GetId()))
+	assert.Equal(t, channelID, ptr.Val(msg.GetChannelIdentity().GetChannelId()))
+	assert.Equal(t, groupID, ptr.Val(msg.GetChannelIdentity().GetTeamId()))
+	assert.Equal(t, len(replies), info.ReplyCount)
+	assert.Equal(t, msg.GetFrom().GetUser().GetDisplayName(), info.MessageCreator)
+	assert.Equal(t, lastReply, info.LastReplyAt)
+	assert.Equal(t, str.Preview(ptr.Val(msg.GetBody().GetContent()), 16), info.MessagePreview)
+
+	msgReplyIDs := map[string]struct{}{}
+
+	for _, reply := range msg.GetReplies() {
+		msgReplyIDs[ptr.Val(reply.GetId())] = struct{}{}
+	}
+
+	assert.Equal(t, replyIDs, msgReplyIDs)
 }

--- a/src/pkg/services/m365/api/config.go
+++ b/src/pkg/services/m365/api/config.go
@@ -87,7 +87,13 @@ func newEventualConsistencyHeaders() *abstractions.RequestHeaders {
 
 // makes a slice with []string{"id", s...}
 func idAnd(ss ...string) []string {
-	return append([]string{"id"}, ss...)
+	id := []string{"id"}
+
+	if len(ss) == 0 {
+		return id
+	}
+
+	return append(id, ss...)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/services/m365/api/events.go
+++ b/src/pkg/services/m365/api/events.go
@@ -212,9 +212,10 @@ func (c Events) GetItem(
 	// cancelledOccurrences end up in AdditionalData
 	// https://learn.microsoft.com/en-us/graph/api/resources/event?view=graph-rest-beta#properties
 	rawURL := fmt.Sprintf(eventExceptionsBetaURLTemplate, userID, itemID)
-	builder := users.NewItemEventsEventItemRequestBuilder(rawURL, c.Stable.Adapter())
 
-	event, err = builder.Get(ctx, config)
+	event, err = users.
+		NewItemEventsEventItemRequestBuilder(rawURL, c.Stable.Adapter()).
+		Get(ctx, config)
 	if err != nil {
 		return nil, nil, graph.Stack(ctx, err)
 	}


### PR DESCRIPTION
when streaming channel message items into a backup, collect all replies in a message at the same time that the item gets looked up.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #3989

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
