### PR TITLE
move drive expand to config property

### DIFF
--- a/src/internal/m365/collection/site/collection.go
+++ b/src/internal/m365/collection/site/collection.go
@@ -290,7 +290,7 @@ func (sc *Collection) retrievePages(
 		return metrics, clues.New("beta service required").WithClues(ctx)
 	}
 
-	parent, err := as.GetByID(ctx, sc.fullPath.ProtectedResource())
+	parent, err := as.GetByID(ctx, sc.fullPath.ProtectedResource(), api.CallConfig{})
 	if err != nil {
 		return metrics, err
 	}

--- a/src/internal/m365/controller.go
+++ b/src/internal/m365/controller.go
@@ -205,7 +205,11 @@ type resourceClient struct {
 }
 
 type getIDAndNamer interface {
-	GetIDAndName(ctx context.Context, owner string) (
+	GetIDAndName(
+		ctx context.Context,
+		owner string,
+		cc api.CallConfig,
+	) (
 		ownerID string,
 		ownerName string,
 		err error,
@@ -254,7 +258,7 @@ func (r resourceClient) getOwnerIDAndNameFrom(
 		err      error
 	)
 
-	id, name, err = r.getter.GetIDAndName(ctx, owner)
+	id, name, err = r.getter.GetIDAndName(ctx, owner, api.CallConfig{})
 	if err != nil {
 		if graph.IsErrUserNotFound(err) {
 			return "", "", clues.Stack(graph.ErrResourceOwnerNotFound, err)

--- a/src/internal/m365/mock/id_name_getter.go
+++ b/src/internal/m365/mock/id_name_getter.go
@@ -1,6 +1,10 @@
 package mock
 
-import "context"
+import (
+	"context"
+
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+)
 
 type IDNameGetter struct {
 	ID, Name string
@@ -10,6 +14,7 @@ type IDNameGetter struct {
 func (ing IDNameGetter) GetIDAndName(
 	_ context.Context,
 	_ string,
+	_ api.CallConfig,
 ) (string, string, error) {
 	return ing.ID, ing.Name, ing.Err
 }

--- a/src/pkg/services/m365/api/client.go
+++ b/src/pkg/services/m365/api/client.go
@@ -118,3 +118,11 @@ func (c Client) Get(
 ) (*http.Response, error) {
 	return c.Requester.Request(ctx, http.MethodGet, url, nil, headers)
 }
+
+// ---------------------------------------------------------------------------
+// per-call config
+// ---------------------------------------------------------------------------
+
+type CallConfig struct {
+	Expand []string
+}

--- a/src/pkg/services/m365/api/groups.go
+++ b/src/pkg/services/m365/api/groups.go
@@ -231,7 +231,11 @@ func IsTeam(ctx context.Context, mg models.Groupable) bool {
 
 // GetIDAndName looks up the group matching the given ID, and returns
 // its canonical ID and the name.
-func (c Groups) GetIDAndName(ctx context.Context, groupID string) (string, string, error) {
+func (c Groups) GetIDAndName(
+	ctx context.Context,
+	groupID string,
+	_ CallConfig, // not currently supported
+) (string, string, error) {
 	s, err := c.GetByID(ctx, groupID)
 	if err != nil {
 		return "", "", err

--- a/src/pkg/services/m365/api/sites_test.go
+++ b/src/pkg/services/m365/api/sites_test.go
@@ -232,7 +232,11 @@ func (suite *SitesIntgSuite) TestSites_GetByID() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			site, err := sitesAPI.GetByID(ctx, test.id)
+			cc := api.CallConfig{
+				Expand: []string{"drive"},
+			}
+
+			site, err := sitesAPI.GetByID(ctx, test.id, cc)
 			expectedErr := test.expectErr(t, err)
 
 			if expectedErr {

--- a/src/pkg/services/m365/api/users.go
+++ b/src/pkg/services/m365/api/users.go
@@ -131,7 +131,11 @@ func (c Users) GetByID(ctx context.Context, identifier string) (models.Userable,
 
 // GetIDAndName looks up the user matching the given ID, and returns
 // its canonical ID and the PrincipalName as the name.
-func (c Users) GetIDAndName(ctx context.Context, userID string) (string, string, error) {
+func (c Users) GetIDAndName(
+	ctx context.Context,
+	userID string,
+	_ CallConfig, // not currently supported
+) (string, string, error) {
 	u, err := c.GetByID(ctx, userID)
 	if err != nil {
 		return "", "", err

--- a/src/pkg/services/m365/sites.go
+++ b/src/pkg/services/m365/sites.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type SiteOwnerType string
@@ -58,7 +59,11 @@ func SiteByID(
 		return nil, clues.Stack(err).WithClues(ctx)
 	}
 
-	s, err := ac.Sites().GetByID(ctx, id)
+	cc := api.CallConfig{
+		Expand: []string{"drive"},
+	}
+
+	s, err := ac.Sites().GetByID(ctx, id, cc)
 	if err != nil {
 		return nil, clues.Stack(err)
 	}


### PR DESCRIPTION
the addition of the drive expand requires onedrive permissions in order to retrieve sites by ID.  This causes some users to violate customer contract by requiring unwanted permissions.  This change allows configuration of the getbyID call to optionally include the drive extend, which enables the backup process to return to the permission set as expected from v0.12

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #4337

#### Test Plan

- [ ] :muscle: Manual
- [ ] :green_heart: E2E
