### PR TITLE
Use HumanString for export folder names

### DIFF
--- a/src/internal/m365/service/groups/export.go
+++ b/src/internal/m365/service/groups/export.go
@@ -40,7 +40,7 @@ func ProduceExportCollections(
 		var (
 			fp      = restoreColl.FullPath()
 			cat     = fp.Category()
-			folders = []string{cat.String()}
+			folders = []string{cat.HumanString()}
 			coll    export.Collectioner
 		)
 
@@ -66,13 +66,13 @@ func ProduceExportCollections(
 				driveName = drivePath.DriveID
 			}
 
-			folders := restoreColl.FullPath().Folders()
-			siteName := folders[1] // use siteID by default
+			rfds := restoreColl.FullPath().Folders()
+			siteName := rfds[1] // use siteID by default
 
 			webURL, ok := backupSiteIDWebURL.NameOf(siteName)
 			if !ok {
 				// This should not happen, but just in case
-				logger.Ctx(ctx).With("site_id", folders[1]).Info("site weburl not found, using site id")
+				logger.Ctx(ctx).With("site_id", rfds[1]).Info("site weburl not found, using site id")
 			}
 
 			if len(webURL) != 0 {
@@ -83,7 +83,7 @@ func ProduceExportCollections(
 			}
 
 			baseDir := path.Builder{}.
-				Append("Libraries").
+				Append(folders...).
 				Append(siteName).
 				Append(driveName).
 				Append(drivePath.Folders...)

--- a/src/internal/m365/service/groups/export_test.go
+++ b/src/internal/m365/service/groups/export_test.go
@@ -67,7 +67,7 @@ func (suite *ExportUnitSuite) TestExportRestoreCollections_messages() {
 		body          = io.NopCloser(bytes.NewBufferString(
 			`{"displayname": "` + dii.Groups.ItemName + `"}`))
 		exportCfg     = control.ExportConfig{}
-		expectedPath  = path.ChannelMessagesCategory.String() + "/" + containerName
+		expectedPath  = path.ChannelMessagesCategory.HumanString() + "/" + containerName
 		expectedItems = []export.Item{
 			{
 				ID:   itemID,

--- a/src/internal/m365/service/sharepoint/export.go
+++ b/src/internal/m365/service/sharepoint/export.go
@@ -47,7 +47,7 @@ func ProduceExportCollections(
 		}
 
 		baseDir := path.Builder{}.
-			Append("Libraries").
+			Append(path.LibrariesCategory.HumanString()).
 			Append(driveName).
 			Append(drivePath.Folders...)
 

--- a/src/internal/m365/service/sharepoint/export_test.go
+++ b/src/internal/m365/service/sharepoint/export_test.go
@@ -67,7 +67,7 @@ func (suite *ExportUnitSuite) TestExportRestoreCollections() {
 			// Cache check with lowercased ids
 			map[string]string{strings.ToLower(driveID): driveName})
 		dii           = odStub.DriveItemInfo()
-		expectedPath  = "Libraries/" + driveName
+		expectedPath  = path.LibrariesCategory.HumanString() + "/" + driveName
 		expectedItems = []export.Item{
 			{
 				ID:   "id1.data",


### PR DESCRIPTION
`Libraries` is what gets used for SP libraries and using `channelMessages` here did not look good.

Ref: https://github.com/alcionai/corso/blob/fe77c30e849307274d7d7f6570260fb6fab2a622/src/internal/m365/service/sharepoint/export.go#L49-L52

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
