### PR TITLE
aggregate flags for consistency and clarity

### DIFF
--- a/src/cli/backup/backup.go
+++ b/src/cli/backup/backup.go
@@ -48,34 +48,14 @@ func AddCommands(cmd *cobra.Command) {
 
 	for _, sc := range subCommandFuncs {
 		subCommand := sc()
+		flags.AddAllProviderFlags(subCommand)
+		flags.AddAllStorageFlags(subCommand)
 		backupC.AddCommand(subCommand)
 
 		for _, addBackupTo := range serviceCommands {
 			addBackupTo(subCommand)
 		}
 	}
-}
-
-// ---------------------------------------------------------------------------
-// common flags and flag attachers for commands
-// ---------------------------------------------------------------------------
-
-func addFailedItemsFN(cmd *cobra.Command) {
-	cmd.Flags().StringVar(
-		&flags.ListFailedItemsFV, flags.FailedItemsFN, "show",
-		"Toggles showing or hiding the list of items that failed.")
-}
-
-func addSkippedItemsFN(cmd *cobra.Command) {
-	cmd.Flags().StringVar(
-		&flags.ListSkippedItemsFV, flags.SkippedItemsFN, "show",
-		"Toggles showing or hiding the list of items that were skipped.")
-}
-
-func addRecoveredErrorsFN(cmd *cobra.Command) {
-	cmd.Flags().StringVar(
-		&flags.ListRecoveredErrorsFV, flags.RecoveredErrorsFN, "show",
-		"Toggles showing or hiding the list of errors which corso recovered from.")
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -84,9 +84,6 @@ func addExchangeCommands(cmd *cobra.Command) *cobra.Command {
 		// More generic (ex: --user) and more frequently used flags take precedence.
 		flags.AddMailBoxFlag(c)
 		flags.AddDataFlag(c, []string{dataEmail, dataContacts, dataEvents}, false)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
-		flags.AddAzureCredsFlags(c)
 		flags.AddFetchParallelismFlag(c)
 		flags.AddFailFastFlag(c)
 		flags.AddDisableIncrementalsFlag(c)
@@ -101,12 +98,7 @@ func addExchangeCommands(cmd *cobra.Command) *cobra.Command {
 		fs.SortFlags = false
 
 		flags.AddBackupIDFlag(c, false)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
-		flags.AddAzureCredsFlags(c)
-		addFailedItemsFN(c)
-		addSkippedItemsFN(c)
-		addRecoveredErrorsFN(c)
+		flags.AddAllBackupListFlags(c)
 
 	case detailsCommand:
 		c, fs = utils.AddCommand(cmd, exchangeDetailsCmd())
@@ -120,9 +112,6 @@ func addExchangeCommands(cmd *cobra.Command) *cobra.Command {
 		// Flags addition ordering should follow the order we want them to appear in help and docs:
 		// More generic (ex: --user) and more frequently used flags take precedence.
 		flags.AddBackupIDFlag(c, true)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
-		flags.AddAzureCredsFlags(c)
 		flags.AddExchangeDetailsAndRestoreFlags(c)
 
 	case deleteCommand:
@@ -133,9 +122,6 @@ func addExchangeCommands(cmd *cobra.Command) *cobra.Command {
 		c.Example = exchangeServiceCommandDeleteExamples
 
 		flags.AddBackupIDFlag(c, true)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
-		flags.AddAzureCredsFlags(c)
 	}
 
 	return c

--- a/src/cli/backup/groups.go
+++ b/src/cli/backup/groups.go
@@ -75,9 +75,6 @@ func addGroupsCommands(cmd *cobra.Command) *cobra.Command {
 		// Flags addition ordering should follow the order we want them to appear in help and docs:
 		flags.AddGroupFlag(c)
 		flags.AddDataFlag(c, []string{flags.DataLibraries, flags.DataMessages}, false)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
-		flags.AddAzureCredsFlags(c)
 		flags.AddFetchParallelismFlag(c)
 		flags.AddFailFastFlag(c)
 		flags.AddDisableDeltaFlag(c)
@@ -89,12 +86,7 @@ func addGroupsCommands(cmd *cobra.Command) *cobra.Command {
 		fs.SortFlags = false
 
 		flags.AddBackupIDFlag(c, false)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
-		flags.AddAzureCredsFlags(c)
-		addFailedItemsFN(c)
-		addSkippedItemsFN(c)
-		addRecoveredErrorsFN(c)
+		flags.AddAllBackupListFlags(c)
 
 	case detailsCommand:
 		c, fs = utils.AddCommand(cmd, groupsDetailsCmd(), utils.MarkPreviewCommand())
@@ -109,9 +101,6 @@ func addGroupsCommands(cmd *cobra.Command) *cobra.Command {
 		// More generic (ex: --user) and more frequently used flags take precedence.
 		flags.AddBackupIDFlag(c, true)
 		flags.AddGroupDetailsAndRestoreFlags(c)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
-		flags.AddAzureCredsFlags(c)
 		flags.AddSharePointDetailsAndRestoreFlags(c)
 
 	case deleteCommand:
@@ -122,9 +111,6 @@ func addGroupsCommands(cmd *cobra.Command) *cobra.Command {
 		c.Example = groupsServiceCommandDeleteExamples
 
 		flags.AddBackupIDFlag(c, true)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
-		flags.AddAzureCredsFlags(c)
 	}
 
 	return c

--- a/src/cli/backup/groups_test.go
+++ b/src/cli/backup/groups_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/cli/flags"
+	flagsTD "github.com/alcionai/corso/src/cli/flags/testdata"
 	"github.com/alcionai/corso/src/cli/utils"
-	"github.com/alcionai/corso/src/cli/utils/testdata"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/control"
 )
@@ -130,68 +130,68 @@ func (suite *GroupsUnitSuite) TestBackupCreateFlags() {
 
 	cmd := &cobra.Command{Use: createCommand}
 
-	// normally a persistent flag from the root.
-	// required to ensure a dry run.
+	// global flags not added by addCommands
 	flags.AddRunModeFlag(cmd, true)
+	flags.AddAllProviderFlags(cmd)
+	flags.AddAllStorageFlags(cmd)
 
 	c := addGroupsCommands(cmd)
 	require.NotNil(t, c)
 
+	flagsTD.WithFlags(
+		cmd,
+		groupsServiceCommand,
+		[]string{
+			"--" + flags.RunModeFN, flags.RunModeFlagTest,
+			"--" + flags.BackupFN, flagsTD.BackupInput,
+		},
+		flagsTD.PreparedProviderFlags(),
+		flagsTD.PreparedStorageFlags())
+
 	// Test arg parsing for few args
-	cmd.SetArgs([]string{
+	args := []string{
 		groupsServiceCommand,
 		"--" + flags.RunModeFN, flags.RunModeFlagTest,
 
-		"--" + flags.GroupFN, testdata.FlgInputs(testdata.GroupsInput),
-		"--" + flags.CategoryDataFN, testdata.FlgInputs(testdata.GroupsCategoryDataInput),
+		"--" + flags.GroupFN, flagsTD.FlgInputs(flagsTD.GroupsInput),
+		"--" + flags.CategoryDataFN, flagsTD.FlgInputs(flagsTD.GroupsCategoryDataInput),
 
-		"--" + flags.AWSAccessKeyFN, testdata.AWSAccessKeyID,
-		"--" + flags.AWSSecretAccessKeyFN, testdata.AWSSecretAccessKey,
-		"--" + flags.AWSSessionTokenFN, testdata.AWSSessionToken,
-
-		"--" + flags.AzureClientIDFN, testdata.AzureClientID,
-		"--" + flags.AzureClientTenantFN, testdata.AzureTenantID,
-		"--" + flags.AzureClientSecretFN, testdata.AzureClientSecret,
-
-		"--" + flags.CorsoPassphraseFN, testdata.CorsoPassphrase,
-
-		"--" + flags.FetchParallelismFN, testdata.FetchParallelism,
+		"--" + flags.FetchParallelismFN, flagsTD.FetchParallelism,
 
 		// bool flags
 		"--" + flags.FailFastFN,
 		"--" + flags.DisableIncrementalsFN,
 		"--" + flags.ForceItemDataDownloadFN,
 		"--" + flags.DisableDeltaFN,
-	})
+	}
+
+	args = append(args, flagsTD.PreparedProviderFlags()...)
+	args = append(args, flagsTD.PreparedStorageFlags()...)
+
+	cmd.SetArgs(args)
 
 	cmd.SetOut(new(bytes.Buffer)) // drop output
 	cmd.SetErr(new(bytes.Buffer)) // drop output
+
 	err := cmd.Execute()
 	assert.NoError(t, err, clues.ToCore(err))
 
 	opts := utils.MakeGroupsOpts(cmd)
 	co := utils.Control()
 
-	assert.ElementsMatch(t, testdata.GroupsInput, opts.Groups)
+	assert.ElementsMatch(t, flagsTD.GroupsInput, opts.Groups)
 	// no assertion for category data input
 
-	assert.Equal(t, testdata.AWSAccessKeyID, flags.AWSAccessKeyFV)
-	assert.Equal(t, testdata.AWSSecretAccessKey, flags.AWSSecretAccessKeyFV)
-	assert.Equal(t, testdata.AWSSessionToken, flags.AWSSessionTokenFV)
-
-	assert.Equal(t, testdata.AzureClientID, flags.AzureClientIDFV)
-	assert.Equal(t, testdata.AzureTenantID, flags.AzureClientTenantFV)
-	assert.Equal(t, testdata.AzureClientSecret, flags.AzureClientSecretFV)
-
-	assert.Equal(t, testdata.CorsoPassphrase, flags.CorsoPassphraseFV)
-
-	assert.Equal(t, testdata.FetchParallelism, strconv.Itoa(co.Parallelism.ItemFetch))
+	assert.Equal(t, flagsTD.FetchParallelism, strconv.Itoa(co.Parallelism.ItemFetch))
 
 	// bool flags
 	assert.Equal(t, control.FailFast, co.FailureHandling)
 	assert.True(t, co.ToggleFeatures.DisableIncrementals)
 	assert.True(t, co.ToggleFeatures.ForceItemDataDownload)
 	assert.True(t, co.ToggleFeatures.DisableDelta)
+
+	flagsTD.AssertProviderFlags(t, cmd)
+	flagsTD.AssertStorageFlags(t, cmd)
 }
 
 func (suite *GroupsUnitSuite) TestBackupListFlags() {
@@ -199,55 +199,36 @@ func (suite *GroupsUnitSuite) TestBackupListFlags() {
 
 	cmd := &cobra.Command{Use: listCommand}
 
-	// normally a persistent flag from the root.
-	// required to ensure a dry run.
+	// global flags not added by addCommands
 	flags.AddRunModeFlag(cmd, true)
+	flags.AddAllProviderFlags(cmd)
+	flags.AddAllStorageFlags(cmd)
 
 	c := addGroupsCommands(cmd)
 	require.NotNil(t, c)
 
-	// Test arg parsing for few args
-	cmd.SetArgs([]string{
+	flagsTD.WithFlags(
+		cmd,
 		groupsServiceCommand,
-		"--" + flags.RunModeFN, flags.RunModeFlagTest,
-		"--" + flags.BackupFN, testdata.BackupInput,
-
-		"--" + flags.AWSAccessKeyFN, testdata.AWSAccessKeyID,
-		"--" + flags.AWSSecretAccessKeyFN, testdata.AWSSecretAccessKey,
-		"--" + flags.AWSSessionTokenFN, testdata.AWSSessionToken,
-
-		"--" + flags.AzureClientIDFN, testdata.AzureClientID,
-		"--" + flags.AzureClientTenantFN, testdata.AzureTenantID,
-		"--" + flags.AzureClientSecretFN, testdata.AzureClientSecret,
-
-		"--" + flags.CorsoPassphraseFN, testdata.CorsoPassphrase,
-
-		// bool flags
-		"--" + flags.FailedItemsFN, "show",
-		"--" + flags.SkippedItemsFN, "show",
-		"--" + flags.RecoveredErrorsFN, "show",
-	})
+		[]string{
+			"--" + flags.RunModeFN, flags.RunModeFlagTest,
+			"--" + flags.BackupFN, flagsTD.BackupInput,
+		},
+		flagsTD.PreparedBackupListFlags(),
+		flagsTD.PreparedProviderFlags(),
+		flagsTD.PreparedStorageFlags())
 
 	cmd.SetOut(new(bytes.Buffer)) // drop output
 	cmd.SetErr(new(bytes.Buffer)) // drop output
+
 	err := cmd.Execute()
 	assert.NoError(t, err, clues.ToCore(err))
 
-	assert.Equal(t, testdata.BackupInput, flags.BackupIDFV)
+	assert.Equal(t, flagsTD.BackupInput, flags.BackupIDFV)
 
-	assert.Equal(t, testdata.AWSAccessKeyID, flags.AWSAccessKeyFV)
-	assert.Equal(t, testdata.AWSSecretAccessKey, flags.AWSSecretAccessKeyFV)
-	assert.Equal(t, testdata.AWSSessionToken, flags.AWSSessionTokenFV)
-
-	assert.Equal(t, testdata.AzureClientID, flags.AzureClientIDFV)
-	assert.Equal(t, testdata.AzureTenantID, flags.AzureClientTenantFV)
-	assert.Equal(t, testdata.AzureClientSecret, flags.AzureClientSecretFV)
-
-	assert.Equal(t, testdata.CorsoPassphrase, flags.CorsoPassphraseFV)
-
-	assert.Equal(t, flags.ListFailedItemsFV, "show")
-	assert.Equal(t, flags.ListSkippedItemsFV, "show")
-	assert.Equal(t, flags.ListRecoveredErrorsFV, "show")
+	flagsTD.AssertBackupListFlags(t, cmd)
+	flagsTD.AssertProviderFlags(t, cmd)
+	flagsTD.AssertStorageFlags(t, cmd)
 }
 
 func (suite *GroupsUnitSuite) TestBackupDetailsFlags() {
@@ -255,53 +236,39 @@ func (suite *GroupsUnitSuite) TestBackupDetailsFlags() {
 
 	cmd := &cobra.Command{Use: detailsCommand}
 
-	// normally a persistent flag from the root.
-	// required to ensure a dry run.
+	// global flags not added by addCommands
 	flags.AddRunModeFlag(cmd, true)
+	flags.AddAllProviderFlags(cmd)
+	flags.AddAllStorageFlags(cmd)
 
 	c := addGroupsCommands(cmd)
 	require.NotNil(t, c)
 
-	// Test arg parsing for few args
-	cmd.SetArgs([]string{
+	flagsTD.WithFlags(
+		cmd,
 		groupsServiceCommand,
-		"--" + flags.RunModeFN, flags.RunModeFlagTest,
-		"--" + flags.BackupFN, testdata.BackupInput,
-
-		"--" + flags.AWSAccessKeyFN, testdata.AWSAccessKeyID,
-		"--" + flags.AWSSecretAccessKeyFN, testdata.AWSSecretAccessKey,
-		"--" + flags.AWSSessionTokenFN, testdata.AWSSessionToken,
-
-		"--" + flags.AzureClientIDFN, testdata.AzureClientID,
-		"--" + flags.AzureClientTenantFN, testdata.AzureTenantID,
-		"--" + flags.AzureClientSecretFN, testdata.AzureClientSecret,
-
-		"--" + flags.CorsoPassphraseFN, testdata.CorsoPassphrase,
-
-		// bool flags
-		"--" + flags.SkipReduceFN,
-	})
+		[]string{
+			"--" + flags.RunModeFN, flags.RunModeFlagTest,
+			"--" + flags.BackupFN, flagsTD.BackupInput,
+			"--" + flags.SkipReduceFN,
+		},
+		flagsTD.PreparedProviderFlags(),
+		flagsTD.PreparedStorageFlags())
 
 	cmd.SetOut(new(bytes.Buffer)) // drop output
 	cmd.SetErr(new(bytes.Buffer)) // drop output
+
 	err := cmd.Execute()
 	assert.NoError(t, err, clues.ToCore(err))
 
 	co := utils.Control()
 
-	assert.Equal(t, testdata.BackupInput, flags.BackupIDFV)
-
-	assert.Equal(t, testdata.AWSAccessKeyID, flags.AWSAccessKeyFV)
-	assert.Equal(t, testdata.AWSSecretAccessKey, flags.AWSSecretAccessKeyFV)
-	assert.Equal(t, testdata.AWSSessionToken, flags.AWSSessionTokenFV)
-
-	assert.Equal(t, testdata.AzureClientID, flags.AzureClientIDFV)
-	assert.Equal(t, testdata.AzureTenantID, flags.AzureClientTenantFV)
-	assert.Equal(t, testdata.AzureClientSecret, flags.AzureClientSecretFV)
-
-	assert.Equal(t, testdata.CorsoPassphrase, flags.CorsoPassphraseFV)
+	assert.Equal(t, flagsTD.BackupInput, flags.BackupIDFV)
 
 	assert.True(t, co.SkipReduce)
+
+	flagsTD.AssertProviderFlags(t, cmd)
+	flagsTD.AssertStorageFlags(t, cmd)
 }
 
 func (suite *GroupsUnitSuite) TestBackupDeleteFlags() {
@@ -309,44 +276,44 @@ func (suite *GroupsUnitSuite) TestBackupDeleteFlags() {
 
 	cmd := &cobra.Command{Use: deleteCommand}
 
-	// normally a persistent flag from the root.
-	// required to ensure a dry run.
+	// global flags not added by addCommands
 	flags.AddRunModeFlag(cmd, true)
+	flags.AddAllProviderFlags(cmd)
+	flags.AddAllStorageFlags(cmd)
 
 	c := addGroupsCommands(cmd)
 	require.NotNil(t, c)
 
+	flagsTD.WithFlags(
+		cmd,
+		groupsServiceCommand,
+		[]string{
+			"--" + flags.RunModeFN, flags.RunModeFlagTest,
+			"--" + flags.BackupFN, flagsTD.BackupInput,
+		},
+		flagsTD.PreparedProviderFlags(),
+		flagsTD.PreparedStorageFlags())
+
 	// Test arg parsing for few args
-	cmd.SetArgs([]string{
+	args := []string{
 		groupsServiceCommand,
 		"--" + flags.RunModeFN, flags.RunModeFlagTest,
-		"--" + flags.BackupFN, testdata.BackupInput,
+		"--" + flags.BackupFN, flagsTD.BackupInput,
+	}
 
-		"--" + flags.AWSAccessKeyFN, testdata.AWSAccessKeyID,
-		"--" + flags.AWSSecretAccessKeyFN, testdata.AWSSecretAccessKey,
-		"--" + flags.AWSSessionTokenFN, testdata.AWSSessionToken,
+	args = append(args, flagsTD.PreparedProviderFlags()...)
+	args = append(args, flagsTD.PreparedStorageFlags()...)
 
-		"--" + flags.AzureClientIDFN, testdata.AzureClientID,
-		"--" + flags.AzureClientTenantFN, testdata.AzureTenantID,
-		"--" + flags.AzureClientSecretFN, testdata.AzureClientSecret,
-
-		"--" + flags.CorsoPassphraseFN, testdata.CorsoPassphrase,
-	})
+	cmd.SetArgs(args)
 
 	cmd.SetOut(new(bytes.Buffer)) // drop output
 	cmd.SetErr(new(bytes.Buffer)) // drop output
+
 	err := cmd.Execute()
 	assert.NoError(t, err, clues.ToCore(err))
 
-	assert.Equal(t, testdata.BackupInput, flags.BackupIDFV)
+	assert.Equal(t, flagsTD.BackupInput, flags.BackupIDFV)
 
-	assert.Equal(t, testdata.AWSAccessKeyID, flags.AWSAccessKeyFV)
-	assert.Equal(t, testdata.AWSSecretAccessKey, flags.AWSSecretAccessKeyFV)
-	assert.Equal(t, testdata.AWSSessionToken, flags.AWSSessionTokenFV)
-
-	assert.Equal(t, testdata.AzureClientID, flags.AzureClientIDFV)
-	assert.Equal(t, testdata.AzureTenantID, flags.AzureClientTenantFV)
-	assert.Equal(t, testdata.AzureClientSecret, flags.AzureClientSecretFV)
-
-	assert.Equal(t, testdata.CorsoPassphrase, flags.CorsoPassphraseFV)
+	flagsTD.AssertProviderFlags(t, cmd)
+	flagsTD.AssertStorageFlags(t, cmd)
 }

--- a/src/cli/backup/onedrive.go
+++ b/src/cli/backup/onedrive.go
@@ -71,10 +71,6 @@ func addOneDriveCommands(cmd *cobra.Command) *cobra.Command {
 		c.Example = oneDriveServiceCommandCreateExamples
 
 		flags.AddUserFlag(c)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
-		flags.AddAzureCredsFlags(c)
-
 		flags.AddFailFastFlag(c)
 		flags.AddDisableIncrementalsFlag(c)
 		flags.AddForceItemDataDownloadFlag(c)
@@ -84,12 +80,7 @@ func addOneDriveCommands(cmd *cobra.Command) *cobra.Command {
 		fs.SortFlags = false
 
 		flags.AddBackupIDFlag(c, false)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
-		flags.AddAzureCredsFlags(c)
-		addFailedItemsFN(c)
-		addSkippedItemsFN(c)
-		addRecoveredErrorsFN(c)
+		flags.AddAllBackupListFlags(c)
 
 	case detailsCommand:
 		c, fs = utils.AddCommand(cmd, oneDriveDetailsCmd())
@@ -100,9 +91,6 @@ func addOneDriveCommands(cmd *cobra.Command) *cobra.Command {
 
 		flags.AddSkipReduceFlag(c)
 		flags.AddBackupIDFlag(c, true)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
-		flags.AddAzureCredsFlags(c)
 		flags.AddOneDriveDetailsAndRestoreFlags(c)
 
 	case deleteCommand:
@@ -113,9 +101,6 @@ func addOneDriveCommands(cmd *cobra.Command) *cobra.Command {
 		c.Example = oneDriveServiceCommandDeleteExamples
 
 		flags.AddBackupIDFlag(c, true)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
-		flags.AddAzureCredsFlags(c)
 	}
 
 	return c

--- a/src/cli/backup/onedrive_test.go
+++ b/src/cli/backup/onedrive_test.go
@@ -12,8 +12,9 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/cli/flags"
+	flagsTD "github.com/alcionai/corso/src/cli/flags/testdata"
 	"github.com/alcionai/corso/src/cli/utils"
-	"github.com/alcionai/corso/src/cli/utils/testdata"
+	utilsTD "github.com/alcionai/corso/src/cli/utils/testdata"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/version"
 	dtd "github.com/alcionai/corso/src/pkg/backup/details/testdata"
@@ -93,61 +94,46 @@ func (suite *OneDriveUnitSuite) TestBackupCreateFlags() {
 
 	cmd := &cobra.Command{Use: createCommand}
 
-	// normally a persistent flag from the root.
-	// required to ensure a dry run.
+	// global flags not added by addCommands
 	flags.AddRunModeFlag(cmd, true)
+	flags.AddAllProviderFlags(cmd)
+	flags.AddAllStorageFlags(cmd)
 
 	c := addOneDriveCommands(cmd)
 	require.NotNil(t, c)
 
-	// Test arg parsing for few args
-	cmd.SetArgs([]string{
+	flagsTD.WithFlags(
+		cmd,
 		oneDriveServiceCommand,
-		"--" + flags.RunModeFN, flags.RunModeFlagTest,
-
-		"--" + flags.UserFN, testdata.FlgInputs(testdata.UsersInput),
-
-		"--" + flags.AWSAccessKeyFN, testdata.AWSAccessKeyID,
-		"--" + flags.AWSSecretAccessKeyFN, testdata.AWSSecretAccessKey,
-		"--" + flags.AWSSessionTokenFN, testdata.AWSSessionToken,
-
-		"--" + flags.AzureClientIDFN, testdata.AzureClientID,
-		"--" + flags.AzureClientTenantFN, testdata.AzureTenantID,
-		"--" + flags.AzureClientSecretFN, testdata.AzureClientSecret,
-
-		"--" + flags.CorsoPassphraseFN, testdata.CorsoPassphrase,
-
-		// bool flags
-		"--" + flags.FailFastFN,
-		"--" + flags.DisableIncrementalsFN,
-		"--" + flags.ForceItemDataDownloadFN,
-	})
+		[]string{
+			"--" + flags.RunModeFN, flags.RunModeFlagTest,
+			"--" + flags.UserFN, flagsTD.FlgInputs(flagsTD.UsersInput),
+			"--" + flags.FailFastFN,
+			"--" + flags.DisableIncrementalsFN,
+			"--" + flags.ForceItemDataDownloadFN,
+		},
+		flagsTD.PreparedProviderFlags(),
+		flagsTD.PreparedStorageFlags())
 
 	cmd.SetOut(new(bytes.Buffer)) // drop output
 	cmd.SetErr(new(bytes.Buffer)) // drop output
+
 	err := cmd.Execute()
 	assert.NoError(t, err, clues.ToCore(err))
 
 	opts := utils.MakeOneDriveOpts(cmd)
 	co := utils.Control()
 
-	assert.ElementsMatch(t, testdata.UsersInput, opts.Users)
+	assert.ElementsMatch(t, flagsTD.UsersInput, opts.Users)
 	// no assertion for category data input
-
-	assert.Equal(t, testdata.AWSAccessKeyID, flags.AWSAccessKeyFV)
-	assert.Equal(t, testdata.AWSSecretAccessKey, flags.AWSSecretAccessKeyFV)
-	assert.Equal(t, testdata.AWSSessionToken, flags.AWSSessionTokenFV)
-
-	assert.Equal(t, testdata.AzureClientID, flags.AzureClientIDFV)
-	assert.Equal(t, testdata.AzureTenantID, flags.AzureClientTenantFV)
-	assert.Equal(t, testdata.AzureClientSecret, flags.AzureClientSecretFV)
-
-	assert.Equal(t, testdata.CorsoPassphrase, flags.CorsoPassphraseFV)
 
 	// bool flags
 	assert.Equal(t, control.FailFast, co.FailureHandling)
 	assert.True(t, co.ToggleFeatures.DisableIncrementals)
 	assert.True(t, co.ToggleFeatures.ForceItemDataDownload)
+
+	flagsTD.AssertProviderFlags(t, cmd)
+	flagsTD.AssertStorageFlags(t, cmd)
 }
 
 func (suite *OneDriveUnitSuite) TestBackupListFlags() {
@@ -155,55 +141,36 @@ func (suite *OneDriveUnitSuite) TestBackupListFlags() {
 
 	cmd := &cobra.Command{Use: listCommand}
 
-	// normally a persistent flag from the root.
-	// required to ensure a dry run.
+	// global flags not added by addCommands
 	flags.AddRunModeFlag(cmd, true)
+	flags.AddAllProviderFlags(cmd)
+	flags.AddAllStorageFlags(cmd)
 
 	c := addOneDriveCommands(cmd)
 	require.NotNil(t, c)
 
-	// Test arg parsing for few args
-	cmd.SetArgs([]string{
+	flagsTD.WithFlags(
+		cmd,
 		oneDriveServiceCommand,
-		"--" + flags.RunModeFN, flags.RunModeFlagTest,
-		"--" + flags.BackupFN, testdata.BackupInput,
-
-		"--" + flags.AWSAccessKeyFN, testdata.AWSAccessKeyID,
-		"--" + flags.AWSSecretAccessKeyFN, testdata.AWSSecretAccessKey,
-		"--" + flags.AWSSessionTokenFN, testdata.AWSSessionToken,
-
-		"--" + flags.AzureClientIDFN, testdata.AzureClientID,
-		"--" + flags.AzureClientTenantFN, testdata.AzureTenantID,
-		"--" + flags.AzureClientSecretFN, testdata.AzureClientSecret,
-
-		"--" + flags.CorsoPassphraseFN, testdata.CorsoPassphrase,
-
-		// bool flags
-		"--" + flags.FailedItemsFN, "show",
-		"--" + flags.SkippedItemsFN, "show",
-		"--" + flags.RecoveredErrorsFN, "show",
-	})
+		[]string{
+			"--" + flags.RunModeFN, flags.RunModeFlagTest,
+			"--" + flags.BackupFN, flagsTD.BackupInput,
+		},
+		flagsTD.PreparedBackupListFlags(),
+		flagsTD.PreparedProviderFlags(),
+		flagsTD.PreparedStorageFlags())
 
 	cmd.SetOut(new(bytes.Buffer)) // drop output
 	cmd.SetErr(new(bytes.Buffer)) // drop output
+
 	err := cmd.Execute()
 	assert.NoError(t, err, clues.ToCore(err))
 
-	assert.Equal(t, testdata.BackupInput, flags.BackupIDFV)
+	assert.Equal(t, flagsTD.BackupInput, flags.BackupIDFV)
 
-	assert.Equal(t, testdata.AWSAccessKeyID, flags.AWSAccessKeyFV)
-	assert.Equal(t, testdata.AWSSecretAccessKey, flags.AWSSecretAccessKeyFV)
-	assert.Equal(t, testdata.AWSSessionToken, flags.AWSSessionTokenFV)
-
-	assert.Equal(t, testdata.AzureClientID, flags.AzureClientIDFV)
-	assert.Equal(t, testdata.AzureTenantID, flags.AzureClientTenantFV)
-	assert.Equal(t, testdata.AzureClientSecret, flags.AzureClientSecretFV)
-
-	assert.Equal(t, testdata.CorsoPassphrase, flags.CorsoPassphraseFV)
-
-	assert.Equal(t, flags.ListFailedItemsFV, "show")
-	assert.Equal(t, flags.ListSkippedItemsFV, "show")
-	assert.Equal(t, flags.ListRecoveredErrorsFV, "show")
+	flagsTD.AssertBackupListFlags(t, cmd)
+	flagsTD.AssertProviderFlags(t, cmd)
+	flagsTD.AssertStorageFlags(t, cmd)
 }
 
 func (suite *OneDriveUnitSuite) TestBackupDetailsFlags() {
@@ -211,53 +178,39 @@ func (suite *OneDriveUnitSuite) TestBackupDetailsFlags() {
 
 	cmd := &cobra.Command{Use: detailsCommand}
 
-	// normally a persistent flag from the root.
-	// required to ensure a dry run.
+	// global flags not added by addCommands
 	flags.AddRunModeFlag(cmd, true)
+	flags.AddAllProviderFlags(cmd)
+	flags.AddAllStorageFlags(cmd)
 
 	c := addOneDriveCommands(cmd)
 	require.NotNil(t, c)
 
-	// Test arg parsing for few args
-	cmd.SetArgs([]string{
+	flagsTD.WithFlags(
+		cmd,
 		oneDriveServiceCommand,
-		"--" + flags.RunModeFN, flags.RunModeFlagTest,
-		"--" + flags.BackupFN, testdata.BackupInput,
-
-		"--" + flags.AWSAccessKeyFN, testdata.AWSAccessKeyID,
-		"--" + flags.AWSSecretAccessKeyFN, testdata.AWSSecretAccessKey,
-		"--" + flags.AWSSessionTokenFN, testdata.AWSSessionToken,
-
-		"--" + flags.AzureClientIDFN, testdata.AzureClientID,
-		"--" + flags.AzureClientTenantFN, testdata.AzureTenantID,
-		"--" + flags.AzureClientSecretFN, testdata.AzureClientSecret,
-
-		"--" + flags.CorsoPassphraseFN, testdata.CorsoPassphrase,
-
-		// bool flags
-		"--" + flags.SkipReduceFN,
-	})
+		[]string{
+			"--" + flags.RunModeFN, flags.RunModeFlagTest,
+			"--" + flags.BackupFN, flagsTD.BackupInput,
+			"--" + flags.SkipReduceFN,
+		},
+		flagsTD.PreparedProviderFlags(),
+		flagsTD.PreparedStorageFlags())
 
 	cmd.SetOut(new(bytes.Buffer)) // drop output
 	cmd.SetErr(new(bytes.Buffer)) // drop output
+
 	err := cmd.Execute()
 	assert.NoError(t, err, clues.ToCore(err))
 
 	co := utils.Control()
 
-	assert.Equal(t, testdata.BackupInput, flags.BackupIDFV)
-
-	assert.Equal(t, testdata.AWSAccessKeyID, flags.AWSAccessKeyFV)
-	assert.Equal(t, testdata.AWSSecretAccessKey, flags.AWSSecretAccessKeyFV)
-	assert.Equal(t, testdata.AWSSessionToken, flags.AWSSessionTokenFV)
-
-	assert.Equal(t, testdata.AzureClientID, flags.AzureClientIDFV)
-	assert.Equal(t, testdata.AzureTenantID, flags.AzureClientTenantFV)
-	assert.Equal(t, testdata.AzureClientSecret, flags.AzureClientSecretFV)
-
-	assert.Equal(t, testdata.CorsoPassphrase, flags.CorsoPassphraseFV)
+	assert.Equal(t, flagsTD.BackupInput, flags.BackupIDFV)
 
 	assert.True(t, co.SkipReduce)
+
+	flagsTD.AssertProviderFlags(t, cmd)
+	flagsTD.AssertStorageFlags(t, cmd)
 }
 
 func (suite *OneDriveUnitSuite) TestBackupDeleteFlags() {
@@ -265,46 +218,34 @@ func (suite *OneDriveUnitSuite) TestBackupDeleteFlags() {
 
 	cmd := &cobra.Command{Use: deleteCommand}
 
-	// normally a persistent flag from the root.
-	// required to ensure a dry run.
+	// global flags not added by addCommands
 	flags.AddRunModeFlag(cmd, true)
+	flags.AddAllProviderFlags(cmd)
+	flags.AddAllStorageFlags(cmd)
 
 	c := addOneDriveCommands(cmd)
 	require.NotNil(t, c)
 
-	// Test arg parsing for few args
-	cmd.SetArgs([]string{
+	flagsTD.WithFlags(
+		cmd,
 		oneDriveServiceCommand,
-		"--" + flags.RunModeFN, flags.RunModeFlagTest,
-		"--" + flags.BackupFN, testdata.BackupInput,
-
-		"--" + flags.AWSAccessKeyFN, testdata.AWSAccessKeyID,
-		"--" + flags.AWSSecretAccessKeyFN, testdata.AWSSecretAccessKey,
-		"--" + flags.AWSSessionTokenFN, testdata.AWSSessionToken,
-
-		"--" + flags.AzureClientIDFN, testdata.AzureClientID,
-		"--" + flags.AzureClientTenantFN, testdata.AzureTenantID,
-		"--" + flags.AzureClientSecretFN, testdata.AzureClientSecret,
-
-		"--" + flags.CorsoPassphraseFN, testdata.CorsoPassphrase,
-	})
+		[]string{
+			"--" + flags.RunModeFN, flags.RunModeFlagTest,
+			"--" + flags.BackupFN, flagsTD.BackupInput,
+		},
+		flagsTD.PreparedProviderFlags(),
+		flagsTD.PreparedStorageFlags())
 
 	cmd.SetOut(new(bytes.Buffer)) // drop output
 	cmd.SetErr(new(bytes.Buffer)) // drop output
+
 	err := cmd.Execute()
 	assert.NoError(t, err, clues.ToCore(err))
 
-	assert.Equal(t, testdata.BackupInput, flags.BackupIDFV)
+	assert.Equal(t, flagsTD.BackupInput, flags.BackupIDFV)
 
-	assert.Equal(t, testdata.AWSAccessKeyID, flags.AWSAccessKeyFV)
-	assert.Equal(t, testdata.AWSSecretAccessKey, flags.AWSSecretAccessKeyFV)
-	assert.Equal(t, testdata.AWSSessionToken, flags.AWSSessionTokenFV)
-
-	assert.Equal(t, testdata.AzureClientID, flags.AzureClientIDFV)
-	assert.Equal(t, testdata.AzureTenantID, flags.AzureClientTenantFV)
-	assert.Equal(t, testdata.AzureClientSecret, flags.AzureClientSecretFV)
-
-	assert.Equal(t, testdata.CorsoPassphrase, flags.CorsoPassphraseFV)
+	flagsTD.AssertProviderFlags(t, cmd)
+	flagsTD.AssertStorageFlags(t, cmd)
 }
 
 func (suite *OneDriveUnitSuite) TestValidateOneDriveBackupCreateFlags() {
@@ -334,14 +275,14 @@ func (suite *OneDriveUnitSuite) TestValidateOneDriveBackupCreateFlags() {
 func (suite *OneDriveUnitSuite) TestOneDriveBackupDetailsSelectors() {
 	for v := 0; v <= version.Backup; v++ {
 		suite.Run(fmt.Sprintf("version%d", v), func() {
-			for _, test := range testdata.OneDriveOptionDetailLookups {
+			for _, test := range utilsTD.OneDriveOptionDetailLookups {
 				suite.Run(test.Name, func() {
 					t := suite.T()
 
 					ctx, flush := tester.NewContext(t)
 					defer flush()
 
-					bg := testdata.VersionedBackupGetter{
+					bg := utilsTD.VersionedBackupGetter{
 						Details: dtd.GetDetailsSetForVersion(t, v),
 					}
 
@@ -360,7 +301,7 @@ func (suite *OneDriveUnitSuite) TestOneDriveBackupDetailsSelectors() {
 }
 
 func (suite *OneDriveUnitSuite) TestOneDriveBackupDetailsSelectorsBadFormats() {
-	for _, test := range testdata.BadOneDriveOptionsFormats {
+	for _, test := range utilsTD.BadOneDriveOptionsFormats {
 		suite.Run(test.Name, func() {
 			t := suite.T()
 

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -81,9 +81,6 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 
 		flags.AddSiteFlag(c)
 		flags.AddSiteIDFlag(c)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
-		flags.AddAzureCredsFlags(c)
 		flags.AddDataFlag(c, []string{flags.DataLibraries}, true)
 		flags.AddFailFastFlag(c)
 		flags.AddDisableIncrementalsFlag(c)
@@ -94,12 +91,7 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 		fs.SortFlags = false
 
 		flags.AddBackupIDFlag(c, false)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
-		flags.AddAzureCredsFlags(c)
-		addFailedItemsFN(c)
-		addSkippedItemsFN(c)
-		addRecoveredErrorsFN(c)
+		flags.AddAllBackupListFlags(c)
 
 	case detailsCommand:
 		c, fs = utils.AddCommand(cmd, sharePointDetailsCmd())
@@ -110,9 +102,6 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 
 		flags.AddSkipReduceFlag(c)
 		flags.AddBackupIDFlag(c, true)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
-		flags.AddAzureCredsFlags(c)
 		flags.AddSharePointDetailsAndRestoreFlags(c)
 
 	case deleteCommand:
@@ -123,9 +112,6 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 		c.Example = sharePointServiceCommandDeleteExamples
 
 		flags.AddBackupIDFlag(c, true)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
-		flags.AddAzureCredsFlags(c)
 	}
 
 	return c

--- a/src/cli/export/export.go
+++ b/src/cli/export/export.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alcionai/clues"
 	"github.com/spf13/cobra"
 
+	"github.com/alcionai/corso/src/cli/flags"
 	. "github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/cli/utils"
 	"github.com/alcionai/corso/src/internal/common/dttm"
@@ -25,11 +26,12 @@ var exportCommands = []func(cmd *cobra.Command) *cobra.Command{
 
 // AddCommands attaches all `corso export * *` commands to the parent.
 func AddCommands(cmd *cobra.Command) {
-	exportC := exportCmd()
-	cmd.AddCommand(exportC)
+	subCommand := exportCmd()
+	flags.AddAllStorageFlags(subCommand)
+	cmd.AddCommand(subCommand)
 
 	for _, addExportTo := range exportCommands {
-		addExportTo(exportC)
+		addExportTo(subCommand)
 	}
 }
 

--- a/src/cli/export/groups.go
+++ b/src/cli/export/groups.go
@@ -30,8 +30,6 @@ func addGroupsCommands(cmd *cobra.Command) *cobra.Command {
 		flags.AddGroupDetailsAndRestoreFlags(c)
 		flags.AddExportConfigFlags(c)
 		flags.AddFailFastFlag(c)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
 	}
 
 	return c

--- a/src/cli/export/onedrive.go
+++ b/src/cli/export/onedrive.go
@@ -30,8 +30,6 @@ func addOneDriveCommands(cmd *cobra.Command) *cobra.Command {
 		flags.AddOneDriveDetailsAndRestoreFlags(c)
 		flags.AddExportConfigFlags(c)
 		flags.AddFailFastFlag(c)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
 	}
 
 	return c

--- a/src/cli/export/onedrive_test.go
+++ b/src/cli/export/onedrive_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/cli/flags"
+	flagsTD "github.com/alcionai/corso/src/cli/flags/testdata"
 	"github.com/alcionai/corso/src/cli/utils"
-	"github.com/alcionai/corso/src/cli/utils/testdata"
 	"github.com/alcionai/corso/src/internal/tester"
 )
 
@@ -42,9 +42,9 @@ func (suite *OneDriveUnitSuite) TestAddOneDriveCommands() {
 
 			cmd := &cobra.Command{Use: test.use}
 
-			// normally a persistent flag from the root.
-			// required to ensure a dry run.
+			// global flags not added by addCommands
 			flags.AddRunModeFlag(cmd, true)
+			flags.AddAllStorageFlags(cmd)
 
 			c := addOneDriveCommands(cmd)
 			require.NotNil(t, c)
@@ -57,53 +57,47 @@ func (suite *OneDriveUnitSuite) TestAddOneDriveCommands() {
 			assert.Equal(t, test.expectShort, child.Short)
 			tester.AreSameFunc(t, test.expectRunE, child.RunE)
 
-			cmd.SetArgs([]string{
-				"onedrive",
-				testdata.RestoreDestination,
-				"--" + flags.RunModeFN, flags.RunModeFlagTest,
-				"--" + flags.BackupFN, testdata.BackupInput,
-				"--" + flags.FileFN, testdata.FlgInputs(testdata.FileNameInput),
-				"--" + flags.FolderFN, testdata.FlgInputs(testdata.FolderPathInput),
-				"--" + flags.FileCreatedAfterFN, testdata.FileCreatedAfterInput,
-				"--" + flags.FileCreatedBeforeFN, testdata.FileCreatedBeforeInput,
-				"--" + flags.FileModifiedAfterFN, testdata.FileModifiedAfterInput,
-				"--" + flags.FileModifiedBeforeFN, testdata.FileModifiedBeforeInput,
+			flagsTD.WithFlags(
+				cmd,
+				oneDriveServiceCommand,
+				[]string{
+					flagsTD.RestoreDestination,
+					"--" + flags.RunModeFN, flags.RunModeFlagTest,
+					"--" + flags.BackupFN, flagsTD.BackupInput,
+					"--" + flags.FileFN, flagsTD.FlgInputs(flagsTD.FileNameInput),
+					"--" + flags.FolderFN, flagsTD.FlgInputs(flagsTD.FolderPathInput),
+					"--" + flags.FileCreatedAfterFN, flagsTD.FileCreatedAfterInput,
+					"--" + flags.FileCreatedBeforeFN, flagsTD.FileCreatedBeforeInput,
+					"--" + flags.FileModifiedAfterFN, flagsTD.FileModifiedAfterInput,
+					"--" + flags.FileModifiedBeforeFN, flagsTD.FileModifiedBeforeInput,
 
-				"--" + flags.AWSAccessKeyFN, testdata.AWSAccessKeyID,
-				"--" + flags.AWSSecretAccessKeyFN, testdata.AWSSecretAccessKey,
-				"--" + flags.AWSSessionTokenFN, testdata.AWSSessionToken,
+					"--" + flags.FormatFN, flagsTD.FormatType,
 
-				"--" + flags.CorsoPassphraseFN, testdata.CorsoPassphrase,
-
-				"--" + flags.FormatFN, testdata.FormatType,
-
-				// bool flags
-				"--" + flags.ArchiveFN,
-			})
+					// bool flags
+					"--" + flags.ArchiveFN,
+				},
+				flagsTD.PreparedProviderFlags(),
+				flagsTD.PreparedStorageFlags())
 
 			cmd.SetOut(new(bytes.Buffer)) // drop output
 			cmd.SetErr(new(bytes.Buffer)) // drop output
+
 			err := cmd.Execute()
 			assert.NoError(t, err, clues.ToCore(err))
 
 			opts := utils.MakeOneDriveOpts(cmd)
-			assert.Equal(t, testdata.BackupInput, flags.BackupIDFV)
+			assert.Equal(t, flagsTD.BackupInput, flags.BackupIDFV)
 
-			assert.ElementsMatch(t, testdata.FileNameInput, opts.FileName)
-			assert.ElementsMatch(t, testdata.FolderPathInput, opts.FolderPath)
-			assert.Equal(t, testdata.FileCreatedAfterInput, opts.FileCreatedAfter)
-			assert.Equal(t, testdata.FileCreatedBeforeInput, opts.FileCreatedBefore)
-			assert.Equal(t, testdata.FileModifiedAfterInput, opts.FileModifiedAfter)
-			assert.Equal(t, testdata.FileModifiedBeforeInput, opts.FileModifiedBefore)
+			assert.ElementsMatch(t, flagsTD.FileNameInput, opts.FileName)
+			assert.ElementsMatch(t, flagsTD.FolderPathInput, opts.FolderPath)
+			assert.Equal(t, flagsTD.FileCreatedAfterInput, opts.FileCreatedAfter)
+			assert.Equal(t, flagsTD.FileCreatedBeforeInput, opts.FileCreatedBefore)
+			assert.Equal(t, flagsTD.FileModifiedAfterInput, opts.FileModifiedAfter)
+			assert.Equal(t, flagsTD.FileModifiedBeforeInput, opts.FileModifiedBefore)
 
-			assert.Equal(t, testdata.Archive, opts.ExportCfg.Archive)
-			assert.Equal(t, testdata.FormatType, opts.ExportCfg.Format)
+			assert.Equal(t, flagsTD.CorsoPassphrase, flags.CorsoPassphraseFV)
 
-			assert.Equal(t, testdata.AWSAccessKeyID, flags.AWSAccessKeyFV)
-			assert.Equal(t, testdata.AWSSecretAccessKey, flags.AWSSecretAccessKeyFV)
-			assert.Equal(t, testdata.AWSSessionToken, flags.AWSSessionTokenFV)
-
-			assert.Equal(t, testdata.CorsoPassphrase, flags.CorsoPassphraseFV)
+			flagsTD.AssertStorageFlags(t, cmd)
 		})
 	}
 }

--- a/src/cli/export/sharepoint.go
+++ b/src/cli/export/sharepoint.go
@@ -30,8 +30,6 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 		flags.AddSharePointDetailsAndRestoreFlags(c)
 		flags.AddExportConfigFlags(c)
 		flags.AddFailFastFlag(c)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
 	}
 
 	return c

--- a/src/cli/export/sharepoint_test.go
+++ b/src/cli/export/sharepoint_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/cli/flags"
+	flagsTD "github.com/alcionai/corso/src/cli/flags/testdata"
 	"github.com/alcionai/corso/src/cli/utils"
-	"github.com/alcionai/corso/src/cli/utils/testdata"
 	"github.com/alcionai/corso/src/internal/tester"
 )
 
@@ -42,9 +42,9 @@ func (suite *SharePointUnitSuite) TestAddSharePointCommands() {
 
 			cmd := &cobra.Command{Use: test.use}
 
-			// normally a persistent flag from the root.
-			// required to ensure a dry run.
+			// global flags not added by addCommands
 			flags.AddRunModeFlag(cmd, true)
+			flags.AddAllStorageFlags(cmd)
 
 			c := addSharePointCommands(cmd)
 			require.NotNil(t, c)
@@ -57,65 +57,60 @@ func (suite *SharePointUnitSuite) TestAddSharePointCommands() {
 			assert.Equal(t, test.expectShort, child.Short)
 			tester.AreSameFunc(t, test.expectRunE, child.RunE)
 
-			cmd.SetArgs([]string{
-				"sharepoint",
-				testdata.RestoreDestination,
-				"--" + flags.RunModeFN, flags.RunModeFlagTest,
-				"--" + flags.BackupFN, testdata.BackupInput,
-				"--" + flags.LibraryFN, testdata.LibraryInput,
-				"--" + flags.FileFN, testdata.FlgInputs(testdata.FileNameInput),
-				"--" + flags.FolderFN, testdata.FlgInputs(testdata.FolderPathInput),
-				"--" + flags.FileCreatedAfterFN, testdata.FileCreatedAfterInput,
-				"--" + flags.FileCreatedBeforeFN, testdata.FileCreatedBeforeInput,
-				"--" + flags.FileModifiedAfterFN, testdata.FileModifiedAfterInput,
-				"--" + flags.FileModifiedBeforeFN, testdata.FileModifiedBeforeInput,
-				"--" + flags.ListItemFN, testdata.FlgInputs(testdata.ListItemInput),
-				"--" + flags.ListFolderFN, testdata.FlgInputs(testdata.ListFolderInput),
-				"--" + flags.PageFN, testdata.FlgInputs(testdata.PageInput),
-				"--" + flags.PageFolderFN, testdata.FlgInputs(testdata.PageFolderInput),
+			flagsTD.WithFlags(
+				cmd,
+				sharePointServiceCommand,
+				[]string{
+					flagsTD.RestoreDestination,
+					"--" + flags.RunModeFN, flags.RunModeFlagTest,
+					"--" + flags.BackupFN, flagsTD.BackupInput,
+					"--" + flags.LibraryFN, flagsTD.LibraryInput,
+					"--" + flags.FileFN, flagsTD.FlgInputs(flagsTD.FileNameInput),
+					"--" + flags.FolderFN, flagsTD.FlgInputs(flagsTD.FolderPathInput),
+					"--" + flags.FileCreatedAfterFN, flagsTD.FileCreatedAfterInput,
+					"--" + flags.FileCreatedBeforeFN, flagsTD.FileCreatedBeforeInput,
+					"--" + flags.FileModifiedAfterFN, flagsTD.FileModifiedAfterInput,
+					"--" + flags.FileModifiedBeforeFN, flagsTD.FileModifiedBeforeInput,
+					"--" + flags.ListItemFN, flagsTD.FlgInputs(flagsTD.ListItemInput),
+					"--" + flags.ListFolderFN, flagsTD.FlgInputs(flagsTD.ListFolderInput),
+					"--" + flags.PageFN, flagsTD.FlgInputs(flagsTD.PageInput),
+					"--" + flags.PageFolderFN, flagsTD.FlgInputs(flagsTD.PageFolderInput),
 
-				"--" + flags.AWSAccessKeyFN, testdata.AWSAccessKeyID,
-				"--" + flags.AWSSecretAccessKeyFN, testdata.AWSSecretAccessKey,
-				"--" + flags.AWSSessionTokenFN, testdata.AWSSessionToken,
+					"--" + flags.FormatFN, flagsTD.FormatType,
 
-				"--" + flags.CorsoPassphraseFN, testdata.CorsoPassphrase,
-
-				"--" + flags.FormatFN, testdata.FormatType,
-
-				// bool flags
-				"--" + flags.ArchiveFN,
-			})
+					// bool flags
+					"--" + flags.ArchiveFN,
+				},
+				flagsTD.PreparedProviderFlags(),
+				flagsTD.PreparedStorageFlags())
 
 			cmd.SetOut(new(bytes.Buffer)) // drop output
 			cmd.SetErr(new(bytes.Buffer)) // drop output
+
 			err := cmd.Execute()
 			assert.NoError(t, err, clues.ToCore(err))
 
 			opts := utils.MakeSharePointOpts(cmd)
-			assert.Equal(t, testdata.BackupInput, flags.BackupIDFV)
+			assert.Equal(t, flagsTD.BackupInput, flags.BackupIDFV)
 
-			assert.Equal(t, testdata.LibraryInput, opts.Library)
-			assert.ElementsMatch(t, testdata.FileNameInput, opts.FileName)
-			assert.ElementsMatch(t, testdata.FolderPathInput, opts.FolderPath)
-			assert.Equal(t, testdata.FileCreatedAfterInput, opts.FileCreatedAfter)
-			assert.Equal(t, testdata.FileCreatedBeforeInput, opts.FileCreatedBefore)
-			assert.Equal(t, testdata.FileModifiedAfterInput, opts.FileModifiedAfter)
-			assert.Equal(t, testdata.FileModifiedBeforeInput, opts.FileModifiedBefore)
+			assert.Equal(t, flagsTD.LibraryInput, opts.Library)
+			assert.ElementsMatch(t, flagsTD.FileNameInput, opts.FileName)
+			assert.ElementsMatch(t, flagsTD.FolderPathInput, opts.FolderPath)
+			assert.Equal(t, flagsTD.FileCreatedAfterInput, opts.FileCreatedAfter)
+			assert.Equal(t, flagsTD.FileCreatedBeforeInput, opts.FileCreatedBefore)
+			assert.Equal(t, flagsTD.FileModifiedAfterInput, opts.FileModifiedAfter)
+			assert.Equal(t, flagsTD.FileModifiedBeforeInput, opts.FileModifiedBefore)
 
-			assert.ElementsMatch(t, testdata.ListItemInput, opts.ListItem)
-			assert.ElementsMatch(t, testdata.ListFolderInput, opts.ListFolder)
+			assert.ElementsMatch(t, flagsTD.ListItemInput, opts.ListItem)
+			assert.ElementsMatch(t, flagsTD.ListFolderInput, opts.ListFolder)
 
-			assert.ElementsMatch(t, testdata.PageInput, opts.Page)
-			assert.ElementsMatch(t, testdata.PageFolderInput, opts.PageFolder)
+			assert.ElementsMatch(t, flagsTD.PageInput, opts.Page)
+			assert.ElementsMatch(t, flagsTD.PageFolderInput, opts.PageFolder)
 
-			assert.Equal(t, testdata.Archive, opts.ExportCfg.Archive)
-			assert.Equal(t, testdata.FormatType, opts.ExportCfg.Format)
+			assert.Equal(t, flagsTD.Archive, opts.ExportCfg.Archive)
+			assert.Equal(t, flagsTD.FormatType, opts.ExportCfg.Format)
 
-			assert.Equal(t, testdata.AWSAccessKeyID, flags.AWSAccessKeyFV)
-			assert.Equal(t, testdata.AWSSecretAccessKey, flags.AWSSecretAccessKeyFV)
-			assert.Equal(t, testdata.AWSSessionToken, flags.AWSSessionTokenFV)
-
-			assert.Equal(t, testdata.CorsoPassphrase, flags.CorsoPassphraseFV)
+			flagsTD.AssertStorageFlags(t, cmd)
 		})
 	}
 }

--- a/src/cli/flags/backup_list.go
+++ b/src/cli/flags/backup_list.go
@@ -1,0 +1,29 @@
+package flags
+
+import "github.com/spf13/cobra"
+
+const Show = "show"
+
+func AddAllBackupListFlags(cmd *cobra.Command) {
+	AddFailedItemsFN(cmd)
+	AddSkippedItemsFN(cmd)
+	AddRecoveredErrorsFN(cmd)
+}
+
+func AddFailedItemsFN(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&ListFailedItemsFV, FailedItemsFN, Show,
+		"Toggles showing or hiding the list of items that failed.")
+}
+
+func AddSkippedItemsFN(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&ListSkippedItemsFV, SkippedItemsFN, Show,
+		"Toggles showing or hiding the list of items that were skipped.")
+}
+
+func AddRecoveredErrorsFN(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&ListRecoveredErrorsFV, RecoveredErrorsFN, Show,
+		"Toggles showing or hiding the list of errors which Corso recovered from.")
+}

--- a/src/cli/flags/repo.go
+++ b/src/cli/flags/repo.go
@@ -33,6 +33,16 @@ func AddBackupIDFlag(cmd *cobra.Command, require bool) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// storage
+// ---------------------------------------------------------------------------
+
+func AddAllStorageFlags(cmd *cobra.Command) {
+	AddCorsoPassphaseFlags(cmd)
+	AddS3BucketFlags(cmd)
+	AddAWSCredsFlags(cmd)
+}
+
 func AddAWSCredsFlags(cmd *cobra.Command) {
 	fs := cmd.Flags()
 	fs.StringVar(&AWSAccessKeyFV, AWSAccessKeyFN, "", "S3 access key")
@@ -47,4 +57,12 @@ func AddCorsoPassphaseFlags(cmd *cobra.Command) {
 		CorsoPassphraseFN,
 		"",
 		"Passphrase to protect encrypted repository contents")
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+func AddAllProviderFlags(cmd *cobra.Command) {
+	AddAzureCredsFlags(cmd)
 }

--- a/src/cli/flags/repo.go
+++ b/src/cli/flags/repo.go
@@ -39,7 +39,6 @@ func AddBackupIDFlag(cmd *cobra.Command, require bool) {
 
 func AddAllStorageFlags(cmd *cobra.Command) {
 	AddCorsoPassphaseFlags(cmd)
-	AddS3BucketFlags(cmd)
 	AddAWSCredsFlags(cmd)
 }
 

--- a/src/cli/flags/testdata/backup_list.go
+++ b/src/cli/flags/testdata/backup_list.go
@@ -1,0 +1,23 @@
+package testdata
+
+import (
+	"testing"
+
+	"github.com/alcionai/corso/src/cli/flags"
+	"github.com/spf13/cobra"
+	"gotest.tools/v3/assert"
+)
+
+func PreparedBackupListFlags() []string {
+	return []string{
+		"--" + flags.FailedItemsFN, flags.Show,
+		"--" + flags.SkippedItemsFN, flags.Show,
+		"--" + flags.RecoveredErrorsFN, flags.Show,
+	}
+}
+
+func AssertBackupListFlags(t *testing.T, cmd *cobra.Command) {
+	assert.Equal(t, flags.Show, flags.ListFailedItemsFV)
+	assert.Equal(t, flags.Show, flags.ListSkippedItemsFV)
+	assert.Equal(t, flags.Show, flags.ListRecoveredErrorsFV)
+}

--- a/src/cli/flags/testdata/flags.go
+++ b/src/cli/flags/testdata/flags.go
@@ -1,6 +1,10 @@
 package testdata
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+)
 
 func FlgInputs(in []string) string { return strings.Join(in, ",") }
 
@@ -81,3 +85,17 @@ var (
 	EnableImmutableID         = true
 	DisableConcurrencyLimiter = true
 )
+
+func WithFlags(
+	cc *cobra.Command,
+	command string,
+	flagSets ...[]string,
+) {
+	args := []string{command}
+
+	for _, sl := range flagSets {
+		args = append(args, sl...)
+	}
+
+	cc.SetArgs(args)
+}

--- a/src/cli/flags/testdata/repo.go
+++ b/src/cli/flags/testdata/repo.go
@@ -1,0 +1,42 @@
+package testdata
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"gotest.tools/v3/assert"
+
+	"github.com/alcionai/corso/src/cli/flags"
+)
+
+func PreparedStorageFlags() []string {
+	return []string{
+		"--" + flags.AWSAccessKeyFN, AWSAccessKeyID,
+		"--" + flags.AWSSecretAccessKeyFN, AWSSecretAccessKey,
+		"--" + flags.AWSSessionTokenFN, AWSSessionToken,
+
+		"--" + flags.CorsoPassphraseFN, CorsoPassphrase,
+	}
+}
+
+func AssertStorageFlags(t *testing.T, cmd *cobra.Command) {
+	assert.Equal(t, AWSAccessKeyID, flags.AWSAccessKeyFV)
+	assert.Equal(t, AWSSecretAccessKey, flags.AWSSecretAccessKeyFV)
+	assert.Equal(t, AWSSessionToken, flags.AWSSessionTokenFV)
+
+	assert.Equal(t, CorsoPassphrase, flags.CorsoPassphraseFV)
+}
+
+func PreparedProviderFlags() []string {
+	return []string{
+		"--" + flags.AzureClientIDFN, AzureClientID,
+		"--" + flags.AzureClientTenantFN, AzureTenantID,
+		"--" + flags.AzureClientSecretFN, AzureClientSecret,
+	}
+}
+
+func AssertProviderFlags(t *testing.T, cmd *cobra.Command) {
+	assert.Equal(t, AzureClientID, flags.AzureClientIDFV)
+	assert.Equal(t, AzureTenantID, flags.AzureClientTenantFV)
+	assert.Equal(t, AzureClientSecret, flags.AzureClientSecretFV)
+}

--- a/src/cli/repo/s3.go
+++ b/src/cli/repo/s3.go
@@ -33,9 +33,8 @@ func addS3Commands(cmd *cobra.Command) *cobra.Command {
 	c.Use = c.Use + " " + s3ProviderCommandUseSuffix
 	c.SetUsageTemplate(cmd.UsageTemplate())
 
-	flags.AddAWSCredsFlags(c)
-	flags.AddAzureCredsFlags(c)
 	flags.AddCorsoPassphaseFlags(c)
+	flags.AddAWSCredsFlags(c)
 	flags.AddS3BucketFlags(c)
 
 	return c

--- a/src/cli/restore/exchange.go
+++ b/src/cli/restore/exchange.go
@@ -30,9 +30,6 @@ func addExchangeCommands(cmd *cobra.Command) *cobra.Command {
 		flags.AddExchangeDetailsAndRestoreFlags(c)
 		flags.AddRestoreConfigFlags(c)
 		flags.AddFailFastFlag(c)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
-		flags.AddAzureCredsFlags(c)
 	}
 
 	return c

--- a/src/cli/restore/exchange_test.go
+++ b/src/cli/restore/exchange_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/cli/flags"
+	flagsTD "github.com/alcionai/corso/src/cli/flags/testdata"
 	"github.com/alcionai/corso/src/cli/utils"
-	"github.com/alcionai/corso/src/cli/utils/testdata"
 	"github.com/alcionai/corso/src/internal/tester"
 )
 
@@ -42,9 +42,10 @@ func (suite *ExchangeUnitSuite) TestAddExchangeCommands() {
 
 			cmd := &cobra.Command{Use: test.use}
 
-			// normally a persistent flag from the root.
-			// required to ensure a dry run.
+			// global flags not added by addCommands
 			flags.AddRunModeFlag(cmd, true)
+			flags.AddAllProviderFlags(cmd)
+			flags.AddAllStorageFlags(cmd)
 
 			c := addExchangeCommands(cmd)
 			require.NotNil(t, c)
@@ -57,86 +58,73 @@ func (suite *ExchangeUnitSuite) TestAddExchangeCommands() {
 			assert.Equal(t, test.expectShort, child.Short)
 			tester.AreSameFunc(t, test.expectRunE, child.RunE)
 
-			// Test arg parsing for few args
-			cmd.SetArgs([]string{
+			flagsTD.WithFlags(
+				cmd,
 				exchangeServiceCommand,
-				"--" + flags.RunModeFN, flags.RunModeFlagTest,
-				"--" + flags.BackupFN, testdata.BackupInput,
+				[]string{
+					"--" + flags.RunModeFN, flags.RunModeFlagTest,
+					"--" + flags.BackupFN, flagsTD.BackupInput,
 
-				"--" + flags.ContactFN, testdata.FlgInputs(testdata.ContactInput),
-				"--" + flags.ContactFolderFN, testdata.FlgInputs(testdata.ContactFldInput),
-				"--" + flags.ContactNameFN, testdata.ContactNameInput,
+					"--" + flags.ContactFN, flagsTD.FlgInputs(flagsTD.ContactInput),
+					"--" + flags.ContactFolderFN, flagsTD.FlgInputs(flagsTD.ContactFldInput),
+					"--" + flags.ContactNameFN, flagsTD.ContactNameInput,
 
-				"--" + flags.EmailFN, testdata.FlgInputs(testdata.EmailInput),
-				"--" + flags.EmailFolderFN, testdata.FlgInputs(testdata.EmailFldInput),
-				"--" + flags.EmailReceivedAfterFN, testdata.EmailReceivedAfterInput,
-				"--" + flags.EmailReceivedBeforeFN, testdata.EmailReceivedBeforeInput,
-				"--" + flags.EmailSenderFN, testdata.EmailSenderInput,
-				"--" + flags.EmailSubjectFN, testdata.EmailSubjectInput,
+					"--" + flags.EmailFN, flagsTD.FlgInputs(flagsTD.EmailInput),
+					"--" + flags.EmailFolderFN, flagsTD.FlgInputs(flagsTD.EmailFldInput),
+					"--" + flags.EmailReceivedAfterFN, flagsTD.EmailReceivedAfterInput,
+					"--" + flags.EmailReceivedBeforeFN, flagsTD.EmailReceivedBeforeInput,
+					"--" + flags.EmailSenderFN, flagsTD.EmailSenderInput,
+					"--" + flags.EmailSubjectFN, flagsTD.EmailSubjectInput,
 
-				"--" + flags.EventFN, testdata.FlgInputs(testdata.EventInput),
-				"--" + flags.EventCalendarFN, testdata.FlgInputs(testdata.EventCalInput),
-				"--" + flags.EventOrganizerFN, testdata.EventOrganizerInput,
-				"--" + flags.EventRecursFN, testdata.EventRecursInput,
-				"--" + flags.EventStartsAfterFN, testdata.EventStartsAfterInput,
-				"--" + flags.EventStartsBeforeFN, testdata.EventStartsBeforeInput,
-				"--" + flags.EventSubjectFN, testdata.EventSubjectInput,
+					"--" + flags.EventFN, flagsTD.FlgInputs(flagsTD.EventInput),
+					"--" + flags.EventCalendarFN, flagsTD.FlgInputs(flagsTD.EventCalInput),
+					"--" + flags.EventOrganizerFN, flagsTD.EventOrganizerInput,
+					"--" + flags.EventRecursFN, flagsTD.EventRecursInput,
+					"--" + flags.EventStartsAfterFN, flagsTD.EventStartsAfterInput,
+					"--" + flags.EventStartsBeforeFN, flagsTD.EventStartsBeforeInput,
+					"--" + flags.EventSubjectFN, flagsTD.EventSubjectInput,
 
-				"--" + flags.CollisionsFN, testdata.Collisions,
-				"--" + flags.DestinationFN, testdata.Destination,
-				"--" + flags.ToResourceFN, testdata.ToResource,
-
-				"--" + flags.AWSAccessKeyFN, testdata.AWSAccessKeyID,
-				"--" + flags.AWSSecretAccessKeyFN, testdata.AWSSecretAccessKey,
-				"--" + flags.AWSSessionTokenFN, testdata.AWSSessionToken,
-
-				"--" + flags.AzureClientIDFN, testdata.AzureClientID,
-				"--" + flags.AzureClientTenantFN, testdata.AzureTenantID,
-				"--" + flags.AzureClientSecretFN, testdata.AzureClientSecret,
-
-				"--" + flags.CorsoPassphraseFN, testdata.CorsoPassphrase,
-			})
+					"--" + flags.CollisionsFN, flagsTD.Collisions,
+					"--" + flags.DestinationFN, flagsTD.Destination,
+					"--" + flags.ToResourceFN, flagsTD.ToResource,
+				},
+				flagsTD.PreparedProviderFlags(),
+				flagsTD.PreparedStorageFlags())
 
 			cmd.SetOut(new(bytes.Buffer)) // drop output
 			cmd.SetErr(new(bytes.Buffer)) // drop output
+
 			err := cmd.Execute()
 			assert.NoError(t, err, clues.ToCore(err))
 
 			opts := utils.MakeExchangeOpts(cmd)
-			assert.Equal(t, testdata.BackupInput, flags.BackupIDFV)
+			assert.Equal(t, flagsTD.BackupInput, flags.BackupIDFV)
 
-			assert.ElementsMatch(t, testdata.ContactInput, opts.Contact)
-			assert.ElementsMatch(t, testdata.ContactFldInput, opts.ContactFolder)
-			assert.Equal(t, testdata.ContactNameInput, opts.ContactName)
+			assert.ElementsMatch(t, flagsTD.ContactInput, opts.Contact)
+			assert.ElementsMatch(t, flagsTD.ContactFldInput, opts.ContactFolder)
+			assert.Equal(t, flagsTD.ContactNameInput, opts.ContactName)
 
-			assert.ElementsMatch(t, testdata.EmailInput, opts.Email)
-			assert.ElementsMatch(t, testdata.EmailFldInput, opts.EmailFolder)
-			assert.Equal(t, testdata.EmailReceivedAfterInput, opts.EmailReceivedAfter)
-			assert.Equal(t, testdata.EmailReceivedBeforeInput, opts.EmailReceivedBefore)
-			assert.Equal(t, testdata.EmailSenderInput, opts.EmailSender)
-			assert.Equal(t, testdata.EmailSubjectInput, opts.EmailSubject)
+			assert.ElementsMatch(t, flagsTD.EmailInput, opts.Email)
+			assert.ElementsMatch(t, flagsTD.EmailFldInput, opts.EmailFolder)
+			assert.Equal(t, flagsTD.EmailReceivedAfterInput, opts.EmailReceivedAfter)
+			assert.Equal(t, flagsTD.EmailReceivedBeforeInput, opts.EmailReceivedBefore)
+			assert.Equal(t, flagsTD.EmailSenderInput, opts.EmailSender)
+			assert.Equal(t, flagsTD.EmailSubjectInput, opts.EmailSubject)
 
-			assert.ElementsMatch(t, testdata.EventInput, opts.Event)
-			assert.ElementsMatch(t, testdata.EventCalInput, opts.EventCalendar)
-			assert.Equal(t, testdata.EventOrganizerInput, opts.EventOrganizer)
-			assert.Equal(t, testdata.EventRecursInput, opts.EventRecurs)
-			assert.Equal(t, testdata.EventStartsAfterInput, opts.EventStartsAfter)
-			assert.Equal(t, testdata.EventStartsBeforeInput, opts.EventStartsBefore)
-			assert.Equal(t, testdata.EventSubjectInput, opts.EventSubject)
+			assert.ElementsMatch(t, flagsTD.EventInput, opts.Event)
+			assert.ElementsMatch(t, flagsTD.EventCalInput, opts.EventCalendar)
+			assert.Equal(t, flagsTD.EventOrganizerInput, opts.EventOrganizer)
+			assert.Equal(t, flagsTD.EventRecursInput, opts.EventRecurs)
+			assert.Equal(t, flagsTD.EventStartsAfterInput, opts.EventStartsAfter)
+			assert.Equal(t, flagsTD.EventStartsBeforeInput, opts.EventStartsBefore)
+			assert.Equal(t, flagsTD.EventSubjectInput, opts.EventSubject)
 
-			assert.Equal(t, testdata.Collisions, opts.RestoreCfg.Collisions)
-			assert.Equal(t, testdata.Destination, opts.RestoreCfg.Destination)
-			assert.Equal(t, testdata.ToResource, opts.RestoreCfg.ProtectedResource)
+			assert.Equal(t, flagsTD.Collisions, opts.RestoreCfg.Collisions)
+			assert.Equal(t, flagsTD.Destination, opts.RestoreCfg.Destination)
+			assert.Equal(t, flagsTD.ToResource, opts.RestoreCfg.ProtectedResource)
 
-			assert.Equal(t, testdata.AWSAccessKeyID, flags.AWSAccessKeyFV)
-			assert.Equal(t, testdata.AWSSecretAccessKey, flags.AWSSecretAccessKeyFV)
-			assert.Equal(t, testdata.AWSSessionToken, flags.AWSSessionTokenFV)
-
-			assert.Equal(t, testdata.AzureClientID, flags.AzureClientIDFV)
-			assert.Equal(t, testdata.AzureTenantID, flags.AzureClientTenantFV)
-			assert.Equal(t, testdata.AzureClientSecret, flags.AzureClientSecretFV)
-
-			assert.Equal(t, testdata.CorsoPassphrase, flags.CorsoPassphraseFV)
+			flagsTD.AssertProviderFlags(t, cmd)
+			flagsTD.AssertStorageFlags(t, cmd)
 		})
 	}
 }

--- a/src/cli/restore/groups.go
+++ b/src/cli/restore/groups.go
@@ -32,9 +32,6 @@ func addGroupsCommands(cmd *cobra.Command) *cobra.Command {
 		flags.AddSiteIDFlag(c)
 		flags.AddRestoreConfigFlags(c)
 		flags.AddFailFastFlag(c)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
-		flags.AddAzureCredsFlags(c)
 	}
 
 	return c

--- a/src/cli/restore/groups_test.go
+++ b/src/cli/restore/groups_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/cli/flags"
+	flagsTD "github.com/alcionai/corso/src/cli/flags/testdata"
 	"github.com/alcionai/corso/src/cli/utils"
-	"github.com/alcionai/corso/src/cli/utils/testdata"
 	"github.com/alcionai/corso/src/internal/tester"
 )
 
@@ -42,9 +42,10 @@ func (suite *GroupsUnitSuite) TestAddGroupsCommands() {
 
 			cmd := &cobra.Command{Use: test.use}
 
-			// normally a persistent flag from the root.
-			// required to ensure a dry run.
+			// global flags not added by addCommands
 			flags.AddRunModeFlag(cmd, true)
+			flags.AddAllProviderFlags(cmd)
+			flags.AddAllStorageFlags(cmd)
 
 			c := addGroupsCommands(cmd)
 			require.NotNil(t, c)
@@ -57,71 +58,60 @@ func (suite *GroupsUnitSuite) TestAddGroupsCommands() {
 			assert.Equal(t, test.expectShort, child.Short)
 			tester.AreSameFunc(t, test.expectRunE, child.RunE)
 
-			cmd.SetArgs([]string{
-				"groups",
-				"--" + flags.RunModeFN, flags.RunModeFlagTest,
-				"--" + flags.BackupFN, testdata.BackupInput,
+			flagsTD.WithFlags(
+				cmd,
+				groupsServiceCommand,
+				[]string{
+					"--" + flags.RunModeFN, flags.RunModeFlagTest,
+					"--" + flags.BackupFN, flagsTD.BackupInput,
 
-				"--" + flags.LibraryFN, testdata.LibraryInput,
-				"--" + flags.FileFN, testdata.FlgInputs(testdata.FileNameInput),
-				"--" + flags.FolderFN, testdata.FlgInputs(testdata.FolderPathInput),
-				"--" + flags.FileCreatedAfterFN, testdata.FileCreatedAfterInput,
-				"--" + flags.FileCreatedBeforeFN, testdata.FileCreatedBeforeInput,
-				"--" + flags.FileModifiedAfterFN, testdata.FileModifiedAfterInput,
-				"--" + flags.FileModifiedBeforeFN, testdata.FileModifiedBeforeInput,
-				"--" + flags.ListItemFN, testdata.FlgInputs(testdata.ListItemInput),
-				"--" + flags.ListFolderFN, testdata.FlgInputs(testdata.ListFolderInput),
-				"--" + flags.PageFN, testdata.FlgInputs(testdata.PageInput),
-				"--" + flags.PageFolderFN, testdata.FlgInputs(testdata.PageFolderInput),
+					"--" + flags.LibraryFN, flagsTD.LibraryInput,
+					"--" + flags.FileFN, flagsTD.FlgInputs(flagsTD.FileNameInput),
+					"--" + flags.FolderFN, flagsTD.FlgInputs(flagsTD.FolderPathInput),
+					"--" + flags.FileCreatedAfterFN, flagsTD.FileCreatedAfterInput,
+					"--" + flags.FileCreatedBeforeFN, flagsTD.FileCreatedBeforeInput,
+					"--" + flags.FileModifiedAfterFN, flagsTD.FileModifiedAfterInput,
+					"--" + flags.FileModifiedBeforeFN, flagsTD.FileModifiedBeforeInput,
+					"--" + flags.ListItemFN, flagsTD.FlgInputs(flagsTD.ListItemInput),
+					"--" + flags.ListFolderFN, flagsTD.FlgInputs(flagsTD.ListFolderInput),
+					"--" + flags.PageFN, flagsTD.FlgInputs(flagsTD.PageInput),
+					"--" + flags.PageFolderFN, flagsTD.FlgInputs(flagsTD.PageFolderInput),
 
-				"--" + flags.CollisionsFN, testdata.Collisions,
-				"--" + flags.DestinationFN, testdata.Destination,
-				"--" + flags.ToResourceFN, testdata.ToResource,
+					"--" + flags.CollisionsFN, flagsTD.Collisions,
+					"--" + flags.DestinationFN, flagsTD.Destination,
+					"--" + flags.ToResourceFN, flagsTD.ToResource,
 
-				"--" + flags.AWSAccessKeyFN, testdata.AWSAccessKeyID,
-				"--" + flags.AWSSecretAccessKeyFN, testdata.AWSSecretAccessKey,
-				"--" + flags.AWSSessionTokenFN, testdata.AWSSessionToken,
-
-				"--" + flags.AzureClientIDFN, testdata.AzureClientID,
-				"--" + flags.AzureClientTenantFN, testdata.AzureTenantID,
-				"--" + flags.AzureClientSecretFN, testdata.AzureClientSecret,
-
-				"--" + flags.CorsoPassphraseFN, testdata.CorsoPassphrase,
-
-				// bool flags
-				"--" + flags.RestorePermissionsFN,
-			})
+					// bool flags
+					"--" + flags.RestorePermissionsFN,
+				},
+				flagsTD.PreparedProviderFlags(),
+				flagsTD.PreparedStorageFlags())
 
 			cmd.SetOut(new(bytes.Buffer)) // drop output
 			cmd.SetErr(new(bytes.Buffer)) // drop output
+
 			err := cmd.Execute()
 			assert.NoError(t, err, clues.ToCore(err))
 
 			opts := utils.MakeGroupsOpts(cmd)
-			assert.Equal(t, testdata.BackupInput, flags.BackupIDFV)
+			assert.Equal(t, flagsTD.BackupInput, flags.BackupIDFV)
 
-			assert.Equal(t, testdata.LibraryInput, opts.Library)
-			assert.ElementsMatch(t, testdata.FileNameInput, opts.FileName)
-			assert.ElementsMatch(t, testdata.FolderPathInput, opts.FolderPath)
-			assert.Equal(t, testdata.FileCreatedAfterInput, opts.FileCreatedAfter)
-			assert.Equal(t, testdata.FileCreatedBeforeInput, opts.FileCreatedBefore)
-			assert.Equal(t, testdata.FileModifiedAfterInput, opts.FileModifiedAfter)
-			assert.Equal(t, testdata.FileModifiedBeforeInput, opts.FileModifiedBefore)
+			assert.Equal(t, flagsTD.LibraryInput, opts.Library)
+			assert.ElementsMatch(t, flagsTD.FileNameInput, opts.FileName)
+			assert.ElementsMatch(t, flagsTD.FolderPathInput, opts.FolderPath)
+			assert.Equal(t, flagsTD.FileCreatedAfterInput, opts.FileCreatedAfter)
+			assert.Equal(t, flagsTD.FileCreatedBeforeInput, opts.FileCreatedBefore)
+			assert.Equal(t, flagsTD.FileModifiedAfterInput, opts.FileModifiedAfter)
+			assert.Equal(t, flagsTD.FileModifiedBeforeInput, opts.FileModifiedBefore)
 
-			assert.Equal(t, testdata.Collisions, opts.RestoreCfg.Collisions)
-			assert.Equal(t, testdata.Destination, opts.RestoreCfg.Destination)
-			assert.Equal(t, testdata.ToResource, opts.RestoreCfg.ProtectedResource)
+			assert.Equal(t, flagsTD.Collisions, opts.RestoreCfg.Collisions)
+			assert.Equal(t, flagsTD.Destination, opts.RestoreCfg.Destination)
+			assert.Equal(t, flagsTD.ToResource, opts.RestoreCfg.ProtectedResource)
 
-			assert.Equal(t, testdata.AWSAccessKeyID, flags.AWSAccessKeyFV)
-			assert.Equal(t, testdata.AWSSecretAccessKey, flags.AWSSecretAccessKeyFV)
-			assert.Equal(t, testdata.AWSSessionToken, flags.AWSSessionTokenFV)
-
-			assert.Equal(t, testdata.AzureClientID, flags.AzureClientIDFV)
-			assert.Equal(t, testdata.AzureTenantID, flags.AzureClientTenantFV)
-			assert.Equal(t, testdata.AzureClientSecret, flags.AzureClientSecretFV)
-
-			assert.Equal(t, testdata.CorsoPassphrase, flags.CorsoPassphraseFV)
 			assert.True(t, flags.RestorePermissionsFV)
+
+			flagsTD.AssertProviderFlags(t, cmd)
+			flagsTD.AssertStorageFlags(t, cmd)
 		})
 	}
 }

--- a/src/cli/restore/onedrive.go
+++ b/src/cli/restore/onedrive.go
@@ -31,9 +31,6 @@ func addOneDriveCommands(cmd *cobra.Command) *cobra.Command {
 		flags.AddRestorePermissionsFlag(c)
 		flags.AddRestoreConfigFlags(c)
 		flags.AddFailFastFlag(c)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
-		flags.AddAzureCredsFlags(c)
 	}
 
 	return c

--- a/src/cli/restore/onedrive_test.go
+++ b/src/cli/restore/onedrive_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/cli/flags"
+	flagsTD "github.com/alcionai/corso/src/cli/flags/testdata"
 	"github.com/alcionai/corso/src/cli/utils"
-	"github.com/alcionai/corso/src/cli/utils/testdata"
 	"github.com/alcionai/corso/src/internal/tester"
 )
 
@@ -42,9 +42,10 @@ func (suite *OneDriveUnitSuite) TestAddOneDriveCommands() {
 
 			cmd := &cobra.Command{Use: test.use}
 
-			// normally a persistent flag from the root.
-			// required to ensure a dry run.
+			// global flags not added by addCommands
 			flags.AddRunModeFlag(cmd, true)
+			flags.AddAllProviderFlags(cmd)
+			flags.AddAllStorageFlags(cmd)
 
 			c := addOneDriveCommands(cmd)
 			require.NotNil(t, c)
@@ -57,64 +58,53 @@ func (suite *OneDriveUnitSuite) TestAddOneDriveCommands() {
 			assert.Equal(t, test.expectShort, child.Short)
 			tester.AreSameFunc(t, test.expectRunE, child.RunE)
 
-			cmd.SetArgs([]string{
-				"onedrive",
-				"--" + flags.RunModeFN, flags.RunModeFlagTest,
-				"--" + flags.BackupFN, testdata.BackupInput,
-				"--" + flags.FileFN, testdata.FlgInputs(testdata.FileNameInput),
-				"--" + flags.FolderFN, testdata.FlgInputs(testdata.FolderPathInput),
-				"--" + flags.FileCreatedAfterFN, testdata.FileCreatedAfterInput,
-				"--" + flags.FileCreatedBeforeFN, testdata.FileCreatedBeforeInput,
-				"--" + flags.FileModifiedAfterFN, testdata.FileModifiedAfterInput,
-				"--" + flags.FileModifiedBeforeFN, testdata.FileModifiedBeforeInput,
+			flagsTD.WithFlags(
+				cmd,
+				oneDriveServiceCommand,
+				[]string{
+					"--" + flags.RunModeFN, flags.RunModeFlagTest,
+					"--" + flags.BackupFN, flagsTD.BackupInput,
+					"--" + flags.FileFN, flagsTD.FlgInputs(flagsTD.FileNameInput),
+					"--" + flags.FolderFN, flagsTD.FlgInputs(flagsTD.FolderPathInput),
+					"--" + flags.FileCreatedAfterFN, flagsTD.FileCreatedAfterInput,
+					"--" + flags.FileCreatedBeforeFN, flagsTD.FileCreatedBeforeInput,
+					"--" + flags.FileModifiedAfterFN, flagsTD.FileModifiedAfterInput,
+					"--" + flags.FileModifiedBeforeFN, flagsTD.FileModifiedBeforeInput,
 
-				"--" + flags.CollisionsFN, testdata.Collisions,
-				"--" + flags.DestinationFN, testdata.Destination,
-				"--" + flags.ToResourceFN, testdata.ToResource,
+					"--" + flags.CollisionsFN, flagsTD.Collisions,
+					"--" + flags.DestinationFN, flagsTD.Destination,
+					"--" + flags.ToResourceFN, flagsTD.ToResource,
 
-				"--" + flags.AWSAccessKeyFN, testdata.AWSAccessKeyID,
-				"--" + flags.AWSSecretAccessKeyFN, testdata.AWSSecretAccessKey,
-				"--" + flags.AWSSessionTokenFN, testdata.AWSSessionToken,
-
-				"--" + flags.AzureClientIDFN, testdata.AzureClientID,
-				"--" + flags.AzureClientTenantFN, testdata.AzureTenantID,
-				"--" + flags.AzureClientSecretFN, testdata.AzureClientSecret,
-
-				"--" + flags.CorsoPassphraseFN, testdata.CorsoPassphrase,
-
-				// bool flags
-				"--" + flags.RestorePermissionsFN,
-			})
+					// bool flags
+					"--" + flags.RestorePermissionsFN,
+				},
+				flagsTD.PreparedProviderFlags(),
+				flagsTD.PreparedStorageFlags())
 
 			cmd.SetOut(new(bytes.Buffer)) // drop output
 			cmd.SetErr(new(bytes.Buffer)) // drop output
+
 			err := cmd.Execute()
 			assert.NoError(t, err, clues.ToCore(err))
 
 			opts := utils.MakeOneDriveOpts(cmd)
-			assert.Equal(t, testdata.BackupInput, flags.BackupIDFV)
+			assert.Equal(t, flagsTD.BackupInput, flags.BackupIDFV)
 
-			assert.ElementsMatch(t, testdata.FileNameInput, opts.FileName)
-			assert.ElementsMatch(t, testdata.FolderPathInput, opts.FolderPath)
-			assert.Equal(t, testdata.FileCreatedAfterInput, opts.FileCreatedAfter)
-			assert.Equal(t, testdata.FileCreatedBeforeInput, opts.FileCreatedBefore)
-			assert.Equal(t, testdata.FileModifiedAfterInput, opts.FileModifiedAfter)
-			assert.Equal(t, testdata.FileModifiedBeforeInput, opts.FileModifiedBefore)
+			assert.ElementsMatch(t, flagsTD.FileNameInput, opts.FileName)
+			assert.ElementsMatch(t, flagsTD.FolderPathInput, opts.FolderPath)
+			assert.Equal(t, flagsTD.FileCreatedAfterInput, opts.FileCreatedAfter)
+			assert.Equal(t, flagsTD.FileCreatedBeforeInput, opts.FileCreatedBefore)
+			assert.Equal(t, flagsTD.FileModifiedAfterInput, opts.FileModifiedAfter)
+			assert.Equal(t, flagsTD.FileModifiedBeforeInput, opts.FileModifiedBefore)
 
-			assert.Equal(t, testdata.Collisions, opts.RestoreCfg.Collisions)
-			assert.Equal(t, testdata.Destination, opts.RestoreCfg.Destination)
-			assert.Equal(t, testdata.ToResource, opts.RestoreCfg.ProtectedResource)
+			assert.Equal(t, flagsTD.Collisions, opts.RestoreCfg.Collisions)
+			assert.Equal(t, flagsTD.Destination, opts.RestoreCfg.Destination)
+			assert.Equal(t, flagsTD.ToResource, opts.RestoreCfg.ProtectedResource)
 
-			assert.Equal(t, testdata.AWSAccessKeyID, flags.AWSAccessKeyFV)
-			assert.Equal(t, testdata.AWSSecretAccessKey, flags.AWSSecretAccessKeyFV)
-			assert.Equal(t, testdata.AWSSessionToken, flags.AWSSessionTokenFV)
-
-			assert.Equal(t, testdata.AzureClientID, flags.AzureClientIDFV)
-			assert.Equal(t, testdata.AzureTenantID, flags.AzureClientTenantFV)
-			assert.Equal(t, testdata.AzureClientSecret, flags.AzureClientSecretFV)
-
-			assert.Equal(t, testdata.CorsoPassphrase, flags.CorsoPassphraseFV)
 			assert.True(t, flags.RestorePermissionsFV)
+
+			flagsTD.AssertProviderFlags(t, cmd)
+			flagsTD.AssertStorageFlags(t, cmd)
 		})
 	}
 }

--- a/src/cli/restore/restore.go
+++ b/src/cli/restore/restore.go
@@ -24,11 +24,13 @@ var restoreCommands = []func(cmd *cobra.Command) *cobra.Command{
 
 // AddCommands attaches all `corso restore * *` commands to the parent.
 func AddCommands(cmd *cobra.Command) {
-	restoreC := restoreCmd()
-	cmd.AddCommand(restoreC)
+	subCommand := restoreCmd()
+	flags.AddAllProviderFlags(subCommand)
+	flags.AddAllStorageFlags(subCommand)
+	cmd.AddCommand(subCommand)
 
 	for _, addRestoreTo := range restoreCommands {
-		addRestoreTo(restoreC)
+		addRestoreTo(subCommand)
 	}
 }
 

--- a/src/cli/restore/sharepoint.go
+++ b/src/cli/restore/sharepoint.go
@@ -31,9 +31,6 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 		flags.AddRestorePermissionsFlag(c)
 		flags.AddRestoreConfigFlags(c)
 		flags.AddFailFastFlag(c)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
-		flags.AddAzureCredsFlags(c)
 	}
 
 	return c

--- a/src/cli/restore/sharepoint_test.go
+++ b/src/cli/restore/sharepoint_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/cli/flags"
+	flagsTD "github.com/alcionai/corso/src/cli/flags/testdata"
 	"github.com/alcionai/corso/src/cli/utils"
-	"github.com/alcionai/corso/src/cli/utils/testdata"
 	"github.com/alcionai/corso/src/internal/tester"
 )
 
@@ -42,9 +42,10 @@ func (suite *SharePointUnitSuite) TestAddSharePointCommands() {
 
 			cmd := &cobra.Command{Use: test.use}
 
-			// normally a persistent flag from the root.
-			// required to ensure a dry run.
+			// global flags not added by addCommands
 			flags.AddRunModeFlag(cmd, true)
+			flags.AddAllProviderFlags(cmd)
+			flags.AddAllStorageFlags(cmd)
 
 			c := addSharePointCommands(cmd)
 			require.NotNil(t, c)
@@ -57,78 +58,66 @@ func (suite *SharePointUnitSuite) TestAddSharePointCommands() {
 			assert.Equal(t, test.expectShort, child.Short)
 			tester.AreSameFunc(t, test.expectRunE, child.RunE)
 
-			cmd.SetArgs([]string{
-				"sharepoint",
-				"--" + flags.RunModeFN, flags.RunModeFlagTest,
-				"--" + flags.BackupFN, testdata.BackupInput,
-				"--" + flags.LibraryFN, testdata.LibraryInput,
-				"--" + flags.FileFN, testdata.FlgInputs(testdata.FileNameInput),
-				"--" + flags.FolderFN, testdata.FlgInputs(testdata.FolderPathInput),
-				"--" + flags.FileCreatedAfterFN, testdata.FileCreatedAfterInput,
-				"--" + flags.FileCreatedBeforeFN, testdata.FileCreatedBeforeInput,
-				"--" + flags.FileModifiedAfterFN, testdata.FileModifiedAfterInput,
-				"--" + flags.FileModifiedBeforeFN, testdata.FileModifiedBeforeInput,
-				"--" + flags.ListItemFN, testdata.FlgInputs(testdata.ListItemInput),
-				"--" + flags.ListFolderFN, testdata.FlgInputs(testdata.ListFolderInput),
-				"--" + flags.PageFN, testdata.FlgInputs(testdata.PageInput),
-				"--" + flags.PageFolderFN, testdata.FlgInputs(testdata.PageFolderInput),
+			flagsTD.WithFlags(
+				cmd,
+				sharePointServiceCommand,
+				[]string{
+					"--" + flags.RunModeFN, flags.RunModeFlagTest,
+					"--" + flags.BackupFN, flagsTD.BackupInput,
+					"--" + flags.LibraryFN, flagsTD.LibraryInput,
+					"--" + flags.FileFN, flagsTD.FlgInputs(flagsTD.FileNameInput),
+					"--" + flags.FolderFN, flagsTD.FlgInputs(flagsTD.FolderPathInput),
+					"--" + flags.FileCreatedAfterFN, flagsTD.FileCreatedAfterInput,
+					"--" + flags.FileCreatedBeforeFN, flagsTD.FileCreatedBeforeInput,
+					"--" + flags.FileModifiedAfterFN, flagsTD.FileModifiedAfterInput,
+					"--" + flags.FileModifiedBeforeFN, flagsTD.FileModifiedBeforeInput,
+					"--" + flags.ListItemFN, flagsTD.FlgInputs(flagsTD.ListItemInput),
+					"--" + flags.ListFolderFN, flagsTD.FlgInputs(flagsTD.ListFolderInput),
+					"--" + flags.PageFN, flagsTD.FlgInputs(flagsTD.PageInput),
+					"--" + flags.PageFolderFN, flagsTD.FlgInputs(flagsTD.PageFolderInput),
 
-				"--" + flags.CollisionsFN, testdata.Collisions,
-				"--" + flags.DestinationFN, testdata.Destination,
-				"--" + flags.ToResourceFN, testdata.ToResource,
+					"--" + flags.CollisionsFN, flagsTD.Collisions,
+					"--" + flags.DestinationFN, flagsTD.Destination,
+					"--" + flags.ToResourceFN, flagsTD.ToResource,
 
-				"--" + flags.AWSAccessKeyFN, testdata.AWSAccessKeyID,
-				"--" + flags.AWSSecretAccessKeyFN, testdata.AWSSecretAccessKey,
-				"--" + flags.AWSSessionTokenFN, testdata.AWSSessionToken,
-
-				"--" + flags.AzureClientIDFN, testdata.AzureClientID,
-				"--" + flags.AzureClientTenantFN, testdata.AzureTenantID,
-				"--" + flags.AzureClientSecretFN, testdata.AzureClientSecret,
-
-				"--" + flags.CorsoPassphraseFN, testdata.CorsoPassphrase,
-
-				// bool flags
-				"--" + flags.RestorePermissionsFN,
-			})
+					// bool flags
+					"--" + flags.RestorePermissionsFN,
+				},
+				flagsTD.PreparedProviderFlags(),
+				flagsTD.PreparedStorageFlags())
 
 			cmd.SetOut(new(bytes.Buffer)) // drop output
 			cmd.SetErr(new(bytes.Buffer)) // drop output
+
 			err := cmd.Execute()
 			assert.NoError(t, err, clues.ToCore(err))
 
 			opts := utils.MakeSharePointOpts(cmd)
-			assert.Equal(t, testdata.BackupInput, flags.BackupIDFV)
+			assert.Equal(t, flagsTD.BackupInput, flags.BackupIDFV)
 
-			assert.Equal(t, testdata.LibraryInput, opts.Library)
-			assert.ElementsMatch(t, testdata.FileNameInput, opts.FileName)
-			assert.ElementsMatch(t, testdata.FolderPathInput, opts.FolderPath)
-			assert.Equal(t, testdata.FileCreatedAfterInput, opts.FileCreatedAfter)
-			assert.Equal(t, testdata.FileCreatedBeforeInput, opts.FileCreatedBefore)
-			assert.Equal(t, testdata.FileModifiedAfterInput, opts.FileModifiedAfter)
-			assert.Equal(t, testdata.FileModifiedBeforeInput, opts.FileModifiedBefore)
+			assert.Equal(t, flagsTD.LibraryInput, opts.Library)
+			assert.ElementsMatch(t, flagsTD.FileNameInput, opts.FileName)
+			assert.ElementsMatch(t, flagsTD.FolderPathInput, opts.FolderPath)
+			assert.Equal(t, flagsTD.FileCreatedAfterInput, opts.FileCreatedAfter)
+			assert.Equal(t, flagsTD.FileCreatedBeforeInput, opts.FileCreatedBefore)
+			assert.Equal(t, flagsTD.FileModifiedAfterInput, opts.FileModifiedAfter)
+			assert.Equal(t, flagsTD.FileModifiedBeforeInput, opts.FileModifiedBefore)
 
-			assert.ElementsMatch(t, testdata.ListItemInput, opts.ListItem)
-			assert.ElementsMatch(t, testdata.ListFolderInput, opts.ListFolder)
+			assert.ElementsMatch(t, flagsTD.ListItemInput, opts.ListItem)
+			assert.ElementsMatch(t, flagsTD.ListFolderInput, opts.ListFolder)
 
-			assert.ElementsMatch(t, testdata.PageInput, opts.Page)
-			assert.ElementsMatch(t, testdata.PageFolderInput, opts.PageFolder)
+			assert.ElementsMatch(t, flagsTD.PageInput, opts.Page)
+			assert.ElementsMatch(t, flagsTD.PageFolderInput, opts.PageFolder)
 
-			assert.Equal(t, testdata.Collisions, opts.RestoreCfg.Collisions)
-			assert.Equal(t, testdata.Destination, opts.RestoreCfg.Destination)
-			assert.Equal(t, testdata.ToResource, opts.RestoreCfg.ProtectedResource)
-
-			assert.Equal(t, testdata.AWSAccessKeyID, flags.AWSAccessKeyFV)
-			assert.Equal(t, testdata.AWSSecretAccessKey, flags.AWSSecretAccessKeyFV)
-			assert.Equal(t, testdata.AWSSessionToken, flags.AWSSessionTokenFV)
-
-			assert.Equal(t, testdata.AzureClientID, flags.AzureClientIDFV)
-			assert.Equal(t, testdata.AzureTenantID, flags.AzureClientTenantFV)
-			assert.Equal(t, testdata.AzureClientSecret, flags.AzureClientSecretFV)
-
-			assert.Equal(t, testdata.CorsoPassphrase, flags.CorsoPassphraseFV)
+			assert.Equal(t, flagsTD.Collisions, opts.RestoreCfg.Collisions)
+			assert.Equal(t, flagsTD.Destination, opts.RestoreCfg.Destination)
+			assert.Equal(t, flagsTD.ToResource, opts.RestoreCfg.ProtectedResource)
 
 			// bool flags
 			assert.True(t, flags.RestorePermissionsFV)
+
+			flagsTD.AssertProviderFlags(t, cmd)
+			flagsTD.AssertStorageFlags(t, cmd)
 		})
 	}
 }


### PR DESCRIPTION
aggregates common flags, such as storage and provider credentials, in places that provide better guarantees that these flags get attached to their expected
commands.

Also aggregates testing setup and assertions around common flags to reduce boilerplate and chaff test
code, allowing flag-checking unit tests to better
identify bespoke flags in each command.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Supportability/Tests
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3988

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
