### PR TITLE
add groups cli selectors

### DIFF
--- a/src/cli/backup/groups.go
+++ b/src/cli/backup/groups.go
@@ -37,26 +37,25 @@ const (
 	groupsServiceCommandDetailsUseSuffix = "--backup <backupId>"
 )
 
-// TODO: correct examples
 const (
-	groupsServiceCommandCreateExamples = `# Backup all Groups data for Alice
-corso backup create groups --group alice@example.com 
+	groupsServiceCommandCreateExamples = `# Backup all Groups and Teams data for the Marketing group
+corso backup create groups --group Marketing
 
-# Backup only Groups contacts for Alice and Bob
-corso backup create groups --group engineering,sales --data contacts
+# Backup only Teams conversations messages
+corso backup create groups --group Marketing --data messages
 
-# Backup all Groups data for all M365 users 
+# Backup all Groups and Teams data for all groups
 corso backup create groups --group '*'`
 
 	groupsServiceCommandDeleteExamples = `# Delete Groups backup with ID 1234abcd-12ab-cd34-56de-1234abcd
 corso backup delete groups --backup 1234abcd-12ab-cd34-56de-1234abcd`
 
-	groupsServiceCommandDetailsExamples = `# Explore items in Alice's latest backup (1234abcd...)
+	groupsServiceCommandDetailsExamples = `# Explore items in Marketing's latest backup (1234abcd...)
 corso backup details groups --backup 1234abcd-12ab-cd34-56de-1234abcd
 
-# Explore calendar events occurring after start of 2022
+# Explore Marketing messages posted after the start of 2022
 corso backup details groups --backup 1234abcd-12ab-cd34-56de-1234abcd \
-    --event-starts-after 2022-01-01T00:00:00`
+    --last-message-reply-after 2022-01-01T00:00:00`
 )
 
 // called by backup.go to map subcommands to provider-specific handling.

--- a/src/cli/backup/groups.go
+++ b/src/cli/backup/groups.go
@@ -106,6 +106,7 @@ func addGroupsCommands(cmd *cobra.Command) *cobra.Command {
 		// Flags addition ordering should follow the order we want them to appear in help and docs:
 		// More generic (ex: --user) and more frequently used flags take precedence.
 		flags.AddBackupIDFlag(c, true)
+		flags.AddGroupDetailsAndRestoreFlags(c)
 		flags.AddCorsoPassphaseFlags(c)
 		flags.AddAWSCredsFlags(c)
 		flags.AddAzureCredsFlags(c)

--- a/src/cli/export/groups.go
+++ b/src/cli/export/groups.go
@@ -36,23 +36,22 @@ func addGroupsCommands(cmd *cobra.Command) *cobra.Command {
 	return c
 }
 
-// TODO: correct examples
 const (
 	groupsServiceCommand          = "groups"
 	teamsServiceCommand           = "teams"
 	groupsServiceCommandUseSuffix = "<destination> --backup <backupId>"
 
 	//nolint:lll
-	groupsServiceCommandExportExamples = `# Export file with ID 98765abcdef in Bob's last backup (1234abcd...) to my-exports directory
-corso export groups my-exports --backup 1234abcd-12ab-cd34-56de-1234abcd --file 98765abcdef
+	groupsServiceCommandExportExamples = `# Export a message in Marketing's last backup (1234abcd...) to my-exports directory
+corso export groups my-exports --backup 1234abcd-12ab-cd34-56de-1234abcd --message 98765abcdef
 
-# Export files named "FY2021 Planning.xlsx" in "Documents/Finance Reports" to current directory
+# Export all messages named in channel "Finance Reports" to the current directory
 corso export groups . --backup 1234abcd-12ab-cd34-56de-1234abcd \
-    --file "FY2021 Planning.xlsx" --folder "Documents/Finance Reports"
+    --message '*' --channel "Finance Reports"
 
-# Export all files and folders in folder "Documents/Finance Reports" that were created before 2020 to my-exports
+# Export all messages in channel "Finance Reports" that were created before 2020 to my-exports
 corso export groups my-exports --backup 1234abcd-12ab-cd34-56de-1234abcd
-    --folder "Documents/Finance Reports" --file-created-before 2020-01-01T00:00:00`
+    --channel "Finance Reports" --message-created-before 2020-01-01T00:00:00`
 )
 
 // `corso export groups [<flag>...] <destination>`

--- a/src/cli/export/groups.go
+++ b/src/cli/export/groups.go
@@ -27,6 +27,7 @@ func addGroupsCommands(cmd *cobra.Command) *cobra.Command {
 		fs.SortFlags = false
 
 		flags.AddBackupIDFlag(c, true)
+		flags.AddGroupDetailsAndRestoreFlags(c)
 		flags.AddExportConfigFlags(c)
 		flags.AddFailFastFlag(c)
 		flags.AddCorsoPassphaseFlags(c)

--- a/src/cli/flags/groups.go
+++ b/src/cli/flags/groups.go
@@ -6,12 +6,60 @@ import (
 
 const DataMessages = "messages"
 
-const GroupFN = "group"
+const (
+	ChannelFN = "channel"
+	GroupFN   = "group"
+	MessageFN = "message"
 
-var GroupFV []string
+	MessageCreatedAfterFN    = "message-created-after"
+	MessageCreatedBeforeFN   = "message-created-before"
+	MessageLastReplyAfterFN  = "message-last-reply-after"
+	MessageLastReplyBeforeFN = "message-last-reply-before"
+)
+
+var (
+	ChannelFV []string
+	GroupFV   []string
+	MessageFV []string
+
+	MessageCreatedAfterFV    string
+	MessageCreatedBeforeFV   string
+	MessageLastReplyAfterFV  string
+	MessageLastReplyBeforeFV string
+)
 
 func AddGroupDetailsAndRestoreFlags(cmd *cobra.Command) {
-	// TODO: implement groups specific flags
+	fs := cmd.Flags()
+
+	fs.StringSliceVar(
+		&ChannelFV,
+		ChannelFN, nil,
+		"Select data within a Team's Channel.")
+
+	fs.StringSliceVar(
+		&MessageFV,
+		MessageFN, nil,
+		"Select messages by reference.")
+
+	fs.StringVar(
+		&MessageCreatedAfterFV,
+		MessageCreatedAfterFN, "",
+		"Select messages created after this datetime.")
+
+	fs.StringVar(
+		&MessageCreatedBeforeFV,
+		MessageCreatedBeforeFN, "",
+		"Select messages created before this datetime.")
+
+	fs.StringVar(
+		&MessageLastReplyAfterFV,
+		MessageLastReplyAfterFN, "",
+		"Select messages with replies after this datetime.")
+
+	fs.StringVar(
+		&MessageLastReplyBeforeFV,
+		MessageLastReplyBeforeFN, "",
+		"Select messages with replies before this datetime.")
 }
 
 // AddGroupFlag adds the --group flag, which accepts id or name values.

--- a/src/cli/flags/onedrive.go
+++ b/src/cli/flags/onedrive.go
@@ -43,6 +43,7 @@ func AddOneDriveDetailsAndRestoreFlags(cmd *cobra.Command) {
 		&FileCreatedAfterFV,
 		FileCreatedAfterFN, "",
 		"Select files created after this datetime.")
+
 	fs.StringVar(
 		&FileCreatedBeforeFV,
 		FileCreatedBeforeFN, "",

--- a/src/cli/utils/onedrive.go
+++ b/src/cli/utils/onedrive.go
@@ -52,19 +52,19 @@ func ValidateOneDriveRestoreFlags(backupID string, opts OneDriveOpts) error {
 	}
 
 	if _, ok := opts.Populated[flags.FileCreatedAfterFN]; ok && !IsValidTimeFormat(opts.FileCreatedAfter) {
-		return clues.New("invalid time format for created-after")
+		return clues.New("invalid time format for " + flags.FileCreatedAfterFN)
 	}
 
 	if _, ok := opts.Populated[flags.FileCreatedBeforeFN]; ok && !IsValidTimeFormat(opts.FileCreatedBefore) {
-		return clues.New("invalid time format for created-before")
+		return clues.New("invalid time format for " + flags.FileCreatedBeforeFN)
 	}
 
 	if _, ok := opts.Populated[flags.FileModifiedAfterFN]; ok && !IsValidTimeFormat(opts.FileModifiedAfter) {
-		return clues.New("invalid time format for modified-after")
+		return clues.New("invalid time format for " + flags.FileModifiedAfterFN)
 	}
 
 	if _, ok := opts.Populated[flags.FileModifiedBeforeFN]; ok && !IsValidTimeFormat(opts.FileModifiedBefore) {
-		return clues.New("invalid time format for modified-before")
+		return clues.New("invalid time format for " + flags.FileModifiedBeforeFN)
 	}
 
 	return validateRestoreConfigFlags(flags.CollisionsFV, opts.RestoreCfg)


### PR DESCRIPTION
populates all selectors in the groups cli.  adds
both info-based filters (such as message creation
time) and also basic channel and mesage selection.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #3989

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
