### PR TITLE
add missing recoverable errs

### DIFF
--- a/src/internal/m365/collection/drive/collection.go
+++ b/src/internal/m365/collection/drive/collection.go
@@ -301,8 +301,11 @@ func (oc *Collection) getDriveItemContent(
 			return nil, clues.Wrap(err, "max oneNote item").Label(graph.LabelsSkippable)
 		}
 
-		logger.CtxErr(ctx, err).Error("downloading item content")
-		errs.AddRecoverable(ctx, clues.Stack(err).WithClues(ctx).Label(fault.LabelForceNoBackupCreation))
+		errs.AddRecoverable(
+			ctx,
+			clues.Wrap(err, "downloading item content").
+				WithClues(ctx).
+				Label(fault.LabelForceNoBackupCreation))
 
 		// return err, not el.Err(), because the lazy reader needs to communicate to
 		// the data consumer that this item is unreadable, regardless of the fault state.

--- a/src/internal/m365/collection/exchange/collection.go
+++ b/src/internal/m365/collection/exchange/collection.go
@@ -244,11 +244,14 @@ func (col *prefetchCollection) streamItems(
 		}(id)
 	}
 
-	parentPath := col.LocationPath().String()
+	var (
+		parentPath = col.LocationPath().String()
+		el         = errs.Local()
+	)
 
 	// add any new items
 	for id := range col.added {
-		if errs.Failure() != nil {
+		if el.Failure() != nil {
 			break
 		}
 
@@ -276,7 +279,7 @@ func (col *prefetchCollection) streamItems(
 					atomic.AddInt64(&success, 1)
 					log.With("err", err).Infow("item not found", clues.InErr(err).Slice()...)
 				} else {
-					errs.AddRecoverable(ctx, clues.Wrap(err, "fetching item").Label(fault.LabelForceNoBackupCreation))
+					el.AddRecoverable(ctx, clues.Wrap(err, "fetching item").Label(fault.LabelForceNoBackupCreation))
 				}
 
 				return

--- a/src/internal/m365/collection/groups/collection.go
+++ b/src/internal/m365/collection/groups/collection.go
@@ -212,18 +212,18 @@ func (col *Collection) streamItems(ctx context.Context, errs *fault.Bus) {
 				parentFolderID,
 				id)
 			if err != nil {
-				logger.CtxErr(ctx, err).Info("writing channel message to serializer")
+				el.AddRecoverable(ctx, clues.Wrap(err, "writing channel message to serializer"))
 				return
 			}
 
 			if err := writer.WriteObjectValue("", item); err != nil {
-				logger.CtxErr(ctx, err).Info("writing channel message to serializer")
+				el.AddRecoverable(ctx, clues.Wrap(err, "writing channel message to serializer"))
 				return
 			}
 
 			data, err := writer.GetSerializedContent()
 			if err != nil {
-				logger.CtxErr(ctx, err).Info("serializing channel message")
+				el.AddRecoverable(ctx, clues.Wrap(err, "serializing channel message"))
 				return
 			}
 


### PR DESCRIPTION
groups collection item streaming is missing
recoverable errors, and is only logging at this time. This may be causing backups to succeed even
when errors should cause a failure.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix

#### Issue(s)

* #3988

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
