### PR TITLE
refactor api pagers to deduplicate spaghetti

### DIFF
--- a/src/cli/backup/backup.go
+++ b/src/cli/backup/backup.go
@@ -229,7 +229,9 @@ func runBackups(
 		err = bo.Run(ictx)
 		if err != nil {
 			if errors.Is(err, graph.ErrServiceNotEnabled) {
-				logger.Ctx(ctx).Infow("service not enabled", "resource_owner_name", bo.ResourceOwner.Name())
+				logger.Ctx(ctx).Infow("service not enabled",
+					"resource_owner_id", bo.ResourceOwner.ID(),
+					"service", serviceName)
 
 				continue
 			}

--- a/src/internal/m365/backup.go
+++ b/src/internal/m365/backup.go
@@ -19,7 +19,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
-	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 // ---------------------------------------------------------------------------
@@ -55,24 +54,25 @@ func (ctrl *Controller) ProduceBackupCollections(
 		return nil, nil, false, clues.Stack(err).WithClues(ctx)
 	}
 
-	serviceEnabled, canMakeDeltaQueries, err := checkServiceEnabled(
-		ctx,
-		ctrl.AC.Users(),
-		service,
-		bpc.ProtectedResource.ID())
-	if err != nil {
-		return nil, nil, false, err
-	}
-
-	if !serviceEnabled {
-		return []data.BackupCollection{}, nil, false, nil
-	}
-
 	var (
 		colls                []data.BackupCollection
 		ssmb                 *prefixmatcher.StringSetMatcher
 		canUsePreviousBackup bool
 	)
+
+	// All services except Exchange can make delta queries by default.
+	// Exchange can only make delta queries if the mailbox is not over quota.
+	canMakeDeltaQueries := true
+	if service == path.ExchangeService {
+		canMakeDeltaQueries, err = exchange.CanMakeDeltaQueries(
+			ctx,
+			service,
+			ctrl.AC.Users(),
+			bpc.ProtectedResource.ID())
+		if err != nil {
+			return nil, nil, false, clues.Stack(err)
+		}
+	}
 
 	if !canMakeDeltaQueries {
 		logger.Ctx(ctx).Info("delta requests not available")
@@ -148,48 +148,23 @@ func (ctrl *Controller) ProduceBackupCollections(
 	return colls, ssmb, canUsePreviousBackup, nil
 }
 
-// IsBackupRunnable verifies that the users provided has the services enabled and
-// data can be backed up. The canMakeDeltaQueries provides info if the mailbox is
-// full and delta queries can be made on it.
-func (ctrl *Controller) IsBackupRunnable(
+func (ctrl *Controller) IsServiceEnabled(
 	ctx context.Context,
 	service path.ServiceType,
 	resourceOwner string,
 ) (bool, error) {
-	if service == path.GroupsService {
-		_, err := ctrl.AC.Groups().GetByID(ctx, resourceOwner)
-		if err != nil {
-			// TODO(meain): check for error message in case groups are
-			// not enabled at all similar to sharepoint
-			return false, err
-		}
-
-		return true, nil
+	switch service {
+	case path.ExchangeService:
+		return exchange.IsServiceEnabled(ctx, ctrl.AC.Users(), resourceOwner)
+	case path.OneDriveService:
+		return onedrive.IsServiceEnabled(ctx, ctrl.AC.Users(), resourceOwner)
+	case path.SharePointService:
+		return sharepoint.IsServiceEnabled(ctx, ctrl.AC.Users().Sites(), resourceOwner)
+	case path.GroupsService:
+		return groups.IsServiceEnabled(ctx, ctrl.AC.Groups(), resourceOwner)
 	}
 
-	if service == path.SharePointService {
-		_, err := ctrl.AC.Sites().GetRoot(ctx)
-		if err != nil {
-			if clues.HasLabel(err, graph.LabelsNoSharePointLicense) {
-				return false, clues.Stack(graph.ErrServiceNotEnabled, err)
-			}
-
-			return false, err
-		}
-
-		return true, nil
-	}
-
-	info, err := ctrl.AC.Users().GetInfo(ctx, resourceOwner)
-	if err != nil {
-		return false, clues.Stack(err)
-	}
-
-	if !info.ServiceEnabled(service) {
-		return false, clues.Wrap(graph.ErrServiceNotEnabled, "checking service access")
-	}
-
-	return true, nil
+	return false, clues.Wrap(clues.New(service.String()), "service not supported").WithClues(ctx)
 }
 
 func verifyBackupInputs(sels selectors.Selector, cachedIDs []string) error {
@@ -210,37 +185,4 @@ func verifyBackupInputs(sels selectors.Selector, cachedIDs []string) error {
 	}
 
 	return nil
-}
-
-type getInfoer interface {
-	GetInfo(context.Context, string) (*api.UserInfo, error)
-}
-
-func checkServiceEnabled(
-	ctx context.Context,
-	gi getInfoer,
-	service path.ServiceType,
-	resource string,
-) (bool, bool, error) {
-	if service == path.SharePointService || service == path.GroupsService {
-		// No "enabled" check required for sharepoint or groups.
-		return true, true, nil
-	}
-
-	info, err := gi.GetInfo(ctx, resource)
-	if err != nil {
-		return false, false, clues.Stack(err)
-	}
-
-	if !info.ServiceEnabled(service) {
-		return false, false, clues.Wrap(graph.ErrServiceNotEnabled, "checking service access")
-	}
-
-	canMakeDeltaQueries := true
-	if service == path.ExchangeService {
-		// we currently can only check quota exceeded for exchange
-		canMakeDeltaQueries = info.CanMakeDeltaQueries()
-	}
-
-	return true, canMakeDeltaQueries, nil
 }

--- a/src/internal/m365/collection/drive/group_handler.go
+++ b/src/internal/m365/collection/drive/group_handler.go
@@ -63,6 +63,11 @@ func (h groupBackupHandler) MetadataPathPrefix(tenantID string) (path.Path, erro
 		return nil, clues.Wrap(err, "making metadata path")
 	}
 
+	p, err = p.Append(false, odConsts.SitesPathDir, h.siteID)
+	if err != nil {
+		return nil, clues.Wrap(err, "appending sites to metadata path")
+	}
+
 	return p, nil
 }
 

--- a/src/internal/m365/collection/drive/group_handler_test.go
+++ b/src/internal/m365/collection/drive/group_handler_test.go
@@ -59,7 +59,7 @@ func (suite *GroupBackupHandlerUnitSuite) TestMetadataPathPrefix() {
 	}{
 		{
 			name:      "group",
-			expect:    "tenant/groupsMetadata/resourceOwner/libraries",
+			expect:    "tenant/groupsMetadata/resourceOwner/libraries/sites/site-id",
 			expectErr: assert.NoError,
 		},
 	}

--- a/src/internal/m365/controller_test.go
+++ b/src/internal/m365/controller_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/alcionai/corso/src/internal/common/idname"
 	inMock "github.com/alcionai/corso/src/internal/common/idname/mock"
 	"github.com/alcionai/corso/src/internal/data"
-	dataMock "github.com/alcionai/corso/src/internal/data/mock"
-	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/m365/mock"
 	"github.com/alcionai/corso/src/internal/m365/resource"
 	exchMock "github.com/alcionai/corso/src/internal/m365/service/exchange/mock"
@@ -373,44 +371,6 @@ func (suite *ControllerIntegrationSuite) SetupSuite() {
 	suite.secondaryUser = tconfig.SecondaryM365UserID(t)
 
 	tester.LogTimeOfTest(t)
-}
-
-func (suite *ControllerIntegrationSuite) TestRestoreFailsBadService() {
-	t := suite.T()
-
-	ctx, flush := tester.NewContext(t)
-	defer flush()
-
-	var (
-		restoreCfg = testdata.DefaultRestoreConfig("")
-		sel        = selectors.Selector{
-			Service: selectors.ServiceUnknown,
-		}
-	)
-
-	restoreCfg.IncludePermissions = true
-
-	rcc := inject.RestoreConsumerConfig{
-		BackupVersion:     version.Backup,
-		Options:           control.DefaultOptions(),
-		ProtectedResource: sel,
-		RestoreConfig:     restoreCfg,
-		Selector:          sel,
-	}
-
-	deets, err := suite.ctrl.ConsumeRestoreCollections(
-		ctx,
-		rcc,
-		[]data.RestoreCollection{&dataMock.Collection{}},
-		fault.New(true),
-		count.New())
-	assert.Error(t, err, graph.ErrServiceNotEnabled, clues.ToCore(err))
-	assert.Nil(t, deets)
-
-	status := suite.ctrl.Wait()
-	assert.Equal(t, 0, status.Objects)
-	assert.Equal(t, 0, status.Folders)
-	assert.Equal(t, 0, status.Successes)
 }
 
 func (suite *ControllerIntegrationSuite) TestEmptyCollections() {

--- a/src/internal/m365/mock/connector.go
+++ b/src/internal/m365/mock/connector.go
@@ -46,7 +46,7 @@ func (ctrl Controller) ProduceBackupCollections(
 	return ctrl.Collections, ctrl.Exclude, ctrl.Err == nil, ctrl.Err
 }
 
-func (ctrl Controller) IsBackupRunnable(
+func (ctrl Controller) IsServiceEnabled(
 	_ context.Context,
 	_ path.ServiceType,
 	_ string,

--- a/src/internal/m365/restore.go
+++ b/src/internal/m365/restore.go
@@ -40,23 +40,11 @@ func (ctrl *Controller) ConsumeRestoreCollections(
 		return nil, clues.New("no data collections to restore")
 	}
 
-	serviceEnabled, _, err := checkServiceEnabled(
-		ctx,
-		ctrl.AC.Users(),
-		rcc.Selector.PathService(),
-		rcc.ProtectedResource.ID())
-	if err != nil {
-		return nil, err
-	}
-
-	if !serviceEnabled {
-		return nil, clues.Stack(graph.ErrServiceNotEnabled).WithClues(ctx)
-	}
-
 	var (
 		service = rcc.Selector.PathService()
 		status  *support.ControllerOperationStatus
 		deets   = &details.Builder{}
+		err     error
 	)
 
 	switch service {

--- a/src/internal/m365/service/exchange/backup.go
+++ b/src/internal/m365/service/exchange/backup.go
@@ -95,3 +95,17 @@ func ProduceBackupCollections(
 
 	return collections, nil, canUsePreviousBackup, el.Failure()
 }
+
+func CanMakeDeltaQueries(
+	ctx context.Context,
+	service path.ServiceType,
+	gmi getMailboxer,
+	resourceOwner string,
+) (bool, error) {
+	mi, err := GetMailboxInfo(ctx, gmi, resourceOwner)
+	if err != nil {
+		return false, clues.Stack(err)
+	}
+
+	return !mi.QuotaExceeded, nil
+}

--- a/src/internal/m365/service/groups/enabled.go
+++ b/src/internal/m365/service/groups/enabled.go
@@ -1,0 +1,21 @@
+package groups
+
+import (
+	"context"
+
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+)
+
+type getByIDer interface {
+	GetByID(ctx context.Context, identifier string) (models.Groupable, error)
+}
+
+func IsServiceEnabled(
+	ctx context.Context,
+	gbi getByIDer,
+	resource string,
+) (bool, error) {
+	// TODO(meain): check for error message in case groups are
+	// not enabled at all similar to sharepoint
+	return true, nil
+}

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -202,23 +202,25 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 	ctx, flushMetrics := events.NewMetrics(ctx, logger.Writer{Ctx: ctx})
 	defer flushMetrics()
 
-	var runnable bool
-
-	// IsBackupRunnable checks if the user has services enabled to run a backup.
-	// it also checks for conditions like mailbox full.
-	runnable, err = op.bp.IsBackupRunnable(ctx, op.Selectors.PathService(), op.ResourceOwner.ID())
+	// Check if the protected resource has the service enabled in order for us
+	// to run a backup.
+	enabled, err := op.bp.IsServiceEnabled(
+		ctx,
+		op.Selectors.PathService(),
+		op.ResourceOwner.ID())
 	if err != nil {
-		logger.CtxErr(ctx, err).Error("verifying backup is runnable")
-		op.Errors.Fail(clues.Wrap(err, "verifying backup is runnable"))
+		logger.CtxErr(ctx, err).Error("verifying service backup is enabled")
+		op.Errors.Fail(clues.Wrap(err, "verifying service backup is enabled"))
 
-		return
+		return err
 	}
 
-	if !runnable {
-		logger.CtxErr(ctx, graph.ErrServiceNotEnabled).Error("checking if backup is enabled")
-		op.Errors.Fail(clues.Wrap(err, "checking if backup is enabled"))
+	if !enabled {
+		// Return named error so that we can check for it in caller.
+		err = clues.Wrap(graph.ErrServiceNotEnabled, "service not enabled for backup")
+		op.Errors.Fail(err)
 
-		return
+		return err
 	}
 
 	// -----

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -1579,7 +1579,7 @@ func (mbp *mockBackupProducer) ProduceBackupCollections(
 	return mbp.colls, nil, true, nil
 }
 
-func (mbp *mockBackupProducer) IsBackupRunnable(
+func (mbp *mockBackupProducer) IsServiceEnabled(
 	context.Context,
 	path.ServiceType,
 	string,

--- a/src/internal/operations/inject/inject.go
+++ b/src/internal/operations/inject/inject.go
@@ -23,7 +23,8 @@ type (
 			bpc BackupProducerConfig,
 			errs *fault.Bus,
 		) ([]data.BackupCollection, prefixmatcher.StringSetReader, bool, error)
-		IsBackupRunnable(ctx context.Context, service path.ServiceType, resourceOwner string) (bool, error)
+
+		IsServiceEnableder
 
 		Wait() *data.CollectionStats
 	}
@@ -37,10 +38,22 @@ type (
 			ctr *count.Bus,
 		) (*details.Details, error)
 
+		IsServiceEnableder
+
 		Wait() *data.CollectionStats
 
 		CacheItemInfoer
 		PopulateProtectedResourceIDAndNamer
+	}
+
+	IsServiceEnableder interface {
+		// IsServiceEnabled checks if the service is enabled for backup/restore
+		// for the provided resource owner.
+		IsServiceEnabled(
+			ctx context.Context,
+			service path.ServiceType,
+			resourceOwner string,
+		) (bool, error)
 	}
 
 	CacheItemInfoer interface {

--- a/src/pkg/backup/details/details.go
+++ b/src/pkg/backup/details/details.go
@@ -46,11 +46,7 @@ func (d *Details) add(
 
 	// Use the item name and the path for the ShortRef. This ensures that renames
 	// within a directory generate unique ShortRefs.
-	if info.infoType() == OneDriveItem || info.infoType() == SharePointLibrary {
-		if info.OneDrive == nil && info.SharePoint == nil {
-			return entry, clues.New("item is not SharePoint or OneDrive type")
-		}
-
+	if info.isDriveItem() {
 		// clean metadata suffixes from item refs
 		entry.ItemRef = withoutMetadataSuffix(entry.ItemRef)
 	}

--- a/src/pkg/backup/details/iteminfo.go
+++ b/src/pkg/backup/details/iteminfo.go
@@ -182,3 +182,14 @@ func (i ItemInfo) updateFolder(f *FolderInfo) error {
 		return clues.New("unsupported type")
 	}
 }
+
+// true if the info represents an item backed by the drive api.
+func (i ItemInfo) isDriveItem() bool {
+	iit := i.infoType()
+
+	if !(iit == OneDriveItem || iit == SharePointLibrary) {
+		return false
+	}
+
+	return !(i.OneDrive == nil && i.SharePoint == nil && i.Groups == nil)
+}

--- a/src/pkg/backup/details/iteminfo_test.go
+++ b/src/pkg/backup/details/iteminfo_test.go
@@ -1,0 +1,86 @@
+package details
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/tester"
+)
+
+type ItemInfoUnitSuite struct {
+	tester.Suite
+}
+
+func TestItemInfoUnitSuite(t *testing.T) {
+	suite.Run(t, &ItemInfoUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *ItemInfoUnitSuite) TestItemInfo_IsDriveItem() {
+	table := []struct {
+		name   string
+		ii     ItemInfo
+		expect assert.BoolAssertionFunc
+	}{
+		{
+			name: "onedrive item",
+			ii: ItemInfo{
+				OneDrive: &OneDriveInfo{
+					ItemType: OneDriveItem,
+				},
+			},
+			expect: assert.True,
+		},
+		{
+			name: "sharepoint library",
+			ii: ItemInfo{
+				SharePoint: &SharePointInfo{
+					ItemType: SharePointLibrary,
+				},
+			},
+			expect: assert.True,
+		},
+		{
+			name: "sharepoint page",
+			ii: ItemInfo{
+				SharePoint: &SharePointInfo{
+					ItemType: SharePointPage,
+				},
+			},
+			expect: assert.False,
+		},
+		{
+			name: "groups library",
+			ii: ItemInfo{
+				Groups: &GroupsInfo{
+					ItemType: SharePointLibrary,
+				},
+			},
+			expect: assert.True,
+		},
+		{
+			name: "groups channel message",
+			ii: ItemInfo{
+				Groups: &GroupsInfo{
+					ItemType: GroupsChannelMessage,
+				},
+			},
+			expect: assert.False,
+		},
+		{
+			name: "exchange anything",
+			ii: ItemInfo{
+				Groups: &GroupsInfo{
+					ItemType: ExchangeMail,
+				},
+			},
+			expect: assert.False,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			test.expect(suite.T(), test.ii.isDriveItem())
+		})
+	}
+}

--- a/src/pkg/services/m365/api/user_info.go
+++ b/src/pkg/services/m365/api/user_info.go
@@ -68,24 +68,6 @@ func newUserInfo() *UserInfo {
 	}
 }
 
-// ServiceEnabled returns true if the UserInfo has an entry for the
-// service.  If no entry exists, the service is assumed to not be enabled.
-func (ui *UserInfo) ServiceEnabled(service path.ServiceType) bool {
-	if ui == nil || len(ui.ServicesEnabled) == 0 {
-		return false
-	}
-
-	_, ok := ui.ServicesEnabled[service]
-
-	return ok
-}
-
-// Returns if we can run delta queries on a mailbox. We cannot run
-// them if the mailbox is full which is indicated by QuotaExceeded.
-func (ui *UserInfo) CanMakeDeltaQueries() bool {
-	return !ui.Mailbox.QuotaExceeded
-}
-
 func ParseMailboxSettings(
 	settings models.Userable,
 	mi MailboxInfo,

--- a/src/pkg/services/m365/api/users.go
+++ b/src/pkg/services/m365/api/users.go
@@ -172,6 +172,7 @@ func appendIfErr(errs []error, err error) []error {
 // Info
 // ---------------------------------------------------------------------------
 
+// TODO(pandeyabs): Remove this once the SDK users have migrated to new APIs
 func (c Users) GetInfo(ctx context.Context, userID string) (*UserInfo, error) {
 	var (
 		// Assume all services are enabled

--- a/src/pkg/services/m365/users.go
+++ b/src/pkg/services/m365/users.go
@@ -192,6 +192,8 @@ func parseUser(item models.Userable) (*User, error) {
 }
 
 // UserInfo returns the corso-specific set of user metadata.
+// TODO(pandeyabs): Remove support for this API. SDK users would be using
+// per service API calls - UserHasMailbox, UserGetMailboxInfo, UserHasDrive, etc.
 func GetUserInfo(
 	ctx context.Context,
 	acct account.Account,


### PR DESCRIPTION
the page-querying design in the api layer has grown organically from the roots of its implementation prior to centralizing calls in the api layer.  As a result, there's a lot of duplicate, or near- duplicate, code handling.  The duplication will, as we grow the layer, eventually lead to maintenance issues and "I forgot that spot" gotchas.

This PR is a first step towards wrangling that code into a clean and centralized pattern.
* Page controller structs are consistent for each type (one for deltas, one for non-deltas).
* All page controllers call into either enumerateItems or deltaEnumerateItems as their centralized runner.
* All variations on data control (only ids, collision keys, etc) are handled as a post-process to the enumeration calls, instead of duplicating the runner process itself in every iteration.

Future PRs can further reduce issues by:
* conforming container enumeration to the same pattern.
* moving pager loop processing out of higher layers and into the api layer.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3988

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
