### PR TITLE
Disable groups and teams tests for now

### DIFF
--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -328,42 +328,45 @@ jobs:
 
 # Groups and Teams
 
-      # generate new entries for test
-      - name: Groups - Create new data
-        id: new-data-creation-groups
-        working-directory: ./src/cmd/factory
-        run: |
-          suffix=$(date +"%Y-%m-%d_%H-%M-%S")
+      # TODO(ashmrtn): Re-enable when things have stabilized a bit more and we
+      # can add data in M365 as needed.
 
-          go run . sharepoint files  \
-            --site ${{ secrets.CORSO_M365_TEST_GROUPS_SITE_URL }} \
-            --user ${{ env.TEST_USER }} \
-            --secondaryuser  ${{ env.CORSO_SECONDARY_M365_TEST_USER_ID }} \
-            --tenant ${{ secrets.TENANT_ID }} \
-            --destination ${{ env.RESTORE_DEST_PFX }}$suffix \
-            --count 4
+      ## generate new entries for test
+      #- name: Groups - Create new data
+      #  id: new-data-creation-groups
+      #  working-directory: ./src/cmd/factory
+      #  run: |
+      #    suffix=$(date +"%Y-%m-%d_%H-%M-%S")
 
-          echo result="${suffix}" >> $GITHUB_OUTPUT
+      #    go run . sharepoint files  \
+      #      --site ${{ secrets.CORSO_M365_TEST_GROUPS_SITE_URL }} \
+      #      --user ${{ env.TEST_USER }} \
+      #      --secondaryuser  ${{ env.CORSO_SECONDARY_M365_TEST_USER_ID }} \
+      #      --tenant ${{ secrets.TENANT_ID }} \
+      #      --destination ${{ env.RESTORE_DEST_PFX }}$suffix \
+      #      --count 4
 
-      - name: Groups - Backup
-        id: groups-backup
-        uses: ./.github/actions/backup-restore-test
-        with:
-          service: groups
-          kind: initial
-          backup-args: '--group "${{ secrets.CORSO_M365_TEST_TEAM_ID }}"'
-          test-folder: '${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-groups.outputs.result }}'
-          log-dir: ${{ env.CORSO_LOG_DIR }}
+      #    echo result="${suffix}" >> $GITHUB_OUTPUT
 
-      - name: Teams - Backup
-        id: teams-backup
-        uses: ./.github/actions/backup-restore-test
-        with:
-          service: teams
-          kind: initial
-          backup-args: '--group "${{ secrets.CORSO_M365_TEST_TEAM_ID }}"'
-          test-folder: '${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-groups.outputs.result }}'
-          log-dir: ${{ env.CORSO_LOG_DIR }}
+      #- name: Groups - Backup
+      #  id: groups-backup
+      #  uses: ./.github/actions/backup-restore-test
+      #  with:
+      #    service: groups
+      #    kind: initial
+      #    backup-args: '--group "${{ secrets.CORSO_M365_TEST_TEAM_ID }}"'
+      #    test-folder: '${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-groups.outputs.result }}'
+      #    log-dir: ${{ env.CORSO_LOG_DIR }}
+
+      #- name: Teams - Backup
+      #  id: teams-backup
+      #  uses: ./.github/actions/backup-restore-test
+      #  with:
+      #    service: teams
+      #    kind: initial
+      #    backup-args: '--group "${{ secrets.CORSO_M365_TEST_TEAM_ID }}"'
+      #    test-folder: '${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-groups.outputs.result }}'
+      #    log-dir: ${{ env.CORSO_LOG_DIR }}
 
       # TODO: incrementals
 


### PR DESCRIPTION
Re-enable these tests when they've stabilized a bit more.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [x] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
