### PR TITLE
Wire service isolation changes into SDK code

### DIFF
--- a/src/internal/m365/service/exchange/enabled.go
+++ b/src/internal/m365/service/exchange/enabled.go
@@ -64,7 +64,7 @@ func GetMailboxInfo(
 
 		mi.ErrGetMailBoxSetting = append(
 			mi.ErrGetMailBoxSetting,
-			api.ErrMailBoxSettingsNotFound)
+			api.ErrMailBoxNotFound)
 
 		return mi, nil
 	}

--- a/src/internal/m365/service/exchange/enabled_test.go
+++ b/src/internal/m365/service/exchange/enabled_test.go
@@ -189,7 +189,7 @@ func (suite *EnabledUnitSuite) TestGetMailboxInfo() {
 				mi := api.MailboxInfo{}
 				mi.ErrGetMailBoxSetting = append(
 					mi.ErrGetMailBoxSetting,
-					api.ErrMailBoxSettingsNotFound)
+					api.ErrMailBoxNotFound)
 
 				return mi
 			},

--- a/src/pkg/services/m365/api/users.go
+++ b/src/pkg/services/m365/api/users.go
@@ -9,6 +9,7 @@ import (
 	msgraphgocore "github.com/microsoftgraph/msgraph-sdk-go-core"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
+	"github.com/pkg/errors"
 
 	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/common/ptr"
@@ -266,6 +267,18 @@ func EvaluateMailboxError(err error) error {
 	}
 
 	return err
+}
+
+// IsErrMailboxNotFound inspects the secondary errors inside MailboxInfo and
+// determines whether the resource has a mailbox.
+func IsErrMailboxNotFound(errs []error) bool {
+	for _, err := range errs {
+		if errors.Is(err, ErrMailBoxNotFound) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (c Users) GetMailboxSettings(

--- a/src/pkg/services/m365/api/users.go
+++ b/src/pkg/services/m365/api/users.go
@@ -20,7 +20,7 @@ import (
 
 // Variables
 var (
-	ErrMailBoxSettingsNotFound     = clues.New("mailbox settings not found")
+	ErrMailBoxNotFound             = clues.New("mailbox not found")
 	ErrMailBoxSettingsAccessDenied = clues.New("mailbox settings access denied")
 )
 
@@ -215,7 +215,7 @@ func (c Users) GetInfo(ctx context.Context, userID string) (*UserInfo, error) {
 	}
 
 	if !mailFolderFound {
-		mi.ErrGetMailBoxSetting = append(mi.ErrGetMailBoxSetting, ErrMailBoxSettingsNotFound)
+		mi.ErrGetMailBoxSetting = append(mi.ErrGetMailBoxSetting, ErrMailBoxNotFound)
 		userInfo.Mailbox = mi
 
 		return userInfo, nil

--- a/src/pkg/services/m365/api/users.go
+++ b/src/pkg/services/m365/api/users.go
@@ -269,9 +269,9 @@ func EvaluateMailboxError(err error) error {
 	return err
 }
 
-// IsErrMailboxNotFound inspects the secondary errors inside MailboxInfo and
+// IsAnyErrMailboxNotFound inspects the secondary errors inside MailboxInfo and
 // determines whether the resource has a mailbox.
-func IsErrMailboxNotFound(errs []error) bool {
+func IsAnyErrMailboxNotFound(errs []error) bool {
 	for _, err := range errs {
 		if errors.Is(err, ErrMailBoxNotFound) {
 			return true

--- a/src/pkg/services/m365/api/users_test.go
+++ b/src/pkg/services/m365/api/users_test.go
@@ -117,6 +117,43 @@ func (suite *UsersUnitSuite) TestEvaluateMailboxError() {
 	}
 }
 
+func (suite *UsersUnitSuite) TestIsErrMailboxNotFound() {
+	table := []struct {
+		name   string
+		errs   []error
+		expect bool
+	}{
+		{
+			name:   "no errors",
+			errs:   nil,
+			expect: false,
+		},
+		{
+			name: "mailbox not found error",
+			errs: []error{
+				clues.New("an error"),
+				api.ErrMailBoxNotFound,
+				clues.New("an error"),
+			},
+			expect: true,
+		},
+		{
+			name: "other errors",
+			errs: []error{
+				clues.New("an error"),
+				api.ErrMailBoxSettingsAccessDenied,
+				clues.New("an error"),
+			},
+			expect: false,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			assert.Equal(suite.T(), test.expect, api.IsErrMailboxNotFound(test.errs))
+		})
+	}
+}
+
 type UsersIntgSuite struct {
 	tester.Suite
 	its intgTesterSetup

--- a/src/pkg/services/m365/api/users_test.go
+++ b/src/pkg/services/m365/api/users_test.go
@@ -117,7 +117,7 @@ func (suite *UsersUnitSuite) TestEvaluateMailboxError() {
 	}
 }
 
-func (suite *UsersUnitSuite) TestIsErrMailboxNotFound() {
+func (suite *UsersUnitSuite) TestIsAnyErrMailboxNotFound() {
 	table := []struct {
 		name   string
 		errs   []error
@@ -149,7 +149,7 @@ func (suite *UsersUnitSuite) TestIsErrMailboxNotFound() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			assert.Equal(suite.T(), test.expect, api.IsErrMailboxNotFound(test.errs))
+			assert.Equal(suite.T(), test.expect, api.IsAnyErrMailboxNotFound(test.errs))
 		})
 	}
 }

--- a/src/pkg/services/m365/m365.go
+++ b/src/pkg/services/m365/m365.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/alcionai/clues"
-	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
@@ -16,10 +15,6 @@ import (
 // ---------------------------------------------------------------------------
 // interfaces & structs
 // ---------------------------------------------------------------------------
-
-type getDefaultDriver interface {
-	GetDefaultDrive(ctx context.Context, userID string) (models.Driveable, error)
-}
 
 type getAller[T any] interface {
 	GetAll(ctx context.Context, errs *fault.Bus) ([]T, error)

--- a/src/pkg/services/m365/users_test.go
+++ b/src/pkg/services/m365/users_test.go
@@ -182,7 +182,7 @@ func (suite *userIntegrationSuite) TestUserGetMailboxInfo() {
 			user: "a53c26f7-5100-4acb-a910-4d20960b2c19", // User: testevents@10rqc2.onmicrosoft.com
 			expect: func(t *testing.T, info api.MailboxInfo) {
 				require.NotNil(t, info)
-				assert.Contains(t, info.ErrGetMailBoxSetting, api.ErrMailBoxSettingsNotFound)
+				assert.Contains(t, info.ErrGetMailBoxSetting, api.ErrMailBoxNotFound)
 			},
 			expectErr: require.NoError,
 		},
@@ -305,7 +305,7 @@ func (suite *userIntegrationSuite) TestGetUserInfo_userWithoutDrive() {
 			expect: &api.UserInfo{
 				ServicesEnabled: map[path.ServiceType]struct{}{},
 				Mailbox: api.MailboxInfo{
-					ErrGetMailBoxSetting: []error{api.ErrMailBoxSettingsNotFound},
+					ErrGetMailBoxSetting: []error{api.ErrMailBoxNotFound},
 				},
 			},
 		},

--- a/src/pkg/services/m365/users_test.go
+++ b/src/pkg/services/m365/users_test.go
@@ -88,7 +88,6 @@ func (suite *userIntegrationSuite) TestUsersCompat_HasNoInfo() {
 	}
 }
 
-// TODO: Add integ tests for mailbox info
 func (suite *userIntegrationSuite) TestUserHasMailbox() {
 	t := suite.T()
 	acct := tconfig.NewM365Account(t)


### PR DESCRIPTION
<!-- PR description-->

Wires `IsServiceEnabled` code into `UserHasMailbox`, `UserHasDrive`, and `UserGetMailboxInfo` SDK APIs.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
*  https://github.com/alcionai/corso/issues/3844

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
