### PR TITLE
Add helper function to get category

### DIFF
--- a/src/internal/data/collection_test.go
+++ b/src/internal/data/collection_test.go
@@ -149,6 +149,7 @@ func (suite *CollectionSuite) TestNewBaseCollection() {
 			assert.Equal(t, loc, b.LocationPath(), "location path")
 			assert.Equal(t, test.expectState, b.State(), "state")
 			assert.Equal(t, test.expectDoNotMerge, b.DoNotMergeItems(), "do not merge")
+			assert.Equal(t, path.EmailCategory, b.Category(), "category")
 		})
 	}
 }

--- a/src/internal/data/implementations.go
+++ b/src/internal/data/implementations.go
@@ -118,6 +118,17 @@ func (col BaseCollection) State() CollectionState {
 	return col.state
 }
 
+func (col BaseCollection) Category() path.CategoryType {
+	switch {
+	case col.FullPath() != nil:
+		return col.FullPath().Category()
+	case col.PreviousPath() != nil:
+		return col.PreviousPath().Category()
+	}
+
+	return path.UnknownCategory
+}
+
 func (col BaseCollection) DoNotMergeItems() bool {
 	return col.doNotMergeItems
 }

--- a/src/internal/m365/collection/exchange/collection.go
+++ b/src/internal/m365/collection/exchange/collection.go
@@ -186,24 +186,16 @@ func (col *prefetchCollection) streamItems(
 	errs *fault.Bus,
 ) {
 	var (
-		category    path.CategoryType
 		success     int64
 		totalBytes  int64
 		wg          sync.WaitGroup
 		colProgress chan<- struct{}
 
 		user = col.user
+		log  = logger.Ctx(ctx).With(
+			"service", path.ExchangeService.String(),
+			"category", col.Category().String())
 	)
-
-	if col.FullPath() != nil {
-		category = col.FullPath().Category()
-	} else {
-		category = col.PreviousPath().Category()
-	}
-
-	log := logger.Ctx(ctx).With(
-		"service", path.ExchangeService.String(),
-		"category", category.String())
 
 	defer func() {
 		close(stream)
@@ -220,7 +212,7 @@ func (col *prefetchCollection) streamItems(
 	if len(col.added)+len(col.removed) > 0 {
 		colProgress = observe.CollectionProgress(
 			ctx,
-			col.FullPath().Category().HumanString(),
+			col.Category().HumanString(),
 			col.LocationPath().Elements())
 		defer close(colProgress)
 	}
@@ -354,18 +346,11 @@ func (col *lazyFetchCollection) streamItems(
 	errs *fault.Bus,
 ) {
 	var (
-		category    path.CategoryType
 		success     int64
 		colProgress chan<- struct{}
 
 		user = col.user
 	)
-
-	if col.FullPath() != nil {
-		category = col.FullPath().Category()
-	} else {
-		category = col.PreviousPath().Category()
-	}
 
 	defer func() {
 		close(stream)
@@ -382,7 +367,7 @@ func (col *lazyFetchCollection) streamItems(
 	if len(col.added)+len(col.removed) > 0 {
 		colProgress = observe.CollectionProgress(
 			ctx,
-			col.FullPath().Category().String(),
+			col.Category().HumanString(),
 			col.LocationPath().Elements())
 		defer close(colProgress)
 	}
@@ -415,7 +400,7 @@ func (col *lazyFetchCollection) streamItems(
 			"item_id", id,
 			"parent_path", path.LoggableDir(parentPath),
 			"service", path.ExchangeService.String(),
-			"category", category.String())
+			"category", col.Category().String())
 
 		stream <- &lazyItem{
 			ctx:          ictx,

--- a/src/internal/m365/collection/groups/backup.go
+++ b/src/internal/m365/collection/groups/backup.go
@@ -191,7 +191,6 @@ func populateCollections(
 				du.Reset),
 			bh,
 			qp.ProtectedResource.ID(),
-			qp.Category,
 			added,
 			removed,
 			statusUpdater)
@@ -243,7 +242,6 @@ func populateCollections(
 				false),
 			bh,
 			qp.ProtectedResource.ID(),
-			qp.Category,
 			nil, // no items added
 			nil, // this deletes a directory, so no items deleted either
 			statusUpdater)

--- a/src/internal/m365/collection/groups/collection.go
+++ b/src/internal/m365/collection/groups/collection.go
@@ -18,7 +18,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
-	"github.com/alcionai/corso/src/pkg/path"
 )
 
 var (
@@ -45,7 +44,6 @@ type Collection struct {
 
 	getter getChannelMessager
 
-	category      path.CategoryType
 	statusUpdater support.StatusUpdater
 }
 
@@ -59,7 +57,6 @@ func NewCollection(
 	baseCol data.BaseCollection,
 	getter getChannelMessager,
 	protectedResource string,
-	category path.CategoryType,
 	added map[string]struct{},
 	removed map[string]struct{},
 	statusUpdater support.StatusUpdater,
@@ -67,7 +64,6 @@ func NewCollection(
 	collection := Collection{
 		BaseCollection:    baseCol,
 		added:             added,
-		category:          category,
 		getter:            getter,
 		removed:           removed,
 		statusUpdater:     statusUpdater,
@@ -149,7 +145,7 @@ func (col *Collection) streamItems(ctx context.Context, errs *fault.Bus) {
 		el            = errs.Local()
 	)
 
-	ctx = clues.Add(ctx, "category", col.category.String())
+	ctx = clues.Add(ctx, "category", col.Category().String())
 
 	defer func() {
 		col.finishPopulation(ctx, streamedItems, totalBytes, errs.Failure())
@@ -158,7 +154,7 @@ func (col *Collection) streamItems(ctx context.Context, errs *fault.Bus) {
 	if len(col.added)+len(col.removed) > 0 {
 		colProgress = observe.CollectionProgress(
 			ctx,
-			col.FullPath().Category().HumanString(),
+			col.Category().HumanString(),
 			col.LocationPath().Elements())
 		defer close(colProgress)
 	}

--- a/src/internal/m365/collection/groups/collection_test.go
+++ b/src/internal/m365/collection/groups/collection_test.go
@@ -108,7 +108,6 @@ func (suite *CollectionUnitSuite) TestNewCollection_state() {
 					false),
 				nil,
 				"g",
-				0,
 				nil, nil,
 				nil)
 			assert.Equal(t, test.expect, c.State(), "collection state")


### PR DESCRIPTION
Expand BaseCollection to have a helper function that returns the Category. Attempts to source from the FullPath and falls back to the PreviousPath if necessary.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #4319

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
