### PR TITLE
Inject versions in generic item

### DIFF
--- a/src/internal/common/readers/serialization_version.go
+++ b/src/internal/common/readers/serialization_version.go
@@ -38,8 +38,8 @@ type SerializationVersion uint16
 const DefaultSerializationVersion SerializationVersion = 1
 
 const (
-	versionFormatSize                               = int(unsafe.Sizeof(persistedSerializationVersion(0)))
-	delInFlightMask   persistedSerializationVersion = 1 << ((versionFormatSize * 8) - 1)
+	VersionFormatSize                               = int(unsafe.Sizeof(persistedSerializationVersion(0)))
+	delInFlightMask   persistedSerializationVersion = 1 << ((VersionFormatSize * 8) - 1)
 )
 
 // SerializationFormat is a struct describing serialization format versions and

--- a/src/internal/common/readers/serialization_version.go
+++ b/src/internal/common/readers/serialization_version.go
@@ -68,7 +68,7 @@ func NewVersionedBackupReader(
 		formattedVersion |= delInFlightMask
 	}
 
-	formattedBuf := make([]byte, versionFormatSize)
+	formattedBuf := make([]byte, VersionFormatSize)
 	binary.BigEndian.PutUint32(formattedBuf, formattedVersion)
 
 	versionReader := io.NopCloser(bytes.NewReader(formattedBuf))
@@ -139,10 +139,10 @@ func (vbr *versionedBackupReader) Close() error {
 func NewVersionedRestoreReader(
 	baseReader io.ReadCloser,
 ) (*VersionedRestoreReader, error) {
-	versionBuf := make([]byte, versionFormatSize)
+	versionBuf := make([]byte, VersionFormatSize)
 
 	// Loop to account for the unlikely case where we get a short read.
-	for read := 0; read < versionFormatSize; {
+	for read := 0; read < VersionFormatSize; {
 		n, err := baseReader.Read(versionBuf[read:])
 		if err != nil {
 			return nil, clues.Wrap(err, "reading serialization version")

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	"unsafe"
 
 	"github.com/alcionai/clues"
 	"github.com/kopia/kopia/fs"
@@ -24,6 +23,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common/prefixmatcher"
 	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/internal/common/readers"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/diagnostics"
 	"github.com/alcionai/corso/src/internal/m365/graph"
@@ -37,7 +37,7 @@ import (
 
 const maxInflateTraversalDepth = 500
 
-var versionSize = int(unsafe.Sizeof(serializationVersion))
+var versionSize = readers.VersionFormatSize
 
 func newBackupStreamReader(version uint32, reader io.ReadCloser) *backupStreamReader {
 	buf := make([]byte, versionSize)

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -436,7 +436,7 @@ func collectionEntries(
 			entry := virtualfs.StreamingFileWithModTimeFromReader(
 				encodedName,
 				modTime,
-				newBackupStreamReader(serializationVersion, e.ToReader()))
+				e.ToReader())
 
 			err = ctr(ctx, entry)
 			if err != nil {

--- a/src/internal/kopia/upload_test.go
+++ b/src/internal/kopia/upload_test.go
@@ -124,12 +124,6 @@ func expectFileData(
 		return
 	}
 
-	// Need to wrap with a restore stream reader to remove the version.
-	r = &restoreStreamReader{
-		ReadCloser:      io.NopCloser(r),
-		expectedVersion: serializationVersion,
-	}
-
 	got, err := io.ReadAll(r)
 	if !assert.NoError(t, err, "reading data in file", name, clues.ToCore(err)) {
 		return
@@ -2420,9 +2414,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSelectsCorrectSubt
 									encodeElements(inboxFileName1)[0],
 									time.Time{},
 									// Wrap with a backup reader so it gets the version injected.
-									newBackupStreamReader(
-										serializationVersion,
-										io.NopCloser(bytes.NewReader(inboxFileData1v2)))),
+									io.NopCloser(bytes.NewReader(inboxFileData1v2))),
 							}),
 					}),
 				virtualfs.NewStaticDirectory(
@@ -2582,9 +2574,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSelectsMigrateSubt
 								virtualfs.StreamingFileWithModTimeFromReader(
 									encodeElements(inboxFileName1)[0],
 									time.Time{},
-									newBackupStreamReader(
-										serializationVersion,
-										io.NopCloser(bytes.NewReader(inboxFileData1)))),
+									io.NopCloser(bytes.NewReader(inboxFileData1))),
 							}),
 					}),
 				virtualfs.NewStaticDirectory(
@@ -2596,9 +2586,7 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTreeSelectsMigrateSubt
 								virtualfs.StreamingFileWithModTimeFromReader(
 									encodeElements(contactsFileName1)[0],
 									time.Time{},
-									newBackupStreamReader(
-										serializationVersion,
-										io.NopCloser(bytes.NewReader(contactsFileData1)))),
+									io.NopCloser(bytes.NewReader(contactsFileData1))),
 							}),
 					}),
 			})
