### PR TITLE
Add export support for Group SharePoint

### DIFF
--- a/src/internal/m365/collection/drive/export.go
+++ b/src/internal/m365/collection/drive/export.go
@@ -76,7 +76,7 @@ func streamItems(
 
 // isMetadataFile is used to determine if a path corresponds to a
 // metadata file.  This is OneDrive specific logic and depends on the
-// version of the backup unlike metadata.IsMetadataFile which only has
+// version of the backup unlike metadata.isMetadataFile which only has
 // to be concerned about the current version.
 func isMetadataFile(id string, backupVersion int) bool {
 	if backupVersion < version.OneDrive1DataAndMetaFiles {

--- a/src/internal/m365/controller.go
+++ b/src/internal/m365/controller.go
@@ -50,10 +50,15 @@ type Controller struct {
 	mu     sync.Mutex
 	status support.ControllerOperationStatus // contains the status of the last run status
 
-	// backupDriveIDNames is populated on restore.  It maps the backup's
-	// drive names to their id. Primarily for use when creating or looking
-	// up a new drive.
+	// backupDriveIDNames is populated on restore and export.  It maps
+	// the backup's drive names to their id. Primarily for use when
+	// creating or looking up a new drive.
 	backupDriveIDNames idname.CacheBuilder
+
+	// backupSiteIDWebURL is populated on restore and export. It maps
+	// the backup's site names to their id. Primarily for use in
+	// exports for groups.
+	backupSiteIDWebURL idname.CacheBuilder
 }
 
 func NewController(
@@ -99,6 +104,7 @@ func NewController(
 		tenant:             acct.ID(),
 		wg:                 &sync.WaitGroup{},
 		backupDriveIDNames: idname.NewCache(nil),
+		backupSiteIDWebURL: idname.NewCache(nil),
 	}
 
 	return &ctrl, nil
@@ -163,10 +169,12 @@ func (ctrl *Controller) incrementAwaitingMessages() {
 func (ctrl *Controller) CacheItemInfo(dii details.ItemInfo) {
 	if dii.Groups != nil {
 		ctrl.backupDriveIDNames.Add(dii.Groups.DriveID, dii.Groups.DriveName)
+		ctrl.backupSiteIDWebURL.Add(dii.Groups.SiteID, dii.Groups.WebURL)
 	}
 
 	if dii.SharePoint != nil {
 		ctrl.backupDriveIDNames.Add(dii.SharePoint.DriveID, dii.SharePoint.DriveName)
+		ctrl.backupSiteIDWebURL.Add(dii.SharePoint.SiteID, dii.SharePoint.WebURL)
 	}
 
 	if dii.OneDrive != nil {

--- a/src/internal/m365/controller_test.go
+++ b/src/internal/m365/controller_test.go
@@ -270,6 +270,8 @@ func (suite *ControllerUnitSuite) TestController_CacheItemInfo() {
 		odname = "od-name"
 		spid   = "sp-id"
 		spname = "sp-name"
+		spsid  = "sp-sid"
+		spurl  = "sp-url"
 		gpid   = "gp-id"
 		gpname = "gp-name"
 		// intentionally declared outside the test loop
@@ -277,32 +279,35 @@ func (suite *ControllerUnitSuite) TestController_CacheItemInfo() {
 			wg:                 &sync.WaitGroup{},
 			region:             &trace.Region{},
 			backupDriveIDNames: idname.NewCache(nil),
+			backupSiteIDWebURL: idname.NewCache(nil),
 		}
 	)
 
 	table := []struct {
-		name       string
-		service    path.ServiceType
-		cat        path.CategoryType
-		dii        details.ItemInfo
-		expectID   string
-		expectName string
+		name             string
+		service          path.ServiceType
+		cat              path.CategoryType
+		dii              details.ItemInfo
+		expectDriveID    string
+		expectDriveName  string
+		expectSiteID     string
+		expectSiteWebURL string
 	}{
 		{
 			name: "exchange",
 			dii: details.ItemInfo{
 				Exchange: &details.ExchangeInfo{},
 			},
-			expectID:   "",
-			expectName: "",
+			expectDriveID:   "",
+			expectDriveName: "",
 		},
 		{
 			name: "folder",
 			dii: details.ItemInfo{
 				Folder: &details.FolderInfo{},
 			},
-			expectID:   "",
-			expectName: "",
+			expectDriveID:   "",
+			expectDriveName: "",
 		},
 		{
 			name: "onedrive",
@@ -312,8 +317,8 @@ func (suite *ControllerUnitSuite) TestController_CacheItemInfo() {
 					DriveName: odname,
 				},
 			},
-			expectID:   odid,
-			expectName: odname,
+			expectDriveID:   odid,
+			expectDriveName: odname,
 		},
 		{
 			name: "sharepoint",
@@ -321,10 +326,14 @@ func (suite *ControllerUnitSuite) TestController_CacheItemInfo() {
 				SharePoint: &details.SharePointInfo{
 					DriveID:   spid,
 					DriveName: spname,
+					SiteID:    spsid,
+					WebURL:    spurl,
 				},
 			},
-			expectID:   spid,
-			expectName: spname,
+			expectDriveID:    spid,
+			expectDriveName:  spname,
+			expectSiteID:     spsid,
+			expectSiteWebURL: spurl,
 		},
 		{
 			name: "groups",
@@ -332,10 +341,14 @@ func (suite *ControllerUnitSuite) TestController_CacheItemInfo() {
 				Groups: &details.GroupsInfo{
 					DriveID:   gpid,
 					DriveName: gpname,
+					SiteID:    spsid,
+					WebURL:    spurl,
 				},
 			},
-			expectID:   gpid,
-			expectName: gpname,
+			expectDriveID:    gpid,
+			expectDriveName:  gpname,
+			expectSiteID:     spsid,
+			expectSiteWebURL: spurl,
 		},
 	}
 	for _, test := range table {
@@ -344,11 +357,17 @@ func (suite *ControllerUnitSuite) TestController_CacheItemInfo() {
 
 			ctrl.CacheItemInfo(test.dii)
 
-			name, _ := ctrl.backupDriveIDNames.NameOf(test.expectID)
-			assert.Equal(t, test.expectName, name)
+			name, _ := ctrl.backupDriveIDNames.NameOf(test.expectDriveID)
+			assert.Equal(t, test.expectDriveName, name)
 
-			id, _ := ctrl.backupDriveIDNames.IDOf(test.expectName)
-			assert.Equal(t, test.expectID, id)
+			id, _ := ctrl.backupDriveIDNames.IDOf(test.expectDriveName)
+			assert.Equal(t, test.expectDriveID, id)
+
+			url, _ := ctrl.backupSiteIDWebURL.NameOf(test.expectSiteID)
+			assert.Equal(t, test.expectSiteWebURL, url)
+
+			sid, _ := ctrl.backupSiteIDWebURL.IDOf(test.expectSiteWebURL)
+			assert.Equal(t, test.expectSiteID, sid)
 		})
 	}
 }

--- a/src/internal/m365/export.go
+++ b/src/internal/m365/export.go
@@ -70,6 +70,7 @@ func (ctrl *Controller) ProduceExportCollections(
 			opts,
 			dcs,
 			ctrl.backupDriveIDNames,
+			ctrl.backupSiteIDWebURL,
 			deets,
 			errs)
 

--- a/src/internal/m365/export.go
+++ b/src/internal/m365/export.go
@@ -69,6 +69,7 @@ func (ctrl *Controller) ProduceExportCollections(
 			exportCfg,
 			opts,
 			dcs,
+			ctrl.backupDriveIDNames,
 			deets,
 			errs)
 

--- a/src/internal/m365/service/groups/export.go
+++ b/src/internal/m365/service/groups/export.go
@@ -25,7 +25,7 @@ func ProduceExportCollections(
 	exportCfg control.ExportConfig,
 	opts control.Options,
 	dcs []data.RestoreCollection,
-	backupDriveIDNames idname.CacheBuilder,
+	backupDriveIDNames idname.Cacher,
 	deets *details.Builder,
 	errs *fault.Bus,
 ) ([]export.Collectioner, error) {
@@ -51,7 +51,7 @@ func ProduceExportCollections(
 				[]data.RestoreCollection{restoreColl},
 				backupVersion,
 				exportCfg)
-		case path.FilesCategory:
+		case path.LibrariesCategory:
 			drivePath, err := path.ToDrivePath(restoreColl.FullPath())
 			if err != nil {
 				return nil, clues.Wrap(err, "transforming path to drive path").WithClues(ctx)
@@ -77,11 +77,11 @@ func ProduceExportCollections(
 			el.AddRecoverable(
 				ctx,
 				clues.New("unsupported category for export").With("category", cat))
+
+			continue
 		}
 
-		if coll != nil {
-			ec = append(ec, coll)
-		}
+		ec = append(ec, coll)
 	}
 
 	return ec, el.Failure()

--- a/src/internal/m365/service/groups/export.go
+++ b/src/internal/m365/service/groups/export.go
@@ -2,7 +2,7 @@ package groups
 
 import (
 	"context"
-	ospath "path"
+	stdlibpath "path"
 
 	"github.com/alcionai/clues"
 
@@ -67,7 +67,7 @@ func ProduceExportCollections(
 			}
 
 			folders := restoreColl.FullPath().Folders()
-			siteName := folders[1] // use siteID by fault
+			siteName := folders[1] // use siteID by default
 
 			webURL, ok := backupSiteIDWebURL.NameOf(siteName)
 			if !ok {
@@ -79,7 +79,7 @@ func ProduceExportCollections(
 				// We can't use the actual name anyways as it might
 				// contain invalid characters. This should also avoid
 				// possibility of name collisions.
-				siteName = ospath.Base(webURL)
+				siteName = stdlibpath.Base(webURL)
 			}
 
 			baseDir := path.Builder{}.

--- a/src/internal/m365/service/groups/export.go
+++ b/src/internal/m365/service/groups/export.go
@@ -3,12 +3,17 @@ package groups
 import (
 	"context"
 
+	"github.com/alcionai/clues"
+
+	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/data"
+	"github.com/alcionai/corso/src/internal/m365/collection/drive"
 	"github.com/alcionai/corso/src/internal/m365/collection/groups"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/export"
 	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
@@ -20,6 +25,7 @@ func ProduceExportCollections(
 	exportCfg control.ExportConfig,
 	opts control.Options,
 	dcs []data.RestoreCollection,
+	backupDriveIDNames idname.CacheBuilder,
 	deets *details.Builder,
 	errs *fault.Bus,
 ) ([]export.Collectioner, error) {
@@ -33,22 +39,49 @@ func ProduceExportCollections(
 			fp      = restoreColl.FullPath()
 			cat     = fp.Category()
 			folders = []string{cat.String()}
+			coll    export.Collectioner
 		)
 
 		switch cat {
 		case path.ChannelMessagesCategory:
 			folders = append(folders, fp.Folders()...)
+
+			coll = groups.NewExportCollection(
+				path.Builder{}.Append(folders...).String(),
+				[]data.RestoreCollection{restoreColl},
+				backupVersion,
+				exportCfg)
+		case path.FilesCategory:
+			drivePath, err := path.ToDrivePath(restoreColl.FullPath())
+			if err != nil {
+				return nil, clues.Wrap(err, "transforming path to drive path").WithClues(ctx)
+			}
+
+			driveName, ok := backupDriveIDNames.NameOf(drivePath.DriveID)
+			if !ok {
+				// This should not happen, but just in case
+				logger.Ctx(ctx).With("drive_id", drivePath.DriveID).Info("drive name not found, using drive id")
+				driveName = drivePath.DriveID
+			}
+
+			baseDir := path.Builder{}.
+				Append("Libraries").
+				Append(driveName).
+				Append(drivePath.Folders...)
+
+			coll = drive.NewExportCollection(
+				baseDir.String(),
+				[]data.RestoreCollection{restoreColl},
+				backupVersion)
 		default:
-			continue
+			el.AddRecoverable(
+				ctx,
+				clues.New("unsupported category for export").With("category", cat))
 		}
 
-		coll := groups.NewExportCollection(
-			path.Builder{}.Append(folders...).String(),
-			[]data.RestoreCollection{restoreColl},
-			backupVersion,
-			exportCfg)
-
-		ec = append(ec, coll)
+		if coll != nil {
+			ec = append(ec, coll)
+		}
 	}
 
 	return ec, el.Failure()


### PR DESCRIPTION
<!-- PR description-->

Ideally goes in after https://github.com/alcionai/corso/pull/4257 .
We could merge this instead of https://github.com/alcionai/corso/pull/4258 but I thought we could skip for now as this as been tested much less. But outside of me being paranoid, I think this should be in a good shape.

If this do go in, we can update the CHANGELOG entry to say that we do support export for SP libs.

This will also need more e2e(sanity) tests which I'll add in a follow up PR.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [x] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* closes https://github.com/alcionai/corso/issues/4259

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
