### PR TITLE
fix language issues with default contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switched to Go 1.21
 - SharePoint exported libraries are now exported with a `Libraries` prefix.
 
+### Fixed
+- Contacts backups no longer slices root-folder data if outlook is set to languages other than english.
+
 ## [v0.12.0] (beta) - 2023-08-29
 
 ### Added

--- a/src/internal/m365/collection/exchange/backup.go
+++ b/src/internal/m365/collection/exchange/backup.go
@@ -142,8 +142,8 @@ func populateCollections(
 				})
 		)
 
-		currPath, locPath, ok := includeContainer(ictx, qp, c, scope, category)
 		// Only create a collection if the path matches the scope.
+		currPath, locPath, ok := includeContainer(ictx, qp, c, scope, category)
 		if !ok {
 			continue
 		}
@@ -334,8 +334,8 @@ func includeContainer(
 	)
 
 	// Clause ensures that DefaultContactFolder is inspected properly
-	if category == path.ContactsCategory && ptr.Val(c.GetDisplayName()) == api.DefaultContacts {
-		loc = loc.Append(api.DefaultContacts)
+	if category == path.ContactsCategory && len(loc.Elements()) == 0 {
+		loc = loc.Append(ptr.Val(c.GetDisplayName()))
 	}
 
 	dirPath, err := pb.ToDataLayerExchangePathForCategory(

--- a/src/internal/m365/collection/exchange/contacts_restore.go
+++ b/src/internal/m365/collection/exchange/contacts_restore.go
@@ -99,14 +99,6 @@ func restoreContact(
 	errs *fault.Bus,
 	ctr *count.Bus,
 ) (*details.ExchangeInfo, error) {
-	// contacts has a weird relationship with its default
-	// folder, which is that the folder is treated as invisible
-	// in many cases.  If we're restoring to a blank location,
-	// we can interpret that as the root.
-	if len(destinationID) == 0 {
-		destinationID = api.DefaultContacts
-	}
-
 	contact, err := api.BytesToContactable(body)
 	if err != nil {
 		return nil, graph.Wrap(ctx, err, "creating contact from bytes")

--- a/src/pkg/services/m365/api/contacts_pager.go
+++ b/src/pkg/services/m365/api/contacts_pager.go
@@ -112,12 +112,6 @@ func (c Contacts) NewContactsPager(
 		options.QueryParameters.Select = selectProps
 	}
 
-	// if we have no container ID, we need to fetch the
-	// base contacts container ID.
-	if len(containerID) == 0 {
-		containerID = DefaultContacts
-	}
-
 	builder := c.Stable.
 		Client().
 		Users().


### PR DESCRIPTION
prepends the default contacts folder display name to the location instead of the well-known defaultContacts value.  This ensures the folder gets compared properly for non-english mailboxes.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix

#### Issue(s)

* #4175

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