@@ -2817,15 +2805,11 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_SelectiveSubtreeP
 				virtualfs.StreamingFileWithModTimeFromReader(
 					encodeElements(fileName5)[0],
 					time.Time{},
-					newBackupStreamReader(
-						serializationVersion,
-						io.NopCloser(bytes.NewReader(fileData5)))),
+					io.NopCloser(bytes.NewReader(fileData5))),
 				virtualfs.StreamingFileWithModTimeFromReader(
 					encodeElements(fileName6)[0],
 					time.Time{},
-					newBackupStreamReader(
-						serializationVersion,
-						io.NopCloser(bytes.NewReader(fileData6)))),
+					io.NopCloser(bytes.NewReader(fileData6))),
 			})
 		counters[folderID3] = count
 
@@ -2835,15 +2819,11 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_SelectiveSubtreeP
 				virtualfs.StreamingFileWithModTimeFromReader(
 					encodeElements(fileName3)[0],
 					time.Time{},
-					newBackupStreamReader(
-						serializationVersion,
-						io.NopCloser(bytes.NewReader(fileData3)))),
+					io.NopCloser(bytes.NewReader(fileData3))),
 				virtualfs.StreamingFileWithModTimeFromReader(
 					encodeElements(fileName4)[0],
 					time.Time{},
-					newBackupStreamReader(
-						serializationVersion,
-						io.NopCloser(bytes.NewReader(fileData4)))),
+					io.NopCloser(bytes.NewReader(fileData4))),
 				folder,
 			})
 		counters[folderID2] = count
@@ -2859,15 +2839,11 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_SelectiveSubtreeP
 				virtualfs.StreamingFileWithModTimeFromReader(
 					encodeElements(fileName1)[0],
 					time.Time{},
-					newBackupStreamReader(
-						serializationVersion,
-						io.NopCloser(bytes.NewReader(fileData1)))),
+					io.NopCloser(bytes.NewReader(fileData1))),
 				virtualfs.StreamingFileWithModTimeFromReader(
 					encodeElements(fileName2)[0],
 					time.Time{},
-					newBackupStreamReader(
-						serializationVersion,
-						io.NopCloser(bytes.NewReader(fileData2)))),
+					io.NopCloser(bytes.NewReader(fileData2))),
 				folder,
 				folder4,
 			})
@@ -2879,15 +2855,11 @@ func (suite *HierarchyBuilderUnitSuite) TestBuildDirectoryTree_SelectiveSubtreeP
 				virtualfs.StreamingFileWithModTimeFromReader(
 					encodeElements(fileName7)[0],
 					time.Time{},
-					newBackupStreamReader(
-						serializationVersion,
-						io.NopCloser(bytes.NewReader(fileData7)))),
+					io.NopCloser(bytes.NewReader(fileData7))),
 				virtualfs.StreamingFileWithModTimeFromReader(
 					encodeElements(fileName8)[0],
 					time.Time{},
-					newBackupStreamReader(
-						serializationVersion,
-						io.NopCloser(bytes.NewReader(fileData8)))),
+					io.NopCloser(bytes.NewReader(fileData8))),
 			})
 		counters[folderID5] = count
 

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/alcionai/corso/src/internal/common/prefixmatcher"
+	"github.com/alcionai/corso/src/internal/common/readers"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/diagnostics"
 	"github.com/alcionai/corso/src/internal/observe"
@@ -36,8 +37,6 @@ const (
 	// possibly corresponding to who is making the backup.
 	corsoHost = "corso-host"
 	corsoUser = "corso"
-
-	serializationVersion uint32 = 1
 )
 
 // common manifest tags
