### PR TITLE
Metadata related path changes

### DIFF
--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -436,12 +436,18 @@ func (c *Collections) Get(
 	}
 
 	// add metadata collections
-	service, category := c.handler.ServiceCat()
+	pathPrefix, err := c.handler.MetadataPathPrefix(c.tenantID)
+	if err != nil {
+		// Technically it's safe to continue here because the logic for starting an
+		// incremental backup should eventually find that the metadata files are
+		// empty/missing and default to a full backup.
+		logger.CtxErr(ctx, err).Info("making metadata collection for future incremental backups")
+
+		return collections, canUsePreviousBackup, nil
+	}
+
 	md, err := graph.MakeMetadataCollection(
-		c.tenantID,
-		c.resourceOwner,
-		service,
-		category,
+		pathPrefix,
 		[]graph.MetadataCollectionEntry{
 			graph.NewMetadataEntry(graph.PreviousPathFileName, folderPaths),
 			graph.NewMetadataEntry(graph.DeltaURLsFileName, deltaURLs),

--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -438,10 +438,10 @@ func (c *Collections) Get(
 	// add metadata collections
 	pathPrefix, err := c.handler.MetadataPathPrefix(c.tenantID)
 	if err != nil {
-		// Technically it's safe to continue here because the logic for starting an
+		// It's safe to return here because the logic for starting an
 		// incremental backup should eventually find that the metadata files are
 		// empty/missing and default to a full backup.
-		logger.CtxErr(ctx, err).Info("making metadata collection for future incremental backups")
+		logger.CtxErr(ctx, err).Info("making metadata collection path prefixes")
 
 		return collections, canUsePreviousBackup, nil
 	}

--- a/src/internal/m365/collection/drive/collections_test.go
+++ b/src/internal/m365/collection/drive/collections_test.go
@@ -1129,11 +1129,16 @@ func (suite *OneDriveCollectionsUnitSuite) TestDeserializeMetadata() {
 			cols := []data.RestoreCollection{}
 
 			for _, c := range test.cols {
-				mc, err := graph.MakeMetadataCollection(
+				pathPrefix, err := path.Builder{}.ToServiceCategoryMetadataPath(
 					tenant,
 					user,
 					path.OneDriveService,
 					path.FilesCategory,
+					false)
+				require.NoError(t, err, clues.ToCore(err))
+
+				mc, err := graph.MakeMetadataCollection(
+					pathPrefix,
 					c(),
 					func(*support.ControllerOperationStatus) {})
 				require.NoError(t, err, clues.ToCore(err))
@@ -2291,11 +2296,12 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 				control.Options{ToggleFeatures: control.Toggles{}})
 
 			prevDelta := "prev-delta"
+
+			pathPrefix, err := mbh.MetadataPathPrefix(tenant)
+			require.NoError(t, err, clues.ToCore(err))
+
 			mc, err := graph.MakeMetadataCollection(
-				tenant,
-				user,
-				path.OneDriveService,
-				path.FilesCategory,
+				pathPrefix,
 				[]graph.MetadataCollectionEntry{
 					graph.NewMetadataEntry(
 						graph.DeltaURLsFileName,

--- a/src/internal/m365/collection/drive/group_handler.go
+++ b/src/internal/m365/collection/drive/group_handler.go
@@ -1,6 +1,8 @@
 package drive
 
 import (
+	"github.com/alcionai/clues"
+
 	odConsts "github.com/alcionai/corso/src/internal/m365/service/onedrive/consts"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
@@ -48,6 +50,20 @@ func (h groupBackupHandler) PathPrefix(
 		odConsts.DrivesPathDir,
 		driveID,
 		odConsts.RootPathDir)
+}
+
+func (h groupBackupHandler) MetadataPathPrefix(tenantID string) (path.Path, error) {
+	p, err := path.Builder{}.ToServiceCategoryMetadataPath(
+		tenantID,
+		h.groupID,
+		h.service,
+		path.LibrariesCategory,
+		false)
+	if err != nil {
+		return nil, clues.Wrap(err, "making metadata path")
+	}
+
+	return p, nil
 }
 
 func (h groupBackupHandler) CanonicalPath(

--- a/src/internal/m365/collection/drive/group_handler.go
+++ b/src/internal/m365/collection/drive/group_handler.go
@@ -5,8 +5,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
-
-	odConsts "github.com/alcionai/corso/src/internal/m365/service/onedrive/consts"
 )
 
 var _ BackupHandler = &groupBackupHandler{}

--- a/src/internal/m365/collection/drive/group_handler.go
+++ b/src/internal/m365/collection/drive/group_handler.go
@@ -5,6 +5,8 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
+
+	odConsts "github.com/alcionai/corso/src/internal/m365/service/onedrive/consts"
 )
 
 var _ BackupHandler = &groupBackupHandler{}

--- a/src/internal/m365/collection/drive/handlers.go
+++ b/src/internal/m365/collection/drive/handlers.go
@@ -41,6 +41,9 @@ type BackupHandler interface {
 	// the given values.
 	PathPrefix(tenantID, driveID string) (path.Path, error)
 
+	// MetadataPathPrefix returns the prefix path for metadata
+	MetadataPathPrefix(tenantID string) (path.Path, error)
+
 	// CanonicalPath constructs the service and category specific path for
 	// the given values.
 	CanonicalPath(folders *path.Builder, tenantID string) (path.Path, error)

--- a/src/internal/m365/collection/drive/item_handler.go
+++ b/src/internal/m365/collection/drive/item_handler.go
@@ -54,6 +54,22 @@ func (h itemBackupHandler) PathPrefix(
 		odConsts.RootPathDir)
 }
 
+func (h itemBackupHandler) MetadataPathPrefix(
+	tenantID string,
+) (path.Path, error) {
+	p, err := path.Builder{}.ToServiceCategoryMetadataPath(
+		tenantID,
+		h.userID,
+		path.OneDriveService,
+		path.FilesCategory,
+		false)
+	if err != nil {
+		return nil, clues.Wrap(err, "making metadata path")
+	}
+
+	return p, nil
+}
+
 func (h itemBackupHandler) CanonicalPath(
 	folders *path.Builder,
 	tenantID string,

--- a/src/internal/m365/collection/drive/library_handler.go
+++ b/src/internal/m365/collection/drive/library_handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/drives"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
@@ -55,6 +56,22 @@ func (h libraryBackupHandler) PathPrefix(
 		odConsts.DrivesPathDir,
 		driveID,
 		odConsts.RootPathDir)
+}
+
+func (h libraryBackupHandler) MetadataPathPrefix(
+	tenantID string,
+) (path.Path, error) {
+	p, err := path.Builder{}.ToServiceCategoryMetadataPath(
+		tenantID,
+		h.siteID,
+		h.service,
+		path.LibrariesCategory,
+		false)
+	if err != nil {
+		return nil, clues.Wrap(err, "making metadata path")
+	}
+
+	return p, nil
 }
 
 func (h libraryBackupHandler) CanonicalPath(

--- a/src/internal/m365/collection/exchange/backup.go
+++ b/src/internal/m365/collection/exchange/backup.go
@@ -266,11 +266,18 @@ func populateCollections(
 		"num_paths_entries", len(currPaths),
 		"num_deltas_entries", len(deltaURLs))
 
-	col, err := graph.MakeMetadataCollection(
+	pathPrefix, err := path.Builder{}.ToServiceCategoryMetadataPath(
 		qp.TenantID,
 		qp.ProtectedResource.ID(),
 		path.ExchangeService,
 		qp.Category,
+		false)
+	if err != nil {
+		return nil, clues.Wrap(err, "making metadata path")
+	}
+
+	col, err := graph.MakeMetadataCollection(
+		pathPrefix,
 		[]graph.MetadataCollectionEntry{
 			graph.NewMetadataEntry(graph.PreviousPathFileName, currPaths),
 			graph.NewMetadataEntry(graph.DeltaURLsFileName, deltaURLs),

--- a/src/internal/m365/collection/exchange/backup_test.go
+++ b/src/internal/m365/collection/exchange/backup_test.go
@@ -299,10 +299,15 @@ func (suite *DataCollectionsUnitSuite) TestParseMetadataCollections() {
 					graph.NewMetadataEntry(d.fileName, map[string]string{"key": d.value}))
 			}
 
-			coll, err := graph.MakeMetadataCollection(
+			pathPrefix, err := path.Builder{}.ToServiceCategoryMetadataPath(
 				"t", "u",
 				path.ExchangeService,
 				path.EmailCategory,
+				false)
+			require.NoError(t, err, "path prefix")
+
+			coll, err := graph.MakeMetadataCollection(
+				pathPrefix,
 				entries,
 				func(cos *support.ControllerOperationStatus) {},
 			)

--- a/src/internal/m365/collection/site/backup.go
+++ b/src/internal/m365/collection/site/backup.go
@@ -43,9 +43,6 @@ func CollectLibraries(
 			bpc.Options)
 	)
 
-	// TODO(meain): backup resource owner should be group id in case
-	// of group sharepoint site backup. As of now, we always use
-	// sharepoint site ids.
 	odcs, canUsePreviousBackup, err := colls.Get(ctx, bpc.MetadataCollections, ssmb, errs)
 	if err != nil {
 		return nil, false, graph.Wrap(ctx, err, "getting library")

--- a/src/internal/m365/graph/metadata_collection.go
+++ b/src/internal/m365/graph/metadata_collection.go
@@ -63,24 +63,12 @@ func (mce MetadataCollectionEntry) toMetadataItem() (MetadataItem, error) {
 // containing all the provided metadata as a single json object. Returns
 // nil if the map does not have any entries.
 func MakeMetadataCollection(
-	tenant, resourceOwner string,
-	service path.ServiceType,
-	cat path.CategoryType,
+	pathPrefix path.Path,
 	metadata []MetadataCollectionEntry,
 	statusUpdater support.StatusUpdater,
 ) (data.BackupCollection, error) {
 	if len(metadata) == 0 {
 		return nil, nil
-	}
-
-	p, err := path.Builder{}.ToServiceCategoryMetadataPath(
-		tenant,
-		resourceOwner,
-		service,
-		cat,
-		false)
-	if err != nil {
-		return nil, clues.Wrap(err, "making metadata path")
 	}
 
 	items := make([]MetadataItem, 0, len(metadata))
@@ -94,7 +82,7 @@ func MakeMetadataCollection(
 		items = append(items, item)
 	}
 
-	coll := NewMetadataCollection(p, items, statusUpdater)
+	coll := NewMetadataCollection(pathPrefix, items, statusUpdater)
 
 	return coll, nil
 }

--- a/src/internal/m365/graph/metadata_collection_test.go
+++ b/src/internal/m365/graph/metadata_collection_test.go
@@ -116,6 +116,7 @@ func (suite *MetadataCollectionUnitSuite) TestMakeMetadataCollection() {
 		cat             path.CategoryType
 		metadata        MetadataCollectionEntry
 		collectionCheck assert.ValueAssertionFunc
+		pathPrefixCheck assert.ErrorAssertionFunc
 		errCheck        assert.ErrorAssertionFunc
 	}{
 		{
@@ -124,6 +125,7 @@ func (suite *MetadataCollectionUnitSuite) TestMakeMetadataCollection() {
 			cat:             path.EmailCategory,
 			metadata:        NewMetadataEntry("", nil),
 			collectionCheck: assert.Nil,
+			pathPrefixCheck: assert.NoError,
 			errCheck:        assert.Error,
 		},
 		{
@@ -137,6 +139,7 @@ func (suite *MetadataCollectionUnitSuite) TestMakeMetadataCollection() {
 					"hola":  "mundo",
 				}),
 			collectionCheck: assert.NotNil,
+			pathPrefixCheck: assert.NoError,
 			errCheck:        assert.NoError,
 		},
 		{
@@ -150,7 +153,8 @@ func (suite *MetadataCollectionUnitSuite) TestMakeMetadataCollection() {
 					"hola":  "mundo",
 				}),
 			collectionCheck: assert.Nil,
-			errCheck:        assert.Error,
+			pathPrefixCheck: assert.Error,
+			errCheck:        assert.NoError,
 		},
 	}
 
@@ -161,11 +165,19 @@ func (suite *MetadataCollectionUnitSuite) TestMakeMetadataCollection() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			col, err := MakeMetadataCollection(
+			pathPrefix, err := path.Builder{}.ToServiceCategoryMetadataPath(
 				tenant,
 				user,
 				test.service,
 				test.cat,
+				false)
+			test.pathPrefixCheck(t, err, "path prefix")
+			if err != nil {
+				return
+			}
+
+			col, err := MakeMetadataCollection(
+				pathPrefix,
 				[]MetadataCollectionEntry{test.metadata},
 				func(*support.ControllerOperationStatus) {})
 

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -1871,11 +1871,16 @@ func (suite *AssistBackupIntegrationSuite) TestBackupTypesForFailureModes() {
 
 			cs := test.collFunc()
 
-			mc, err := graph.MakeMetadataCollection(
+			pathPrefix, err := path.Builder{}.ToServiceCategoryMetadataPath(
 				tenantID,
 				userID,
 				path.OneDriveService,
 				path.FilesCategory,
+				false)
+			require.NoError(t, err, clues.ToCore(err))
+
+			mc, err := graph.MakeMetadataCollection(
+				pathPrefix,
 				makeMetadataCollectionEntries("url/1", driveID, folderID, tmp),
 				func(*support.ControllerOperationStatus) {})
 			require.NoError(t, err, clues.ToCore(err))
@@ -2184,11 +2189,16 @@ func (suite *AssistBackupIntegrationSuite) TestExtensionsIncrementals() {
 
 			cs := test.collFunc()
 
-			mc, err := graph.MakeMetadataCollection(
+			pathPrefix, err := path.Builder{}.ToServiceCategoryMetadataPath(
 				tenantID,
 				userID,
 				path.OneDriveService,
 				path.FilesCategory,
+				false)
+			require.NoError(t, err, clues.ToCore(err))
+
+			mc, err := graph.MakeMetadataCollection(
+				pathPrefix,
 				makeMetadataCollectionEntries("url/1", driveID, folderID, tmp),
 				func(*support.ControllerOperationStatus) {})
 			require.NoError(t, err, clues.ToCore(err))


### PR DESCRIPTION
This adds a `MetadataPathPrefix` func to any drive related handlers. And in case of exchange, we will create a path. These generated paths, in both scenario is what now gets passed to `MakeMetadataCollection` instead of passing the different values.
<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* https://github.com/alcionai/corso/issues/4154

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
