### PR TITLE
iterate pager results with channels

### DIFF
--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -274,13 +275,6 @@ func (c *Collections) Get(
 			excludedItemIDs = map[string]struct{}{}
 			oldPrevPaths    = oldPrevPathsByDriveID[driveID]
 			prevDeltaLink   = prevDriveIDToDelta[driveID]
-
-			// itemCollection is used to identify which collection a
-			// file belongs to. This is useful to delete a file from the
-			// collection it was previously in, in case it was moved to a
-			// different collection within the same delta query
-			// item ID -> item ID
-			itemCollection = map[string]string{}
 		)
 
 		delete(driveTombstones, driveID)
@@ -297,12 +291,16 @@ func (c *Collections) Get(
 			"previous metadata for drive",
 			"num_paths_entries", len(oldPrevPaths))
 
-		items, du, err := c.handler.EnumerateDriveItemsDelta(
-			ictx,
+		du, newPrevPaths, err := c.PopulateDriveCollections(
+			ctx,
 			driveID,
-			prevDeltaLink)
+			driveName,
+			oldPrevPaths,
+			excludedItemIDs,
+			prevDeltaLink,
+			errs)
 		if err != nil {
-			return nil, false, err
+			return nil, false, clues.Stack(err)
 		}
 
 		// It's alright to have an empty folders map (i.e. no folders found) but not
