### PR TITLE
connect to data provider during init/connect

### DIFF
--- a/src/cli/backup/helpers_test.go
+++ b/src/cli/backup/helpers_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
-	ctrlRepo "github.com/alcionai/corso/src/pkg/control/repository"
 	"github.com/alcionai/corso/src/pkg/repository"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/mock"
@@ -162,7 +161,7 @@ func prepM365Test(
 		repository.NewRepoID)
 	require.NoError(t, err, clues.ToCore(err))
 
-	err = repo.Initialize(ctx, ctrlRepo.Retention{})
+	err = repo.Initialize(ctx, repository.InitConfig{})
 	require.NoError(t, err, clues.ToCore(err))
 
 	return dependencies{

--- a/src/cli/repo/filesystem.go
+++ b/src/cli/repo/filesystem.go
@@ -85,7 +85,7 @@ func initFilesystemCmd(cmd *cobra.Command, args []string) error {
 
 	opt := utils.ControlWithConfig(cfg)
 	// Retention is not supported for filesystem repos.
-	retention := ctrlRepo.Retention{}
+	retentionOpts := ctrlRepo.Retention{}
 
 	// SendStartCorsoEvent uses distict ID as tenant ID because repoID is still not generated
 	utils.SendStartCorsoEvent(
@@ -118,7 +118,9 @@ func initFilesystemCmd(cmd *cobra.Command, args []string) error {
 		return Only(ctx, clues.Wrap(err, "Failed to construct the repository controller"))
 	}
 
-	if err = r.Initialize(ctx, retention); err != nil {
+	ric := repository.InitConfig{RetentionOpts: retentionOpts}
+
+	if err = r.Initialize(ctx, ric); err != nil {
 		if flags.SucceedIfExistsFV && errors.Is(err, repository.ErrorRepoAlreadyExists) {
 			return nil
 		}
@@ -205,7 +207,7 @@ func connectFilesystemCmd(cmd *cobra.Command, args []string) error {
 		return Only(ctx, clues.Wrap(err, "Failed to create a repository controller"))
 	}
 
-	if err := r.Connect(ctx); err != nil {
+	if err := r.Connect(ctx, repository.ConnConfig{}); err != nil {
 		return Only(ctx, clues.Wrap(err, "Failed to connect to the filesystem repository"))
 	}
 

--- a/src/cli/repo/filesystem_e2e_test.go
+++ b/src/cli/repo/filesystem_e2e_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
-	ctrlRepo "github.com/alcionai/corso/src/pkg/control/repository"
 	"github.com/alcionai/corso/src/pkg/repository"
 	"github.com/alcionai/corso/src/pkg/storage"
 	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
@@ -140,7 +139,7 @@ func (suite *FilesystemE2ESuite) TestConnectFilesystemCmd() {
 				repository.NewRepoID)
 			require.NoError(t, err, clues.ToCore(err))
 
-			err = r.Initialize(ctx, ctrlRepo.Retention{})
+			err = r.Initialize(ctx, repository.InitConfig{})
 			require.NoError(t, err, clues.ToCore(err))
 
 			// then test it

--- a/src/cli/repo/s3.go
+++ b/src/cli/repo/s3.go
@@ -140,7 +140,9 @@ func initS3Cmd(cmd *cobra.Command, args []string) error {
 		return Only(ctx, clues.Wrap(err, "Failed to construct the repository controller"))
 	}
 
-	if err = r.Initialize(ctx, retentionOpts); err != nil {
+	ric := repository.InitConfig{RetentionOpts: retentionOpts}
+
+	if err = r.Initialize(ctx, ric); err != nil {
 		if flags.SucceedIfExistsFV && errors.Is(err, repository.ErrorRepoAlreadyExists) {
 			return nil
 		}
@@ -225,7 +227,7 @@ func connectS3Cmd(cmd *cobra.Command, args []string) error {
 		return Only(ctx, clues.Wrap(err, "Failed to create a repository controller"))
 	}
 
-	if err := r.Connect(ctx); err != nil {
+	if err := r.Connect(ctx, repository.ConnConfig{}); err != nil {
 		return Only(ctx, clues.Wrap(err, "Failed to connect to the S3 repository"))
 	}
 

--- a/src/cli/repo/s3_e2e_test.go
+++ b/src/cli/repo/s3_e2e_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
-	ctrlRepo "github.com/alcionai/corso/src/pkg/control/repository"
 	"github.com/alcionai/corso/src/pkg/repository"
 	"github.com/alcionai/corso/src/pkg/storage"
 	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
@@ -216,7 +215,7 @@ func (suite *S3E2ESuite) TestConnectS3Cmd() {
 				repository.NewRepoID)
 			require.NoError(t, err, clues.ToCore(err))
 
-			err = r.Initialize(ctx, ctrlRepo.Retention{})
+			err = r.Initialize(ctx, repository.InitConfig{})
 			require.NoError(t, err, clues.ToCore(err))
 
 			// then test it

--- a/src/cli/restore/exchange_e2e_test.go
+++ b/src/cli/restore/exchange_e2e_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
-	ctrlRepo "github.com/alcionai/corso/src/pkg/control/repository"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/repository"
 	"github.com/alcionai/corso/src/pkg/selectors"
@@ -94,7 +93,7 @@ func (suite *RestoreExchangeE2ESuite) SetupSuite() {
 		repository.NewRepoID)
 	require.NoError(t, err, clues.ToCore(err))
 
-	err = suite.repo.Initialize(ctx, ctrlRepo.Retention{})
+	err = suite.repo.Initialize(ctx, repository.InitConfig{Service: path.ExchangeService})
 	require.NoError(t, err, clues.ToCore(err))
 
 	suite.backupOps = make(map[path.CategoryType]operations.BackupOperation)

--- a/src/cli/utils/utils.go
+++ b/src/cli/utils/utils.go
@@ -78,14 +78,8 @@ func GetAccountAndConnectWithOverrides(
 		return nil, RepoDetailsAndOpts{}, clues.Wrap(err, "creating a repository controller")
 	}
 
-	if err := r.Connect(ctx); err != nil {
+	if err := r.Connect(ctx, repository.ConnConfig{Service: pst}); err != nil {
 		return nil, RepoDetailsAndOpts{}, clues.Wrap(err, "connecting to the "+cfg.Storage.Provider.String()+" repository")
-	}
-
-	// this initializes our graph api client configurations,
-	// including control options such as concurency limitations.
-	if _, err := r.ConnectToM365(ctx, pst); err != nil {
-		return nil, RepoDetailsAndOpts{}, clues.Wrap(err, "connecting to m365")
 	}
 
 	rdao := RepoDetailsAndOpts{

--- a/src/cmd/longevity_test/longevity.go
+++ b/src/cmd/longevity_test/longevity.go
@@ -72,7 +72,7 @@ func deleteBackups(
 // Only supported for S3 repos currently.
 func pitrListBackups(
 	ctx context.Context,
-	service path.ServiceType,
+	pst path.ServiceType,
 	pitr time.Time,
 	backupIDs []string,
 ) error {
@@ -113,14 +113,14 @@ func pitrListBackups(
 		return clues.Wrap(err, "creating a repo")
 	}
 
-	err = r.Connect(ctx)
+	err = r.Connect(ctx, repository.ConnConfig{Service: pst})
 	if err != nil {
 		return clues.Wrap(err, "connecting to the repository")
 	}
 
 	defer r.Close(ctx)
 
-	backups, err := r.BackupsByTag(ctx, store.Service(service))
+	backups, err := r.BackupsByTag(ctx, store.Service(pst))
 	if err != nil {
 		return clues.Wrap(err, "listing backups").WithClues(ctx)
 	}

--- a/src/internal/m365/controller.go
+++ b/src/internal/m365/controller.go
@@ -79,20 +79,29 @@ func NewController(
 		return nil, clues.Wrap(err, "creating api client").WithClues(ctx)
 	}
 
-	rc := resource.UnknownResource
+	var rCli *resourceClient
 
-	switch pst {
-	case path.ExchangeService, path.OneDriveService:
-		rc = resource.Users
-	case path.GroupsService:
-		rc = resource.Groups
-	case path.SharePointService:
-		rc = resource.Sites
-	}
+	// no failure for unknown service.
+	// In that case we create a controller that doesn't attempt to look up any resource
+	// data.  This case helps avoid unnecessary service calls when the end user is running
+	// repo init and connect commands via the CLI.  All other callers should be expected
+	// to pass in a known service, or else expect downstream failures.
+	if pst != path.UnknownService {
+		rc := resource.UnknownResource
 
-	rCli, err := getResourceClient(rc, ac)
-	if err != nil {
-		return nil, clues.Wrap(err, "creating resource client").WithClues(ctx)
+		switch pst {
+		case path.ExchangeService, path.OneDriveService:
+			rc = resource.Users
+		case path.GroupsService:
+			rc = resource.Groups
+		case path.SharePointService:
+			rc = resource.Sites
+		}
+
+		rCli, err = getResourceClient(rc, ac)
+		if err != nil {
+			return nil, clues.Wrap(err, "creating resource client").WithClues(ctx)
+		}
 	}
 
 	ctrl := Controller{
@@ -108,6 +117,10 @@ func NewController(
 	}
 
 	return &ctrl, nil
+}
+
+func (ctrl *Controller) VerifyAccess(ctx context.Context) error {
+	return ctrl.AC.Access().GetToken(ctx)
 }
 
 // ---------------------------------------------------------------------------
@@ -195,7 +208,7 @@ func getResourceClient(rc resource.Category, ac api.Client) (*resourceClient, er
 	case resource.Groups:
 		return &resourceClient{enum: rc, getter: ac.Groups()}, nil
 	default:
-		return nil, clues.New("unrecognized owner resource enum").With("resource_enum", rc)
+		return nil, clues.New("unrecognized owner resource type").With("resource_enum", rc)
 	}
 }
 

--- a/src/pkg/path/service_type.go
+++ b/src/pkg/path/service_type.go
@@ -14,6 +14,10 @@ var ErrorUnknownService = clues.New("unknown service string")
 //
 // Metadata services are not considered valid service types for resource paths
 // though they can be used for metadata paths.
+//
+// The string representaton of each enum _must remain the same_.  In case of
+// changes to those values, we'll need migration code to handle transitions
+// across states else we'll get marshalling/unmarshalling errors.
 type ServiceType int
 
 //go:generate stringer -type=ServiceType -linecomment

--- a/src/pkg/path/service_type.go
+++ b/src/pkg/path/service_type.go
@@ -14,10 +14,6 @@ var ErrorUnknownService = clues.New("unknown service string")
 //
 // Metadata services are not considered valid service types for resource paths
 // though they can be used for metadata paths.
-//
-// The order of the enums below can be changed, but the string representation of
-// each enum must remain the same or migration code needs to be added to handle
-// changes to the string format.
 type ServiceType int
 
 //go:generate stringer -type=ServiceType -linecomment

--- a/src/pkg/repository/backups.go
+++ b/src/pkg/repository/backups.go
@@ -71,12 +71,12 @@ func (r repository) NewBackupWithLookup(
 	sel selectors.Selector,
 	ins idname.Cacher,
 ) (operations.BackupOperation, error) {
-	ctrl, err := connectToM365(ctx, sel.PathService(), r.Account, r.Opts)
+	err := r.ConnectDataProvider(ctx, sel.PathService())
 	if err != nil {
 		return operations.BackupOperation{}, clues.Wrap(err, "connecting to m365")
 	}
 
-	ownerID, ownerName, err := ctrl.PopulateProtectedResourceIDAndName(ctx, sel.DiscreteOwner, ins)
+	ownerID, ownerName, err := r.Provider.PopulateProtectedResourceIDAndName(ctx, sel.DiscreteOwner, ins)
 	if err != nil {
 		return operations.BackupOperation{}, clues.Wrap(err, "resolving resource owner details")
 	}
@@ -89,7 +89,7 @@ func (r repository) NewBackupWithLookup(
 		r.Opts,
 		r.dataLayer,
 		store.NewWrapper(r.modelStore),
-		ctrl,
+		r.Provider,
 		r.Account,
 		sel,
 		sel, // the selector acts as an IDNamer for its discrete resource owner.

--- a/src/pkg/repository/data_providers.go
+++ b/src/pkg/repository/data_providers.go
@@ -59,7 +59,9 @@ func connectToM365(
 	if r.Provider != nil {
 		ctrl, ok := r.Provider.(*m365.Controller)
 		if !ok {
-			return nil, clues.New("Attempted to access multiple repository providers")
+			// if the provider is initialized to a non-m365 controller, we should not
+			// attempt to connnect to m365 afterward.
+			return nil, clues.New("Attempted to connect to multiple data providers")
 		}
 
 		return ctrl, nil

--- a/src/pkg/repository/data_providers.go
+++ b/src/pkg/repository/data_providers.go
@@ -7,48 +7,68 @@ import (
 
 	"github.com/alcionai/corso/src/internal/m365"
 	"github.com/alcionai/corso/src/internal/observe"
+	"github.com/alcionai/corso/src/internal/operations/inject"
 	"github.com/alcionai/corso/src/pkg/account"
-	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
 type DataProvider interface {
-	// ConnectToM365 establishes graph api connections
-	// and initializes api client configurations.
-	ConnectToM365(
+	inject.BackupProducer
+	inject.ExportConsumer
+	inject.RestoreConsumer
+}
+
+type DataProviderConnector interface {
+	// ConnectDataProvider initializes configurations
+	// and establishes the client connection with the
+	// data provider for this operation.
+	ConnectDataProvider(
 		ctx context.Context,
 		pst path.ServiceType,
-	) (*m365.Controller, error)
+	) error
 }
 
-func (r repository) ConnectToM365(
+func (r *repository) ConnectDataProvider(
 	ctx context.Context,
 	pst path.ServiceType,
-) (*m365.Controller, error) {
-	ctrl, err := connectToM365(ctx, pst, r.Account, r.Opts)
-	if err != nil {
-		return nil, clues.Wrap(err, "connecting to m365")
+) error {
+	var (
+		provider DataProvider
+		err      error
+	)
+
+	switch r.Account.Provider {
+	case account.ProviderM365:
+		provider, err = connectToM365(ctx, *r, pst)
+	default:
+		err = clues.New("unrecognized provider")
 	}
 
-	return ctrl, nil
-}
+	r.Provider = provider
 
-var m365nonce bool
+	return clues.Wrap(err, "connecting data provider").
+		WithClues(ctx).
+		OrNil()
+}
 
 func connectToM365(
 	ctx context.Context,
+	r repository,
 	pst path.ServiceType,
-	acct account.Account,
-	co control.Options,
 ) (*m365.Controller, error) {
-	if !m365nonce {
-		m365nonce = true
+	if r.Provider != nil {
+		ctrl, ok := r.Provider.(*m365.Controller)
+		if !ok {
+			return nil, clues.New("Attempted to access multiple repository providers")
+		}
 
-		progressBar := observe.MessageWithCompletion(ctx, "Connecting to M365")
-		defer close(progressBar)
+		return ctrl, nil
 	}
 
-	ctrl, err := m365.NewController(ctx, acct, pst, co)
+	progressBar := observe.MessageWithCompletion(ctx, "Connecting to M365")
+	defer close(progressBar)
+
+	ctrl, err := m365.NewController(ctx, r.Account, pst, r.Opts)
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/repository/exports.go
+++ b/src/pkg/repository/exports.go
@@ -3,8 +3,6 @@ package repository
 import (
 	"context"
 
-	"github.com/alcionai/clues"
-
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/internal/operations"
 	"github.com/alcionai/corso/src/pkg/control"
@@ -28,17 +26,12 @@ func (r repository) NewExport(
 	sel selectors.Selector,
 	exportCfg control.ExportConfig,
 ) (operations.ExportOperation, error) {
-	ctrl, err := connectToM365(ctx, sel.PathService(), r.Account, r.Opts)
-	if err != nil {
-		return operations.ExportOperation{}, clues.Wrap(err, "connecting to m365")
-	}
-
 	return operations.NewExportOperation(
 		ctx,
 		r.Opts,
 		r.dataLayer,
 		store.NewWrapper(r.modelStore),
-		ctrl,
+		r.Provider,
 		r.Account,
 		model.StableID(backupID),
 		sel,

--- a/src/pkg/repository/loadtest/repository_load_test.go
+++ b/src/pkg/repository/loadtest/repository_load_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control"
-	ctrlRepo "github.com/alcionai/corso/src/pkg/control/repository"
 	ctrlTD "github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -111,7 +110,7 @@ func initM365Repo(t *testing.T) (
 		repository.NewRepoID)
 	require.NoError(t, err, clues.ToCore(err))
 
-	err = r.Initialize(ctx, ctrlRepo.Retention{})
+	err = r.Initialize(ctx, repository.InitConfig{})
 	require.NoError(t, err, clues.ToCore(err))
 
 	return ctx, r, ac, st

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -123,8 +123,7 @@ func New(
 
 type InitConfig struct {
 	// tells the data provider which service to
-	// use for its connection pattern.  Leave empty
-	// to skip the provider connection.
+	// use for its connection pattern.  Optional.
 	Service       path.ServiceType
 	RetentionOpts ctrlRepo.Retention
 }
@@ -151,10 +150,8 @@ func (r *repository) Initialize(
 		}
 	}()
 
-	if cfg.Service != path.UnknownService {
-		if err := r.ConnectDataProvider(ctx, cfg.Service); err != nil {
-			return clues.Stack(err)
-		}
+	if err := r.ConnectDataProvider(ctx, cfg.Service); err != nil {
+		return clues.Stack(err)
 	}
 
 	kopiaRef := kopia.NewConn(r.Storage)
@@ -216,10 +213,8 @@ func (r *repository) Connect(
 		}
 	}()
 
-	if cfg.Service != path.UnknownService {
-		if err := r.ConnectDataProvider(ctx, cfg.Service); err != nil {
-			return clues.Stack(err)
-		}
+	if err := r.ConnectDataProvider(ctx, cfg.Service); err != nil {
+		return clues.Stack(err)
 	}
 
 	progressBar := observe.MessageWithCompletion(ctx, "Connecting to repository")

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -19,6 +19,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/control"
 	ctrlRepo "github.com/alcionai/corso/src/pkg/control/repository"
 	"github.com/alcionai/corso/src/pkg/logger"
+	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/storage"
 	"github.com/alcionai/corso/src/pkg/store"
 )
@@ -35,10 +36,16 @@ type Repositoryer interface {
 	BackupGetter
 	Restorer
 	Exporter
-	DataProvider
+	DataProviderConnector
 
-	Initialize(ctx context.Context, retentionOpts ctrlRepo.Retention) error
-	Connect(ctx context.Context) error
+	Initialize(
+		ctx context.Context,
+		cfg InitConfig,
+	) error
+	Connect(
+		ctx context.Context,
+		cfg ConnConfig,
+	) error
 	GetID() string
 	Close(context.Context) error
 
@@ -58,9 +65,10 @@ type repository struct {
 	CreatedAt time.Time
 	Version   string // in case of future breaking changes
 
-	Account account.Account // the user's m365 account connection details
-	Storage storage.Storage // the storage provider details and configuration
-	Opts    control.Options
+	Account  account.Account // the user's m365 account connection details
+	Storage  storage.Storage // the storage provider details and configuration
+	Opts     control.Options
+	Provider DataProvider // the client controller used for external user data CRUD
 
 	Bus        events.Eventer
 	dataLayer  *kopia.Wrapper
@@ -113,6 +121,14 @@ func New(
 	return &r, nil
 }
 
+type InitConfig struct {
+	// tells the data provider which service to
+	// use for its connection pattern.  Leave empty
+	// to skip the provider connection.
+	Service       path.ServiceType
+	RetentionOpts ctrlRepo.Retention
+}
+
 // Initialize will:
 //   - connect to the m365 account to ensure communication capability
 //   - initialize the kopia repo with the provider and retention parameters
@@ -121,7 +137,7 @@ func New(
 //   - connect to the provider
 func (r *repository) Initialize(
 	ctx context.Context,
-	retentionOpts ctrlRepo.Retention,
+	cfg InitConfig,
 ) (err error) {
 	ctx = clues.Add(
 		ctx,
@@ -135,8 +151,14 @@ func (r *repository) Initialize(
 		}
 	}()
 
+	if cfg.Service != path.UnknownService {
+		if err := r.ConnectDataProvider(ctx, cfg.Service); err != nil {
+			return clues.Stack(err)
+		}
+	}
+
 	kopiaRef := kopia.NewConn(r.Storage)
-	if err := kopiaRef.Initialize(ctx, r.Opts.Repo, retentionOpts); err != nil {
+	if err := kopiaRef.Initialize(ctx, r.Opts.Repo, cfg.RetentionOpts); err != nil {
 		// replace common internal errors so that sdk users can check results with errors.Is()
 		if errors.Is(err, kopia.ErrorRepoAlreadyExists) {
 			return clues.Stack(ErrorRepoAlreadyExists, err).WithClues(ctx)
@@ -167,11 +189,21 @@ func (r *repository) Initialize(
 	return nil
 }
 
+type ConnConfig struct {
+	// tells the data provider which service to
+	// use for its connection pattern.  Leave empty
+	// to skip the provider connection.
+	Service path.ServiceType
+}
+
 // Connect will:
 //   - connect to the m365 account
 //   - connect to the provider storage
 //   - return the connected repository
-func (r *repository) Connect(ctx context.Context) (err error) {
+func (r *repository) Connect(
+	ctx context.Context,
+	cfg ConnConfig,
+) (err error) {
 	ctx = clues.Add(
 		ctx,
 		"acct_provider", r.Account.Provider.String(),
@@ -184,10 +216,11 @@ func (r *repository) Connect(ctx context.Context) (err error) {
 		}
 	}()
 
-	// ctrl, err = connectToM365(ctx, sel.PathService(), r.Account, r.Opts)
-	// if err != nil {
-	// 	return operations.BackupOperation{}, clues.Wrap(err, "connecting to m365")
-	// }
+	if cfg.Service != path.UnknownService {
+		if err := r.ConnectDataProvider(ctx, cfg.Service); err != nil {
+			return clues.Stack(err)
+		}
+	}
 
 	progressBar := observe.MessageWithCompletion(ctx, "Connecting to repository")
 	defer close(progressBar)

--- a/src/pkg/repository/repository_test.go
+++ b/src/pkg/repository/repository_test.go
@@ -69,7 +69,7 @@ func (suite *RepositoryUnitSuite) TestInitialize() {
 				NewRepoID)
 			require.NoError(t, err, clues.ToCore(err))
 
-			err = r.Initialize(ctx, ctrlRepo.Retention{})
+			err = r.Initialize(ctx, InitConfig{})
 			test.errCheck(t, err, clues.ToCore(err))
 		})
 	}
@@ -111,7 +111,7 @@ func (suite *RepositoryUnitSuite) TestConnect() {
 				NewRepoID)
 			require.NoError(t, err, clues.ToCore(err))
 
-			err = r.Connect(ctx)
+			err = r.Connect(ctx, ConnConfig{})
 			test.errCheck(t, err, clues.ToCore(err))
 		})
 	}
@@ -162,7 +162,7 @@ func (suite *RepositoryIntegrationSuite) TestInitialize() {
 				NewRepoID)
 			require.NoError(t, err, clues.ToCore(err))
 
-			err = r.Initialize(ctx, ctrlRepo.Retention{})
+			err = r.Initialize(ctx, InitConfig{})
 			if err == nil {
 				defer func() {
 					err := r.Close(ctx)
@@ -204,7 +204,7 @@ func (suite *RepositoryIntegrationSuite) TestInitializeWithRole() {
 		NewRepoID)
 	require.NoError(t, err, clues.ToCore(err))
 
-	err = r.Initialize(ctx, ctrlRepo.Retention{})
+	err = r.Initialize(ctx, InitConfig{})
 	require.NoError(t, err)
 
 	defer func() {
@@ -228,11 +228,11 @@ func (suite *RepositoryIntegrationSuite) TestConnect() {
 		NewRepoID)
 	require.NoError(t, err, clues.ToCore(err))
 
-	err = r.Initialize(ctx, ctrlRepo.Retention{})
+	err = r.Initialize(ctx, InitConfig{})
 	require.NoError(t, err, clues.ToCore(err))
 
 	// now re-connect
-	err = r.Connect(ctx)
+	err = r.Connect(ctx, ConnConfig{})
 	assert.NoError(t, err, clues.ToCore(err))
 }
 
@@ -252,7 +252,7 @@ func (suite *RepositoryIntegrationSuite) TestConnect_sameID() {
 		NewRepoID)
 	require.NoError(t, err, clues.ToCore(err))
 
-	err = r.Initialize(ctx, ctrlRepo.Retention{})
+	err = r.Initialize(ctx, InitConfig{})
 	require.NoError(t, err, clues.ToCore(err))
 
 	oldID := r.GetID()
@@ -261,7 +261,7 @@ func (suite *RepositoryIntegrationSuite) TestConnect_sameID() {
 	require.NoError(t, err, clues.ToCore(err))
 
 	// now re-connect
-	err = r.Connect(ctx)
+	err = r.Connect(ctx, ConnConfig{})
 	require.NoError(t, err, clues.ToCore(err))
 	assert.Equal(t, oldID, r.GetID())
 }
@@ -284,7 +284,7 @@ func (suite *RepositoryIntegrationSuite) TestNewBackup() {
 		NewRepoID)
 	require.NoError(t, err, clues.ToCore(err))
 
-	err = r.Initialize(ctx, ctrlRepo.Retention{})
+	err = r.Initialize(ctx, InitConfig{})
 	require.NoError(t, err, clues.ToCore(err))
 
 	userID := tconfig.M365UserID(t)
@@ -313,7 +313,7 @@ func (suite *RepositoryIntegrationSuite) TestNewRestore() {
 		"")
 	require.NoError(t, err, clues.ToCore(err))
 
-	err = r.Initialize(ctx, ctrlRepo.Retention{})
+	err = r.Initialize(ctx, InitConfig{})
 	require.NoError(t, err, clues.ToCore(err))
 
 	ro, err := r.NewRestore(
@@ -343,7 +343,7 @@ func (suite *RepositoryIntegrationSuite) TestNewBackupAndDelete() {
 		NewRepoID)
 	require.NoError(t, err, clues.ToCore(err))
 
-	err = r.Initialize(ctx, ctrlRepo.Retention{})
+	err = r.Initialize(ctx, InitConfig{})
 	require.NoError(t, err, clues.ToCore(err))
 
 	userID := tconfig.M365UserID(t)
@@ -396,7 +396,7 @@ func (suite *RepositoryIntegrationSuite) TestNewMaintenance() {
 		NewRepoID)
 	require.NoError(t, err, clues.ToCore(err))
 
-	err = r.Initialize(ctx, ctrlRepo.Retention{})
+	err = r.Initialize(ctx, InitConfig{})
 	require.NoError(t, err, clues.ToCore(err))
 
 	mo, err := r.NewMaintenance(ctx, ctrlRepo.Maintenance{})
@@ -465,11 +465,11 @@ func (suite *RepositoryIntegrationSuite) Test_Options() {
 				NewRepoID)
 			require.NoError(t, err, clues.ToCore(err))
 
-			err = r.Initialize(ctx, ctrlRepo.Retention{})
+			err = r.Initialize(ctx, InitConfig{})
 			require.NoError(t, err)
 			assert.Equal(t, test.expectedLen, len(r.Opts.ItemExtensionFactory))
 
-			err = r.Connect(ctx)
+			err = r.Connect(ctx, ConnConfig{})
 			assert.NoError(t, err)
 			assert.Equal(t, test.expectedLen, len(r.Opts.ItemExtensionFactory))
 		})

--- a/src/pkg/repository/restores.go
+++ b/src/pkg/repository/restores.go
@@ -3,8 +3,6 @@ package repository
 import (
 	"context"
 
-	"github.com/alcionai/clues"
-
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/internal/operations"
 	"github.com/alcionai/corso/src/pkg/control"
@@ -29,17 +27,12 @@ func (r repository) NewRestore(
 	sel selectors.Selector,
 	restoreCfg control.RestoreConfig,
 ) (operations.RestoreOperation, error) {
-	ctrl, err := connectToM365(ctx, sel.PathService(), r.Account, r.Opts)
-	if err != nil {
-		return operations.RestoreOperation{}, clues.Wrap(err, "connecting to m365")
-	}
-
 	return operations.NewRestoreOperation(
 		ctx,
 		r.Opts,
 		r.dataLayer,
 		store.NewWrapper(r.modelStore),
-		ctrl,
+		r.Provider,
 		r.Account,
 		model.StableID(backupID),
 		sel,

--- a/src/pkg/services/m365/api/access.go
+++ b/src/pkg/services/m365/api/access.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/alcionai/clues"
+
+	"github.com/alcionai/corso/src/internal/m365/graph"
+)
+
+// ---------------------------------------------------------------------------
+// controller
+// ---------------------------------------------------------------------------
+
+func (c Client) Access() Access {
+	return Access{c}
+}
+
+// Access is an interface-compliant provider of the client.
+type Access struct {
+	Client
+}
+
+// GetToken retrieves a m365 application auth token using client id and secret credentials.
+// This token is not normally needed in order for corso to function, and is implemented
+// primarily as a way to exercise the validity of those credentials without need of specific
+// permissions.
+func (c Access) GetToken(
+	ctx context.Context,
+) error {
+	var (
+		//nolint:lll
+		// https://learn.microsoft.com/en-us/graph/connecting-external-content-connectors-api-postman#step-5-get-an-authentication-token
+		rawURL = fmt.Sprintf(
+			"https://login.microsoftonline.com/%s/oauth2/v2.0/token",
+			c.Credentials.AzureTenantID)
+		headers = map[string]string{
+			"Content-Type": "application/x-www-form-urlencoded",
+		}
+		body = strings.NewReader(fmt.Sprintf(
+			"client_id=%s"+
+				"&client_secret=%s"+
+				"&scope=https://graph.microsoft.com/.default"+
+				"&grant_type=client_credentials",
+			c.Credentials.AzureClientID,
+			c.Credentials.AzureClientSecret))
+	)
+
+	resp, err := c.Post(ctx, rawURL, headers, body)
+	if err != nil {
+		return graph.Stack(ctx, err)
+	}
+
+	if resp.StatusCode == http.StatusBadRequest {
+		return clues.New("incorrect tenant or application parameters")
+	}
+
+	if resp.StatusCode/100 == 4 || resp.StatusCode/100 == 5 {
+		return clues.New("non-2xx response: " + resp.Status)
+	}
+
+	defer resp.Body.Close()
+
+	return nil
+}

--- a/src/pkg/services/m365/api/access_test.go
+++ b/src/pkg/services/m365/api/access_test.go
@@ -1,0 +1,123 @@
+package api_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/clues"
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
+	"github.com/alcionai/corso/src/pkg/account"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+)
+
+type AccessAPIIntgSuite struct {
+	tester.Suite
+	its intgTesterSetup
+}
+
+func TestAccessAPIIntgSuite(t *testing.T) {
+	suite.Run(t, &AccessAPIIntgSuite{
+		Suite: tester.NewIntegrationSuite(
+			t,
+			[][]string{tconfig.M365AcctCredEnvs}),
+	})
+}
+
+func (suite *AccessAPIIntgSuite) SetupSuite() {
+	suite.its = newIntegrationTesterSetup(suite.T())
+}
+
+func (suite *AccessAPIIntgSuite) TestGetToken() {
+
+	tests := []struct {
+		name      string
+		creds     func() account.M365Config
+		expectErr require.ErrorAssertionFunc
+	}{
+		{
+			name:      "good",
+			creds:     func() account.M365Config { return suite.its.ac.Credentials },
+			expectErr: require.NoError,
+		},
+		{
+			name: "bad tenant ID",
+			creds: func() account.M365Config {
+				creds := suite.its.ac.Credentials
+				creds.AzureTenantID = "ZIM"
+
+				return creds
+			},
+			expectErr: require.Error,
+		},
+		{
+			name: "missing tenant ID",
+			creds: func() account.M365Config {
+				creds := suite.its.ac.Credentials
+				creds.AzureTenantID = ""
+
+				return creds
+			},
+			expectErr: require.Error,
+		},
+		{
+			name: "bad client ID",
+			creds: func() account.M365Config {
+				creds := suite.its.ac.Credentials
+				creds.AzureClientID = "GIR"
+
+				return creds
+			},
+			expectErr: require.Error,
+		},
+		{
+			name: "missing client ID",
+			creds: func() account.M365Config {
+				creds := suite.its.ac.Credentials
+				creds.AzureClientID = ""
+
+				return creds
+			},
+			expectErr: require.Error,
+		},
+		{
+			name: "bad client secret",
+			creds: func() account.M365Config {
+				creds := suite.its.ac.Credentials
+				creds.AzureClientSecret = "MY TALLEST"
+
+				return creds
+			},
+			expectErr: require.Error,
+		},
+		{
+			name: "missing client secret",
+			creds: func() account.M365Config {
+				creds := suite.its.ac.Credentials
+				creds.AzureClientSecret = ""
+
+				return creds
+			},
+			expectErr: require.Error,
+		},
+	}
+	for _, test := range tests {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			ac, err := api.NewClient(suite.its.ac.Credentials, control.DefaultOptions())
+			require.NoError(t, err, clues.ToCore(err))
+
+			ac.Credentials = test.creds()
+
+			err = ac.Access().GetToken(ctx)
+			test.expectErr(t, err, clues.ToCore(err))
+		})
+	}
+}

--- a/src/pkg/services/m365/api/client.go
+++ b/src/pkg/services/m365/api/client.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"io"
 	"net/http"
 
 	"github.com/alcionai/clues"
@@ -117,6 +118,16 @@ func (c Client) Get(
 	headers map[string]string,
 ) (*http.Response, error) {
 	return c.Requester.Request(ctx, http.MethodGet, url, nil, headers)
+}
+
+// Get performs an ad-hoc get request using its graph.Requester
+func (c Client) Post(
+	ctx context.Context,
+	url string,
+	headers map[string]string,
+	body io.Reader,
+) (*http.Response, error) {
+	return c.Requester.Request(ctx, http.MethodGet, url, body, headers)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Takes two steps towards better data provider valiation on init and connect:
1. abstracts the data provider in a repository to replace hard-coded references to m365 with an interface
for connecting to any generic data provider specified by the account.Provider.
2. connects to the data provider during the init and connect steps so that the provider details are validated early in usage, presumably before we write said
connection credentials to the config file.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #2025

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
