### PR TITLE
Backup/Restore/Export multiples sites in Groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduce backup runtime for OneDrive and SharePoint incremental backups that have no file changes.
 - Increase Exchange backup performance by lazily fetching data only for items whose content changed.
 - Added `--backups` flag to delete multiple backups in `corso backup delete` command.
+- We no backup all sites that belongs to a team and not just the root site.
 
 ## Fixed
 - Teams Channels that cannot support delta tokens (those without messages) fall back to non-delta enumeration and no longer fail a backup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduce backup runtime for OneDrive and SharePoint incremental backups that have no file changes.
 - Increase Exchange backup performance by lazily fetching data only for items whose content changed.
 - Added `--backups` flag to delete multiple backups in `corso backup delete` command.
-- We no backup all sites that belongs to a team and not just the root site.
+- Backup now includes all sites that belongs to a team, not just the root site.
 
 ## Fixed
 - Teams Channels that cannot support delta tokens (those without messages) fall back to non-delta enumeration and no longer fail a backup.

--- a/src/cli/flags/testdata/backup_list.go
+++ b/src/cli/flags/testdata/backup_list.go
@@ -3,9 +3,10 @@ package testdata
 import (
 	"testing"
 
-	"github.com/alcionai/corso/src/cli/flags"
 	"github.com/spf13/cobra"
 	"gotest.tools/v3/assert"
+
+	"github.com/alcionai/corso/src/cli/flags"
 )
 
 func PreparedBackupListFlags() []string {

--- a/src/internal/m365/graph/errors.go
+++ b/src/internal/m365/graph/errors.go
@@ -70,6 +70,7 @@ const (
 	NoSPLicense                     errorMessage = "Tenant does not have a SPO license"
 	parameterDeltaTokenNotSupported errorMessage = "Parameter 'DeltaToken' not supported for this request"
 	usersCannotBeResolved           errorMessage = "One or more users could not be resolved"
+	siteCouldNotBeFound             errorMessage = "Requested site could not be found"
 )
 
 const (
@@ -257,6 +258,10 @@ func IsErrFolderExists(err error) bool {
 
 func IsErrUsersCannotBeResolved(err error) bool {
 	return hasErrorCode(err, noResolvedUsers) || hasErrorMessage(err, usersCannotBeResolved)
+}
+
+func IsErrSiteCouldNotBeFound(err error) bool {
+	return hasErrorMessage(err, siteCouldNotBeFound)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/internal/m365/graph/errors.go
+++ b/src/internal/m365/graph/errors.go
@@ -70,7 +70,7 @@ const (
 	NoSPLicense                     errorMessage = "Tenant does not have a SPO license"
 	parameterDeltaTokenNotSupported errorMessage = "Parameter 'DeltaToken' not supported for this request"
 	usersCannotBeResolved           errorMessage = "One or more users could not be resolved"
-	siteCouldNotBeFound             errorMessage = "Requested site could not be found"
+	requestedSiteCouldNotBeFound    errorMessage = "Requested site could not be found"
 )
 
 const (
@@ -260,8 +260,8 @@ func IsErrUsersCannotBeResolved(err error) bool {
 	return hasErrorCode(err, noResolvedUsers) || hasErrorMessage(err, usersCannotBeResolved)
 }
 
-func IsErrSiteCouldNotBeFound(err error) bool {
-	return hasErrorMessage(err, siteCouldNotBeFound)
+func IsErrSiteNotFound(err error) bool {
+	return hasErrorMessage(err, requestedSiteCouldNotBeFound)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/internal/m365/graph/errors_test.go
+++ b/src/internal/m365/graph/errors_test.go
@@ -651,24 +651,24 @@ func (suite *GraphErrorsUnitSuite) TestIsErrSiteCouldNotBeFound() {
 		},
 		{
 			name:   "matching oDataErr msg",
-			err:    odErrMsg("InvalidRequest", string(siteCouldNotBeFound)),
+			err:    odErrMsg("InvalidRequest", string(requestedSiteCouldNotBeFound)),
 			expect: assert.True,
 		},
 		// next two tests are to make sure the checks are case insensitive
 		{
 			name:   "oDataErr uppercase",
-			err:    odErrMsg("InvalidRequest", strings.ToUpper(string(siteCouldNotBeFound))),
+			err:    odErrMsg("InvalidRequest", strings.ToUpper(string(requestedSiteCouldNotBeFound))),
 			expect: assert.True,
 		},
 		{
 			name:   "oDataErr lowercase",
-			err:    odErrMsg("InvalidRequest", strings.ToLower(string(siteCouldNotBeFound))),
+			err:    odErrMsg("InvalidRequest", strings.ToLower(string(requestedSiteCouldNotBeFound))),
 			expect: assert.True,
 		},
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			test.expect(suite.T(), IsErrSiteCouldNotBeFound(test.err))
+			test.expect(suite.T(), IsErrSiteNotFound(test.err))
 		})
 	}
 }

--- a/src/internal/m365/graph/errors_test.go
+++ b/src/internal/m365/graph/errors_test.go
@@ -628,6 +628,51 @@ func (suite *GraphErrorsUnitSuite) TestIsErrUsersCannotBeResolved() {
 	}
 }
 
+func (suite *GraphErrorsUnitSuite) TestIsErrSiteCouldNotBeFound() {
+	table := []struct {
+		name   string
+		err    error
+		expect assert.BoolAssertionFunc
+	}{
+		{
+			name:   "nil",
+			err:    nil,
+			expect: assert.False,
+		},
+		{
+			name:   "non-matching",
+			err:    assert.AnError,
+			expect: assert.False,
+		},
+		{
+			name:   "non-matching oDataErr",
+			err:    odErrMsg("InvalidRequest", "cant resolve sites"),
+			expect: assert.False,
+		},
+		{
+			name:   "matching oDataErr msg",
+			err:    odErrMsg("InvalidRequest", string(siteCouldNotBeFound)),
+			expect: assert.True,
+		},
+		// next two tests are to make sure the checks are case insensitive
+		{
+			name:   "oDataErr uppercase",
+			err:    odErrMsg("InvalidRequest", strings.ToUpper(string(siteCouldNotBeFound))),
+			expect: assert.True,
+		},
+		{
+			name:   "oDataErr lowercase",
+			err:    odErrMsg("InvalidRequest", strings.ToLower(string(siteCouldNotBeFound))),
+			expect: assert.True,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			test.expect(suite.T(), IsErrSiteCouldNotBeFound(test.err))
+		})
+	}
+}
+
 func (suite *GraphErrorsUnitSuite) TestIsErrCannotOpenFileAttachment() {
 	table := []struct {
 		name   string

--- a/src/internal/m365/restore.go
+++ b/src/internal/m365/restore.go
@@ -84,6 +84,7 @@ func (ctrl *Controller) ConsumeRestoreCollections(
 			rcc,
 			ctrl.AC,
 			ctrl.backupDriveIDNames,
+			ctrl.backupSiteIDWebURL,
 			dcs,
 			deets,
 			errs,

--- a/src/internal/m365/service/groups/backup.go
+++ b/src/internal/m365/service/groups/backup.go
@@ -129,6 +129,9 @@ func ProduceBackupCollections(
 				}
 
 				dbcs = append(dbcs, cs...)
+
+				// FIXME(meain): This can cause incorrect backup
+				// https://github.com/alcionai/corso/issues/4371
 				canUsePreviousBackup = canUsePreviousBackup || cupb
 			}
 

--- a/src/internal/m365/service/groups/restore.go
+++ b/src/internal/m365/service/groups/restore.go
@@ -78,7 +78,7 @@ func ConsumeRestoreCollections(
 			// deleted, skip that site with a warning.
 			siteName, ok := siteNames[webURL]
 			if !ok {
-				site, err := ac.Sites().GetByID(ctx, webURL)
+				site, err := ac.Sites().GetByID(ctx, webURL, api.CallConfig{})
 				if err != nil {
 					siteNames[webURL] = ""
 

--- a/src/internal/m365/service/groups/restore.go
+++ b/src/internal/m365/service/groups/restore.go
@@ -5,13 +5,13 @@ import (
 	"errors"
 
 	"github.com/alcionai/clues"
-	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
 	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive"
+	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/m365/support"
 	"github.com/alcionai/corso/src/internal/operations/inject"
 	"github.com/alcionai/corso/src/pkg/backup/details"
@@ -29,6 +29,7 @@ func ConsumeRestoreCollections(
 	rcc inject.RestoreConsumerConfig,
 	ac api.Client,
 	backupDriveIDNames idname.Cacher,
+	backupSiteIDWebURL idname.Cacher,
 	dcs []data.RestoreCollection,
 	deets *details.Builder,
 	errs *fault.Bus,
@@ -39,13 +40,8 @@ func ConsumeRestoreCollections(
 		caches         = drive.NewRestoreCaches(backupDriveIDNames)
 		lrh            = drive.NewLibraryRestoreHandler(ac, rcc.Selector.PathService())
 		el             = errs.Local()
+		siteNames      = map[string]string{}
 	)
-
-	// TODO: uncomment when a handler is available
-	// err := caches.Populate(ctx, lrh, rcc.ProtectedResource.ID())
-	// if err != nil {
-	// 	return nil, clues.Wrap(err, "initializing restore caches")
-	// }
 
 	// Reorder collections so that the parents directories are created
 	// before the child directories; a requirement for permissions.
@@ -59,7 +55,6 @@ func ConsumeRestoreCollections(
 
 		var (
 			err      error
-			resp     models.Siteable
 			category = dc.FullPath().Category()
 			metrics  support.CollectionMetrics
 			ictx     = clues.Add(ctx,
@@ -71,16 +66,47 @@ func ConsumeRestoreCollections(
 
 		switch dc.FullPath().Category() {
 		case path.LibrariesCategory:
-			// TODO(meain): As of now we only restore the root site
-			// and that too to whatever is currently the root site of the
-			// group and not the original one. Not sure if the
-			// original can be changed.
-			resp, err = ac.Groups().GetRootSite(ctx, rcc.ProtectedResource.ID())
-			if err != nil {
-				return nil, err
+			siteID := dc.FullPath().Folders()[1]
+
+			webURL, ok := backupSiteIDWebURL.NameOf(siteID)
+			if !ok {
+				// This should not happen, but just in case
+				logger.Ctx(ctx).With("site_id", siteID).Info("site weburl not found, using site id")
 			}
 
-			pr := idname.NewProvider(ptr.Val(resp.GetId()), ptr.Val(resp.GetName()))
+			// In case a site that we had previously backed up was
+			// deleted, skip that site with a warning.
+			siteName, ok := siteNames[webURL]
+			if !ok {
+				site, err := ac.Sites().GetByID(ctx, webURL)
+				if err != nil {
+					siteNames[webURL] = ""
+
+					if graph.IsErrSiteCouldNotBeFound(err) {
+						// TODO(meain): Should we surface this to the user somehow?
+						logger.Ctx(ctx).With("web_url", webURL, "site_id", siteID).
+							Info("Site does not exist, skipping restore.")
+					} else {
+						el.AddRecoverable(ctx, clues.Wrap(err, "getting site").
+							With("web_url", webURL, "site_id", siteID))
+					}
+
+					continue
+				}
+
+				// `/sites` sends `displayName` as name, but
+				// `/sites/<site-id>` send base of `webURL` as name
+				siteName = ptr.Val(site.GetDisplayName())
+				siteNames[webURL] = siteName
+			}
+
+			if ok && len(siteName) == 0 {
+				// We have previously seen it but the site was
+				// unavailable
+				continue
+			}
+
+			pr := idname.NewProvider(siteID, siteName)
 			srcc := inject.RestoreConsumerConfig{
 				BackupVersion:     rcc.BackupVersion,
 				Options:           rcc.Options,

--- a/src/internal/m365/service/groups/restore.go
+++ b/src/internal/m365/service/groups/restore.go
@@ -78,7 +78,7 @@ func ConsumeRestoreCollections(
 			// deleted, skip that site with a warning.
 			siteName, ok := siteNames[webURL]
 			if !ok {
-				site, err := ac.Sites().GetByID(ctx, webURL, api.CallConfig{})
+				site, err := ac.Sites().GetByID(ctx, siteID, api.CallConfig{})
 				if err != nil {
 					siteNames[webURL] = ""
 

--- a/src/internal/m365/service/groups/restore.go
+++ b/src/internal/m365/service/groups/restore.go
@@ -94,8 +94,6 @@ func ConsumeRestoreCollections(
 					continue
 				}
 
-				// `/sites` sends `displayName` as name, but
-				// `/sites/<site-id>` send base of `webURL` as name
 				siteName = ptr.Val(site.GetDisplayName())
 				siteNames[webURL] = siteName
 			}

--- a/src/internal/m365/service/groups/restore_test.go
+++ b/src/internal/m365/service/groups/restore_test.go
@@ -52,6 +52,7 @@ func (suite *GroupsUnitSuite) TestConsumeRestoreCollections_noErrorOnGroups() {
 		rcc,
 		api.Client{},
 		idname.NewCache(map[string]string{}),
+		idname.NewCache(map[string]string{}),
 		dcs,
 		nil,
 		fault.New(false),

--- a/src/internal/m365/service/groups/restore_test.go
+++ b/src/internal/m365/service/groups/restore_test.go
@@ -7,12 +7,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/exp/slices"
 
 	"github.com/alcionai/corso/src/internal/common/idname"
+	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/data/mock"
+	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/operations/inject"
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
@@ -58,4 +63,112 @@ func (suite *GroupsUnitSuite) TestConsumeRestoreCollections_noErrorOnGroups() {
 		fault.New(false),
 		nil)
 	assert.NoError(t, err, "Groups Channels restore")
+}
+
+type groupsIntegrationSuite struct {
+	tester.Suite
+	resource string
+	tenantID string
+	ac       api.Client
+}
+
+func TestGroupsIntegrationSuite(t *testing.T) {
+	suite.Run(t, &groupsIntegrationSuite{
+		Suite: tester.NewIntegrationSuite(
+			t,
+			[][]string{tconfig.M365AcctCredEnvs}),
+	})
+}
+
+func (suite *groupsIntegrationSuite) SetupSuite() {
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	graph.InitializeConcurrencyLimiter(ctx, true, 4)
+
+	suite.resource = tconfig.M365TeamID(t)
+
+	acct := tconfig.NewM365Account(t)
+	creds, err := acct.M365Config()
+	require.NoError(t, err, clues.ToCore(err))
+
+	suite.ac, err = api.NewClient(creds, control.DefaultOptions())
+	require.NoError(t, err, clues.ToCore(err))
+
+	suite.tenantID = creds.AzureTenantID
+}
+
+// test for getSiteName
+func (suite *groupsIntegrationSuite) TestGetSiteName() {
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	rootSite, err := suite.ac.Groups().GetRootSite(ctx, suite.resource)
+	require.NoError(t, err, clues.ToCore(err))
+
+	// Generate a fake site ID that appears valid to graph API but doesn't actually exist.
+	// This "could" be flaky, but highly unlikely
+	unavailableSiteID := []rune(ptr.Val(rootSite.GetId()))
+	firstIDChar := slices.Index(unavailableSiteID, ',') + 1
+
+	if unavailableSiteID[firstIDChar] != '2' {
+		unavailableSiteID[firstIDChar] = '2'
+	} else {
+		unavailableSiteID[firstIDChar] = '1'
+	}
+
+	tests := []struct {
+		name              string
+		siteID            string
+		webURL            string
+		siteName          string
+		webURLToSiteNames map[string]string
+		expectErr         assert.ErrorAssertionFunc
+	}{
+		{
+			name:              "valid",
+			siteID:            ptr.Val(rootSite.GetId()),
+			webURL:            ptr.Val(rootSite.GetWebUrl()),
+			siteName:          *rootSite.GetDisplayName(),
+			webURLToSiteNames: map[string]string{},
+			expectErr:         assert.NoError,
+		},
+		{
+			name:              "unavailable",
+			siteID:            string(unavailableSiteID),
+			webURL:            "https://does-not-matter",
+			siteName:          "",
+			webURLToSiteNames: map[string]string{},
+			expectErr:         assert.NoError,
+		},
+		{
+			name:              "previously found",
+			siteID:            "random-id",
+			webURL:            "https://random-url",
+			siteName:          "random-name",
+			webURLToSiteNames: map[string]string{"https://random-url": "random-name"},
+			expectErr:         assert.NoError,
+		},
+	}
+
+	for _, test := range tests {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			siteName, err := getSiteName(
+				ctx,
+				test.siteID,
+				test.webURL,
+				suite.ac.Sites(),
+				test.webURLToSiteNames)
+			require.NoError(t, err, clues.ToCore(err))
+
+			test.expectErr(t, err)
+			assert.Equal(t, test.siteName, siteName)
+		})
+	}
 }

--- a/src/internal/operations/test/onedrive_test.go
+++ b/src/internal/operations/test/onedrive_test.go
@@ -762,11 +762,10 @@ func runDriveIncrementalTest(
 				true)
 
 			// do some additional checks to ensure the incremental dealt with fewer items.
-			// +2 on read/writes to account for metadata: 1 delta and 1 path.
 			var (
-				expectWrites        = test.itemsWritten + 2
+				expectWrites        = test.itemsWritten
 				expectNonMetaWrites = test.nonMetaItemsWritten
-				expectReads         = test.itemsRead + 2
+				expectReads         = test.itemsRead
 				assertReadWrite     = assert.Equal
 			)
 
@@ -775,6 +774,17 @@ func runDriveIncrementalTest(
 				// /libraries/sites/previouspath
 				expectWrites++
 				expectReads++
+
+				// +2 on read/writes to account for metadata: 1 delta and 1 path (for each site)
+				sites, err := ac.Groups().GetAllSites(ctx, owner, fault.New(true))
+				require.NoError(t, err, clues.ToCore(err))
+
+				expectWrites += len(sites) * 2
+				expectReads += len(sites) * 2
+			} else {
+				// +2 on read/writes to account for metadata: 1 delta and 1 path.
+				expectWrites += 2
+				expectReads += 2
 			}
 
 			// Sharepoint can produce a superset of permissions by nature of

--- a/src/pkg/services/m365/api/groups.go
+++ b/src/pkg/services/m365/api/groups.go
@@ -165,12 +165,12 @@ func (c Groups) GetAllSites(
 ) ([]models.Siteable, error) {
 	root, err := c.GetRootSite(ctx, identifier)
 	if err != nil {
-		return nil, clues.Wrap(err, "getting channels")
+		return nil, clues.Wrap(err, "getting root site")
 	}
 
 	sites := []models.Siteable{root}
 
-	channels, err := Channels{c.Client}.GetChannels(ctx, identifier)
+	channels, err := Channels(c).GetChannels(ctx, identifier)
 	if err != nil {
 		return nil, clues.Wrap(err, "getting channels")
 	}
@@ -208,7 +208,7 @@ func (c Groups) GetAllSites(
 		dwurlSplits := strings.Split(documentWebURL, "/")
 		siteWebURL := strings.Join(dwurlSplits[:5], "/")
 
-		site, err := Sites{c.Client}.GetByID(ctx, siteWebURL)
+		site, err := Sites(c).GetByID(ctx, siteWebURL, CallConfig{})
 		if err != nil {
 			// TODO(meain): should this be a recoverable error?
 			return nil, clues.Wrap(err, "getting site").

--- a/src/pkg/services/m365/api/groups.go
+++ b/src/pkg/services/m365/api/groups.go
@@ -154,6 +154,23 @@ func (c Groups) GetByID(
 	return group, nil
 }
 
+// GetAllSites gets all the sites that belong to a group. This is
+// necessary as private and shared channels gets their on individual
+// sites. All the other channels make use of the root site.
+func (c Groups) GetAllSites(
+	ctx context.Context,
+	identifier string,
+	errs *fault.Bus,
+) ([]models.Siteable, error) {
+	// TODO(meain): Get all sites belonging to the group
+	root, err := c.GetRootSite(ctx, identifier)
+	if err != nil {
+		return nil, err
+	}
+
+	return []models.Siteable{root}, nil
+}
+
 func (c Groups) GetRootSite(
 	ctx context.Context,
 	identifier string,

--- a/src/pkg/services/m365/api/groups_test.go
+++ b/src/pkg/services/m365/api/groups_test.go
@@ -110,6 +110,33 @@ func (suite *GroupsIntgSuite) TestGetAll() {
 	require.NotZero(t, len(groups), "must have at least one group")
 }
 
+func (suite *GroupsIntgSuite) TestGetAllSites() {
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	channels, err := suite.its.ac.
+		Channels().GetChannels(ctx, suite.its.group.id)
+	require.NoError(t, err, "getting channels")
+	require.NotZero(t, len(channels), "must have at least one channel")
+
+	siteCount := 1
+
+	for _, c := range channels {
+		if ptr.Val(c.GetMembershipType()) != models.STANDARD_CHANNELMEMBERSHIPTYPE {
+			siteCount++
+		}
+	}
+
+	sites, err := suite.its.ac.
+		Groups().
+		GetAllSites(ctx, suite.its.group.id, fault.New(true))
+	require.NoError(t, err)
+	require.NotZero(t, len(sites), "must have at least one site")
+	require.Equal(t, siteCount, len(sites), "incorrect number of sites")
+}
+
 func (suite *GroupsIntgSuite) TestGroups_GetByID() {
 	t := suite.T()
 

--- a/src/pkg/services/m365/api/sites.go
+++ b/src/pkg/services/m365/api/sites.go
@@ -142,6 +142,8 @@ func (c Sites) GetByID(
 			options.QueryParameters.Expand = cc.Expand
 		}
 
+		// NOTE: `/sites` sends `displayName` as name, but
+		// `/sites/<site-id>` send base of `webURL` as name
 		resp, err = c.Stable.
 			Client().
 			Sites().


### PR DESCRIPTION
I've updated the Team used in the CI to include private and shared channels. Sanity tests should ideally do the e2e tests for multi site backups.

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