@@ -312,20 +310,6 @@ func (c *Collections) Get(
 		// for collections when not actually getting delta results.
 		if len(du.URL) > 0 {
 			driveIDToDeltaLink[driveID] = du.URL
-		}
-
-		newPrevPaths, err := c.UpdateCollections(
-			ctx,
-			driveID,
-			driveName,
-			items,
-			oldPrevPaths,
-			itemCollection,
-			excludedItemIDs,
-			du.Reset,
-			errs)
-		if err != nil {
-			return nil, false, clues.Stack(err)
 		}
 
 		// Avoid the edge case where there's no paths but we do have a valid delta
@@ -686,223 +670,289 @@ func (c *Collections) getCollectionPath(
 	return collectionPath, nil
 }
 
-// UpdateCollections initializes and adds the provided drive items to Collections
-// A new collection is created for every drive folder (or package).
+// PopulateDriveCollections initializes and adds the provided drive items to Collections
+// A new collection is created for every drive folder.
 // oldPrevPaths is the unchanged data that was loaded from the metadata file.
 // This map is not modified during the call.
 // currPrevPaths starts as a copy of oldPaths and is updated as changes are found in
 // the returned results.  Items are added to this collection throughout the call.
 // newPrevPaths, ie: the items added during this call, get returned as a map.
-func (c *Collections) UpdateCollections(
+func (c *Collections) PopulateDriveCollections(
 	ctx context.Context,
 	driveID, driveName string,
-	items []models.DriveItemable,
 	oldPrevPaths map[string]string,
-	currPrevPaths map[string]string,
-	excluded map[string]struct{},
-	invalidPrevDelta bool,
+	excludedItemIDs map[string]struct{},
+	prevDeltaLink string,
 	errs *fault.Bus,
-) (map[string]string, error) {
+) (api.DeltaUpdate, map[string]string, error) {
 	var (
-		el           = errs.Local()
-		newPrevPaths = map[string]string{}
+		el               = errs.Local()
+		newPrevPaths     = map[string]string{}
+		invalidPrevDelta = len(prevDeltaLink) == 0
+		ch               = make(chan api.NextPage[models.DriveItemable], 1)
+		wg               = sync.WaitGroup{}
+
+		// currPrevPaths is used to identify which collection a
+		// file belongs to. This is useful to delete a file from the
+		// collection it was previously in, in case it was moved to a
+		// different collection within the same delta query
+		// item ID -> item ID
+		currPrevPaths = map[string]string{}
 	)
 
 	if !invalidPrevDelta {
 		maps.Copy(newPrevPaths, oldPrevPaths)
 	}
 
-	for _, item := range items {
-		if el.Failure() != nil {
-			break
-		}
+	go func() {
+		defer wg.Done()
 
-		var (
-			itemID   = ptr.Val(item.GetId())
-			itemName = ptr.Val(item.GetName())
-			isFolder = item.GetFolder() != nil || item.GetPackageEscaped() != nil
-			ictx     = clues.Add(
-				ctx,
-				"item_id", itemID,
-				"item_name", clues.Hide(itemName),
-				"item_is_folder", isFolder)
-		)
-
-		if item.GetMalware() != nil {
-			addtl := graph.ItemInfo(item)
-			skip := fault.FileSkip(fault.SkipMalware, driveID, itemID, itemName, addtl)
-
-			if isFolder {
-				skip = fault.ContainerSkip(fault.SkipMalware, driveID, itemID, itemName, addtl)
+		for pg := range ch {
+			if el.Failure() != nil {
+				// exhaust the channel to ensure it closes
+				continue
 			}
 
-			errs.AddSkip(ctx, skip)
-			logger.Ctx(ctx).Infow("malware detected", "item_details", addtl)
-
-			continue
-		}
-
-		// Deleted file or folder.
-		if item.GetDeleted() != nil {
-			if err := c.handleDelete(
-				itemID,
-				driveID,
-				oldPrevPaths,
-				currPrevPaths,
-				newPrevPaths,
-				isFolder,
-				excluded,
-				invalidPrevDelta); err != nil {
-				return nil, clues.Stack(err).WithClues(ictx)
+			if pg.Reset {
+				newPrevPaths = map[string]string{}
+				currPrevPaths = map[string]string{}
+				c.CollectionMap[driveID] = map[string]*Collection{}
+				invalidPrevDelta = true
 			}
 
-			continue
-		}
+			for _, item := range pg.Items {
+				if el.Failure() != nil {
+					continue
+				}
 
-		collectionPath, err := c.getCollectionPath(driveID, item)
-		if err != nil {
-			el.AddRecoverable(ctx, clues.Stack(err).
-				WithClues(ictx).
-				Label(fault.LabelForceNoBackupCreation))
-
-			continue
-		}
-
-		// Skip items that don't match the folder selectors we were given.
-		if shouldSkip(ctx, collectionPath, c.handler, driveName) {
-			logger.Ctx(ictx).Debugw("path not selected", "skipped_path", collectionPath.String())
-			continue
-		}
-
-		switch {
-		case isFolder:
-			// Deletions are handled above so this is just moves/renames.
-			var prevPath path.Path
-
-			prevPathStr, ok := oldPrevPaths[itemID]
-			if ok {
-				prevPath, err = path.FromDataLayerPath(prevPathStr, false)
+				err := c.processItem(
+					ctx,
+					item,
+					driveID,
+					driveName,
+					oldPrevPaths,
+					currPrevPaths,
+					newPrevPaths,
+					excludedItemIDs,
+					invalidPrevDelta,
+					el)
 				if err != nil {
-					el.AddRecoverable(ctx, clues.Wrap(err, "invalid previous path").
-						WithClues(ictx).
-						With("prev_path_string", path.LoggableDir(prevPathStr)))
-				}
-			} else if item.GetRoot() != nil {
-				// Root doesn't move or get renamed.
-				prevPath = collectionPath
-			}
-
-			// Moved folders don't cause delta results for any subfolders nested in
-			// them. We need to go through and update paths to handle that. We only
-			// update newPaths so we don't accidentally clobber previous deletes.
-			updatePath(newPrevPaths, itemID, collectionPath.String())
-
-			found, err := updateCollectionPaths(driveID, itemID, c.CollectionMap, collectionPath)
-			if err != nil {
-				return nil, clues.Stack(err).WithClues(ictx)
-			}
-
-			if found {
-				continue
-			}
-
-			colScope := CollectionScopeFolder
-			if item.GetPackageEscaped() != nil {
-				colScope = CollectionScopePackage
-			}
-
-			col, err := NewCollection(
-				c.handler,
-				collectionPath,
-				prevPath,
-				driveID,
-				c.statusUpdater,
-				c.ctrl,
-				colScope,
-				invalidPrevDelta,
-				nil)
-			if err != nil {
-				return nil, clues.Stack(err).WithClues(ictx)
-			}
-
-			col.driveName = driveName
-
-			c.CollectionMap[driveID][itemID] = col
-			c.NumContainers++
-
-			if item.GetRoot() != nil {
-				continue
-			}
-
-			// Add an entry to fetch permissions into this collection. This assumes
-			// that OneDrive always returns all folders on the path of an item
-			// before the item. This seems to hold true for now at least.
-			if col.Add(item) {
-				c.NumItems++
-			}
-
-		case item.GetFile() != nil:
-			// Deletions are handled above so this is just moves/renames.
-			if len(ptr.Val(item.GetParentReference().GetId())) == 0 {
-				return nil, clues.New("file without parent ID").WithClues(ictx)
-			}
-
-			// Get the collection for this item.
-			parentID := ptr.Val(item.GetParentReference().GetId())
-			ictx = clues.Add(ictx, "parent_id", parentID)
-
-			collection, ok := c.CollectionMap[driveID][parentID]
-			if !ok {
-				return nil, clues.New("item seen before parent folder").WithClues(ictx)
-			}
-
-			// This will only kick in if the file was moved multiple times
-			// within a single delta query.  We delete the file from the previous
-			// collection so that it doesn't appear in two places.
-			prevParentContainerID, ok := currPrevPaths[itemID]
-			if ok {
-				prevColl, found := c.CollectionMap[driveID][prevParentContainerID]
-				if !found {
-					return nil, clues.New("previous collection not found").
-						With("prev_parent_container_id", prevParentContainerID).
-						WithClues(ictx)
-				}
-
-				if ok := prevColl.Remove(itemID); !ok {
-					return nil, clues.New("removing item from prev collection").
-						With("prev_parent_container_id", prevParentContainerID).
-						WithClues(ictx)
+					el.AddRecoverable(ctx, clues.Stack(err))
 				}
 			}
-
-			currPrevPaths[itemID] = parentID
-
-			if collection.Add(item) {
-				c.NumItems++
-				c.NumFiles++
-			}
-
-			// Do this after adding the file to the collection so if we fail to add
-			// the item to the collection for some reason and we're using best effort
-			// we don't just end up deleting the item in the resulting backup. The
-			// resulting backup will be slightly incorrect, but it will have the most
-			// data that we were able to preserve.
-			if !invalidPrevDelta {
-				// Always add a file to the excluded list. The file may have been
-				// renamed/moved/modified, so we still have to drop the
-				// original one and download a fresh copy.
-				excluded[itemID+metadata.DataFileSuffix] = struct{}{}
-				excluded[itemID+metadata.MetaFileSuffix] = struct{}{}
-			}
-
-		default:
-			el.AddRecoverable(ictx, clues.New("item is neither folder nor file").
-				WithClues(ictx).
-				Label(fault.LabelForceNoBackupCreation))
 		}
+	}()
+
+	wg.Add(1)
+
+	du, err := c.handler.EnumerateDriveItemsDelta(
+		ctx,
+		ch,
+		driveID,
+		prevDeltaLink)
+	if err != nil {
+		return du, nil, clues.Stack(err)
 	}
 
-	return newPrevPaths, el.Failure()
+	wg.Wait()
+
+	return du, newPrevPaths, el.Failure()
+}
+
+func (c *Collections) processItem(
+	ctx context.Context,
+	item models.DriveItemable,
+	driveID, driveName string,
+	oldPrevPaths, currPrevPaths, newPrevPaths map[string]string,
+	excluded map[string]struct{},
+	invalidPrevDelta bool,
+	skipper fault.AddSkipper,
+) error {
+	var (
+		itemID   = ptr.Val(item.GetId())
+		itemName = ptr.Val(item.GetName())
+		isFolder = item.GetFolder() != nil || item.GetPackageEscaped() != nil
+		ictx     = clues.Add(
+			ctx,
+			"item_id", itemID,
+			"item_name", clues.Hide(itemName),
+			"item_is_folder", isFolder)
+	)
+
+	if item.GetMalware() != nil {
+		addtl := graph.ItemInfo(item)
+		skip := fault.FileSkip(fault.SkipMalware, driveID, itemID, itemName, addtl)
+
+		if isFolder {
+			skip = fault.ContainerSkip(fault.SkipMalware, driveID, itemID, itemName, addtl)
+		}
+
+		skipper.AddSkip(ctx, skip)
+		logger.Ctx(ctx).Infow("malware detected", "item_details", addtl)
+
+		return nil
+	}
+
+	// Deleted file or folder.
+	if item.GetDeleted() != nil {
+		err := c.handleDelete(
+			itemID,
+			driveID,
+			oldPrevPaths,
+			currPrevPaths,
+			newPrevPaths,
+			isFolder,
+			excluded,
+			invalidPrevDelta)
+
+		return clues.Stack(err).WithClues(ictx).OrNil()
+	}
+
+	collectionPath, err := c.getCollectionPath(driveID, item)
+	if err != nil {
+		return clues.Stack(err).
+			WithClues(ictx).
+			Label(fault.LabelForceNoBackupCreation)
+	}
+
+	// Skip items that don't match the folder selectors we were given.
+	if shouldSkip(ctx, collectionPath, c.handler, driveName) {
+		logger.Ctx(ictx).Debugw("path not selected", "skipped_path", collectionPath.String())
+		return nil
+	}
+
+	switch {
+	case isFolder:
+		// Deletions are handled above so this is just moves/renames.
+		var prevPath path.Path
+
+		prevPathStr, ok := oldPrevPaths[itemID]
+		if ok {
+			prevPath, err = path.FromDataLayerPath(prevPathStr, false)
+			if err != nil {
+				return clues.Wrap(err, "invalid previous path").
+					WithClues(ictx).
+					With("prev_path_string", prevPathStr)
+			}
+		} else if item.GetRoot() != nil {
+			// Root doesn't move or get renamed.
+			prevPath = collectionPath
+		}
+
+		// Moved folders don't cause delta results for any subfolders nested in
+		// them. We need to go through and update paths to handle that. We only
+		// update newPaths so we don't accidentally clobber previous deletes.
+		updatePath(newPrevPaths, itemID, collectionPath.String())
+
+		found, err := updateCollectionPaths(
+			driveID,
+			itemID,
+			c.CollectionMap,
+			collectionPath)
+		if err != nil {
+			return clues.Stack(err).WithClues(ictx)
+		}
+
+		if found {
+			return nil
+		}
+
+		colScope := CollectionScopeFolder
+		if item.GetPackageEscaped() != nil {
+			colScope = CollectionScopePackage
+		}
+
+		col, err := NewCollection(
+			c.handler,
+			collectionPath,
+			prevPath,
+			driveID,
+			c.statusUpdater,
+			c.ctrl,
+			colScope,
+			invalidPrevDelta,
+			nil)
+		if err != nil {
+			return clues.Stack(err).WithClues(ictx)
+		}
+
+		col.driveName = driveName
+
+		c.CollectionMap[driveID][itemID] = col
+		c.NumContainers++
+
+		if item.GetRoot() != nil {
+			return nil
+		}
+
+		// Add an entry to fetch permissions into this collection. This assumes
+		// that OneDrive always returns all folders on the path of an item
+		// before the item. This seems to hold true for now at least.
+		if col.Add(item) {
+			c.NumItems++
+		}
+
+	case item.GetFile() != nil:
+		// Deletions are handled above so this is just moves/renames.
+		if len(ptr.Val(item.GetParentReference().GetId())) == 0 {
+			return clues.New("file without parent ID").WithClues(ictx)
+		}
+
+		// Get the collection for this item.
+		parentID := ptr.Val(item.GetParentReference().GetId())
+		ictx = clues.Add(ictx, "parent_id", parentID)
+
+		collection, ok := c.CollectionMap[driveID][parentID]
+		if !ok {
+			return clues.New("item seen before parent folder").WithClues(ictx)
+		}
+
+		// This will only kick in if the file was moved multiple times
+		// within a single delta query.  We delete the file from the previous
+		// collection so that it doesn't appear in two places.
+		prevParentContainerID, ok := currPrevPaths[itemID]
+		if ok {
+			prevColl, found := c.CollectionMap[driveID][prevParentContainerID]
+			if !found {
+				return clues.New("previous collection not found").
+					With("prev_parent_container_id", prevParentContainerID).
+					WithClues(ictx)
+			}
+
+			if ok := prevColl.Remove(itemID); !ok {
+				return clues.New("removing item from prev collection").
+					With("prev_parent_container_id", prevParentContainerID).
+					WithClues(ictx)
+			}
+		}
+
+		currPrevPaths[itemID] = parentID
+
+		if collection.Add(item) {
+			c.NumItems++
+			c.NumFiles++
+		}
+
+		// Do this after adding the file to the collection so if we fail to add
+		// the item to the collection for some reason and we're using best effort
+		// we don't just end up deleting the item in the resulting backup. The
+		// resulting backup will be slightly incorrect, but it will have the most
+		// data that we were able to preserve.
+		if !invalidPrevDelta {
+			// Always add a file to the excluded list. The file may have been
+			// renamed/moved/modified, so we still have to drop the
+			// original one and download a fresh copy.
+			excluded[itemID+metadata.DataFileSuffix] = struct{}{}
+			excluded[itemID+metadata.MetaFileSuffix] = struct{}{}
+		}
+
+	default:
+		return clues.New("item is neither folder nor file").
+			WithClues(ictx).
+			Label(fault.LabelForceNoBackupCreation)
+	}
+
+	return nil
 }
 
 type dirScopeChecker interface {
@@ -910,7 +960,12 @@ type dirScopeChecker interface {
 	IncludesDir(dir string) bool
 }
 
-func shouldSkip(ctx context.Context, drivePath path.Path, dsc dirScopeChecker, driveName string) bool {
+func shouldSkip(
+	ctx context.Context,
+	drivePath path.Path,
+	dsc dirScopeChecker,
+	driveName string,
+) bool {
 	return !includePath(ctx, dsc, drivePath) ||
 		(drivePath.Category() == path.LibrariesCategory && restrictedDirectory == driveName)
 }

--- a/src/internal/m365/collection/drive/collections_test.go
+++ b/src/internal/m365/collection/drive/collections_test.go
@@ -117,7 +117,7 @@ func getDelList(files ...string) map[string]struct{} {
 	return delList
 }
 
-func (suite *OneDriveCollectionsUnitSuite) TestUpdateCollections() {
+func (suite *OneDriveCollectionsUnitSuite) TestPopulateDriveCollections() {
 	anyFolder := (&selectors.OneDriveBackup{}).Folders(selectors.Any())[0]
 
 	const (
@@ -688,8 +688,10 @@ func (suite *OneDriveCollectionsUnitSuite) TestUpdateCollections() {
 			expectedItemCount:      0,
 			expectedFileCount:      0,
 			expectedContainerCount: 1,
-			expectedPrevPaths:      nil,
-			expectedExcludes:       map[string]struct{}{},
+			expectedPrevPaths: map[string]string{
+				"root": expectedPath(""),
+			},
+			expectedExcludes: map[string]struct{}{},
 		},
 		{
 			name: "1 root file, 1 folder, 1 package, 1 good file, 1 malware",
@@ -730,15 +732,31 @@ func (suite *OneDriveCollectionsUnitSuite) TestUpdateCollections() {
 			defer flush()
 
 			var (
-				excludes      = map[string]struct{}{}
-				currPrevPaths = map[string]string{}
-				errs          = fault.New(true)
+				mbh = mock.DefaultOneDriveBH(user)
+				du  = api.DeltaUpdate{
+					URL:   "notempty",
+					Reset: false,
+				}
+				excludes = map[string]struct{}{}
+				errs     = fault.New(true)
 			)
 
-			maps.Copy(currPrevPaths, test.inputFolderMap)
+			mbh.DriveItemEnumeration = mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID: {
+						{Items: test.items},
+					},
+				},
+				DeltaUpdate: map[string]api.DeltaUpdate{driveID: du},
+			}
+
+			sel := selectors.NewOneDriveBackup([]string{user})
+			sel.Include([]selectors.OneDriveScope{test.scope})
+
+			mbh.Sel = sel.Selector
 
 			c := NewCollections(
-				&itemBackupHandler{api.Drives{}, user, test.scope},
+				mbh,
 				tenant,
 				user,
 				nil,
@@ -746,18 +764,19 @@ func (suite *OneDriveCollectionsUnitSuite) TestUpdateCollections() {
 
 			c.CollectionMap[driveID] = map[string]*Collection{}
 
-			newPrevPaths, err := c.UpdateCollections(
+			_, newPrevPaths, err := c.PopulateDriveCollections(
 				ctx,
 				driveID,
 				"General",
-				test.items,
 				test.inputFolderMap,
-				currPrevPaths,
 				excludes,
-				false,
+				"smarf",
 				errs)
 			test.expect(t, err, clues.ToCore(err))
-			assert.Equal(t, len(test.expectedCollectionIDs), len(c.CollectionMap[driveID]), "total collections")
+			assert.ElementsMatch(
+				t,
+				maps.Keys(test.expectedCollectionIDs),
+				maps.Keys(c.CollectionMap[driveID]))
 			assert.Equal(t, test.expectedItemCount, c.NumItems, "item count")
 			assert.Equal(t, test.expectedFileCount, c.NumFiles, "file count")
 			assert.Equal(t, test.expectedContainerCount, c.NumContainers, "container count")
@@ -1160,7 +1179,6 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		tenant = "a-tenant"
 		user   = "a-user"
 		empty  = ""
-		next   = "next"
 		delta  = "delta1"
 		delta2 = "delta2"
 	)
@@ -1202,7 +1220,7 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 	table := []struct {
 		name                 string
 		drives               []models.Driveable
-		items                map[string][]apiMock.PagerResult[models.DriveItemable]
+		enumerator           mock.EnumeratesDriveItemsDelta[models.DriveItemable]
 		canUsePreviousBackup bool
 		errCheck             assert.ErrorAssertionFunc
 		prevFolderPaths      map[string]map[string]string
@@ -1221,16 +1239,19 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "OneDrive_OneItemPage_DelFileOnly_NoFolders_NoErrors",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{Items: []models.DriveItemable{
 							driveRootItem("root"), // will be present, not needed
 							delItem("file", driveBasePath1, "root", true, false, false),
-						},
-						DeltaLink: &delta,
+						}},
 					},
 				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {URL: delta},
+				},
+				Err: map[string]error{driveID1: nil},
 			},
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
@@ -1253,16 +1274,19 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "OneDrive_OneItemPage_NoFolderDeltas_NoErrors",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{Items: []models.DriveItemable{
 							driveRootItem("root"),
 							driveItem("file", "file", driveBasePath1, "root", true, false, false),
-						},
-						DeltaLink: &delta,
+						}},
 					},
 				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {URL: delta},
+				},
+				Err: map[string]error{driveID1: nil},
 			},
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
@@ -1285,18 +1309,20 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "OneDrive_OneItemPage_NoErrors",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{Items: []models.DriveItemable{
 							driveRootItem("root"),
 							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
 							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
-						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
+						}},
 					},
 				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {URL: delta, Reset: true},
+				},
+				Err: map[string]error{driveID1: nil},
 			},
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
@@ -1323,19 +1349,21 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "OneDrive_OneItemPage_NoErrors_FileRenamedMultiple",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{Items: []models.DriveItemable{
 							driveRootItem("root"),
 							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
 							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
 							driveItem("file", "file2", driveBasePath1+"/folder", "folder", true, false, false),
-						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
+						}},
 					},
 				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {URL: delta, Reset: true},
+				},
+				Err: map[string]error{driveID1: nil},
 			},
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
@@ -1362,18 +1390,21 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "OneDrive_OneItemPage_NoErrors_FileMovedMultiple",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{Items: []models.DriveItemable{
 							driveRootItem("root"),
 							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
 							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
 							driveItem("file", "file2", driveBasePath1, "root", true, false, false),
-						},
-						DeltaLink: &delta,
+						}},
 					},
 				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {URL: delta},
