### PR TITLE
Introduce new interfaces for storage configuration

### DIFF
--- a/src/cli/backup/helpers_test.go
+++ b/src/cli/backup/helpers_test.go
@@ -140,8 +140,10 @@ func prepM365Test(
 		recorder = strings.Builder{}
 	)
 
-	cfg, err := st.S3Config()
+	sc, err := st.StorageConfig()
 	require.NoError(t, err, clues.ToCore(err))
+
+	cfg := sc.(*storage.S3Config)
 
 	force := map[string]string{
 		tconfig.TestCfgAccountProvider: account.ProviderM365.String(),

--- a/src/cli/config/config_test.go
+++ b/src/cli/config/config_test.go
@@ -79,13 +79,11 @@ func (suite *ConfigSuite) TestReadRepoConfigBasic() {
 	)
 
 	const (
-		b      = "read-repo-config-basic-bucket"
-		tID    = "6f34ac30-8196-469b-bf8f-d83deadbbbba"
-		accKey = "aws-test-access-key"
-		secret = "aws-test-secret-key"
-		// intentionally empty so that we don't error out if testing with
-		// local minio s3 server
-		token                  = ""
+		b                      = "read-repo-config-basic-bucket"
+		tID                    = "6f34ac30-8196-469b-bf8f-d83deadbbbba"
+		accKey                 = "aws-test-access-key"
+		secret                 = "aws-test-secret-key"
+		token                  = "aws-test-session-token"
 		passphrase             = "passphrase-test"
 		azureClientID          = "azure-client-id-test"
 		azureSecret            = "azure-secret-test"

--- a/src/cli/config/config_test.go
+++ b/src/cli/config/config_test.go
@@ -26,20 +26,20 @@ import (
 
 const (
 	configFileTemplate = `
-` + BucketNameKey + ` = '%s'
-` + EndpointKey + ` = 's3.amazonaws.com'
-` + PrefixKey + ` = 'test-prefix/'
+` + storage.BucketNameKey + ` = '%s'
+` + storage.EndpointKey + ` = 's3.amazonaws.com'
+` + storage.PrefixKey + ` = 'test-prefix/'
 ` + storage.StorageProviderTypeKey + ` = 'S3'
 ` + account.AccountProviderTypeKey + ` = 'M365'
 ` + account.AzureTenantIDKey + ` = '%s'
-` + AccessKey + ` = '%s'
-` + SecretAccessKey + ` = '%s'
-` + SessionToken + ` = '%s'
+` + storage.AccessKey + ` = '%s'
+` + storage.SecretAccessKey + ` = '%s'
+` + storage.SessionToken + ` = '%s'
 ` + CorsoPassphrase + ` = '%s'
 ` + account.AzureClientID + ` = '%s'
 ` + account.AzureSecret + ` = '%s'
-` + DisableTLSKey + ` = '%s'
-` + DisableTLSVerificationKey + ` = '%s'
+` + storage.DisableTLSKey + ` = '%s'
+` + storage.DisableTLSVerificationKey + ` = '%s'
 `
 )
 
@@ -107,15 +107,23 @@ func (suite *ConfigSuite) TestReadRepoConfigBasic() {
 	err = vpr.ReadInConfig()
 	require.NoError(t, err, "reading repo config", clues.ToCore(err))
 
-	s3Cfg, err := s3ConfigsFromViper(vpr)
+	// Unset AWS env vars so that we can test reading creds from config file
+	os.Unsetenv(credentials.AWSAccessKeyID)
+	os.Unsetenv(credentials.AWSSecretAccessKey)
+	os.Unsetenv(credentials.AWSSessionToken)
+
+	sc, err := storage.NewStorageConfig(storage.ProviderS3)
 	require.NoError(t, err, clues.ToCore(err))
+	err = sc.ApplyConfigOverrides(vpr, true, true, nil)
+	require.NoError(t, err, clues.ToCore(err))
+
+	s3Cfg := sc.(*storage.S3Config)
+
 	assert.Equal(t, b, s3Cfg.Bucket)
 	assert.Equal(t, "test-prefix/", s3Cfg.Prefix)
 	assert.Equal(t, disableTLS, strconv.FormatBool(s3Cfg.DoNotUseTLS))
 	assert.Equal(t, disableTLSVerification, strconv.FormatBool(s3Cfg.DoNotVerifyTLS))
 
-	s3Cfg, err = s3CredsFromViper(vpr, s3Cfg)
-	require.NoError(t, err, clues.ToCore(err))
 	assert.Equal(t, accKey, s3Cfg.AWS.AccessKey)
 	assert.Equal(t, secret, s3Cfg.AWS.SecretKey)
 	assert.Equal(t, token, s3Cfg.AWS.SessionToken)
@@ -146,7 +154,11 @@ func (suite *ConfigSuite) TestWriteReadConfig() {
 	err := initWithViper(vpr, testConfigFilePath)
 	require.NoError(t, err, "initializing repo config", clues.ToCore(err))
 
-	s3Cfg := storage.S3Config{Bucket: bkt, DoNotUseTLS: true, DoNotVerifyTLS: true}
+	s3Cfg := &storage.S3Config{
+		Bucket:         bkt,
+		DoNotUseTLS:    true,
+		DoNotVerifyTLS: true,
+	}
 	m365 := account.M365Config{AzureTenantID: tid}
 
 	rOpts := repository.Options{
@@ -160,8 +172,12 @@ func (suite *ConfigSuite) TestWriteReadConfig() {
 	err = vpr.ReadInConfig()
 	require.NoError(t, err, "reading repo config", clues.ToCore(err))
 
-	readS3Cfg, err := s3ConfigsFromViper(vpr)
+	sc, err := storage.NewStorageConfig(storage.ProviderS3)
 	require.NoError(t, err, clues.ToCore(err))
+	err = sc.ApplyConfigOverrides(vpr, true, true, nil)
+	require.NoError(t, err, clues.ToCore(err))
+
+	readS3Cfg := sc.(*storage.S3Config)
 	assert.Equal(t, readS3Cfg.Bucket, s3Cfg.Bucket)
 	assert.Equal(t, readS3Cfg.DoNotUseTLS, s3Cfg.DoNotUseTLS)
 	assert.Equal(t, readS3Cfg.DoNotVerifyTLS, s3Cfg.DoNotVerifyTLS)
@@ -191,7 +207,7 @@ func (suite *ConfigSuite) TestMustMatchConfig() {
 	err := initWithViper(vpr, testConfigFilePath)
 	require.NoError(t, err, "initializing repo config")
 
-	s3Cfg := storage.S3Config{Bucket: bkt}
+	s3Cfg := &storage.S3Config{Bucket: bkt}
 	m365 := account.M365Config{AzureTenantID: tid}
 
 	err = writeRepoConfigWithViper(vpr, s3Cfg, m365, repository.Options{}, "repoid")
@@ -330,9 +346,14 @@ func (suite *ConfigSuite) TestReadFromFlags() {
 		true,
 		false,
 		overrides)
+	require.NoError(t, err, "getting storage and account from config", clues.ToCore(err))
 
 	m365Config, _ := repoDetails.Account.M365Config()
-	s3Cfg, _ := repoDetails.Storage.S3Config()
+
+	sc, err := repoDetails.Storage.StorageConfig()
+	require.NoError(t, err, "reading s3 config from storage", clues.ToCore(err))
+
+	s3Cfg := sc.(*storage.S3Config)
 	commonConfig, _ := repoDetails.Storage.CommonConfig()
 	pass := commonConfig.Corso.CorsoPassphrase
 
@@ -386,7 +407,7 @@ func (suite *ConfigIntegrationSuite) TestGetStorageAndAccount() {
 	err := initWithViper(vpr, testConfigFilePath)
 	require.NoError(t, err, "initializing repo config", clues.ToCore(err))
 
-	s3Cfg := storage.S3Config{
+	s3Cfg := &storage.S3Config{
 		Bucket:         bkt,
 		Endpoint:       end,
 		Prefix:         pfx,
@@ -404,8 +425,11 @@ func (suite *ConfigIntegrationSuite) TestGetStorageAndAccount() {
 	cfg, err := getStorageAndAccountWithViper(vpr, storage.ProviderS3, true, true, nil)
 	require.NoError(t, err, "getting storage and account from config", clues.ToCore(err))
 
-	readS3Cfg, err := cfg.Storage.S3Config()
+	sc, err := cfg.Storage.StorageConfig()
 	require.NoError(t, err, "reading s3 config from storage", clues.ToCore(err))
+
+	readS3Cfg := sc.(*storage.S3Config)
+
 	assert.Equal(t, readS3Cfg.Bucket, s3Cfg.Bucket)
 	assert.Equal(t, readS3Cfg.Endpoint, s3Cfg.Endpoint)
 	assert.Equal(t, readS3Cfg.Prefix, s3Cfg.Prefix)
@@ -452,8 +476,11 @@ func (suite *ConfigIntegrationSuite) TestGetStorageAndAccount_noFileOnlyOverride
 	cfg, err := getStorageAndAccountWithViper(vpr, storage.ProviderS3, false, true, overrides)
 	require.NoError(t, err, "getting storage and account from config", clues.ToCore(err))
 
-	readS3Cfg, err := cfg.Storage.S3Config()
+	sc, err := cfg.Storage.StorageConfig()
 	require.NoError(t, err, "reading s3 config from storage", clues.ToCore(err))
+
+	readS3Cfg := sc.(*storage.S3Config)
+
 	assert.Equal(t, readS3Cfg.Bucket, bkt)
 	assert.Equal(t, cfg.RepoID, "")
 	assert.Equal(t, readS3Cfg.Endpoint, end)

--- a/src/cli/config/config_test.go
+++ b/src/cli/config/config_test.go
@@ -121,16 +121,20 @@ func (suite *ConfigSuite) TestReadRepoConfigBasic() {
 	assert.Equal(t, disableTLS, strconv.FormatBool(s3Cfg.DoNotUseTLS))
 	assert.Equal(t, disableTLSVerification, strconv.FormatBool(s3Cfg.DoNotVerifyTLS))
 
-	// Config file is not the source of truth for below values. These will be
-	// overridden by env vars. Other alternatives are to
+	// Config file may or may not be the source of truth for below values. These may be
+	// overridden by env vars (and flags but not relevant for this test).
+	//
+	// Other alternatives are:
 	// 1) unset env vars temporarily so that we can test against config file values. But that
 	// may be problematic if we decide to parallelize tests in future.
-	// 2) assert against env var values instead of config file values.
-	// Going with 2 so that we atleast have some coverage.
+	// 2) assert against env var values instead of config file values. This can cause issues
+	// if CI/local env have different config override mechanisms.
+	// 3) Skip asserts for these keys. They will be validated in other tests. Choosing this
+	// option.
 
-	assert.Equal(t, os.Getenv(credentials.AWSAccessKeyID), s3Cfg.AWS.AccessKey)
-	assert.Equal(t, os.Getenv(credentials.AWSSecretAccessKey), s3Cfg.AWS.SecretKey)
-	assert.Equal(t, os.Getenv(credentials.AWSSessionToken), s3Cfg.AWS.SessionToken)
+	// assert.Equal(t, accKey, s3Cfg.AWS.AccessKey)
+	// assert.Equal(t, secret, s3Cfg.AWS.SecretKey)
+	// assert.Equal(t, token, s3Cfg.AWS.SessionToken)
 
 	m365, err := m365ConfigsFromViper(vpr)
 	require.NoError(t, err, clues.ToCore(err))

--- a/src/cli/config/storage.go
+++ b/src/cli/config/storage.go
@@ -4,51 +4,15 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/alcionai/clues"
-	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/spf13/viper"
 
 	"github.com/alcionai/corso/src/cli/flags"
-	"github.com/alcionai/corso/src/internal/common"
 	"github.com/alcionai/corso/src/internal/common/str"
 	"github.com/alcionai/corso/src/pkg/credentials"
 	"github.com/alcionai/corso/src/pkg/storage"
 )
-
-// prerequisite: readRepoConfig must have been run prior to this to populate the global viper values.
-func s3ConfigsFromViper(vpr *viper.Viper) (storage.S3Config, error) {
-	var s3Config storage.S3Config
-
-	s3Config.Bucket = vpr.GetString(BucketNameKey)
-	s3Config.Endpoint = vpr.GetString(EndpointKey)
-	s3Config.Prefix = vpr.GetString(PrefixKey)
-	s3Config.DoNotUseTLS = vpr.GetBool(DisableTLSKey)
-	s3Config.DoNotVerifyTLS = vpr.GetBool(DisableTLSVerificationKey)
-
-	return s3Config, nil
-}
-
-// prerequisite: readRepoConfig must have been run prior to this to populate the global viper values.
-func s3CredsFromViper(vpr *viper.Viper, s3Config storage.S3Config) (storage.S3Config, error) {
-	s3Config.AccessKey = vpr.GetString(AccessKey)
-	s3Config.SecretKey = vpr.GetString(SecretAccessKey)
-	s3Config.SessionToken = vpr.GetString(SessionToken)
-
-	return s3Config, nil
-}
-
-func s3Overrides(in map[string]string) map[string]string {
-	return map[string]string{
-		storage.Bucket:                 in[storage.Bucket],
-		storage.Endpoint:               in[storage.Endpoint],
-		storage.Prefix:                 in[storage.Prefix],
-		storage.DoNotUseTLS:            in[storage.DoNotUseTLS],
-		storage.DoNotVerifyTLS:         in[storage.DoNotVerifyTLS],
-		storage.StorageProviderTypeKey: in[storage.StorageProviderTypeKey],
-	}
-}
 
 // configureStorage builds a complete storage configuration from a mix of
 // viper properties and manual overrides.
@@ -59,72 +23,20 @@ func configureStorage(
 	matchFromConfig bool,
 	overrides map[string]string,
 ) (storage.Storage, error) {
-	var (
-		s3Cfg storage.S3Config
-		store storage.Storage
-		err   error
-	)
+	var store storage.Storage
 
-	if readConfigFromViper {
-		if s3Cfg, err = s3ConfigsFromViper(vpr); err != nil {
-			return store, clues.Wrap(err, "reading s3 configs from corso config file")
-		}
-
-		if b, ok := overrides[storage.Bucket]; ok {
-			overrides[storage.Bucket] = common.NormalizeBucket(b)
-		}
-
-		if p, ok := overrides[storage.Prefix]; ok {
-			overrides[storage.Prefix] = common.NormalizePrefix(p)
-		}
-
-		if matchFromConfig {
-			providerType := vpr.GetString(storage.StorageProviderTypeKey)
-			if providerType != storage.ProviderS3.String() {
-				return store, clues.New("unsupported storage provider: " + providerType)
-			}
-
-			if err := mustMatchConfig(vpr, s3Overrides(overrides)); err != nil {
-				return store, clues.Wrap(err, "verifying s3 configs in corso config file")
-			}
-		}
+	sc, err := storage.NewStorageConfig(provider)
+	if err != nil {
+		return store, clues.Stack(err)
 	}
 
-	if s3Cfg, err = s3CredsFromViper(vpr, s3Cfg); err != nil {
-		return store, clues.Wrap(err, "reading s3 configs from corso config file")
-	}
-
-	aws := credentials.GetAWS(overrides)
-
-	if len(aws.AccessKey) <= 0 || len(aws.SecretKey) <= 0 {
-		_, err = defaults.CredChain(defaults.Config().WithCredentialsChainVerboseErrors(true), defaults.Handlers()).Get()
-		if err != nil && (len(s3Cfg.AccessKey) > 0 || len(s3Cfg.SecretKey) > 0) {
-			aws = credentials.AWS{
-				AccessKey:    s3Cfg.AccessKey,
-				SecretKey:    s3Cfg.SecretKey,
-				SessionToken: s3Cfg.SessionToken,
-			}
-			err = nil
-		}
-
-		if err != nil {
-			return store, clues.Wrap(err, "validating aws credentials")
-		}
-	}
-
-	s3Cfg = storage.S3Config{
-		AWS:      aws,
-		Bucket:   str.First(overrides[storage.Bucket], s3Cfg.Bucket),
-		Endpoint: str.First(overrides[storage.Endpoint], s3Cfg.Endpoint, "s3.amazonaws.com"),
-		Prefix:   str.First(overrides[storage.Prefix], s3Cfg.Prefix),
-		DoNotUseTLS: str.ParseBool(str.First(
-			overrides[storage.DoNotUseTLS],
-			strconv.FormatBool(s3Cfg.DoNotUseTLS),
-			"false")),
-		DoNotVerifyTLS: str.ParseBool(str.First(
-			overrides[storage.DoNotVerifyTLS],
-			strconv.FormatBool(s3Cfg.DoNotVerifyTLS),
-			"false")),
+	err = sc.ApplyConfigOverrides(
+		vpr,
+		readConfigFromViper,
+		matchFromConfig,
+		overrides)
+	if err != nil {
+		return store, clues.Stack(err)
 	}
 
 	// compose the common config and credentials
@@ -146,14 +58,13 @@ func configureStorage(
 
 	// ensure required properties are present
 	if err := requireProps(map[string]string{
-		storage.Bucket:              s3Cfg.Bucket,
 		credentials.CorsoPassphrase: corso.CorsoPassphrase,
 	}); err != nil {
 		return storage.Storage{}, err
 	}
 
 	// build the storage
-	store, err = storage.NewStorage(provider, s3Cfg, cCfg)
+	store, err = storage.NewStorage(provider, sc, cCfg)
 	if err != nil {
 		return store, clues.Wrap(err, "configuring repository storage")
 	}

--- a/src/cli/flags/s3.go
+++ b/src/cli/flags/s3.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/credentials"
 	"github.com/alcionai/corso/src/pkg/storage"
 )
@@ -55,8 +54,7 @@ func S3FlagOverrides(cmd *cobra.Command) map[string]string {
 
 func PopulateS3Flags(flagset PopulatedFlags) map[string]string {
 	s3Overrides := make(map[string]string)
-	// TODO(pandeyabs): Move account overrides out of s3 flags
-	s3Overrides[account.AccountProviderTypeKey] = account.ProviderM365.String()
+
 	s3Overrides[storage.StorageProviderTypeKey] = storage.ProviderS3.String()
 
 	if _, ok := flagset[AWSAccessKeyFN]; ok {

--- a/src/cli/flags/s3.go
+++ b/src/cli/flags/s3.go
@@ -53,9 +53,9 @@ func S3FlagOverrides(cmd *cobra.Command) map[string]string {
 }
 
 func PopulateS3Flags(flagset PopulatedFlags) map[string]string {
-	s3Overrides := make(map[string]string)
-
-	s3Overrides[storage.StorageProviderTypeKey] = storage.ProviderS3.String()
+	s3Overrides := map[string]string{
+		storage.StorageProviderTypeKey: storage.ProviderS3.String(),
+	}
 
 	if _, ok := flagset[AWSAccessKeyFN]; ok {
 		s3Overrides[credentials.AWSAccessKeyID] = AWSAccessKeyFV

--- a/src/cli/repo/s3.go
+++ b/src/cli/repo/s3.go
@@ -112,10 +112,12 @@ func initS3Cmd(cmd *cobra.Command, args []string) error {
 		cfg.Account.ID(),
 		opt)
 
-	s3Cfg, err := cfg.Storage.S3Config()
+	sc, err := cfg.Storage.StorageConfig()
 	if err != nil {
 		return Only(ctx, clues.Wrap(err, "Retrieving s3 configuration"))
 	}
+
+	s3Cfg := sc.(*storage.S3Config)
 
 	if strings.HasPrefix(s3Cfg.Endpoint, "http://") || strings.HasPrefix(s3Cfg.Endpoint, "https://") {
 		invalidEndpointErr := "endpoint doesn't support specifying protocol. " +
@@ -189,10 +191,12 @@ func connectS3Cmd(cmd *cobra.Command, args []string) error {
 		repoID = events.RepoIDNotFound
 	}
 
-	s3Cfg, err := cfg.Storage.S3Config()
+	sc, err := cfg.Storage.StorageConfig()
 	if err != nil {
 		return Only(ctx, clues.Wrap(err, "Retrieving s3 configuration"))
 	}
+
+	s3Cfg := sc.(*storage.S3Config)
 
 	m365, err := cfg.Account.M365Config()
 	if err != nil {

--- a/src/cli/repo/s3_e2e_test.go
+++ b/src/cli/repo/s3_e2e_test.go
@@ -63,8 +63,10 @@ func (suite *S3E2ESuite) TestInitS3Cmd() {
 			defer flush()
 
 			st := storeTD.NewPrefixedS3Storage(t)
-			cfg, err := st.S3Config()
+
+			sc, err := st.StorageConfig()
 			require.NoError(t, err, clues.ToCore(err))
+			cfg := sc.(*storage.S3Config)
 
 			vpr, configFP := tconfig.MakeTempTestConfigClone(t, nil)
 			if !test.hasConfigFile {
@@ -100,8 +102,10 @@ func (suite *S3E2ESuite) TestInitMultipleTimes() {
 	defer flush()
 
 	st := storeTD.NewPrefixedS3Storage(t)
-	cfg, err := st.S3Config()
+	sc, err := st.StorageConfig()
 	require.NoError(t, err, clues.ToCore(err))
+
+	cfg := sc.(*storage.S3Config)
 
 	vpr, configFP := tconfig.MakeTempTestConfigClone(t, nil)
 
@@ -129,8 +133,11 @@ func (suite *S3E2ESuite) TestInitS3Cmd_missingBucket() {
 	defer flush()
 
 	st := storeTD.NewPrefixedS3Storage(t)
-	cfg, err := st.S3Config()
+
+	sc, err := st.StorageConfig()
 	require.NoError(t, err, clues.ToCore(err))
+
+	cfg := sc.(*storage.S3Config)
 
 	force := map[string]string{
 		tconfig.TestCfgBucket: "",
@@ -182,8 +189,9 @@ func (suite *S3E2ESuite) TestConnectS3Cmd() {
 			defer flush()
 
 			st := storeTD.NewPrefixedS3Storage(t)
-			cfg, err := st.S3Config()
+			sc, err := st.StorageConfig()
 			require.NoError(t, err, clues.ToCore(err))
+			cfg := sc.(*storage.S3Config)
 
 			force := map[string]string{
 				tconfig.TestCfgAccountProvider: account.ProviderM365.String(),
@@ -230,8 +238,10 @@ func (suite *S3E2ESuite) TestConnectS3Cmd_BadBucket() {
 	defer flush()
 
 	st := storeTD.NewPrefixedS3Storage(t)
-	cfg, err := st.S3Config()
+	sc, err := st.StorageConfig()
 	require.NoError(t, err, clues.ToCore(err))
+
+	cfg := sc.(*storage.S3Config)
 
 	vpr, configFP := tconfig.MakeTempTestConfigClone(t, nil)
 
@@ -256,8 +266,10 @@ func (suite *S3E2ESuite) TestConnectS3Cmd_BadPrefix() {
 	defer flush()
 
 	st := storeTD.NewPrefixedS3Storage(t)
-	cfg, err := st.S3Config()
+	sc, err := st.StorageConfig()
 	require.NoError(t, err, clues.ToCore(err))
+
+	cfg := sc.(*storage.S3Config)
 
 	vpr, configFP := tconfig.MakeTempTestConfigClone(t, nil)
 

--- a/src/cli/restore/exchange_e2e_test.go
+++ b/src/cli/restore/exchange_e2e_test.go
@@ -66,8 +66,10 @@ func (suite *RestoreExchangeE2ESuite) SetupSuite() {
 	suite.acct = tconfig.NewM365Account(t)
 	suite.st = storeTD.NewPrefixedS3Storage(t)
 
-	cfg, err := suite.st.S3Config()
+	sc, err := suite.st.StorageConfig()
 	require.NoError(t, err, clues.ToCore(err))
+
+	cfg := sc.(*storage.S3Config)
 
 	force := map[string]string{
 		tconfig.TestCfgAccountProvider: account.ProviderM365.String(),

--- a/src/cli/utils/utils.go
+++ b/src/cli/utils/utils.go
@@ -89,11 +89,13 @@ func AccountConnectAndWriteRepoConfig(
 		return nil, nil, err
 	}
 
-	s3Config, err := stg.S3Config()
+	sc, err := stg.StorageConfig()
 	if err != nil {
 		logger.CtxErr(ctx, err).Info("getting storage configuration")
 		return nil, nil, err
 	}
+
+	s3Config := sc.(*storage.S3Config)
 
 	m365Config, err := acc.M365Config()
 	if err != nil {

--- a/src/cli/utils/utils.go
+++ b/src/cli/utils/utils.go
@@ -32,7 +32,7 @@ func GetAccountAndConnectWithOverrides(
 ) (repository.Repository, *storage.Storage, *account.Account, *control.Options, error) {
 	provider, overrides, err := GetStorageProviderAndOverrides(ctx, cmd)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, clues.Stack(err)
 	}
 
 	return GetAccountAndConnect(ctx, pst, provider, overrides)

--- a/src/cmd/s3checker/s3checker.go
+++ b/src/cmd/s3checker/s3checker.go
@@ -197,10 +197,12 @@ func handleCheckerCommand(cmd *cobra.Command, args []string, f flags) error {
 		return clues.Wrap(err, "getting storage config")
 	}
 
-	cfg, err := repoDetails.Storage.S3Config()
+	sc, err := repoDetails.Storage.StorageConfig()
 	if err != nil {
 		return clues.Wrap(err, "getting S3 config")
 	}
+
+	cfg := sc.(*storage.S3Config)
 
 	endpoint := defaultS3Endpoint
 	if len(cfg.Endpoint) > 0 {

--- a/src/internal/events/events_test.go
+++ b/src/internal/events/events_test.go
@@ -33,7 +33,7 @@ func (suite *EventsIntegrationSuite) TestNewBus() {
 
 	s, err := storage.NewStorage(
 		storage.ProviderS3,
-		storage.S3Config{
+		&storage.S3Config{
 			Bucket: "bckt",
 			Prefix: "prfx",
 		})

--- a/src/internal/kopia/s3.go
+++ b/src/internal/kopia/s3.go
@@ -20,10 +20,12 @@ func s3BlobStorage(
 	repoOpts repository.Options,
 	s storage.Storage,
 ) (blob.Storage, error) {
-	cfg, err := s.S3Config()
+	sc, err := s.StorageConfig()
 	if err != nil {
 		return nil, clues.Stack(err).WithClues(ctx)
 	}
+
+	cfg := sc.(*storage.S3Config)
 
 	endpoint := defaultS3Endpoint
 	if len(cfg.Endpoint) > 0 {

--- a/src/pkg/storage/s3.go
+++ b/src/pkg/storage/s3.go
@@ -4,6 +4,8 @@ import (
 	"strconv"
 
 	"github.com/alcionai/clues"
+	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/spf13/cast"
 
 	"github.com/alcionai/corso/src/internal/common"
 	"github.com/alcionai/corso/src/internal/common/str"
@@ -40,7 +42,27 @@ const (
 	DoNotVerifyTLS = "donotverifytls"
 )
 
-func (c S3Config) Normalize() S3Config {
+// config file keys
+const (
+	BucketNameKey             = "bucket"
+	EndpointKey               = "endpoint"
+	PrefixKey                 = "prefix"
+	DisableTLSKey             = "disable_tls"
+	DisableTLSVerificationKey = "disable_tls_verification"
+
+	AccessKey       = "aws_access_key_id"
+	SecretAccessKey = "aws_secret_access_key"
+	SessionToken    = "aws_session_token"
+)
+
+var s3constToTomlKeyMap = map[string]string{
+	Bucket:                 BucketNameKey,
+	Endpoint:               EndpointKey,
+	Prefix:                 PrefixKey,
+	StorageProviderTypeKey: StorageProviderTypeKey,
+}
+
+func (c *S3Config) normalize() S3Config {
 	return S3Config{
 		Bucket:         common.NormalizeBucket(c.Bucket),
 		Endpoint:       c.Endpoint,
@@ -53,8 +75,8 @@ func (c S3Config) Normalize() S3Config {
 // StringConfig transforms a s3Config struct into a plain
 // map[string]string.  All values in the original struct which
 // serialize into the map are expected to be strings.
-func (c S3Config) StringConfig() (map[string]string, error) {
-	cn := c.Normalize()
+func (c *S3Config) StringConfig() (map[string]string, error) {
+	cn := c.normalize()
 	cfg := map[string]string{
 		keyS3AccessKey:      c.AccessKey,
 		keyS3Bucket:         cn.Bucket,
@@ -66,29 +88,28 @@ func (c S3Config) StringConfig() (map[string]string, error) {
 		keyS3DoNotVerifyTLS: strconv.FormatBool(cn.DoNotVerifyTLS),
 	}
 
-	return cfg, c.validate()
+	return cfg, cn.validate()
 }
 
-// S3Config retrieves the S3Config details from the Storage config.
-func (s Storage) S3Config() (S3Config, error) {
-	c := S3Config{}
+func buildS3ConfigFromMap(config map[string]string) (*S3Config, error) {
+	c := &S3Config{}
 
-	if len(s.Config) > 0 {
-		c.AccessKey = orEmptyString(s.Config[keyS3AccessKey])
-		c.SecretKey = orEmptyString(s.Config[keyS3SecretKey])
-		c.SessionToken = orEmptyString(s.Config[keyS3SessionToken])
+	if len(config) > 0 {
+		c.AccessKey = orEmptyString(config[keyS3AccessKey])
+		c.SecretKey = orEmptyString(config[keyS3SecretKey])
+		c.SessionToken = orEmptyString(config[keyS3SessionToken])
 
-		c.Bucket = orEmptyString(s.Config[keyS3Bucket])
-		c.Endpoint = orEmptyString(s.Config[keyS3Endpoint])
-		c.Prefix = orEmptyString(s.Config[keyS3Prefix])
-		c.DoNotUseTLS = str.ParseBool(s.Config[keyS3DoNotUseTLS])
-		c.DoNotVerifyTLS = str.ParseBool(s.Config[keyS3DoNotVerifyTLS])
+		c.Bucket = orEmptyString(config[keyS3Bucket])
+		c.Endpoint = orEmptyString(config[keyS3Endpoint])
+		c.Prefix = orEmptyString(config[keyS3Prefix])
+		c.DoNotUseTLS = str.ParseBool(config[keyS3DoNotUseTLS])
+		c.DoNotVerifyTLS = str.ParseBool(config[keyS3DoNotVerifyTLS])
 	}
 
 	return c, c.validate()
 }
 
-func (c S3Config) validate() error {
+func (c *S3Config) validate() error {
 	check := map[string]string{
 		Bucket: c.Bucket,
 	}
@@ -99,4 +120,116 @@ func (c S3Config) validate() error {
 	}
 
 	return nil
+}
+
+func s3Overrides(in map[string]string) map[string]string {
+	return map[string]string{
+		Bucket:                 in[Bucket],
+		Endpoint:               in[Endpoint],
+		Prefix:                 in[Prefix],
+		DoNotUseTLS:            in[DoNotUseTLS],
+		DoNotVerifyTLS:         in[DoNotVerifyTLS],
+		StorageProviderTypeKey: in[StorageProviderTypeKey],
+	}
+}
+
+func (c *S3Config) s3ConfigsFromStore(kvg KVStoreGetter) {
+	c.Bucket = cast.ToString(kvg.Get(BucketNameKey))
+	c.Endpoint = cast.ToString(kvg.Get(EndpointKey))
+	c.Prefix = cast.ToString(kvg.Get(PrefixKey))
+	c.DoNotUseTLS = cast.ToBool(kvg.Get(DisableTLSKey))
+	c.DoNotVerifyTLS = cast.ToBool(kvg.Get(DisableTLSVerificationKey))
+}
+
+func (c *S3Config) s3CredsFromStore(kvg KVStoreGetter) {
+	c.AccessKey = cast.ToString(kvg.Get(AccessKey))
+	c.SecretKey = cast.ToString(kvg.Get(SecretAccessKey))
+	c.SessionToken = cast.ToString(kvg.Get(SessionToken))
+}
+
+var _ Configurer = &S3Config{}
+
+func (c *S3Config) ApplyConfigOverrides(
+	kvg KVStoreGetter,
+	readConfigFromStore bool,
+	matchFromConfig bool,
+	overrides map[string]string,
+) error {
+	if readConfigFromStore {
+		c.s3ConfigsFromStore(kvg)
+
+		if b, ok := overrides[Bucket]; ok {
+			overrides[Bucket] = common.NormalizeBucket(b)
+		}
+
+		if p, ok := overrides[Prefix]; ok {
+			overrides[Prefix] = common.NormalizePrefix(p)
+		}
+
+		if matchFromConfig {
+			providerType := cast.ToString(kvg.Get(StorageProviderTypeKey))
+			if providerType != ProviderS3.String() {
+				return clues.New("unsupported storage provider: " + providerType)
+			}
+
+			if err := mustMatchConfig(kvg, s3constToTomlKeyMap, s3Overrides(overrides)); err != nil {
+				return clues.Wrap(err, "verifying s3 configs in corso config file")
+			}
+		}
+	}
+
+	c.s3CredsFromStore(kvg)
+
+	// 1. Check flag overrides first.
+	aws := credentials.GetAWS(overrides)
+	if len(aws.AccessKey) <= 0 || len(aws.SecretKey) <= 0 {
+		// 2. Check env vars.
+		_, err := defaults.CredChain(
+			defaults.Config().WithCredentialsChainVerboseErrors(true),
+			defaults.Handlers()).Get()
+		// 3. Fall back to config file.
+		if err != nil && (len(c.AccessKey) > 0 || len(c.SecretKey) > 0) {
+			aws = credentials.AWS{
+				AccessKey:    c.AccessKey,
+				SecretKey:    c.SecretKey,
+				SessionToken: c.SessionToken,
+			}
+
+			err = nil
+		}
+
+		if err != nil {
+			return clues.Wrap(err, "validating aws credentials")
+		}
+	}
+
+	c.AWS = aws
+	c.Bucket = str.First(overrides[Bucket], c.Bucket)
+	c.Endpoint = str.First(overrides[Endpoint], c.Endpoint, "s3.amazonaws.com")
+	c.Prefix = str.First(overrides[Prefix], c.Prefix)
+	c.DoNotUseTLS = str.ParseBool(str.First(
+		overrides[DoNotUseTLS],
+		strconv.FormatBool(c.DoNotUseTLS),
+		"false"))
+	c.DoNotVerifyTLS = str.ParseBool(str.First(
+		overrides[DoNotVerifyTLS],
+		strconv.FormatBool(c.DoNotVerifyTLS),
+		"false"))
+
+	return c.validate()
+}
+
+var _ WriteConfigToStorer = &S3Config{}
+
+func (c *S3Config) WriteConfigToStore(
+	kvs KVStoreSetter,
+) {
+	s3Config := c.normalize()
+
+	kvs.Set(StorageProviderTypeKey, ProviderS3.String())
+	kvs.Set(BucketNameKey, s3Config.Bucket)
+	kvs.Set(EndpointKey, s3Config.Endpoint)
+	kvs.Set(PrefixKey, s3Config.Prefix)
+	kvs.Set(DisableTLSKey, s3Config.DoNotUseTLS)
+	kvs.Set(DisableTLSVerificationKey, s3Config.DoNotVerifyTLS)
 }

--- a/src/pkg/storage/s3.go
+++ b/src/pkg/storage/s3.go
@@ -158,8 +158,13 @@ func (c *S3Config) ApplyConfigOverrides(
 	if readConfigFromStore {
 		c.s3ConfigsFromStore(kvg)
 
-		overrides[Bucket] = common.NormalizeBucket(overrides[Bucket])
-		overrides[Prefix] = common.NormalizePrefix(overrides[Prefix])
+		if b, ok := overrides[Bucket]; ok {
+			overrides[Bucket] = common.NormalizeBucket(b)
+		}
+
+		if p, ok := overrides[Prefix]; ok {
+			overrides[Prefix] = common.NormalizePrefix(p)
+		}
 
 		if matchFromConfig {
 			providerType := cast.ToString(kvg.Get(StorageProviderTypeKey))

--- a/src/pkg/storage/s3_test.go
+++ b/src/pkg/storage/s3_test.go
@@ -64,11 +64,12 @@ func (suite *S3CfgSuite) TestStorage_S3Config() {
 	t := suite.T()
 
 	in := goodS3Config
-	s, err := NewStorage(ProviderS3, in)
+	s, err := NewStorage(ProviderS3, &in)
 	assert.NoError(t, err, clues.ToCore(err))
-	out, err := s.S3Config()
+	sc, err := s.StorageConfig()
 	assert.NoError(t, err, clues.ToCore(err))
 
+	out := sc.(*S3Config)
 	assert.Equal(t, in.Bucket, out.Bucket)
 	assert.Equal(t, in.Endpoint, out.Endpoint)
 	assert.Equal(t, in.Prefix, out.Prefix)
@@ -93,7 +94,7 @@ func (suite *S3CfgSuite) TestStorage_S3Config_invalidCases() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			_, err := NewStorage(ProviderUnknown, test.cfg)
+			_, err := NewStorage(ProviderUnknown, &test.cfg)
 			assert.Error(suite.T(), err)
 		})
 	}
@@ -114,10 +115,10 @@ func (suite *S3CfgSuite) TestStorage_S3Config_invalidCases() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			st, err := NewStorage(ProviderUnknown, goodS3Config)
+			st, err := NewStorage(ProviderUnknown, &goodS3Config)
 			assert.NoError(t, err, clues.ToCore(err))
 			test.amend(st)
-			_, err = st.S3Config()
+			_, err = st.StorageConfig()
 			assert.Error(t, err)
 		})
 	}
@@ -187,7 +188,7 @@ func (suite *S3CfgSuite) TestStorage_S3Config_Normalize() {
 		Bucket: prefixedBkt,
 	}
 
-	result := st.Normalize()
+	result := st.normalize()
 	assert.Equal(suite.T(), normalBkt, result.Bucket)
 	assert.NotEqual(suite.T(), st.Bucket, result.Bucket)
 }

--- a/src/pkg/storage/storage.go
+++ b/src/pkg/storage/storage.go
@@ -112,18 +112,18 @@ func NewStorageConfig(provider ProviderType) (Configurer, error) {
 	return nil, clues.New("unsupported storage provider: " + provider.String())
 }
 
-type KVStoreGetter interface {
+type Getter interface {
 	Get(key string) any
 }
 
-type KVStoreSetter interface {
+type Setter interface {
 	Set(key string, value any)
 }
 
 // WriteConfigToStorer writes config key value pairs to provided store.
 type WriteConfigToStorer interface {
 	WriteConfigToStore(
-		kvs KVStoreSetter,
+		s Setter,
 	)
 }
 
@@ -134,7 +134,7 @@ type Configurer interface {
 	// from sources like environment variables and flags, and updates the
 	// underlying configuration accordingly.
 	ApplyConfigOverrides(
-		kvg KVStoreGetter,
+		g Getter,
 		readConfigFromStore bool,
 		matchFromConfig bool,
 		overrides map[string]string,
@@ -147,7 +147,7 @@ type Configurer interface {
 // If any value differs from the store value, an error is returned.
 // values in m that aren't stored in the config are ignored.
 func mustMatchConfig(
-	kvg KVStoreGetter,
+	g Getter,
 	tomlMap map[string]string,
 	m map[string]string,
 ) error {
@@ -161,7 +161,7 @@ func mustMatchConfig(
 			continue // m may declare values which aren't stored in the config file
 		}
 
-		vv := cast.ToString(kvg.Get(tomlK))
+		vv := cast.ToString(g.Get(tomlK))
 		if v != vv {
 			return clues.New("value of " + k + " (" + v + ") does not match corso configuration value (" + vv + ")")
 		}

--- a/src/pkg/storage/storage.go
+++ b/src/pkg/storage/storage.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/alcionai/clues"
+	"github.com/spf13/cast"
 
 	"github.com/alcionai/corso/src/internal/common"
 )
@@ -91,4 +92,80 @@ func orEmptyString(v any) string {
 	}
 
 	return v.(string)
+}
+
+func (s Storage) StorageConfig() (Configurer, error) {
+	switch s.Provider {
+	case ProviderS3:
+		return buildS3ConfigFromMap(s.Config)
+	}
+
+	return nil, clues.New("unsupported storage provider: " + s.Provider.String())
+}
+
+func NewStorageConfig(provider ProviderType) (Configurer, error) {
+	switch provider {
+	case ProviderS3:
+		return &S3Config{}, nil
+	}
+
+	return nil, clues.New("unsupported storage provider: " + provider.String())
+}
+
+type KVStoreGetter interface {
+	Get(key string) any
+}
+
+type KVStoreSetter interface {
+	Set(key string, value any)
+}
+
+// WriteConfigToStorer writes config key value pairs to provided store.
+type WriteConfigToStorer interface {
+	WriteConfigToStore(
+		kvs KVStoreSetter,
+	)
+}
+
+type Configurer interface {
+	common.StringConfigurer
+
+	// ApplyOverrides fetches config from file, processes overrides
+	// from sources like environment variables and flags, and updates the
+	// underlying configuration accordingly.
+	ApplyConfigOverrides(
+		kvg KVStoreGetter,
+		readConfigFromStore bool,
+		matchFromConfig bool,
+		overrides map[string]string,
+	) error
+
+	WriteConfigToStorer
+}
+
+// mustMatchConfig compares the values of each key to their config file value in store.
+// If any value differs from the store value, an error is returned.
+// values in m that aren't stored in the config are ignored.
+func mustMatchConfig(
+	kvg KVStoreGetter,
+	tomlMap map[string]string,
+	m map[string]string,
+) error {
+	for k, v := range m {
+		if len(v) == 0 {
+			continue // empty variables will get caught by configuration validators, if necessary
+		}
+
+		tomlK, ok := tomlMap[k]
+		if !ok {
+			continue // m may declare values which aren't stored in the config file
+		}
+
+		vv := cast.ToString(kvg.Get(tomlK))
+		if v != vv {
+			return clues.New("value of " + k + " (" + v + ") does not match corso configuration value (" + vv + ")")
+		}
+	}
+
+	return nil
 }

--- a/src/pkg/storage/testdata/storage.go
+++ b/src/pkg/storage/testdata/storage.go
@@ -38,7 +38,7 @@ func NewPrefixedS3Storage(t tester.TestT) storage.Storage {
 
 	st, err := storage.NewStorage(
 		storage.ProviderS3,
-		storage.S3Config{
+		&storage.S3Config{
 			Bucket: cfg[tconfig.TestCfgBucket],
 			Prefix: prefix,
 		},


### PR DESCRIPTION
<!-- PR description-->
Introducing a new `Configurer` interface to abstract out storage config information(for s3, filesystem etc) from caller code. I consider this as a short term solution. We need to consolidate overall config handling in a better way, but that's out of scope for this PR chain.

Testing
* Most of the changes here are code movement under the hood. So relying on existing tests.
* I'll address any test gaps in a later PR.


---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* https://github.com/alcionai/corso/issues/1416

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
