### PR TITLE
Rename s3checker cmd flags

### DIFF
--- a/.github/workflows/longevity_test.yml
+++ b/.github/workflows/longevity_test.yml
@@ -352,14 +352,14 @@ jobs:
             #   - x - index blobs
             ./s3checker \
               --bucket ${{ secrets.CI_RETENTION_TESTS_S3_BUCKET }} \
-              --bucket-prefix ${{ env.PREFIX }} \
+              --prefix ${{ env.PREFIX }} \
               --retention-mode ${{ env.RETENTION_MODE }} \
               --live-retention-duration "$((${{ env.RETENTION_DURATION }}-1))h" \
-              --prefix "kopia.blobcfg" \
-              --prefix "kopia.repository" \
-              --prefix "p" \
-              --prefix "q" \
-              --prefix "x"
+              --object-prefix "kopia.blobcfg" \
+              --object-prefix "kopia.repository" \
+              --object-prefix "p" \
+              --object-prefix "q" \
+              --object-prefix "x"
           fi
 
       ##########################################################################

--- a/src/cmd/s3checker/s3checker.go
+++ b/src/cmd/s3checker/s3checker.go
@@ -52,12 +52,12 @@ func checkerCommand() (*cobra.Command, error) {
 		"Name of bucket to check")
 	fs.StringVar(
 		&f.bucketPrefix,
-		"bucket-prefix",
+		"prefix",
 		"",
 		"Prefix to add to all object lookups")
 	fs.StringSliceVar(
 		&f.prefixes,
-		"prefix",
+		"object-prefix",
 		nil,
 		"Set of object prefixes to check. Pass multiple times for multiple prefixes")
 


### PR DESCRIPTION
<!-- PR description-->

* Rename some flags to bring parity with corso cli flags. `--bucket-prefix` to `--prefix`, `--prefix` to `--object-prefix`. This is so that we can avoid passing overrides until sometime later. 
* Ideally this change should not be needed. This is part of a stopgap solution to remove s3 coupling from corso cli package.
* A more architectural solution is [managing overrides using viper](https://github.com/alcionai/corso/issues/4219). That change is a bit more involved, so i'll be adding that later. 
---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
