### PR TITLE
Add specific mailbox info api

### DIFF
--- a/src/pkg/services/m365/users.go
+++ b/src/pkg/services/m365/users.go
@@ -209,3 +209,21 @@ func GetUserInfo(
 
 	return ui, nil
 }
+
+func GetMailboxInfo(ctx context.Context, acct account.Account, userID string) (*api.MailboxInfo, error) {
+	ac, err := makeAC(ctx, acct, path.ExchangeService)
+	if err != nil {
+		return nil, clues.Stack(err).WithClues(ctx)
+	}
+
+	info, err := ac.Users().GetMailboxInfo(ctx, userID)
+	if err != nil {
+		if err := api.EvaluateMailboxError(err); err != nil {
+			return nil, clues.Stack(err)
+		}
+
+		return nil, nil
+	}
+
+	return info, nil
+}

--- a/src/pkg/services/m365/users_test.go
+++ b/src/pkg/services/m365/users_test.go
@@ -214,6 +214,48 @@ func (suite *userIntegrationSuite) TestGetUserInfo() {
 	}
 }
 
+func (suite *userIntegrationSuite) TestGetMailboxInfo() {
+	table := []struct {
+		name      string
+		user      string
+		expect    *api.MailboxInfo
+		expectErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "standard test user",
+			user: tconfig.M365UserID(suite.T()),
+			expect: &api.MailboxInfo{
+				Purpose:              "user",
+				ErrGetMailBoxSetting: nil,
+			},
+			expectErr: require.NoError,
+		},
+		{
+			name:      "user does not exist",
+			user:      uuid.NewString(),
+			expect:    &api.MailboxInfo{},
+			expectErr: require.Error,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			result, err := GetMailboxInfo(ctx, suite.acct, test.user)
+			test.expectErr(t, err, clues.ToCore(err))
+
+			if err != nil {
+				return
+			}
+
+			assert.Equal(t, test.expect, result)
+		})
+	}
+}
+
 func (suite *userIntegrationSuite) TestGetUserInfo_userWithoutDrive() {
 	userID := tconfig.M365UserID(suite.T())
 


### PR DESCRIPTION
We initaly introduced `UserHasMaibox` and `UserHasDrive` to  allow callers to avoid calling `/drives` when we only want mailbox info. `GetUserInfo` also calls both drives and mailbox. Creating a specific `GetMailboxInfo` 

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
