### PR TITLE
Track assist bases and merge bases separately

### DIFF
--- a/src/internal/kopia/backup_bases.go
+++ b/src/internal/kopia/backup_bases.go
@@ -28,6 +28,11 @@ type BackupBases interface {
 		other BackupBases,
 		reasonToKey func(identity.Reasoner) string,
 	) BackupBases
+	// SnapshotAssistBases returns the set of bases to use for kopia assisted
+	// incremental snapshot operations. It consists of the union of merge bases
+	// and assist bases. If DisableAssistBases has been called then it returns
+	// nil.
+	SnapshotAssistBases() []ManifestEntry
 }
 
 type backupBases struct {
@@ -44,6 +49,14 @@ type backupBases struct {
 	// disableMergeBases denotes whether any bases should be returned from calls
 	// to MergeBases().
 	disableMergeBases bool
+}
+
+func (bb *backupBases) SnapshotAssistBases() []ManifestEntry {
+	if bb.disableAssistBases {
+		return nil
+	}
+
+	return append(bb.UniqueAssistBases(), bb.MergeBases()...)
 }
 
 func (bb *backupBases) RemoveMergeBaseByManifestID(manifestID manifest.ID) {

--- a/src/internal/kopia/backup_bases.go
+++ b/src/internal/kopia/backup_bases.go
@@ -15,9 +15,9 @@ import (
 // TODO(ashmrtn): Move this into some inject package. Here to avoid import
 // cycles.
 type BackupBases interface {
-	// MakeAssistBase converts the base with the given item data snapshot ID from
-	// a merge base to an assist base.
-	MakeAssistBase(manifestID manifest.ID)
+	// ConvertToAssistBase converts the base with the given item data snapshot ID
+	// from a merge base to an assist base.
+	ConvertToAssistBase(manifestID manifest.ID)
 	Backups() []BackupEntry
 	UniqueAssistBackups() []BackupEntry
 	MinBackupVersion() int
@@ -63,7 +63,7 @@ func (bb *backupBases) SnapshotAssistBases() []ManifestEntry {
 	return append(slices.Clone(bb.assistBases), bb.mergeBases...)
 }
 
-func (bb *backupBases) MakeAssistBase(manifestID manifest.ID) {
+func (bb *backupBases) ConvertToAssistBase(manifestID manifest.ID) {
 	var (
 		snapshotMan ManifestEntry
 		base        BackupEntry

--- a/src/internal/kopia/backup_bases_test.go
+++ b/src/internal/kopia/backup_bases_test.go
@@ -201,6 +201,9 @@ func (suite *BackupBasesUnitSuite) TestDisableMergeBases() {
 	// Assist base set should be unchanged.
 	assert.Len(t, bb.UniqueAssistBackups(), 2)
 	assert.Len(t, bb.UniqueAssistBases(), 2)
+	// Merge bases should still appear in the assist base set passed in for kopia
+	// snapshots.
+	assert.Len(t, bb.SnapshotAssistBases(), 4)
 }
 
 func (suite *BackupBasesUnitSuite) TestDisableAssistBases() {
@@ -215,6 +218,7 @@ func (suite *BackupBasesUnitSuite) TestDisableAssistBases() {
 	bb.DisableAssistBases()
 	assert.Empty(t, bb.UniqueAssistBases())
 	assert.Empty(t, bb.UniqueAssistBackups())
+	assert.Empty(t, bb.SnapshotAssistBases())
 
 	// Merge base should be unchanged.
 	assert.Len(t, bb.Backups(), 2)

--- a/src/internal/kopia/backup_bases_test.go
+++ b/src/internal/kopia/backup_bases_test.go
@@ -84,7 +84,7 @@ func (suite *BackupBasesUnitSuite) TestMinBackupVersion() {
 	}
 }
 
-func (suite *BackupBasesUnitSuite) TestRemoveMergeBaseByManifestID() {
+func (suite *BackupBasesUnitSuite) TestMakeAssistBase() {
 	backups := []BackupEntry{
 		{Backup: &backup.Backup{SnapshotID: "1"}},
 		{Backup: &backup.Backup{SnapshotID: "2"}},
@@ -179,7 +179,7 @@ func (suite *BackupBasesUnitSuite) TestRemoveMergeBaseByManifestID() {
 				bb.assistBases = append(bb.assistBases, merges[i])
 			}
 
-			bb.RemoveMergeBaseByManifestID(delID)
+			bb.MakeAssistBase(delID)
 			AssertBackupBasesEqual(t, expected, bb)
 		})
 	}

--- a/src/internal/kopia/backup_bases_test.go
+++ b/src/internal/kopia/backup_bases_test.go
@@ -97,68 +97,71 @@ func (suite *BackupBasesUnitSuite) TestMakeAssistBase() {
 		makeManifest("3", "", ""),
 	}
 
-	expected := &backupBases{
-		backups:     []BackupEntry{backups[0], backups[1]},
-		mergeBases:  []ManifestEntry{merges[0], merges[1]},
-		assistBases: []ManifestEntry{merges[0], merges[1]},
-	}
-
 	delID := manifest.ID("3")
 
 	table := []struct {
 		name string
 		// Below indices specify which items to add from the defined sets above.
-		backup []int
-		merge  []int
-		assist []int
+		backup       []int
+		merge        []int
+		assist       []int
+		expectAssist []int
 	}{
 		{
-			name:   "Not In Bases",
-			backup: []int{0, 1},
-			merge:  []int{0, 1},
-			assist: []int{0, 1},
+			name:         "Not In Bases",
+			backup:       []int{0, 1},
+			merge:        []int{0, 1},
+			assist:       []int{0, 1},
+			expectAssist: []int{0, 1},
 		},
 		{
-			name:   "Different Indexes",
-			backup: []int{2, 0, 1},
-			merge:  []int{0, 2, 1},
-			assist: []int{0, 1, 2},
+			name:         "Different Indexes",
+			backup:       []int{2, 0, 1},
+			merge:        []int{0, 2, 1},
+			assist:       []int{0, 1},
+			expectAssist: []int{0, 1, 2},
 		},
 		{
-			name:   "First Item",
-			backup: []int{2, 0, 1},
-			merge:  []int{2, 0, 1},
-			assist: []int{2, 0, 1},
+			name:         "First Item",
+			backup:       []int{2, 0, 1},
+			merge:        []int{2, 0, 1},
+			assist:       []int{0, 1},
+			expectAssist: []int{0, 1, 2},
 		},
 		{
-			name:   "Middle Item",
-			backup: []int{0, 2, 1},
-			merge:  []int{0, 2, 1},
-			assist: []int{0, 2, 1},
+			name:         "Middle Item",
+			backup:       []int{0, 2, 1},
+			merge:        []int{0, 2, 1},
+			assist:       []int{0, 1},
+			expectAssist: []int{0, 1, 2},
 		},
 		{
-			name:   "Final Item",
-			backup: []int{0, 1, 2},
-			merge:  []int{0, 1, 2},
-			assist: []int{0, 1, 2},
+			name:         "Final Item",
+			backup:       []int{0, 1, 2},
+			merge:        []int{0, 1, 2},
+			assist:       []int{0, 1},
+			expectAssist: []int{0, 1, 2},
 		},
 		{
-			name:   "Only In Backups",
-			backup: []int{0, 1, 2},
-			merge:  []int{0, 1},
-			assist: []int{0, 1},
+			name:         "Only In Backups",
+			backup:       []int{0, 1, 2},
+			merge:        []int{0, 1},
+			assist:       []int{0, 1},
+			expectAssist: []int{0, 1},
 		},
 		{
-			name:   "Only In Merges",
-			backup: []int{0, 1},
-			merge:  []int{0, 1, 2},
-			assist: []int{0, 1},
+			name:         "Only In Merges",
+			backup:       []int{0, 1},
+			merge:        []int{0, 1, 2},
+			assist:       []int{0, 1},
+			expectAssist: []int{0, 1},
 		},
 		{
-			name:   "Only In Assists",
-			backup: []int{0, 1},
-			merge:  []int{0, 1},
-			assist: []int{0, 1, 2},
+			name:         "Only In Assists Noops",
+			backup:       []int{0, 1},
+			merge:        []int{0, 1},
+			assist:       []int{0, 1, 2},
+			expectAssist: []int{0, 1, 2},
 		},
 	}
 
@@ -177,6 +180,17 @@ func (suite *BackupBasesUnitSuite) TestMakeAssistBase() {
 
 			for _, i := range test.assist {
 				bb.assistBases = append(bb.assistBases, merges[i])
+				bb.assistBackups = append(bb.assistBackups, backups[i])
+			}
+
+			expected := &backupBases{
+				backups:    []BackupEntry{backups[0], backups[1]},
+				mergeBases: []ManifestEntry{merges[0], merges[1]},
+			}
+
+			for _, i := range test.expectAssist {
+				expected.assistBases = append(expected.assistBases, merges[i])
+				expected.assistBackups = append(expected.assistBackups, backups[i])
 			}
 
 			bb.MakeAssistBase(delID)
@@ -246,7 +260,6 @@ func (suite *BackupBasesUnitSuite) TestMergeBackupBases() {
 			}
 
 			m := makeManifest(baseID, "", "b"+baseID, reasons...)
-			res.assistBases = append(res.assistBases, m)
 
 			b := BackupEntry{
 				Backup: &backup.Backup{
@@ -592,7 +605,7 @@ func (suite *BackupBasesUnitSuite) TestFixupAndVerify() {
 			}(),
 			expect: func() *backupBases {
 				res := validMail1()
-				res.assistBases = res.mergeBases
+				res.assistBases = nil
 				res.assistBackups = nil
 
 				return res
@@ -624,7 +637,7 @@ func (suite *BackupBasesUnitSuite) TestFixupAndVerify() {
 			}(),
 			expect: func() *backupBases {
 				res := validMail1()
-				res.assistBases = res.mergeBases
+				res.assistBases = nil
 				res.assistBackups = nil
 
 				return res
@@ -655,14 +668,9 @@ func (suite *BackupBasesUnitSuite) TestFixupAndVerify() {
 			}(),
 		},
 		{
-			name: "Single Valid Entry",
-			bb:   validMail1(),
-			expect: func() *backupBases {
-				res := validMail1()
-				res.assistBases = append(res.mergeBases, res.assistBases...)
-
-				return res
-			}(),
+			name:   "Single Valid Entry",
+			bb:     validMail1(),
+			expect: validMail1(),
 		},
 		{
 			name: "Single Valid Entry With Incomplete Assist With Same Reason",
@@ -674,12 +682,7 @@ func (suite *BackupBasesUnitSuite) TestFixupAndVerify() {
 
 				return res
 			}(),
-			expect: func() *backupBases {
-				res := validMail1()
-
-				res.assistBases = append(res.mergeBases, res.assistBases...)
-				return res
-			}(),
+			expect: validMail1(),
 		},
 		{
 			name: "Single Valid Entry With Backup With Old Deets ID",
@@ -700,8 +703,6 @@ func (suite *BackupBasesUnitSuite) TestFixupAndVerify() {
 
 				res.assistBackups[0].DetailsID = res.assistBackups[0].StreamStoreID
 				res.assistBackups[0].StreamStoreID = ""
-
-				res.assistBases = append(res.mergeBases, res.assistBases...)
 
 				return res
 			}(),
@@ -729,8 +730,6 @@ func (suite *BackupBasesUnitSuite) TestFixupAndVerify() {
 				res.assistBases[0].Reasons = append(
 					res.assistBases[0].Reasons,
 					NewReason("", ro, path.ExchangeService, path.ContactsCategory))
-
-				res.assistBases = append(res.mergeBases, res.assistBases...)
 
 				return res
 			}(),
@@ -795,7 +794,6 @@ func (suite *BackupBasesUnitSuite) TestFixupAndVerify() {
 				res.mergeBases = append(
 					res.mergeBases,
 					makeMan(path.EventsCategory, "id4", "", "bid4"))
-				res.assistBases = append(res.mergeBases, res.assistBases...)
 
 				return res
 			}(),
@@ -848,8 +846,6 @@ func (suite *BackupBasesUnitSuite) TestFixupAndVerify() {
 				res.assistBases = append(
 					res.assistBases,
 					makeMan(path.EventsCategory, "id4", "", "bid4"))
-
-				res.assistBases = append(res.mergeBases, res.assistBases...)
 
 				return res
 			}(),

--- a/src/internal/kopia/backup_bases_test.go
+++ b/src/internal/kopia/backup_bases_test.go
@@ -84,7 +84,7 @@ func (suite *BackupBasesUnitSuite) TestMinBackupVersion() {
 	}
 }
 
-func (suite *BackupBasesUnitSuite) TestMakeAssistBase() {
+func (suite *BackupBasesUnitSuite) TestConvertToAssistBase() {
 	backups := []BackupEntry{
 		{Backup: &backup.Backup{SnapshotID: "1"}},
 		{Backup: &backup.Backup{SnapshotID: "2"}},
@@ -193,7 +193,7 @@ func (suite *BackupBasesUnitSuite) TestMakeAssistBase() {
 				expected.assistBackups = append(expected.assistBackups, backups[i])
 			}
 
-			bb.MakeAssistBase(delID)
+			bb.ConvertToAssistBase(delID)
 			AssertBackupBasesEqual(t, expected, bb)
 		})
 	}

--- a/src/internal/kopia/base_finder_test.go
+++ b/src/internal/kopia/base_finder_test.go
@@ -300,6 +300,7 @@ func (suite *BaseFinderUnitSuite) TestNoResult_NoBackupsOrSnapshots() {
 	bb := bf.FindBases(ctx, reasons, nil)
 	assert.Empty(t, bb.MergeBases())
 	assert.Empty(t, bb.UniqueAssistBases())
+	assert.Empty(t, bb.SnapshotAssistBases())
 }
 
 func (suite *BaseFinderUnitSuite) TestNoResult_ErrorListingSnapshots() {
@@ -319,6 +320,7 @@ func (suite *BaseFinderUnitSuite) TestNoResult_ErrorListingSnapshots() {
 	bb := bf.FindBases(ctx, reasons, nil)
 	assert.Empty(t, bb.MergeBases())
 	assert.Empty(t, bb.UniqueAssistBases())
+	assert.Empty(t, bb.SnapshotAssistBases())
 }
 
 func (suite *BaseFinderUnitSuite) TestGetBases() {

--- a/src/internal/kopia/base_finder_test.go
+++ b/src/internal/kopia/base_finder_test.go
@@ -333,11 +333,8 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 		expectedBaseReasons map[int][]identity.Reasoner
 		// Use this to denote the Reasons a kopia assised incrementals manifest is
 		// selected. The int maps to the index of the manifest in data.
-		// TODO(pandeyabs): Remove this once we have 1:1 mapping between snapshots
-		// and backup models.
-		expectedAssistManifestReasons map[int][]identity.Reasoner
-		expectedAssistReasons         map[int][]identity.Reasoner
-		backupData                    []backupInfo
+		expectedAssistReasons map[int][]identity.Reasoner
+		backupData            []backupInfo
 	}{
 		{
 			name:  "Return Older Merge Base If Fail To Get Manifest",
@@ -363,10 +360,6 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 			expectedBaseReasons: map[int][]identity.Reasoner{
 				1: testUser1Mail,
 			},
-			expectedAssistManifestReasons: map[int][]identity.Reasoner{
-				1: testUser1Mail,
-			},
-			expectedAssistReasons: map[int][]identity.Reasoner{},
 			backupData: []backupInfo{
 				newBackupModel(testBackup2, true, true, false, nil, nil),
 				newBackupModel(testBackup1, true, true, false, nil, nil),
@@ -392,10 +385,6 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					nil,
 					testMail,
 					testUser1),
-			},
-			expectedBaseReasons: map[int][]identity.Reasoner{},
-			expectedAssistManifestReasons: map[int][]identity.Reasoner{
-				1: testUser1Mail,
 			},
 			expectedAssistReasons: map[int][]identity.Reasoner{
 				1: testUser1Mail,
@@ -435,9 +424,6 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 			expectedBaseReasons: map[int][]identity.Reasoner{
 				1: testUser1Mail,
 			},
-			expectedAssistManifestReasons: map[int][]identity.Reasoner{
-				1: testUser1Mail,
-			},
 			backupData: []backupInfo{
 				newBackupModel(testBackup2, false, false, false, nil, assert.AnError),
 				newBackupModel(testBackup1, true, true, false, nil, nil),
@@ -467,10 +453,6 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 			expectedBaseReasons: map[int][]identity.Reasoner{
 				1: testUser1Mail,
 			},
-			expectedAssistManifestReasons: map[int][]identity.Reasoner{
-				1: testUser1Mail,
-			},
-			expectedAssistReasons: map[int][]identity.Reasoner{},
 			backupData: []backupInfo{
 				newBackupModel(testBackup2, true, false, false, nil, nil),
 				newBackupModel(testBackup1, true, true, false, nil, nil),
@@ -495,10 +477,6 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 			expectedBaseReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
-			expectedAssistManifestReasons: map[int][]identity.Reasoner{
-				0: testUser1Mail,
-			},
-			expectedAssistReasons: map[int][]identity.Reasoner{},
 			backupData: []backupInfo{
 				newBackupModel(testBackup1, true, true, true, nil, nil),
 			},
@@ -522,10 +500,6 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 			expectedBaseReasons: map[int][]identity.Reasoner{
 				0: testAllUsersAllCats,
 			},
-			expectedAssistManifestReasons: map[int][]identity.Reasoner{
-				0: testAllUsersAllCats,
-			},
-			expectedAssistReasons: map[int][]identity.Reasoner{},
 			backupData: []backupInfo{
 				newBackupModel(testBackup1, true, true, false, nil, nil),
 			},
@@ -545,10 +519,6 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					testUser1,
 					testUser2,
 					testUser3),
-			},
-			expectedBaseReasons: map[int][]identity.Reasoner{},
-			expectedAssistManifestReasons: map[int][]identity.Reasoner{
-				0: testAllUsersAllCats,
 			},
 			expectedAssistReasons: map[int][]identity.Reasoner{
 				0: testAllUsersAllCats,
@@ -601,18 +571,6 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					NewReason("", testUser3, path.ExchangeService, path.EventsCategory),
 				},
 			},
-			expectedAssistManifestReasons: map[int][]identity.Reasoner{
-				0: {
-					NewReason("", testUser1, path.ExchangeService, path.EmailCategory),
-					NewReason("", testUser2, path.ExchangeService, path.EmailCategory),
-					NewReason("", testUser3, path.ExchangeService, path.EmailCategory),
-				},
-				1: {
-					NewReason("", testUser1, path.ExchangeService, path.EventsCategory),
-					NewReason("", testUser2, path.ExchangeService, path.EventsCategory),
-					NewReason("", testUser3, path.ExchangeService, path.EventsCategory),
-				},
-			},
 			backupData: []backupInfo{
 				newBackupModel(testBackup1, true, true, false, nil, nil),
 				newBackupModel(testBackup2, true, true, false, nil, nil),
@@ -652,22 +610,6 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					testUser2),
 			},
 			expectedBaseReasons: map[int][]identity.Reasoner{
-				2: {
-					NewReason("", testUser1, path.ExchangeService, path.EmailCategory),
-					NewReason("", testUser2, path.ExchangeService, path.EmailCategory),
-					NewReason("", testUser1, path.ExchangeService, path.EventsCategory),
-					NewReason("", testUser2, path.ExchangeService, path.EventsCategory),
-				},
-			},
-			expectedAssistManifestReasons: map[int][]identity.Reasoner{
-				0: {
-					NewReason("", testUser1, path.ExchangeService, path.EventsCategory),
-					NewReason("", testUser2, path.ExchangeService, path.EventsCategory),
-				},
-				1: {
-					NewReason("", testUser1, path.ExchangeService, path.EmailCategory),
-					NewReason("", testUser2, path.ExchangeService, path.EmailCategory),
-				},
 				2: {
 					NewReason("", testUser1, path.ExchangeService, path.EmailCategory),
 					NewReason("", testUser2, path.ExchangeService, path.EmailCategory),
@@ -727,9 +669,6 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 			expectedBaseReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
-			expectedAssistManifestReasons: map[int][]identity.Reasoner{
-				0: testUser1Mail,
-			},
 			backupData: []backupInfo{
 				newBackupModel(testBackup1, true, true, false, nil, nil),
 				// Shouldn't be returned but have here just so we can see.
@@ -760,9 +699,6 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 			expectedBaseReasons: map[int][]identity.Reasoner{
 				1: testUser1Mail,
 			},
-			expectedAssistManifestReasons: map[int][]identity.Reasoner{
-				1: testUser1Mail,
-			},
 			backupData: []backupInfo{
 				// Shouldn't be returned but have here just so we can see.
 				newBackupModel(testBackup1, true, true, false, nil, nil),
@@ -790,8 +726,6 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					testMail,
 					testUser1),
 			},
-			expectedBaseReasons:           map[int][]identity.Reasoner{},
-			expectedAssistManifestReasons: map[int][]identity.Reasoner{},
 			backupData: []backupInfo{
 				// Shouldn't be returned but have here just so we can see.
 				newBackupModel(testBackup1, true, true, false, nil, nil),
@@ -812,9 +746,6 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					testUser1),
 			},
 			expectedBaseReasons: map[int][]identity.Reasoner{
-				0: testUser1Mail,
-			},
-			expectedAssistManifestReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
 			backupData: []backupInfo{
@@ -845,9 +776,6 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					testUser1),
 			},
 			expectedBaseReasons: map[int][]identity.Reasoner{
-				0: testUser1Mail,
-			},
-			expectedAssistManifestReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
 			backupData: []backupInfo{
@@ -896,10 +824,6 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 			expectedBaseReasons: map[int][]identity.Reasoner{
 				2: testUser1Mail,
 			},
-			expectedAssistManifestReasons: map[int][]identity.Reasoner{
-				0: testUser1Mail,
-				2: testUser1Mail,
-			},
 			expectedAssistReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
@@ -946,10 +870,6 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 			expectedBaseReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
-			expectedAssistManifestReasons: map[int][]identity.Reasoner{
-				0: testUser1Mail,
-			},
-			expectedAssistReasons: map[int][]identity.Reasoner{},
 			backupData: []backupInfo{
 				newBackupModel(testBackup2, true, true, false, nil, nil),
 				newBackupModel(
@@ -981,10 +901,6 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 					nil,
 					testMail,
 					testUser1),
-			},
-			expectedBaseReasons: map[int][]identity.Reasoner{},
-			expectedAssistManifestReasons: map[int][]identity.Reasoner{
-				0: testUser1Mail,
 			},
 			expectedAssistReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
@@ -1022,10 +938,6 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 			expectedBaseReasons: map[int][]identity.Reasoner{
 				0: testUser1Mail,
 			},
-			expectedAssistManifestReasons: map[int][]identity.Reasoner{
-				0: testUser1Mail,
-			},
-			expectedAssistReasons: map[int][]identity.Reasoner{},
 			backupData: []backupInfo{
 				newBackupModel(testBackup2, true, true, false, nil, nil),
 				newBackupModel(
@@ -1076,7 +988,7 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 				t,
 				bb.UniqueAssistBases(),
 				test.manifestData,
-				test.expectedAssistManifestReasons)
+				test.expectedAssistReasons)
 		})
 	}
 }

--- a/src/internal/kopia/mock_backup_base.go
+++ b/src/internal/kopia/mock_backup_base.go
@@ -52,8 +52,6 @@ func (bb *MockBackupBases) WithBackups(b ...BackupEntry) *MockBackupBases {
 
 func (bb *MockBackupBases) WithMergeBases(m ...ManifestEntry) *MockBackupBases {
 	bb.backupBases.mergeBases = append(bb.MergeBases(), m...)
-	bb.backupBases.assistBases = append(bb.UniqueAssistBases(), m...)
-
 	return bb
 }
 
@@ -67,7 +65,12 @@ func (bb *MockBackupBases) WithAssistBases(m ...ManifestEntry) *MockBackupBases 
 	return bb
 }
 
-func (bb *MockBackupBases) ClearMockAssistBases() *MockBackupBases {
-	bb.backupBases.DisableAssistBases()
+func (bb *MockBackupBases) MockDisableAssistBases() *MockBackupBases {
+	bb.DisableAssistBases()
+	return bb
+}
+
+func (bb *MockBackupBases) MockDisableMergeBases() *MockBackupBases {
+	bb.DisableMergeBases()
 	return bb
 }

--- a/src/internal/kopia/mock_backup_base.go
+++ b/src/internal/kopia/mock_backup_base.go
@@ -16,6 +16,7 @@ func AssertBackupBasesEqual(t *testing.T, expect, got BackupBases) {
 		assert.Empty(t, got.MergeBases(), "merge bases")
 		assert.Empty(t, got.UniqueAssistBackups(), "assist backups")
 		assert.Empty(t, got.UniqueAssistBases(), "assist bases")
+		assert.Empty(t, got.SnapshotAssistBases(), "snapshot assist bases")
 
 		return
 	}
@@ -24,7 +25,8 @@ func AssertBackupBasesEqual(t *testing.T, expect, got BackupBases) {
 		if len(expect.Backups()) > 0 ||
 			len(expect.MergeBases()) > 0 ||
 			len(expect.UniqueAssistBackups()) > 0 ||
-			len(expect.UniqueAssistBases()) > 0 {
+			len(expect.UniqueAssistBases()) > 0 ||
+			len(expect.SnapshotAssistBases()) > 0 {
 			assert.Fail(t, "got was nil but expected non-nil result %v", expect)
 		}
 
@@ -35,6 +37,7 @@ func AssertBackupBasesEqual(t *testing.T, expect, got BackupBases) {
 	assert.ElementsMatch(t, expect.MergeBases(), got.MergeBases(), "merge bases")
 	assert.ElementsMatch(t, expect.UniqueAssistBackups(), got.UniqueAssistBackups(), "assist backups")
 	assert.ElementsMatch(t, expect.UniqueAssistBases(), got.UniqueAssistBases(), "assist bases")
+	assert.ElementsMatch(t, expect.SnapshotAssistBases(), got.SnapshotAssistBases(), "snapshot assist bases")
 }
 
 func NewMockBackupBases() *MockBackupBases {

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -178,7 +178,7 @@ func (w Wrapper) ConsumeBackupCollections(
 			mergeBase = bases.MergeBases()
 		}
 
-		assistBase = bases.UniqueAssistBases()
+		assistBase = bases.SnapshotAssistBases()
 	}
 
 	dirTree, err := inflateDirTree(

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -1002,7 +1002,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 		{
 			name: "Merge Only",
 			baseBackups: func(base ManifestEntry) BackupBases {
-				return NewMockBackupBases().WithMergeBases(base).ClearMockAssistBases()
+				return NewMockBackupBases().WithMergeBases(base).MockDisableAssistBases()
 			},
 			// Pass in empty collections to force a backup. Otherwise we'll skip
 			// actually trying to do anything because we'll see there's nothing that


### PR DESCRIPTION
Do a few things to separate merge and assist bases
* use distinct sets for each base type
* make another function to return all base snapshots to pass to kopia assisted incrementals
* update function that removes a merge base to make it into an assist base

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3943
* #4178

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