+				},
+				Err: map[string]error{driveID1: nil},
 			},
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
@@ -1402,18 +1433,20 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "OneDrive_OneItemPage_EmptyDelta_NoErrors",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{Items: []models.DriveItemable{
 							driveRootItem("root"),
 							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
 							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
-						},
-						DeltaLink:  &empty, // probably will never happen with graph
-						ResetDelta: true,
+						}},
 					},
 				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {URL: empty, Reset: true},
+				},
+				Err: map[string]error{driveID1: nil},
 			},
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
@@ -1440,27 +1473,150 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "OneDrive_TwoItemPages_NoErrors",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
-							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+								driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+							},
 						},
-						NextLink:   &next,
-						ResetDelta: true,
-					},
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
-							driveItem("file2", "file2", driveBasePath1+"/folder", "folder", true, false, false),
+						{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+								driveItem("file2", "file2", driveBasePath1+"/folder", "folder", true, false, false),
+							},
 						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
 					},
 				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {URL: delta, Reset: true},
+				},
+				Err: map[string]error{driveID1: nil},
+			},
+			canUsePreviousBackup: true,
+			errCheck:             assert.NoError,
+			prevFolderPaths: map[string]map[string]string{
+				driveID1: {},
+			},
+			expectedCollections: map[string]map[data.CollectionState][]string{
+				rootFolderPath1: {data.NewState: {}},
+				folderPath1:     {data.NewState: {"folder", "file", "file2"}},
+			},
+			expectedDeltaURLs: map[string]string{
+				driveID1: delta,
+			},
+			expectedFolderPaths: map[string]map[string]string{
+				driveID1: {
+					"root":   rootFolderPath1,
+					"folder": folderPath1,
+				},
+			},
+			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
+			doNotMergeItems: map[string]bool{
+				rootFolderPath1: true,
+				folderPath1:     true,
+			},
+		},
+		{
+			name:   "OneDrive_TwoItemPages_WithReset",
+			drives: []models.Driveable{drive1},
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+								driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+							},
+						},
+						{
+							Items: []models.DriveItemable{},
+							Reset: true,
+						},
+						{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+								driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+							},
+						},
+						{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+								driveItem("file2", "file2", driveBasePath1+"/folder", "folder", true, false, false),
+							},
+						},
+					},
+				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {URL: delta, Reset: true},
+				},
+				Err: map[string]error{driveID1: nil},
+			},
+			canUsePreviousBackup: true,
+			errCheck:             assert.NoError,
+			prevFolderPaths: map[string]map[string]string{
+				driveID1: {},
+			},
+			expectedCollections: map[string]map[data.CollectionState][]string{
+				rootFolderPath1: {data.NewState: {}},
+				folderPath1:     {data.NewState: {"folder", "file", "file2"}},
+			},
+			expectedDeltaURLs: map[string]string{
+				driveID1: delta,
+			},
+			expectedFolderPaths: map[string]map[string]string{
+				driveID1: {
+					"root":   rootFolderPath1,
+					"folder": folderPath1,
+				},
+			},
+			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
+			doNotMergeItems: map[string]bool{
+				rootFolderPath1: true,
+				folderPath1:     true,
+			},
+		},
+		{
+			name:   "OneDrive_TwoItemPages_WithResetCombinedWithItems",
+			drives: []models.Driveable{drive1},
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+								driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+							},
+						},
+						{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+								driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+							},
+							Reset: true,
+						},
+						{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+								driveItem("file2", "file2", driveBasePath1+"/folder", "folder", true, false, false),
+							},
+						},
+					},
+				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {URL: delta, Reset: true},
+				},
+				Err: map[string]error{driveID1: nil},
 			},
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
@@ -1492,29 +1648,28 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 				drive1,
 				drive2,
 			},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{Items: []models.DriveItemable{
 							driveRootItem("root"),
 							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
 							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
-						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
+						}},
 					},
