### PR TITLE
quick cleanup before next step

### DIFF
--- a/src/cli/backup/backup.go
+++ b/src/cli/backup/backup.go
@@ -265,10 +265,7 @@ func genericDeleteCommand(
 
 	ctx := clues.Add(cmd.Context(), "delete_backup_id", bID)
 
-	r, _, _, _, err := utils.GetAccountAndConnectWithOverrides(
-		ctx,
-		cmd,
-		pst)
+	r, _, err := utils.GetAccountAndConnect(ctx, cmd, pst)
 	if err != nil {
 		return Only(ctx, err)
 	}
@@ -298,10 +295,7 @@ func genericListCommand(
 		return nil
 	}
 
-	r, _, _, _, err := utils.GetAccountAndConnectWithOverrides(
-		ctx,
-		cmd,
-		service)
+	r, _, err := utils.GetAccountAndConnect(ctx, cmd, service)
 	if err != nil {
 		return Only(ctx, err)
 	}

--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -275,17 +275,19 @@ func detailsExchangeCmd(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	opts := utils.MakeExchangeOpts(cmd)
 
-	r, _, _, ctrlOpts, err := utils.GetAccountAndConnectWithOverrides(
-		ctx,
-		cmd,
-		path.ExchangeService)
+	r, rdao, err := utils.GetAccountAndConnect(ctx, cmd, path.ExchangeService)
 	if err != nil {
 		return Only(ctx, err)
 	}
 
 	defer utils.CloseRepo(ctx, r)
 
-	ds, err := runDetailsExchangeCmd(ctx, r, flags.BackupIDFV, opts, ctrlOpts.SkipReduce)
+	ds, err := runDetailsExchangeCmd(
+		ctx,
+		r,
+		flags.BackupIDFV,
+		opts,
+		rdao.Opts.SkipReduce)
 	if err != nil {
 		return Only(ctx, err)
 	}

--- a/src/cli/backup/groups.go
+++ b/src/cli/backup/groups.go
@@ -228,17 +228,19 @@ func detailsGroupsCmd(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	opts := utils.MakeGroupsOpts(cmd)
 
-	r, _, _, ctrlOpts, err := utils.GetAccountAndConnectWithOverrides(
-		ctx,
-		cmd,
-		path.GroupsService)
+	r, rdao, err := utils.GetAccountAndConnect(ctx, cmd, path.GroupsService)
 	if err != nil {
 		return Only(ctx, err)
 	}
 
 	defer utils.CloseRepo(ctx, r)
 
-	ds, err := runDetailsGroupsCmd(ctx, r, flags.BackupIDFV, opts, ctrlOpts.SkipReduce)
+	ds, err := runDetailsGroupsCmd(
+		ctx,
+		r,
+		flags.BackupIDFV,
+		opts,
+		rdao.Opts.SkipReduce)
 	if err != nil {
 		return Only(ctx, err)
 	}

--- a/src/cli/backup/onedrive.go
+++ b/src/cli/backup/onedrive.go
@@ -232,17 +232,19 @@ func detailsOneDriveCmd(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	opts := utils.MakeOneDriveOpts(cmd)
 
-	r, _, _, ctrlOpts, err := utils.GetAccountAndConnectWithOverrides(
-		ctx,
-		cmd,
-		path.OneDriveService)
+	r, rdao, err := utils.GetAccountAndConnect(ctx, cmd, path.OneDriveService)
 	if err != nil {
 		return Only(ctx, err)
 	}
 
 	defer utils.CloseRepo(ctx, r)
 
-	ds, err := runDetailsOneDriveCmd(ctx, r, flags.BackupIDFV, opts, ctrlOpts.SkipReduce)
+	ds, err := runDetailsOneDriveCmd(
+		ctx,
+		r,
+		flags.BackupIDFV,
+		opts,
+		rdao.Opts.SkipReduce)
 	if err != nil {
 		return Only(ctx, err)
 	}

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -327,17 +327,19 @@ func detailsSharePointCmd(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	opts := utils.MakeSharePointOpts(cmd)
 
-	r, _, _, ctrlOpts, err := utils.GetAccountAndConnectWithOverrides(
-		ctx,
-		cmd,
-		path.SharePointService)
+	r, rdao, err := utils.GetAccountAndConnect(ctx, cmd, path.SharePointService)
 	if err != nil {
 		return Only(ctx, err)
 	}
 
 	defer utils.CloseRepo(ctx, r)
 
-	ds, err := runDetailsSharePointCmd(ctx, r, flags.BackupIDFV, opts, ctrlOpts.SkipReduce)
+	ds, err := runDetailsSharePointCmd(
+		ctx,
+		r,
+		flags.BackupIDFV,
+		opts,
+		rdao.Opts.SkipReduce)
 	if err != nil {
 		return Only(ctx, err)
 	}

--- a/src/cli/export/export.go
+++ b/src/cli/export/export.go
@@ -67,10 +67,7 @@ func runExport(
 		return Only(ctx, err)
 	}
 
-	r, _, _, _, err := utils.GetAccountAndConnectWithOverrides(
-		ctx,
-		cmd,
-		sel.PathService())
+	r, _, err := utils.GetAccountAndConnect(ctx, cmd, sel.PathService())
 	if err != nil {
 		return Only(ctx, err)
 	}

--- a/src/cli/restore/restore.go
+++ b/src/cli/restore/restore.go
@@ -100,10 +100,7 @@ func runRestore(
 		return Only(ctx, err)
 	}
 
-	r, _, _, _, err := utils.GetAccountAndConnectWithOverrides(
-		ctx,
-		cmd,
-		sel.PathService())
+	r, _, err := utils.GetAccountAndConnect(ctx, cmd, sel.PathService())
 	if err != nil {
 		return Only(ctx, err)
 	}

--- a/src/cli/utils/utils.go
+++ b/src/cli/utils/utils.go
@@ -22,30 +22,35 @@ import (
 	"github.com/alcionai/corso/src/pkg/storage"
 )
 
+type RepoDetailsAndOpts struct {
+	Repo config.RepoDetails
+	Opts control.Options
+}
+
 var ErrNotYetImplemented = clues.New("not yet implemented")
 
-// GetAccountAndConnectWithOverrides is a wrapper for GetAccountAndConnect
-// that also gets the storage provider and any storage provider specific
+// GetAccountAndConnect is a wrapper for GetAccountAndConnectWithOverrides
+// that automatically gets the storage provider and any storage provider specific
 // flag overrides from the command line.
-func GetAccountAndConnectWithOverrides(
+func GetAccountAndConnect(
 	ctx context.Context,
 	cmd *cobra.Command,
 	pst path.ServiceType,
-) (repository.Repositoryer, *storage.Storage, *account.Account, *control.Options, error) {
+) (repository.Repositoryer, RepoDetailsAndOpts, error) {
 	provider, overrides, err := GetStorageProviderAndOverrides(ctx, cmd)
 	if err != nil {
-		return nil, nil, nil, nil, clues.Stack(err)
+		return nil, RepoDetailsAndOpts{}, clues.Stack(err)
 	}
 
-	return GetAccountAndConnect(ctx, pst, provider, overrides)
+	return GetAccountAndConnectWithOverrides(ctx, pst, provider, overrides)
 }
 
-func GetAccountAndConnect(
+func GetAccountAndConnectWithOverrides(
 	ctx context.Context,
 	pst path.ServiceType,
 	provider storage.ProviderType,
 	overrides map[string]string,
-) (repository.Repositoryer, *storage.Storage, *account.Account, *control.Options, error) {
+) (repository.Repositoryer, RepoDetailsAndOpts, error) {
 	cfg, err := config.GetConfigRepoDetails(
 		ctx,
 		provider,
@@ -53,7 +58,7 @@ func GetAccountAndConnect(
 		true,
 		overrides)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, RepoDetailsAndOpts{}, err
 	}
 
 	repoID := cfg.RepoID
@@ -70,20 +75,25 @@ func GetAccountAndConnect(
 		opts,
 		repoID)
 	if err != nil {
-		return nil, nil, nil, nil, clues.Wrap(err, "creating a repository controller")
+		return nil, RepoDetailsAndOpts{}, clues.Wrap(err, "creating a repository controller")
 	}
 
 	if err := r.Connect(ctx); err != nil {
-		return nil, nil, nil, nil, clues.Wrap(err, "connecting to the "+cfg.Storage.Provider.String()+" repository")
+		return nil, RepoDetailsAndOpts{}, clues.Wrap(err, "connecting to the "+cfg.Storage.Provider.String()+" repository")
 	}
 
 	// this initializes our graph api client configurations,
 	// including control options such as concurency limitations.
 	if _, err := r.ConnectToM365(ctx, pst); err != nil {
-		return nil, nil, nil, nil, clues.Wrap(err, "connecting to m365")
+		return nil, RepoDetailsAndOpts{}, clues.Wrap(err, "connecting to m365")
 	}
 
-	return r, &cfg.Storage, &cfg.Account, &opts, nil
+	rdao := RepoDetailsAndOpts{
+		Repo: cfg,
+		Opts: opts,
+	}
+
+	return r, rdao, nil
 }
 
 func AccountConnectAndWriteRepoConfig(
@@ -91,22 +101,19 @@ func AccountConnectAndWriteRepoConfig(
 	cmd *cobra.Command,
 	pst path.ServiceType,
 ) (repository.Repositoryer, *account.Account, error) {
-	r, stg, acc, opts, err := GetAccountAndConnectWithOverrides(
-		ctx,
-		cmd,
-		pst)
+	r, rdao, err := GetAccountAndConnect(ctx, cmd, pst)
 	if err != nil {
 		logger.CtxErr(ctx, err).Info("getting and connecting account")
 		return nil, nil, err
 	}
 
-	sc, err := stg.StorageConfig()
+	sc, err := rdao.Repo.Storage.StorageConfig()
 	if err != nil {
 		logger.CtxErr(ctx, err).Info("getting storage configuration")
 		return nil, nil, err
 	}
 
-	m365Config, err := acc.M365Config()
+	m365Config, err := rdao.Repo.Account.M365Config()
 	if err != nil {
 		logger.CtxErr(ctx, err).Info("getting m365 configuration")
 		return nil, nil, err
@@ -114,13 +121,13 @@ func AccountConnectAndWriteRepoConfig(
 
 	// repo config gets set during repo connect and init.
 	// This call confirms we have the correct values.
-	err = config.WriteRepoConfig(ctx, sc, m365Config, opts.Repo, r.GetID())
+	err = config.WriteRepoConfig(ctx, sc, m365Config, rdao.Opts.Repo, r.GetID())
 	if err != nil {
 		logger.CtxErr(ctx, err).Info("writing to repository configuration")
 		return nil, nil, err
 	}
 
-	return r, acc, nil
+	return r, &rdao.Repo.Account, nil
 }
 
 // CloseRepo handles closing a repo.

--- a/src/cmd/longevity_test/longevity.go
+++ b/src/cmd/longevity_test/longevity.go
@@ -31,11 +31,7 @@ func deleteBackups(
 ) ([]string, error) {
 	ctx = clues.Add(ctx, "cutoff_days", deletionDays)
 
-	r, _, _, _, err := utils.GetAccountAndConnect(
-		ctx,
-		service,
-		storage.ProviderS3,
-		nil)
+	r, _, err := utils.GetAccountAndConnectWithOverrides(ctx, service, storage.ProviderS3, nil)
 	if err != nil {
 		return nil, clues.Wrap(err, "connecting to account").WithClues(ctx)
 	}


### PR DESCRIPTION
adds a container-of-things to reduce mostly-unused return value bloat, and updates some func names to be more appropriate to their behavior.

No logical changes, just renaming/movement.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup