### PR TITLE
Add sites metadata in Groups backup

### DIFF
--- a/src/internal/m365/collection/drive/group_handler.go
+++ b/src/internal/m365/collection/drive/group_handler.go
@@ -65,7 +65,7 @@ func (h groupBackupHandler) MetadataPathPrefix(tenantID string) (path.Path, erro
 
 	p, err = p.Append(false, odConsts.SitesPathDir, h.siteID)
 	if err != nil {
-		return nil, clues.Wrap(err, "appending sites to metadata path")
+		return nil, clues.Wrap(err, "appending site id to metadata path")
 	}
 
 	return p, nil

--- a/src/internal/m365/collection/drive/group_handler.go
+++ b/src/internal/m365/collection/drive/group_handler.go
@@ -86,6 +86,17 @@ func (h groupBackupHandler) CanonicalPath(
 	)
 }
 
+func (h groupBackupHandler) SitePathPrefix(tenantID string) (path.Path, error) {
+	return path.Build(
+		tenantID,
+		h.groupID,
+		h.service,
+		path.LibrariesCategory,
+		false,
+		odConsts.SitesPathDir,
+		h.siteID)
+}
+
 func (h groupBackupHandler) IsAllPass() bool {
 	return h.scope.IsAny(selectors.GroupsLibraryFolder)
 }

--- a/src/internal/m365/collection/drive/group_handler_test.go
+++ b/src/internal/m365/collection/drive/group_handler_test.go
@@ -49,6 +49,35 @@ func (suite *GroupBackupHandlerUnitSuite) TestPathPrefix() {
 	}
 }
 
+func (suite *GroupBackupHandlerUnitSuite) TestSitePathPrefix() {
+	tenantID, resourceOwner := "tenant", "resourceOwner"
+
+	table := []struct {
+		name      string
+		expect    string
+		expectErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:      "group",
+			expect:    "tenant/groups/resourceOwner/libraries/sites/site-id",
+			expectErr: assert.NoError,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+			h := NewGroupBackupHandler(resourceOwner, "site-id", api.Drives{}, nil)
+
+			result, err := h.SitePathPrefix(tenantID)
+			test.expectErr(t, err, clues.ToCore(err))
+
+			if result != nil {
+				assert.Equal(t, test.expect, result.String())
+			}
+		})
+	}
+}
+
 func (suite *GroupBackupHandlerUnitSuite) TestMetadataPathPrefix() {
 	tenantID, resourceOwner := "tenant", "resourceOwner"
 

--- a/src/internal/m365/graph/consts.go
+++ b/src/internal/m365/graph/consts.go
@@ -46,9 +46,6 @@ const (
 	// PreviousPathFileName is the name of the file containing previous path(s) for a
 	// given endpoint.
 	PreviousPathFileName = "previouspath"
-
-	// SitesFileName is the file containing information about sites within a group
-	SitesFileName = "sites"
 )
 
 // ---------------------------------------------------------------------------

--- a/src/internal/m365/graph/consts.go
+++ b/src/internal/m365/graph/consts.go
@@ -46,6 +46,9 @@ const (
 	// PreviousPathFileName is the name of the file containing previous path(s) for a
 	// given endpoint.
 	PreviousPathFileName = "previouspath"
+
+	// SitesFileName is the file containing information about sites within a group
+	SitesFileName = "sites"
 )
 
 // ---------------------------------------------------------------------------

--- a/src/internal/m365/service/groups/backup.go
+++ b/src/internal/m365/service/groups/backup.go
@@ -84,8 +84,7 @@ func ProduceBackupCollections(
 				bpc.ProtectedResource.ID(),
 				ptr.Val(resp.GetId()),
 				ac.Drives(),
-				scope,
-			)
+				scope)
 
 			cp, err := bh.SitePathPrefix(creds.AzureTenantID)
 			if err != nil {
@@ -164,8 +163,8 @@ func getSitesMetadataCollection(
 	sites map[string]string,
 	su support.StatusUpdater,
 ) (data.BackupCollection, error) {
-	// TODO(meain): Should we store this one level above? If so, how would we
-	// separate different resources? Use different name for each resource?
+	// TODO(meain): Switch to using BuildMetadata
+	// https://github.com/alcionai/corso/pull/4184#discussion_r1316139701
 	p, err := path.Builder{}.ToServiceCategoryMetadataPath(
 		tenantID,
 		groupID,


### PR DESCRIPTION
Add sites metadata (previous paths) under `groupID/libraries/sites/previouspath`.

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