-				},
-				driveID2: {
-					{
-						Values: []models.DriveItemable{
+					driveID2: {
+						{Items: []models.DriveItemable{
 							driveRootItem("root2"),
 							driveItem("folder2", "folder", driveBasePath2, "root2", false, true, false),
 							driveItem("file2", "file", driveBasePath2+"/folder", "folder2", true, false, false),
-						},
-						DeltaLink:  &delta2,
-						ResetDelta: true,
+						}},
 					},
 				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {URL: delta, Reset: true},
+					driveID2: {URL: delta2, Reset: true},
+				},
+				Err: map[string]error{driveID1: nil},
 			},
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
@@ -1556,29 +1711,28 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 				drive1,
 				drive2,
 			},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{Items: []models.DriveItemable{
 							driveRootItem("root"),
 							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
 							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
-						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
+						}},
 					},
-				},
-				driveID2: {
-					{
-						Values: []models.DriveItemable{
+					driveID2: {
+						{Items: []models.DriveItemable{
 							driveRootItem("root"),
 							driveItem("folder", "folder", driveBasePath2, "root", false, true, false),
 							driveItem("file2", "file", driveBasePath2+"/folder", "folder", true, false, false),
-						},
-						DeltaLink:  &delta2,
-						ResetDelta: true,
+						}},
 					},
 				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {URL: delta, Reset: true},
+					driveID2: {URL: delta2, Reset: true},
+				},
+				Err: map[string]error{driveID1: nil},
 			},
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
@@ -1617,12 +1771,16 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "OneDrive_OneItemPage_Errors",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Err: assert.AnError,
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{Items: []models.DriveItemable{}},
 					},
 				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {},
+				},
+				Err: map[string]error{driveID1: assert.AnError},
 			},
 			canUsePreviousBackup: false,
 			errCheck:             assert.Error,
@@ -1635,67 +1793,81 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 			expectedDelList:     nil,
 		},
 		{
-			name:   "OneDrive_TwoItemPage_NoDeltaError",
+			name:   "OneDrive_OneItemPage_InvalidPrevDelta_DeleteNonExistentFolder",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("file", "file", driveBasePath1, "root", true, false, false),
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{
+							Items: []models.DriveItemable{},
+							Reset: true,
 						},
-						NextLink: &next,
-					},
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
-							driveItem("file2", "file", driveBasePath1+"/folder", "folder", true, false, false),
+						{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								driveItem("folder2", "folder2", driveBasePath1, "root", false, true, false),
+								driveItem("file", "file", driveBasePath1+"/folder2", "folder2", true, false, false),
+							},
 						},
-						DeltaLink: &delta,
 					},
 				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {URL: delta, Reset: true},
+				},
+				Err: map[string]error{driveID1: nil},
 			},
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			prevFolderPaths: map[string]map[string]string{
 				driveID1: {
-					"root": rootFolderPath1,
+					"root":   rootFolderPath1,
+					"folder": folderPath1,
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				rootFolderPath1:          {data.NotMovedState: {"file"}},
-				expectedPath1("/folder"): {data.NewState: {"folder", "file2"}},
+				rootFolderPath1:           {data.NewState: {}},
+				expectedPath1("/folder"):  {data.DeletedState: {}},
+				expectedPath1("/folder2"): {data.NewState: {"folder2", "file"}},
 			},
 			expectedDeltaURLs: map[string]string{
 				driveID1: delta,
 			},
 			expectedFolderPaths: map[string]map[string]string{
 				driveID1: {
-					"root":   rootFolderPath1,
-					"folder": folderPath1,
+					"root":    rootFolderPath1,
+					"folder2": expectedPath1("/folder2"),
 				},
 			},
-			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{
-				rootFolderPath1: getDelList("file", "file2"),
-			}),
-			doNotMergeItems: map[string]bool{},
+			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
+			doNotMergeItems: map[string]bool{
+				rootFolderPath1:           true,
+				folderPath1:               true,
+				expectedPath1("/folder2"): true,
+			},
 		},
 		{
-			name:   "OneDrive_OneItemPage_InvalidPrevDelta_DeleteNonExistentFolder",
+			name:   "OneDrive_OneItemPage_InvalidPrevDeltaCombinedWithItems_DeleteNonExistentFolder",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("folder2", "folder2", driveBasePath1, "root", false, true, false),
-							driveItem("file", "file", driveBasePath1+"/folder2", "folder2", true, false, false),
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{
+							Items: []models.DriveItemable{},
+							Reset: true,
 						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
+						{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								driveItem("folder2", "folder2", driveBasePath1, "root", false, true, false),
+								driveItem("file", "file", driveBasePath1+"/folder2", "folder2", true, false, false),
+							},
+						},
 					},
 				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {URL: delta, Reset: true},
+				},
+				Err: map[string]error{driveID1: nil},
 			},
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
@@ -1729,18 +1901,37 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "OneDrive_OneItemPage_InvalidPrevDelta_AnotherFolderAtDeletedLocation",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("folder2", "folder", driveBasePath1, "root", false, true, false),
-							driveItem("file", "file", driveBasePath1+"/folder", "folder2", true, false, false),
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{
+							// on the first page, if this is the total data, we'd expect both folder and folder2
+							// since new previousPaths merge with the old previousPaths.
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								driveItem("folder2", "folder", driveBasePath1, "root", false, true, false),
+								driveItem("file", "file", driveBasePath1+"/folder", "folder2", true, false, false),
+							},
 						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
+						{
+							Items: []models.DriveItemable{},
+							Reset: true,
+						},
+						{
+							// but after a delta reset, we treat this as the total end set of folders, which means
+							// we don't expect folder to exist any longer.
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								driveItem("folder2", "folder", driveBasePath1, "root", false, true, false),
+								driveItem("file", "file", driveBasePath1+"/folder", "folder2", true, false, false),
+							},
+						},
 					},
 				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {URL: delta, Reset: true},
+				},
+				Err: map[string]error{driveID1: nil},
 			},
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
@@ -1777,28 +1968,31 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "OneDrive Two Item Pages with Malware",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
-							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
-							malwareItem("malware", "malware", driveBasePath1+"/folder", "folder", true, false, false),
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+								driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+								malwareItem("malware", "malware", driveBasePath1+"/folder", "folder", true, false, false),
+							},
 						},
-						NextLink: &next,
-					},
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
-							driveItem("file2", "file2", driveBasePath1+"/folder", "folder", true, false, false),
-							malwareItem("malware2", "malware2", driveBasePath1+"/folder", "folder", true, false, false),
+						{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+								driveItem("file2", "file2", driveBasePath1+"/folder", "folder", true, false, false),
+								malwareItem("malware2", "malware2", driveBasePath1+"/folder", "folder", true, false, false),
+							},
 						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
 					},
 				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {URL: delta, Reset: true},
+				},
+				Err: map[string]error{driveID1: nil},
 			},
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
@@ -1826,30 +2020,38 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 			expectedSkippedCount: 2,
 		},
 		{
-			name:   "One Drive Deleted Folder In New Results",
+			name:   "One Drive Deleted Folder In New Results With Invalid Delta",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
-							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
-							driveItem("folder2", "folder2", driveBasePath1, "root", false, true, false),
-							driveItem("file2", "file2", driveBasePath1+"/folder2", "folder2", true, false, false),
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+								driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+								driveItem("folder2", "folder2", driveBasePath1, "root", false, true, false),
+								driveItem("file2", "file2", driveBasePath1+"/folder2", "folder2", true, false, false),
+							},
 						},
-						NextLink: &next,
-					},
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							delItem("folder2", driveBasePath1, "root", false, true, false),
-							delItem("file2", driveBasePath1, "root", true, false, false),
+						{
+							Reset: true,
 						},
-						DeltaLink:  &delta2,
-						ResetDelta: true,
+						{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+								driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+								delItem("folder2", driveBasePath1, "root", false, true, false),
+								delItem("file2", driveBasePath1, "root", true, false, false),
+							},
+						},
 					},
 				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {URL: delta2, Reset: true},
+				},
+				Err: map[string]error{driveID1: nil},
 			},
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
@@ -1882,19 +2084,24 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 			},
 		},
 		{
-			name:   "One Drive Random Folder Delete",
+			name:   "One Drive Folder Delete After Invalid Delta",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							delItem("folder", driveBasePath1, "root", false, true, false),
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								delItem("folder", driveBasePath1, "root", false, true, false),
+							},
+							Reset: true,
 						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
 					},
 				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {URL: delta, Reset: true},
