### PR TITLE
Fix restore backup tests

### DIFF
--- a/src/internal/m365/backup_test.go
+++ b/src/internal/m365/backup_test.go
@@ -458,9 +458,8 @@ func (suite *SPCollectionIntgSuite) TestCreateSharePointCollection_Lists() {
 		for item := range collection.Items(ctx, fault.New(true)) {
 			t.Log("File: " + item.ID())
 
-			bs, err := io.ReadAll(item.ToReader())
+			_, err := io.ReadAll(item.ToReader())
 			require.NoError(t, err, clues.ToCore(err))
-			t.Log(string(bs))
 		}
 	}
 }

--- a/src/internal/m365/controller_test.go
+++ b/src/internal/m365/controller_test.go
@@ -887,6 +887,7 @@ func (suite *ControllerIntegrationSuite) TestRestoreAndBackup_core() {
 				},
 			},
 		},
+		// TODO(ashmrtn): Re-enable when we can restore contacts to nested folders.
 		//{
 		//	name:    "MultipleContactsSingleFolder",
 		//	service: path.ExchangeService,
@@ -1044,6 +1045,7 @@ func (suite *ControllerIntegrationSuite) TestRestoreAndBackup_core() {
 
 func (suite *ControllerIntegrationSuite) TestMultiFolderBackupDifferentNames() {
 	table := []restoreBackupInfo{
+		// TODO(ashmrtn): Re-enable when we can restore contacts to nested folders.
 		//{
 		//	name:    "Contacts",
 		//	service: path.ExchangeService,

--- a/src/internal/m365/controller_test.go
+++ b/src/internal/m365/controller_test.go
@@ -860,6 +860,33 @@ func (suite *ControllerIntegrationSuite) TestRestoreAndBackup_core() {
 				},
 			},
 		},
+		{
+			name:    "MultipleContactsInRestoreFolder",
+			service: path.ExchangeService,
+			collections: []stub.ColInfo{
+				{
+					PathElements: []string{"Contacts"},
+					Category:     path.ContactsCategory,
+					Items: []stub.ItemInfo{
+						{
+							Name:      "someencodeditemID",
+							Data:      exchMock.ContactBytes("Ghimley"),
+							LookupKey: "Ghimley",
+						},
+						{
+							Name:      "someencodeditemID2",
+							Data:      exchMock.ContactBytes("Irgot"),
+							LookupKey: "Irgot",
+						},
+						{
+							Name:      "someencodeditemID3",
+							Data:      exchMock.ContactBytes("Jannes"),
+							LookupKey: "Jannes",
+						},
+					},
+				},
+			},
+		},
 		//{
 		//	name:    "MultipleContactsSingleFolder",
 		//	service: path.ExchangeService,

--- a/src/internal/m365/controller_test.go
+++ b/src/internal/m365/controller_test.go
@@ -860,76 +860,76 @@ func (suite *ControllerIntegrationSuite) TestRestoreAndBackup_core() {
 				},
 			},
 		},
