### PR TITLE
separate delta not supported from invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Increase Exchange backup performance by lazily fetching data only for items whose content changed.
 - Added `--backups` flag to delete multiple backups in `corso backup delete` command.
 
+## Fixed
+- Teams Channels that cannot support delta tokens (those without messages) fall back to non-delta enumeration and no longer fail a backup.
+
 ## [v0.13.0] (beta) - 2023-09-18
 
 ### Added

--- a/src/internal/m365/graph/errors_test.go
+++ b/src/internal/m365/graph/errors_test.go
@@ -247,11 +247,6 @@ func (suite *GraphErrorsUnitSuite) TestIsErrInvalidDelta() {
 			err:    odErr(string(syncStateInvalid)),
 			expect: assert.True,
 		},
-		{
-			name:   "deltatoken not supported oDataErrMsg",
-			err:    odErrMsg("fnords", string(parameterDeltaTokenNotSupported)),
-			expect: assert.True,
-		},
 		// next two tests are to make sure the checks are case insensitive
 		{
 			name:   "resync-required oDataErr camelcase",
@@ -267,6 +262,55 @@ func (suite *GraphErrorsUnitSuite) TestIsErrInvalidDelta() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			test.expect(suite.T(), IsErrInvalidDelta(test.err))
+		})
+	}
+}
+
+func (suite *GraphErrorsUnitSuite) TestIsErrDeltaNotSupported() {
+	table := []struct {
+		name   string
+		err    error
+		expect assert.BoolAssertionFunc
+	}{
+		{
+			name:   "nil",
+			err:    nil,
+			expect: assert.False,
+		},
+		{
+			name:   "non-matching",
+			err:    assert.AnError,
+			expect: assert.False,
+		},
+		{
+			name:   "as",
+			err:    ErrDeltaNotSupported,
+			expect: assert.True,
+		},
+		{
+			name:   "non-matching oDataErr",
+			err:    odErr("fnords"),
+			expect: assert.False,
+		},
+		{
+			name:   "non-matching oDataErrMsg",
+			err:    odErrMsg("fnords", "deltatoken not supported"),
+			expect: assert.False,
+		},
+		{
+			name:   "deltatoken not supported oDataErrMsg",
+			err:    odErrMsg("fnords", string(parameterDeltaTokenNotSupported)),
+			expect: assert.True,
+		},
+		{
+			name:   "deltatoken not supported oDataErrMsg with punctuation",
+			err:    odErrMsg("fnords", string(parameterDeltaTokenNotSupported)+"."),
+			expect: assert.True,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			test.expect(suite.T(), IsErrDeltaNotSupported(test.err))
 		})
 	}
 }


### PR DESCRIPTION
groups backup has a failing case where delta
queries are not supported, but we aren't distinguishing
that case from the invalid delta case as expected. This
results in backup failures, instead of success with no data.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

#### Type of change

- [x] :bug: Bugfix

#### Issue(s)

* #3988

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
