### PR TITLE
Fix nightly tests for exchange, onedrive and groups

### DIFF
--- a/src/cli/backup/exchange_e2e_test.go
+++ b/src/cli/backup/exchange_e2e_test.go
@@ -561,10 +561,8 @@ func runExchangeDetailsCmdTest(suite *PreparedBackupExchangeE2ESuite, category p
 
 type BackupDeleteExchangeE2ESuite struct {
 	tester.Suite
-	dpnd           dependencies
-	backupOp       operations.BackupOperation
-	secondBackupOp operations.BackupOperation
-	thirdBackupOp  operations.BackupOperation
+	dpnd      dependencies
+	backupOps [3]operations.BackupOperation
 }
 
 func TestBackupDeleteExchangeE2ESuite(t *testing.T) {
@@ -590,29 +588,15 @@ func (suite *BackupDeleteExchangeE2ESuite) SetupSuite() {
 	sel := selectors.NewExchangeBackup(users)
 	sel.Include(sel.MailFolders([]string{api.MailInbox}, selectors.PrefixMatch()))
 
-	backupOp, err := suite.dpnd.repo.NewBackup(ctx, sel.Selector)
-	require.NoError(t, err, clues.ToCore(err))
+	for i := 0; i < cap(suite.backupOps); i++ {
+		backupOp, err := suite.dpnd.repo.NewBackup(ctx, sel.Selector)
+		require.NoError(t, err, clues.ToCore(err))
 
-	suite.backupOp = backupOp
+		suite.backupOps[i] = backupOp
 
-	err = suite.backupOp.Run(ctx)
-	require.NoError(t, err, clues.ToCore(err))
-
-	secondBackupOp, err := suite.dpnd.repo.NewBackup(ctx, sel.Selector)
-	require.NoError(t, err, clues.ToCore(err))
-
-	suite.secondBackupOp = secondBackupOp
-
-	err = suite.secondBackupOp.Run(ctx)
-	require.NoError(t, err, clues.ToCore(err))
-
-	thirdBackupOp, err := suite.dpnd.repo.NewBackup(ctx, sel.Selector)
-	require.NoError(t, err, clues.ToCore(err))
-
-	suite.thirdBackupOp = thirdBackupOp
-
-	err = suite.thirdBackupOp.Run(ctx)
-	require.NoError(t, err, clues.ToCore(err))
+		err = suite.backupOps[i].Run(ctx)
+		require.NoError(t, err, clues.ToCore(err))
+	}
 }
 
 func (suite *BackupDeleteExchangeE2ESuite) TestExchangeBackupDeleteCmd() {
@@ -628,8 +612,8 @@ func (suite *BackupDeleteExchangeE2ESuite) TestExchangeBackupDeleteCmd() {
 		"--config-file", suite.dpnd.configFilePath,
 		"--"+flags.BackupIDsFN,
 		fmt.Sprintf("%s,%s",
-			string(suite.backupOp.Results.BackupID),
-			string(suite.secondBackupOp.Results.BackupID)))
+			string(suite.backupOps[0].Results.BackupID),
+			string(suite.backupOps[1].Results.BackupID)))
 	cli.BuildCommandTree(cmd)
 
 	// run the command
@@ -640,7 +624,7 @@ func (suite *BackupDeleteExchangeE2ESuite) TestExchangeBackupDeleteCmd() {
 	cmd = cliTD.StubRootCmd(
 		"backup", "details", "exchange",
 		"--config-file", suite.dpnd.configFilePath,
-		"--backup", string(suite.backupOp.Results.BackupID))
+		"--backup", string(suite.backupOps[0].Results.BackupID))
 	cli.BuildCommandTree(cmd)
 
 	err = cmd.ExecuteContext(ctx)
@@ -650,7 +634,7 @@ func (suite *BackupDeleteExchangeE2ESuite) TestExchangeBackupDeleteCmd() {
 	cmd = cliTD.StubRootCmd(
 		"backup", "details", "exchange",
 		"--config-file", suite.dpnd.configFilePath,
-		"--backup", string(suite.secondBackupOp.Results.BackupID))
+		"--backup", string(suite.backupOps[1].Results.BackupID))
 	cli.BuildCommandTree(cmd)
 
 	err = cmd.ExecuteContext(ctx)
@@ -669,7 +653,7 @@ func (suite *BackupDeleteExchangeE2ESuite) TestExchangeBackupDeleteCmd_SingleID(
 		"backup", "delete", "exchange",
 		"--config-file", suite.dpnd.configFilePath,
 		"--"+flags.BackupFN,
-		string(suite.thirdBackupOp.Results.BackupID))
+		string(suite.backupOps[2].Results.BackupID))
 	cli.BuildCommandTree(cmd)
 
 	// run the command