+				},
+				Err: map[string]error{driveID1: nil},
 			},
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
@@ -1923,19 +2130,24 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 			},
 		},
 		{
-			name:   "One Drive Random Item Delete",
+			name:   "One Drive Item Delete After Invalid Delta",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							delItem("file", driveBasePath1, "root", true, false, false),
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								delItem("file", driveBasePath1, "root", true, false, false),
+							},
+							Reset: true,
 						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
 					},
 				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {URL: delta, Reset: true},
+				},
+				Err: map[string]error{driveID1: nil},
 			},
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
@@ -1963,26 +2175,29 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "One Drive Folder Made And Deleted",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
-							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+								driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+							},
 						},
-						NextLink: &next,
-					},
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							delItem("folder", driveBasePath1, "root", false, true, false),
-							delItem("file", driveBasePath1, "root", true, false, false),
+						{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								delItem("folder", driveBasePath1, "root", false, true, false),
+								delItem("file", driveBasePath1, "root", true, false, false),
+							},
 						},
-						DeltaLink:  &delta2,
-						ResetDelta: true,
 					},
 				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {URL: delta2, Reset: true},
+				},
+				Err: map[string]error{driveID1: nil},
 			},
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
@@ -2008,25 +2223,28 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "One Drive Item Made And Deleted",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
-							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+								driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+							},
 						},
-						NextLink: &next,
-					},
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							delItem("file", driveBasePath1, "root", true, false, false),
+						{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								delItem("file", driveBasePath1, "root", true, false, false),
+							},
 						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
 					},
 				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {URL: delta, Reset: true},
+				},
+				Err: map[string]error{driveID1: nil},
 			},
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
@@ -2055,17 +2273,19 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "One Drive Random Folder Delete",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{Items: []models.DriveItemable{
 							driveRootItem("root"),
 							delItem("folder", driveBasePath1, "root", false, true, false),
-						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
+						}},
 					},
 				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {URL: delta, Reset: true},
+				},
+				Err: map[string]error{driveID1: nil},
 			},
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
@@ -2091,17 +2311,19 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "One Drive Random Item Delete",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{Items: []models.DriveItemable{
 							driveRootItem("root"),
 							delItem("file", driveBasePath1, "root", true, false, false),
-						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
+						}},
 					},
 				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {URL: delta, Reset: true},
+				},
+				Err: map[string]error{driveID1: nil},
 			},
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
@@ -2127,15 +2349,18 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "TwoPriorDrives_OneTombstoned",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
+			enumerator: mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+				Pages: map[string][]api.NextPage[models.DriveItemable]{
+					driveID1: {
+						{Items: []models.DriveItemable{
 							driveRootItem("root"), // will be present
-						},
-						DeltaLink: &delta,
+						}},
 					},
 				},
+				DeltaUpdate: map[string]api.DeltaUpdate{
+					driveID1: {URL: delta},
+				},
+				Err: map[string]error{driveID1: nil},
 			},
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
@@ -2170,18 +2395,9 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 				},
 			}
 
-			itemPagers := map[string]api.DeltaPager[models.DriveItemable]{}
-
-			for driveID := range test.items {
-				itemPagers[driveID] = &apiMock.DeltaPager[models.DriveItemable]{
-					ToReturn: test.items[driveID],
-				}
-			}
-
 			mbh := mock.DefaultOneDriveBH("a-user")
 			mbh.DrivePagerV = mockDrivePager
