### PR TITLE
Add repo maintenance command to sanity tests

### DIFF
--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -149,6 +149,18 @@ jobs:
             exit 1
           fi
 
+      # Run maintenance on an empty repo just to make sure the command still
+      # works.
+      - name: Repo maintenance test
+        run: |
+          set -euo pipefail
+          echo -e "\nRepo maintenance test\n" >> ${{ env.CORSO_LOG_FILE }}
+          ./corso repo maintenance \
+            --no-stats \
+            --hide-progress \
+            --mode complete \
+            2>&1 | tee ${{ env.CORSO_LOG_DIR }}/gotest-repo-maintenance.log
+
 ##########################################################################################################################################
 
 # Exchange


### PR DESCRIPTION
Runs on an empty repo for speed but will
help ensure that at least the CLI layer
is working as expected.

Manual test run (expected failure) [here](https://github.com/alcionai/corso/actions/runs/6177888032/job/16769984698)

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [x] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3217

Merge after the below to avoid failures
* #4240

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
