### PR TITLE
Reenable exchange kopia assisted incrementals

### DIFF
--- a/src/internal/m365/collection/exchange/backup.go
+++ b/src/internal/m365/collection/exchange/backup.go
@@ -160,7 +160,7 @@ func populateCollections(
 
 		ictx = clues.Add(ictx, "previous_path", prevPath)
 
-		added, _, removed, newDelta, err := bh.itemEnumerator().
+		added, validModTimes, removed, newDelta, err := bh.itemEnumerator().
 			GetAddedAndRemovedItemIDs(
 				ictx,
 				qp.ProtectedResource.ID(),
@@ -199,9 +199,7 @@ func populateCollections(
 			bh.itemHandler(),
 			added,
 			removed,
-			// TODO(ashmrtn): Set to value returned by pager when we have deletion
-			// markers in files.
-			false,
+			validModTimes,
 			statusUpdater)
 
 		collections[cID] = edc


### PR DESCRIPTION
Allow creation of lazy collections and lazy
items again thus allowing exchange kopia
assisted incrementals.

Manually tested that a backup where an email
switches folders after enumeration results
in an empty file in kopia except for the
serialization header which includes the
deleted in flight flag. The next backup
removes the empty file from the folder in
kopia. The item doesn't appear in backup
details since it has no data

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #2023

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
