### PR TITLE
full incremental backup support for channels

### DIFF
--- a/src/internal/m365/collection/groups/backup.go
+++ b/src/internal/m365/collection/groups/backup.go
@@ -6,12 +6,14 @@ import (
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
+	"github.com/alcionai/corso/src/internal/common/pii"
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/m365/support"
 	"github.com/alcionai/corso/src/internal/observe"
 	"github.com/alcionai/corso/src/internal/operations/inject"
+	"github.com/alcionai/corso/src/pkg/backup/metadata"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
@@ -33,10 +35,9 @@ func CreateCollections(
 	bh backupHandler,
 	tenantID string,
 	scope selectors.GroupsScope,
-	// dps DeltaPaths,
 	su support.StatusUpdater,
 	errs *fault.Bus,
-) ([]data.BackupCollection, error) {
+) ([]data.BackupCollection, bool, error) {
 	ctx = clues.Add(ctx, "category", scope.Category().PathType())
 
 	var (
@@ -49,6 +50,13 @@ func CreateCollections(
 		}
 	)
 
+	cdps, canUsePreviousBackup, err := parseMetadataCollections(ctx, bpc.MetadataCollections)
+	if err != nil {
+		return nil, false, err
+	}
+
+	ctx = clues.Add(ctx, "can_use_previous_backup", canUsePreviousBackup)
+
 	catProgress := observe.MessageWithCompletion(
 		ctx,
 		observe.Bulletf("%s", qp.Category))
@@ -56,7 +64,7 @@ func CreateCollections(
 
 	channels, err := bh.getChannels(ctx)
 	if err != nil {
-		return nil, clues.Stack(err)
+		return nil, false, clues.Stack(err)
 	}
 
 	collections, err := populateCollections(
@@ -66,18 +74,18 @@ func CreateCollections(
 		su,
 		channels,
 		scope,
-		// dps,
+		cdps[scope.Category().PathType()],
 		bpc.Options,
 		errs)
 	if err != nil {
-		return nil, clues.Wrap(err, "filling collections")
+		return nil, false, clues.Wrap(err, "filling collections")
 	}
 
 	for _, coll := range collections {
 		allCollections = append(allCollections, coll)
 	}
 
-	return allCollections, nil
+	return allCollections, canUsePreviousBackup, nil
 }
 
 func populateCollections(
@@ -87,68 +95,66 @@ func populateCollections(
 	statusUpdater support.StatusUpdater,
 	channels []models.Channelable,
 	scope selectors.GroupsScope,
-	// dps DeltaPaths,
+	dps metadata.DeltaPaths,
 	ctrlOpts control.Options,
 	errs *fault.Bus,
 ) (map[string]data.BackupCollection, error) {
 	var (
 		// channel ID -> BackupCollection.
-		channelCollections = map[string]data.BackupCollection{}
+		collections = map[string]data.BackupCollection{}
 		// channel ID -> delta url or folder path lookups
 		deltaURLs = map[string]string{}
 		currPaths = map[string]string{}
 		// copy of previousPaths.  every channel present in the slice param
 		// gets removed from this map; the remaining channels at the end of
 		// the process have been deleted.
-		// tombstones = makeTombstones(dps)
+		tombstones = makeTombstones(dps)
+		el         = errs.Local()
 	)
 
-	logger.Ctx(ctx).Info("filling collections")
-	// , "len_deltapaths", len(dps))
-
-	el := errs.Local()
+	logger.Ctx(ctx).Info("filling collections", "len_deltapaths", len(dps))
 
 	for _, c := range channels {
 		if el.Failure() != nil {
 			return nil, el.Failure()
 		}
 
-		// delete(tombstones, cID)
-
 		var (
-			cID   = ptr.Val(c.GetId())
-			cName = ptr.Val(c.GetDisplayName())
-			err   error
-			// dp          = dps[cID]
-			// prevDelta   = dp.Delta
-			// prevPathStr = dp.Path // do not log: pii; log prevPath instead
-			// prevPath    path.Path
-			ictx = clues.Add(
+			cID         = ptr.Val(c.GetId())
+			cName       = ptr.Val(c.GetDisplayName())
+			err         error
+			dp          = dps[cID]
+			prevDelta   = dp.Delta
+			prevPathStr = dp.Path // do not log: pii; log prevPath instead
+			prevPath    path.Path
+			ictx        = clues.Add(
 				ctx,
-				"channel_id", cID)
-			// "previous_delta", pii.SafeURL{
-			// 	URL:           prevDelta,
-			// 	SafePathElems: graph.SafeURLPathParams,
-			// 	SafeQueryKeys: graph.SafeURLQueryParams,
-			// })
+				"channel_id", cID,
+				"previous_delta", pii.SafeURL{
+					URL:           prevDelta,
+					SafePathElems: graph.SafeURLPathParams,
+					SafeQueryKeys: graph.SafeURLQueryParams,
+				})
 		)
+
+		delete(tombstones, cID)
 
 		// Only create a collection if the path matches the scope.
 		if !bh.includeContainer(ictx, qp, c, scope) {
 			continue
 		}
 
-		// if len(prevPathStr) > 0 {
-		// 	if prevPath, err = pathFromPrevString(prevPathStr); err != nil {
-		// 		logger.CtxErr(ictx, err).Error("parsing prev path")
-		// 		// if the previous path is unusable, then the delta must be, too.
-		// 		prevDelta = ""
-		// 	}
-		// }
+		if len(prevPathStr) > 0 {
+			if prevPath, err = pathFromPrevString(prevPathStr); err != nil {
+				logger.CtxErr(ictx, err).Error("parsing prev path")
+				// if the previous path is unusable, then the delta must be, too.
+				prevDelta = ""
+			}
+		}
 
-		// ictx = clues.Add(ictx, "previous_path", prevPath)
+		ictx = clues.Add(ictx, "previous_path", prevPath)
 
-		added, removed, du, err := bh.getChannelMessageIDsDelta(ctx, cID, "")
+		added, removed, du, err := bh.getChannelMessageIDsDelta(ctx, cID, prevDelta)
 		if err != nil {
 			el.AddRecoverable(ctx, clues.Stack(err))
 			continue
@@ -159,8 +165,6 @@ func populateCollections(
 		} else if !du.Reset {
 			logger.Ctx(ictx).Info("missing delta url")
 		}
-
-		var prevPath path.Path
 
 		currPath, err := bh.canonicalPath(path.Builder{}.Append(cID), qp.TenantID)
 		if err != nil {
@@ -188,19 +192,64 @@ func populateCollections(
 			ctrlOpts,
 			du.Reset)
 
-		channelCollections[cID] = &edc
+		collections[cID] = &edc
 
 		// add the current path for the container ID to be used in the next backup
 		// as the "previous path", for reference in case of a rename or relocation.
 		currPaths[cID] = currPath.String()
 	}
 
-	// TODO: handle tombstones here
+	// A tombstone is a channel that needs to be marked for deletion.
+	// The only situation where a tombstone should appear is if the channel exists
+	// in the `previousPath` set, but does not exist in the enumeration.
+	for id, p := range tombstones {
+		if el.Failure() != nil {
+			return nil, el.Failure()
+		}
+
+		var (
+			err  error
+			ictx = clues.Add(ctx, "tombstone_id", id)
+		)
+
+		if collections[id] != nil {
+			el.AddRecoverable(ctx, clues.Wrap(err, "conflict: tombstone exists for a live collection").WithClues(ictx))
+			continue
+		}
+
+		// only occurs if it was a new folder that we picked up during the container
+		// resolver phase that got deleted in flight by the time we hit this stage.
+		if len(p) == 0 {
+			continue
+		}
+
+		prevPath, err := pathFromPrevString(p)
+		if err != nil {
+			// technically shouldn't ever happen.  But just in case...
+			logger.CtxErr(ictx, err).Error("parsing tombstone prev path")
+			continue
+		}
+
+		edc := NewCollection(
+			bh,
+			qp.ProtectedResource.ID(),
+			nil, // marks the collection as deleted
+			prevPath,
+			nil, // tombstones don't need a location
+			qp.Category,
+			nil, // no items added
+			nil, // this deletes a directory, so no items deleted either
+			statusUpdater,
+			ctrlOpts,
+			false)
+
+		collections[id] = &edc
+	}
 
 	logger.Ctx(ctx).Infow(
 		"adding metadata collection entries",
-		// "num_deltas_entries", len(deltaURLs),
-		"num_paths_entries", len(channelCollections))
+		"num_deltas_entries", len(deltaURLs),
+		"num_paths_entries", len(collections))
 
 	pathPrefix, err := path.Builder{}.ToServiceCategoryMetadataPath(
 		qp.TenantID,
@@ -215,15 +264,15 @@ func populateCollections(
 	col, err := graph.MakeMetadataCollection(
 		pathPrefix,
 		[]graph.MetadataCollectionEntry{
-			graph.NewMetadataEntry(graph.PreviousPathFileName, currPaths),
-			graph.NewMetadataEntry(graph.DeltaURLsFileName, deltaURLs),
+			graph.NewMetadataEntry(metadata.PreviousPathFileName, currPaths),
+			graph.NewMetadataEntry(metadata.DeltaURLsFileName, deltaURLs),
 		},
 		statusUpdater)
 	if err != nil {
 		return nil, clues.Wrap(err, "making metadata collection")
 	}
 
-	channelCollections["metadata"] = col
+	collections["metadata"] = col
 
-	return channelCollections, el.Failure()
+	return collections, el.Failure()
 }

--- a/src/internal/m365/collection/groups/testdata/channels.go
+++ b/src/internal/m365/collection/groups/testdata/channels.go
@@ -7,13 +7,13 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 )
 
-func StubChannels(names ...string) []models.Channelable {
-	sl := make([]models.Channelable, 0, len(names))
+func StubChannels(ids ...string) []models.Channelable {
+	sl := make([]models.Channelable, 0, len(ids))
 
-	for _, name := range names {
+	for _, id := range ids {
 		ch := models.NewChannel()
-		ch.SetDisplayName(ptr.To(name))
-		ch.SetId(ptr.To(uuid.NewString()))
+		ch.SetDisplayName(ptr.To(id))
+		ch.SetId(ptr.To(id))
 
 		sl = append(sl, ch)
 	}
@@ -21,15 +21,15 @@ func StubChannels(names ...string) []models.Channelable {
 	return sl
 }
 
-func StubChatMessages(names ...string) []models.ChatMessageable {
-	sl := make([]models.ChatMessageable, 0, len(names))
+func StubChatMessages(ids ...string) []models.ChatMessageable {
+	sl := make([]models.ChatMessageable, 0, len(ids))
 
-	for _, name := range names {
+	for _, id := range ids {
 		cm := models.NewChatMessage()
 		cm.SetId(ptr.To(uuid.NewString()))
 
 		body := models.NewItemBody()
-		body.SetContent(ptr.To(name))
+		body.SetContent(ptr.To(id))
 
 		cm.SetBody(body)
 

--- a/src/internal/m365/service/groups/backup.go
+++ b/src/internal/m365/service/groups/backup.go
@@ -97,7 +97,7 @@ func ProduceBackupCollections(
 			}
 
 		case path.ChannelMessagesCategory:
-			dbcs, err = groups.CreateCollections(
+			dbcs, canUsePreviousBackup, err = groups.CreateCollections(
 				ctx,
 				bpc,
 				groups.NewChannelBackupHandler(bpc.ProtectedResource.ID(), ac.Channels()),


### PR DESCRIPTION
Finishes the incremental backup support for channel messasges. Tested manually via the cli, but not yet fully stressed.  Follow-up PRs will address automated testing and manual exercises.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #3989

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
