### PR TITLE
split message ids into added, deleted

### DIFF
--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -19,6 +19,7 @@ import (
 	odConsts "github.com/alcionai/corso/src/internal/m365/service/onedrive/consts"
 	"github.com/alcionai/corso/src/internal/m365/support"
 	"github.com/alcionai/corso/src/internal/observe"
+	bupMD "github.com/alcionai/corso/src/pkg/backup/metadata"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
@@ -120,10 +121,10 @@ func deserializeMetadata(
 				)
 
 				switch item.ID() {
-				case graph.PreviousPathFileName:
+				case bupMD.PreviousPathFileName:
 					err = deserializeMap(item.ToReader(), prevFolders)
 
-				case graph.DeltaURLsFileName:
+				case bupMD.DeltaURLsFileName:
 					err = deserializeMap(item.ToReader(), prevDeltas)
 
 				default:
@@ -449,8 +450,8 @@ func (c *Collections) Get(
 	md, err := graph.MakeMetadataCollection(
 		pathPrefix,
 		[]graph.MetadataCollectionEntry{
-			graph.NewMetadataEntry(graph.PreviousPathFileName, folderPaths),
-			graph.NewMetadataEntry(graph.DeltaURLsFileName, deltaURLs),
+			graph.NewMetadataEntry(bupMD.PreviousPathFileName, folderPaths),
+			graph.NewMetadataEntry(bupMD.DeltaURLsFileName, deltaURLs),
 		},
 		c.statusUpdater)
 

--- a/src/internal/m365/collection/drive/collections_test.go
+++ b/src/internal/m365/collection/drive/collections_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/service/onedrive/mock"
 	"github.com/alcionai/corso/src/internal/m365/support"
 	"github.com/alcionai/corso/src/internal/tester"
+	bupMD "github.com/alcionai/corso/src/pkg/backup/metadata"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -815,11 +816,11 @@ func (suite *OneDriveCollectionsUnitSuite) TestDeserializeMetadata() {
 				func() []graph.MetadataCollectionEntry {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
-							graph.DeltaURLsFileName,
+							bupMD.DeltaURLsFileName,
 							map[string]string{driveID1: deltaURL1},
 						),
 						graph.NewMetadataEntry(
-							graph.PreviousPathFileName,
+							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
 								driveID1: {
 									folderID1: path1,
@@ -846,7 +847,7 @@ func (suite *OneDriveCollectionsUnitSuite) TestDeserializeMetadata() {
 				func() []graph.MetadataCollectionEntry {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
-							graph.DeltaURLsFileName,
+							bupMD.DeltaURLsFileName,
 							map[string]string{driveID1: deltaURL1},
 						),
 					}
@@ -863,7 +864,7 @@ func (suite *OneDriveCollectionsUnitSuite) TestDeserializeMetadata() {
 				func() []graph.MetadataCollectionEntry {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
-							graph.PreviousPathFileName,
+							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
 								driveID1: {
 									folderID1: path1,
@@ -891,11 +892,11 @@ func (suite *OneDriveCollectionsUnitSuite) TestDeserializeMetadata() {
 				func() []graph.MetadataCollectionEntry {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
-							graph.DeltaURLsFileName,
+							bupMD.DeltaURLsFileName,
 							map[string]string{driveID1: deltaURL1},
 						),
 						graph.NewMetadataEntry(
-							graph.PreviousPathFileName,
+							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
 								driveID1: {},
 							},
@@ -917,13 +918,13 @@ func (suite *OneDriveCollectionsUnitSuite) TestDeserializeMetadata() {
 				func() []graph.MetadataCollectionEntry {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
-							graph.DeltaURLsFileName,
+							bupMD.DeltaURLsFileName,
 							map[string]string{
 								driveID1: "",
 							},
 						),
 						graph.NewMetadataEntry(
-							graph.PreviousPathFileName,
+							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
 								driveID1: {
 									folderID1: path1,
@@ -948,11 +949,11 @@ func (suite *OneDriveCollectionsUnitSuite) TestDeserializeMetadata() {
 				func() []graph.MetadataCollectionEntry {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
-							graph.DeltaURLsFileName,
+							bupMD.DeltaURLsFileName,
 							map[string]string{driveID1: deltaURL1},
 						),
 						graph.NewMetadataEntry(
-							graph.PreviousPathFileName,
+							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
 								driveID1: {
 									folderID1: path1,
@@ -964,11 +965,11 @@ func (suite *OneDriveCollectionsUnitSuite) TestDeserializeMetadata() {
 				func() []graph.MetadataCollectionEntry {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
-							graph.DeltaURLsFileName,
+							bupMD.DeltaURLsFileName,
 							map[string]string{driveID2: deltaURL2},
 						),
 						graph.NewMetadataEntry(
-							graph.PreviousPathFileName,
+							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
 								driveID2: {
 									folderID2: path2,
@@ -1001,7 +1002,7 @@ func (suite *OneDriveCollectionsUnitSuite) TestDeserializeMetadata() {
 				func() []graph.MetadataCollectionEntry {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
-							graph.PreviousPathFileName,
+							bupMD.PreviousPathFileName,
 							map[string]string{driveID1: deltaURL1},
 						),
 					}
@@ -1018,11 +1019,11 @@ func (suite *OneDriveCollectionsUnitSuite) TestDeserializeMetadata() {
 				func() []graph.MetadataCollectionEntry {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
-							graph.DeltaURLsFileName,
+							bupMD.DeltaURLsFileName,
 							map[string]string{driveID1: deltaURL1},
 						),
 						graph.NewMetadataEntry(
-							graph.PreviousPathFileName,
+							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
 								driveID1: {
 									folderID1: path1,
@@ -1053,11 +1054,11 @@ func (suite *OneDriveCollectionsUnitSuite) TestDeserializeMetadata() {
 				func() []graph.MetadataCollectionEntry {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
-							graph.DeltaURLsFileName,
+							bupMD.DeltaURLsFileName,
 							map[string]string{driveID1: deltaURL1},
 						),
 						graph.NewMetadataEntry(
-							graph.PreviousPathFileName,
+							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
 								driveID1: {
 									folderID1: path1,
@@ -1069,7 +1070,7 @@ func (suite *OneDriveCollectionsUnitSuite) TestDeserializeMetadata() {
 				func() []graph.MetadataCollectionEntry {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
-							graph.PreviousPathFileName,
+							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
 								driveID1: {
 									folderID2: path2,
@@ -1090,11 +1091,11 @@ func (suite *OneDriveCollectionsUnitSuite) TestDeserializeMetadata() {
 				func() []graph.MetadataCollectionEntry {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
-							graph.DeltaURLsFileName,
+							bupMD.DeltaURLsFileName,
 							map[string]string{driveID1: deltaURL1},
 						),
 						graph.NewMetadataEntry(
-							graph.PreviousPathFileName,
+							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
 								driveID1: {
 									folderID1: path1,
@@ -1106,7 +1107,7 @@ func (suite *OneDriveCollectionsUnitSuite) TestDeserializeMetadata() {
 				func() []graph.MetadataCollectionEntry {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
-							graph.DeltaURLsFileName,
+							bupMD.DeltaURLsFileName,
 							map[string]string{driveID1: deltaURL2},
 						),
 					}
@@ -2304,13 +2305,13 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 				pathPrefix,
 				[]graph.MetadataCollectionEntry{
 					graph.NewMetadataEntry(
-						graph.DeltaURLsFileName,
+						bupMD.DeltaURLsFileName,
 						map[string]string{
 							driveID1: prevDelta,
 							driveID2: prevDelta,
 						}),
 					graph.NewMetadataEntry(
-						graph.PreviousPathFileName,
+						bupMD.PreviousPathFileName,
 						test.prevFolderPaths),
 				},
 				func(*support.ControllerOperationStatus) {},

--- a/src/internal/m365/collection/exchange/backup.go
+++ b/src/internal/m365/collection/exchange/backup.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/support"
 	"github.com/alcionai/corso/src/internal/observe"
 	"github.com/alcionai/corso/src/internal/operations/inject"
+	"github.com/alcionai/corso/src/pkg/backup/metadata"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
@@ -29,7 +30,7 @@ func CreateCollections(
 	handlers map[path.CategoryType]backupHandler,
 	tenantID string,
 	scope selectors.ExchangeScope,
-	dps DeltaPaths,
+	dps metadata.DeltaPaths,
 	su support.StatusUpdater,
 	errs *fault.Bus,
 ) ([]data.BackupCollection, error) {
@@ -98,7 +99,7 @@ func populateCollections(
 	statusUpdater support.StatusUpdater,
 	resolver graph.ContainerResolver,
 	scope selectors.ExchangeScope,
-	dps DeltaPaths,
+	dps metadata.DeltaPaths,
 	ctrlOpts control.Options,
 	errs *fault.Bus,
 ) (map[string]data.BackupCollection, error) {
@@ -280,8 +281,8 @@ func populateCollections(
 	col, err := graph.MakeMetadataCollection(
 		pathPrefix,
 		[]graph.MetadataCollectionEntry{
-			graph.NewMetadataEntry(graph.PreviousPathFileName, currPaths),
-			graph.NewMetadataEntry(graph.DeltaURLsFileName, deltaURLs),
+			graph.NewMetadataEntry(metadata.PreviousPathFileName, currPaths),
+			graph.NewMetadataEntry(metadata.DeltaURLsFileName, deltaURLs),
 		},
 		statusUpdater)
 	if err != nil {
@@ -296,7 +297,7 @@ func populateCollections(
 // produces a set of id:path pairs from the deltapaths map.
 // Each entry in the set will, if not removed, produce a collection
 // that will delete the tombstone by path.
-func makeTombstones(dps DeltaPaths) map[string]string {
+func makeTombstones(dps metadata.DeltaPaths) map[string]string {
 	r := make(map[string]string, len(dps))
 
 	for id, v := range dps {

--- a/src/internal/m365/collection/groups/backup.go
+++ b/src/internal/m365/collection/groups/backup.go
@@ -5,14 +5,15 @@ import (
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
-	"golang.org/x/exp/maps"
 
+	"github.com/alcionai/corso/src/internal/common/pii"
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/m365/support"
 	"github.com/alcionai/corso/src/internal/observe"
 	"github.com/alcionai/corso/src/internal/operations/inject"
+	"github.com/alcionai/corso/src/pkg/backup/metadata"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
@@ -34,10 +35,9 @@ func CreateCollections(
 	bh backupHandler,
 	tenantID string,
 	scope selectors.GroupsScope,
-	// dps DeltaPaths,
 	su support.StatusUpdater,
 	errs *fault.Bus,
-) ([]data.BackupCollection, error) {
+) ([]data.BackupCollection, bool, error) {
 	ctx = clues.Add(ctx, "category", scope.Category().PathType())
 
 	var (
@@ -50,6 +50,13 @@ func CreateCollections(
 		}
 	)
 
+	cdps, canUsePreviousBackup, err := parseMetadataCollections(ctx, bpc.MetadataCollections)
+	if err != nil {
+		return nil, false, err
+	}
+
+	ctx = clues.Add(ctx, "can_use_previous_backup", canUsePreviousBackup)
+
 	catProgress := observe.MessageWithCompletion(
 		ctx,
 		observe.Bulletf("%s", qp.Category))
@@ -57,7 +64,7 @@ func CreateCollections(
 
 	channels, err := bh.getChannels(ctx)
 	if err != nil {
-		return nil, clues.Stack(err)
+		return nil, false, clues.Stack(err)
 	}
 
 	collections, err := populateCollections(
@@ -67,18 +74,18 @@ func CreateCollections(
 		su,
 		channels,
 		scope,
-		// dps,
+		cdps[scope.Category().PathType()],
 		bpc.Options,
 		errs)
 	if err != nil {
-		return nil, clues.Wrap(err, "filling collections")
+		return nil, false, clues.Wrap(err, "filling collections")
 	}
 
 	for _, coll := range collections {
 		allCollections = append(allCollections, coll)
 	}
 
-	return allCollections, nil
+	return allCollections, canUsePreviousBackup, nil
 }
 
 func populateCollections(
@@ -88,84 +95,88 @@ func populateCollections(
 	statusUpdater support.StatusUpdater,
 	channels []models.Channelable,
 	scope selectors.GroupsScope,
-	// dps DeltaPaths,
+	dps metadata.DeltaPaths,
 	ctrlOpts control.Options,
 	errs *fault.Bus,
 ) (map[string]data.BackupCollection, error) {
-	// channel ID -> BackupCollection.
-	channelCollections := map[string]data.BackupCollection{}
+	var (
+		// channel ID -> BackupCollection.
+		collections = map[string]data.BackupCollection{}
+		// channel ID -> delta url or folder path lookups
+		deltaURLs = map[string]string{}
+		currPaths = map[string]string{}
+		// copy of previousPaths.  every channel present in the slice param
+		// gets removed from this map; the remaining channels at the end of
+		// the process have been deleted.
+		tombstones = makeTombstones(dps)
+		el         = errs.Local()
+	)
 
-	// channel ID -> delta url or folder path lookups
-	// deltaURLs = map[string]string{}
-	// currPaths = map[string]string{}
-	// copy of previousPaths.  every channel present in the slice param
-	// gets removed from this map; the remaining channels at the end of
-	// the process have been deleted.
-	// tombstones = makeTombstones(dps)
-
-	logger.Ctx(ctx).Info("filling collections")
-	// , "len_deltapaths", len(dps))
-
-	el := errs.Local()
+	logger.Ctx(ctx).Info("filling collections", "len_deltapaths", len(dps))
 
 	for _, c := range channels {
 		if el.Failure() != nil {
 			return nil, el.Failure()
 		}
 
-		// delete(tombstones, cID)
-
 		var (
-			cID   = ptr.Val(c.GetId())
-			cName = ptr.Val(c.GetDisplayName())
-			err   error
-			// dp          = dps[cID]
-			// prevDelta   = dp.Delta
-			// prevPathStr = dp.Path // do not log: pii; log prevPath instead
-			// prevPath    path.Path
-			ictx = clues.Add(
+			cID         = ptr.Val(c.GetId())
+			cName       = ptr.Val(c.GetDisplayName())
+			err         error
+			dp          = dps[cID]
+			prevDelta   = dp.Delta
+			prevPathStr = dp.Path // do not log: pii; log prevPath instead
+			prevPath    path.Path
+			ictx        = clues.Add(
 				ctx,
-				"channel_id", cID)
-			// "previous_delta", pii.SafeURL{
-			// 	URL:           prevDelta,
-			// 	SafePathElems: graph.SafeURLPathParams,
-			// 	SafeQueryKeys: graph.SafeURLQueryParams,
-			// })
+				"channel_id", cID,
+				"previous_delta", pii.SafeURL{
+					URL:           prevDelta,
+					SafePathElems: graph.SafeURLPathParams,
+					SafeQueryKeys: graph.SafeURLQueryParams,
+				})
 		)
+
+		delete(tombstones, cID)
 
 		// Only create a collection if the path matches the scope.
 		if !bh.includeContainer(ictx, qp, c, scope) {
 			continue
 		}
 
-		// if len(prevPathStr) > 0 {
-		// 	if prevPath, err = pathFromPrevString(prevPathStr); err != nil {
-		// 		logger.CtxErr(ictx, err).Error("parsing prev path")
-		// 		// if the previous path is unusable, then the delta must be, too.
-		// 		prevDelta = ""
-		// 	}
-		// }
+		if len(prevPathStr) > 0 {
+			if prevPath, err = pathFromPrevString(prevPathStr); err != nil {
+				logger.CtxErr(ictx, err).Error("parsing prev path")
+				// if the previous path is unusable, then the delta must be, too.
+				prevDelta = ""
+			}
+		}
 
-		// ictx = clues.Add(ictx, "previous_path", prevPath)
+		ictx = clues.Add(ictx, "previous_path", prevPath)
 
-		added, removed, _, err := bh.getChannelMessageIDsDelta(ctx, cID, "")
+		added, removed, du, err := bh.getChannelMessageIDsDelta(ctx, cID, prevDelta)
 		if err != nil {
 			el.AddRecoverable(ctx, clues.Stack(err))
 			continue
 		}
 
-		// if len(newDelta.URL) > 0 {
-		// 	deltaURLs[cID] = newDelta.URL
-		// } else if !newDelta.Reset {
-		// 	logger.Ctx(ictx).Info("missing delta url")
-		// }
-
-		var prevPath path.Path
+		if len(du.URL) > 0 {
+			deltaURLs[cID] = du.URL
+		} else if !du.Reset {
+			logger.Ctx(ictx).Info("missing delta url")
+		}
 
 		currPath, err := bh.canonicalPath(path.Builder{}.Append(cID), qp.TenantID)
 		if err != nil {
 			el.AddRecoverable(ctx, clues.Stack(err))
 			continue
+		}
+
+		// Remove any deleted IDs from the set of added IDs because items that are
+		// deleted and then restored will have a different ID than they did
+		// originally.
+		for remove := range removed {
+			delete(added, remove)
 		}
 
 		edc := NewCollection(
@@ -175,50 +186,93 @@ func populateCollections(
 			prevPath,
 			path.Builder{}.Append(cName),
 			qp.Category,
+			added,
+			removed,
 			statusUpdater,
-			ctrlOpts)
+			ctrlOpts,
+			du.Reset)
 
-		channelCollections[cID] = &edc
+		collections[cID] = &edc
 
-		// Remove any deleted IDs from the set of added IDs because items that are
-		// deleted and then restored will have a different ID than they did
-		// originally.
-		for remove := range removed {
-			delete(edc.added, remove)
-			edc.removed[remove] = struct{}{}
-		}
-
-		// // add the current path for the container ID to be used in the next backup
-		// // as the "previous path", for reference in case of a rename or relocation.
-		// currPaths[cID] = currPath.String()
-
-		// FIXME: normally this goes before removal, but the linters require no bottom comments
-		maps.Copy(edc.added, added)
-		maps.Copy(edc.removed, removed)
+		// add the current path for the container ID to be used in the next backup
+		// as the "previous path", for reference in case of a rename or relocation.
+		currPaths[cID] = currPath.String()
 	}
 
-	// TODO: handle tombstones here
+	// A tombstone is a channel that needs to be marked for deletion.
+	// The only situation where a tombstone should appear is if the channel exists
+	// in the `previousPath` set, but does not exist in the enumeration.
+	for id, p := range tombstones {
+		if el.Failure() != nil {
+			return nil, el.Failure()
+		}
+
+		var (
+			err  error
+			ictx = clues.Add(ctx, "tombstone_id", id)
+		)
+
+		if collections[id] != nil {
+			el.AddRecoverable(ctx, clues.Wrap(err, "conflict: tombstone exists for a live collection").WithClues(ictx))
+			continue
+		}
+
+		// only occurs if it was a new folder that we picked up during the container
+		// resolver phase that got deleted in flight by the time we hit this stage.
+		if len(p) == 0 {
+			continue
+		}
+
+		prevPath, err := pathFromPrevString(p)
+		if err != nil {
+			// technically shouldn't ever happen.  But just in case...
+			logger.CtxErr(ictx, err).Error("parsing tombstone prev path")
+			continue
+		}
+
+		edc := NewCollection(
+			bh,
+			qp.ProtectedResource.ID(),
+			nil, // marks the collection as deleted
+			prevPath,
+			nil, // tombstones don't need a location
+			qp.Category,
+			nil, // no items added
+			nil, // this deletes a directory, so no items deleted either
+			statusUpdater,
+			ctrlOpts,
+			false)
+
+		collections[id] = &edc
+	}
 
 	logger.Ctx(ctx).Infow(
 		"adding metadata collection entries",
-		// "num_deltas_entries", len(deltaURLs),
-		"num_paths_entries", len(channelCollections))
+		"num_deltas_entries", len(deltaURLs),
+		"num_paths_entries", len(collections))
 
-	// col, err := graph.MakeMetadataCollection(
-	// 	qp.TenantID,
-	// 	qp.ProtectedResource.ID(),
-	// 	path.ExchangeService,
-	// 	qp.Category,
-	// 	[]graph.MetadataCollectionEntry{
-	// 		graph.NewMetadataEntry(graph.PreviousPathFileName, currPaths),
-	// 		graph.NewMetadataEntry(graph.DeltaURLsFileName, deltaURLs),
-	// 	},
-	// 	statusUpdater)
-	// if err != nil {
-	// 	return nil, clues.Wrap(err, "making metadata collection")
-	// }
+	pathPrefix, err := path.Builder{}.ToServiceCategoryMetadataPath(
+		qp.TenantID,
+		qp.ProtectedResource.ID(),
+		path.GroupsService,
+		qp.Category,
+		false)
+	if err != nil {
+		return nil, clues.Wrap(err, "making metadata path")
+	}
 
-	// channelCollections["metadata"] = col
+	col, err := graph.MakeMetadataCollection(
+		pathPrefix,
+		[]graph.MetadataCollectionEntry{
+			graph.NewMetadataEntry(metadata.PreviousPathFileName, currPaths),
+			graph.NewMetadataEntry(metadata.DeltaURLsFileName, deltaURLs),
+		},
+		statusUpdater)
+	if err != nil {
+		return nil, clues.Wrap(err, "making metadata collection")
+	}
 
-	return channelCollections, el.Failure()
+	collections["metadata"] = col
+
+	return collections, el.Failure()
 }

--- a/src/internal/m365/collection/groups/backup.go
+++ b/src/internal/m365/collection/groups/backup.go
@@ -148,7 +148,7 @@ func populateCollections(
 
 		// ictx = clues.Add(ictx, "previous_path", prevPath)
 
-		items, _, err := bh.getChannelMessageIDsDelta(ctx, cID, "")
+		added, removed, _, err := bh.getChannelMessageIDsDelta(ctx, cID, "")
 		if err != nil {
 			el.AddRecoverable(ctx, clues.Stack(err))
 			continue
@@ -180,21 +180,21 @@ func populateCollections(
 
 		channelCollections[cID] = &edc
 
-		// TODO: handle deleted items for v1 backup.
-		// // Remove any deleted IDs from the set of added IDs because items that are
-		// // deleted and then restored will have a different ID than they did
-		// // originally.
-		// for _, remove := range removed {
-		// 	delete(edc.added, remove)
-		// 	edc.removed[remove] = struct{}{}
-		// }
+		// Remove any deleted IDs from the set of added IDs because items that are
+		// deleted and then restored will have a different ID than they did
+		// originally.
+		for remove := range removed {
+			delete(edc.added, remove)
+			edc.removed[remove] = struct{}{}
+		}
 
 		// // add the current path for the container ID to be used in the next backup
 		// // as the "previous path", for reference in case of a rename or relocation.
 		// currPaths[cID] = currPath.String()
 
 		// FIXME: normally this goes before removal, but the linters require no bottom comments
-		maps.Copy(edc.added, items)
+		maps.Copy(edc.added, added)
+		maps.Copy(edc.removed, removed)
 	}
 
 	// TODO: handle tombstones here

--- a/src/internal/m365/collection/groups/backup_test.go
+++ b/src/internal/m365/collection/groups/backup_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/backup/metadata"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -116,19 +117,15 @@ func (suite *BackupUnitSuite) TestPopulateCollections() {
 			TenantID:          suite.creds.AzureTenantID,
 		}
 		statusUpdater = func(*support.ControllerOperationStatus) {}
-		allScope      = selectors.NewGroupsBackup(nil).Channels(selectors.Any())[0]
 	)
 
 	table := []struct {
-		name                  string
-		mock                  mockBackupHandler
-		scope                 selectors.GroupsScope
-		failFast              control.FailurePolicy
-		expectErr             require.ErrorAssertionFunc
-		expectColls           int
-		expectNewColls        int
-		expectMetadataColls   int
-		expectDoNotMergeColls int
+		name                string
+		mock                mockBackupHandler
+		expectErr           require.ErrorAssertionFunc
+		expectColls         int
+		expectNewColls      int
+		expectMetadataColls int
 	}{
 		{
 			name: "happy path, one container",
@@ -136,12 +133,10 @@ func (suite *BackupUnitSuite) TestPopulateCollections() {
 				channels:   testdata.StubChannels("one"),
 				messageIDs: map[string]struct{}{"msg-one": {}},
 			},
-			scope:                 allScope,
-			expectErr:             require.NoError,
-			expectColls:           1,
-			expectNewColls:        1,
-			expectMetadataColls:   0,
-			expectDoNotMergeColls: 1,
+			expectErr:           require.NoError,
+			expectColls:         2,
+			expectNewColls:      1,
+			expectMetadataColls: 1,
 		},
 		{
 			name: "happy path, one container, only deleted messages",
@@ -149,12 +144,10 @@ func (suite *BackupUnitSuite) TestPopulateCollections() {
 				channels:      testdata.StubChannels("one"),
 				deletedMsgIDs: map[string]struct{}{"msg-one": {}},
 			},
-			scope:                 allScope,
-			expectErr:             require.NoError,
-			expectColls:           1,
-			expectNewColls:        1,
-			expectMetadataColls:   0,
-			expectDoNotMergeColls: 1,
+			expectErr:           require.NoError,
+			expectColls:         2,
+			expectNewColls:      1,
+			expectMetadataColls: 1,
 		},
 		{
 			name: "happy path, many containers",
@@ -162,12 +155,10 @@ func (suite *BackupUnitSuite) TestPopulateCollections() {
 				channels:   testdata.StubChannels("one", "two"),
 				messageIDs: map[string]struct{}{"msg-one": {}},
 			},
-			scope:                 allScope,
-			expectErr:             require.NoError,
-			expectColls:           2,
-			expectNewColls:        2,
-			expectMetadataColls:   0,
-			expectDoNotMergeColls: 2,
+			expectErr:           require.NoError,
+			expectColls:         3,
+			expectNewColls:      2,
+			expectMetadataColls: 1,
 		},
 		{
 			name: "no containers pass scope",
@@ -175,34 +166,28 @@ func (suite *BackupUnitSuite) TestPopulateCollections() {
 				channels:     testdata.StubChannels("one"),
 				doNotInclude: true,
 			},
-			scope:                 selectors.NewGroupsBackup(nil).Channels(selectors.None())[0],
-			expectErr:             require.NoError,
-			expectColls:           0,
-			expectNewColls:        0,
-			expectMetadataColls:   0,
-			expectDoNotMergeColls: 0,
+			expectErr:           require.NoError,
+			expectColls:         1,
+			expectNewColls:      0,
+			expectMetadataColls: 1,
 		},
 		{
-			name:                  "no channels",
-			mock:                  mockBackupHandler{},
-			scope:                 allScope,
-			expectErr:             require.NoError,
-			expectColls:           0,
-			expectNewColls:        0,
-			expectMetadataColls:   0,
-			expectDoNotMergeColls: 0,
+			name:                "no channels",
+			mock:                mockBackupHandler{},
+			expectErr:           require.NoError,
+			expectColls:         1,
+			expectNewColls:      0,
+			expectMetadataColls: 1,
 		},
 		{
 			name: "no channel messages",
 			mock: mockBackupHandler{
 				channels: testdata.StubChannels("one"),
 			},
-			scope:                 allScope,
-			expectErr:             require.NoError,
-			expectColls:           1,
-			expectNewColls:        1,
-			expectMetadataColls:   0,
-			expectDoNotMergeColls: 1,
+			expectErr:           require.NoError,
+			expectColls:         2,
+			expectNewColls:      1,
+			expectMetadataColls: 1,
 		},
 		{
 			name: "err: deleted in flight",
@@ -210,12 +195,10 @@ func (suite *BackupUnitSuite) TestPopulateCollections() {
 				channels:    testdata.StubChannels("one"),
 				messagesErr: graph.ErrDeletedInFlight,
 			},
-			scope:                 allScope,
-			expectErr:             require.Error,
-			expectColls:           0,
-			expectNewColls:        0,
-			expectMetadataColls:   0,
-			expectDoNotMergeColls: 0,
+			expectErr:           require.Error,
+			expectColls:         1,
+			expectNewColls:      0,
+			expectMetadataColls: 1,
 		},
 		{
 			name: "err: other error",
@@ -223,32 +206,20 @@ func (suite *BackupUnitSuite) TestPopulateCollections() {
 				channels:    testdata.StubChannels("one"),
 				messagesErr: assert.AnError,
 			},
-			scope:                 allScope,
-			expectErr:             require.Error,
-			expectColls:           0,
-			expectNewColls:        0,
-			expectMetadataColls:   0,
-			expectDoNotMergeColls: 0,
+			expectErr:           require.Error,
+			expectColls:         1,
+			expectNewColls:      0,
+			expectMetadataColls: 1,
 		},
 	}
 	for _, test := range table {
-		// for _, canMakeDeltaQueries := range []bool{true, false} {
-		name := test.name
-
-		// 	if canMakeDeltaQueries {
-		// 		name += "-delta"
-		// 	} else {
-		// 		name += "-non-delta"
-		// 	}
-
-		suite.Run(name, func() {
+		suite.Run(test.name, func() {
 			t := suite.T()
 
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			ctrlOpts := control.Options{FailureHandling: test.failFast}
-			// ctrlOpts.ToggleFeatures.DisableDelta = !canMakeDeltaQueries
+			ctrlOpts := control.Options{FailureHandling: control.FailFast}
 
 			collections, err := populateCollections(
 				ctx,
@@ -256,7 +227,8 @@ func (suite *BackupUnitSuite) TestPopulateCollections() {
 				test.mock,
 				statusUpdater,
 				test.mock.channels,
-				test.scope,
+				selectors.NewGroupsBackup(nil).Channels(selectors.Any())[0],
+				nil,
 				ctrlOpts,
 				fault.New(true))
 			test.expectErr(t, err, clues.ToCore(err))
@@ -287,12 +259,168 @@ func (suite *BackupUnitSuite) TestPopulateCollections() {
 			assert.Zero(t, deleteds, "deleted collections")
 			assert.Equal(t, test.expectNewColls, news, "new collections")
 			assert.Equal(t, test.expectMetadataColls, metadatas, "metadata collections")
-			assert.Equal(t, test.expectDoNotMergeColls, doNotMerges, "doNotMerge collections")
 		})
 	}
 }
 
-// }
+func (suite *BackupUnitSuite) TestPopulateCollections_incremental() {
+	var (
+		qp = graph.QueryParams{
+			Category:          path.ChannelMessagesCategory, // doesn't matter which one we use.
+			ProtectedResource: inMock.NewProvider("group_id", "user_name"),
+			TenantID:          suite.creds.AzureTenantID,
+		}
+		statusUpdater = func(*support.ControllerOperationStatus) {}
+		allScope      = selectors.NewGroupsBackup(nil).Channels(selectors.Any())[0]
+	)
+
+	chanPath, err := path.Build("tid", "grp", path.GroupsService, path.ChannelMessagesCategory, false, "chan")
+	require.NoError(suite.T(), err, clues.ToCore(err))
+
+	table := []struct {
+		name                string
+		mock                mockBackupHandler
+		deltaPaths          metadata.DeltaPaths
+		expectErr           require.ErrorAssertionFunc
+		expectColls         int
+		expectNewColls      int
+		expectTombstoneCols int
+		expectMetadataColls int
+	}{
+		{
+			name: "non incremental",
+			mock: mockBackupHandler{
+				channels:   testdata.StubChannels("chan"),
+				messageIDs: map[string]struct{}{"msg": {}},
+			},
+			deltaPaths:          metadata.DeltaPaths{},
+			expectErr:           require.NoError,
+			expectColls:         2,
+			expectNewColls:      1,
+			expectTombstoneCols: 0,
+			expectMetadataColls: 1,
+		},
+		{
+			name: "incremental",
+			mock: mockBackupHandler{
+				channels:      testdata.StubChannels("chan"),
+				deletedMsgIDs: map[string]struct{}{"msg": {}},
+			},
+			deltaPaths: metadata.DeltaPaths{
+				"chan": {
+					Delta: "chan",
+					Path:  chanPath.String(),
+				},
+			},
+			expectErr:           require.NoError,
+			expectColls:         2,
+			expectNewColls:      0,
+			expectTombstoneCols: 0,
+			expectMetadataColls: 1,
+		},
+		{
+			name: "incremental no new messages",
+			mock: mockBackupHandler{
+				channels: testdata.StubChannels("chan"),
+			},
+			deltaPaths: metadata.DeltaPaths{
+				"chan": {
+					Delta: "chan",
+					Path:  chanPath.String(),
+				},
+			},
+			expectErr:           require.NoError,
+			expectColls:         2,
+			expectNewColls:      0,
+			expectTombstoneCols: 0,
+			expectMetadataColls: 1,
+		},
+		{
+			name: "incremental deleted channel",
+			mock: mockBackupHandler{
+				channels: testdata.StubChannels(),
+			},
+			deltaPaths: metadata.DeltaPaths{
+				"chan": {
+					Delta: "chan",
+					Path:  chanPath.String(),
+				},
+			},
+			expectErr:           require.NoError,
+			expectColls:         2,
+			expectNewColls:      0,
+			expectTombstoneCols: 1,
+			expectMetadataColls: 1,
+		},
+		{
+			name: "incremental new and deleted channel",
+			mock: mockBackupHandler{
+				channels:   testdata.StubChannels("chan2"),
+				messageIDs: map[string]struct{}{"msg": {}},
+			},
+			deltaPaths: metadata.DeltaPaths{
+				"chan": {
+					Delta: "chan",
+					Path:  chanPath.String(),
+				},
+			},
+			expectErr:           require.NoError,
+			expectColls:         3,
+			expectNewColls:      1,
+			expectTombstoneCols: 1,
+			expectMetadataColls: 1,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			ctrlOpts := control.Options{FailureHandling: control.FailFast}
+
+			collections, err := populateCollections(
+				ctx,
+				qp,
+				test.mock,
+				statusUpdater,
+				test.mock.channels,
+				allScope,
+				test.deltaPaths,
+				ctrlOpts,
+				fault.New(true))
+			test.expectErr(t, err, clues.ToCore(err))
+			assert.Len(t, collections, test.expectColls, "number of collections")
+
+			// collection assertions
+
+			tombstones, news, metadatas, doNotMerges := 0, 0, 0, 0
+			for _, c := range collections {
+				if c.FullPath() != nil && c.FullPath().Service() == path.GroupsMetadataService {
+					metadatas++
+					continue
+				}
+
+				if c.State() == data.DeletedState {
+					tombstones++
+				}
+
+				if c.State() == data.NewState {
+					news++
+				}
+
+				if c.DoNotMergeItems() {
+					doNotMerges++
+				}
+			}
+
+			assert.Equal(t, test.expectNewColls, news, "new collections")
+			assert.Equal(t, test.expectTombstoneCols, tombstones, "tombstone collections")
+			assert.Equal(t, test.expectMetadataColls, metadatas, "metadata collections")
+		})
+	}
+}
 
 // ---------------------------------------------------------------------------
 // Integration tests
@@ -341,18 +469,16 @@ func (suite *BackupIntgSuite) TestCreateCollections() {
 	)
 
 	tests := []struct {
-		name                string
-		scope               selectors.GroupsScope
-		channelNames        map[string]struct{}
-		canMakeDeltaQueries bool
+		name         string
+		scope        selectors.GroupsScope
+		channelNames map[string]struct{}
 	}{
 		{
-			name:  "channel messages non-delta",
+			name:  "channel messages",
 			scope: selTD.GroupsBackupChannelScope(selectors.NewGroupsBackup(resources))[0],
 			channelNames: map[string]struct{}{
 				selTD.TestChannelName: {},
 			},
-			canMakeDeltaQueries: false,
 		},
 	}
 
@@ -364,7 +490,6 @@ func (suite *BackupIntgSuite) TestCreateCollections() {
 			defer flush()
 
 			ctrlOpts := control.DefaultOptions()
-			ctrlOpts.ToggleFeatures.DisableDelta = !test.canMakeDeltaQueries
 
 			sel := selectors.NewGroupsBackup([]string{protectedResource})
 			sel.Include(selTD.GroupsBackupChannelScope(sel))
@@ -376,7 +501,7 @@ func (suite *BackupIntgSuite) TestCreateCollections() {
 				Selector:          sel.Selector,
 			}
 
-			collections, err := CreateCollections(
+			collections, _, err := CreateCollections(
 				ctx,
 				bpc,
 				handler,

--- a/src/internal/m365/collection/groups/channel_handler.go
+++ b/src/internal/m365/collection/groups/channel_handler.go
@@ -39,7 +39,7 @@ func (bh channelsBackupHandler) getChannels(
 func (bh channelsBackupHandler) getChannelMessageIDsDelta(
 	ctx context.Context,
 	channelID, prevDelta string,
-) (map[string]struct{}, api.DeltaUpdate, error) {
+) (map[string]struct{}, map[string]struct{}, api.DeltaUpdate, error) {
 	return bh.ac.GetChannelMessageIDsDelta(ctx, bh.protectedResource, channelID, prevDelta)
 }
 

--- a/src/internal/m365/collection/groups/collection.go
+++ b/src/internal/m365/collection/groups/collection.go
@@ -64,7 +64,7 @@ type Collection struct {
 	state data.CollectionState
 
 	// doNotMergeItems should only be true if the old delta token expired.
-	// doNotMergeItems bool
+	doNotMergeItems bool
 }
 
 // NewExchangeDataCollection creates an ExchangeDataCollection.
@@ -79,20 +79,22 @@ func NewCollection(
 	curr, prev path.Path,
 	location *path.Builder,
 	category path.CategoryType,
+	added map[string]struct{},
+	removed map[string]struct{},
 	statusUpdater support.StatusUpdater,
 	ctrlOpts control.Options,
-	// doNotMergeItems bool,
+	doNotMergeItems bool,
 ) Collection {
 	collection := Collection{
-		added:    map[string]struct{}{},
-		category: category,
-		ctrl:     ctrlOpts,
-		// doNotMergeItems:   doNotMergeItems,
+		added:             added,
+		category:          category,
+		ctrl:              ctrlOpts,
+		doNotMergeItems:   doNotMergeItems,
 		fullPath:          curr,
 		getter:            getter,
 		locationPath:      location,
 		prevPath:          prev,
-		removed:           make(map[string]struct{}, 0),
+		removed:           removed,
 		state:             data.StateOf(prev, curr),
 		statusUpdater:     statusUpdater,
 		stream:            make(chan data.Item, collectionChannelBufferSize),

--- a/src/internal/m365/collection/groups/collection_test.go
+++ b/src/internal/m365/collection/groups/collection_test.go
@@ -124,8 +124,10 @@ func (suite *CollectionSuite) TestNewCollection_state() {
 				"g",
 				test.curr, test.prev, test.loc,
 				0,
+				nil, nil,
 				nil,
-				control.DefaultOptions())
+				control.DefaultOptions(),
+				false)
 			assert.Equal(t, test.expect, c.State(), "collection state")
 			assert.Equal(t, test.curr, c.fullPath, "full path")
 			assert.Equal(t, test.prev, c.prevPath, "prev path")

--- a/src/internal/m365/collection/groups/handlers.go
+++ b/src/internal/m365/collection/groups/handlers.go
@@ -24,7 +24,7 @@ type backupHandler interface {
 	getChannelMessageIDsDelta(
 		ctx context.Context,
 		channelID, prevDelta string,
-	) (map[string]struct{}, api.DeltaUpdate, error)
+	) (map[string]struct{}, map[string]struct{}, api.DeltaUpdate, error)
 
 	// includeContainer evaluates whether the channel is included
 	// in the provided scope.

--- a/src/internal/m365/collection/groups/testdata/channels.go
+++ b/src/internal/m365/collection/groups/testdata/channels.go
@@ -7,13 +7,13 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 )
 
-func StubChannels(names ...string) []models.Channelable {
-	sl := make([]models.Channelable, 0, len(names))
+func StubChannels(ids ...string) []models.Channelable {
+	sl := make([]models.Channelable, 0, len(ids))
 
-	for _, name := range names {
+	for _, id := range ids {
 		ch := models.NewChannel()
-		ch.SetDisplayName(ptr.To(name))
-		ch.SetId(ptr.To(uuid.NewString()))
+		ch.SetDisplayName(ptr.To(id))
+		ch.SetId(ptr.To(id))
 
 		sl = append(sl, ch)
 	}
@@ -21,15 +21,15 @@ func StubChannels(names ...string) []models.Channelable {
 	return sl
 }
 
-func StubChatMessages(names ...string) []models.ChatMessageable {
-	sl := make([]models.ChatMessageable, 0, len(names))
+func StubChatMessages(ids ...string) []models.ChatMessageable {
+	sl := make([]models.ChatMessageable, 0, len(ids))
 
-	for _, name := range names {
+	for _, id := range ids {
 		cm := models.NewChatMessage()
 		cm.SetId(ptr.To(uuid.NewString()))
 
 		body := models.NewItemBody()
-		body.SetContent(ptr.To(name))
+		body.SetContent(ptr.To(id))
 
 		cm.SetBody(body)
 

--- a/src/internal/m365/graph/consts.go
+++ b/src/internal/m365/graph/consts.go
@@ -35,20 +35,6 @@ const (
 )
 
 // ---------------------------------------------------------------------------
-// Metadata Files
-// ---------------------------------------------------------------------------
-
-const (
-	// DeltaURLsFileName is the name of the file containing delta token(s) for a
-	// given endpoint. The endpoint granularity varies by service.
-	DeltaURLsFileName = "delta"
-
-	// PreviousPathFileName is the name of the file containing previous path(s) for a
-	// given endpoint.
-	PreviousPathFileName = "previouspath"
-)
-
-// ---------------------------------------------------------------------------
 // Runtime Configuration
 // ---------------------------------------------------------------------------
 

--- a/src/internal/m365/graph/service.go
+++ b/src/internal/m365/graph/service.go
@@ -37,12 +37,6 @@ const (
 	defaultHTTPClientTimeout  = 1 * time.Hour
 )
 
-// AllMetadataFileNames produces the standard set of filenames used to store graph
-// metadata such as delta tokens and folderID->path references.
-func AllMetadataFileNames() []string {
-	return []string{DeltaURLsFileName, PreviousPathFileName}
-}
-
 type QueryParams struct {
 	Category          path.CategoryType
 	ProtectedResource idname.Provider

--- a/src/internal/m365/service/groups/backup.go
+++ b/src/internal/m365/service/groups/backup.go
@@ -97,7 +97,7 @@ func ProduceBackupCollections(
 			}
 
 		case path.ChannelMessagesCategory:
-			dbcs, err = groups.CreateCollections(
+			dbcs, canUsePreviousBackup, err = groups.CreateCollections(
 				ctx,
 				bpc,
 				groups.NewChannelBackupHandler(bpc.ProtectedResource.ID(), ac.Channels()),

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	deeTD "github.com/alcionai/corso/src/pkg/backup/details/testdata"
 	"github.com/alcionai/corso/src/pkg/backup/identity"
+	"github.com/alcionai/corso/src/pkg/backup/metadata"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/repository"
 	"github.com/alcionai/corso/src/pkg/extensions"
@@ -1615,11 +1616,11 @@ func makeMetadataCollectionEntries(
 ) []graph.MetadataCollectionEntry {
 	return []graph.MetadataCollectionEntry{
 		graph.NewMetadataEntry(
-			graph.DeltaURLsFileName,
+			metadata.DeltaURLsFileName,
 			map[string]string{driveID: deltaURL},
 		),
 		graph.NewMetadataEntry(
-			graph.PreviousPathFileName,
+			metadata.PreviousPathFileName,
 			map[string]map[string]string{
 				driveID: {
 					folderID: p.PlainString(),

--- a/src/internal/operations/manifests.go
+++ b/src/internal/operations/manifests.go
@@ -9,8 +9,8 @@ import (
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/kopia"
 	"github.com/alcionai/corso/src/internal/kopia/inject"
-	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/pkg/backup/identity"
+	"github.com/alcionai/corso/src/pkg/backup/metadata"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -63,7 +63,7 @@ func getManifestsAndMetadata(
 ) (kopia.BackupBases, []data.RestoreCollection, bool, error) {
 	var (
 		tags          = map[string]string{kopia.TagBackupCategory: ""}
-		metadataFiles = graph.AllMetadataFileNames()
+		metadataFiles = metadata.AllMetadataFileNames()
 		collections   []data.RestoreCollection
 	)
 

--- a/src/internal/operations/test/onedrive_test.go
+++ b/src/internal/operations/test/onedrive_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	deeTD "github.com/alcionai/corso/src/pkg/backup/details/testdata"
+	bupMD "github.com/alcionai/corso/src/pkg/backup/metadata"
 	"github.com/alcionai/corso/src/pkg/control"
 	ctrlTD "github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/count"
@@ -176,7 +177,7 @@ func runDriveIncrementalTest(
 		now = dttm.FormatNow(dttm.SafeForTesting)
 
 		categories = map[path.CategoryType][]string{
-			category: {graph.DeltaURLsFileName, graph.PreviousPathFileName},
+			category: {bupMD.DeltaURLsFileName, bupMD.PreviousPathFileName},
 		}
 		container1      = fmt.Sprintf("%s%d_%s", incrementalsDestContainerPrefix, 1, now)
 		container2      = fmt.Sprintf("%s%d_%s", incrementalsDestContainerPrefix, 2, now)
@@ -790,7 +791,7 @@ func (suite *OneDriveBackupIntgSuite) TestBackup_Run_oneDriveOwnerMigration() {
 		mb   = evmock.NewBus()
 
 		categories = map[path.CategoryType][]string{
-			path.FilesCategory: {graph.DeltaURLsFileName, graph.PreviousPathFileName},
+			path.FilesCategory: {bupMD.DeltaURLsFileName, bupMD.PreviousPathFileName},
 		}
 	)
 

--- a/src/pkg/backup/metadata/metadata.go
+++ b/src/pkg/backup/metadata/metadata.go
@@ -1,0 +1,51 @@
+package metadata
+
+import "github.com/alcionai/corso/src/pkg/path"
+
+const (
+	// DeltaURLsFileName is the name of the file containing delta token(s) for a
+	// given endpoint. The endpoint granularity varies by service.
+	DeltaURLsFileName = "delta"
+
+	// PreviousPathFileName is the name of the file containing previous path(s) for a
+	// given endpoint.
+	PreviousPathFileName = "previouspath"
+
+	PathKey  = "path"
+	DeltaKey = "delta"
+)
+
+type (
+	CatDeltaPaths map[path.CategoryType]DeltaPaths
+	DeltaPaths    map[string]DeltaPath
+	DeltaPath     struct {
+		Delta string
+		Path  string
+	}
+)
+
+func (dps DeltaPaths) AddDelta(k, d string) {
+	dp, ok := dps[k]
+	if !ok {
+		dp = DeltaPath{}
+	}
+
+	dp.Delta = d
+	dps[k] = dp
+}
+
+func (dps DeltaPaths) AddPath(k, p string) {
+	dp, ok := dps[k]
+	if !ok {
+		dp = DeltaPath{}
+	}
+
+	dp.Path = p
+	dps[k] = dp
+}
+
+// AllMetadataFileNames produces the standard set of filenames used to store graph
+// metadata such as delta tokens and folderID->path references.
+func AllMetadataFileNames() []string {
+	return []string{DeltaURLsFileName, PreviousPathFileName}
+}

--- a/src/pkg/path/category_type.go
+++ b/src/pkg/path/category_type.go
@@ -26,7 +26,7 @@ const (
 	LibrariesCategory       CategoryType = 6 // libraries
 	PagesCategory           CategoryType = 7 // pages
 	DetailsCategory         CategoryType = 8 // details
-	ChannelMessagesCategory CategoryType = 9 // channel messages
+	ChannelMessagesCategory CategoryType = 9 // channelMessages
 )
 
 func ToCategoryType(category string) CategoryType {

--- a/src/pkg/path/categorytype_string.go
+++ b/src/pkg/path/categorytype_string.go
@@ -20,9 +20,9 @@ func _() {
 	_ = x[ChannelMessagesCategory-9]
 }
 
-const _CategoryType_name = "UnknownCategoryemailcontactseventsfileslistslibrariespagesdetailschannel messages"
+const _CategoryType_name = "UnknownCategoryemailcontactseventsfileslistslibrariespagesdetailschannelMessages"
 
-var _CategoryType_index = [...]uint8{0, 15, 20, 28, 34, 39, 44, 53, 58, 65, 81}
+var _CategoryType_index = [...]uint8{0, 15, 20, 28, 34, 39, 44, 53, 58, 65, 80}
 
 func (i CategoryType) String() string {
 	if i < 0 || i >= CategoryType(len(_CategoryType_index)-1) {

--- a/src/pkg/services/m365/api/channels_pager_test.go
+++ b/src/pkg/services/m365/api/channels_pager_test.go
@@ -56,27 +56,28 @@ func (suite *ChannelsPagerIntgSuite) TestEnumerateChannelMessages() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	msgIDs, du, err := ac.GetChannelMessageIDsDelta(
+	addedIDs, _, du, err := ac.GetChannelMessageIDsDelta(
 		ctx,
 		suite.its.group.id,
 		suite.its.group.testContainerID,
 		"")
 	require.NoError(t, err, clues.ToCore(err))
-	require.NotEmpty(t, msgIDs)
+	require.NotEmpty(t, addedIDs)
 	require.NotZero(t, du.URL, "delta link")
 	require.True(t, du.Reset, "reset due to empty prev delta link")
 
-	msgIDs, du, err = ac.GetChannelMessageIDsDelta(
+	addedIDs, deletedIDs, du, err := ac.GetChannelMessageIDsDelta(
 		ctx,
 		suite.its.group.id,
 		suite.its.group.testContainerID,
 		du.URL)
 	require.NoError(t, err, clues.ToCore(err))
-	require.Empty(t, msgIDs, "should have no new messages from delta")
+	require.Empty(t, addedIDs, "should have no new messages from delta")
+	require.Empty(t, deletedIDs, "should have no deleted messages from delta")
 	require.NotZero(t, du.URL, "delta link")
 	require.False(t, du.Reset, "prev delta link should be valid")
 
-	for id := range msgIDs {
+	for id := range addedIDs {
 		suite.Run(id+"-replies", func() {
 			testEnumerateChannelMessageReplies(
 				suite.T(),


### PR DESCRIPTION
splits the retrieval of channel message ids into two maps: one for new (added) messages, another for deleted messages.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #3989

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
