### PR TITLE
Revert "⬆️ Bump tw-elements from 1.0.0-alpha13 to 1.0.0-beta1 in /website"

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -26,7 +26,7 @@
         "react-dom": "^17.0.2",
         "sass": "^1.67.0",
         "tiny-slider": "^2.9.4",
-        "tw-elements": "^1.0.0-beta1",
+        "tw-elements": "^1.0.0-alpha13",
         "wow.js": "^1.2.2"
       },
       "devDependencies": {
@@ -10648,6 +10648,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12064,6 +12065,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
       "dependencies": {
         "pify": "^2.3.0"
       }
@@ -13848,18 +13850,18 @@
       "license": "0BSD"
     },
     "node_modules/tw-elements": {
-      "version": "1.0.0-beta1",
-      "resolved": "https://registry.npmjs.org/tw-elements/-/tw-elements-1.0.0-beta1.tgz",
-      "integrity": "sha512-N7YBHpco5kOBGwPzCrnyxTbjFreb7SisEFw+paJpUHGgZUwdI6KUP2QJzM3YZSFrcigWIjRwR0jOb/PQcIuk5g==",
+      "version": "1.0.0-alpha13",
+      "resolved": "https://registry.npmjs.org/tw-elements/-/tw-elements-1.0.0-alpha13.tgz",
+      "integrity": "sha512-lz1D583ZGDF4s8e89dmXkhfD8m2abgAlaK8/J6cAEm3DLxz7RtqKdunzja6xcKxDZO3bXEd6oGNdQ5QHpyCqrg==",
       "dependencies": {
         "@popperjs/core": "^2.6.0",
         "chart.js": "^2.9.4",
         "chartjs-plugin-datalabels": "^0.7.0",
         "deepmerge": "^4.2.2",
         "detect-autofill": "^1.1.3",
-        "perfect-scrollbar": "^1.5.5",
+        "perfect-scrollbar": "^1.5.0",
         "popper.js": "^1.16.1",
-        "tailwindcss": "3.2.4"
+        "tailwindcss": "~3.0.7"
       }
     },
     "node_modules/tw-elements/node_modules/color-name": {
@@ -13878,28 +13880,12 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/tw-elements/node_modules/postcss-import": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-14.1.0.tgz",
-      "integrity": "sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==",
-      "dependencies": {
-        "postcss-value-parser": "^4.0.0",
-        "read-cache": "^1.0.0",
-        "resolve": "^1.1.7"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.0"
-      }
-    },
     "node_modules/tw-elements/node_modules/postcss-nested": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.0.tgz",
-      "integrity": "sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.6.tgz",
+      "integrity": "sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==",
       "dependencies": {
-        "postcss-selector-parser": "^6.0.10"
+        "postcss-selector-parser": "^6.0.6"
       },
       "engines": {
         "node": ">=12.0"
@@ -13913,33 +13899,31 @@
       }
     },
     "node_modules/tw-elements/node_modules/tailwindcss": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.2.4.tgz",
-      "integrity": "sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==",
+      "version": "3.0.24",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.0.24.tgz",
+      "integrity": "sha512-H3uMmZNWzG6aqmg9q07ZIRNIawoiEcNFKDfL+YzOPuPsXuDXxJxB9icqzLgdzKNwjG3SAro2h9SYav8ewXNgig==",
       "dependencies": {
-        "arg": "^5.0.2",
+        "arg": "^5.0.1",
         "chokidar": "^3.5.3",
         "color-name": "^1.1.4",
-        "detective": "^5.2.1",
+        "detective": "^5.2.0",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
-        "fast-glob": "^3.2.12",
+        "fast-glob": "^3.2.11",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "lilconfig": "^2.0.6",
-        "micromatch": "^4.0.5",
+        "lilconfig": "^2.0.5",
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.18",
-        "postcss-import": "^14.1.0",
+        "postcss": "^8.4.12",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.4",
-        "postcss-nested": "6.0.0",
+        "postcss-nested": "5.0.6",
         "postcss-selector-parser": "^6.0.10",
         "postcss-value-parser": "^4.2.0",
         "quick-lru": "^5.1.1",
-        "resolve": "^1.22.1"
+        "resolve": "^1.22.0"
       },
       "bin": {
         "tailwind": "lib/cli.js",
@@ -22691,7 +22675,8 @@
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true
     },
     "pirates": {
       "version": "4.0.5",
@@ -23562,6 +23547,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
       "requires": {
         "pify": "^2.3.0"
       }
@@ -24803,18 +24789,18 @@
       "version": "2.4.0"
     },
     "tw-elements": {
-      "version": "1.0.0-beta1",
-      "resolved": "https://registry.npmjs.org/tw-elements/-/tw-elements-1.0.0-beta1.tgz",
-      "integrity": "sha512-N7YBHpco5kOBGwPzCrnyxTbjFreb7SisEFw+paJpUHGgZUwdI6KUP2QJzM3YZSFrcigWIjRwR0jOb/PQcIuk5g==",
+      "version": "1.0.0-alpha13",
+      "resolved": "https://registry.npmjs.org/tw-elements/-/tw-elements-1.0.0-alpha13.tgz",
+      "integrity": "sha512-lz1D583ZGDF4s8e89dmXkhfD8m2abgAlaK8/J6cAEm3DLxz7RtqKdunzja6xcKxDZO3bXEd6oGNdQ5QHpyCqrg==",
       "requires": {
         "@popperjs/core": "^2.6.0",
         "chart.js": "^2.9.4",
         "chartjs-plugin-datalabels": "^0.7.0",
         "deepmerge": "^4.2.2",
         "detect-autofill": "^1.1.3",
-        "perfect-scrollbar": "^1.5.5",
+        "perfect-scrollbar": "^1.5.0",
         "popper.js": "^1.16.1",
-        "tailwindcss": "3.2.4"
+        "tailwindcss": "~3.0.7"
       },
       "dependencies": {
         "color-name": {
@@ -24830,52 +24816,40 @@
             "is-glob": "^4.0.3"
           }
         },
-        "postcss-import": {
-          "version": "14.1.0",
-          "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-14.1.0.tgz",
-          "integrity": "sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==",
-          "requires": {
-            "postcss-value-parser": "^4.0.0",
-            "read-cache": "^1.0.0",
-            "resolve": "^1.1.7"
-          }
-        },
         "postcss-nested": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.0.tgz",
-          "integrity": "sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==",
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.6.tgz",
+          "integrity": "sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==",
           "requires": {
-            "postcss-selector-parser": "^6.0.10"
+            "postcss-selector-parser": "^6.0.6"
           }
         },
         "tailwindcss": {
-          "version": "3.2.4",
-          "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.2.4.tgz",
-          "integrity": "sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==",
+          "version": "3.0.24",
+          "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.0.24.tgz",
+          "integrity": "sha512-H3uMmZNWzG6aqmg9q07ZIRNIawoiEcNFKDfL+YzOPuPsXuDXxJxB9icqzLgdzKNwjG3SAro2h9SYav8ewXNgig==",
           "requires": {
-            "arg": "^5.0.2",
+            "arg": "^5.0.1",
             "chokidar": "^3.5.3",
             "color-name": "^1.1.4",
-            "detective": "^5.2.1",
+            "detective": "^5.2.0",
             "didyoumean": "^1.2.2",
             "dlv": "^1.1.3",
-            "fast-glob": "^3.2.12",
+            "fast-glob": "^3.2.11",
             "glob-parent": "^6.0.2",
             "is-glob": "^4.0.3",
-            "lilconfig": "^2.0.6",
-            "micromatch": "^4.0.5",
+            "lilconfig": "^2.0.5",
             "normalize-path": "^3.0.0",
             "object-hash": "^3.0.0",
             "picocolors": "^1.0.0",
-            "postcss": "^8.4.18",
-            "postcss-import": "^14.1.0",
+            "postcss": "^8.4.12",
             "postcss-js": "^4.0.0",
             "postcss-load-config": "^3.1.4",
-            "postcss-nested": "6.0.0",
+            "postcss-nested": "5.0.6",
             "postcss-selector-parser": "^6.0.10",
             "postcss-value-parser": "^4.2.0",
             "quick-lru": "^5.1.1",
-            "resolve": "^1.22.1"
+            "resolve": "^1.22.0"
           }
         }
       }

--- a/website/package.json
+++ b/website/package.json
@@ -32,7 +32,7 @@
     "react-dom": "^17.0.2",
     "sass": "^1.67.0",
     "tiny-slider": "^2.9.4",
-    "tw-elements": "^1.0.0-beta1",
+    "tw-elements": "^1.0.0-alpha13",
     "wow.js": "^1.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts alcionai/corso#4268 to go back to the MIT licensed version of the code.