@@ -447,7 +446,7 @@ func loadDirsAndItems(
 				dir:             dir,
 				items:           dirItems.items,
 				counter:         bcounter,
-				expectedVersion: serializationVersion,
+				expectedVersion: readers.DefaultSerializationVersion,
 			}
 
 			if err := mergeCol.addCollection(dirItems.dir.String(), dc); err != nil {

--- a/src/internal/m365/collection/drive/collections_test.go
+++ b/src/internal/m365/collection/drive/collections_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/prefixmatcher"
 	pmMock "github.com/alcionai/corso/src/internal/common/prefixmatcher/mock"
 	"github.com/alcionai/corso/src/internal/data"
+	dataMock "github.com/alcionai/corso/src/internal/data/mock"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive/metadata"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	odConsts "github.com/alcionai/corso/src/internal/m365/service/onedrive/consts"
@@ -1114,7 +1115,9 @@ func (suite *OneDriveCollectionsUnitSuite) TestDeserializeMetadata() {
 					func(*support.ControllerOperationStatus) {})
 				require.NoError(t, err, clues.ToCore(err))
 
-				cols = append(cols, data.NoFetchRestoreCollection{Collection: mc})
+				cols = append(cols, dataMock.NewUnversionedRestoreCollection(
+					t,
+					data.NoFetchRestoreCollection{Collection: mc}))
 			}
 
 			deltas, paths, canUsePreviousBackup, err := deserializeMetadata(ctx, cols)
@@ -2211,7 +2214,9 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 				func(*support.ControllerOperationStatus) {})
 			assert.NoError(t, err, "creating metadata collection", clues.ToCore(err))
 
-			prevMetadata := []data.RestoreCollection{data.NoFetchRestoreCollection{Collection: mc}}
+			prevMetadata := []data.RestoreCollection{
+				dataMock.NewUnversionedRestoreCollection(t, data.NoFetchRestoreCollection{Collection: mc}),
+			}
 			errs := fault.New(true)
 
 			delList := prefixmatcher.NewStringSetBuilder()
