### PR TITLE
Add linter for checking with empty string

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,6 +503,13 @@ jobs:
             echo "No trailing commas for function calls"
             exit 1
           fi
+      - name: Check for empty string comparison
+        run: |
+          # Using `grep .` as the exit codes are always true for correct grammar
+          if tree-grepper -q go '((binary_expression (identifier) ["==" "!="] (interpreted_string_literal) @ri) (#eq? @ri "\"\""))' | grep .; then
+            echo "Use len check instead of empty string comparison"
+            exit 1
+          fi
 
   # ----------------------------------------------------------------------------------------------------
   # --- GitHub Actions Linting -------------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -506,7 +506,7 @@ jobs:
       - name: Check for empty string comparison
         run: |
           # Using `grep .` as the exit codes are always true for correct grammar
-          if tree-grepper -q go '((binary_expression (identifier) ["==" "!="] (interpreted_string_literal) @ri) (#eq? @ri "\"\""))' | grep .; then
+          if tree-grepper -q go '((binary_expression (identifier) ["==" "!="] (interpreted_string_literal) @_ri) @exp (#eq? @_ri "\"\""))' | grep .; then
             echo "Use len check instead of empty string comparison"
             exit 1
           fi

--- a/src/cli/config/config.go
+++ b/src/cli/config/config.go
@@ -118,7 +118,7 @@ func InitFunc(cmd *cobra.Command, args []string) error {
 // struct for testing.
 func initWithViper(vpr *viper.Viper, configFP string) error {
 	// Configure default config file location
-	if configFP == "" || configFP == displayDefaultFP {
+	if len(configFP) == 0 || configFP == displayDefaultFP {
 		// Find home directory.
 		_, err := os.Stat(configDir)
 		if err != nil {

--- a/src/cmd/mdgen/mdgen.go
+++ b/src/cmd/mdgen/mdgen.go
@@ -182,13 +182,13 @@ func printFlags(buf *bytes.Buffer, flags *pflag.FlagSet) {
 		buf.WriteString(fmt.Sprintf("`--%s`", flag.Name))
 		buf.WriteString("|")
 
-		if flag.Shorthand != "" && flag.ShorthandDeprecated == "" {
+		if len(flag.Shorthand) > 0 && flag.ShorthandDeprecated == "" {
 			buf.WriteString(fmt.Sprintf("`-%s`", flag.Shorthand))
 		}
 
 		buf.WriteString("|")
 
-		if flag.DefValue != "" {
+		if len(flag.DefValue) > 0 {
 			defValue := flag.DefValue
 			if defValue == "[]" {
 				defValue = ""

--- a/src/internal/m365/collection/drive/metadata/permissions.go
+++ b/src/internal/m365/collection/drive/metadata/permissions.go
@@ -48,11 +48,11 @@ func (p Permission) Equals(other Permission) bool {
 	// have EntityID/Email as we backup permissions for all the
 	// parents and children when we have a change in permissions.
 	// We cannot just compare id because of the problem described in #3117
-	if p.EntityID != "" && p.EntityID != other.EntityID {
+	if len(p.EntityID) > 0 && p.EntityID != other.EntityID {
 		return false
 	}
 
-	if p.Email != "" && p.Email != other.Email {
+	if len(p.Email) > 0 && p.Email != other.Email {
 		return false
 	}
 
@@ -165,7 +165,7 @@ func FilterPermissions(ctx context.Context, perms []models.Permissionable) []Per
 
 		// Technically GrantedToV2 can also contain devices, but the
 		// documentation does not mention about devices in permissions
-		if entityID == "" {
+		if len(entityID) == 0 {
 			// This should ideally not be hit
 			continue
 		}
@@ -204,7 +204,7 @@ func FilterLinkShares(ctx context.Context, perms []models.Permissionable) []Link
 
 			// Technically GrantedToV2 can also contain devices, but the
 			// documentation does not mention about devices in permissions
-			if entityID == "" {
+			if len(entityID) == 0 {
 				// This should ideally not be hit
 				continue
 			}

--- a/src/internal/m365/graph/betasdk/beta_client.go
+++ b/src/internal/m365/graph/betasdk/beta_client.go
@@ -73,7 +73,7 @@ func NewBetaClient(requestAdapter abstractions.RequestAdapter) *BetaClient {
 		return kform.NewFormParseNodeFactory()
 	})
 
-	if m.requestAdapter.GetBaseUrl() == "" {
+	if len(m.requestAdapter.GetBaseUrl()) == 0 {
 		m.requestAdapter.SetBaseUrl("https://graph.microsoft.com/beta")
 	}
 	return m
@@ -85,7 +85,7 @@ func (m *BetaClient) SitesById(id string) *i1a3c1a5501c5e41b7fd169f2d4c768dce9b0
 	for idx, item := range m.pathParameters {
 		urlTplParams[idx] = item
 	}
-	if id != "" {
+	if len(id) > 0 {
 		urlTplParams["site%2Did"] = id
 	}
 	return i1a3c1a5501c5e41b7fd169f2d4c768dce9b096ac28fb5431bf02afcc57295411.NewSiteItemRequestBuilderInternal(urlTplParams, m.requestAdapter)

--- a/src/internal/m365/graph/betasdk/sites/item_pages_item_canvas_layout_horizontal_sections_horizontal_section_item_request_builder.go
+++ b/src/internal/m365/graph/betasdk/sites/item_pages_item_canvas_layout_horizontal_sections_horizontal_section_item_request_builder.go
@@ -75,7 +75,7 @@ func (m *ItemPagesItemCanvasLayoutHorizontalSectionsHorizontalSectionItemRequest
 		urlTplParams[idx] = item
 	}
 
-	if id != "" {
+	if len(id) > 0 {
 		urlTplParams["horizontalSectionColumn%2Did"] = id
 	}
 	//nolint:lll

--- a/src/internal/m365/graph/betasdk/sites/item_pages_item_canvas_layout_horizontal_sections_item_columns_horizontal_section_column_item_request_builder.go
+++ b/src/internal/m365/graph/betasdk/sites/item_pages_item_canvas_layout_horizontal_sections_item_columns_horizontal_section_column_item_request_builder.go
@@ -239,7 +239,7 @@ func (m *ItemPagesItemCanvasLayoutHorizontalSectionsItemColumnsHorizontalSection
 		urlTplParams[idx] = item
 	}
 
-	if id != "" {
+	if len(id) > 0 {
 		urlTplParams["webPart%2Did"] = id
 	}
 

--- a/src/internal/m365/graph/betasdk/sites/item_pages_item_canvas_layout_request_builder.go
+++ b/src/internal/m365/graph/betasdk/sites/item_pages_item_canvas_layout_request_builder.go
@@ -194,7 +194,7 @@ func (m *ItemPagesItemCanvasLayoutRequestBuilder) HorizontalSectionsById(id stri
 	for idx, item := range m.pathParameters {
 		urlTplParams[idx] = item
 	}
-	if id != "" {
+	if len(id) > 0 {
 		urlTplParams["horizontalSection%2Did"] = id
 	}
 	return NewItemPagesItemCanvasLayoutHorizontalSectionsHorizontalSectionItemRequestBuilderInternal(urlTplParams, m.requestAdapter)

--- a/src/internal/m365/graph/betasdk/sites/item_pages_item_canvas_layout_vertical_section_request_builder.go
+++ b/src/internal/m365/graph/betasdk/sites/item_pages_item_canvas_layout_vertical_section_request_builder.go
@@ -219,7 +219,7 @@ func (m *ItemPagesItemCanvasLayoutVerticalSectionRequestBuilder) WebpartsById(id
 	for idx, item := range m.pathParameters {
 		urlTplParams[idx] = item
 	}
-	if id != "" {
+	if len(id) > 0 {
 		urlTplParams["webPart%2Did"] = id
 	}
 	return NewItemPagesItemCanvasLayoutVerticalSectionWebpartsWebPartItemRequestBuilderInternal(urlTplParams, m.requestAdapter)

--- a/src/internal/m365/graph/betasdk/sites/item_pages_site_page_item_request_builder.go
+++ b/src/internal/m365/graph/betasdk/sites/item_pages_site_page_item_request_builder.go
@@ -230,7 +230,7 @@ func (m *ItemPagesSitePageItemRequestBuilder) WebPartsById(id string) *ItemPages
 	for idx, item := range m.pathParameters {
 		urlTplParams[idx] = item
 	}
-	if id != "" {
+	if len(id) > 0 {
 		urlTplParams["webPart%2Did"] = id
 	}
 	return NewItemPagesItemWebPartsWebPartItemRequestBuilderInternal(urlTplParams, m.requestAdapter)

--- a/src/internal/m365/graph/betasdk/sites/site_item_request_builder.go
+++ b/src/internal/m365/graph/betasdk/sites/site_item_request_builder.go
@@ -196,7 +196,7 @@ func (m *SiteItemRequestBuilder) PagesById(id string) *ItemPagesSitePageItemRequ
 	for idx, item := range m.pathParameters {
 		urlTplParams[idx] = item
 	}
-	if id != "" {
+	if len(id) > 0 {
 		urlTplParams["sitePage%2Did"] = id
 	}
 	return NewItemPagesSitePageItemRequestBuilderInternal(urlTplParams, m.requestAdapter)
@@ -240,7 +240,7 @@ func (m *SiteItemRequestBuilder) SitesById(id string) *ItemSitesSiteItemRequestB
 	for idx, item := range m.pathParameters {
 		urlTplParams[idx] = item
 	}
-	if id != "" {
+	if len(id) > 0 {
 		urlTplParams["site%2Did1"] = id
 	}
 	return NewItemSitesSiteItemRequestBuilderInternal(urlTplParams, m.requestAdapter)

--- a/src/internal/m365/graph/middleware.go
+++ b/src/internal/m365/graph/middleware.go
@@ -357,7 +357,7 @@ func (mw RetryMiddleware) getRetryDelay(
 		retryAfter = resp.Header.Get(retryAfterHeader)
 	}
 
-	if retryAfter != "" {
+	if len(retryAfter) > 0 {
 		retryAfterDelay, err := strconv.ParseFloat(retryAfter, 64)
 		if err == nil {
 			return time.Duration(retryAfterDelay) * time.Second

--- a/src/internal/m365/graph/uploadsession.go
+++ b/src/internal/m365/graph/uploadsession.go
@@ -91,7 +91,7 @@ func (iw *largeItemWriter) Write(p []byte) (int, error) {
 	// https://outlook.office.com/api/v2.0/Users('<user-id>')/Messages('<message-id>')/Attachments('<attachment-id>')
 	// Ref: https://learn.microsoft.com/en-us/graph/outlook-large-attachments?tabs=http
 	loc := resp.Header.Get("Location")
-	if loc != "" {
+	if len(loc) > 0 {
 		splits := strings.Split(loc, "'")
 		if len(splits) != 7 || splits[4] != ")/Attachments(" || len(splits[5]) == 0 {
 			return 0, clues.New("invalid format for upload completion url").

--- a/src/internal/operations/export_test.go
+++ b/src/internal/operations/export_test.go
@@ -315,7 +315,7 @@ func (suite *ExportUnitSuite) TestZipExports() {
 						Body: item.Body,
 					}
 
-					if col.BasePath() != "" {
+					if len(col.BasePath()) > 0 {
 						expected.Name = strings.Join([]string{col.BasePath(), item.Name}, "/")
 					}
 

--- a/src/internal/tester/tester.go
+++ b/src/internal/tester/tester.go
@@ -36,7 +36,7 @@ func LogTimeOfTest(t TestT) string {
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	name := t.Name()
 
-	if name == "" {
+	if len(name) == 0 {
 		t.Logf("Test run at %s.", now)
 		return now
 	}

--- a/src/pkg/backup/details/groups.go
+++ b/src/pkg/backup/details/groups.go
@@ -24,7 +24,7 @@ func NewGroupsLocationIDer(
 	pb := path.Builder{}.Append(category.String())
 	prefixElems := 1
 
-	if driveID != "" { // non sp paths don't have driveID
+	if len(driveID) > 0 { // non sp paths don't have driveID
 		pb = pb.Append(driveID)
 
 		prefixElems = 2

--- a/src/pkg/logger/logpath_xdg.go
+++ b/src/pkg/logger/logpath_xdg.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	if os.Getenv("XDG_CACHE_HOME") != "" {
+	if len(os.Getenv("XDG_CACHE_HOME")) > 0 {
 		userLogsDir = os.Getenv("XDG_CACHE_HOME")
 	} else {
 		userLogsDir = filepath.Join(os.Getenv("HOME"), ".cache")

--- a/src/pkg/services/m365/api/item_pager_test.go
+++ b/src/pkg/services/m365/api/item_pager_test.go
@@ -91,7 +91,7 @@ type testIDsPager struct {
 func (p *testIDsPager) GetPage(
 	ctx context.Context,
 ) (NextLinkValuer[any], error) {
-	if p.errorCode != "" {
+	if len(p.errorCode) > 0 {
 		ierr := odataerrors.NewMainError()
 		ierr.SetCode(&p.errorCode)
 
@@ -145,7 +145,7 @@ type testIDsDeltaPager struct {
 func (p *testIDsDeltaPager) GetPage(
 	ctx context.Context,
 ) (DeltaLinkValuer[any], error) {
-	if p.errorCode != "" {
+	if len(p.errorCode) > 0 {
 		ierr := odataerrors.NewMainError()
 		ierr.SetCode(&p.errorCode)
 


### PR DESCRIPTION
Finding failing cases:

``` bash
tree-grepper -q go '((binary_expression (identifier) ["==" "!="] (interpreted_string_literal) @ri) (#eq? @ri "\"\""))'
```

Fixing failing cases:

``` bash
comby 'if :[1~[^ ]*] == ""' 'if len(:[1]) == 0' -matcher .go -in-place
comby 'if :[1~[^ ]*] != ""' 'if len(:[1]) > 0' -matcher .go -in-place
```

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* closes https://github.com/alcionai/corso/issues/3654

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
