### PR TITLE
refactor api pagers to deduplicate spaghetti

### DIFF
--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -248,7 +248,7 @@ func (c *Collections) Get(
 	// Enumerate drives for the specified resourceOwner
 	pager := c.handler.NewDrivePager(c.resourceOwner, nil)
 
-	drives, err := api.GetAllDrives(ctx, pager, true, maxDrivesRetries)
+	drives, err := api.GetAllDrives(ctx, pager)
 	if err != nil {
 		return nil, false, err
 	}

--- a/src/internal/m365/collection/drive/item_collector.go
+++ b/src/internal/m365/collection/drive/item_collector.go
@@ -72,7 +72,7 @@ func collectItems(
 
 	if !invalidPrevDelta {
 		maps.Copy(newPaths, oldPaths)
-		pager.SetNext(prevDelta)
+		pager.SetNextLink(prevDelta)
 	}
 
 	for {
@@ -94,10 +94,7 @@ func collectItems(
 			return DeltaUpdate{}, nil, nil, graph.Wrap(ctx, err, "getting page")
 		}
 
-		vals, err := pager.ValuesIn(page)
-		if err != nil {
-			return DeltaUpdate{}, nil, nil, graph.Wrap(ctx, err, "extracting items from response")
-		}
+		vals := page.GetValue()
 
 		err = collector(
 			ctx,
@@ -126,7 +123,7 @@ func collectItems(
 		}
 
 		logger.Ctx(ctx).Debugw("Found nextLink", "link", nextLink)
-		pager.SetNext(nextLink)
+		pager.SetNextLink(nextLink)
 	}
 
 	return DeltaUpdate{URL: newDeltaURL, Reset: invalidPrevDelta}, newPaths, excluded, nil

--- a/src/internal/m365/collection/drive/item_collector_test.go
+++ b/src/internal/m365/collection/drive/item_collector_test.go
@@ -83,7 +83,6 @@ func (suite *ItemCollectorUnitSuite) TestDrives() {
 	table := []struct {
 		name            string
 		pagerResults    []mock.PagerResult[models.Driveable]
-		retry           bool
 		expectedErr     assert.ErrorAssertionFunc
 		expectedResults []models.Driveable
 	}{
@@ -96,7 +95,6 @@ func (suite *ItemCollectorUnitSuite) TestDrives() {
 					Err:      nil,
 				},
 			},
-			retry:           false,
 			expectedErr:     assert.NoError,
 			expectedResults: resultDrives,
 		},
@@ -109,7 +107,6 @@ func (suite *ItemCollectorUnitSuite) TestDrives() {
 					Err:      nil,
 				},
 			},
-			retry:           false,
 			expectedErr:     assert.NoError,
 			expectedResults: resultDrives,
 		},
@@ -127,7 +124,6 @@ func (suite *ItemCollectorUnitSuite) TestDrives() {
 					Err:      nil,
 				},
 			},
-			retry:           false,
 			expectedErr:     assert.NoError,
 			expectedResults: resultDrives,
 		},
@@ -145,7 +141,6 @@ func (suite *ItemCollectorUnitSuite) TestDrives() {
 					Err:      nil,
 				},
 			},
-			retry:           false,
 			expectedErr:     assert.NoError,
 			expectedResults: resultDrives,
 		},
@@ -163,7 +158,6 @@ func (suite *ItemCollectorUnitSuite) TestDrives() {
 					Err:      assert.AnError,
 				},
 			},
-			retry:           true,
 			expectedErr:     assert.Error,
 			expectedResults: nil,
 		},
@@ -176,7 +170,6 @@ func (suite *ItemCollectorUnitSuite) TestDrives() {
 					Err:      graph.Stack(ctx, mySiteURLNotFound),
 				},
 			},
-			retry:           true,
 			expectedErr:     assert.NoError,
 			expectedResults: nil,
 		},
@@ -189,7 +182,6 @@ func (suite *ItemCollectorUnitSuite) TestDrives() {
 					Err:      graph.Stack(ctx, mySiteNotFound),
 				},
 			},
-			retry:           true,
 			expectedErr:     assert.NoError,
 			expectedResults: nil,
 		},
@@ -212,7 +204,6 @@ func (suite *ItemCollectorUnitSuite) TestDrives() {
 					Err:      nil,
 				},
 			},
-			retry:           true,
 			expectedErr:     assert.NoError,
 			expectedResults: resultDrives,
 		},
@@ -235,7 +226,6 @@ func (suite *ItemCollectorUnitSuite) TestDrives() {
 					Err:      nil,
 				},
 			},
-			retry:           false,
 			expectedErr:     assert.Error,
 			expectedResults: nil,
 		},
@@ -251,7 +241,6 @@ func (suite *ItemCollectorUnitSuite) TestDrives() {
 				},
 				tooManyRetries...,
 			),
-			retry:           true,
 			expectedErr:     assert.Error,
 			expectedResults: nil,
 		},
@@ -267,7 +256,7 @@ func (suite *ItemCollectorUnitSuite) TestDrives() {
 				ToReturn: test.pagerResults,
 			}
 
-			drives, err := api.GetAllDrives(ctx, pager, test.retry, maxDrivesRetries)
+			drives, err := api.GetAllDrives(ctx, pager)
 			test.expectedErr(t, err, clues.ToCore(err))
 
 			assert.ElementsMatch(t, test.expectedResults, drives)

--- a/src/internal/m365/collection/drive/item_test.go
+++ b/src/internal/m365/collection/drive/item_test.go
@@ -51,7 +51,7 @@ func (suite *ItemIntegrationSuite) SetupSuite() {
 
 	pager := suite.service.ac.Drives().NewUserDrivePager(suite.user, nil)
 
-	odDrives, err := api.GetAllDrives(ctx, pager, true, maxDrivesRetries)
+	odDrives, err := api.GetAllDrives(ctx, pager)
 	require.NoError(t, err, clues.ToCore(err))
 	// Test Requirement 1: Need a drive
 	require.Greaterf(t, len(odDrives), 0, "user %s does not have a drive", suite.user)

--- a/src/internal/m365/collection/drive/restore_caches.go
+++ b/src/internal/m365/collection/drive/restore_caches.go
@@ -68,9 +68,7 @@ func (rc *restoreCaches) Populate(
 ) error {
 	drives, err := api.GetAllDrives(
 		ctx,
-		gdparf.NewDrivePager(protectedResourceID, nil),
-		true,
-		maxDrivesRetries)
+		gdparf.NewDrivePager(protectedResourceID, nil))
 	if err != nil {
 		return clues.Wrap(err, "getting drives")
 	}

--- a/src/internal/operations/test/sharepoint_test.go
+++ b/src/internal/operations/test/sharepoint_test.go
@@ -381,7 +381,7 @@ func (suite *SharePointRestoreNightlyIntgSuite) TestRestore_Run_sharepointDelete
 			Drives().
 			NewSiteDrivePager(suite.its.site.ID, []string{"id", "name"})
 
-		drives, err := api.GetAllDrives(ctx, pgr, false, -1)
+		drives, err := api.GetAllDrives(ctx, pgr)
 		require.NoError(t, err, clues.ToCore(err))
 
 		var created models.Driveable

--- a/src/pkg/services/m365/api/channels_pager.go
+++ b/src/pkg/services/m365/api/channels_pager.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
-	"github.com/alcionai/corso/src/pkg/logger"
 )
 
 // ---------------------------------------------------------------------------
