### PR TITLE
Use generic item in Drive backup

### DIFF
--- a/src/internal/m365/collection/drive/collection_test.go
+++ b/src/internal/m365/collection/drive/collection_test.go
@@ -981,14 +981,16 @@ func (suite *CollectionUnitSuite) TestItemExtensions() {
 			ei, ok := collItem.(data.ItemInfo)
 			assert.True(t, ok)
 
-			itemInfo, err := ei.Info()
-			require.NoError(t, err, clues.ToCore(err))
+			r := collItem.ToReader()
 
-			_, err = io.ReadAll(collItem.ToReader())
+			_, err = io.ReadAll(r)
 			test.expectReadErr(t, err, clues.ToCore(err))
 
-			err = collItem.ToReader().Close()
+			err = r.Close()
 			test.expectCloseErr(t, err, clues.ToCore(err))
+
+			itemInfo, err := ei.Info()
+			require.NoError(t, err, clues.ToCore(err))
 
 			// Verify extension data
 			test.expect(t, itemInfo, test.payload)

--- a/src/internal/m365/helper_test.go
+++ b/src/internal/m365/helper_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/data"
-	"github.com/alcionai/corso/src/internal/m365/collection/drive"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive/metadata"
 	odStub "github.com/alcionai/corso/src/internal/m365/service/onedrive/stub"
 	m365Stub "github.com/alcionai/corso/src/internal/m365/stub"
@@ -731,7 +730,7 @@ func compareDriveItem(
 	)
 
 	if !isMeta {
-		oitem := item.(*drive.Item)
+		oitem := item.(data.ItemInfo)
 
 		info, err := oitem.Info()
 		if !assert.NoError(t, err, clues.ToCore(err)) {


### PR DESCRIPTION
Use generic lazy item implementation for drive
backups. This is a bit of a stop-gap
implementation since the drive logic is more
complex than exchange logic

Refactoring the drive logic to streamline it
would help reduce the number of functions
called to download a single item etc.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #4191

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
