### PR TITLE
Add ability to easily test sanity test workflow

### DIFF
--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -411,7 +411,7 @@ jobs:
           retention-days: 14
 
       - name: Notify failure in slack
-        if: failure()
+        if: failure() &&  github.ref == 'refs/heads/main'
         uses: ./.github/actions/slack-message
         with:
           msg: "[FAILED] Sanity Tests"

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    paths:
+      - ".github/workflows/sanity-test.yaml" # ability to create DRAFT PR to test workflow
   workflow_dispatch:
     inputs:
       user:


### PR DESCRIPTION
We should now(ideally) be able to create a DRAFT pr and the sanity test workflow would run if the sanity test workflow file was changed.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
