### PR TITLE
Refactor exchange collection

### DIFF
--- a/src/internal/m365/collection/exchange/backup.go
+++ b/src/internal/m365/collection/exchange/backup.go
@@ -193,7 +193,6 @@ func populateCollections(
 			currPath,
 			prevPath,
 			locPath,
-			category,
 			bh.itemHandler(),
 			statusUpdater,
 			ctrlOpts,
@@ -255,7 +254,6 @@ func populateCollections(
 			nil, // marks the collection as deleted
 			prevPath,
 			nil, // tombstones don't need a location
-			category,
 			bh.itemHandler(),
 			statusUpdater,
 			ctrlOpts,

--- a/src/internal/m365/collection/exchange/backup.go
+++ b/src/internal/m365/collection/exchange/backup.go
@@ -189,14 +189,15 @@ func populateCollections(
 		}
 
 		edc := NewCollection(
+			NewBaseCollection(
+				currPath,
+				prevPath,
+				locPath,
+				ctrlOpts,
+				newDelta.Reset),
 			qp.ProtectedResource.ID(),
-			currPath,
-			prevPath,
-			locPath,
 			bh.itemHandler(),
-			statusUpdater,
-			ctrlOpts,
-			newDelta.Reset)
+			statusUpdater)
 
 		collections[cID] = &edc
 
@@ -250,14 +251,15 @@ func populateCollections(
 		}
 
 		edc := NewCollection(
+			NewBaseCollection(
+				nil, // marks the collection as deleted
+				prevPath,
+				nil, // tombstones don't need a location
+				ctrlOpts,
+				false),
 			qp.ProtectedResource.ID(),
-			nil, // marks the collection as deleted
-			prevPath,
-			nil, // tombstones don't need a location
 			bh.itemHandler(),
-			statusUpdater,
-			ctrlOpts,
-			false)
+			statusUpdater)
 		collections[id] = &edc
 	}
 

--- a/src/internal/m365/collection/exchange/collection.go
+++ b/src/internal/m365/collection/exchange/collection.go
@@ -36,6 +36,22 @@ const (
 	numberOfRetries             = 4
 )
 
+func NewBaseCollection(
+	curr, prev path.Path,
+	location *path.Builder,
+	ctrlOpts control.Options,
+	doNotMergeItems bool,
+) baseCollection {
+	return baseCollection{
+		ctrl:            ctrlOpts,
+		doNotMergeItems: doNotMergeItems,
+		fullPath:        curr,
+		locationPath:    location,
+		prevPath:        prev,
+		state:           data.StateOf(prev, curr),
+	}
+}
+
 // baseCollection contains basic functionality like returning path, location,
 // and state information. It can be embedded in other implementations to provide
 // this functionality.
@@ -155,28 +171,18 @@ func getItemAndInfo(
 // If both are populated, then state is either moved (if they differ),
 // or notMoved (if they match).
 func NewCollection(
+	bc baseCollection,
 	user string,
-	curr, prev path.Path,
-	location *path.Builder,
 	items itemGetterSerializer,
 	statusUpdater support.StatusUpdater,
-	ctrlOpts control.Options,
-	doNotMergeItems bool,
 ) Collection {
 	collection := Collection{
-		baseCollection: baseCollection{
-			ctrl:            ctrlOpts,
-			doNotMergeItems: doNotMergeItems,
-			fullPath:        curr,
-			locationPath:    location,
-			prevPath:        prev,
-			state:           data.StateOf(prev, curr),
-		},
-		user:          user,
-		added:         make(map[string]struct{}, 0),
-		removed:       make(map[string]struct{}, 0),
-		getter:        items,
-		statusUpdater: statusUpdater,
+		baseCollection: bc,
+		user:           user,
+		added:          map[string]struct{}{},
+		removed:        map[string]struct{}{},
+		getter:         items,
+		statusUpdater:  statusUpdater,
 	}
 
 	return collection

--- a/src/internal/m365/collection/exchange/collection_test.go
+++ b/src/internal/m365/collection/exchange/collection_test.go
@@ -72,8 +72,10 @@ func (suite *CollectionUnitSuite) TestCollection_NewCollection() {
 	require.NoError(t, err, clues.ToCore(err))
 
 	edc := Collection{
-		user:     name,
-		fullPath: fullPath,
+		baseCollection: baseCollection{
+			fullPath: fullPath,
+		},
+		user: name,
 	}
 	assert.Equal(t, name, edc.user)
 	assert.Equal(t, fullPath, edc.FullPath())


### PR DESCRIPTION
No real changes to API or internal structure,
but pull out more generic functionality like
getting the path/location info for an
exchange collection into a separate struct
and factor out some soon-to-be common
functions

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #2023

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
