### PR TITLE
Mark all folders we're not keeping as tombstoned

### DIFF
--- a/src/internal/m365/collection/exchange/backup.go
+++ b/src/internal/m365/collection/exchange/backup.go
@@ -124,7 +124,6 @@ func populateCollections(
 		}
 
 		cID := ptr.Val(c.GetId())
-		delete(tombstones, cID)
 
 		var (
 			err         error
@@ -147,6 +146,8 @@ func populateCollections(
 		if !ok {
 			continue
 		}
+
+		delete(tombstones, cID)
 
 		if len(prevPathStr) > 0 {
 			if prevPath, err = pathFromPrevString(prevPathStr); err != nil {


### PR DESCRIPTION
Increase the number of folders that we
tombstone so that we only keep the
things that were explicitly requested
for the backup.

This also helps keep things consistent
since we only add folders to the
previous paths and previous deltas
maps if they were selected during the
backup

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #4175

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