-			mbh.ItemPagerV = itemPagers
-			mbh.DriveItemEnumeration = mock.PagerResultToEDID(test.items)
+			mbh.DriveItemEnumeration = test.enumerator
 
 			c := NewCollections(
 				mbh,
@@ -2252,10 +2468,10 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 
 				collectionCount++
 
-				// TODO(ashmrtn): We should really be getting items in the collection
-				// via the Items() channel, but we don't have a way to mock out the
-				// actual item fetch yet (mostly wiring issues). The lack of that makes
-				// this check a bit more bittle since internal details can change.
+				// TODO: We should really be getting items in the collection
+				// via the Items() channel. The lack of that makes this check a bit more
+				// bittle since internal details can change.  The wiring to support
+				// mocked GetItems is available.  We just haven't plugged it in yet.
 				col, ok := baseCol.(*Collection)
 				require.True(t, ok, "getting onedrive.Collection handle")
 

--- a/src/internal/m365/collection/drive/handlers.go
+++ b/src/internal/m365/collection/drive/handlers.go
@@ -83,12 +83,9 @@ type GetItemer interface {
 type EnumerateDriveItemsDeltaer interface {
 	EnumerateDriveItemsDelta(
 		ctx context.Context,
+		ch chan<- api.NextPage[models.DriveItemable],
 		driveID, prevDeltaLink string,
-	) (
-		[]models.DriveItemable,
-		api.DeltaUpdate,
-		error,
-	)
+	) (api.DeltaUpdate, error)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/internal/m365/collection/drive/item_collector_test.go
+++ b/src/internal/m365/collection/drive/item_collector_test.go
@@ -149,8 +149,10 @@ func (suite *ItemCollectorUnitSuite) TestDrives() {
 					Err:      assert.AnError,
 				},
 			},
-			expectedErr:     assert.Error,
-			expectedResults: nil,
+			expectedErr: assert.Error,
+			// even though we error, the func will return both the
+			// error and the prior results
+			expectedResults: resultDrives,
 		},
 		{
 			name: "MySiteURLNotFound",

--- a/src/internal/m365/collection/drive/item_handler.go
+++ b/src/internal/m365/collection/drive/item_handler.go
@@ -134,9 +134,10 @@ func (h itemBackupHandler) IncludesDir(dir string) bool {
 
 func (h itemBackupHandler) EnumerateDriveItemsDelta(
 	ctx context.Context,
+	ch chan<- api.NextPage[models.DriveItemable],
 	driveID, prevDeltaLink string,
-) ([]models.DriveItemable, api.DeltaUpdate, error) {
-	return h.ac.EnumerateDriveItemsDelta(ctx, driveID, prevDeltaLink)
+) (api.DeltaUpdate, error) {
+	return h.ac.EnumerateDriveItemsDelta(ctx, ch, driveID, prevDeltaLink)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/internal/m365/collection/drive/library_handler.go
+++ b/src/internal/m365/collection/drive/library_handler.go
@@ -172,9 +172,10 @@ func (h libraryBackupHandler) IncludesDir(dir string) bool {
 
 func (h libraryBackupHandler) EnumerateDriveItemsDelta(
 	ctx context.Context,
+	ch chan<- api.NextPage[models.DriveItemable],
 	driveID, prevDeltaLink string,
-) ([]models.DriveItemable, api.DeltaUpdate, error) {
-	return h.ac.EnumerateDriveItemsDelta(ctx, driveID, prevDeltaLink)
+) (api.DeltaUpdate, error) {
+	return h.ac.EnumerateDriveItemsDelta(ctx, ch, driveID, prevDeltaLink)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/internal/m365/collection/drive/url_cache.go
+++ b/src/internal/m365/collection/drive/url_cache.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/str"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 const (
@@ -46,7 +47,7 @@ type urlCache struct {
 	refreshMu       sync.Mutex
 	deltaQueryCount int
 
-	edid EnumerateDriveItemsDeltaer
+	enumerator EnumerateDriveItemsDeltaer
 
 	errs *fault.Bus
 }
@@ -55,10 +56,10 @@ type urlCache struct {
 func newURLCache(
 	driveID, prevDelta string,
 	refreshInterval time.Duration,
-	edid EnumerateDriveItemsDeltaer,
+	enumerator EnumerateDriveItemsDeltaer,
 	errs *fault.Bus,
 ) (*urlCache, error) {
-	err := validateCacheParams(driveID, refreshInterval, edid)
+	err := validateCacheParams(driveID, refreshInterval, enumerator)
 	if err != nil {
 		return nil, clues.Wrap(err, "cache params")
 	}
@@ -67,7 +68,7 @@ func newURLCache(
 			idToProps:       make(map[string]itemProps),
 			lastRefreshTime: time.Time{},
 			driveID:         driveID,
-			edid:            edid,
+			enumerator:      enumerator,
 			prevDelta:       prevDelta,
 			refreshInterval: refreshInterval,
 			errs:            errs,
@@ -79,7 +80,7 @@ func newURLCache(
 func validateCacheParams(
 	driveID string,
 	refreshInterval time.Duration,
-	edid EnumerateDriveItemsDeltaer,
+	enumerator EnumerateDriveItemsDeltaer,
 ) error {
 	if len(driveID) == 0 {
 		return clues.New("drive id is empty")
@@ -89,8 +90,8 @@ func validateCacheParams(
 		return clues.New("invalid refresh interval")
 	}
 
-	if edid == nil {
-		return clues.New("nil item enumerator")
+	if enumerator == nil {
+		return clues.New("missing item enumerator")
 	}
 
 	return nil
@@ -156,16 +157,45 @@ func (uc *urlCache) refreshCache(
 	// Issue a delta query to graph
 	logger.Ctx(ctx).Info("refreshing url cache")
 
-	items, du, err := uc.edid.EnumerateDriveItemsDelta(ctx, uc.driveID, uc.prevDelta)
+	var (
+		ch       = make(chan api.NextPage[models.DriveItemable], 1)
+		cacheErr error
+		wg       = sync.WaitGroup{}
+	)
+
+	go func() {
+		defer wg.Done()
+
+		for pg := range ch {
+			if cacheErr != nil {
+				continue
+			}
+
+			uc.deltaQueryCount++
+
+			err := uc.updateCache(
+				ctx,
+				pg.Items,
+				pg.Reset,
+				uc.errs)
+			if err != nil {
+				cacheErr = clues.Wrap(err, "updating cache")
+			}
+		}
+	}()
+
+	wg.Add(1)
+
+	du, err := uc.enumerator.EnumerateDriveItemsDelta(ctx, ch, uc.driveID, uc.prevDelta)
 	if err != nil {
 		uc.idToProps = make(map[string]itemProps)
 		return clues.Stack(err)
 	}
 
-	uc.deltaQueryCount++
+	wg.Wait()
 
-	if err := uc.updateCache(ctx, items, uc.errs); err != nil {
-		return clues.Stack(err)
+	if cacheErr != nil {
+		return clues.Stack(cacheErr)
 	}
 
 	logger.Ctx(ctx).Info("url cache refreshed")
@@ -200,9 +230,14 @@ func (uc *urlCache) readCache(
 func (uc *urlCache) updateCache(
 	ctx context.Context,
 	items []models.DriveItemable,
+	reset bool,
 	errs *fault.Bus,
 ) error {
 	el := errs.Local()
+
+	if reset {
+		uc.idToProps = map[string]itemProps{}
+	}
 
 	for _, item := range items {
 		if el.Failure() != nil {

--- a/src/internal/m365/service/onedrive/mock/handlers.go
+++ b/src/internal/m365/service/onedrive/mock/handlers.go
@@ -8,23 +8,25 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/drives"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
-	"github.com/alcionai/corso/src/internal/common/ptr"
 	odConsts "github.com/alcionai/corso/src/internal/m365/service/onedrive/consts"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
-	apiMock "github.com/alcionai/corso/src/pkg/services/m365/api/mock"
 )
 
 // ---------------------------------------------------------------------------
 // Backup Handler
 // ---------------------------------------------------------------------------
 
-type BackupHandler struct {
+type BackupHandler[T any] struct {
 	ItemInfo details.ItemInfo
+	// FIXME: this is a hacky solution.  Better to use an interface
+	// and plug in the selector scope there.
+	Sel selectors.Selector
 
-	DriveItemEnumeration EnumeratesDriveItemsDelta
+	DriveItemEnumeration EnumeratesDriveItemsDelta[T]
 
 	GI  GetsItem
 	GIP GetsItemPermission
@@ -53,13 +55,17 @@ type BackupHandler struct {
 	GetErrs  []error
 }
 
-func DefaultOneDriveBH(resourceOwner string) *BackupHandler {
-	return &BackupHandler{
+func DefaultOneDriveBH(resourceOwner string) *BackupHandler[models.DriveItemable] {
+	sel := selectors.NewOneDriveBackup([]string{resourceOwner})
+	sel.Include(sel.AllData())
+
+	return &BackupHandler[models.DriveItemable]{
 		ItemInfo: details.ItemInfo{
 			OneDrive:  &details.OneDriveInfo{},
 			Extension: &details.ExtensionData{},
 		},
-		DriveItemEnumeration: EnumeratesDriveItemsDelta{},
+		Sel:                  sel.Selector,
+		DriveItemEnumeration: EnumeratesDriveItemsDelta[models.DriveItemable]{},
 		GI:                   GetsItem{Err: clues.New("not defined")},
 		GIP:                  GetsItemPermission{Err: clues.New("not defined")},
 		PathPrefixFn:         defaultOneDrivePathPrefixer,
@@ -74,12 +80,16 @@ func DefaultOneDriveBH(resourceOwner string) *BackupHandler {
 	}
 }
 
-func DefaultSharePointBH(resourceOwner string) *BackupHandler {
-	return &BackupHandler{
+func DefaultSharePointBH(resourceOwner string) *BackupHandler[models.DriveItemable] {
+	sel := selectors.NewOneDriveBackup([]string{resourceOwner})
+	sel.Include(sel.AllData())
+
+	return &BackupHandler[models.DriveItemable]{
 		ItemInfo: details.ItemInfo{
 			SharePoint: &details.SharePointInfo{},
 			Extension:  &details.ExtensionData{},
 		},
+		Sel:                  sel.Selector,
 		GI:                   GetsItem{Err: clues.New("not defined")},
 		GIP:                  GetsItemPermission{Err: clues.New("not defined")},
 		PathPrefixFn:         defaultSharePointPathPrefixer,
@@ -94,7 +104,7 @@ func DefaultSharePointBH(resourceOwner string) *BackupHandler {
 	}
 }
 
-func (h BackupHandler) PathPrefix(tID, driveID string) (path.Path, error) {
+func (h BackupHandler[T]) PathPrefix(tID, driveID string) (path.Path, error) {
 	pp, err := h.PathPrefixFn(tID, h.ResourceOwner, driveID)
 	if err != nil {
 		return nil, err
@@ -103,7 +113,7 @@ func (h BackupHandler) PathPrefix(tID, driveID string) (path.Path, error) {
 	return pp, h.PathPrefixErr
 }
 
-func (h BackupHandler) MetadataPathPrefix(tID string) (path.Path, error) {
+func (h BackupHandler[T]) MetadataPathPrefix(tID string) (path.Path, error) {
 	pp, err := h.MetadataPathPrefixFn(tID, h.ResourceOwner)
 	if err != nil {
 		return nil, err
@@ -112,7 +122,7 @@ func (h BackupHandler) MetadataPathPrefix(tID string) (path.Path, error) {
 	return pp, h.PathPrefixErr
 }
 
-func (h BackupHandler) CanonicalPath(pb *path.Builder, tID string) (path.Path, error) {
+func (h BackupHandler[T]) CanonicalPath(pb *path.Builder, tID string) (path.Path, error) {
 	cp, err := h.CanonPathFn(pb, tID, h.ResourceOwner)
 	if err != nil {
 		return nil, err
@@ -121,27 +131,32 @@ func (h BackupHandler) CanonicalPath(pb *path.Builder, tID string) (path.Path, e
 	return cp, h.CanonPathErr
 }
 
-func (h BackupHandler) ServiceCat() (path.ServiceType, path.CategoryType) {
+func (h BackupHandler[T]) ServiceCat() (path.ServiceType, path.CategoryType) {
 	return h.Service, h.Category
 }
 
-func (h BackupHandler) NewDrivePager(string, []string) api.Pager[models.Driveable] {
+func (h BackupHandler[T]) NewDrivePager(string, []string) api.Pager[models.Driveable] {
 	return h.DrivePagerV
 }
 
-func (h BackupHandler) FormatDisplayPath(_ string, pb *path.Builder) string {
+func (h BackupHandler[T]) FormatDisplayPath(_ string, pb *path.Builder) string {
 	return "/" + pb.String()
 }
 
-func (h BackupHandler) NewLocationIDer(driveID string, elems ...string) details.LocationIDer {
+func (h BackupHandler[T]) NewLocationIDer(driveID string, elems ...string) details.LocationIDer {
 	return h.LocationIDFn(driveID, elems...)
 }
 
-func (h BackupHandler) AugmentItemInfo(details.ItemInfo, models.DriveItemable, int64, *path.Builder) details.ItemInfo {
+func (h BackupHandler[T]) AugmentItemInfo(
+	details.ItemInfo,
+	models.DriveItemable,
+	int64,
+	*path.Builder,
+) details.ItemInfo {
 	return h.ItemInfo
 }
 
-func (h *BackupHandler) Get(context.Context, string, map[string]string) (*http.Response, error) {
+func (h *BackupHandler[T]) Get(context.Context, string, map[string]string) (*http.Response, error) {
 	c := h.getCall
 	h.getCall++
 
@@ -153,18 +168,23 @@ func (h *BackupHandler) Get(context.Context, string, map[string]string) (*http.R
 	return h.GetResps[c], h.GetErrs[c]
 }
 
-func (h BackupHandler) EnumerateDriveItemsDelta(
+func (h BackupHandler[T]) EnumerateDriveItemsDelta(
 	ctx context.Context,
+	ch chan<- api.NextPage[T],
 	driveID, prevDeltaLink string,
-) ([]models.DriveItemable, api.DeltaUpdate, error) {
-	return h.DriveItemEnumeration.EnumerateDriveItemsDelta(ctx, driveID, prevDeltaLink)
+) (api.DeltaUpdate, error) {
+	return h.DriveItemEnumeration.EnumerateDriveItemsDelta(
+		ctx,
+		ch,
+		driveID,
+		prevDeltaLink)
 }
 
-func (h BackupHandler) GetItem(ctx context.Context, _, _ string) (models.DriveItemable, error) {
+func (h BackupHandler[T]) GetItem(ctx context.Context, _, _ string) (models.DriveItemable, error) {
 	return h.GI.GetItem(ctx, "", "")
 }
 
-func (h BackupHandler) GetItemPermission(
+func (h BackupHandler[T]) GetItemPermission(
 	ctx context.Context,
 	_, _ string,
 ) (models.PermissionCollectionResponseable, error) {
@@ -238,12 +258,16 @@ var defaultSharePointLocationIDer = func(driveID string, elems ...string) detail
 	return details.NewSharePointLocationIDer(driveID, elems...)
 }
 
-func (h BackupHandler) IsAllPass() bool {
-	return true
+func (h BackupHandler[T]) IsAllPass() bool {
+	scope := h.Sel.Includes[0]
+	return selectors.IsAnyTarget(selectors.SharePointScope(scope), selectors.SharePointLibraryFolder) ||
+		selectors.IsAnyTarget(selectors.OneDriveScope(scope), selectors.OneDriveFolder)
 }
 
-func (h BackupHandler) IncludesDir(string) bool {
-	return true
+func (h BackupHandler[T]) IncludesDir(dir string) bool {
+	scope := h.Sel.Includes[0]
+	return selectors.SharePointScope(scope).Matches(selectors.SharePointLibraryFolder, dir) ||
+		selectors.OneDriveScope(scope).Matches(selectors.OneDriveFolder, dir)
 }
 
 // ---------------------------------------------------------------------------
@@ -266,59 +290,24 @@ func (m GetsItem) GetItem(
 // Enumerates Drive Items
 // ---------------------------------------------------------------------------
 
-type EnumeratesDriveItemsDelta struct {
-	Items       map[string][]models.DriveItemable
+type EnumeratesDriveItemsDelta[T any] struct {
+	Pages       map[string][]api.NextPage[T]
 	DeltaUpdate map[string]api.DeltaUpdate
 	Err         map[string]error
 }
 
-func (edi EnumeratesDriveItemsDelta) EnumerateDriveItemsDelta(
+func (edi EnumeratesDriveItemsDelta[T]) EnumerateDriveItemsDelta(
 	_ context.Context,
+	ch chan<- api.NextPage[T],
 	driveID, _ string,
-) (
-	[]models.DriveItemable,
-	api.DeltaUpdate,
-	error,
-) {
-	return edi.Items[driveID], edi.DeltaUpdate[driveID], edi.Err[driveID]
-}
+) (api.DeltaUpdate, error) {
+	defer close(ch)
 
-func PagerResultToEDID(
-	m map[string][]apiMock.PagerResult[models.DriveItemable],
-) EnumeratesDriveItemsDelta {
-	edi := EnumeratesDriveItemsDelta{
-		Items:       map[string][]models.DriveItemable{},
-		DeltaUpdate: map[string]api.DeltaUpdate{},
-		Err:         map[string]error{},
+	for _, page := range edi.Pages[driveID] {
+		ch <- page
 	}
 
-	for driveID, results := range m {
-		var (
-			err         error
-			items       = []models.DriveItemable{}
-			deltaUpdate api.DeltaUpdate
-		)
-
-		for _, pr := range results {
-			items = append(items, pr.Values...)
-
-			if pr.DeltaLink != nil {
-				deltaUpdate = api.DeltaUpdate{URL: ptr.Val(pr.DeltaLink)}
-			}
-
-			if pr.Err != nil {
-				err = pr.Err
-			}
-
-			deltaUpdate.Reset = deltaUpdate.Reset || pr.ResetDelta
-		}
-
-		edi.Items[driveID] = items
-		edi.Err[driveID] = err
-		edi.DeltaUpdate[driveID] = deltaUpdate
-	}
-
-	return edi
+	return edi.DeltaUpdate[driveID], edi.Err[driveID]
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/fault/fault.go
+++ b/src/pkg/fault/fault.go
@@ -384,20 +384,20 @@ func (pec printableErrCore) Values() []string {
 // funcs, and the function that spawned the local bus should always
 // return `local.Failure()` to ensure that hard failures are propagated
 // back upstream.
-func (e *Bus) Local() *LocalBus {
-	return &LocalBus{
+func (e *Bus) Local() *localBus {
+	return &localBus{
 		mu:  &sync.Mutex{},
 		bus: e,
 	}
 }
 
-type LocalBus struct {
+type localBus struct {
 	mu      *sync.Mutex
 	bus     *Bus
 	current error
 }
 
-func (e *LocalBus) AddRecoverable(ctx context.Context, err error) {
+func (e *localBus) AddRecoverable(ctx context.Context, err error) {
 	if err == nil {
 		return
 	}
@@ -412,6 +412,10 @@ func (e *LocalBus) AddRecoverable(ctx context.Context, err error) {
 	e.bus.logAndAddRecoverable(ctx, err, 1)
 }
 
+type AddSkipper interface {
+	AddSkip(ctx context.Context, s *Skipped)
+}
+
 // AddSkip appends a record of a Skipped item to the local bus.
 // Importantly, skipped items are not the same as recoverable
 // errors.  An item should only be skipped under the following
@@ -422,7 +426,7 @@ func (e *LocalBus) AddRecoverable(ctx context.Context, err error) {
 // 2. Skipping avoids a permanent and consistent failure.  If
 // the underlying reason is transient or otherwise recoverable,
 // the item should not be skipped.
-func (e *LocalBus) AddSkip(ctx context.Context, s *Skipped) {
+func (e *localBus) AddSkip(ctx context.Context, s *Skipped) {
 	if s == nil {
 		return
 	}
@@ -437,7 +441,7 @@ func (e *LocalBus) AddSkip(ctx context.Context, s *Skipped) {
 // It does not return the underlying bus.Failure(), only the failure
 // that was recorded within the local bus instance.  This error should
 // get returned by any func which created a local bus.
-func (e *LocalBus) Failure() error {
+func (e *localBus) Failure() error {
 	return e.current
 }
 

--- a/src/pkg/services/m365/api/channels_pager.go
+++ b/src/pkg/services/m365/api/channels_pager.go
@@ -227,7 +227,7 @@ func (c Channels) GetChannelMessageReplies(
 	ctx context.Context,
 	teamID, channelID, messageID string,
 ) ([]models.ChatMessageable, error) {
-	return enumerateItems[models.ChatMessageable](
+	return batchEnumerateItems[models.ChatMessageable](
 		ctx,
 		c.NewChannelMessageRepliesPager(teamID, channelID, messageID))
 }
@@ -284,5 +284,5 @@ func (c Channels) GetChannels(
 	ctx context.Context,
 	teamID string,
 ) ([]models.Channelable, error) {
-	return enumerateItems[models.Channelable](ctx, c.NewChannelPager(teamID))
+	return batchEnumerateItems[models.Channelable](ctx, c.NewChannelPager(teamID))
 }

--- a/src/pkg/services/m365/api/contacts_pager.go
+++ b/src/pkg/services/m365/api/contacts_pager.go
@@ -84,7 +84,7 @@ func (c Contacts) EnumerateContainers(
 		pgr = c.NewContactFoldersPager(userID, baseContainerID, immutableIDs)
 	)
 
-	containers, err := enumerateItems(ctx, pgr)
+	containers, err := batchEnumerateItems(ctx, pgr)
 	if err != nil {
 		return graph.Stack(ctx, err)
 	}
@@ -165,7 +165,7 @@ func (c Contacts) GetItemsInContainerByCollisionKey(
 	ctx = clues.Add(ctx, "container_id", containerID)
 	pager := c.NewContactsPager(userID, containerID, false, contactCollisionKeyProps()...)
 
-	items, err := enumerateItems(ctx, pager)
+	items, err := batchEnumerateItems(ctx, pager)
 	if err != nil {
 		return nil, graph.Wrap(ctx, err, "enumerating contacts")
 	}
@@ -186,7 +186,7 @@ func (c Contacts) GetItemIDsInContainer(
 	ctx = clues.Add(ctx, "container_id", containerID)
 	pager := c.NewContactsPager(userID, containerID, false, idAnd()...)
 
-	items, err := enumerateItems(ctx, pager)
+	items, err := batchEnumerateItems(ctx, pager)
 	if err != nil {
 		return nil, graph.Wrap(ctx, err, "enumerating contacts")
 	}

--- a/src/pkg/services/m365/api/events_pager.go
+++ b/src/pkg/services/m365/api/events_pager.go
@@ -85,7 +85,7 @@ func (c Events) EnumerateContainers(
 		pgr = c.NewEventCalendarsPager(userID, immutableIDs)
 	)
 
-	containers, err := enumerateItems(ctx, pgr)
+	containers, err := batchEnumerateItems(ctx, pgr)
 	if err != nil {
 		return graph.Stack(ctx, err)
 	}
@@ -169,7 +169,7 @@ func (c Events) GetItemsInContainerByCollisionKey(
 	ctx = clues.Add(ctx, "container_id", containerID)
 	pager := c.NewEventsPager(userID, containerID, false, eventCollisionKeyProps()...)
 
-	items, err := enumerateItems(ctx, pager)
+	items, err := batchEnumerateItems(ctx, pager)
 	if err != nil {
 		return nil, graph.Wrap(ctx, err, "enumerating events")
 	}
@@ -190,7 +190,7 @@ func (c Events) GetItemIDsInContainer(
 	ctx = clues.Add(ctx, "container_id", containerID)
 	pager := c.NewEventsPager(userID, containerID, false, idAnd()...)
 
-	items, err := enumerateItems(ctx, pager)
+	items, err := batchEnumerateItems(ctx, pager)
 	if err != nil {
 		return nil, graph.Wrap(ctx, err, "enumerating events")
 	}

--- a/src/pkg/services/m365/api/item_pager.go
+++ b/src/pkg/services/m365/api/item_pager.go
@@ -27,6 +27,15 @@ type DeltaUpdate struct {
 	Reset bool
 }
 
+type NextPage[T any] struct {
+	Items []T
+	// Reset is only true on the iteration where the delta pager's Reset()
+	// is called.  Callers can use it to reset any data aggregation they
+	// currently use.  After that loop, it will be false again, though the
+	// DeltaUpdate will still contain the expected value.
+	Reset bool
+}
+
 // ---------------------------------------------------------------------------
 // common interfaces
 // ---------------------------------------------------------------------------
@@ -100,7 +109,10 @@ type Pager[T any] interface {
 func enumerateItems[T any](
 	ctx context.Context,
 	pager Pager[T],
-) ([]T, error) {
+	ch chan<- NextPage[T],
+) error {
+	defer close(ch)
+
 	var (
 		result = make([]T, 0)
 		// stubbed initial value to ensure we enter the loop.
@@ -111,10 +123,11 @@ func enumerateItems[T any](
 		// get the next page of data, check for standard errors
 		page, err := pager.GetPage(ctx)
 		if err != nil {
-			return nil, graph.Stack(ctx, err)
+			return graph.Stack(ctx, err)
 		}
 
-		result = append(result, page.GetValue()...)
+		ch <- NextPage[T]{Items: page.GetValue()}
+
 		nextLink = NextLink(page)
 
 		pager.SetNextLink(nextLink)
@@ -122,7 +135,27 @@ func enumerateItems[T any](
 
 	logger.Ctx(ctx).Infow("completed delta item enumeration", "result_count", len(result))
 
-	return result, nil
+	return nil
+}
+
+func batchEnumerateItems[T any](
+	ctx context.Context,
+	pager Pager[T],
+) ([]T, error) {
+	var (
+		ch      = make(chan NextPage[T])
+		results = []T{}
+	)
+
+	go func() {
+		for np := range ch {
+			results = append(results, np.Items...)
+		}
+	}()
+
+	err := enumerateItems[T](ctx, pager, ch)
+
+	return results, clues.Stack(err).OrNil()
 }
 
 // ---------------------------------------------------------------------------
@@ -136,11 +169,19 @@ type DeltaPager[T any] interface {
 	ValidModTimer
 }
 
+// enumerates pages of items, streaming each page to the provided channel.
+// the DeltaUpdate, reset notifications, and any errors are also fed to the
+// same channel.
+// Returns false if conditions disallow making delta calls for the provided
+// pager.  Returns true otherwise, even in the event of an error.
 func deltaEnumerateItems[T any](
 	ctx context.Context,
 	pager DeltaPager[T],
+	ch chan<- NextPage[T],
 	prevDeltaLink string,
-) ([]T, DeltaUpdate, error) {
+) (DeltaUpdate, error) {
+	defer close(ch)
+
 	var (
 		result = make([]T, 0)
 		// stubbed initial value to ensure we enter the loop.
@@ -154,26 +195,30 @@ func deltaEnumerateItems[T any](
 		page, err := pager.GetPage(graph.ConsumeNTokens(ctx, graph.SingleGetOrDeltaLC))
 		if graph.IsErrDeltaNotSupported(err) {
 			logger.Ctx(ctx).Infow("delta queries not supported")
-			return nil, DeltaUpdate{}, clues.Stack(graph.ErrDeltaNotSupported, err)
+
+			pager.Reset(ctx)
+			ch <- NextPage[T]{Reset: true}
+
+			return DeltaUpdate{}, clues.Stack(err)
 		}
 
 		if graph.IsErrInvalidDelta(err) {
 			logger.Ctx(ctx).Infow("invalid previous delta", "delta_link", prevDeltaLink)
 
 			invalidPrevDelta = true
-			result = make([]T, 0)
 
 			// Reset tells the pager to try again after ditching its delta history.
 			pager.Reset(ctx)
+			ch <- NextPage[T]{Reset: true}
 
 			continue
 		}
 
 		if err != nil {
-			return nil, DeltaUpdate{}, graph.Wrap(ctx, err, "retrieving page")
+			return DeltaUpdate{}, clues.Stack(err)
 		}
 
-		result = append(result, page.GetValue()...)
+		ch <- NextPage[T]{Items: page.GetValue()}
 
 		nl, deltaLink := NextAndDeltaLink(page)
 		if len(deltaLink) > 0 {
@@ -191,7 +236,32 @@ func deltaEnumerateItems[T any](
 		Reset: invalidPrevDelta,
 	}
 
-	return result, du, nil
+	return du, nil
+}
+
+func batchDeltaEnumerateItems[T any](
+	ctx context.Context,
+	pager DeltaPager[T],
+	prevDeltaLink string,
+) ([]T, DeltaUpdate, error) {
+	var (
+		ch      = make(chan NextPage[T])
+		results = []T{}
+	)
+
+	go func() {
+		for np := range ch {
+			if np.Reset {
+				results = []T{}
+			}
+
+			results = append(results, np.Items...)
+		}
+	}()
+
+	du, err := deltaEnumerateItems[T](ctx, pager, ch, prevDeltaLink)
+
+	return results, du, clues.Stack(err).OrNil()
 }
 
 // ---------------------------------------------------------------------------
@@ -209,7 +279,7 @@ func getAddedAndRemovedItemIDs[T any](
 	aarh addedAndRemovedHandler[T],
 ) (map[string]time.Time, bool, []string, DeltaUpdate, error) {
 	if canMakeDeltaQueries {
-		ts, du, err := deltaEnumerateItems[T](ctx, deltaPager, prevDeltaLink)
+		ts, du, err := batchDeltaEnumerateItems[T](ctx, deltaPager, prevDeltaLink)
 		if err != nil && !graph.IsErrInvalidDelta(err) && !graph.IsErrDeltaNotSupported(err) {
 			return nil, false, nil, DeltaUpdate{}, graph.Stack(ctx, err)
 		}
@@ -222,7 +292,7 @@ func getAddedAndRemovedItemIDs[T any](
 
 	du := DeltaUpdate{Reset: true}
 
-	ts, err := enumerateItems(ctx, pager)
+	ts, err := batchEnumerateItems(ctx, pager)
 	if err != nil {
 		return nil, false, nil, DeltaUpdate{}, graph.Stack(ctx, err)
 	}

--- a/src/pkg/services/m365/api/item_pager_test.go
+++ b/src/pkg/services/m365/api/item_pager_test.go
@@ -245,7 +245,7 @@ func (suite *PagerUnitSuite) TestEnumerateItems() {
 					pageErr: assert.AnError,
 				}
 			},
-			expect:    nil,
+			expect:    []any{},
 			expectErr: require.Error,
 		},
 	}
@@ -257,7 +257,7 @@ func (suite *PagerUnitSuite) TestEnumerateItems() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			result, err := enumerateItems(ctx, test.getPager(t, ctx))
+			result, err := batchEnumerateItems(ctx, test.getPager(t, ctx))
 			test.expectErr(t, err, clues.ToCore(err))
 
 			require.EqualValues(t, test.expect, result)

--- a/src/pkg/services/m365/api/mail_pager.go
+++ b/src/pkg/services/m365/api/mail_pager.go
@@ -81,7 +81,7 @@ func (c Mail) EnumerateContainers(
 		pgr = c.NewMailFoldersPager(userID, immutableIDs)
 	)
 
-	containers, err := enumerateItems(ctx, pgr)
+	containers, err := batchEnumerateItems(ctx, pgr)
 	if err != nil {
 		return graph.Stack(ctx, err)
 	}
@@ -162,7 +162,7 @@ func (c Mail) GetItemsInContainerByCollisionKey(
 	ctx = clues.Add(ctx, "container_id", containerID)
 	pager := c.NewMailPager(userID, containerID, false, mailCollisionKeyProps()...)
 
-	items, err := enumerateItems(ctx, pager)
+	items, err := batchEnumerateItems(ctx, pager)
 	if err != nil {
 		return nil, graph.Wrap(ctx, err, "enumerating mails")
 	}
@@ -183,7 +183,7 @@ func (c Mail) GetItemIDsInContainer(
 	ctx = clues.Add(ctx, "container_id", containerID)
 	pager := c.NewMailPager(userID, containerID, false, idAnd()...)
 
-	items, err := enumerateItems(ctx, pager)
+	items, err := batchEnumerateItems(ctx, pager)
 	if err != nil {
 		return nil, graph.Wrap(ctx, err, "enumerating mails")
 	}


### PR DESCRIPTION
corrects the prior PRs full-scale batching of driveItems by adding a channel to the api layer's enumerateItems and driveEnumerateItems funcs.  To avoid changes
in most parts of code, also adds batch wrappers
that hide these changes from existing pager usage.

DriveItem collection processing now ranges over
a channel of pager results, allowing it to process pages in a stream rather than batching all items.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
