### PR TITLE
Fix repo maintenance command

### DIFF
--- a/src/cli/repo/repo.go
+++ b/src/cli/repo/repo.go
@@ -121,7 +121,12 @@ func handleMaintenanceCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	r, _, err := utils.AccountConnectAndWriteRepoConfig(ctx, path.UnknownService, S3Overrides(cmd))
+	r, _, err := utils.AccountConnectAndWriteRepoConfig(
+		ctx,
+		// Need to give it a valid service so it won't error out on us even though
+		// we don't need the graph client.
+		path.OneDriveService,
+		S3Overrides(cmd))
 	if err != nil {
 		return print.Only(ctx, err)
 	}


### PR DESCRIPTION
If we continue passing UnknownService then the
command fails when trying to initialize the
graph client. Longer term we should rework the
logic in the helper functions for connecting
to a repo (see #4239)

This issue isn't present in the most recent
release

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3217

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
