### PR TITLE
Do not try to restore channel messages for Groups

### DIFF
--- a/src/internal/m365/service/groups/restore.go
+++ b/src/internal/m365/service/groups/restore.go
@@ -18,6 +18,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/count"
 	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
@@ -103,6 +104,9 @@ func ConsumeRestoreCollections(
 				control.DefaultRestoreContainerName(dttm.HumanReadableDriveItem),
 				errs,
 				ctr)
+		case path.ChannelMessagesCategory:
+			// Message cannot be restored as of now using Graph API.
+			logger.Ctx(ctx).Debug("Skipping restore for channel messages")
 		default:
 			return nil, clues.New("data category not supported").
 				With("category", category).

--- a/src/internal/m365/service/groups/restore_test.go
+++ b/src/internal/m365/service/groups/restore_test.go
@@ -1,0 +1,60 @@
+package groups
+
+import (
+	"testing"
+
+	"github.com/alcionai/clues"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/common/idname"
+	"github.com/alcionai/corso/src/internal/data"
+	"github.com/alcionai/corso/src/internal/data/mock"
+	"github.com/alcionai/corso/src/internal/operations/inject"
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+)
+
+type GroupsUnitSuite struct {
+	tester.Suite
+}
+
+func TestGroupsUnitSuite(t *testing.T) {
+	suite.Run(t, &GroupsUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *GroupsUnitSuite) TestConsumeRestoreCollections_noErrorOnGroups() {
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	rcc := inject.RestoreConsumerConfig{}
+	pth, err := path.Builder{}.
+		Append("General").
+		ToDataLayerPath(
+			"t",
+			"g",
+			path.GroupsService,
+			path.ChannelMessagesCategory,
+			false)
+	require.NoError(t, err, clues.ToCore(err))
+
+	dcs := []data.RestoreCollection{
+		mock.Collection{Path: pth},
+	}
+
+	_, err = ConsumeRestoreCollections(
+		ctx,
+		rcc,
+		api.Client{},
+		idname.NewCache(map[string]string{}),
+		dcs,
+		nil,
+		fault.New(false),
+		nil)
+	assert.NoError(t, err, "Groups Channels restore")
+}

--- a/src/pkg/storage/testdata/storage.go
+++ b/src/pkg/storage/testdata/storage.go
@@ -56,7 +56,7 @@ func NewFilesystemStorage(t tester.TestT) storage.Storage {
 	now := tester.LogTimeOfTest(t)
 	repoPath := filepath.Join(t.TempDir(), now)
 
-	err := os.MkdirAll(repoPath, 0700)
+	err := os.MkdirAll(repoPath, 0o700)
 	require.NoErrorf(t, err, "creating filesystem repo: %+v", clues.ToCore(err))
 
 	t.Logf("testing at filesystem repo [%s]", repoPath)


### PR DESCRIPTION
<!-- PR description-->

As of now, we try to restore channel messages and fail with the following error:

```
Error: Failed to run Groups restore: running restore: restoring collections: data category not supported
```

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