@@ -680,7 +664,7 @@ func (suite *BackupDeleteExchangeE2ESuite) TestExchangeBackupDeleteCmd_SingleID(
 	cmd = cliTD.StubRootCmd(
 		"backup", "details", "exchange",
 		"--config-file", suite.dpnd.configFilePath,
-		"--backup", string(suite.thirdBackupOp.Results.BackupID))
+		"--backup", string(suite.backupOps[2].Results.BackupID))
 	cli.BuildCommandTree(cmd)
 
 	err = cmd.ExecuteContext(ctx)

--- a/src/cli/backup/groups_e2e_test.go
+++ b/src/cli/backup/groups_e2e_test.go
@@ -497,9 +497,10 @@ func runGroupsDetailsCmdTest(suite *PreparedBackupGroupsE2ESuite, category path.
 
 type BackupDeleteGroupsE2ESuite struct {
 	tester.Suite
-	dpnd              dependencies
-	backupOp          operations.BackupOperation
-	secondaryBackupOp operations.BackupOperation
+	dpnd           dependencies
+	backupOp       operations.BackupOperation
+	secondBackupOp operations.BackupOperation
+	thirdBackupOp  operations.BackupOperation
 }
 
 func TestBackupDeleteGroupsE2ESuite(t *testing.T) {
@@ -533,13 +534,22 @@ func (suite *BackupDeleteGroupsE2ESuite) SetupSuite() {
 	err = suite.backupOp.Run(ctx)
 	require.NoError(t, err, clues.ToCore(err))
 
-	// secondary backup
-	secondaryBackupOp, err := suite.dpnd.repo.NewBackup(ctx, sel.Selector)
+	// second backup
+	secondBackupOp, err := suite.dpnd.repo.NewBackup(ctx, sel.Selector)
 	require.NoError(t, err, clues.ToCore(err))
 
-	suite.secondaryBackupOp = secondaryBackupOp
+	suite.secondBackupOp = secondBackupOp
 
-	err = suite.secondaryBackupOp.Run(ctx)
+	err = suite.secondBackupOp.Run(ctx)
+	require.NoError(t, err, clues.ToCore(err))
+
+	// third backup
+	thirdBackupOp, err := suite.dpnd.repo.NewBackup(ctx, sel.Selector)
+	require.NoError(t, err, clues.ToCore(err))
+
+	suite.thirdBackupOp = thirdBackupOp
+
+	err = suite.thirdBackupOp.Run(ctx)
 	require.NoError(t, err, clues.ToCore(err))
 }
 
@@ -557,7 +567,7 @@ func (suite *BackupDeleteGroupsE2ESuite) TestGroupsBackupDeleteCmd() {
 		"--"+flags.BackupIDsFN,
 		fmt.Sprintf("%s,%s",
 			string(suite.backupOp.Results.BackupID),
-			string(suite.secondaryBackupOp.Results.BackupID)))
+			string(suite.secondBackupOp.Results.BackupID)))
 	cli.BuildCommandTree(cmd)
 
 	// run the command
@@ -587,7 +597,7 @@ func (suite *BackupDeleteGroupsE2ESuite) TestGroupsBackupDeleteCmd_SingleID() {
 		"backup", "delete", "groups",
 		"--config-file", suite.dpnd.configFilePath,
 		"--"+flags.BackupFN,
-		string(suite.backupOp.Results.BackupID))
+		string(suite.thirdBackupOp.Results.BackupID))
 	cli.BuildCommandTree(cmd)
 
 	// run the command
@@ -598,7 +608,7 @@ func (suite *BackupDeleteGroupsE2ESuite) TestGroupsBackupDeleteCmd_SingleID() {
 	cmd = cliTD.StubRootCmd(
 		"backup", "details", "groups",
 		"--config-file", suite.dpnd.configFilePath,
-		"--backup", string(suite.backupOp.Results.BackupID))
+		"--backup", string(suite.thirdBackupOp.Results.BackupID))
 	cli.BuildCommandTree(cmd)
 
 	err = cmd.ExecuteContext(ctx)


### PR DESCRIPTION
We were trying to delete a single backupOp multiple times across different tests. Added another backupOp to for use in the new test.

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
