### PR TITLE
ensure groups resource is set

### DIFF
--- a/src/cmd/factory/impl/common.go
+++ b/src/cmd/factory/impl/common.go
@@ -17,7 +17,6 @@ import (
 	"github.com/alcionai/corso/src/internal/common/str"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/m365"
-	"github.com/alcionai/corso/src/internal/m365/resource"
 	exchMock "github.com/alcionai/corso/src/internal/m365/service/exchange/mock"
 	odStub "github.com/alcionai/corso/src/internal/m365/service/onedrive/stub"
 	m365Stub "github.com/alcionai/corso/src/internal/m365/stub"
@@ -121,7 +120,6 @@ func generateAndRestoreItems(
 
 func getControllerAndVerifyResourceOwner(
 	ctx context.Context,
-	resourceCat resource.Category,
 	resourceOwner string,
 	pst path.ServiceType,
 ) (
@@ -147,7 +145,7 @@ func getControllerAndVerifyResourceOwner(
 		return nil, account.Account{}, nil, clues.Wrap(err, "finding m365 account details")
 	}
 
-	ctrl, err := m365.NewController(ctx, acct, resourceCat, pst, control.Options{})
+	ctrl, err := m365.NewController(ctx, acct, pst, control.Options{})
 	if err != nil {
 		return nil, account.Account{}, nil, clues.Wrap(err, "connecting to graph api")
 	}
@@ -430,7 +428,6 @@ func generateAndRestoreDriveItems(
 
 	config := m365Stub.ConfigInfo{
 		Opts:           opts,
-		Resource:       resource.Users,
 		Service:        service,
 		Tenant:         tenantID,
 		ResourceOwners: []string{protectedResource.ID()},

--- a/src/cmd/factory/impl/exchange.go
+++ b/src/cmd/factory/impl/exchange.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/cli/utils"
-	"github.com/alcionai/corso/src/internal/m365/resource"
 	exchMock "github.com/alcionai/corso/src/internal/m365/service/exchange/mock"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/count"
@@ -53,7 +52,7 @@ func handleExchangeEmailFactory(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	ctrl, _, _, err := getControllerAndVerifyResourceOwner(ctx, resource.Users, User, path.ExchangeService)
+	ctrl, _, _, err := getControllerAndVerifyResourceOwner(ctx, User, path.ExchangeService)
 	if err != nil {
 		return Only(ctx, err)
 	}
@@ -100,7 +99,7 @@ func handleExchangeCalendarEventFactory(cmd *cobra.Command, args []string) error
 		return nil
 	}
 
-	ctrl, _, _, err := getControllerAndVerifyResourceOwner(ctx, resource.Users, User, path.ExchangeService)
+	ctrl, _, _, err := getControllerAndVerifyResourceOwner(ctx, User, path.ExchangeService)
 	if err != nil {
 		return Only(ctx, err)
 	}
@@ -149,7 +148,7 @@ func handleExchangeContactFactory(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	ctrl, _, _, err := getControllerAndVerifyResourceOwner(ctx, resource.Users, User, path.ExchangeService)
+	ctrl, _, _, err := getControllerAndVerifyResourceOwner(ctx, User, path.ExchangeService)
 	if err != nil {
 		return Only(ctx, err)
 	}

--- a/src/cmd/factory/impl/onedrive.go
+++ b/src/cmd/factory/impl/onedrive.go
@@ -7,7 +7,6 @@ import (
 
 	. "github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/cli/utils"
-	"github.com/alcionai/corso/src/internal/m365/resource"
 	"github.com/alcionai/corso/src/pkg/count"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
@@ -37,7 +36,7 @@ func handleOneDriveFileFactory(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	ctrl, acct, inp, err := getControllerAndVerifyResourceOwner(ctx, resource.Users, User, path.OneDriveService)
+	ctrl, acct, inp, err := getControllerAndVerifyResourceOwner(ctx, User, path.OneDriveService)
 	if err != nil {
 		return Only(ctx, err)
 	}

--- a/src/cmd/factory/impl/sharepoint.go
+++ b/src/cmd/factory/impl/sharepoint.go
@@ -7,7 +7,6 @@ import (
 
 	. "github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/cli/utils"
-	"github.com/alcionai/corso/src/internal/m365/resource"
 	"github.com/alcionai/corso/src/pkg/count"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
@@ -37,7 +36,7 @@ func handleSharePointLibraryFileFactory(cmd *cobra.Command, args []string) error
 		return nil
 	}
 
-	ctrl, acct, inp, err := getControllerAndVerifyResourceOwner(ctx, resource.Sites, Site, path.SharePointService)
+	ctrl, acct, inp, err := getControllerAndVerifyResourceOwner(ctx, Site, path.SharePointService)
 	if err != nil {
 		return Only(ctx, err)
 	}

--- a/src/internal/m365/backup_test.go
+++ b/src/internal/m365/backup_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	inMock "github.com/alcionai/corso/src/internal/common/idname/mock"
-	"github.com/alcionai/corso/src/internal/m365/resource"
 	"github.com/alcionai/corso/src/internal/m365/service/exchange"
 	"github.com/alcionai/corso/src/internal/m365/service/sharepoint"
 	"github.com/alcionai/corso/src/internal/operations/inject"
@@ -68,7 +67,7 @@ func (suite *DataCollectionIntgSuite) TestExchangeDataCollection() {
 
 	selUsers := []string{suite.user}
 
-	ctrl := newController(ctx, suite.T(), resource.Users, path.ExchangeService)
+	ctrl := newController(ctx, suite.T(), path.ExchangeService)
 	tests := []struct {
 		name        string
 		getSelector func(t *testing.T) selectors.Selector
@@ -174,7 +173,7 @@ func (suite *DataCollectionIntgSuite) TestDataCollections_invalidResourceOwner()
 	defer flush()
 
 	owners := []string{"snuffleupagus"}
-	ctrl := newController(ctx, suite.T(), resource.Users, path.ExchangeService)
+	ctrl := newController(ctx, suite.T(), path.ExchangeService)
 	tests := []struct {
 		name        string
 		getSelector func(t *testing.T) selectors.Selector
@@ -262,7 +261,7 @@ func (suite *DataCollectionIntgSuite) TestSharePointDataCollection() {
 	defer flush()
 
 	selSites := []string{suite.site}
-	ctrl := newController(ctx, suite.T(), resource.Sites, path.SharePointService)
+	ctrl := newController(ctx, suite.T(), path.SharePointService)
 	tests := []struct {
 		name        string
 		expected    int
@@ -360,7 +359,7 @@ func (suite *SPCollectionIntgSuite) SetupSuite() {
 	ctx, flush := tester.NewContext(suite.T())
 	defer flush()
 
-	suite.connector = newController(ctx, suite.T(), resource.Sites, path.SharePointService)
+	suite.connector = newController(ctx, suite.T(), path.SharePointService)
 	suite.user = tconfig.M365UserID(suite.T())
 
 	tester.LogTimeOfTest(suite.T())
@@ -374,7 +373,7 @@ func (suite *SPCollectionIntgSuite) TestCreateSharePointCollection_Libraries() {
 
 	var (
 		siteID  = tconfig.M365SiteID(t)
-		ctrl    = newController(ctx, t, resource.Sites, path.SharePointService)
+		ctrl    = newController(ctx, t, path.SharePointService)
 		siteIDs = []string{siteID}
 	)
 
@@ -424,7 +423,7 @@ func (suite *SPCollectionIntgSuite) TestCreateSharePointCollection_Lists() {
 
 	var (
 		siteID  = tconfig.M365SiteID(t)
-		ctrl    = newController(ctx, t, resource.Sites, path.SharePointService)
+		ctrl    = newController(ctx, t, path.SharePointService)
 		siteIDs = []string{siteID}
 	)
 
@@ -488,7 +487,7 @@ func (suite *GroupsCollectionIntgSuite) SetupSuite() {
 	ctx, flush := tester.NewContext(suite.T())
 	defer flush()
 
-	suite.connector = newController(ctx, suite.T(), resource.Sites, path.GroupsService)
+	suite.connector = newController(ctx, suite.T(), path.GroupsService)
 	suite.user = tconfig.M365UserID(suite.T())
 
 	tester.LogTimeOfTest(suite.T())
@@ -502,7 +501,7 @@ func (suite *GroupsCollectionIntgSuite) TestCreateGroupsCollection_SharePoint() 
 
 	var (
 		groupID  = tconfig.M365GroupID(t)
-		ctrl     = newController(ctx, t, resource.Groups, path.GroupsService)
+		ctrl     = newController(ctx, t, path.GroupsService)
 		groupIDs = []string{groupID}
 	)
 

--- a/src/internal/m365/controller.go
+++ b/src/internal/m365/controller.go
@@ -59,7 +59,6 @@ type Controller struct {
 func NewController(
 	ctx context.Context,
 	acct account.Account,
-	rc resource.Category,
 	pst path.ServiceType,
 	co control.Options,
 ) (*Controller, error) {
@@ -73,6 +72,17 @@ func NewController(
 	ac, err := api.NewClient(creds, co)
 	if err != nil {
 		return nil, clues.Wrap(err, "creating api client").WithClues(ctx)
+	}
+
+	rc := resource.UnknownResource
+
+	switch pst {
+	case path.ExchangeService, path.OneDriveService:
+		rc = resource.Users
+	case path.GroupsService:
+		rc = resource.Groups
+	case path.SharePointService:
+		rc = resource.Sites
 	}
 
 	rCli, err := getResourceClient(rc, ac)

--- a/src/internal/m365/controller_test.go
+++ b/src/internal/m365/controller_test.go
@@ -366,7 +366,7 @@ func (suite *ControllerIntegrationSuite) SetupSuite() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	suite.ctrl = newController(ctx, t, resource.Users, path.ExchangeService)
+	suite.ctrl = newController(ctx, t, path.ExchangeService)
 	suite.user = tconfig.M365UserID(t)
 	suite.secondaryUser = tconfig.SecondaryM365UserID(t)
 
@@ -472,7 +472,7 @@ func runRestore(
 
 	start := time.Now()
 
-	restoreCtrl := newController(ctx, t, sci.Resource, path.ExchangeService)
+	restoreCtrl := newController(ctx, t, path.ExchangeService)
 	restoreSel := getSelectorWith(t, sci.Service, sci.ResourceOwners, true)
 
 	rcc := inject.RestoreConsumerConfig{
@@ -541,7 +541,7 @@ func runBackupAndCompare(
 		nameToID[ro] = ro
 	}
 
-	backupCtrl := newController(ctx, t, sci.Resource, path.ExchangeService)
+	backupCtrl := newController(ctx, t, path.ExchangeService)
 	backupCtrl.IDNameLookup = inMock.NewCache(idToName, nameToID)
 
 	backupSel := backupSelectorForExpected(t, sci.Service, expectedDests)
@@ -597,7 +597,6 @@ func runRestoreBackupTest(
 
 	cfg := stub.ConfigInfo{
 		Opts:           opts,
-		Resource:       test.resourceCat,
 		Service:        test.service,
 		Tenant:         tenant,
 		ResourceOwners: resourceOwners,
@@ -643,7 +642,6 @@ func runRestoreTestWithVersion(
 
 	cfg := stub.ConfigInfo{
 		Opts:           opts,
-		Resource:       test.resourceCat,
 		Service:        test.service,
 		Tenant:         tenant,
 		ResourceOwners: resourceOwners,
@@ -681,7 +679,6 @@ func runRestoreBackupTestVersions(
 
 	cfg := stub.ConfigInfo{
 		Opts:           opts,
-		Resource:       test.resourceCat,
 		Service:        test.service,
 		Tenant:         tenant,
 		ResourceOwners: resourceOwners,
@@ -725,9 +722,8 @@ func (suite *ControllerIntegrationSuite) TestRestoreAndBackup_core() {
 
 	table := []restoreBackupInfo{
 		{
-			name:        "EmailsWithAttachments",
-			service:     path.ExchangeService,
-			resourceCat: resource.Users,
+			name:    "EmailsWithAttachments",
+			service: path.ExchangeService,
 			collections: []stub.ColInfo{
 				{
 					PathElements: []string{api.MailInbox},
@@ -752,9 +748,8 @@ func (suite *ControllerIntegrationSuite) TestRestoreAndBackup_core() {
 			},
 		},
 		{
-			name:        "MultipleEmailsMultipleFolders",
-			service:     path.ExchangeService,
-			resourceCat: resource.Users,
+			name:    "MultipleEmailsMultipleFolders",
+			service: path.ExchangeService,
 			collections: []stub.ColInfo{
 				{
 					PathElements: []string{api.MailInbox},
@@ -828,9 +823,8 @@ func (suite *ControllerIntegrationSuite) TestRestoreAndBackup_core() {
 			},
 		},
 		{
-			name:        "MultipleContactsSingleFolder",
-			service:     path.ExchangeService,
-			resourceCat: resource.Users,
+			name:    "MultipleContactsSingleFolder",
+			service: path.ExchangeService,
 			collections: []stub.ColInfo{
 				{
 					PathElements: []string{"Contacts"},
@@ -856,9 +850,8 @@ func (suite *ControllerIntegrationSuite) TestRestoreAndBackup_core() {
 			},
 		},
 		{
-			name:        "MultipleContactsMultipleFolders",
-			service:     path.ExchangeService,
-			resourceCat: resource.Users,
+			name:    "MultipleContactsMultipleFolders",
+			service: path.ExchangeService,
 			collections: []stub.ColInfo{
 				{
 					PathElements: []string{"Work"},
@@ -987,9 +980,8 @@ func (suite *ControllerIntegrationSuite) TestRestoreAndBackup_core() {
 func (suite *ControllerIntegrationSuite) TestMultiFolderBackupDifferentNames() {
 	table := []restoreBackupInfo{
 		{
-			name:        "Contacts",
-			service:     path.ExchangeService,
-			resourceCat: resource.Users,
+			name:    "Contacts",
+			service: path.ExchangeService,
 			collections: []stub.ColInfo{
 				{
 					PathElements: []string{"Work"},
@@ -1093,7 +1085,7 @@ func (suite *ControllerIntegrationSuite) TestMultiFolderBackupDifferentNames() {
 					restoreCfg.Location,
 				)
 
-				restoreCtrl := newController(ctx, t, test.resourceCat, path.ExchangeService)
+				restoreCtrl := newController(ctx, t, path.ExchangeService)
 
 				rcc := inject.RestoreConsumerConfig{
 					BackupVersion:     version.Backup,
@@ -1127,7 +1119,7 @@ func (suite *ControllerIntegrationSuite) TestMultiFolderBackupDifferentNames() {
 
 			// Run a backup and compare its output with what we put in.
 
-			backupCtrl := newController(ctx, t, test.resourceCat, path.ExchangeService)
+			backupCtrl := newController(ctx, t, path.ExchangeService)
 			backupSel := backupSelectorForExpected(t, test.service, expectedDests)
 			t.Log("Selective backup of", backupSel)
 
@@ -1175,9 +1167,8 @@ func (suite *ControllerIntegrationSuite) TestRestoreAndBackup_largeMailAttachmen
 	subjectText := "Test message for restore with large attachment"
 
 	test := restoreBackupInfo{
-		name:        "EmailsWithLargeAttachments",
-		service:     path.ExchangeService,
-		resourceCat: resource.Users,
+		name:    "EmailsWithLargeAttachments",
+		service: path.ExchangeService,
 		collections: []stub.ColInfo{
 			{
 				PathElements: []string{api.MailInbox},
@@ -1278,7 +1269,7 @@ func (suite *ControllerIntegrationSuite) TestBackup_CreatesPrefixCollections() {
 			defer flush()
 
 			var (
-				backupCtrl = newController(ctx, t, test.resourceCat, path.ExchangeService)
+				backupCtrl = newController(ctx, t, path.ExchangeService)
 				backupSel  = test.selectorFunc(t)
 				errs       = fault.New(true)
 				start      = time.Now()

--- a/src/internal/m365/helper_test.go
+++ b/src/internal/m365/helper_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive/metadata"
-	"github.com/alcionai/corso/src/internal/m365/resource"
 	odStub "github.com/alcionai/corso/src/internal/m365/service/onedrive/stub"
 	m365Stub "github.com/alcionai/corso/src/internal/m365/stub"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
@@ -106,14 +105,12 @@ type restoreBackupInfo struct {
 	name        string
 	service     path.ServiceType
 	collections []m365Stub.ColInfo
-	resourceCat resource.Category
 }
 
 type restoreBackupInfoMultiVersion struct {
 	service             path.ServiceType
 	collectionsLatest   []m365Stub.ColInfo
 	collectionsPrevious []m365Stub.ColInfo
-	resourceCat         resource.Category
 	backupVersion       int
 }
 
@@ -1197,12 +1194,11 @@ func getSelectorWith(
 func newController(
 	ctx context.Context,
 	t *testing.T,
-	r resource.Category,
 	pst path.ServiceType,
 ) *Controller {
 	a := tconfig.NewM365Account(t)
 
-	controller, err := NewController(ctx, a, r, pst, control.Options{})
+	controller, err := NewController(ctx, a, pst, control.Options{})
 	require.NoError(t, err, clues.ToCore(err))
 
 	return controller

--- a/src/internal/m365/onedrive_test.go
+++ b/src/internal/m365/onedrive_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive/metadata"
 	"github.com/alcionai/corso/src/internal/m365/graph"
-	"github.com/alcionai/corso/src/internal/m365/resource"
 	odConsts "github.com/alcionai/corso/src/internal/m365/service/onedrive/consts"
 	"github.com/alcionai/corso/src/internal/m365/service/onedrive/stub"
 	"github.com/alcionai/corso/src/internal/tester"
@@ -91,7 +90,6 @@ type suiteInfo interface {
 	// also be a site.
 	ResourceOwner() string
 	Service() path.ServiceType
-	Resource() resource.Category
 }
 
 type oneDriveSuite interface {
@@ -100,17 +98,16 @@ type oneDriveSuite interface {
 }
 
 type suiteInfoImpl struct {
-	ac               api.Client
-	controller       *Controller
-	resourceOwner    string
-	resourceCategory resource.Category
-	secondaryUser    string
-	secondaryUserID  string
-	service          path.ServiceType
-	tertiaryUser     string
-	tertiaryUserID   string
-	user             string
-	userID           string
+	ac              api.Client
+	controller      *Controller
+	resourceOwner   string
+	secondaryUser   string
+	secondaryUserID string
+	service         path.ServiceType
+	tertiaryUser    string
+	tertiaryUserID  string
+	user            string
+	userID          string
 }
 
 func NewSuiteInfoImpl(
@@ -119,22 +116,16 @@ func NewSuiteInfoImpl(
 	resourceOwner string,
 	service path.ServiceType,
 ) suiteInfoImpl {
-	rsc := resource.Users
-	if service == path.SharePointService {
-		rsc = resource.Sites
-	}
-
-	ctrl := newController(ctx, t, rsc, path.OneDriveService)
+	ctrl := newController(ctx, t, path.OneDriveService)
 
 	return suiteInfoImpl{
-		ac:               ctrl.AC,
-		controller:       ctrl,
-		resourceOwner:    resourceOwner,
-		resourceCategory: rsc,
-		secondaryUser:    tconfig.SecondaryM365UserID(t),
-		service:          service,
-		tertiaryUser:     tconfig.TertiaryM365UserID(t),
-		user:             tconfig.M365UserID(t),
+		ac:            ctrl.AC,
+		controller:    ctrl,
+		resourceOwner: resourceOwner,
+		secondaryUser: tconfig.SecondaryM365UserID(t),
+		service:       service,
+		tertiaryUser:  tconfig.TertiaryM365UserID(t),
+		user:          tconfig.M365UserID(t),
 	}
 }
 
@@ -164,10 +155,6 @@ func (si suiteInfoImpl) ResourceOwner() string {
 
 func (si suiteInfoImpl) Service() path.ServiceType {
 	return si.service
-}
-
-func (si suiteInfoImpl) Resource() resource.Category {
-	return si.resourceCategory
 }
 
 // ---------------------------------------------------------------------------
@@ -512,7 +499,6 @@ func testRestoreAndBackupMultipleFilesAndFoldersNoPermissions(
 
 			testData := restoreBackupInfoMultiVersion{
 				service:             suite.Service(),
-				resourceCat:         suite.Resource(),
 				backupVersion:       vn,
 				collectionsPrevious: input,
 				collectionsLatest:   expected,
@@ -761,7 +747,6 @@ func testPermissionsRestoreAndBackup(suite oneDriveSuite, startVersion int) {
 
 			testData := restoreBackupInfoMultiVersion{
 				service:             suite.Service(),
-				resourceCat:         suite.Resource(),
 				backupVersion:       vn,
 				collectionsPrevious: input,
 				collectionsLatest:   expected,
@@ -851,7 +836,6 @@ func testRestoreNoPermissionsAndBackup(suite oneDriveSuite, startVersion int) {
 
 			testData := restoreBackupInfoMultiVersion{
 				service:             suite.Service(),
-				resourceCat:         suite.Resource(),
 				backupVersion:       vn,
 				collectionsPrevious: input,
 				collectionsLatest:   expected,
@@ -1056,7 +1040,6 @@ func testPermissionsInheritanceRestoreAndBackup(suite oneDriveSuite, startVersio
 
 			testData := restoreBackupInfoMultiVersion{
 				service:             suite.Service(),
-				resourceCat:         suite.Resource(),
 				backupVersion:       vn,
 				collectionsPrevious: input,
 				collectionsLatest:   expected,
@@ -1251,7 +1234,6 @@ func testLinkSharesInheritanceRestoreAndBackup(suite oneDriveSuite, startVersion
 
 			testData := restoreBackupInfoMultiVersion{
 				service:             suite.Service(),
-				resourceCat:         suite.Resource(),
 				backupVersion:       vn,
 				collectionsPrevious: input,
 				collectionsLatest:   expected,
@@ -1368,7 +1350,6 @@ func testRestoreFolderNamedFolderRegression(
 
 			testData := restoreBackupInfoMultiVersion{
 				service:             suite.Service(),
-				resourceCat:         suite.Resource(),
 				backupVersion:       vn,
 				collectionsPrevious: input,
 				collectionsLatest:   expected,

--- a/src/internal/m365/stub/stub.go
+++ b/src/internal/m365/stub/stub.go
@@ -10,7 +10,6 @@ import (
 	dataMock "github.com/alcionai/corso/src/internal/data/mock"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive/metadata"
 	"github.com/alcionai/corso/src/internal/m365/mock"
-	"github.com/alcionai/corso/src/internal/m365/resource"
 	exchMock "github.com/alcionai/corso/src/internal/m365/service/exchange/mock"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -43,7 +42,6 @@ type ItemInfo struct {
 
 type ConfigInfo struct {
 	Opts           control.Options
-	Resource       resource.Category
 	Service        path.ServiceType
 	Tenant         string
 	ResourceOwners []string

--- a/src/internal/operations/help_test.go
+++ b/src/internal/operations/help_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/m365"
-	"github.com/alcionai/corso/src/internal/m365/resource"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/selectors"
@@ -22,12 +21,11 @@ func ControllerWithSelector(
 	t *testing.T,
 	ctx context.Context, //revive:disable-line:context-as-argument
 	acct account.Account,
-	cr resource.Category,
 	sel selectors.Selector,
 	ins idname.Cacher,
 	onFail func(),
 ) (*m365.Controller, selectors.Selector) {
-	ctrl, err := m365.NewController(ctx, acct, cr, sel.PathService(), control.DefaultOptions())
+	ctrl, err := m365.NewController(ctx, acct, sel.PathService(), control.DefaultOptions())
 	if !assert.NoError(t, err, clues.ToCore(err)) {
 		if onFail != nil {
 			onFail()

--- a/src/internal/operations/restore_test.go
+++ b/src/internal/operations/restore_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/alcionai/corso/src/internal/m365"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/m365/mock"
-	"github.com/alcionai/corso/src/internal/m365/resource"
 	exchMock "github.com/alcionai/corso/src/internal/m365/service/exchange/mock"
 	"github.com/alcionai/corso/src/internal/operations/inject"
 	"github.com/alcionai/corso/src/internal/stats"
@@ -344,7 +343,6 @@ func (suite *RestoreOpIntegrationSuite) TestRestore_Run_errorNoBackup() {
 	ctrl, err := m365.NewController(
 		ctx,
 		suite.acct,
-		resource.Users,
 		rsel.PathService(),
 		control.DefaultOptions())
 	require.NoError(t, err, clues.ToCore(err))

--- a/src/internal/operations/test/exchange_test.go
+++ b/src/internal/operations/test/exchange_test.go
@@ -20,7 +20,6 @@ import (
 	evmock "github.com/alcionai/corso/src/internal/events/mock"
 	"github.com/alcionai/corso/src/internal/m365/collection/exchange"
 	"github.com/alcionai/corso/src/internal/m365/graph"
-	"github.com/alcionai/corso/src/internal/m365/resource"
 	exchMock "github.com/alcionai/corso/src/internal/m365/service/exchange/mock"
 	exchTD "github.com/alcionai/corso/src/internal/m365/service/exchange/testdata"
 	"github.com/alcionai/corso/src/internal/tester"
@@ -264,7 +263,7 @@ func testExchangeContinuousBackups(suite *ExchangeBackupIntgSuite, toggles contr
 	)
 
 	opts.ToggleFeatures = toggles
-	ctrl, sels := ControllerWithSelector(t, ctx, acct, resource.Users, sel.Selector, nil, nil)
+	ctrl, sels := ControllerWithSelector(t, ctx, acct, sel.Selector, nil, nil)
 	sel.DiscreteOwner = sels.ID()
 	sel.DiscreteOwnerName = sels.Name()
 

--- a/src/internal/operations/test/onedrive_test.go
+++ b/src/internal/operations/test/onedrive_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/collection/drive"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive/metadata"
 	"github.com/alcionai/corso/src/internal/m365/graph"
-	"github.com/alcionai/corso/src/internal/m365/resource"
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/internal/streamstore"
 	"github.com/alcionai/corso/src/internal/tester"
@@ -140,7 +139,6 @@ func (suite *OneDriveBackupIntgSuite) TestBackup_Run_incrementalOneDrive() {
 		suite,
 		suite.its.user.ID,
 		suite.its.user.ID,
-		resource.Users,
 		path.OneDriveService,
 		path.FilesCategory,
 		ic,
@@ -152,7 +150,6 @@ func (suite *OneDriveBackupIntgSuite) TestBackup_Run_incrementalOneDrive() {
 func runDriveIncrementalTest(
 	suite tester.Suite,
 	owner, permissionsUser string,
-	rc resource.Category,
 	service path.ServiceType,
 	category path.CategoryType,
 	includeContainers func([]string) selectors.Selector,
@@ -195,7 +192,7 @@ func runDriveIncrementalTest(
 	creds, err := acct.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
-	ctrl, sel := ControllerWithSelector(t, ctx, acct, rc, sel, nil, nil)
+	ctrl, sel := ControllerWithSelector(t, ctx, acct, sel, nil, nil)
 	ac := ctrl.AC.Drives()
 	rh := getRestoreHandler(ctrl.AC)
 
@@ -684,7 +681,7 @@ func runDriveIncrementalTest(
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			cleanCtrl, err := m365.NewController(ctx, acct, rc, sel.PathService(), control.DefaultOptions())
+			cleanCtrl, err := m365.NewController(ctx, acct, sel.PathService(), control.DefaultOptions())
 			require.NoError(t, err, clues.ToCore(err))
 
 			bod.ctrl = cleanCtrl
@@ -800,7 +797,6 @@ func (suite *OneDriveBackupIntgSuite) TestBackup_Run_oneDriveOwnerMigration() {
 	ctrl, err := m365.NewController(
 		ctx,
 		acct,
-		resource.Users,
 		path.OneDriveService,
 		control.DefaultOptions())
 	require.NoError(t, err, clues.ToCore(err))

--- a/src/internal/operations/test/restore_helper_test.go
+++ b/src/internal/operations/test/restore_helper_test.go
@@ -13,7 +13,6 @@ import (
 	evmock "github.com/alcionai/corso/src/internal/events/mock"
 	"github.com/alcionai/corso/src/internal/kopia"
 	"github.com/alcionai/corso/src/internal/m365"
-	"github.com/alcionai/corso/src/internal/m365/resource"
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/internal/operations"
 	"github.com/alcionai/corso/src/internal/streamstore"
@@ -107,20 +106,10 @@ func prepNewTestRestoreOp(
 
 	rod.sw = store.NewWrapper(rod.kms)
 
-	connectorResource := resource.Users
-
-	switch sel.Service {
-	case selectors.ServiceSharePoint:
-		connectorResource = resource.Sites
-	case selectors.ServiceGroups:
-		connectorResource = resource.Groups
-	}
-
 	rod.ctrl, rod.sel = ControllerWithSelector(
 		t,
 		ctx,
 		rod.acct,
-		connectorResource,
 		sel,
 		nil,
 		rod.close)

--- a/src/internal/operations/test/sharepoint_test.go
+++ b/src/internal/operations/test/sharepoint_test.go
@@ -15,7 +15,6 @@ import (
 	evmock "github.com/alcionai/corso/src/internal/events/mock"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive"
 	"github.com/alcionai/corso/src/internal/m365/graph"
-	"github.com/alcionai/corso/src/internal/m365/resource"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/internal/version"
@@ -81,7 +80,6 @@ func (suite *SharePointBackupIntgSuite) TestBackup_Run_incrementalSharePoint() {
 		suite,
 		suite.its.site.ID,
 		suite.its.user.ID,
-		resource.Sites,
 		path.SharePointService,
 		path.LibrariesCategory,
 		ic,

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -16,7 +16,6 @@ import (
 	"github.com/alcionai/corso/src/internal/kopia"
 	"github.com/alcionai/corso/src/internal/m365"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive/metadata"
-	"github.com/alcionai/corso/src/internal/m365/resource"
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/internal/observe"
 	"github.com/alcionai/corso/src/internal/operations"
@@ -768,13 +767,7 @@ func connectToM365(
 		defer close(progressBar)
 	}
 
-	// retrieve data from the producer
-	rc := resource.Users
-	if pst == path.SharePointService {
-		rc = resource.Sites
-	}
-
-	ctrl, err := m365.NewController(ctx, acct, rc, pst, co)
+	ctrl, err := m365.NewController(ctx, acct, pst, co)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
ensure that the repository creation correctly sets the resource category to match the
service.

This change contains a lot of deletion of code where we had previously pushed ownership of identifying the resource category outward to upper layers of code.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix

#### Issue(s)

* #3990

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
