### PR TITLE
Skip exporting SharePoint Libraries from Groups

### DIFF
--- a/src/internal/m365/service/groups/export.go
+++ b/src/internal/m365/service/groups/export.go
@@ -38,6 +38,8 @@ func ProduceExportCollections(
 		switch cat {
 		case path.ChannelMessagesCategory:
 			folders = append(folders, fp.Folders()...)
+		default:
+			continue
 		}
 
 		coll := groups.NewExportCollection(


### PR DESCRIPTION
We currently don't have support for SP export in groups. Do not try to do them.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
