### PR TITLE
add drive info to site get by id

### DIFF
--- a/src/pkg/services/m365/api/sites.go
+++ b/src/pkg/services/m365/api/sites.go
@@ -10,11 +10,11 @@ import (
 	"github.com/alcionai/clues"
 	msgraphgocore "github.com/microsoftgraph/msgraph-sdk-go-core"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/microsoftgraph/msgraph-sdk-go/sites"
 	"github.com/pkg/errors"
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
-	"github.com/alcionai/corso/src/internal/m365/graph/betasdk/sites"
 	"github.com/alcionai/corso/src/pkg/fault"
 )
 
@@ -103,7 +103,7 @@ const uuidRE = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9
 // deadbeef-0000-0000-0000-000000000000,beefdead-0000-0000-0000-000000000000
 var siteIDRE = regexp.MustCompile(`(.+,)?` + uuidRE + "," + uuidRE)
 
-const webURLGetTemplate = "https://graph.microsoft.com/v1.0/sites/%s:/%s"
+const sitesWebURLGetTemplate = "https://graph.microsoft.com/v1.0/sites/%s:/%s?$expand=drive"
 
 // GetByID looks up the site matching the given identifier.  The identifier can be either a
 // canonical site id or a webURL.  Assumes the webURL is complete and well formed;
