### PR TITLE
Add sites to metadata path

### DIFF
--- a/src/internal/m365/collection/drive/group_handler.go
+++ b/src/internal/m365/collection/drive/group_handler.go
@@ -63,6 +63,11 @@ func (h groupBackupHandler) MetadataPathPrefix(tenantID string) (path.Path, erro
 		return nil, clues.Wrap(err, "making metadata path")
 	}
 
+	p, err = p.Append(false, odConsts.SitesPathDir, h.siteID)
+	if err != nil {
+		return nil, clues.Wrap(err, "appending sites to metadata path")
+	}
+
 	return p, nil
 }
 

--- a/src/internal/m365/collection/drive/group_handler_test.go
+++ b/src/internal/m365/collection/drive/group_handler_test.go
@@ -59,7 +59,7 @@ func (suite *GroupBackupHandlerUnitSuite) TestMetadataPathPrefix() {
 	}{
 		{
 			name:      "group",
-			expect:    "tenant/groupsMetadata/resourceOwner/libraries",
+			expect:    "tenant/groupsMetadata/resourceOwner/libraries/sites/site-id",
 			expectErr: assert.NoError,
 		},
 	}


### PR DESCRIPTION
This makes the following change to the metadata path:

```diff
-tenant/groupsMetadata/resourceOwner/libraries
+tenant/groupsMetadata/resourceOwner/libraries/sites/site-id
```

The change only affect groups and no other services.
<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
