### PR TITLE
Push item download requests through drive rate limiter

### DIFF
--- a/src/internal/m365/collection/drive/collection.go
+++ b/src/internal/m365/collection/drive/collection.go
@@ -567,6 +567,14 @@ func (oc *Collection) streamDriveItem(
 		parentPath)
 
 	ctx = clues.Add(ctx, "item_info", itemInfo)
+	// Drive content download requests are also rate limited by graph api.
+	// Ensure that this request goes through the drive limiter & not the default
+	// limiter.
+	ctx = graph.BindRateLimiterConfig(
+		ctx,
+		graph.LimiterCfg{
+			Service: path.OneDriveService,
+		})
 
 	if isFile {
 		dataSuffix := metadata.DataFileSuffix

--- a/src/internal/m365/graph/concurrency_middleware.go
+++ b/src/internal/m365/graph/concurrency_middleware.go
@@ -149,8 +149,7 @@ const limiterConsumptionCtxKey limiterConsumptionKey = "corsoGraphRateLimiterCon
 const (
 	// https://learn.microsoft.com/en-us/sharepoint/dev/general-development
 	// /how-to-avoid-getting-throttled-or-blocked-in-sharepoint-online#application-throttling
-	defaultLC      = 1
-	driveDefaultLC = 1
+	defaultLC = 1
 	// limit consumption rate for single-item GETs requests,
 	// or delta-based multi-item GETs, or item content download requests.
 	SingleGetOrDeltaLC = 1
@@ -187,12 +186,8 @@ func ctxLimiterConsumption(ctx context.Context, defaultConsumption int) int {
 // the next token set is available.
 func QueueRequest(ctx context.Context) {
 	limiter := ctxLimiter(ctx)
+
 	defaultConsumed := defaultLC
-
-	if limiter == driveLimiter {
-		defaultConsumed = driveDefaultLC
-	}
-
 	consume := ctxLimiterConsumption(ctx, defaultConsumed)
 
 	if err := limiter.WaitN(ctx, consume); err != nil {

--- a/src/internal/m365/graph/concurrency_middleware.go
+++ b/src/internal/m365/graph/concurrency_middleware.go
@@ -150,10 +150,12 @@ const (
 	// https://learn.microsoft.com/en-us/sharepoint/dev/general-development
 	// /how-to-avoid-getting-throttled-or-blocked-in-sharepoint-online#application-throttling
 	defaultLC      = 1
-	driveDefaultLC = 2
+	driveDefaultLC = 1
 	// limit consumption rate for single-item GETs requests,
-	// or delta-based multi-item GETs.
+	// or delta-based multi-item GETs, or item content download requests.
 	SingleGetOrDeltaLC = 1
+	// delta queries without a delta token cost 2 units
+	DeltaNoTokenLC = 2
 	// limit consumption rate for anything permissions related
 	PermissionsLC = 5
 )

--- a/src/internal/m365/graph/concurrency_middleware.go
+++ b/src/internal/m365/graph/concurrency_middleware.go
@@ -186,9 +186,7 @@ func ctxLimiterConsumption(ctx context.Context, defaultConsumption int) int {
 // the next token set is available.
 func QueueRequest(ctx context.Context) {
 	limiter := ctxLimiter(ctx)
-
-	defaultConsumed := defaultLC
-	consume := ctxLimiterConsumption(ctx, defaultConsumed)
+	consume := ctxLimiterConsumption(ctx, defaultLC)
 
 	if err := limiter.WaitN(ctx, consume); err != nil {
 		logger.CtxErr(ctx, err).Error("graph middleware waiting on the limiter")

--- a/src/internal/m365/graph/http_wrapper.go
+++ b/src/internal/m365/graph/http_wrapper.go
@@ -82,7 +82,7 @@ func (hw httpWrapper) Request(
 	body io.Reader,
 	headers map[string]string,
 ) (*http.Response, error) {
-	req, err := http.NewRequest(method, url, body)
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return nil, clues.Wrap(err, "new http request")
 	}

--- a/src/pkg/services/m365/api/item_pager.go
+++ b/src/pkg/services/m365/api/item_pager.go
@@ -147,13 +147,12 @@ func deltaEnumerateItems[T any](
 		newDeltaLink     = ""
 		invalidPrevDelta = len(prevDeltaLink) == 0
 		nextLink         = "do-while"
-		consume          = graph.DeltaNoTokenLC
+		consume          = graph.SingleGetOrDeltaLC
 	)
 
-	if !invalidPrevDelta {
-		// Delta queries with a valid delta token cost lower than queries with
-		// no token.
-		consume = graph.SingleGetOrDeltaLC
+	if invalidPrevDelta {
+		// Delta queries with no previous token cost more.
+		consume = graph.DeltaNoTokenLC
 	}
 
 	// Loop through all pages returned by Graph API.

--- a/src/pkg/services/m365/api/item_pager.go
+++ b/src/pkg/services/m365/api/item_pager.go
@@ -147,11 +147,18 @@ func deltaEnumerateItems[T any](
 		newDeltaLink     = ""
 		invalidPrevDelta = len(prevDeltaLink) == 0
 		nextLink         = "do-while"
+		consume          = graph.DeltaNoTokenLC
 	)
+
+	if !invalidPrevDelta {
+		// Delta queries with a valid delta token cost lower than queries with
+		// no token.
+		consume = graph.SingleGetOrDeltaLC
+	}
 
 	// Loop through all pages returned by Graph API.
 	for len(nextLink) > 0 {
-		page, err := pager.GetPage(graph.ConsumeNTokens(ctx, graph.SingleGetOrDeltaLC))
+		page, err := pager.GetPage(graph.ConsumeNTokens(ctx, consume))
 		if graph.IsErrDeltaNotSupported(err) {
 			logger.Ctx(ctx).Infow("delta queries not supported")
 			return nil, DeltaUpdate{}, clues.Stack(graph.ErrDeltaNotSupported, err)
@@ -161,6 +168,8 @@ func deltaEnumerateItems[T any](
 			logger.Ctx(ctx).Infow("invalid previous delta", "delta_link", prevDeltaLink)
 
 			invalidPrevDelta = true
+			// Reset limiter consumption since we don't have a valid delta token.
+			consume = graph.DeltaNoTokenLC
 			result = make([]T, 0)
 
 			// Reset tells the pager to try again after ditching its delta history.


### PR DESCRIPTION
<!-- PR description-->

**Changes:** 
1. Count item download requests under drive rate limit quota . Currently this is under exchange limiter.
2. Use 1 rate limit token instead of 2 for drive calls by default. 
3. Use 2 tokens instead of 1 for initial delta query ( which has no token). 

Sharing internal docs separately to go along with the review. 

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