@@ -2238,7 +2243,9 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 					deltas, paths, _, err := deserializeMetadata(
 						ctx,
 						[]data.RestoreCollection{
-							data.NoFetchRestoreCollection{Collection: baseCol},
+							dataMock.NewUnversionedRestoreCollection(
+								t,
+								data.NoFetchRestoreCollection{Collection: baseCol}),
 						})
 					if !assert.NoError(t, err, "deserializing metadata", clues.ToCore(err)) {
 						continue

--- a/src/internal/m365/collection/exchange/backup_test.go
+++ b/src/internal/m365/collection/exchange/backup_test.go
@@ -15,7 +15,9 @@ import (
 
 	inMock "github.com/alcionai/corso/src/internal/common/idname/mock"
 	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/internal/common/readers"
 	"github.com/alcionai/corso/src/internal/data"
+	dataMock "github.com/alcionai/corso/src/internal/data/mock"
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/m365/support"
 	"github.com/alcionai/corso/src/internal/operations/inject"
@@ -322,7 +324,7 @@ func (suite *DataCollectionsUnitSuite) TestParseMetadataCollections() {
 			require.NoError(t, err, clues.ToCore(err))
 
 			cdps, canUsePreviousBackup, err := ParseMetadataCollections(ctx, []data.RestoreCollection{
-				data.NoFetchRestoreCollection{Collection: coll},
+				dataMock.NewUnversionedRestoreCollection(t, data.NoFetchRestoreCollection{Collection: coll}),
 			})
 			test.expectError(t, err, clues.ToCore(err))
 
@@ -591,7 +593,7 @@ func (suite *BackupIntgSuite) TestDelta() {
 			require.NotNil(t, metadata, "collections contains a metadata collection")
 
 			cdps, canUsePreviousBackup, err := ParseMetadataCollections(ctx, []data.RestoreCollection{
-				data.NoFetchRestoreCollection{Collection: metadata},
+				dataMock.NewUnversionedRestoreCollection(t, data.NoFetchRestoreCollection{Collection: metadata}),
 			})
 			require.NoError(t, err, clues.ToCore(err))
 			assert.True(t, canUsePreviousBackup, "can use previous backup")
@@ -666,7 +668,12 @@ func (suite *BackupIntgSuite) TestMailSerializationRegression() {
 			for stream := range streamChannel {
 				buf := &bytes.Buffer{}
 
-				read, err := buf.ReadFrom(stream.ToReader())
+				rr, err := readers.NewVersionedRestoreReader(stream.ToReader())
+				require.NoError(t, err, clues.ToCore(err))
+
+				assert.Equal(t, readers.DefaultSerializationVersion, rr.Format().Version)
+
+				read, err := buf.ReadFrom(rr)
 				assert.NoError(t, err, clues.ToCore(err))
 				assert.NotZero(t, read)
 
@@ -744,7 +751,13 @@ func (suite *BackupIntgSuite) TestContactSerializationRegression() {
 
 				for stream := range edc.Items(ctx, fault.New(true)) {
 					buf := &bytes.Buffer{}
-					read, err := buf.ReadFrom(stream.ToReader())
+
+					rr, err := readers.NewVersionedRestoreReader(stream.ToReader())
+					require.NoError(t, err, clues.ToCore(err))
+
+					assert.Equal(t, readers.DefaultSerializationVersion, rr.Format().Version)
+
+					read, err := buf.ReadFrom(rr)
 					assert.NoError(t, err, clues.ToCore(err))
 					assert.NotZero(t, read)
 
@@ -878,7 +891,12 @@ func (suite *BackupIntgSuite) TestEventsSerializationRegression() {
 				for item := range edc.Items(ctx, fault.New(true)) {
 					buf := &bytes.Buffer{}
 
-					read, err := buf.ReadFrom(item.ToReader())
+					rr, err := readers.NewVersionedRestoreReader(item.ToReader())
+					require.NoError(t, err, clues.ToCore(err))
+
+					assert.Equal(t, readers.DefaultSerializationVersion, rr.Format().Version)
+
+					read, err := buf.ReadFrom(rr)
 					assert.NoError(t, err, clues.ToCore(err))
 					assert.NotZero(t, read)
 
@@ -1198,7 +1216,9 @@ func checkMetadata(
 ) {
 	catPaths, _, err := ParseMetadataCollections(
 		ctx,
-		[]data.RestoreCollection{data.NoFetchRestoreCollection{Collection: c}})
+		[]data.RestoreCollection{
+			dataMock.NewUnversionedRestoreCollection(t, data.NoFetchRestoreCollection{Collection: c}),
+		})
 	if !assert.NoError(t, err, "getting metadata", clues.ToCore(err)) {
 		return
 	}

--- a/src/internal/m365/collection/site/collection.go
+++ b/src/internal/m365/collection/site/collection.go
@@ -211,11 +211,17 @@ func (sc *Collection) retrieveLists(
 			metrics.Bytes += size
 
 			metrics.Successes++
-			sc.data <- data.NewPrefetchedItem(
+
+			item, err := data.NewPrefetchedItem(
 				io.NopCloser(bytes.NewReader(byteArray)),
 				ptr.Val(lst.GetId()),
 				details.ItemInfo{SharePoint: ListToSPInfo(lst, size)})
+			if err != nil {
+				el.AddRecoverable(ctx, clues.Stack(err).WithClues(ctx).Label(fault.LabelForceNoBackupCreation))
+				continue
+			}
 
+			sc.data <- item
 			progress <- struct{}{}
 		}
 	}
@@ -272,11 +278,17 @@ func (sc *Collection) retrievePages(
 		if size > 0 {
 			metrics.Bytes += size
 			metrics.Successes++
-			sc.data <- data.NewPrefetchedItem(
+
+			item, err := data.NewPrefetchedItem(
 				io.NopCloser(bytes.NewReader(byteArray)),
 				ptr.Val(pg.GetId()),
 				details.ItemInfo{SharePoint: pageToSPInfo(pg, root, size)})
+			if err != nil {
+				el.AddRecoverable(ctx, clues.Stack(err).WithClues(ctx).Label(fault.LabelForceNoBackupCreation))
+				continue
+			}
 
+			sc.data <- item
 			progress <- struct{}{}
 		}
 	}

--- a/src/internal/m365/collection/site/collection_test.go
+++ b/src/internal/m365/collection/site/collection_test.go
@@ -103,10 +103,11 @@ func (suite *SharePointCollectionSuite) TestCollection_Items() {
 				byteArray, err := ow.GetSerializedContent()
 				require.NoError(t, err, clues.ToCore(err))
 
-				data := data.NewPrefetchedItem(
+				data, err := data.NewPrefetchedItem(
 					io.NopCloser(bytes.NewReader(byteArray)),
 					name,
 					details.ItemInfo{SharePoint: ListToSPInfo(listing, int64(len(byteArray)))})
+				require.NoError(t, err, clues.ToCore(err))
 
 				return data
 			},
@@ -132,10 +133,11 @@ func (suite *SharePointCollectionSuite) TestCollection_Items() {
 				page, err := betaAPI.CreatePageFromBytes(byteArray)
 				require.NoError(t, err, clues.ToCore(err))
 
-				data := data.NewPrefetchedItem(
+				data, err := data.NewPrefetchedItem(
 					io.NopCloser(bytes.NewReader(byteArray)),
 					itemName,
 					details.ItemInfo{SharePoint: betaAPI.PageInfo(page, int64(len(byteArray)))})
+				require.NoError(t, err, clues.ToCore(err))
 
 				return data
 			},
@@ -194,10 +196,11 @@ func (suite *SharePointCollectionSuite) TestListCollection_Restore() {
 	byteArray, err := service.Serialize(listing)
 	require.NoError(t, err, clues.ToCore(err))
 
-	listData := data.NewPrefetchedItem(
+	listData, err := data.NewPrefetchedItem(
 		io.NopCloser(bytes.NewReader(byteArray)),
 		testName,
 		details.ItemInfo{SharePoint: ListToSPInfo(listing, int64(len(byteArray)))})
+	require.NoError(t, err, clues.ToCore(err))
 
 	destName := testdata.DefaultRestoreConfig("").Location
 

--- a/src/internal/m365/graph/metadata_collection.go
+++ b/src/internal/m365/graph/metadata_collection.go
@@ -57,11 +57,16 @@ func (mce MetadataCollectionEntry) toMetadataItem() (metadataItem, error) {
 		return metadataItem{}, clues.Wrap(err, "serializing metadata")
 	}
 
+	item, err := data.NewUnindexedPrefetchedItem(
+		io.NopCloser(buf),
+		mce.fileName,
+		time.Now())
+	if err != nil {
+		return metadataItem{}, clues.Stack(err)
+	}
+
 	return metadataItem{
-		Item: data.NewUnindexedPrefetchedItem(
-			io.NopCloser(buf),
-			mce.fileName,
-			time.Now()),
+		Item: item,
 		size: int64(buf.Len()),
 	}, nil
 }

--- a/src/internal/m365/service/sharepoint/api/pages_test.go
+++ b/src/internal/m365/service/sharepoint/api/pages_test.go
@@ -109,10 +109,11 @@ func (suite *SharePointPageSuite) TestRestoreSinglePage() {
 	//nolint:lll
 	byteArray := spMock.Page("Byte Test")
 
-	pageData := data.NewUnindexedPrefetchedItem(
+	pageData, err := data.NewUnindexedPrefetchedItem(
 		io.NopCloser(bytes.NewReader(byteArray)),
 		testName,
 		time.Now())
+	require.NoError(t, err, clues.ToCore(err))
 
 	info, err := api.RestoreSitePage(
 		ctx,

--- a/src/internal/streamstore/streamstore.go
+++ b/src/internal/streamstore/streamstore.go
@@ -182,12 +182,17 @@ func collect(
 		return nil, clues.Wrap(err, "marshalling body").WithClues(ctx)
 	}
 
+	item, err := data.NewUnindexedPrefetchedItem(
+		io.NopCloser(bytes.NewReader(bs)),
+		col.itemName,
+		time.Now())
+	if err != nil {
+		return nil, clues.Stack(err).WithClues(ctx)
+	}
+
 	dc := streamCollection{
 		folderPath: p,
-		item: data.NewUnindexedPrefetchedItem(
-			io.NopCloser(bytes.NewReader(bs)),
-			col.itemName,
-			time.Now()),
+		item:       item,
 	}
 
 	return &dc, nil


### PR DESCRIPTION
Leverage the generic item struct to inject
serialization format information for all
items

Unwires the old code that injected versions
in kopia wrapper but leaves some code in
the wrapper to strip out the serialization
format during restore

Future PRs should move the process of
pulling out serialization format to
individual services

Viewing by commit may make review
easier

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #4328

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
