### PR TITLE
fix getting owner of sites

### DIFF
--- a/src/pkg/services/m365/sites.go
+++ b/src/pkg/services/m365/sites.go
@@ -114,22 +114,26 @@ func ParseSite(item models.Siteable) *Site {
 
 	if item.GetDrive() != nil &&
 		item.GetDrive().GetOwner() != nil &&
-		item.GetDrive().GetOwner().GetUser() != nil {
+		item.GetDrive().GetOwner().GetUser() != nil &&
+		// some users might come back with a nil ID
+		// most likely in the case of deleted users
+		item.GetDrive().GetOwner().GetUser().GetId() != nil {
 		s.OwnerType = SiteOwnerUser
 		s.OwnerID = ptr.Val(item.GetDrive().GetOwner().GetUser().GetId())
-	}
+	} else if item.GetDrive() != nil && item.GetDrive().GetOwner() != nil {
+		ownerItem := item.GetDrive().GetOwner()
+		if _, ok := ownerItem.GetAdditionalData()["group"]; ok {
+			s.OwnerType = SiteOwnerGroup
 
-	if _, ok := item.GetAdditionalData()["group"]; ok {
-		s.OwnerType = SiteOwnerGroup
+			group, err := tform.AnyValueToT[map[string]any]("group", ownerItem.GetAdditionalData())
+			if err != nil {
+				return s
+			}
 
-		group, err := tform.AnyValueToT[map[string]any]("group", item.GetAdditionalData())
-		if err != nil {
-			return s
-		}
-
-		s.OwnerID, err = str.AnyValueToString("id", group)
-		if err != nil {
-			return s
+			s.OwnerID, err = str.AnyValueToString("id", group)
+			if err != nil {
+				return s
+			}
 		}
 	}
 

--- a/src/pkg/services/m365/sites_test.go
+++ b/src/pkg/services/m365/sites_test.go
@@ -61,6 +61,34 @@ func (suite *siteIntegrationSuite) TestSites() {
 	}
 }
 
+func (suite *siteIntegrationSuite) TestSites_GetByID() {
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	acct := tconfig.NewM365Account(t)
+
+	sites, err := Sites(ctx, acct, fault.New(true))
+	assert.NoError(t, err, clues.ToCore(err))
+	assert.NotEmpty(t, sites)
+
+	for _, s := range sites {
+		suite.Run("site_"+s.ID, func() {
+			t := suite.T()
+			site, err := SiteByID(ctx, acct, s.ID)
+			assert.NoError(t, err, clues.ToCore(err))
+			assert.NotEmpty(t, site.WebURL)
+			assert.NotEmpty(t, site.ID)
+			assert.NotEmpty(t, site.DisplayName)
+			if site.OwnerType != SiteOwnerUnknown {
+				assert.NotEmpty(t, site.OwnerID)
+				assert.NotEmpty(t, site.OwnerType)
+			}
+		})
+	}
+}
+
 func (suite *siteIntegrationSuite) TestSites_InvalidCredentials() {
 	table := []struct {
 		name string


### PR DESCRIPTION
Fixes an issue where Get Site by id is looking for the `group` details in the additional data of the site items. It should be looking in `site.drive.owner` instead.
---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E

Added a new test and tested using the `10rqc2` test tenant.

```
CORSO_CI_TESTS=true go test -run TestSiteIntegrationSuite/TestSites_GetByID -v
=== RUN   TestSiteIntegrationSuite
    tester.go:44: TestSiteIntegrationSuite run at 2023-09-26T17:34:05.383766Z
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID
    tester.go:44: TestSiteIntegrationSuite/TestSites_GetByID run at 2023-09-26T17:34:05.3883Z
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,96772abb-cfbe-496d-a770-301650888b3a,7ff3cdd8-1bf4-4e5d-999d-830a276c8490
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,8be0b20e-6eff-4ac8-8505-53c7030c9fb8,316e3a01-1d93-412b-9f31-8758a267bb4a
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,32c3d871-e17d-47de-abff-b5d7e3491a31,316e3a01-1d93-412b-9f31-8758a267bb4a
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,7a8d49ec-d275-4589-8fc1-a8088ed31332,cd8ae214-0f28-43e1-8ec4-ad3b9fb11809
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,0bd5608f-159c-488c-ac51-cd80f747bc1d,cd8ae214-0f28-43e1-8ec4-ad3b9fb11809
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,4aae01c8-1d30-4202-9962-9e7b64b6bc10,cd8ae214-0f28-43e1-8ec4-ad3b9fb11809
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,d530b5ab-0dd9-4858-a07c-9d76a8f09b83,cd8ae214-0f28-43e1-8ec4-ad3b9fb11809
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,c87270a2-f375-44ec-b582-09f1b7ddd842,cd8ae214-0f28-43e1-8ec4-ad3b9fb11809
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,055d896c-88bc-45c3-aa4b-5af71f326bcc,cd8ae214-0f28-43e1-8ec4-ad3b9fb11809
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,13a2ff8b-537f-428f-aaf2-f2e4b08e4bde,cd8ae214-0f28-43e1-8ec4-ad3b9fb11809
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,1e16d84e-9e42-406e-b628-5d4b303309ed,41e5f79b-fe25-47c0-996b-d3e77571dbb1
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,2f9743f8-4ca3-411f-b85d-32e6441eefd2,11810f05-e8bd-45e2-9728-92e434260750
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,4d799bb6-222e-46ce-a626-51051eb2f311,11810f05-e8bd-45e2-9728-92e434260750
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,b0d4432d-432b-4681-9cdb-2ab789dfe145,ce88f380-fbaa-48aa-a3a1-e04599594e95
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,f10c5f9a-1b2b-4764-8685-d08e9883888c,ce88f380-fbaa-48aa-a3a1-e04599594e95
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,8df7082a-62eb-4165-97f9-ead8cf04c0d8,11810f05-e8bd-45e2-9728-92e434260750
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,053684d8-ca6c-4376-a03e-2567816bb091,9b3e9abe-6a5e-4084-8b44-ea5a356fe02c
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,ba5dbd17-6f68-4405-b1b6-e1160c0ba746,8e229f4f-e962-42ef-a087-dc54daa2e48c
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,e946c519-47f6-443f-9544-574ab9f3966f,8e229f4f-e962-42ef-a087-dc54daa2e48c
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,846d8363-c646-496b-a603-06a2a22e0196,9b3e9abe-6a5e-4084-8b44-ea5a356fe02c
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,bf300606-e52e-41d7-a860-e5927f57a46d,8e229f4f-e962-42ef-a087-dc54daa2e48c
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,bf83915f-7454-4f2a-b3c1-1932251c714f,bf2bed00-f5ec-4551-96c1-dc7069392eb8
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,038e0095-4509-4f53-b045-0c86a7971b6a,3086932f-402c-494b-9aea-bf2bb1bf8303
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,25ca6d57-b92b-4731-9b87-23050e080eac,cf53a987-f1bb-4cea-a27e-62ee282ecca7
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,8b672056-0409-46f6-98bb-4a9f5626830f,cf53a987-f1bb-4cea-a27e-62ee282ecca7
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,e1d12403-62e6-44d0-9798-15fd194858f7,69ca49fc-e607-438b-ba24-3bb40fc7baba
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,4892edf5-2ebf-46be-a6e5-a40b2cbf1c1a,38ab6d06-fc82-4417-af93-22d8733c22be
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,6884eaa6-108e-42ee-ac1e-8f8d344d5e53,42c29db5-bf88-46b7-af47-05a5ca15c1b3
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,5cdb15ec-4440-4115-be94-d9221b9135b3,42c29db5-bf88-46b7-af47-05a5ca15c1b3
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,4637d353-1c6d-4967-98a3-a75db4e1a925,42c29db5-bf88-46b7-af47-05a5ca15c1b3
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,8b510176-8837-4a81-a26e-2020565adb92,276af97a-8a5e-4001-aa86-53958ac9548c
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,3d374d63-f5fa-4c6a-b5c3-119280bd5442,42c29db5-bf88-46b7-af47-05a5ca15c1b3
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,8fa2edf7-1f13-47e5-834d-ccdb81879302,276af97a-8a5e-4001-aa86-53958ac9548c
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,7a8dccfa-aa6b-4a75-b7bd-eab3f85af9b0,859ccc3c-2ed3-4258-84d1-ec735b39adc1
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,54bc7530-a81c-4d90-8cfb-a8625168187f,859ccc3c-2ed3-4258-84d1-ec735b39adc1
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,2d6ba44f-0638-4950-8fee-537c854e9e28,859ccc3c-2ed3-4258-84d1-ec735b39adc1
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,23283ae3-170b-4db6-b50f-895b12373524,859ccc3c-2ed3-4258-84d1-ec735b39adc1
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,f238d00a-af70-4273-9017-6042a6d8a8e1,859ccc3c-2ed3-4258-84d1-ec735b39adc1
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,ee9af367-a8ef-4f56-99ad-72f53d1cd64f,859ccc3c-2ed3-4258-84d1-ec735b39adc1
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,291e91dd-f9f9-4e0f-8abc-269ade15e1be,a470fff3-c3a7-456a-98c3-ad51d166e222
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,5edef5e8-6654-4fb7-870b-52365d9818f4,859ccc3c-2ed3-4258-84d1-ec735b39adc1
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,203db13c-aa6b-4cb4-bb11-7b5ce9c2b5b6,7f2cd296-9f7c-44e1-af81-3c06d0d43007
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,b8fff07f-350b-4f62-b35f-854b0920f180,7f2cd296-9f7c-44e1-af81-3c06d0d43007
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,26b58876-c2c2-4bee-9fae-a2acbb0ebeb0,7f2cd296-9f7c-44e1-af81-3c06d0d43007
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,b39c8064-43bf-4740-83cf-8d4814ee8591,7f2cd296-9f7c-44e1-af81-3c06d0d43007
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,01af6484-492e-4bae-bd3b-ed7d14ed3369,7f2cd296-9f7c-44e1-af81-3c06d0d43007
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,6e27eab3-0ccc-4ce1-80ae-b32912c9468d,7f2cd296-9f7c-44e1-af81-3c06d0d43007
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,bb5d5b4a-e089-4e66-9868-9e263ecc635d,4fa3a2c0-fa81-4e6f-8e8b-1479a8927bc6
=== RUN   TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,009d6803-aa00-4db7-8233-e2cbd7d9f503,5408143c-ebd0-4130-82e6-767375686853
--- PASS: TestSiteIntegrationSuite (30.98s)
    --- PASS: TestSiteIntegrationSuite/TestSites_GetByID (30.97s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,96772abb-cfbe-496d-a770-301650888b3a,7ff3cdd8-1bf4-4e5d-999d-830a276c8490 (0.61s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,8be0b20e-6eff-4ac8-8505-53c7030c9fb8,316e3a01-1d93-412b-9f31-8758a267bb4a (0.64s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,32c3d871-e17d-47de-abff-b5d7e3491a31,316e3a01-1d93-412b-9f31-8758a267bb4a (0.81s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,7a8d49ec-d275-4589-8fc1-a8088ed31332,cd8ae214-0f28-43e1-8ec4-ad3b9fb11809 (0.59s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,0bd5608f-159c-488c-ac51-cd80f747bc1d,cd8ae214-0f28-43e1-8ec4-ad3b9fb11809 (0.61s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,4aae01c8-1d30-4202-9962-9e7b64b6bc10,cd8ae214-0f28-43e1-8ec4-ad3b9fb11809 (0.65s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,d530b5ab-0dd9-4858-a07c-9d76a8f09b83,cd8ae214-0f28-43e1-8ec4-ad3b9fb11809 (0.61s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,c87270a2-f375-44ec-b582-09f1b7ddd842,cd8ae214-0f28-43e1-8ec4-ad3b9fb11809 (0.69s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,055d896c-88bc-45c3-aa4b-5af71f326bcc,cd8ae214-0f28-43e1-8ec4-ad3b9fb11809 (0.71s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,13a2ff8b-537f-428f-aaf2-f2e4b08e4bde,cd8ae214-0f28-43e1-8ec4-ad3b9fb11809 (0.65s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,1e16d84e-9e42-406e-b628-5d4b303309ed,41e5f79b-fe25-47c0-996b-d3e77571dbb1 (0.57s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,2f9743f8-4ca3-411f-b85d-32e6441eefd2,11810f05-e8bd-45e2-9728-92e434260750 (0.62s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,4d799bb6-222e-46ce-a626-51051eb2f311,11810f05-e8bd-45e2-9728-92e434260750 (0.79s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,b0d4432d-432b-4681-9cdb-2ab789dfe145,ce88f380-fbaa-48aa-a3a1-e04599594e95 (0.52s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,f10c5f9a-1b2b-4764-8685-d08e9883888c,ce88f380-fbaa-48aa-a3a1-e04599594e95 (0.51s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,8df7082a-62eb-4165-97f9-ead8cf04c0d8,11810f05-e8bd-45e2-9728-92e434260750 (0.62s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,053684d8-ca6c-4376-a03e-2567816bb091,9b3e9abe-6a5e-4084-8b44-ea5a356fe02c (0.55s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,ba5dbd17-6f68-4405-b1b6-e1160c0ba746,8e229f4f-e962-42ef-a087-dc54daa2e48c (0.63s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,e946c519-47f6-443f-9544-574ab9f3966f,8e229f4f-e962-42ef-a087-dc54daa2e48c (0.66s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,846d8363-c646-496b-a603-06a2a22e0196,9b3e9abe-6a5e-4084-8b44-ea5a356fe02c (0.50s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,bf300606-e52e-41d7-a860-e5927f57a46d,8e229f4f-e962-42ef-a087-dc54daa2e48c (0.73s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,bf83915f-7454-4f2a-b3c1-1932251c714f,bf2bed00-f5ec-4551-96c1-dc7069392eb8 (0.56s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,038e0095-4509-4f53-b045-0c86a7971b6a,3086932f-402c-494b-9aea-bf2bb1bf8303 (0.60s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,25ca6d57-b92b-4731-9b87-23050e080eac,cf53a987-f1bb-4cea-a27e-62ee282ecca7 (0.54s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,8b672056-0409-46f6-98bb-4a9f5626830f,cf53a987-f1bb-4cea-a27e-62ee282ecca7 (0.52s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,e1d12403-62e6-44d0-9798-15fd194858f7,69ca49fc-e607-438b-ba24-3bb40fc7baba (0.51s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,4892edf5-2ebf-46be-a6e5-a40b2cbf1c1a,38ab6d06-fc82-4417-af93-22d8733c22be (0.49s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,6884eaa6-108e-42ee-ac1e-8f8d344d5e53,42c29db5-bf88-46b7-af47-05a5ca15c1b3 (0.53s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,5cdb15ec-4440-4115-be94-d9221b9135b3,42c29db5-bf88-46b7-af47-05a5ca15c1b3 (0.50s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,4637d353-1c6d-4967-98a3-a75db4e1a925,42c29db5-bf88-46b7-af47-05a5ca15c1b3 (0.55s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,8b510176-8837-4a81-a26e-2020565adb92,276af97a-8a5e-4001-aa86-53958ac9548c (0.53s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,3d374d63-f5fa-4c6a-b5c3-119280bd5442,42c29db5-bf88-46b7-af47-05a5ca15c1b3 (0.54s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,8fa2edf7-1f13-47e5-834d-ccdb81879302,276af97a-8a5e-4001-aa86-53958ac9548c (0.53s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,7a8dccfa-aa6b-4a75-b7bd-eab3f85af9b0,859ccc3c-2ed3-4258-84d1-ec735b39adc1 (0.61s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,54bc7530-a81c-4d90-8cfb-a8625168187f,859ccc3c-2ed3-4258-84d1-ec735b39adc1 (0.54s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,2d6ba44f-0638-4950-8fee-537c854e9e28,859ccc3c-2ed3-4258-84d1-ec735b39adc1 (0.67s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,23283ae3-170b-4db6-b50f-895b12373524,859ccc3c-2ed3-4258-84d1-ec735b39adc1 (0.80s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,f238d00a-af70-4273-9017-6042a6d8a8e1,859ccc3c-2ed3-4258-84d1-ec735b39adc1 (0.74s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,ee9af367-a8ef-4f56-99ad-72f53d1cd64f,859ccc3c-2ed3-4258-84d1-ec735b39adc1 (0.76s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,291e91dd-f9f9-4e0f-8abc-269ade15e1be,a470fff3-c3a7-456a-98c3-ad51d166e222 (0.61s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,5edef5e8-6654-4fb7-870b-52365d9818f4,859ccc3c-2ed3-4258-84d1-ec735b39adc1 (0.59s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,203db13c-aa6b-4cb4-bb11-7b5ce9c2b5b6,7f2cd296-9f7c-44e1-af81-3c06d0d43007 (0.63s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,b8fff07f-350b-4f62-b35f-854b0920f180,7f2cd296-9f7c-44e1-af81-3c06d0d43007 (0.62s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,26b58876-c2c2-4bee-9fae-a2acbb0ebeb0,7f2cd296-9f7c-44e1-af81-3c06d0d43007 (0.58s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,b39c8064-43bf-4740-83cf-8d4814ee8591,7f2cd296-9f7c-44e1-af81-3c06d0d43007 (0.67s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,01af6484-492e-4bae-bd3b-ed7d14ed3369,7f2cd296-9f7c-44e1-af81-3c06d0d43007 (0.69s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,6e27eab3-0ccc-4ce1-80ae-b32912c9468d,7f2cd296-9f7c-44e1-af81-3c06d0d43007 (0.63s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,bb5d5b4a-e089-4e66-9868-9e263ecc635d,4fa3a2c0-fa81-4e6f-8e8b-1479a8927bc6 (0.67s)
        --- PASS: TestSiteIntegrationSuite/TestSites_GetByID/site_10rqc2.sharepoint.com,009d6803-aa00-4db7-8233-e2cbd7d9f503,5408143c-ebd0-4130-82e6-767375686853 (0.57s)
PASS
ok  	github.com/alcionai/corso/src/pkg/services/m365	31.635s
```