-		{
-			name:    "MultipleContactsSingleFolder",
-			service: path.ExchangeService,
-			collections: []stub.ColInfo{
-				{
-					PathElements: []string{"Contacts"},
-					Category:     path.ContactsCategory,
-					Items: []stub.ItemInfo{
-						{
-							Name:      "someencodeditemID",
-							Data:      exchMock.ContactBytes("Ghimley"),
-							LookupKey: "Ghimley",
-						},
-						{
-							Name:      "someencodeditemID2",
-							Data:      exchMock.ContactBytes("Irgot"),
-							LookupKey: "Irgot",
-						},
-						{
-							Name:      "someencodeditemID3",
-							Data:      exchMock.ContactBytes("Jannes"),
-							LookupKey: "Jannes",
-						},
-					},
-				},
-			},
-		},
-		{
-			name:    "MultipleContactsMultipleFolders",
-			service: path.ExchangeService,
-			collections: []stub.ColInfo{
-				{
-					PathElements: []string{"Work"},
-					Category:     path.ContactsCategory,
-					Items: []stub.ItemInfo{
-						{
-							Name:      "someencodeditemID",
-							Data:      exchMock.ContactBytes("Ghimley"),
-							LookupKey: "Ghimley",
-						},
-						{
-							Name:      "someencodeditemID2",
-							Data:      exchMock.ContactBytes("Irgot"),
-							LookupKey: "Irgot",
-						},
-						{
-							Name:      "someencodeditemID3",
-							Data:      exchMock.ContactBytes("Jannes"),
-							LookupKey: "Jannes",
-						},
-					},
-				},
-				{
-					PathElements: []string{"Personal"},
-					Category:     path.ContactsCategory,
-					Items: []stub.ItemInfo{
-						{
-							Name:      "someencodeditemID4",
-							Data:      exchMock.ContactBytes("Argon"),
-							LookupKey: "Argon",
-						},
-						{
-							Name:      "someencodeditemID5",
-							Data:      exchMock.ContactBytes("Bernard"),
-							LookupKey: "Bernard",
-						},
-					},
-				},
-			},
-		},
+		//{
+		//	name:    "MultipleContactsSingleFolder",
+		//	service: path.ExchangeService,
+		//	collections: []stub.ColInfo{
+		//		{
+		//			PathElements: []string{"Contacts"},
+		//			Category:     path.ContactsCategory,
+		//			Items: []stub.ItemInfo{
+		//				{
+		//					Name:      "someencodeditemID",
+		//					Data:      exchMock.ContactBytes("Ghimley"),
+		//					LookupKey: "Ghimley",
+		//				},
+		//				{
+		//					Name:      "someencodeditemID2",
+		//					Data:      exchMock.ContactBytes("Irgot"),
+		//					LookupKey: "Irgot",
+		//				},
+		//				{
+		//					Name:      "someencodeditemID3",
+		//					Data:      exchMock.ContactBytes("Jannes"),
+		//					LookupKey: "Jannes",
+		//				},
+		//			},
+		//		},
+		//	},
+		//},
+		//{
+		//	name:    "MultipleContactsMultipleFolders",
+		//	service: path.ExchangeService,
+		//	collections: []stub.ColInfo{
+		//		{
+		//			PathElements: []string{"Work"},
+		//			Category:     path.ContactsCategory,
+		//			Items: []stub.ItemInfo{
+		//				{
+		//					Name:      "someencodeditemID",
+		//					Data:      exchMock.ContactBytes("Ghimley"),
+		//					LookupKey: "Ghimley",
+		//				},
+		//				{
+		//					Name:      "someencodeditemID2",
+		//					Data:      exchMock.ContactBytes("Irgot"),
+		//					LookupKey: "Irgot",
+		//				},
+		//				{
+		//					Name:      "someencodeditemID3",
+		//					Data:      exchMock.ContactBytes("Jannes"),
+		//					LookupKey: "Jannes",
+		//				},
+		//			},
+		//		},
+		//		{
+		//			PathElements: []string{"Personal"},
+		//			Category:     path.ContactsCategory,
+		//			Items: []stub.ItemInfo{
+		//				{
+		//					Name:      "someencodeditemID4",
+		//					Data:      exchMock.ContactBytes("Argon"),
+		//					LookupKey: "Argon",
+		//				},
+		//				{
+		//					Name:      "someencodeditemID5",
+		//					Data:      exchMock.ContactBytes("Bernard"),
+		//					LookupKey: "Bernard",
+		//				},
+		//			},
+		//		},
+		//	},
+		//},
 		// {
 		// 	name:    "MultipleEventsSingleCalendar",
 		// 	service: path.ExchangeService,
