### PR TITLE
add non-delta message paging path

### DIFF
--- a/src/internal/common/str/str.go
+++ b/src/internal/common/str/str.go
@@ -80,3 +80,13 @@ func Preview(s string, size int) string {
 
 	return ss
 }
+
+func SliceToMap(ss []string) map[string]struct{} {
+	m := map[string]struct{}{}
+
+	for _, s := range ss {
+		m[s] = struct{}{}
+	}
+
+	return m
+}

--- a/src/internal/m365/collection/groups/channel_handler.go
+++ b/src/internal/m365/collection/groups/channel_handler.go
@@ -36,11 +36,12 @@ func (bh channelsBackupHandler) getChannels(
 	return bh.ac.GetChannels(ctx, bh.protectedResource)
 }
 
-func (bh channelsBackupHandler) getChannelMessageIDsDelta(
+func (bh channelsBackupHandler) getChannelMessageIDs(
 	ctx context.Context,
 	channelID, prevDelta string,
-) (map[string]struct{}, map[string]struct{}, api.DeltaUpdate, error) {
-	return bh.ac.GetChannelMessageIDsDelta(ctx, bh.protectedResource, channelID, prevDelta)
+	canMakeDeltaQueries bool,
+) ([]string, []string, api.DeltaUpdate, error) {
+	return bh.ac.GetChannelMessageIDs(ctx, bh.protectedResource, channelID, prevDelta, canMakeDeltaQueries)
 }
 
 func (bh channelsBackupHandler) includeContainer(

--- a/src/internal/m365/collection/groups/handlers.go
+++ b/src/internal/m365/collection/groups/handlers.go
@@ -20,11 +20,12 @@ type backupHandler interface {
 		ctx context.Context,
 	) ([]models.Channelable, error)
 
-	// gets all message IDs by delta in the channel
-	getChannelMessageIDsDelta(
+	// gets all message IDs (by delta, if possible) in the channel
+	getChannelMessageIDs(
 		ctx context.Context,
 		channelID, prevDelta string,
-	) (map[string]struct{}, map[string]struct{}, api.DeltaUpdate, error)
+		canMakeDeltaQueries bool,
+	) ([]string, []string, api.DeltaUpdate, error)
 
 	// includeContainer evaluates whether the channel is included
 	// in the provided scope.

--- a/src/pkg/services/m365/api/channels_pager.go
+++ b/src/pkg/services/m365/api/channels_pager.go
@@ -3,10 +3,10 @@ package api
 import (
 	"context"
 
+	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/teams"
 
-	"github.com/alcionai/clues"
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 )

--- a/src/pkg/services/m365/api/channels_pager_test.go
+++ b/src/pkg/services/m365/api/channels_pager_test.go
@@ -56,28 +56,30 @@ func (suite *ChannelsPagerIntgSuite) TestEnumerateChannelMessages() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	addedIDs, _, du, err := ac.GetChannelMessageIDsDelta(
+	addedIDs, _, du, err := ac.GetChannelMessageIDs(
 		ctx,
 		suite.its.group.id,
 		suite.its.group.testContainerID,
-		"")
+		"",
+		true)
 	require.NoError(t, err, clues.ToCore(err))
 	require.NotEmpty(t, addedIDs)
 	require.NotZero(t, du.URL, "delta link")
 	require.True(t, du.Reset, "reset due to empty prev delta link")
 
-	addedIDs, deletedIDs, du, err := ac.GetChannelMessageIDsDelta(
+	addedIDs, deletedIDs, du, err := ac.GetChannelMessageIDs(
 		ctx,
 		suite.its.group.id,
 		suite.its.group.testContainerID,
-		du.URL)
+		du.URL,
+		true)
 	require.NoError(t, err, clues.ToCore(err))
 	require.Empty(t, addedIDs, "should have no new messages from delta")
 	require.Empty(t, deletedIDs, "should have no deleted messages from delta")
 	require.NotZero(t, du.URL, "delta link")
 	require.False(t, du.Reset, "prev delta link should be valid")
 
-	for id := range addedIDs {
+	for _, id := range addedIDs {
 		suite.Run(id+"-replies", func() {
 			testEnumerateChannelMessageReplies(
 				suite.T(),

--- a/src/pkg/services/m365/api/contacts_pager.go
+++ b/src/pkg/services/m365/api/contacts_pager.go
@@ -278,5 +278,6 @@ func (c Contacts) GetAddedAndRemovedItemIDs(
 		pager,
 		deltaPager,
 		prevDeltaLink,
-		canMakeDeltaQueries)
+		canMakeDeltaQueries,
+		addedAndRemovedByAddtlData)
 }

--- a/src/pkg/services/m365/api/events_pager.go
+++ b/src/pkg/services/m365/api/events_pager.go
@@ -277,5 +277,6 @@ func (c Events) GetAddedAndRemovedItemIDs(
 		pager,
 		deltaPager,
 		prevDeltaLink,
-		canMakeDeltaQueries)
+		canMakeDeltaQueries,
+		addedAndRemovedByAddtlData)
 }

--- a/src/pkg/services/m365/api/item_pager.go
+++ b/src/pkg/services/m365/api/item_pager.go
@@ -258,9 +258,6 @@ func addedAndRemovedByDeletedDateTime[T any](items []T) ([]string, []string, err
 				With("item_type", fmt.Sprintf("%T", item))
 		}
 
-		// if the additional data contains a `@removed` key, the value will either
-		// be 'changed' or 'deleted'.  We don't really care about the cause: both
-		// cases are handled the same way in storage.
 		if giaddt.GetDeletedDateTime() == nil {
 			added = append(added, ptr.Val(giaddt.GetId()))
 		} else {

--- a/src/pkg/services/m365/api/item_pager_test.go
+++ b/src/pkg/services/m365/api/item_pager_test.go
@@ -363,7 +363,8 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs() {
 				test.pagerGetter(t),
 				test.deltaPagerGetter(t),
 				test.prevDelta,
-				test.canDelta)
+				test.canDelta,
+				addedAndRemovedByAddtlData)
 
 			require.NoErrorf(t, err, "getting added and removed item IDs: %+v", clues.ToCore(err))
 			require.EqualValues(t, test.expect.added, added, "added item IDs")

--- a/src/pkg/services/m365/api/mail_pager.go
+++ b/src/pkg/services/m365/api/mail_pager.go
@@ -308,5 +308,6 @@ func (c Mail) GetAddedAndRemovedItemIDs(
 		pager,
 		deltaPager,
 		prevDeltaLink,
-		canMakeDeltaQueries)
+		canMakeDeltaQueries,
+		addedAndRemovedByAddtlData)
 }


### PR DESCRIPTION
similar to exchange, there are conditions under
which channel messages are unable to use the
delta api.  In particular, when the channel has no valid email property.  This change ensures that
we enumerate the entire channel under those
conditions, instead of failing out.

Technically, the only situation we know of where
the email property is missing, and thus the channel cannot make delta queries, is when there are
zero messages in the channel already.  However,
there may be unknown cases that we haven't caught, so instead of skipping the channel we're going to
handle non-delta enumeration for future safeguarding.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix

#### Issue(s)

* #3989 

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