@@ -24,13 +23,13 @@ type channelMessageDeltaPageCtrl struct {
 	options               *teams.ItemChannelsItemMessagesDeltaRequestBuilderGetRequestConfiguration
 }
 
-func (p *channelMessageDeltaPageCtrl) SetNext(nextLink string) {
+func (p *channelMessageDeltaPageCtrl) SetNextLink(nextLink string) {
 	p.builder = teams.NewItemChannelsItemMessagesDeltaRequestBuilder(nextLink, p.gs.Adapter())
 }
 
 func (p *channelMessageDeltaPageCtrl) GetPage(
 	ctx context.Context,
-) (DeltaPageLinker, error) {
+) (DeltaLinkValuer[models.ChatMessageable], error) {
 	resp, err := p.builder.Get(ctx, p.options)
 	return resp, graph.Stack(ctx, err).OrNil()
 }
@@ -44,10 +43,6 @@ func (p *channelMessageDeltaPageCtrl) Reset(context.Context) {
 		ByChannelIdString(p.channelID).
 		Messages().
 		Delta()
-}
-
-func (p *channelMessageDeltaPageCtrl) ValuesIn(l PageLinker) ([]models.ChatMessageable, error) {
-	return getValues[models.ChatMessageable](l)
 }
 
 func (c Channels) NewChannelMessageDeltaPager(
@@ -97,56 +92,16 @@ func (c Channels) GetChannelMessageIDsDelta(
 		// because we need the follow-up get request to gather
 		// all replies to the message.
 		// selectProps      = idAnd()
-		pager            = c.NewChannelMessageDeltaPager(teamID, channelID, prevDelta)
-		invalidPrevDelta = len(prevDelta) == 0
-		newDeltaLink     string
+		pager = c.NewChannelMessageDeltaPager(teamID, channelID, prevDelta)
 	)
 
-	// Loop through all pages returned by Graph API.
-	for {
-		page, err := pager.GetPage(graph.ConsumeNTokens(ctx, graph.SingleGetOrDeltaLC))
-		if graph.IsErrInvalidDelta(err) {
-			logger.Ctx(ctx).Infow("Invalid previous delta", "delta_link", prevDelta)
-
-			invalidPrevDelta = true
-			vs = map[string]struct{}{}
-
-			pager.Reset(ctx)
-
-			continue
-		}
-
-		if err != nil {
-			return nil, DeltaUpdate{}, graph.Wrap(ctx, err, "retrieving page of channel messages")
-		}
-
-		vals, err := pager.ValuesIn(page)
-		if err != nil {
-			return nil, DeltaUpdate{}, graph.Wrap(ctx, err, "extracting channel messages from response")
-		}
-
-		for _, v := range vals {
-			vs[ptr.Val(v.GetId())] = struct{}{}
-		}
-
-		nextLink, deltaLink := NextAndDeltaLink(page)
-
-		if len(deltaLink) > 0 {
-			newDeltaLink = deltaLink
-		}
-
-		if len(nextLink) == 0 {
-			break
-		}
-
-		pager.SetNext(nextLink)
+	results, du, err := deltaEnumerateItems[models.ChatMessageable](ctx, pager, prevDelta)
+	if err != nil {
+		return nil, DeltaUpdate{}, graph.Wrap(ctx, err, "extracting channel messages from response")
 	}
 
-	logger.Ctx(ctx).Debugf("retrieved %d channel messages", len(vs))
-
-	du := DeltaUpdate{
-		URL:   newDeltaLink,
-		Reset: invalidPrevDelta,
+	for _, r := range results {
+		vs[ptr.Val(r.GetId())] = struct{}{}
 	}
 
 	return vs, du, nil
@@ -164,23 +119,19 @@ type channelMessageRepliesPageCtrl struct {
 	options *teams.ItemChannelsItemMessagesItemRepliesRequestBuilderGetRequestConfiguration
 }
 
-func (p *channelMessageRepliesPageCtrl) SetNext(nextLink string) {
+func (p *channelMessageRepliesPageCtrl) SetNextLink(nextLink string) {
 	p.builder = teams.NewItemChannelsItemMessagesItemRepliesRequestBuilder(nextLink, p.gs.Adapter())
 }
 
 func (p *channelMessageRepliesPageCtrl) GetPage(
 	ctx context.Context,
-) (PageLinker, error) {
+) (NextLinkValuer[models.ChatMessageable], error) {
 	resp, err := p.builder.Get(ctx, p.options)
 	return resp, graph.Stack(ctx, err).OrNil()
 }
 
 func (p *channelMessageRepliesPageCtrl) GetOdataNextLink() *string {
 	return ptr.To("")
-}
-
-func (p *channelMessageRepliesPageCtrl) ValuesIn(l PageLinker) ([]models.ChatMessageable, error) {
-	return getValues[models.ChatMessageable](l)
 }
 
 func (c Channels) NewChannelMessageRepliesPager(
@@ -217,42 +168,7 @@ func (c Channels) GetChannelMessageReplies(
 	ctx context.Context,
 	teamID, channelID, messageID string,
 ) ([]models.ChatMessageable, error) {
-	var (
-		vs = []models.ChatMessageable{}
-		// select is not currently enabled for replies.
-		// selectProps = idAnd(
-		// 	"messageType",
-		// 	"createdDateTime",
-		// 	"from",
-		// 	"body")
-		pager = c.NewChannelMessageRepliesPager(teamID, channelID, messageID)
-	)
-
-	// Loop through all pages returned by Graph API.
-	for {
-		page, err := pager.GetPage(ctx)
-		if err != nil {
-			return nil, graph.Wrap(ctx, err, "retrieving page of channels")
-		}
-
-		vals, err := pager.ValuesIn(page)
-		if err != nil {
-			return nil, graph.Wrap(ctx, err, "extracting channels from response")
-		}
-
-		vs = append(vs, vals...)
-
-		nextLink := ptr.Val(page.GetOdataNextLink())
-		if len(nextLink) == 0 {
-			break
-		}
-
-		pager.SetNext(nextLink)
-	}
-
-	logger.Ctx(ctx).Debugf("retrieved %d channel message replies", len(vs))
-
-	return vs, nil
+	return enumerateItems[models.ChatMessageable](ctx, c.NewChannelMessageRepliesPager(teamID, channelID, messageID))
 }
 
 // ---------------------------------------------------------------------------
@@ -267,19 +183,15 @@ type channelPageCtrl struct {
 	options *teams.ItemChannelsRequestBuilderGetRequestConfiguration
 }
 
-func (p *channelPageCtrl) SetNext(nextLink string) {
+func (p *channelPageCtrl) SetNextLink(nextLink string) {
 	p.builder = teams.NewItemChannelsRequestBuilder(nextLink, p.gs.Adapter())
 }
 
 func (p *channelPageCtrl) GetPage(
 	ctx context.Context,
-) (PageLinker, error) {
+) (NextLinkValuer[models.Channelable], error) {
 	resp, err := p.builder.Get(ctx, p.options)
 	return resp, graph.Stack(ctx, err).OrNil()
-}
-
-func (p *channelPageCtrl) ValuesIn(l PageLinker) ([]models.Channelable, error) {
-	return getValues[models.Channelable](l)
 }
 
 func (c Channels) NewChannelPager(
@@ -307,34 +219,5 @@ func (c Channels) GetChannels(
 	ctx context.Context,
 	teamID string,
 ) ([]models.Channelable, error) {
-	var (
-		vs    = []models.Channelable{}
-		pager = c.NewChannelPager(teamID)
-	)
-
-	// Loop through all pages returned by Graph API.
-	for {
-		page, err := pager.GetPage(ctx)
-		if err != nil {
-			return nil, graph.Wrap(ctx, err, "retrieving page of channels")
-		}
-
-		vals, err := pager.ValuesIn(page)
-		if err != nil {
-			return nil, graph.Wrap(ctx, err, "extracting channels from response")
-		}
-
-		vs = append(vs, vals...)
-
-		nextLink := ptr.Val(page.GetOdataNextLink())
-		if len(nextLink) == 0 {
-			break
-		}
-
-		pager.SetNext(nextLink)
-	}
-
-	logger.Ctx(ctx).Debugf("retrieved %d channels", len(vs))
-
-	return vs, nil
+	return enumerateItems[models.Channelable](ctx, c.NewChannelPager(teamID))
 }

--- a/src/pkg/services/m365/api/config.go
+++ b/src/pkg/services/m365/api/config.go
@@ -17,6 +17,7 @@ const (
 // get easily misspelled.
 // eg: we don't need a const for "id"
 const (
+	additionalData    = "additionalData"
 	bccRecipients     = "bccRecipients"
 	ccRecipients      = "ccRecipients"
 	createdDateTime   = "createdDateTime"

--- a/src/pkg/services/m365/api/contacts_pager.go
+++ b/src/pkg/services/m365/api/contacts_pager.go
@@ -10,7 +10,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/pkg/fault"
-	"github.com/alcionai/corso/src/pkg/selectors"
+	"github.com/alcionai/corso/src/pkg/path"
 )
 
 // ---------------------------------------------------------------------------
@@ -22,6 +22,7 @@ import (
 // fn(cf) on each one.
 // Folder hierarchy is represented in its current state, and does
 // not contain historical data.
+// TODO: use enumerateItems for containers
 func (c Contacts) EnumerateContainers(
 	ctx context.Context,
 	userID, baseContainerID string,
@@ -90,7 +91,7 @@ func (c Contacts) EnumerateContainers(
 // item pager
 // ---------------------------------------------------------------------------
 
-var _ itemPager[models.Contactable] = &contactsPageCtrl{}
+var _ Pager[models.Contactable] = &contactsPageCtrl{}
 
 type contactsPageCtrl struct {
 	gs      graph.Servicer
@@ -100,10 +101,11 @@ type contactsPageCtrl struct {
 
 func (c Contacts) NewContactsPager(
 	userID, containerID string,
+	immutableIDs bool,
 	selectProps ...string,
-) itemPager[models.Contactable] {
+) Pager[models.Contactable] {
 	options := &users.ItemContactFoldersItemContactsRequestBuilderGetRequestConfiguration{
-		Headers:         newPreferHeaders(preferPageSize(maxNonDeltaPageSize)),
+		Headers:         newPreferHeaders(preferPageSize(maxNonDeltaPageSize), preferImmutableIDs(immutableIDs)),
 		QueryParameters: &users.ItemContactFoldersItemContactsRequestBuilderGetQueryParameters{},
 		// do NOT set Top.  It limits the total items received.
 	}
@@ -123,28 +125,23 @@ func (c Contacts) NewContactsPager(
 	return &contactsPageCtrl{c.Stable, builder, options}
 }
 
-//lint:ignore U1000 False Positive
-func (p *contactsPageCtrl) getPage(ctx context.Context) (PageLinkValuer[models.Contactable], error) {
+func (p *contactsPageCtrl) GetPage(
+	ctx context.Context,
+) (NextLinkValuer[models.Contactable], error) {
 	resp, err := p.builder.Get(ctx, p.options)
-	if err != nil {
-		return nil, graph.Stack(ctx, err)
-	}
-
-	return EmptyDeltaLinker[models.Contactable]{PageLinkValuer: resp}, nil
+	return resp, graph.Stack(ctx, err).OrNil()
 }
 
-//lint:ignore U1000 False Positive
-func (p *contactsPageCtrl) setNext(nextLink string) {
+func (p *contactsPageCtrl) SetNextLink(nextLink string) {
 	p.builder = users.NewItemContactFoldersItemContactsRequestBuilder(nextLink, p.gs.Adapter())
 }
 
-//lint:ignore U1000 False Positive
 func (c Contacts) GetItemsInContainerByCollisionKey(
 	ctx context.Context,
 	userID, containerID string,
 ) (map[string]string, error) {
 	ctx = clues.Add(ctx, "container_id", containerID)
-	pager := c.NewContactsPager(userID, containerID, contactCollisionKeyProps()...)
+	pager := c.NewContactsPager(userID, containerID, false, contactCollisionKeyProps()...)
 
 	items, err := enumerateItems(ctx, pager)
 	if err != nil {
@@ -165,7 +162,7 @@ func (c Contacts) GetItemIDsInContainer(
 	userID, containerID string,
 ) (map[string]struct{}, error) {
 	ctx = clues.Add(ctx, "container_id", containerID)
-	pager := c.NewContactsPager(userID, containerID, "id")
+	pager := c.NewContactsPager(userID, containerID, false, idAnd()...)
 
 	items, err := enumerateItems(ctx, pager)
 	if err != nil {
@@ -182,68 +179,12 @@ func (c Contacts) GetItemIDsInContainer(
 }
 
 // ---------------------------------------------------------------------------
-// item ID pager
-// ---------------------------------------------------------------------------
-
-var _ DeltaPager[getIDAndAddtler] = &contactIDPager{}
-
-type contactIDPager struct {
-	gs      graph.Servicer
-	builder *users.ItemContactFoldersItemContactsRequestBuilder
-	options *users.ItemContactFoldersItemContactsRequestBuilderGetRequestConfiguration
-}
-
-func (c Contacts) NewContactIDsPager(
-	ctx context.Context,
-	userID, containerID string,
-	immutableIDs bool,
-) DeltaPager[getIDAndAddtler] {
-	config := &users.ItemContactFoldersItemContactsRequestBuilderGetRequestConfiguration{
-		QueryParameters: &users.ItemContactFoldersItemContactsRequestBuilderGetQueryParameters{
-			Select: idAnd(parentFolderID),
-			// do NOT set Top.  It limits the total items received.
-		},
-		Headers: newPreferHeaders(preferPageSize(maxNonDeltaPageSize), preferImmutableIDs(immutableIDs)),
-	}
-
-	builder := c.Stable.
-		Client().
-		Users().
-		ByUserIdString(userID).
-		ContactFolders().
-		ByContactFolderIdString(containerID).
-		Contacts()
-
-	return &contactIDPager{c.Stable, builder, config}
-}
-
-func (p *contactIDPager) GetPage(ctx context.Context) (DeltaPageLinker, error) {
-	resp, err := p.builder.Get(ctx, p.options)
-	if err != nil {
-		return nil, graph.Stack(ctx, err)
-	}
-
-	return EmptyDeltaLinker[models.Contactable]{PageLinkValuer: resp}, nil
-}
-
-func (p *contactIDPager) SetNext(nextLink string) {
-	p.builder = users.NewItemContactFoldersItemContactsRequestBuilder(nextLink, p.gs.Adapter())
-}
-
-// non delta pagers don't need reset
-func (p *contactIDPager) Reset(context.Context) {}
-
-func (p *contactIDPager) ValuesIn(pl PageLinker) ([]getIDAndAddtler, error) {
-	return toValues[models.Contactable](pl)
-}
-
-// ---------------------------------------------------------------------------
 // delta item ID pager
 // ---------------------------------------------------------------------------
 
-var _ DeltaPager[getIDAndAddtler] = &contactDeltaIDPager{}
+var _ DeltaPager[models.Contactable] = &contactDeltaPager{}
 
-type contactDeltaIDPager struct {
+type contactDeltaPager struct {
 	gs          graph.Servicer
 	userID      string
 	containerID string
@@ -268,63 +209,75 @@ func getContactDeltaBuilder(
 	return builder
 }
 
-func (c Contacts) NewContactDeltaIDsPager(
+func (c Contacts) NewContactsDeltaPager(
 	ctx context.Context,
-	userID, containerID, oldDelta string,
+	userID, containerID, prevDeltaLink string,
 	immutableIDs bool,
-) DeltaPager[getIDAndAddtler] {
+	selectProps ...string,
+) DeltaPager[models.Contactable] {
 	options := &users.ItemContactFoldersItemContactsDeltaRequestBuilderGetRequestConfiguration{
-		QueryParameters: &users.ItemContactFoldersItemContactsDeltaRequestBuilderGetQueryParameters{
-			Select: idAnd(parentFolderID),
-			// do NOT set Top.  It limits the total items received.
-		},
-		Headers: newPreferHeaders(preferPageSize(c.options.DeltaPageSize), preferImmutableIDs(immutableIDs)),
+		// do NOT set Top.  It limits the total items received.
+		QueryParameters: &users.ItemContactFoldersItemContactsDeltaRequestBuilderGetQueryParameters{},
+		Headers:         newPreferHeaders(preferPageSize(c.options.DeltaPageSize), preferImmutableIDs(immutableIDs)),
+	}
+
+	if len(selectProps) > 0 {
+		options.QueryParameters.Select = selectProps
 	}
 
 	var builder *users.ItemContactFoldersItemContactsDeltaRequestBuilder
-	if oldDelta != "" {
-		builder = users.NewItemContactFoldersItemContactsDeltaRequestBuilder(oldDelta, c.Stable.Adapter())
+	if len(prevDeltaLink) == 0 {
+		builder = users.NewItemContactFoldersItemContactsDeltaRequestBuilder(prevDeltaLink, c.Stable.Adapter())
 	} else {
 		builder = getContactDeltaBuilder(ctx, c.Stable, userID, containerID, options)
 	}
 
-	return &contactDeltaIDPager{c.Stable, userID, containerID, builder, options}
+	return &contactDeltaPager{c.Stable, userID, containerID, builder, options}
 }
 
-func (p *contactDeltaIDPager) GetPage(ctx context.Context) (DeltaPageLinker, error) {
+func (p *contactDeltaPager) GetPage(
+	ctx context.Context,
+) (DeltaLinkValuer[models.Contactable], error) {
 	resp, err := p.builder.Get(ctx, p.options)
-	if err != nil {
-		return nil, graph.Stack(ctx, err)
-	}
-
-	return resp, nil
+	return resp, graph.Stack(ctx, err).OrNil()
 }
 
-func (p *contactDeltaIDPager) SetNext(nextLink string) {
+func (p *contactDeltaPager) SetNextLink(nextLink string) {
 	p.builder = users.NewItemContactFoldersItemContactsDeltaRequestBuilder(nextLink, p.gs.Adapter())
 }
 
-func (p *contactDeltaIDPager) Reset(ctx context.Context) {
+func (p *contactDeltaPager) Reset(ctx context.Context) {
 	p.builder = getContactDeltaBuilder(ctx, p.gs, p.userID, p.containerID, p.options)
-}
-
-func (p *contactDeltaIDPager) ValuesIn(pl PageLinker) ([]getIDAndAddtler, error) {
-	return toValues[models.Contactable](pl)
 }
 
 func (c Contacts) GetAddedAndRemovedItemIDs(
 	ctx context.Context,
-	userID, containerID, oldDelta string,
+	userID, containerID, prevDeltaLink string,
 	immutableIDs bool,
 	canMakeDeltaQueries bool,
 ) ([]string, []string, DeltaUpdate, error) {
 	ctx = clues.Add(
 		ctx,
-		"category", selectors.ExchangeContact,
+		"data_category", path.ContactsCategory,
 		"container_id", containerID)
 
-	pager := c.NewContactIDsPager(ctx, userID, containerID, immutableIDs)
-	deltaPager := c.NewContactDeltaIDsPager(ctx, userID, containerID, oldDelta, immutableIDs)
+	deltaPager := c.NewContactsDeltaPager(
+		ctx,
+		userID,
+		containerID,
+		prevDeltaLink,
+		immutableIDs,
+		idAnd(additionalData)...)
+	pager := c.NewContactsPager(
+		userID,
+		containerID,
+		immutableIDs,
+		idAnd(additionalData)...)
 
-	return getAddedAndRemovedItemIDs(ctx, c.Stable, pager, deltaPager, oldDelta, canMakeDeltaQueries)
+	return getAddedAndRemovedItemIDs[models.Contactable](
+		ctx,
+		pager,
+		deltaPager,
+		prevDeltaLink,
+		canMakeDeltaQueries)
 }

--- a/src/pkg/services/m365/api/drive_pager.go
+++ b/src/pkg/services/m365/api/drive_pager.go
@@ -2,8 +2,6 @@ package api
 
 import (
 	"context"
-	"fmt"
-	"time"
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/drives"
@@ -21,7 +19,7 @@ import (
 // non-delta item pager
 // ---------------------------------------------------------------------------
 
-var _ itemPager[models.DriveItemable] = &driveItemPageCtrl{}
+var _ Pager[models.DriveItemable] = &driveItemPageCtrl{}
 
 type driveItemPageCtrl struct {
 	gs      graph.Servicer
@@ -32,7 +30,7 @@ type driveItemPageCtrl struct {
 func (c Drives) NewDriveItemPager(
 	driveID, containerID string,
 	selectProps ...string,
-) itemPager[models.DriveItemable] {
+) Pager[models.DriveItemable] {
 	options := &drives.ItemItemsItemChildrenRequestBuilderGetRequestConfiguration{
 		QueryParameters: &drives.ItemItemsItemChildrenRequestBuilderGetQueryParameters{},
 	}
@@ -52,18 +50,14 @@ func (c Drives) NewDriveItemPager(
 	return &driveItemPageCtrl{c.Stable, builder, options}
 }
 
-//lint:ignore U1000 False Positive
-func (p *driveItemPageCtrl) getPage(ctx context.Context) (PageLinkValuer[models.DriveItemable], error) {
+func (p *driveItemPageCtrl) GetPage(
+	ctx context.Context,
+) (NextLinkValuer[models.DriveItemable], error) {
 	page, err := p.builder.Get(ctx, p.options)
-	if err != nil {
-		return nil, graph.Stack(ctx, err)
-	}
-
-	return EmptyDeltaLinker[models.DriveItemable]{PageLinkValuer: page}, nil
+	return page, graph.Stack(ctx, err).OrNil()
 }
 
-//lint:ignore U1000 False Positive
-func (p *driveItemPageCtrl) setNext(nextLink string) {
+func (p *driveItemPageCtrl) SetNextLink(nextLink string) {
 	p.builder = drives.NewItemItemsItemChildrenRequestBuilder(nextLink, p.gs.Adapter())
 }
 
@@ -171,21 +165,14 @@ func (c Drives) NewDriveItemDeltaPager(
 	return res
 }
 
-func (p *DriveItemDeltaPageCtrl) GetPage(ctx context.Context) (DeltaPageLinker, error) {
-	var (
-		resp DeltaPageLinker
-		err  error
-	)
-
-	resp, err = p.builder.Get(ctx, p.options)
-	if err != nil {
-		return nil, graph.Stack(ctx, err)
-	}
-
-	return resp, nil
+func (p *DriveItemDeltaPageCtrl) GetPage(
+	ctx context.Context,
+) (DeltaLinkValuer[models.DriveItemable], error) {
+	resp, err := p.builder.Get(ctx, p.options)
+	return resp, graph.Stack(ctx, err).OrNil()
 }
 
-func (p *DriveItemDeltaPageCtrl) SetNext(link string) {
+func (p *DriveItemDeltaPageCtrl) SetNextLink(link string) {
 	p.builder = drives.NewItemItemsItemDeltaRequestBuilder(link, p.gs.Adapter())
 }
 
@@ -196,10 +183,6 @@ func (p *DriveItemDeltaPageCtrl) Reset(context.Context) {
 		Items().
 		ByDriveItemIdString(onedrive.RootID).
 		Delta()
-}
-
-func (p *DriveItemDeltaPageCtrl) ValuesIn(l PageLinker) ([]models.DriveItemable, error) {
-	return getValues[models.DriveItemable](l)
 }
 
 // ---------------------------------------------------------------------------
@@ -239,57 +222,34 @@ func (c Drives) NewUserDrivePager(
 	return res
 }
 
-type nopUserDrivePageLinker struct {
+type nopUserDrivePage struct {
 	drive models.Driveable
 }
 
-func (nl nopUserDrivePageLinker) GetOdataNextLink() *string { return nil }
+func (nl nopUserDrivePage) GetValue() []models.Driveable {
+	return []models.Driveable{nl.drive}
+}
 
-func (p *userDrivePager) GetPage(ctx context.Context) (PageLinker, error) {
-	var (
-		resp PageLinker
-		err  error
-	)
+func (nl nopUserDrivePage) GetOdataNextLink() *string {
+	return nil
+}
 
+func (p *userDrivePager) GetPage(
+	ctx context.Context,
+) (NextLinkValuer[models.Driveable], error) {
+	// we only ever want to return the user's default drive.
 	d, err := p.gs.
 		Client().
 		Users().
 		ByUserIdString(p.userID).
 		Drive().
 		Get(ctx, nil)
-	if err != nil {
-		return nil, graph.Stack(ctx, err)
-	}
 
-	resp = &nopUserDrivePageLinker{drive: d}
-
-	// TODO(keepers): turn back on when we can separate drive enumeration
-	// from default drive lookup.
-
-	// resp, err = p.builder.Get(ctx, p.options)
-	// if err != nil {
-	// 	return nil, graph.Stack(ctx, err)
-	// }
-
-	return resp, nil
+	return &nopUserDrivePage{drive: d}, graph.Stack(ctx, err).OrNil()
 }
 
-func (p *userDrivePager) SetNext(link string) {
+func (p *userDrivePager) SetNextLink(link string) {
 	p.builder = users.NewItemDrivesRequestBuilder(link, p.gs.Adapter())
-}
-
-func (p *userDrivePager) ValuesIn(l PageLinker) ([]models.Driveable, error) {
-	nl, ok := l.(*nopUserDrivePageLinker)
-	if !ok || nl == nil {
-		return nil, clues.New(fmt.Sprintf("improper page linker struct for user drives: %T", l))
-	}
-
-	// TODO(keepers): turn back on when we can separate drive enumeration
-	// from default drive lookup.
-
-	// return getValues[models.Driveable](l)
-
-	return []models.Driveable{nl.drive}, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -332,26 +292,15 @@ func (c Drives) NewSiteDrivePager(
 	return res
 }
 
-func (p *siteDrivePager) GetPage(ctx context.Context) (PageLinker, error) {
-	var (
-		resp PageLinker
-		err  error
-	)
-
-	resp, err = p.builder.Get(ctx, p.options)
-	if err != nil {
-		return nil, graph.Stack(ctx, err)
-	}
-
-	return resp, nil
+func (p *siteDrivePager) GetPage(
+	ctx context.Context,
+) (NextLinkValuer[models.Driveable], error) {
+	resp, err := p.builder.Get(ctx, p.options)
+	return resp, graph.Stack(ctx, err).OrNil()
 }
 
-func (p *siteDrivePager) SetNext(link string) {
+func (p *siteDrivePager) SetNextLink(link string) {
 	p.builder = sites.NewItemDrivesRequestBuilder(link, p.gs.Adapter())
-}
-
-func (p *siteDrivePager) ValuesIn(l PageLinker) ([]models.Driveable, error) {
-	return getValues[models.Driveable](l)
 }
 
 // ---------------------------------------------------------------------------
@@ -362,74 +311,13 @@ func (p *siteDrivePager) ValuesIn(l PageLinker) ([]models.Driveable, error) {
 func GetAllDrives(
 	ctx context.Context,
 	pager Pager[models.Driveable],
-	retry bool,
-	maxRetryCount int,
 ) ([]models.Driveable, error) {
-	ds := []models.Driveable{}
-
-	if !retry {
-		maxRetryCount = 0
+	ds, err := enumerateItems(ctx, pager)
+	if err != nil && (clues.HasLabel(err, graph.LabelsMysiteNotFound) ||
+		clues.HasLabel(err, graph.LabelsNoSharePointLicense)) {
+		logger.CtxErr(ctx, err).Infof("resource owner does not have a drive")
+		return make([]models.Driveable, 0), nil // no license or drives.
 	}
 
-	// Loop through all pages returned by Graph API.
-	for {
-		var (
-			err  error
-			page PageLinker
-		)
-
-		// Retry Loop for Drive retrieval. Request can timeout
-		for i := 0; i <= maxRetryCount; i++ {
-			page, err = pager.GetPage(ctx)
-			if err != nil {
-				if clues.HasLabel(err, graph.LabelsMysiteNotFound) || clues.HasLabel(err, graph.LabelsNoSharePointLicense) {
-					logger.CtxErr(ctx, err).Infof("resource owner does not have a drive")
-					return make([]models.Driveable, 0), nil // no license or drives.
-				}
-
-				if graph.IsErrTimeout(err) && i < maxRetryCount {
-					time.Sleep(time.Duration(3*(i+1)) * time.Second)
-					continue
-				}
-
-				return nil, graph.Wrap(ctx, err, "retrieving drives")
-			}
-
-			// No error encountered, break the retry loop so we can extract results
-			// and see if there's another page to fetch.
-			break
-		}
-
-		tmp, err := pager.ValuesIn(page)
-		if err != nil {
-			return nil, graph.Wrap(ctx, err, "extracting drives from response")
-		}
-
-		ds = append(ds, tmp...)
-
-		nextLink := ptr.Val(page.GetOdataNextLink())
-		if len(nextLink) == 0 {
-			break
-		}
-
-		pager.SetNext(nextLink)
-	}
-
-	logger.Ctx(ctx).Debugf("retrieved %d valid drives", len(ds))
-
-	return ds, nil
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-func getValues[T any](l PageLinker) ([]T, error) {
-	page, ok := l.(interface{ GetValue() []T })
-	if !ok {
-		return nil, clues.New("page does not comply with GetValue() interface").
-			With("page_item_type", fmt.Sprintf("%T", l))
-	}
-
-	return page.GetValue(), nil
+	return ds, graph.Stack(ctx, err).OrNil()
 }

--- a/src/pkg/services/m365/api/events_pager.go
+++ b/src/pkg/services/m365/api/events_pager.go
@@ -14,9 +14,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
-const (
-	eventBetaDeltaURLTemplate = "https://graph.microsoft.com/beta/users/%s/calendars/%s/events/delta"
-)
+const eventBetaDeltaURLTemplate = "https://graph.microsoft.com/beta/users/%s/calendars/%s/events/delta"
 
 // ---------------------------------------------------------------------------
 // container pager
@@ -98,7 +96,7 @@ func (c Events) EnumerateContainers(
 // item pager
 // ---------------------------------------------------------------------------
 
-var _ itemPager[models.Eventable] = &eventsPageCtrl{}
+var _ Pager[models.Eventable] = &eventsPageCtrl{}
 
 type eventsPageCtrl struct {
 	gs      graph.Servicer
@@ -108,13 +106,13 @@ type eventsPageCtrl struct {
 
 func (c Events) NewEventsPager(
 	userID, containerID string,
+	immutableIDs bool,
 	selectProps ...string,
-) itemPager[models.Eventable] {
+) Pager[models.Eventable] {
 	options := &users.ItemCalendarsItemEventsRequestBuilderGetRequestConfiguration{
-		Headers:         newPreferHeaders(preferPageSize(maxNonDeltaPageSize)),
-		QueryParameters: &users.ItemCalendarsItemEventsRequestBuilderGetQueryParameters{
-			// do NOT set Top.  It limits the total items received.
-		},
+		Headers:         newPreferHeaders(preferPageSize(maxNonDeltaPageSize), preferImmutableIDs(immutableIDs)),
+		QueryParameters: &users.ItemCalendarsItemEventsRequestBuilderGetQueryParameters{},
+		// do NOT set Top.  It limits the total items received.
 	}
 
 	if len(selectProps) > 0 {
@@ -132,28 +130,23 @@ func (c Events) NewEventsPager(
 	return &eventsPageCtrl{c.Stable, builder, options}
 }
 
-//lint:ignore U1000 False Positive
-func (p *eventsPageCtrl) getPage(ctx context.Context) (PageLinkValuer[models.Eventable], error) {
+func (p *eventsPageCtrl) GetPage(
+	ctx context.Context,
+) (NextLinkValuer[models.Eventable], error) {
 	resp, err := p.builder.Get(ctx, p.options)
-	if err != nil {
-		return nil, graph.Stack(ctx, err)
-	}
-
-	return resp, nil
+	return resp, graph.Stack(ctx, err).OrNil()
 }
 
-//lint:ignore U1000 False Positive
-func (p *eventsPageCtrl) setNext(nextLink string) {
+func (p *eventsPageCtrl) SetNextLink(nextLink string) {
 	p.builder = users.NewItemCalendarsItemEventsRequestBuilder(nextLink, p.gs.Adapter())
 }
 
-//lint:ignore U1000 False Positive
 func (c Events) GetItemsInContainerByCollisionKey(
 	ctx context.Context,
 	userID, containerID string,
 ) (map[string]string, error) {
 	ctx = clues.Add(ctx, "container_id", containerID)
-	pager := c.NewEventsPager(userID, containerID, eventCollisionKeyProps()...)
+	pager := c.NewEventsPager(userID, containerID, false, eventCollisionKeyProps()...)
 
 	items, err := enumerateItems(ctx, pager)
 	if err != nil {
@@ -169,96 +162,39 @@ func (c Events) GetItemsInContainerByCollisionKey(
 	return m, nil
 }
 
-// ---------------------------------------------------------------------------
-// item ID pager
-// ---------------------------------------------------------------------------
-
-var _ DeltaPager[getIDAndAddtler] = &eventIDPager{}
-
-type eventIDPager struct {
-	gs      graph.Servicer
-	builder *users.ItemCalendarsItemEventsRequestBuilder
-	options *users.ItemCalendarsItemEventsRequestBuilderGetRequestConfiguration
-}
-
-func (c Events) NewEventIDsPager(
+func (c Events) GetItemIDsInContainer(
 	ctx context.Context,
 	userID, containerID string,
-	immutableIDs bool,
-) (DeltaPager[getIDAndAddtler], error) {
-	options := &users.ItemCalendarsItemEventsRequestBuilderGetRequestConfiguration{
-		Headers:         newPreferHeaders(preferPageSize(maxNonDeltaPageSize), preferImmutableIDs(immutableIDs)),
-		QueryParameters: &users.ItemCalendarsItemEventsRequestBuilderGetQueryParameters{
-			// do NOT set Top.  It limits the total items received.
-		},
-	}
+) (map[string]struct{}, error) {
+	ctx = clues.Add(ctx, "container_id", containerID)
+	pager := c.NewEventsPager(userID, containerID, false, idAnd()...)
 
-	builder := c.Stable.
-		Client().
-		Users().
-		ByUserIdString(userID).
-		Calendars().
-		ByCalendarIdString(containerID).
-		Events()
-
-	return &eventIDPager{c.Stable, builder, options}, nil
-}
-
-func (p *eventIDPager) GetPage(ctx context.Context) (DeltaPageLinker, error) {
-	resp, err := p.builder.Get(ctx, p.options)
+	items, err := enumerateItems(ctx, pager)
 	if err != nil {
-		return nil, graph.Stack(ctx, err)
+		return nil, graph.Wrap(ctx, err, "enumerating events")
 	}
 
-	return EmptyDeltaLinker[models.Eventable]{PageLinkValuer: resp}, nil
-}
+	m := map[string]struct{}{}
 
-func (p *eventIDPager) SetNext(nextLink string) {
-	p.builder = users.NewItemCalendarsItemEventsRequestBuilder(nextLink, p.gs.Adapter())
-}
+	for _, item := range items {
+		m[ptr.Val(item.GetId())] = struct{}{}
+	}
 
-// non delta pagers don't need reset
-func (p *eventIDPager) Reset(context.Context) {}
-
-func (p *eventIDPager) ValuesIn(pl PageLinker) ([]getIDAndAddtler, error) {
-	return toValues[models.Eventable](pl)
+	return m, nil
 }
 
 // ---------------------------------------------------------------------------
 // delta item ID pager
 // ---------------------------------------------------------------------------
 
-var _ DeltaPager[getIDAndAddtler] = &eventDeltaIDPager{}
+var _ DeltaPager[models.Eventable] = &eventDeltaPager{}
 
-type eventDeltaIDPager struct {
+type eventDeltaPager struct {
 	gs          graph.Servicer
 	userID      string
 	containerID string
 	builder     *users.ItemCalendarsItemEventsDeltaRequestBuilder
 	options     *users.ItemCalendarsItemEventsDeltaRequestBuilderGetRequestConfiguration
-}
-
-func (c Events) NewEventDeltaIDsPager(
-	ctx context.Context,
-	userID, containerID, oldDelta string,
-	immutableIDs bool,
-) (DeltaPager[getIDAndAddtler], error) {
-	options := &users.ItemCalendarsItemEventsDeltaRequestBuilderGetRequestConfiguration{
-		Headers:         newPreferHeaders(preferPageSize(c.options.DeltaPageSize), preferImmutableIDs(immutableIDs)),
-		QueryParameters: &users.ItemCalendarsItemEventsDeltaRequestBuilderGetQueryParameters{
-			// do NOT set Top.  It limits the total items received.
-		},
-	}
-
-	var builder *users.ItemCalendarsItemEventsDeltaRequestBuilder
-
-	if oldDelta == "" {
-		builder = getEventDeltaBuilder(ctx, c.Stable, userID, containerID, options)
-	} else {
-		builder = users.NewItemCalendarsItemEventsDeltaRequestBuilder(oldDelta, c.Stable.Adapter())
-	}
-
-	return &eventDeltaIDPager{c.Stable, userID, containerID, builder, options}, nil
 }
 
 func getEventDeltaBuilder(
@@ -267,58 +203,88 @@ func getEventDeltaBuilder(
 	userID, containerID string,
 	options *users.ItemCalendarsItemEventsDeltaRequestBuilderGetRequestConfiguration,
 ) *users.ItemCalendarsItemEventsDeltaRequestBuilder {
-	// Graph SDK only supports delta queries against events on the beta version, so we're
-	// manufacturing use of the beta version url to make the call instead.
-	// See: https://learn.microsoft.com/ko-kr/graph/api/event-delta?view=graph-rest-beta&tabs=http
-	// Note that the delta item body is skeletal compared to the actual event struct.  Lucky
-	// for us, we only need the item ID.  As a result, even though we hacked the version, the
-	// response body parses properly into the v1.0 structs and complies with our wanted interfaces.
-	// Likewise, the NextLink and DeltaLink odata tags carry our hack forward, so the rest of the code
-	// works as intended (until, at least, we want to _not_ call the beta anymore).
-	rawURL := fmt.Sprintf(eventBetaDeltaURLTemplate, userID, containerID)
-	builder := users.NewItemCalendarsItemEventsDeltaRequestBuilder(rawURL, gs.Adapter())
+	builder := gs.Client().
+		Users().
+		ByUserIdString(userID).
+		Calendars().
+		ByCalendarIdString(containerID).
+		Events().
+		Delta()
 
 	return builder
 }
 
-func (p *eventDeltaIDPager) GetPage(ctx context.Context) (DeltaPageLinker, error) {
-	resp, err := p.builder.Get(ctx, p.options)
-	if err != nil {
-		return nil, graph.Stack(ctx, err)
+func (c Events) NewEventsDeltaPager(
+	ctx context.Context,
+	userID, containerID, prevDeltaLink string,
+	immutableIDs bool,
+	selectProps ...string,
+) DeltaPager[models.Eventable] {
+	options := &users.ItemCalendarsItemEventsDeltaRequestBuilderGetRequestConfiguration{
+		// do NOT set Top.  It limits the total items received.
+		QueryParameters: &users.ItemCalendarsItemEventsDeltaRequestBuilderGetQueryParameters{},
+		Headers:         newPreferHeaders(preferPageSize(c.options.DeltaPageSize), preferImmutableIDs(immutableIDs)),
 	}
 
-	return resp, nil
+	if len(selectProps) > 0 {
+		options.QueryParameters.Select = selectProps
+	}
+
+	var builder *users.ItemCalendarsItemEventsDeltaRequestBuilder
+
+	if len(prevDeltaLink) == 0 {
+		rawURL := fmt.Sprintf(eventBetaDeltaURLTemplate, userID, containerID)
+		builder = users.NewItemCalendarsItemEventsDeltaRequestBuilder(rawURL, c.Stable.Adapter())
+	} else {
+		builder = getEventDeltaBuilder(ctx, c.Stable, userID, containerID, options)
+	}
+
+	return &eventDeltaPager{c.Stable, userID, containerID, builder, options}
 }
 
-func (p *eventDeltaIDPager) SetNext(nextLink string) {
+func (p *eventDeltaPager) GetPage(
+	ctx context.Context,
+) (DeltaLinkValuer[models.Eventable], error) {
+	resp, err := p.builder.Get(ctx, p.options)
+	return resp, graph.Stack(ctx, err).OrNil()
+}
+
+func (p *eventDeltaPager) SetNextLink(nextLink string) {
 	p.builder = users.NewItemCalendarsItemEventsDeltaRequestBuilder(nextLink, p.gs.Adapter())
 }
 
-func (p *eventDeltaIDPager) Reset(ctx context.Context) {
+func (p *eventDeltaPager) Reset(ctx context.Context) {
 	p.builder = getEventDeltaBuilder(ctx, p.gs, p.userID, p.containerID, p.options)
-}
-
-func (p *eventDeltaIDPager) ValuesIn(pl PageLinker) ([]getIDAndAddtler, error) {
-	return toValues[models.Eventable](pl)
 }
 
 func (c Events) GetAddedAndRemovedItemIDs(
 	ctx context.Context,
-	userID, containerID, oldDelta string,
+	userID, containerID, prevDeltaLink string,
 	immutableIDs bool,
 	canMakeDeltaQueries bool,
 ) ([]string, []string, DeltaUpdate, error) {
-	ctx = clues.Add(ctx, "container_id", containerID)
+	ctx = clues.Add(
+		ctx,
+		"data_category", path.EventsCategory,
+		"container_id", containerID)
 
-	pager, err := c.NewEventIDsPager(ctx, userID, containerID, immutableIDs)
-	if err != nil {
-		return nil, nil, DeltaUpdate{}, graph.Wrap(ctx, err, "creating non-delta pager")
-	}
+	deltaPager := c.NewEventsDeltaPager(
+		ctx,
+		userID,
+		containerID,
+		prevDeltaLink,
+		immutableIDs,
+		idAnd(additionalData)...)
+	pager := c.NewEventsPager(
+		userID,
+		containerID,
+		immutableIDs,
+		idAnd(additionalData)...)
 
-	deltaPager, err := c.NewEventDeltaIDsPager(ctx, userID, containerID, oldDelta, immutableIDs)
-	if err != nil {
-		return nil, nil, DeltaUpdate{}, graph.Wrap(ctx, err, "creating delta pager")
-	}
-
-	return getAddedAndRemovedItemIDs(ctx, c.Stable, pager, deltaPager, oldDelta, canMakeDeltaQueries)
+	return getAddedAndRemovedItemIDs[models.Eventable](
+		ctx,
+		pager,
+		deltaPager,
+		prevDeltaLink,
+		canMakeDeltaQueries)
 }

--- a/src/pkg/services/m365/api/item_pager.go
+++ b/src/pkg/services/m365/api/item_pager.go
@@ -67,19 +67,6 @@ func NextAndDeltaLink(pl DeltaLinker) (string, string) {
 	return NextLink(pl), ptr.Val(pl.GetOdataDeltaLink())
 }
 
-// EmptyDeltaLinker is used to convert PageLinker to DeltaPageLinker
-// type EmptyDeltaLinker[T any] struct {
-// 	PageLinkValuer[T]
-// }
-
-// func (EmptyDeltaLinker[T]) GetOdataDeltaLink() *string {
-// 	return ptr.To("")
-// }
-
-// func (e EmptyDeltaLinker[T]) GetValue() []T {
-// 	return e.PageLinkValuer.GetValue()
-// }
-
 // ---------------------------------------------------------------------------
 // non-delta item paging
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
the page-querying design in the api layer has grown organically from the roots of its implementation prior to centralizing calls in the api layer.  As a result, there's a lot of duplicate, or near- duplicate, code handling.  The duplication will, as we grow the layer, eventually lead to maintenance issues and "I forgot that spot" gotchas.

This PR is a first step towards wrangling that code into a clean and centralized pattern.
* Page controller structs are consistent for each type (one for deltas, one for non-deltas).
* All page controllers call into either enumerateItems or deltaEnumerateItems as their centralized runner.
* All variations on data control (only ids, collision keys, etc) are handled as a post-process to the enumeration calls, instead of duplicating the runner process itself in every iteration.

Future PRs can further reduce issues by:
* conforming container enumeration to the same pattern.
* moving pager loop processing out of higher layers and into the api layer.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3988

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
