### PR TITLE
Rename existing Exchange collection implementation

### DIFF
--- a/src/internal/m365/collection/exchange/backup_test.go
+++ b/src/internal/m365/collection/exchange/backup_test.go
@@ -617,8 +617,8 @@ func (suite *BackupIntgSuite) TestDelta() {
 			// a sanity check that the minimum behavior won't break.
 			for _, coll := range collections {
 				if coll.FullPath().Service() != path.ExchangeMetadataService {
-					ec, ok := coll.(*Collection)
-					require.True(t, ok, "collection is *Collection")
+					ec, ok := coll.(*prefetchCollection)
+					require.True(t, ok, "collection is *prefetchCollection")
 					assert.NotNil(t, ec)
 				}
 			}
@@ -697,7 +697,7 @@ func (suite *BackupIntgSuite) TestMailSerializationRegression() {
 }
 
 // TestContactSerializationRegression verifies ability to query contact items
-// and to store contact within Collection. Downloaded contacts are run through
+// and to store contact within prefetchCollection. Downloaded contacts are run through
 // a regression test to ensure that downloaded items can be uploaded.
 func (suite *BackupIntgSuite) TestContactSerializationRegression() {
 	var (
@@ -1176,8 +1176,8 @@ func (suite *CollectionPopulationSuite) TestPopulateCollections() {
 						continue
 					}
 
-					exColl, ok := coll.(*Collection)
-					require.True(t, ok, "collection is an *exchange.Collection")
+					exColl, ok := coll.(*prefetchCollection)
+					require.True(t, ok, "collection is an *exchange.prefetchCollection")
 
 					ids := [][]string{
 						make([]string, 0, len(exColl.added)),
@@ -1511,8 +1511,8 @@ func (suite *CollectionPopulationSuite) TestFilterContainersAndFillCollections_D
 							continue
 						}
 
-						exColl, ok := coll.(*Collection)
-						require.True(t, ok, "collection is an *exchange.Collection")
+						exColl, ok := coll.(*prefetchCollection)
+						require.True(t, ok, "collection is an *exchange.prefetchCollection")
 
 						ids := [][]string{
 							make([]string, 0, len(exColl.added)),
@@ -1677,8 +1677,8 @@ func (suite *CollectionPopulationSuite) TestFilterContainersAndFillCollections_r
 					continue
 				}
 
-				exColl, ok := coll.(*Collection)
-				require.True(t, ok, "collection is an *exchange.Collection")
+				exColl, ok := coll.(*prefetchCollection)
+				require.True(t, ok, "collection is an *exchange.prefetchCollection")
 
 				assert.Equal(t, test.expectAdded, exColl.added, "added items")
 				assert.Equal(t, test.expectRemoved, exColl.removed, "removed items")

--- a/src/internal/m365/collection/exchange/collection.go
+++ b/src/internal/m365/collection/exchange/collection.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	_ data.BackupCollection = &Collection{}
+	_ data.BackupCollection = &prefetchCollection{}
 	_ data.Item             = &Item{}
 	_ data.ItemInfo         = &Item{}
 	_ data.ItemModTime      = &Item{}
@@ -175,8 +175,8 @@ func NewCollection(
 	user string,
 	items itemGetterSerializer,
 	statusUpdater support.StatusUpdater,
-) Collection {
-	collection := Collection{
+) prefetchCollection {
+	collection := prefetchCollection{
 		baseCollection: bc,
 		user:           user,
 		added:          map[string]struct{}{},
@@ -188,9 +188,9 @@ func NewCollection(
 	return collection
 }
 
-// Collection implements the interface from data.Collection
+// prefetchCollection implements the interface from data.BackupCollection
 // Structure holds data for an Exchange application for a single user
-type Collection struct {
+type prefetchCollection struct {
 	baseCollection
 
 	user string
@@ -207,7 +207,7 @@ type Collection struct {
 
 // Items utility function to asynchronously execute process to fill data channel with
 // M365 exchange objects and returns the data channel
-func (col *Collection) Items(ctx context.Context, errs *fault.Bus) <-chan data.Item {
+func (col *prefetchCollection) Items(ctx context.Context, errs *fault.Bus) <-chan data.Item {
 	stream := make(chan data.Item, collectionChannelBufferSize)
 	go col.streamItems(ctx, stream, errs)
 
@@ -216,7 +216,7 @@ func (col *Collection) Items(ctx context.Context, errs *fault.Bus) <-chan data.I
 
 // streamItems is a utility function that uses col.collectionType to be able to serialize
 // all the M365IDs defined in the added field. data channel is closed by this function
-func (col *Collection) streamItems(
+func (col *prefetchCollection) streamItems(
 	ctx context.Context,
 	stream chan<- data.Item,
 	errs *fault.Bus,

--- a/src/internal/m365/collection/exchange/collection_test.go
+++ b/src/internal/m365/collection/exchange/collection_test.go
@@ -71,7 +71,7 @@ func (suite *CollectionUnitSuite) TestCollection_NewCollection() {
 		folder)
 	require.NoError(t, err, clues.ToCore(err))
 
-	edc := Collection{
+	edc := prefetchCollection{
 		baseCollection: baseCollection{
 			fullPath: fullPath,
 		},


### PR DESCRIPTION
Will be making another collection type based
on the same skeleton.

No logic changes in this PR, just naming.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #2023

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
