### PR TITLE
ensure account details on init/connect

### DIFF
--- a/src/internal/m365/controller.go
+++ b/src/internal/m365/controller.go
@@ -81,6 +81,11 @@ func NewController(
 
 	var rCli *resourceClient
 
+	// no failure for unknown service.
+	// In that case we create a controller that doesn't attempt to look up any resource
+	// data.  This case helps avoid unnecessary service calls when the end user is running
+	// repo init and connect commands via the CLI.  All other callers should be expected
+	// to pass in a known service, or else expect downstream failures.
 	if pst != path.UnknownService {
 		rc := resource.UnknownResource
 

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -123,8 +123,7 @@ func New(
 
 type InitConfig struct {
 	// tells the data provider which service to
-	// use for its connection pattern.  Leave empty
-	// to skip the provider connection.
+	// use for its connection pattern.  Optional.
 	Service       path.ServiceType
 	RetentionOpts ctrlRepo.Retention
 }
@@ -151,10 +150,8 @@ func (r *repository) Initialize(
 		}
 	}()
 
-	if cfg.Service != path.UnknownService {
-		if err := r.ConnectDataProvider(ctx, cfg.Service); err != nil {
-			return clues.Stack(err)
-		}
+	if err := r.ConnectDataProvider(ctx, cfg.Service); err != nil {
+		return clues.Stack(err)
 	}
 
 	kopiaRef := kopia.NewConn(r.Storage)
@@ -216,10 +213,8 @@ func (r *repository) Connect(
 		}
 	}()
 
-	if cfg.Service != path.UnknownService {
-		if err := r.ConnectDataProvider(ctx, cfg.Service); err != nil {
-			return clues.Stack(err)
-		}
+	if err := r.ConnectDataProvider(ctx, cfg.Service); err != nil {
+		return clues.Stack(err)
 	}
 
 	progressBar := observe.MessageWithCompletion(ctx, "Connecting to repository")

--- a/src/pkg/services/m365/api/access.go
+++ b/src/pkg/services/m365/api/access.go
@@ -24,10 +24,16 @@ type Access struct {
 	Client
 }
 
+// GetToken retrieves a m365 application auth token using client id and secret credentials.
+// This token is not normally needed in order for corso to function, and is implemented
+// primarily as a way to exercise the validity of those credentials without need of specific
+// permissions.
 func (c Access) GetToken(
 	ctx context.Context,
 ) error {
 	var (
+		//nolint:lll
+		// https://learn.microsoft.com/en-us/graph/connecting-external-content-connectors-api-postman#step-5-get-an-authentication-token
 		rawURL = fmt.Sprintf(
 			"https://login.microsoftonline.com/%s/oauth2/v2.0/token",
 			c.Credentials.AzureTenantID)

--- a/src/pkg/services/m365/api/access.go
+++ b/src/pkg/services/m365/api/access.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/alcionai/clues"
+
+	"github.com/alcionai/corso/src/internal/m365/graph"
+)
+
+// ---------------------------------------------------------------------------
+// controller
+// ---------------------------------------------------------------------------
+
+func (c Client) Access() Access {
+	return Access{c}
+}
+
+// Access is an interface-compliant provider of the client.
+type Access struct {
+	Client
+}
+
+func (c Access) GetToken(
+	ctx context.Context,
+) error {
+	var (
+		rawURL = fmt.Sprintf(
+			"https://login.microsoftonline.com/%s/oauth2/v2.0/token",
+			c.Credentials.AzureTenantID)
+		headers = map[string]string{
+			"Content-Type": "application/x-www-form-urlencoded",
+		}
+		body = strings.NewReader(fmt.Sprintf(
+			"client_id=%s"+
+				"&client_secret=%s"+
+				"&scope=https://graph.microsoft.com/.default"+
+				"&grant_type=client_credentials",
+			c.Credentials.AzureClientID,
+			c.Credentials.AzureClientSecret))
+	)
+
+	resp, err := c.Post(ctx, rawURL, headers, body)
+	if err != nil {
+		return graph.Stack(ctx, err)
+	}
+
+	if resp.StatusCode == http.StatusBadRequest {
+		return clues.New("incorrect tenant or application parameters")
+	}
+
+	if resp.StatusCode/100 == 4 || resp.StatusCode/100 == 5 {
+		return clues.New("non-2xx response: " + resp.Status)
+	}
+
+	defer resp.Body.Close()
+
+	return nil
+}

--- a/src/pkg/services/m365/api/access_test.go
+++ b/src/pkg/services/m365/api/access_test.go
@@ -1,0 +1,123 @@
+package api_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/clues"
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
+	"github.com/alcionai/corso/src/pkg/account"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+)
+
+type AccessAPIIntgSuite struct {
+	tester.Suite
+	its intgTesterSetup
+}
+
+func TestAccessAPIIntgSuite(t *testing.T) {
+	suite.Run(t, &AccessAPIIntgSuite{
+		Suite: tester.NewIntegrationSuite(
+			t,
+			[][]string{tconfig.M365AcctCredEnvs}),
+	})
+}
+
+func (suite *AccessAPIIntgSuite) SetupSuite() {
+	suite.its = newIntegrationTesterSetup(suite.T())
+}
+
+func (suite *AccessAPIIntgSuite) TestGetToken() {
+
+	tests := []struct {
+		name      string
+		creds     func() account.M365Config
+		expectErr require.ErrorAssertionFunc
+	}{
+		{
+			name:      "good",
+			creds:     func() account.M365Config { return suite.its.ac.Credentials },
+			expectErr: require.NoError,
+		},
+		{
+			name: "bad tenant ID",
+			creds: func() account.M365Config {
+				creds := suite.its.ac.Credentials
+				creds.AzureTenantID = "ZIM"
+
+				return creds
+			},
+			expectErr: require.Error,
+		},
+		{
+			name: "missing tenant ID",
+			creds: func() account.M365Config {
+				creds := suite.its.ac.Credentials
+				creds.AzureTenantID = ""
+
+				return creds
+			},
+			expectErr: require.Error,
+		},
+		{
+			name: "bad client ID",
+			creds: func() account.M365Config {
+				creds := suite.its.ac.Credentials
+				creds.AzureClientID = "GIR"
+
+				return creds
+			},
+			expectErr: require.Error,
+		},
+		{
+			name: "missing client ID",
+			creds: func() account.M365Config {
+				creds := suite.its.ac.Credentials
+				creds.AzureClientID = ""
+
+				return creds
+			},
+			expectErr: require.Error,
+		},
+		{
+			name: "bad client secret",
+			creds: func() account.M365Config {
+				creds := suite.its.ac.Credentials
+				creds.AzureClientSecret = "MY TALLEST"
+
+				return creds
+			},
+			expectErr: require.Error,
+		},
+		{
+			name: "missing client secret",
+			creds: func() account.M365Config {
+				creds := suite.its.ac.Credentials
+				creds.AzureClientSecret = ""
+
+				return creds
+			},
+			expectErr: require.Error,
+		},
+	}
+	for _, test := range tests {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			ac, err := api.NewClient(suite.its.ac.Credentials, control.DefaultOptions())
+			require.NoError(t, err, clues.ToCore(err))
+
+			ac.Credentials = test.creds()
+
+			err = ac.Access().GetToken(ctx)
+			test.expectErr(t, err, clues.ToCore(err))
+		})
+	}
+}

--- a/src/pkg/services/m365/api/client.go
+++ b/src/pkg/services/m365/api/client.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"io"
 	"net/http"
 
 	"github.com/alcionai/clues"
@@ -117,6 +118,16 @@ func (c Client) Get(
 	headers map[string]string,
 ) (*http.Response, error) {
 	return c.Requester.Request(ctx, http.MethodGet, url, nil, headers)
+}
+
+// Get performs an ad-hoc get request using its graph.Requester
+func (c Client) Post(
+	ctx context.Context,
+	url string,
+	headers map[string]string,
+	body io.Reader,
+) (*http.Response, error) {
+	return c.Requester.Request(ctx, http.MethodGet, url, body, headers)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
use m365 connection details to retrieve an
application token on init and connect as a way to
validate that the user has provided correct and
usable connection details.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [x] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
