### PR TITLE
use concrete types for store configs

### DIFF
--- a/src/cli/backup/helpers_test.go
+++ b/src/cli/backup/helpers_test.go
@@ -140,10 +140,8 @@ func prepM365Test(
 		recorder = strings.Builder{}
 	)
 
-	sc, err := st.StorageConfig()
+	cfg, err := st.ToS3Config()
 	require.NoError(t, err, clues.ToCore(err))
-
-	cfg := sc.(*storage.S3Config)
 
 	force := map[string]string{
 		tconfig.TestCfgAccountProvider: account.ProviderM365.String(),

--- a/src/cli/config/config_test.go
+++ b/src/cli/config/config_test.go
@@ -356,10 +356,9 @@ func (suite *ConfigSuite) TestReadFromFlags() {
 
 	m365Config, _ := repoDetails.Account.M365Config()
 
-	sc, err := repoDetails.Storage.StorageConfig()
+	s3Cfg, err := repoDetails.Storage.ToS3Config()
 	require.NoError(t, err, "reading s3 config from storage", clues.ToCore(err))
 
-	s3Cfg := sc.(*storage.S3Config)
 	commonConfig, _ := repoDetails.Storage.CommonConfig()
 	pass := commonConfig.Corso.CorsoPassphrase
 
@@ -437,10 +436,8 @@ func (suite *ConfigIntegrationSuite) TestGetStorageAndAccount() {
 	cfg, err := getStorageAndAccountWithViper(vpr, storage.ProviderS3, true, true, nil)
 	require.NoError(t, err, "getting storage and account from config", clues.ToCore(err))
 
-	sc, err := cfg.Storage.StorageConfig()
+	readS3Cfg, err := cfg.Storage.ToS3Config()
 	require.NoError(t, err, "reading s3 config from storage", clues.ToCore(err))
-
-	readS3Cfg := sc.(*storage.S3Config)
 
 	assert.Equal(t, readS3Cfg.Bucket, s3Cfg.Bucket)
 	assert.Equal(t, readS3Cfg.Endpoint, s3Cfg.Endpoint)
@@ -488,10 +485,8 @@ func (suite *ConfigIntegrationSuite) TestGetStorageAndAccount_noFileOnlyOverride
 	cfg, err := getStorageAndAccountWithViper(vpr, storage.ProviderS3, false, true, overrides)
 	require.NoError(t, err, "getting storage and account from config", clues.ToCore(err))
 
-	sc, err := cfg.Storage.StorageConfig()
+	readS3Cfg, err := cfg.Storage.ToS3Config()
 	require.NoError(t, err, "reading s3 config from storage", clues.ToCore(err))
-
-	readS3Cfg := sc.(*storage.S3Config)
 
 	assert.Equal(t, readS3Cfg.Bucket, bkt)
 	assert.Equal(t, cfg.RepoID, "")

--- a/src/cli/repo/filesystem.go
+++ b/src/cli/repo/filesystem.go
@@ -121,7 +121,7 @@ func initFilesystemCmd(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 
-		return Only(ctx, clues.Wrap(err, "Failed to initialize a new filesystem repository"))
+		return Only(ctx, clues.Stack(ErrInitializingRepo, err))
 	}
 
 	defer utils.CloseRepo(ctx, r)
@@ -208,7 +208,7 @@ func connectFilesystemCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := r.Connect(ctx); err != nil {
-		return Only(ctx, clues.Wrap(err, "Failed to connect to the filesystem repository"))
+		return Only(ctx, clues.Stack(ErrConnectingRepo, err))
 	}
 
 	defer utils.CloseRepo(ctx, r)

--- a/src/cli/repo/filesystem.go
+++ b/src/cli/repo/filesystem.go
@@ -96,12 +96,10 @@ func initFilesystemCmd(cmd *cobra.Command, args []string) error {
 		cfg.Account.ID(),
 		opt)
 
-	sc, err := cfg.Storage.StorageConfig()
+	storageCfg, err := cfg.Storage.ToFilesystemConfig()
 	if err != nil {
 		return Only(ctx, clues.Wrap(err, "Retrieving filesystem configuration"))
 	}
-
-	storageCfg := sc.(*storage.FilesystemConfig)
 
 	m365, err := cfg.Account.M365Config()
 	if err != nil {
@@ -130,7 +128,13 @@ func initFilesystemCmd(cmd *cobra.Command, args []string) error {
 
 	Infof(ctx, "Initialized a repository at path %s", storageCfg.Path)
 
-	if err = config.WriteRepoConfig(ctx, sc, m365, opt.Repo, r.GetID()); err != nil {
+	err = config.WriteRepoConfig(
+		ctx,
+		storageCfg,
+		m365,
+		opt.Repo,
+		r.GetID())
+	if err != nil {
 		return Only(ctx, clues.Wrap(err, "Failed to write repository configuration"))
 	}
 
@@ -181,12 +185,10 @@ func connectFilesystemCmd(cmd *cobra.Command, args []string) error {
 		repoID = events.RepoIDNotFound
 	}
 
-	sc, err := cfg.Storage.StorageConfig()
+	storageCfg, err := cfg.Storage.ToFilesystemConfig()
 	if err != nil {
 		return Only(ctx, clues.Wrap(err, "Retrieving filesystem configuration"))
 	}
-
-	storageCfg := sc.(*storage.FilesystemConfig)
 
 	m365, err := cfg.Account.M365Config()
 	if err != nil {
@@ -213,7 +215,13 @@ func connectFilesystemCmd(cmd *cobra.Command, args []string) error {
 
 	Infof(ctx, "Connected to repository at path %s", storageCfg.Path)
 
-	if err = config.WriteRepoConfig(ctx, sc, m365, opts.Repo, r.GetID()); err != nil {
+	err = config.WriteRepoConfig(
+		ctx,
+		storageCfg,
+		m365,
+		opts.Repo,
+		r.GetID())
+	if err != nil {
 		return Only(ctx, clues.Wrap(err, "Failed to write repository configuration"))
 	}
 

--- a/src/cli/repo/filesystem_e2e_test.go
+++ b/src/cli/repo/filesystem_e2e_test.go
@@ -56,9 +56,8 @@ func (suite *FilesystemE2ESuite) TestInitFilesystemCmd() {
 
 			st := storeTD.NewFilesystemStorage(t)
 
-			sc, err := st.StorageConfig()
+			cfg, err := st.ToFilesystemConfig()
 			require.NoError(t, err, clues.ToCore(err))
-			cfg := sc.(*storage.FilesystemConfig)
 
 			force := map[string]string{
 				tconfig.TestCfgStorageProvider: storage.ProviderFilesystem.String(),
@@ -113,9 +112,8 @@ func (suite *FilesystemE2ESuite) TestConnectFilesystemCmd() {
 			defer flush()
 
 			st := storeTD.NewFilesystemStorage(t)
-			sc, err := st.StorageConfig()
+			cfg, err := st.ToFilesystemConfig()
 			require.NoError(t, err, clues.ToCore(err))
-			cfg := sc.(*storage.FilesystemConfig)
 
 			force := map[string]string{
 				tconfig.TestCfgAccountProvider: account.ProviderM365.String(),

--- a/src/cli/repo/repo.go
+++ b/src/cli/repo/repo.go
@@ -20,6 +20,11 @@ const (
 	maintenanceCommand = "maintenance"
 )
 
+var (
+	ErrConnectingRepo   = clues.New("connecting repository")
+	ErrInitializingRepo = clues.New("initializing repository")
+)
+
 var repoCommands = []func(cmd *cobra.Command) *cobra.Command{
 	addS3Commands,
 	addFilesystemCommands,

--- a/src/cli/repo/s3.go
+++ b/src/cli/repo/s3.go
@@ -143,9 +143,7 @@ func initS3Cmd(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 
-		err = clues.Stack(ErrInitializingRepo, err)
-
-		return Only(ctx, clues.Wrap(err, "Failed to initialize a new S3 repository"))
+		return Only(ctx, clues.Stack(ErrInitializingRepo, err))
 	}
 
 	defer utils.CloseRepo(ctx, r)
@@ -224,8 +222,7 @@ func connectS3Cmd(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := r.Connect(ctx); err != nil {
-		err = clues.Stack(ErrConnectingRepo, err)
-		return Only(ctx, clues.Wrap(err, "Failed to connect to the S3 repository"))
+		return Only(ctx, clues.Stack(ErrConnectingRepo, err))
 	}
 
 	defer utils.CloseRepo(ctx, r)

--- a/src/cli/repo/s3.go
+++ b/src/cli/repo/s3.go
@@ -111,12 +111,10 @@ func initS3Cmd(cmd *cobra.Command, args []string) error {
 		cfg.Account.ID(),
 		opt)
 
-	sc, err := cfg.Storage.StorageConfig()
+	s3Cfg, err := cfg.Storage.ToS3Config()
 	if err != nil {
 		return Only(ctx, clues.Wrap(err, "Retrieving s3 configuration"))
 	}
-
-	s3Cfg := sc.(*storage.S3Config)
 
 	if strings.HasPrefix(s3Cfg.Endpoint, "http://") || strings.HasPrefix(s3Cfg.Endpoint, "https://") {
 		invalidEndpointErr := "endpoint doesn't support specifying protocol. " +
@@ -196,12 +194,10 @@ func connectS3Cmd(cmd *cobra.Command, args []string) error {
 		repoID = events.RepoIDNotFound
 	}
 
-	sc, err := cfg.Storage.StorageConfig()
+	s3Cfg, err := cfg.Storage.ToS3Config()
 	if err != nil {
 		return Only(ctx, clues.Wrap(err, "Retrieving s3 configuration"))
 	}
-
-	s3Cfg := sc.(*storage.S3Config)
 
 	m365, err := cfg.Account.M365Config()
 	if err != nil {

--- a/src/cli/repo/s3_e2e_test.go
+++ b/src/cli/repo/s3_e2e_test.go
@@ -66,9 +66,8 @@ func (suite *S3E2ESuite) TestInitS3Cmd() {
 
 			st := storeTD.NewPrefixedS3Storage(t)
 
-			sc, err := st.StorageConfig()
+			cfg, err := st.ToS3Config()
 			require.NoError(t, err, clues.ToCore(err))
-			cfg := sc.(*storage.S3Config)
 
 			vpr, configFP := tconfig.MakeTempTestConfigClone(t, nil)
 			if !test.hasConfigFile {
@@ -104,10 +103,9 @@ func (suite *S3E2ESuite) TestInitMultipleTimes() {
 	defer flush()
 
 	st := storeTD.NewPrefixedS3Storage(t)
-	sc, err := st.StorageConfig()
-	require.NoError(t, err, clues.ToCore(err))
 
-	cfg := sc.(*storage.S3Config)
+	cfg, err := st.ToS3Config()
+	require.NoError(t, err, clues.ToCore(err))
 
 	vpr, configFP := tconfig.MakeTempTestConfigClone(t, nil)
 
@@ -136,10 +134,8 @@ func (suite *S3E2ESuite) TestInitS3Cmd_missingBucket() {
 
 	st := storeTD.NewPrefixedS3Storage(t)
 
-	sc, err := st.StorageConfig()
+	cfg, err := st.ToS3Config()
 	require.NoError(t, err, clues.ToCore(err))
-
-	cfg := sc.(*storage.S3Config)
 
 	force := map[string]string{
 		tconfig.TestCfgBucket: "",
@@ -191,9 +187,9 @@ func (suite *S3E2ESuite) TestConnectS3Cmd() {
 			defer flush()
 
 			st := storeTD.NewPrefixedS3Storage(t)
-			sc, err := st.StorageConfig()
+
+			cfg, err := st.ToS3Config()
 			require.NoError(t, err, clues.ToCore(err))
-			cfg := sc.(*storage.S3Config)
 
 			force := map[string]string{
 				tconfig.TestCfgAccountProvider: account.ProviderM365.String(),
@@ -266,10 +262,9 @@ func (suite *S3E2ESuite) TestConnectS3Cmd_badInputs() {
 			defer flush()
 
 			st := storeTD.NewPrefixedS3Storage(t)
-			sc, err := st.StorageConfig()
+			cfg, err := st.ToS3Config()
 			require.NoError(t, err, clues.ToCore(err))
 
-			cfg := sc.(*storage.S3Config)
 			bucket := str.First(test.bucket, cfg.Bucket)
 			prefix := str.First(test.prefix, cfg.Prefix)
 

--- a/src/cli/restore/exchange_e2e_test.go
+++ b/src/cli/restore/exchange_e2e_test.go
@@ -66,10 +66,8 @@ func (suite *RestoreExchangeE2ESuite) SetupSuite() {
 	suite.acct = tconfig.NewM365Account(t)
 	suite.st = storeTD.NewPrefixedS3Storage(t)
 
-	sc, err := suite.st.StorageConfig()
+	cfg, err := suite.st.ToS3Config()
 	require.NoError(t, err, clues.ToCore(err))
-
-	cfg := sc.(*storage.S3Config)
 
 	force := map[string]string{
 		tconfig.TestCfgAccountProvider: account.ProviderM365.String(),

--- a/src/cmd/s3checker/s3checker.go
+++ b/src/cmd/s3checker/s3checker.go
@@ -197,12 +197,10 @@ func handleCheckerCommand(cmd *cobra.Command, args []string, f flags) error {
 		return clues.Wrap(err, "getting storage config")
 	}
 
-	sc, err := repoDetails.Storage.StorageConfig()
+	cfg, err := repoDetails.Storage.ToS3Config()
 	if err != nil {
 		return clues.Wrap(err, "getting S3 config")
 	}
-
-	cfg := sc.(*storage.S3Config)
 
 	endpoint := defaultS3Endpoint
 	if len(cfg.Endpoint) > 0 {

--- a/src/internal/kopia/conn.go
+++ b/src/internal/kopia/conn.go
@@ -205,7 +205,7 @@ func (w *conn) commonConnect(
 		bst,
 		password,
 		kopiaOpts); err != nil {
-		return clues.Wrap(err, "connecting to repo").WithClues(ctx)
+		return clues.Wrap(err, "connecting to kopia repo").WithClues(ctx)
 	}
 
 	if err := w.open(ctx, cfgFile, password); err != nil {

--- a/src/internal/kopia/filesystem.go
+++ b/src/internal/kopia/filesystem.go
@@ -16,12 +16,11 @@ func filesystemStorage(
 	repoOpts repository.Options,
 	s storage.Storage,
 ) (blob.Storage, error) {
-	cfg, err := s.StorageConfig()
+	fsCfg, err := s.ToFilesystemConfig()
 	if err != nil {
 		return nil, clues.Stack(err).WithClues(ctx)
 	}
 
-	fsCfg := cfg.(*storage.FilesystemConfig)
 	opts := filesystem.Options{
 		Path: fsCfg.Path,
 	}

--- a/src/internal/kopia/s3.go
+++ b/src/internal/kopia/s3.go
@@ -20,12 +20,10 @@ func s3BlobStorage(
 	repoOpts repository.Options,
 	s storage.Storage,
 ) (blob.Storage, error) {
-	sc, err := s.StorageConfig()
+	cfg, err := s.ToS3Config()
 	if err != nil {
 		return nil, clues.Stack(err).WithClues(ctx)
 	}
-
-	cfg := sc.(*storage.S3Config)
 
 	endpoint := defaultS3Endpoint
 	if len(cfg.Endpoint) > 0 {

--- a/src/pkg/repository/repository.go
+++ b/src/pkg/repository/repository.go
@@ -187,6 +187,8 @@ func (r *repository) Initialize(
 		}
 	}()
 
+	observe.Message(ctx, "Initializing repository")
+
 	kopiaRef := kopia.NewConn(r.Storage)
 	if err := kopiaRef.Initialize(ctx, r.Opts.Repo, retentionOpts); err != nil {
 		// replace common internal errors so that sdk users can check results with errors.Is()
@@ -237,8 +239,7 @@ func (r *repository) Connect(ctx context.Context) (err error) {
 		}
 	}()
 
-	progressBar := observe.MessageWithCompletion(ctx, "Connecting to repository")
-	defer close(progressBar)
+	observe.Message(ctx, "Connecting to repository")
 
 	kopiaRef := kopia.NewConn(r.Storage)
 	if err := kopiaRef.Connect(ctx, r.Opts.Repo); err != nil {

--- a/src/pkg/storage/common_test.go
+++ b/src/pkg/storage/common_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/alcionai/corso/src/pkg/storage"
 )
 
-type CommonCfgSuite struct {
+type CommonCfgUnitSuite struct {
 	tester.Suite
 }
 
-func TestCommonCfgSuite(t *testing.T) {
-	suite.Run(t, new(CommonCfgSuite))
+func TestCommonCfgUnitSuite(t *testing.T) {
+	suite.Run(t, &CommonCfgUnitSuite{Suite: tester.NewUnitSuite(t)})
 }
 
 var goodCommonConfig = storage.CommonConfig{
@@ -26,7 +26,7 @@ var goodCommonConfig = storage.CommonConfig{
 	},
 }
 
-func (suite *CommonCfgSuite) TestCommonConfig_Config() {
+func (suite *CommonCfgUnitSuite) TestCommonConfig_Config() {
 	cfg := goodCommonConfig
 	c, err := cfg.StringConfig()
 	assert.NoError(suite.T(), err, clues.ToCore(err))
@@ -44,7 +44,7 @@ func (suite *CommonCfgSuite) TestCommonConfig_Config() {
 	}
 }
 
-func (suite *CommonCfgSuite) TestStorage_CommonConfig() {
+func (suite *CommonCfgUnitSuite) TestStorage_CommonConfig() {
 	t := suite.T()
 
 	in := goodCommonConfig
@@ -56,7 +56,7 @@ func (suite *CommonCfgSuite) TestStorage_CommonConfig() {
 	assert.Equal(t, in.CorsoPassphrase, out.CorsoPassphrase)
 }
 
-func (suite *CommonCfgSuite) TestStorage_CommonConfig_InvalidCases() {
+func (suite *CommonCfgUnitSuite) TestStorage_CommonConfig_InvalidCases() {
 	// missing required properties
 	table := []struct {
 		name string

--- a/src/pkg/storage/filesystem.go
+++ b/src/pkg/storage/filesystem.go
@@ -20,6 +20,10 @@ type FilesystemConfig struct {
 	Path string
 }
 
+func (s Storage) ToFilesystemConfig() (*FilesystemConfig, error) {
+	return buildFilesystemConfigFromMap(s.Config)
+}
+
 func buildFilesystemConfigFromMap(config map[string]string) (*FilesystemConfig, error) {
 	c := &FilesystemConfig{}
 
@@ -69,7 +73,7 @@ func (c *FilesystemConfig) ApplyConfigOverrides(
 		if matchFromConfig {
 			providerType := cast.ToString(g.Get(StorageProviderTypeKey))
 			if providerType != ProviderFilesystem.String() {
-				return clues.New("unsupported storage provider in config file: " + providerType)
+				return clues.New("unsupported storage provider in config file: [" + providerType + "]")
 			}
 
 			// This is matching override values from config file.

--- a/src/pkg/storage/s3_test.go
+++ b/src/pkg/storage/s3_test.go
@@ -8,11 +8,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/credentials"
 )
 
 type S3CfgSuite struct {
-	suite.Suite
+	tester.Suite
 }
 
 func TestS3CfgSuite(t *testing.T) {
@@ -62,14 +63,14 @@ func (suite *S3CfgSuite) TestS3Config_Config() {
 
 func (suite *S3CfgSuite) TestStorage_S3Config() {
 	t := suite.T()
-
 	in := goodS3Config
+
 	s, err := NewStorage(ProviderS3, &in)
 	assert.NoError(t, err, clues.ToCore(err))
-	sc, err := s.StorageConfig()
+
+	out, err := s.ToS3Config()
 	assert.NoError(t, err, clues.ToCore(err))
 
-	out := sc.(*S3Config)
 	assert.Equal(t, in.Bucket, out.Bucket)
 	assert.Equal(t, in.Endpoint, out.Endpoint)
 	assert.Equal(t, in.Prefix, out.Prefix)
@@ -118,8 +119,9 @@ func (suite *S3CfgSuite) TestStorage_S3Config_invalidCases() {
 			st, err := NewStorage(ProviderUnknown, &goodS3Config)
 			assert.NoError(t, err, clues.ToCore(err))
 			test.amend(st)
-			_, err = st.StorageConfig()
-			assert.Error(t, err)
+
+			_, err = st.ToS3Config()
+			assert.Error(t, err, clues.ToCore(err))
 		})
 	}
 }

--- a/src/pkg/storage/s3_test.go
+++ b/src/pkg/storage/s3_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/alcionai/corso/src/pkg/credentials"
 )
 
-type S3CfgSuite struct {
+type S3CfgUnitSuite struct {
 	tester.Suite
 }
 
-func TestS3CfgSuite(t *testing.T) {
-	suite.Run(t, new(S3CfgSuite))
+func TestS3CfgUnitSuite(t *testing.T) {
+	suite.Run(t, &S3CfgUnitSuite{Suite: tester.NewUnitSuite(t)})
 }
 
 var (
@@ -42,7 +42,7 @@ var (
 	}
 )
 
-func (suite *S3CfgSuite) TestS3Config_Config() {
+func (suite *S3CfgUnitSuite) TestS3Config_Config() {
 	s3 := goodS3Config
 
 	c, err := s3.StringConfig()
@@ -61,7 +61,7 @@ func (suite *S3CfgSuite) TestS3Config_Config() {
 	}
 }
 
-func (suite *S3CfgSuite) TestStorage_S3Config() {
+func (suite *S3CfgUnitSuite) TestStorage_S3Config() {
 	t := suite.T()
 	in := goodS3Config
 
@@ -85,7 +85,7 @@ func makeTestS3Cfg(bkt, end, pre, access, secret, session string) S3Config {
 	}
 }
 
-func (suite *S3CfgSuite) TestStorage_S3Config_invalidCases() {
+func (suite *S3CfgUnitSuite) TestStorage_S3Config_invalidCases() {
 	// missing required properties
 	table := []struct {
 		name string
@@ -126,7 +126,7 @@ func (suite *S3CfgSuite) TestStorage_S3Config_invalidCases() {
 	}
 }
 
-func (suite *S3CfgSuite) TestStorage_S3Config_StringConfig() {
+func (suite *S3CfgUnitSuite) TestStorage_S3Config_StringConfig() {
 	table := []struct {
 		name   string
 		input  S3Config
@@ -180,7 +180,7 @@ func (suite *S3CfgSuite) TestStorage_S3Config_StringConfig() {
 	}
 }
 
-func (suite *S3CfgSuite) TestStorage_S3Config_Normalize() {
+func (suite *S3CfgUnitSuite) TestStorage_S3Config_Normalize() {
 	const (
 		prefixedBkt = "s3://bkt"
 		normalBkt   = "bkt"

--- a/src/pkg/storage/storage_test.go
+++ b/src/pkg/storage/storage_test.go
@@ -19,15 +19,15 @@ func (c testConfig) StringConfig() (map[string]string, error) {
 	return map[string]string{"expect": c.expect}, c.err
 }
 
-type StorageSuite struct {
+type StorageUnitSuite struct {
 	tester.Suite
 }
 
-func TestStorageSuite(t *testing.T) {
-	suite.Run(t, new(StorageSuite))
+func TestStorageUnitSuite(t *testing.T) {
+	suite.Run(t, &StorageUnitSuite{Suite: tester.NewUnitSuite(t)})
 }
 
-func (suite *StorageSuite) TestNewStorage() {
+func (suite *StorageUnitSuite) TestNewStorage() {
 	table := []struct {
 		name     string
 		p        ProviderType


### PR DESCRIPTION
removes the casting from StorageConfig interfaces
back to the construction of concrete structs wherever struct casting occurs with storageConfig.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