@@ -1017,34 +1017,34 @@ func (suite *ControllerIntegrationSuite) TestRestoreAndBackup_core() {
 
 func (suite *ControllerIntegrationSuite) TestMultiFolderBackupDifferentNames() {
 	table := []restoreBackupInfo{
-		{
-			name:    "Contacts",
-			service: path.ExchangeService,
-			collections: []stub.ColInfo{
-				{
-					PathElements: []string{"Work"},
-					Category:     path.ContactsCategory,
-					Items: []stub.ItemInfo{
-						{
-							Name:      "someencodeditemID",
-							Data:      exchMock.ContactBytes("Ghimley"),
-							LookupKey: "Ghimley",
-						},
-					},
-				},
-				{
-					PathElements: []string{"Personal"},
-					Category:     path.ContactsCategory,
-					Items: []stub.ItemInfo{
-						{
-							Name:      "someencodeditemID2",
-							Data:      exchMock.ContactBytes("Irgot"),
-							LookupKey: "Irgot",
-						},
-					},
-				},
-			},
-		},
+		//{
+		//	name:    "Contacts",
+		//	service: path.ExchangeService,
+		//	collections: []stub.ColInfo{
+		//		{
+		//			PathElements: []string{"Work"},
+		//			Category:     path.ContactsCategory,
+		//			Items: []stub.ItemInfo{
+		//				{
+		//					Name:      "someencodeditemID",
+		//					Data:      exchMock.ContactBytes("Ghimley"),
+		//					LookupKey: "Ghimley",
+		//				},
+		//			},
+		//		},
+		//		{
+		//			PathElements: []string{"Personal"},
+		//			Category:     path.ContactsCategory,
+		//			Items: []stub.ItemInfo{
+		//				{
+		//					Name:      "someencodeditemID2",
+		//					Data:      exchMock.ContactBytes("Irgot"),
+		//					LookupKey: "Irgot",
+		//				},
+		//			},
+		//		},
+		//	},
+		//},
 		// {
 		// 	name:    "Events",
 		// 	service: path.ExchangeService,

--- a/src/internal/m365/helper_test.go
+++ b/src/internal/m365/helper_test.go
@@ -946,16 +946,16 @@ func checkCollections(
 
 	for _, returned := range got {
 		var (
-			expectedColData map[string][]byte
-			hasItems        bool
-			service         = returned.FullPath().Service()
-			category        = returned.FullPath().Category()
-			folders         = returned.FullPath().Elements()
-			rootDir         = folders[len(folders)-1] == mci.RestoreCfg.Location
+			expectedColDataByLoc map[string][]byte
+			hasItems             bool
+			service              = returned.FullPath().Service()
+			category             = returned.FullPath().Category()
+			folders              = returned.FullPath().Elements()
+			rootDir              = folders[len(folders)-1] == mci.RestoreCfg.Location
 		)
 
 		if p, ok := returned.(data.LocationPather); ok {
-			expectedColData = expected[p.LocationPath().String()]
+			expectedColDataByLoc = expected[p.LocationPath().String()]
 		}
 
 		// Need to iterate through all items even if we don't expect to find a match
@@ -977,14 +977,14 @@ func checkCollections(
 			hasItems = true
 			gotItems++
 
-			if expectedColData == nil {
+			if expectedColDataByLoc == nil {
 				continue
 			}
 
 			if !compareItem(
 				t,
 				returned.FullPath(),
-				expectedColData,
+				expectedColDataByLoc,
 				service,
 				category,
 				item,

--- a/src/internal/m365/helper_test.go
+++ b/src/internal/m365/helper_test.go
@@ -925,7 +925,6 @@ func checkHasCollections(
 
 		loc := g.(data.LocationPather).LocationPath()
 
-
 		gotNames = append(gotNames, loc.String())
 	}
 

--- a/src/internal/m365/stub/stub.go
+++ b/src/internal/m365/stub/stub.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 
+	"github.com/alcionai/clues"
 	"golang.org/x/exp/maps"
 
 	"github.com/alcionai/corso/src/internal/data"
@@ -163,28 +164,22 @@ func CollectionsForInfo(
 func backupOutputPathFromRestore(
 	restoreCfg control.RestoreConfig,
 	inputPath path.Path,
-) (path.Path, error) {
+) (*path.Builder, error) {
 	base := []string{restoreCfg.Location}
+	folders := inputPath.Folders()
 
 	// OneDrive has leading information like the drive ID.
 	if inputPath.Service() == path.OneDriveService || inputPath.Service() == path.SharePointService {
-		folders := inputPath.Folders()
-		base = append(append([]string{}, folders[:3]...), restoreCfg.Location)
-
-		if len(folders) > 3 {
-			base = append(base, folders[3:]...)
+		p, err := path.ToDrivePath(inputPath)
+		if err != nil {
+			return nil, clues.Stack(err)
 		}
+
+		// Remove driveID, root, etc.
+		folders = p.Folders
+		// Re-add root, but it needs to be in front of the restore folder.
+		base = append([]string{p.Root}, base...)
 	}
 
-	if inputPath.Service() == path.ExchangeService && inputPath.Category() == path.EmailCategory {
-		base = append(base, inputPath.Folders()...)
-	}
-
-	return path.Build(
-		inputPath.Tenant(),
-		inputPath.ProtectedResource(),
-		inputPath.Service(),
-		inputPath.Category(),
-		false,
-		base...)
+	return path.Builder{}.Append(append(base, folders...)...), nil
 }

--- a/src/internal/m365/stub/stub.go
+++ b/src/internal/m365/stub/stub.go
@@ -168,8 +168,9 @@ func backupOutputPathFromRestore(
 	base := []string{restoreCfg.Location}
 	folders := inputPath.Folders()
 
+	switch inputPath.Service() {
 	// OneDrive has leading information like the drive ID.
-	if inputPath.Service() == path.OneDriveService || inputPath.Service() == path.SharePointService {
+	case path.OneDriveService, path.SharePointService:
 		p, err := path.ToDrivePath(inputPath)
 		if err != nil {
 			return nil, clues.Stack(err)
@@ -179,6 +180,12 @@ func backupOutputPathFromRestore(
 		folders = p.Folders
 		// Re-add root, but it needs to be in front of the restore folder.
 		base = append([]string{p.Root}, base...)
+
+	// Currently contacts restore doesn't have nested folders.
+	case path.ExchangeService:
+		if inputPath.Category() == path.ContactsCategory {
+			folders = nil
+		}
 	}
 
 	return path.Builder{}.Append(append(base, folders...)...), nil


### PR DESCRIPTION
Exchange tests inadvertently got disabled since
it wasn't finding path matches for returned
BackupCollections. This switches to using
LocationPath which does allow for matching

Most contacts tests are disabled since restore
doesn't support nested folders

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