@@ -117,11 +117,17 @@ func (c Sites) GetByID(ctx context.Context, identifier string) (models.Siteable,
 	ctx = clues.Add(ctx, "given_site_id", identifier)
 
 	if siteIDRE.MatchString(identifier) {
+		options := &sites.SiteItemRequestBuilderGetRequestConfiguration{
+			QueryParameters: &sites.SiteItemRequestBuilderGetQueryParameters{
+				Expand: []string{"drive"},
+			},
+		}
+
 		resp, err = c.Stable.
 			Client().
 			Sites().
 			BySiteIdString(identifier).
-			Get(ctx, nil)
+			Get(ctx, options)
 		if err != nil {
 			err := graph.Wrap(ctx, err, "getting site by id")
 
@@ -153,7 +159,7 @@ func (c Sites) GetByID(ctx context.Context, identifier string) (models.Siteable,
 
 	// don't construct a path with double leading slashes
 	path := strings.TrimPrefix(u.Path, "/")
-	rawURL := fmt.Sprintf(webURLGetTemplate, u.Host, path)
+	rawURL := fmt.Sprintf(sitesWebURLGetTemplate, u.Host, path)
 
 	resp, err = sites.
 		NewItemSitesSiteItemRequestBuilder(rawURL, c.Stable.Adapter()).

--- a/src/pkg/services/m365/api/sites.go
+++ b/src/pkg/services/m365/api/sites.go
@@ -36,11 +36,17 @@ type Sites struct {
 // ---------------------------------------------------------------------------
 
 func (c Sites) GetRoot(ctx context.Context) (models.Siteable, error) {
+	options := &sites.SiteItemRequestBuilderGetRequestConfiguration{
+		QueryParameters: &sites.SiteItemRequestBuilderGetQueryParameters{
+			Expand: []string{"drive"},
+		},
+	}
+
 	resp, err := c.Stable.
 		Client().
 		Sites().
 		BySiteIdString("root").
-		Get(ctx, nil)
+		Get(ctx, options)
 	if err != nil {
 		return nil, graph.Wrap(ctx, err, "getting root site")
 	}

--- a/src/pkg/services/m365/api/sites_test.go
+++ b/src/pkg/services/m365/api/sites_test.go
@@ -224,8 +224,11 @@ func (suite *SitesIntgSuite) TestSites_GetByID() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			_, err := sitesAPI.GetByID(ctx, test.id)
+			site, err := sitesAPI.GetByID(ctx, test.id)
 			test.expectErr(t, err)
+			require.NotEmpty(t, ptr.Val(site.GetId()), "must have an id")
+			require.NotNil(t, site.GetDrive(), "must have drive info")
+			require.NotNil(t, site.GetDrive().GetOwner(), "must have drive owner info")
 		})
 	}
 }
@@ -240,4 +243,6 @@ func (suite *SitesIntgSuite) TestGetRoot() {
 	require.NoError(t, err)
 	require.NotNil(t, result, "must find the root site")
 	require.NotEmpty(t, ptr.Val(result.GetId()), "must have an id")
+	require.NotNil(t, result.GetDrive(), "must have drive info")
+	require.NotNil(t, result.GetDrive().GetOwner(), "must have drive owner info")
 }

--- a/src/pkg/services/m365/api/sites_test.go
+++ b/src/pkg/services/m365/api/sites_test.go
@@ -158,62 +158,70 @@ func (suite *SitesIntgSuite) TestSites_GetByID() {
 	table := []struct {
 		name      string
 		id        string
-		expectErr func(*testing.T, error)
+		expectErr func(*testing.T, error) bool
 	}{
 		{
 			name: "3 part id",
 			id:   siteID,
-			expectErr: func(t *testing.T, err error) {
+			expectErr: func(t *testing.T, err error) bool {
 				assert.NoError(t, err, clues.ToCore(err))
+				return false
 			},
 		},
 		{
 			name: "2 part id",
 			id:   uuids,
-			expectErr: func(t *testing.T, err error) {
+			expectErr: func(t *testing.T, err error) bool {
 				assert.NoError(t, err, clues.ToCore(err))
+				return false
 			},
 		},
 		{
 			name: "malformed id",
 			id:   uuid.NewString(),
-			expectErr: func(t *testing.T, err error) {
+			expectErr: func(t *testing.T, err error) bool {
 				assert.Error(t, err, clues.ToCore(err))
+				return true
 			},
 		},
 		{
 			name: "random id",
 			id:   uuid.NewString() + "," + uuid.NewString(),
-			expectErr: func(t *testing.T, err error) {
+			expectErr: func(t *testing.T, err error) bool {
 				assert.ErrorIs(t, err, graph.ErrResourceOwnerNotFound, clues.ToCore(err))
+				return true
 			},
 		},
 		{
 			name: "url",
 			id:   siteURL,
-			expectErr: func(t *testing.T, err error) {
+			expectErr: func(t *testing.T, err error) bool {
 				assert.NoError(t, err, clues.ToCore(err))
+				return false
 			},
 		},
 		{
 			name: "malformed url",
 			id:   "barunihlda",
-			expectErr: func(t *testing.T, err error) {
+			expectErr: func(t *testing.T, err error) bool {
 				assert.Error(t, err, clues.ToCore(err))
+				return true
 			},
 		},
 		{
 			name: "well formed url, invalid hostname",
 			id:   "https://test/sites/testing",
-			expectErr: func(t *testing.T, err error) {
+			expectErr: func(t *testing.T, err error) bool {
 				assert.Error(t, err, clues.ToCore(err))
+				return true
 			},
 		},
 		{
 			name: "well formed url, no sites match",
 			id:   modifiedSiteURL,
-			expectErr: func(t *testing.T, err error) {
+			expectErr: func(t *testing.T, err error) bool {
 				assert.ErrorIs(t, err, graph.ErrResourceOwnerNotFound, clues.ToCore(err))
+				return true
 			},
 		},
 	}
@@ -225,7 +233,12 @@ func (suite *SitesIntgSuite) TestSites_GetByID() {
 			defer flush()
 
 			site, err := sitesAPI.GetByID(ctx, test.id)
-			test.expectErr(t, err)
+			expectedErr := test.expectErr(t, err)
+
+			if expectedErr {
+				return
+			}
+
 			require.NotEmpty(t, ptr.Val(site.GetId()), "must have an id")
 			require.NotNil(t, site.GetDrive(), "must have drive info")
 			require.NotNil(t, site.GetDrive().GetOwner(), "must have drive owner info")


### PR DESCRIPTION
extends the site get-by-id call to include drive info. Useful for detecting whether the site is owned by
a user, or a group or team.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
