### PR TITLE
Revert sanity tests for Groups incrementals and restore

### DIFF
--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -364,34 +364,10 @@ jobs:
           service: groups
           kind: initial
           backup-args: '--group "${{ vars.CORSO_M365_TEST_TEAM_ID }}"'
-          restore-args: '--folder ${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-sharepoint.outputs.result }}'
           test-folder: '${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-groups.outputs.result }}'
           log-dir: ${{ env.CORSO_LOG_DIR }}
-          with-export: true
 
-      # generate some more enteries for incremental check
-      - name: Groups - Create new data (for incremental)
-        working-directory: ./src/cmd/factory
-        run: |
-          go run . sharepoint files  \
-            --site ${{ secrets.CORSO_M365_TEST_SITE_URL }} \
-            --user ${{ env.TEST_USER }} \
-            --secondaryuser  ${{ env.CORSO_SECONDARY_M365_TEST_USER_ID }} \
-            --tenant ${{ secrets.TENANT_ID }} \
-            --destination ${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-groups.outputs.result }} \
-            --count 4
-
-      - name: Groups - Incremental backup
-        id: groups-incremental
-        uses: ./.github/actions/backup-restore-test
-        with:
-          service: groups
-          kind: incremental
-          backup-args: '--site "${{ secrets.CORSO_M365_TEST_SITE_URL }}"'
-          restore-args: '--folder ${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-groups.outputs.result }}'
-          test-folder: '${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-groups.outputs.result }}'
-          log-dir: ${{ env.CORSO_LOG_DIR }}
-          with-export: true
+      # TODO: incrementals
 
 ##########################################################################################################################################
 


### PR DESCRIPTION
This reverts commit bc25869173df9052e358a055867539f32af8935c. #4373

We need more work for groups restore and export sanity tests to be functional. Reverting this to make the CI pass for now.

Example successful run: https://github.com/alcionai/corso/actions/runs/6336809043/job/17210633457

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [x] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
