### PR TITLE
apply channels and streaming to the url cache

### DIFF
--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -272,13 +272,6 @@ func (c *Collections) Get(
 			excludedItemIDs = map[string]struct{}{}
 			oldPrevPaths    = oldPrevPathsByDriveID[driveID]
 			prevDeltaLink   = prevDriveIDToDelta[driveID]
-
-			// itemCollection is used to identify which collection a
-			// file belongs to. This is useful to delete a file from the
-			// collection it was previously in, in case it was moved to a
-			// different collection within the same delta query
-			// item ID -> item ID
-			itemCollection = map[string]string{}
 		)
 
 		delete(driveTombstones, driveID)
@@ -295,13 +288,16 @@ func (c *Collections) Get(
 			"previous metadata for drive",
 			"num_paths_entries", len(oldPrevPaths))
 
-		items, du, err := c.handler.EnumerateDriveItemsDelta(
-			ictx,
+		du, newPrevPaths, err := c.PopulateDriveCollections(
+			ctx,
 			driveID,
+			driveName,
+			oldPrevPaths,
+			excludedItemIDs,
 			prevDeltaLink,
-			api.DefaultDriveItemProps())
+			errs)
 		if err != nil {
-			return nil, false, err
+			return nil, false, clues.Stack(err)
 		}
 
 		// It's alright to have an empty folders map (i.e. no folders found) but not
@@ -311,20 +307,6 @@ func (c *Collections) Get(
 		// for collections when not actually getting delta results.
 		if len(du.URL) > 0 {
 			driveIDToDeltaLink[driveID] = du.URL
-		}
-
-		newPrevPaths, err := c.UpdateCollections(
-			ctx,
-			driveID,
-			driveName,
-			items,
-			oldPrevPaths,
-			itemCollection,
-			excludedItemIDs,
-			du.Reset,
-			errs)
-		if err != nil {
-			return nil, false, clues.Stack(err)
 		}
 
 		// Avoid the edge case where there's no paths but we do have a valid delta
@@ -688,224 +670,280 @@ func (c *Collections) getCollectionPath(
 	return collectionPath, nil
 }
 
-// UpdateCollections initializes and adds the provided drive items to Collections
-// A new collection is created for every drive folder (or package).
-// oldPrevPaths is the unchanged data that was loaded from the metadata file.
-// This map is not modified during the call.
-// currPrevPaths starts as a copy of oldPaths and is updated as changes are found in
-// the returned results.  Items are added to this collection throughout the call.
-// newPrevPaths, ie: the items added during this call, get returned as a map.
-func (c *Collections) UpdateCollections(
+// PopulateDriveCollections initializes and adds the provided drive items to Collections
+// A new collection is created for every drive folder.
+// Along with populating the collection items and updating the excluded item IDs, this func
+// returns the current DeltaUpdate and PreviousPaths for metadata records.
+func (c *Collections) PopulateDriveCollections(
 	ctx context.Context,
 	driveID, driveName string,
-	items []models.DriveItemable,
 	oldPrevPaths map[string]string,
-	currPrevPaths map[string]string,
-	excluded map[string]struct{},
-	invalidPrevDelta bool,
+	excludedItemIDs map[string]struct{},
+	prevDeltaLink string,
 	errs *fault.Bus,
-) (map[string]string, error) {
+) (api.DeltaUpdate, map[string]string, error) {
 	var (
-		el           = errs.Local()
-		newPrevPaths = map[string]string{}
+		el               = errs.Local()
+		newPrevPaths     = map[string]string{}
+		invalidPrevDelta = len(prevDeltaLink) == 0
+
+		// currPrevPaths is used to identify which collection a
+		// file belongs to. This is useful to delete a file from the
+		// collection it was previously in, in case it was moved to a
+		// different collection within the same delta query
+		// item ID -> item ID
+		currPrevPaths = map[string]string{}
 	)
 
 	if !invalidPrevDelta {
 		maps.Copy(newPrevPaths, oldPrevPaths)
 	}
 
-	for _, item := range items {
+	pager := c.handler.EnumerateDriveItemsDelta(
+		ctx,
+		driveID,
+		prevDeltaLink,
+		api.CallConfig{
+			Select: api.DefaultDriveItemProps(),
+		})
+
+	for page, reset, done := pager.NextPage(); !done; page, reset, done = pager.NextPage() {
 		if el.Failure() != nil {
 			break
 		}
 
-		var (
-			itemID   = ptr.Val(item.GetId())
-			itemName = ptr.Val(item.GetName())
-			isFolder = item.GetFolder() != nil || item.GetPackageEscaped() != nil
-			ictx     = clues.Add(
-				ctx,
-				"item_id", itemID,
-				"item_name", clues.Hide(itemName),
-				"item_is_folder", isFolder)
-		)
-
-		if item.GetMalware() != nil {
-			addtl := graph.ItemInfo(item)
-			skip := fault.FileSkip(fault.SkipMalware, driveID, itemID, itemName, addtl)
-
-			if isFolder {
-				skip = fault.ContainerSkip(fault.SkipMalware, driveID, itemID, itemName, addtl)
-			}
-
-			errs.AddSkip(ctx, skip)
-			logger.Ctx(ctx).Infow("malware detected", "item_details", addtl)
-
-			continue
+		if reset {
+			newPrevPaths = map[string]string{}
+			currPrevPaths = map[string]string{}
+			c.CollectionMap[driveID] = map[string]*Collection{}
+			invalidPrevDelta = true
 		}
 
-		// Deleted file or folder.
-		if item.GetDeleted() != nil {
-			if err := c.handleDelete(
-				itemID,
+		for _, item := range page {
+			if el.Failure() != nil {
+				break
+			}
+
+			err := c.processItem(
+				ctx,
+				item,
 				driveID,
+				driveName,
 				oldPrevPaths,
 				currPrevPaths,
 				newPrevPaths,
-				isFolder,
-				excluded,
-				invalidPrevDelta); err != nil {
-				return nil, clues.Stack(err).WithClues(ictx)
-			}
-
-			continue
-		}
-
-		collectionPath, err := c.getCollectionPath(driveID, item)
-		if err != nil {
-			el.AddRecoverable(ctx, clues.Stack(err).
-				WithClues(ictx).
-				Label(fault.LabelForceNoBackupCreation))
-
-			continue
-		}
-
-		// Skip items that don't match the folder selectors we were given.
-		if shouldSkip(ctx, collectionPath, c.handler, driveName) {
-			logger.Ctx(ictx).Debugw("path not selected", "skipped_path", collectionPath.String())
-			continue
-		}
-
-		switch {
-		case isFolder:
-			// Deletions are handled above so this is just moves/renames.
-			var prevPath path.Path
-
-			prevPathStr, ok := oldPrevPaths[itemID]
-			if ok {
-				prevPath, err = path.FromDataLayerPath(prevPathStr, false)
-				if err != nil {
-					el.AddRecoverable(ctx, clues.Wrap(err, "invalid previous path").
-						WithClues(ictx).
-						With("prev_path_string", path.LoggableDir(prevPathStr)))
-				}
-			} else if item.GetRoot() != nil {
-				// Root doesn't move or get renamed.
-				prevPath = collectionPath
-			}
-
-			// Moved folders don't cause delta results for any subfolders nested in
-			// them. We need to go through and update paths to handle that. We only
-			// update newPaths so we don't accidentally clobber previous deletes.
-			updatePath(newPrevPaths, itemID, collectionPath.String())
-
-			found, err := updateCollectionPaths(driveID, itemID, c.CollectionMap, collectionPath)
-			if err != nil {
-				return nil, clues.Stack(err).WithClues(ictx)
-			}
-
-			if found {
-				continue
-			}
-
-			colScope := CollectionScopeFolder
-			if item.GetPackageEscaped() != nil {
-				colScope = CollectionScopePackage
-			}
-
-			col, err := NewCollection(
-				c.handler,
-				c.protectedResource,
-				collectionPath,
-				prevPath,
-				driveID,
-				c.statusUpdater,
-				c.ctrl,
-				colScope,
+				excludedItemIDs,
 				invalidPrevDelta,
-				nil)
+				el)
 			if err != nil {
-				return nil, clues.Stack(err).WithClues(ictx)
+				el.AddRecoverable(ctx, clues.Stack(err))
 			}
-
-			col.driveName = driveName
-
-			c.CollectionMap[driveID][itemID] = col
-			c.NumContainers++
-
-			if item.GetRoot() != nil {
-				continue
-			}
-
-			// Add an entry to fetch permissions into this collection. This assumes
-			// that OneDrive always returns all folders on the path of an item
-			// before the item. This seems to hold true for now at least.
-			if col.Add(item) {
-				c.NumItems++
-			}
-
-		case item.GetFile() != nil:
-			// Deletions are handled above so this is just moves/renames.
-			if len(ptr.Val(item.GetParentReference().GetId())) == 0 {
-				return nil, clues.New("file without parent ID").WithClues(ictx)
-			}
-
-			// Get the collection for this item.
-			parentID := ptr.Val(item.GetParentReference().GetId())
-			ictx = clues.Add(ictx, "parent_id", parentID)
-
-			collection, ok := c.CollectionMap[driveID][parentID]
-			if !ok {
-				return nil, clues.New("item seen before parent folder").WithClues(ictx)
-			}
-
-			// This will only kick in if the file was moved multiple times
-			// within a single delta query.  We delete the file from the previous
-			// collection so that it doesn't appear in two places.
-			prevParentContainerID, ok := currPrevPaths[itemID]
-			if ok {
-				prevColl, found := c.CollectionMap[driveID][prevParentContainerID]
-				if !found {
-					return nil, clues.New("previous collection not found").
-						With("prev_parent_container_id", prevParentContainerID).
-						WithClues(ictx)
-				}
-
-				if ok := prevColl.Remove(itemID); !ok {
-					return nil, clues.New("removing item from prev collection").
-						With("prev_parent_container_id", prevParentContainerID).
-						WithClues(ictx)
-				}
-			}
-
-			currPrevPaths[itemID] = parentID
-
-			if collection.Add(item) {
-				c.NumItems++
-				c.NumFiles++
-			}
-
-			// Do this after adding the file to the collection so if we fail to add
-			// the item to the collection for some reason and we're using best effort
-			// we don't just end up deleting the item in the resulting backup. The
-			// resulting backup will be slightly incorrect, but it will have the most
-			// data that we were able to preserve.
-			if !invalidPrevDelta {
-				// Always add a file to the excluded list. The file may have been
-				// renamed/moved/modified, so we still have to drop the
-				// original one and download a fresh copy.
-				excluded[itemID+metadata.DataFileSuffix] = struct{}{}
-				excluded[itemID+metadata.MetaFileSuffix] = struct{}{}
-			}
-
-		default:
-			el.AddRecoverable(ictx, clues.New("item is neither folder nor file").
-				WithClues(ictx).
-				Label(fault.LabelForceNoBackupCreation))
 		}
 	}
 
-	return newPrevPaths, el.Failure()
+	du, err := pager.Results()
+	if err != nil {
+		return du, nil, clues.Stack(err)
+	}
+
+	return du, newPrevPaths, el.Failure()
+}
+
+func (c *Collections) processItem(
+	ctx context.Context,
+	item models.DriveItemable,
+	driveID, driveName string,
+	oldPrevPaths, currPrevPaths, newPrevPaths map[string]string,
+	excluded map[string]struct{},
+	invalidPrevDelta bool,
+	skipper fault.AddSkipper,
+) error {
+	var (
+		itemID   = ptr.Val(item.GetId())
+		itemName = ptr.Val(item.GetName())
+		isFolder = item.GetFolder() != nil || item.GetPackageEscaped() != nil
+		ictx     = clues.Add(
+			ctx,
+			"item_id", itemID,
+			"item_name", clues.Hide(itemName),
+			"item_is_folder", isFolder)
+	)
+
+	if item.GetMalware() != nil {
+		addtl := graph.ItemInfo(item)
+		skip := fault.FileSkip(fault.SkipMalware, driveID, itemID, itemName, addtl)
+
+		if isFolder {
+			skip = fault.ContainerSkip(fault.SkipMalware, driveID, itemID, itemName, addtl)
+		}
+
+		skipper.AddSkip(ctx, skip)
+		logger.Ctx(ctx).Infow("malware detected", "item_details", addtl)
+
+		return nil
+	}
+
+	// Deleted file or folder.
+	if item.GetDeleted() != nil {
+		err := c.handleDelete(
+			itemID,
+			driveID,
+			oldPrevPaths,
+			currPrevPaths,
+			newPrevPaths,
+			isFolder,
+			excluded,
+			invalidPrevDelta)
+
+		return clues.Stack(err).WithClues(ictx).OrNil()
+	}
+
+	collectionPath, err := c.getCollectionPath(driveID, item)
+	if err != nil {
+		return clues.Stack(err).
+			WithClues(ictx).
+			Label(fault.LabelForceNoBackupCreation)
+	}
+
+	// Skip items that don't match the folder selectors we were given.
+	if shouldSkip(ctx, collectionPath, c.handler, driveName) {
+		logger.Ctx(ictx).Debugw("path not selected", "skipped_path", collectionPath.String())
+		return nil
+	}
+
+	switch {
+	case isFolder:
+		// Deletions are handled above so this is just moves/renames.
+		var prevPath path.Path
+
+		prevPathStr, ok := oldPrevPaths[itemID]
+		if ok {
+			prevPath, err = path.FromDataLayerPath(prevPathStr, false)
+			if err != nil {
+				return clues.Wrap(err, "invalid previous path").
+					WithClues(ictx).
+					With("prev_path_string", path.LoggableDir(prevPathStr))
+			}
+		} else if item.GetRoot() != nil {
+			// Root doesn't move or get renamed.
+			prevPath = collectionPath
+		}
+
+		// Moved folders don't cause delta results for any subfolders nested in
+		// them. We need to go through and update paths to handle that. We only
+		// update newPaths so we don't accidentally clobber previous deletes.
+		updatePath(newPrevPaths, itemID, collectionPath.String())
+
+		found, err := updateCollectionPaths(
+			driveID,
+			itemID,
+			c.CollectionMap,
+			collectionPath)
+		if err != nil {
+			return clues.Stack(err).WithClues(ictx)
+		}
+
+		if found {
+			return nil
+		}
+
+		colScope := CollectionScopeFolder
+		if item.GetPackageEscaped() != nil {
+			colScope = CollectionScopePackage
+		}
+
+		col, err := NewCollection(
+			c.handler,
+			c.protectedResource,
+			collectionPath,
+			prevPath,
+			driveID,
+			c.statusUpdater,
+			c.ctrl,
+			colScope,
+			invalidPrevDelta,
+			nil)
+		if err != nil {
+			return clues.Stack(err).WithClues(ictx)
+		}
+
+		col.driveName = driveName
+
+		c.CollectionMap[driveID][itemID] = col
+		c.NumContainers++
+
+		if item.GetRoot() != nil {
+			return nil
+		}
+
+		// Add an entry to fetch permissions into this collection. This assumes
+		// that OneDrive always returns all folders on the path of an item
+		// before the item. This seems to hold true for now at least.
+		if col.Add(item) {
+			c.NumItems++
+		}
+
+	case item.GetFile() != nil:
+		// Deletions are handled above so this is just moves/renames.
+		if len(ptr.Val(item.GetParentReference().GetId())) == 0 {
+			return clues.New("file without parent ID").WithClues(ictx)
+		}
+
+		// Get the collection for this item.
+		parentID := ptr.Val(item.GetParentReference().GetId())
+		ictx = clues.Add(ictx, "parent_id", parentID)
+
+		collection, ok := c.CollectionMap[driveID][parentID]
+		if !ok {
+			return clues.New("item seen before parent folder").WithClues(ictx)
+		}
+
+		// This will only kick in if the file was moved multiple times
+		// within a single delta query.  We delete the file from the previous
+		// collection so that it doesn't appear in two places.
+		prevParentContainerID, ok := currPrevPaths[itemID]
+		if ok {
+			prevColl, found := c.CollectionMap[driveID][prevParentContainerID]
+			if !found {
+				return clues.New("previous collection not found").
+					With("prev_parent_container_id", prevParentContainerID).
+					WithClues(ictx)
+			}
+
+			if ok := prevColl.Remove(itemID); !ok {
+				return clues.New("removing item from prev collection").
+					With("prev_parent_container_id", prevParentContainerID).
+					WithClues(ictx)
+			}
+		}
+
+		currPrevPaths[itemID] = parentID
+
+		if collection.Add(item) {
+			c.NumItems++
+			c.NumFiles++
+		}
+
+		// Do this after adding the file to the collection so if we fail to add
+		// the item to the collection for some reason and we're using best effort
+		// we don't just end up deleting the item in the resulting backup. The
+		// resulting backup will be slightly incorrect, but it will have the most
+		// data that we were able to preserve.
+		if !invalidPrevDelta {
+			// Always add a file to the excluded list. The file may have been
+			// renamed/moved/modified, so we still have to drop the
+			// original one and download a fresh copy.
+			excluded[itemID+metadata.DataFileSuffix] = struct{}{}
+			excluded[itemID+metadata.MetaFileSuffix] = struct{}{}
+		}
+
+	default:
+		return clues.New("item is neither folder nor file").
+			WithClues(ictx).
+			Label(fault.LabelForceNoBackupCreation)
+	}
+
+	return nil
 }
 
 type dirScopeChecker interface {
@@ -913,7 +951,12 @@ type dirScopeChecker interface {
 	IncludesDir(dir string) bool
 }
 
-func shouldSkip(ctx context.Context, drivePath path.Path, dsc dirScopeChecker, driveName string) bool {
+func shouldSkip(
+	ctx context.Context,
+	drivePath path.Path,
+	dsc dirScopeChecker,
+	driveName string,
+) bool {
 	return !includePath(ctx, dsc, drivePath) ||
 		(drivePath.Category() == path.LibrariesCategory && restrictedDirectory == driveName)
 }

--- a/src/internal/m365/collection/drive/collections_test.go
+++ b/src/internal/m365/collection/drive/collections_test.go
@@ -119,7 +119,7 @@ func getDelList(files ...string) map[string]struct{} {
 	return delList
 }
 
-func (suite *OneDriveCollectionsUnitSuite) TestUpdateCollections() {
+func (suite *OneDriveCollectionsUnitSuite) TestPopulateDriveCollections() {
 	anyFolder := (&selectors.OneDriveBackup{}).Folders(selectors.Any())[0]
 
 	const (
@@ -690,8 +690,10 @@ func (suite *OneDriveCollectionsUnitSuite) TestUpdateCollections() {
 			expectedItemCount:      0,
 			expectedFileCount:      0,
 			expectedContainerCount: 1,
-			expectedPrevPaths:      nil,
-			expectedExcludes:       map[string]struct{}{},
+			expectedPrevPaths: map[string]string{
+				"root": expectedPath(""),
+			},
+			expectedExcludes: map[string]struct{}{},
 		},
 		{
 			name: "1 root file, 1 folder, 1 package, 1 good file, 1 malware",
@@ -732,15 +734,31 @@ func (suite *OneDriveCollectionsUnitSuite) TestUpdateCollections() {
 			defer flush()
 
 			var (
-				excludes      = map[string]struct{}{}
-				currPrevPaths = map[string]string{}
-				errs          = fault.New(true)
+				mbh = mock.DefaultOneDriveBH(user)
+				du  = api.DeltaUpdate{
+					URL:   "notempty",
+					Reset: false,
+				}
+				excludes = map[string]struct{}{}
+				errs     = fault.New(true)
 			)
 
-			maps.Copy(currPrevPaths, test.inputFolderMap)
+			mbh.DriveItemEnumeration = mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID: {
+						Pages:       []mock.NextPage{{Items: test.items}},
+						DeltaUpdate: du,
+					},
+				},
+			}
+
+			sel := selectors.NewOneDriveBackup([]string{user})
+			sel.Include([]selectors.OneDriveScope{test.scope})
+
+			mbh.Sel = sel.Selector
 
 			c := NewCollections(
-				&itemBackupHandler{api.Drives{}, user, test.scope},
+				mbh,
 				tenant,
 				idname.NewProvider(user, user),
 				nil,
@@ -748,18 +766,19 @@ func (suite *OneDriveCollectionsUnitSuite) TestUpdateCollections() {
 
 			c.CollectionMap[driveID] = map[string]*Collection{}
 
-			newPrevPaths, err := c.UpdateCollections(
+			_, newPrevPaths, err := c.PopulateDriveCollections(
 				ctx,
 				driveID,
 				"General",
-				test.items,
 				test.inputFolderMap,
-				currPrevPaths,
 				excludes,
-				false,
+				"smarf",
 				errs)
 			test.expect(t, err, clues.ToCore(err))
-			assert.Equal(t, len(test.expectedCollectionIDs), len(c.CollectionMap[driveID]), "total collections")
+			assert.ElementsMatch(
+				t,
+				maps.Keys(test.expectedCollectionIDs),
+				maps.Keys(c.CollectionMap[driveID]))
 			assert.Equal(t, test.expectedItemCount, c.NumItems, "item count")
 			assert.Equal(t, test.expectedFileCount, c.NumFiles, "file count")
 			assert.Equal(t, test.expectedContainerCount, c.NumContainers, "container count")
@@ -1166,7 +1185,6 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		tenant = "a-tenant"
 		user   = "a-user"
 		empty  = ""
-		next   = "next"
 		delta  = "delta1"
 		delta2 = "delta2"
 	)
@@ -1208,7 +1226,7 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 	table := []struct {
 		name                 string
 		drives               []models.Driveable
-		items                map[string][]apiMock.PagerResult[models.DriveItemable]
+		enumerator           mock.EnumerateItemsDeltaByDrive
 		canUsePreviousBackup bool
 		errCheck             assert.ErrorAssertionFunc
 		prevFolderPaths      map[string]map[string]string
@@ -1227,14 +1245,16 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "OneDrive_OneItemPage_DelFileOnly_NoFolders_NoErrors",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"), // will be present, not needed
-							delItem("file", driveBasePath1, "root", true, false, false),
-						},
-						DeltaLink: &delta,
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{{
+							Items: []models.DriveItemable{
+								driveRootItem("root"), // will be present, not needed
+								delItem("file", driveBasePath1, "root", true, false, false),
+							},
+						}},
+						DeltaUpdate: api.DeltaUpdate{URL: delta},
 					},
 				},
 			},
@@ -1259,14 +1279,16 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "OneDrive_OneItemPage_NoFolderDeltas_NoErrors",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("file", "file", driveBasePath1, "root", true, false, false),
-						},
-						DeltaLink: &delta,
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								driveItem("file", "file", driveBasePath1, "root", true, false, false),
+							},
+						}},
+						DeltaUpdate: api.DeltaUpdate{URL: delta},
 					},
 				},
 			},
@@ -1291,16 +1313,17 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "OneDrive_OneItemPage_NoErrors",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
-							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
-						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+								driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+							},
+						}},
+						DeltaUpdate: api.DeltaUpdate{URL: delta, Reset: true},
 					},
 				},
 			},
@@ -1329,17 +1352,18 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "OneDrive_OneItemPage_NoErrors_FileRenamedMultiple",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
-							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
-							driveItem("file", "file2", driveBasePath1+"/folder", "folder", true, false, false),
-						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+								driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+								driveItem("file", "file2", driveBasePath1+"/folder", "folder", true, false, false),
+							},
+						}},
+						DeltaUpdate: api.DeltaUpdate{URL: delta, Reset: true},
 					},
 				},
 			},
@@ -1368,16 +1392,16 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "OneDrive_OneItemPage_NoErrors_FileMovedMultiple",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{{Items: []models.DriveItemable{
 							driveRootItem("root"),
 							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
 							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
 							driveItem("file", "file2", driveBasePath1, "root", true, false, false),
-						},
-						DeltaLink: &delta,
+						}}},
+						DeltaUpdate: api.DeltaUpdate{URL: delta},
 					},
 				},
 			},
@@ -1408,16 +1432,15 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "OneDrive_OneItemPage_EmptyDelta_NoErrors",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{{Items: []models.DriveItemable{
 							driveRootItem("root"),
 							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
 							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
-						},
-						DeltaLink:  &empty, // probably will never happen with graph
-						ResetDelta: true,
+						}}},
+						DeltaUpdate: api.DeltaUpdate{URL: empty, Reset: true},
 					},
 				},
 			},
@@ -1446,25 +1469,146 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "OneDrive_TwoItemPages_NoErrors",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
-							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{
+							{
+								Items: []models.DriveItemable{
+									driveRootItem("root"),
+									driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+									driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+								},
+							},
+							{
+								Items: []models.DriveItemable{
+									driveRootItem("root"),
+									driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+									driveItem("file2", "file2", driveBasePath1+"/folder", "folder", true, false, false),
+								},
+							},
 						},
-						NextLink:   &next,
-						ResetDelta: true,
+						DeltaUpdate: api.DeltaUpdate{URL: delta, Reset: true},
 					},
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
-							driveItem("file2", "file2", driveBasePath1+"/folder", "folder", true, false, false),
+				},
+			},
+			canUsePreviousBackup: true,
+			errCheck:             assert.NoError,
+			prevFolderPaths: map[string]map[string]string{
+				driveID1: {},
+			},
+			expectedCollections: map[string]map[data.CollectionState][]string{
+				rootFolderPath1: {data.NewState: {}},
+				folderPath1:     {data.NewState: {"folder", "file", "file2"}},
+			},
+			expectedDeltaURLs: map[string]string{
+				driveID1: delta,
+			},
+			expectedFolderPaths: map[string]map[string]string{
+				driveID1: {
+					"root":   rootFolderPath1,
+					"folder": folderPath1,
+				},
+			},
+			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
+			doNotMergeItems: map[string]bool{
+				rootFolderPath1: true,
+				folderPath1:     true,
+			},
+		},
+		{
+			name:   "OneDrive_TwoItemPages_WithReset",
+			drives: []models.Driveable{drive1},
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{
+							{
+								Items: []models.DriveItemable{
+									driveRootItem("root"),
+									driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+									driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+									driveItem("file3", "file3", driveBasePath1+"/folder", "folder", true, false, false),
+								},
+							},
+							{
+								Items: []models.DriveItemable{},
+								Reset: true,
+							},
+							{
+								Items: []models.DriveItemable{
+									driveRootItem("root"),
+									driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+									driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+								},
+							},
+							{
+								Items: []models.DriveItemable{
+									driveRootItem("root"),
+									driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+									driveItem("file2", "file2", driveBasePath1+"/folder", "folder", true, false, false),
+								},
+							},
 						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
+						DeltaUpdate: api.DeltaUpdate{URL: delta, Reset: true},
+					},
+				},
+			},
+			canUsePreviousBackup: true,
+			errCheck:             assert.NoError,
+			prevFolderPaths: map[string]map[string]string{
+				driveID1: {},
+			},
+			expectedCollections: map[string]map[data.CollectionState][]string{
+				rootFolderPath1: {data.NewState: {}},
+				folderPath1:     {data.NewState: {"folder", "file", "file2"}},
+			},
+			expectedDeltaURLs: map[string]string{
+				driveID1: delta,
+			},
+			expectedFolderPaths: map[string]map[string]string{
+				driveID1: {
+					"root":   rootFolderPath1,
+					"folder": folderPath1,
+				},
+			},
+			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
+			doNotMergeItems: map[string]bool{
+				rootFolderPath1: true,
+				folderPath1:     true,
+			},
+		},
+		{
+			name:   "OneDrive_TwoItemPages_WithResetCombinedWithItems",
+			drives: []models.Driveable{drive1},
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{
+							{
+								Items: []models.DriveItemable{
+									driveRootItem("root"),
+									driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+									driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+								},
+							},
+							{
+								Items: []models.DriveItemable{
+									driveRootItem("root"),
+									driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+									driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+								},
+								Reset: true,
+							},
+							{
+								Items: []models.DriveItemable{
+									driveRootItem("root"),
+									driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+									driveItem("file2", "file2", driveBasePath1+"/folder", "folder", true, false, false),
+								},
+							},
+						},
+						DeltaUpdate: api.DeltaUpdate{URL: delta, Reset: true},
 					},
 				},
 			},
@@ -1498,27 +1642,23 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 				drive1,
 				drive2,
 			},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{{Items: []models.DriveItemable{
 							driveRootItem("root"),
 							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
 							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
-						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
+						}}},
+						DeltaUpdate: api.DeltaUpdate{URL: delta, Reset: true},
 					},
-				},
-				driveID2: {
-					{
-						Values: []models.DriveItemable{
+					driveID2: {
+						Pages: []mock.NextPage{{Items: []models.DriveItemable{
 							driveRootItem("root2"),
 							driveItem("folder2", "folder", driveBasePath2, "root2", false, true, false),
 							driveItem("file2", "file", driveBasePath2+"/folder", "folder2", true, false, false),
-						},
-						DeltaLink:  &delta2,
-						ResetDelta: true,
+						}}},
+						DeltaUpdate: api.DeltaUpdate{URL: delta2, Reset: true},
 					},
 				},
 			},
@@ -1562,27 +1702,23 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 				drive1,
 				drive2,
 			},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{{Items: []models.DriveItemable{
 							driveRootItem("root"),
 							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
 							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
-						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
+						}}},
+						DeltaUpdate: api.DeltaUpdate{URL: delta, Reset: true},
 					},
-				},
-				driveID2: {
-					{
-						Values: []models.DriveItemable{
+					driveID2: {
+						Pages: []mock.NextPage{{Items: []models.DriveItemable{
 							driveRootItem("root"),
 							driveItem("folder", "folder", driveBasePath2, "root", false, true, false),
 							driveItem("file2", "file", driveBasePath2+"/folder", "folder", true, false, false),
-						},
-						DeltaLink:  &delta2,
-						ResetDelta: true,
+						}}},
+						DeltaUpdate: api.DeltaUpdate{URL: delta2, Reset: true},
 					},
 				},
 			},
@@ -1623,10 +1759,12 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "OneDrive_OneItemPage_Errors",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Err: assert.AnError,
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages:       []mock.NextPage{{Items: []models.DriveItemable{}}},
+						DeltaUpdate: api.DeltaUpdate{},
+						Err:         assert.AnError,
 					},
 				},
 			},
@@ -1641,24 +1779,25 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 			expectedDelList:     nil,
 		},
 		{
-			name:   "OneDrive_TwoItemPage_NoDeltaError",
+			name:   "OneDrive_OneItemPage_InvalidPrevDelta_DeleteNonExistentFolder",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("file", "file", driveBasePath1, "root", true, false, false),
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{
+							{
+								Items: []models.DriveItemable{},
+								Reset: true,
+							},
+							{
+								Items: []models.DriveItemable{
+									driveRootItem("root"),
+									driveItem("folder2", "folder2", driveBasePath1, "root", false, true, false),
+									driveItem("file", "file", driveBasePath1+"/folder2", "folder2", true, false, false),
+								},
+							},
 						},
-						NextLink: &next,
-					},
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
-							driveItem("file2", "file", driveBasePath1+"/folder", "folder", true, false, false),
-						},
-						DeltaLink: &delta,
+						DeltaUpdate: api.DeltaUpdate{URL: delta, Reset: true},
 					},
 				},
 			},
@@ -1666,40 +1805,51 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 			errCheck:             assert.NoError,
 			prevFolderPaths: map[string]map[string]string{
 				driveID1: {
-					"root": rootFolderPath1,
+					"root":   rootFolderPath1,
+					"folder": folderPath1,
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				rootFolderPath1:          {data.NotMovedState: {"file"}},
-				expectedPath1("/folder"): {data.NewState: {"folder", "file2"}},
+				rootFolderPath1:           {data.NewState: {}},
+				expectedPath1("/folder"):  {data.DeletedState: {}},
+				expectedPath1("/folder2"): {data.NewState: {"folder2", "file"}},
 			},
 			expectedDeltaURLs: map[string]string{
 				driveID1: delta,
 			},
 			expectedFolderPaths: map[string]map[string]string{
 				driveID1: {
-					"root":   rootFolderPath1,
-					"folder": folderPath1,
+					"root":    rootFolderPath1,
+					"folder2": expectedPath1("/folder2"),
 				},
 			},
-			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{
-				rootFolderPath1: getDelList("file", "file2"),
-			}),
-			doNotMergeItems: map[string]bool{},
+			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
+			doNotMergeItems: map[string]bool{
+				rootFolderPath1:           true,
+				folderPath1:               true,
+				expectedPath1("/folder2"): true,
+			},
 		},
 		{
-			name:   "OneDrive_OneItemPage_InvalidPrevDelta_DeleteNonExistentFolder",
+			name:   "OneDrive_OneItemPage_InvalidPrevDeltaCombinedWithItems_DeleteNonExistentFolder",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("folder2", "folder2", driveBasePath1, "root", false, true, false),
-							driveItem("file", "file", driveBasePath1+"/folder2", "folder2", true, false, false),
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{
+							{
+								Items: []models.DriveItemable{},
+								Reset: true,
+							},
+							{
+								Items: []models.DriveItemable{
+									driveRootItem("root"),
+									driveItem("folder2", "folder2", driveBasePath1, "root", false, true, false),
+									driveItem("file", "file", driveBasePath1+"/folder2", "folder2", true, false, false),
+								},
+							},
 						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
+						DeltaUpdate: api.DeltaUpdate{URL: delta, Reset: true},
 					},
 				},
 			},
@@ -1735,16 +1885,89 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "OneDrive_OneItemPage_InvalidPrevDelta_AnotherFolderAtDeletedLocation",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("folder2", "folder", driveBasePath1, "root", false, true, false),
-							driveItem("file", "file", driveBasePath1+"/folder", "folder2", true, false, false),
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{
+							{
+								// on the first page, if this is the total data, we'd expect both folder and folder2
+								// since new previousPaths merge with the old previousPaths.
+								Items: []models.DriveItemable{
+									driveRootItem("root"),
+									driveItem("folder2", "folder", driveBasePath1, "root", false, true, false),
+									driveItem("file", "file", driveBasePath1+"/folder", "folder2", true, false, false),
+								},
+							},
+							{
+								Items: []models.DriveItemable{},
+								Reset: true,
+							},
+							{
+								// but after a delta reset, we treat this as the total end set of folders, which means
+								// we don't expect folder to exist any longer.
+								Items: []models.DriveItemable{
+									driveRootItem("root"),
+									driveItem("folder2", "folder", driveBasePath1, "root", false, true, false),
+									driveItem("file", "file", driveBasePath1+"/folder", "folder2", true, false, false),
+								},
+							},
 						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
+						DeltaUpdate: api.DeltaUpdate{URL: delta, Reset: true},
+					},
+				},
+			},
+			canUsePreviousBackup: true,
+			errCheck:             assert.NoError,
+			prevFolderPaths: map[string]map[string]string{
+				driveID1: {
+					"root":   rootFolderPath1,
+					"folder": folderPath1,
+				},
+			},
+			expectedCollections: map[string]map[data.CollectionState][]string{
+				rootFolderPath1: {data.NewState: {}},
+				expectedPath1("/folder"): {
+					// Old folder path should be marked as deleted since it should compare
+					// by ID.
+					data.DeletedState: {},
+					data.NewState:     {"folder2", "file"},
+				},
+			},
+			expectedDeltaURLs: map[string]string{
+				driveID1: delta,
+			},
+			expectedFolderPaths: map[string]map[string]string{
+				driveID1: {
+					"root":    rootFolderPath1,
+					"folder2": expectedPath1("/folder"),
+				},
+			},
+			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
+			doNotMergeItems: map[string]bool{
+				rootFolderPath1: true,
+				folderPath1:     true,
+			},
+		},
+		{
+			name:   "OneDrive_OneItemPage_InvalidPrevDelta_AnotherFolderAtDeletedLocation",
+			drives: []models.Driveable{drive1},
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{
+							{
+								Items: []models.DriveItemable{},
+								Reset: true,
+							},
+							{
+								Items: []models.DriveItemable{
+									driveRootItem("root"),
+									driveItem("folder2", "folder", driveBasePath1, "root", false, true, false),
+									driveItem("file", "file", driveBasePath1+"/folder", "folder2", true, false, false),
+								},
+							},
+						},
+						DeltaUpdate: api.DeltaUpdate{URL: delta, Reset: true},
 					},
 				},
 			},
@@ -1783,26 +2006,28 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "OneDrive Two Item Pages with Malware",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
-							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
-							malwareItem("malware", "malware", driveBasePath1+"/folder", "folder", true, false, false),
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{
+							{
+								Items: []models.DriveItemable{
+									driveRootItem("root"),
+									driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+									driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+									malwareItem("malware", "malware", driveBasePath1+"/folder", "folder", true, false, false),
+								},
+							},
+							{
+								Items: []models.DriveItemable{
+									driveRootItem("root"),
+									driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+									driveItem("file2", "file2", driveBasePath1+"/folder", "folder", true, false, false),
+									malwareItem("malware2", "malware2", driveBasePath1+"/folder", "folder", true, false, false),
+								},
+							},
 						},
-						NextLink: &next,
-					},
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
-							driveItem("file2", "file2", driveBasePath1+"/folder", "folder", true, false, false),
-							malwareItem("malware2", "malware2", driveBasePath1+"/folder", "folder", true, false, false),
-						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
+						DeltaUpdate: api.DeltaUpdate{URL: delta, Reset: true},
 					},
 				},
 			},
@@ -1832,28 +2057,35 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 			expectedSkippedCount: 2,
 		},
 		{
-			name:   "One Drive Deleted Folder In New Results",
+			name:   "One Drive Deleted Folder In New Results With Invalid Delta",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
-							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
-							driveItem("folder2", "folder2", driveBasePath1, "root", false, true, false),
-							driveItem("file2", "file2", driveBasePath1+"/folder2", "folder2", true, false, false),
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{
+							{
+								Items: []models.DriveItemable{
+									driveRootItem("root"),
+									driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+									driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+									driveItem("folder2", "folder2", driveBasePath1, "root", false, true, false),
+									driveItem("file2", "file2", driveBasePath1+"/folder2", "folder2", true, false, false),
+								},
+							},
+							{
+								Reset: true,
+							},
+							{
+								Items: []models.DriveItemable{
+									driveRootItem("root"),
+									driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+									driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+									delItem("folder2", driveBasePath1, "root", false, true, false),
+									delItem("file2", driveBasePath1, "root", true, false, false),
+								},
+							},
 						},
-						NextLink: &next,
-					},
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							delItem("folder2", driveBasePath1, "root", false, true, false),
-							delItem("file2", driveBasePath1, "root", true, false, false),
-						},
-						DeltaLink:  &delta2,
-						ResetDelta: true,
+						DeltaUpdate: api.DeltaUpdate{URL: delta2, Reset: true},
 					},
 				},
 			},
@@ -1888,17 +2120,19 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 			},
 		},
 		{
-			name:   "One Drive Random Folder Delete",
+			name:   "One Drive Folder Delete After Invalid Delta",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							delItem("folder", driveBasePath1, "root", false, true, false),
-						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								delItem("folder", driveBasePath1, "root", false, true, false),
+							},
+							Reset: true,
+						}},
+						DeltaUpdate: api.DeltaUpdate{URL: delta, Reset: true},
 					},
 				},
 			},
@@ -1929,17 +2163,21 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 			},
 		},
 		{
-			name:   "One Drive Random Item Delete",
+			name:   "One Drive Item Delete After Invalid Delta",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							delItem("file", driveBasePath1, "root", true, false, false),
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{
+							{
+								Items: []models.DriveItemable{
+									driveRootItem("root"),
+									delItem("file", driveBasePath1, "root", true, false, false),
+								},
+								Reset: true,
+							},
 						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
+						DeltaUpdate: api.DeltaUpdate{URL: delta, Reset: true},
 					},
 				},
 			},
@@ -1969,24 +2207,26 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "One Drive Folder Made And Deleted",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
-							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{
+							{
+								Items: []models.DriveItemable{
+									driveRootItem("root"),
+									driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+									driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+								},
+							},
+							{
+								Items: []models.DriveItemable{
+									driveRootItem("root"),
+									delItem("folder", driveBasePath1, "root", false, true, false),
+									delItem("file", driveBasePath1, "root", true, false, false),
+								},
+							},
 						},
-						NextLink: &next,
-					},
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							delItem("folder", driveBasePath1, "root", false, true, false),
-							delItem("file", driveBasePath1, "root", true, false, false),
-						},
-						DeltaLink:  &delta2,
-						ResetDelta: true,
+						DeltaUpdate: api.DeltaUpdate{URL: delta2, Reset: true},
 					},
 				},
 			},
@@ -2014,23 +2254,25 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "One Drive Item Made And Deleted",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
-							driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{
+							{
+								Items: []models.DriveItemable{
+									driveRootItem("root"),
+									driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+									driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+								},
+							},
+							{
+								Items: []models.DriveItemable{
+									driveRootItem("root"),
+									delItem("file", driveBasePath1, "root", true, false, false),
+								},
+							},
 						},
-						NextLink: &next,
-					},
-					{
-						Values: []models.DriveItemable{
-							driveRootItem("root"),
-							delItem("file", driveBasePath1, "root", true, false, false),
-						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
+						DeltaUpdate: api.DeltaUpdate{URL: delta, Reset: true},
 					},
 				},
 			},
@@ -2061,15 +2303,14 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "One Drive Random Folder Delete",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{{Items: []models.DriveItemable{
 							driveRootItem("root"),
 							delItem("folder", driveBasePath1, "root", false, true, false),
-						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
+						}}},
+						DeltaUpdate: api.DeltaUpdate{URL: delta, Reset: true},
 					},
 				},
 			},
@@ -2097,15 +2338,14 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "One Drive Random Item Delete",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{{Items: []models.DriveItemable{
 							driveRootItem("root"),
 							delItem("file", driveBasePath1, "root", true, false, false),
-						},
-						DeltaLink:  &delta,
-						ResetDelta: true,
+						}}},
+						DeltaUpdate: api.DeltaUpdate{URL: delta, Reset: true},
 					},
 				},
 			},
@@ -2133,13 +2373,13 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "TwoPriorDrives_OneTombstoned",
 			drives: []models.Driveable{drive1},
-			items: map[string][]apiMock.PagerResult[models.DriveItemable]{
-				driveID1: {
-					{
-						Values: []models.DriveItemable{
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{{Items: []models.DriveItemable{
 							driveRootItem("root"), // will be present
-						},
-						DeltaLink: &delta,
+						}}},
+						DeltaUpdate: api.DeltaUpdate{URL: delta},
 					},
 				},
 			},
@@ -2176,18 +2416,9 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 				},
 			}
 
-			itemPagers := map[string]api.DeltaPager[models.DriveItemable]{}
-
-			for driveID := range test.items {
-				itemPagers[driveID] = &apiMock.DeltaPager[models.DriveItemable]{
-					ToReturn: test.items[driveID],
-				}
-			}
-
 			mbh := mock.DefaultOneDriveBH("a-user")
 			mbh.DrivePagerV = mockDrivePager
-			mbh.ItemPagerV = itemPagers
-			mbh.DriveItemEnumeration = mock.PagerResultToEDID(test.items)
+			mbh.DriveItemEnumeration = test.enumerator
 
 			c := NewCollections(
 				mbh,
@@ -2262,10 +2493,10 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 
 				collectionCount++
 
-				// TODO(ashmrtn): We should really be getting items in the collection
-				// via the Items() channel, but we don't have a way to mock out the
-				// actual item fetch yet (mostly wiring issues). The lack of that makes
-				// this check a bit more bittle since internal details can change.
+				// TODO: We should really be getting items in the collection
+				// via the Items() channel. The lack of that makes this check a bit more
+				// bittle since internal details can change.  The wiring to support
+				// mocked GetItems is available.  We just haven't plugged it in yet.
 				col, ok := baseCol.(*Collection)
 				require.True(t, ok, "getting onedrive.Collection handle")
 

--- a/src/internal/m365/collection/drive/handlers.go
+++ b/src/internal/m365/collection/drive/handlers.go
@@ -85,8 +85,8 @@ type GetItemer interface {
 type EnumerateDriveItemsDeltaer interface {
 	EnumerateDriveItemsDelta(
 		ctx context.Context,
-		ch chan<- api.NextPage[models.DriveItemable],
 		driveID, prevDeltaLink string,
+		cc api.CallConfig,
 	) api.NextPageResulter[models.DriveItemable]
 }
 

--- a/src/internal/m365/collection/drive/handlers.go
+++ b/src/internal/m365/collection/drive/handlers.go
@@ -85,6 +85,7 @@ type GetItemer interface {
 type EnumerateDriveItemsDeltaer interface {
 	EnumerateDriveItemsDelta(
 		ctx context.Context,
+		ch chan<- api.NextPage[models.DriveItemable],
 		driveID, prevDeltaLink string,
 	) api.NextPageResulter[models.DriveItemable]
 }

--- a/src/internal/m365/collection/drive/item_collector_test.go
+++ b/src/internal/m365/collection/drive/item_collector_test.go
@@ -150,8 +150,10 @@ func (suite *ItemCollectorUnitSuite) TestDrives() {
 					Err:      assert.AnError,
 				},
 			},
-			expectedErr:     assert.Error,
-			expectedResults: nil,
+			expectedErr: assert.Error,
+			// even though we error, the func will return both the
+			// error and the prior results
+			expectedResults: resultDrives,
 		},
 		{
 			name: "MySiteURLNotFound",

--- a/src/internal/m365/collection/drive/item_handler.go
+++ b/src/internal/m365/collection/drive/item_handler.go
@@ -136,6 +136,7 @@ func (h itemBackupHandler) IncludesDir(dir string) bool {
 
 func (h itemBackupHandler) EnumerateDriveItemsDelta(
 	ctx context.Context,
+	ch chan<- api.NextPage[models.DriveItemable],
 	driveID, prevDeltaLink string,
 	selectProps []string,
 ) (api.NextPageResulter[models.DriveItemable], error) {

--- a/src/internal/m365/collection/drive/item_handler.go
+++ b/src/internal/m365/collection/drive/item_handler.go
@@ -136,11 +136,10 @@ func (h itemBackupHandler) IncludesDir(dir string) bool {
 
 func (h itemBackupHandler) EnumerateDriveItemsDelta(
 	ctx context.Context,
-	ch chan<- api.NextPage[models.DriveItemable],
 	driveID, prevDeltaLink string,
-	selectProps []string,
-) (api.NextPageResulter[models.DriveItemable], error) {
-	return h.ac.EnumerateDriveItemsDelta(ctx, driveID, prevDeltaLink, selectProps)
+	cc api.CallConfig,
+) api.NextPageResulter[models.DriveItemable] {
+	return h.ac.EnumerateDriveItemsDelta(ctx, driveID, prevDeltaLink, cc)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/internal/m365/collection/drive/library_handler.go
+++ b/src/internal/m365/collection/drive/library_handler.go
@@ -139,11 +139,10 @@ func (h libraryBackupHandler) IncludesDir(dir string) bool {
 
 func (h libraryBackupHandler) EnumerateDriveItemsDelta(
 	ctx context.Context,
-	ch chan<- api.NextPage[models.DriveItemable],
 	driveID, prevDeltaLink string,
-	selectProps []string,
+	cc api.CallConfig,
 ) api.NextPageResulter[models.DriveItemable] {
-	return h.ac.EnumerateDriveItemsDelta(ctx, driveID, prevDeltaLink, selectProps)
+	return h.ac.EnumerateDriveItemsDelta(ctx, driveID, prevDeltaLink, cc)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/internal/m365/collection/drive/library_handler.go
+++ b/src/internal/m365/collection/drive/library_handler.go
@@ -139,6 +139,7 @@ func (h libraryBackupHandler) IncludesDir(dir string) bool {
 
 func (h libraryBackupHandler) EnumerateDriveItemsDelta(
 	ctx context.Context,
+	ch chan<- api.NextPage[models.DriveItemable],
 	driveID, prevDeltaLink string,
 	selectProps []string,
 ) api.NextPageResulter[models.DriveItemable] {

--- a/src/internal/m365/collection/drive/url_cache.go
+++ b/src/internal/m365/collection/drive/url_cache.go
@@ -165,7 +165,7 @@ func (uc *urlCache) refreshCache(
 			Select: api.URLCacheDriveItemProps(),
 		})
 
-	for page, reset, done := pager.NextPage(); !done; {
+	for page, reset, done := pager.NextPage(); !done; page, reset, done = pager.NextPage() {
 		err := uc.updateCache(
 			ctx,
 			page,

--- a/src/internal/m365/collection/drive/url_cache.go
+++ b/src/internal/m365/collection/drive/url_cache.go
@@ -44,8 +44,8 @@ type urlCache struct {
 	// cacheMu protects idToProps and lastRefreshTime
 	cacheMu sync.RWMutex
 	// refreshMu serializes cache refresh attempts by potential writers
-	refreshMu       sync.Mutex
-	deltaQueryCount int
+	refreshMu    sync.Mutex
+	refreshCount int
 
 	enumerator EnumerateDriveItemsDeltaer
 
@@ -154,8 +154,8 @@ func (uc *urlCache) refreshCache(
 	uc.cacheMu.Lock()
 	defer uc.cacheMu.Unlock()
 
-	// Issue a delta query to graph
 	logger.Ctx(ctx).Info("refreshing url cache")
+	uc.refreshCount++
 
 	pager := uc.enumerator.EnumerateDriveItemsDelta(
 		ctx,
@@ -166,8 +166,6 @@ func (uc *urlCache) refreshCache(
 		})
 
 	for page, reset, done := pager.NextPage(); !done; {
-		uc.deltaQueryCount++
-
 		err := uc.updateCache(
 			ctx,
 			page,

--- a/src/internal/m365/collection/drive/url_cache_test.go
+++ b/src/internal/m365/collection/drive/url_cache_test.go
@@ -204,7 +204,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 
 	table := []struct {
 		name              string
-		pages             []mock.NextPage[models.DriveItemable]
+		pages             []mock.NextPage
 		pagerErr          error
 		expectedItemProps map[string]itemProps
 		expectErr         assert.ErrorAssertionFunc
@@ -212,7 +212,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 	}{
 		{
 			name: "single item in cache",
-			pages: []mock.NextPage[models.DriveItemable]{
+			pages: []mock.NextPage{
 				{Items: []models.DriveItemable{
 					fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
 				}},
@@ -232,7 +232,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		},
 		{
 			name: "multiple items in cache",
-			pages: []mock.NextPage[models.DriveItemable]{
+			pages: []mock.NextPage{
 				{Items: []models.DriveItemable{
 					fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
 					fileItem("2", "file2", "root", "root", "https://dummy2.com", false),
@@ -272,7 +272,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		},
 		{
 			name: "multiple pages",
-			pages: []mock.NextPage[models.DriveItemable]{
+			pages: []mock.NextPage{
 				{Items: []models.DriveItemable{
 					fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
 					fileItem("2", "file2", "root", "root", "https://dummy2.com", false),
@@ -308,15 +308,16 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			expectErr: assert.NoError,
 			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
 				assert.Greater(t, uc.lastRefreshTime, startTime)
-				assert.Equal(t, 2, uc.refreshCount)
+				assert.Equal(t, 1, uc.refreshCount)
 				assert.Equal(t, 5, len(uc.idToProps))
 			},
 		},
 		{
 			name: "multiple pages with resets",
-			pages: []mock.NextPage[models.DriveItemable]{
+			pages: []mock.NextPage{
 				{
 					Items: []models.DriveItemable{
+						fileItem("-1", "file-1", "root", "root", "https://dummy-1.com", false),
 						fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
 						fileItem("2", "file2", "root", "root", "https://dummy2.com", false),
 						fileItem("3", "file3", "root", "root", "https://dummy3.com", false),
@@ -366,13 +367,13 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			expectErr: assert.NoError,
 			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
 				assert.Greater(t, uc.lastRefreshTime, startTime)
-				assert.Equal(t, 4, uc.refreshCount)
-				assert.Equal(t, 5, len(uc.idToProps))
+				assert.Equal(t, 1, uc.refreshCount)
+				assert.Equal(t, 6, len(uc.idToProps))
 			},
 		},
 		{
 			name: "multiple pages with resets and combo reset+items in page",
-			pages: []mock.NextPage[models.DriveItemable]{
+			pages: []mock.NextPage{
 				{
 					Items: []models.DriveItemable{
 						fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
@@ -420,13 +421,13 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			expectErr: assert.NoError,
 			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
 				assert.Greater(t, uc.lastRefreshTime, startTime)
-				assert.Equal(t, 3, uc.refreshCount)
+				assert.Equal(t, 1, uc.refreshCount)
 				assert.Equal(t, 5, len(uc.idToProps))
 			},
 		},
 		{
 			name: "duplicate items with potentially new urls",
-			pages: []mock.NextPage[models.DriveItemable]{
+			pages: []mock.NextPage{
 				{Items: []models.DriveItemable{
 					fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
 					fileItem("2", "file2", "root", "root", "https://dummy2.com", false),
@@ -458,7 +459,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		},
 		{
 			name: "deleted items",
-			pages: []mock.NextPage[models.DriveItemable]{
+			pages: []mock.NextPage{
 				{Items: []models.DriveItemable{
 					fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
 					fileItem("2", "file2", "root", "root", "https://dummy2.com", false),
@@ -484,7 +485,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		},
 		{
 			name: "item not found in cache",
-			pages: []mock.NextPage[models.DriveItemable]{
+			pages: []mock.NextPage{
 				{Items: []models.DriveItemable{
 					fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
 				}},
@@ -501,7 +502,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		},
 		{
 			name: "delta query error",
-			pages: []mock.NextPage[models.DriveItemable]{
+			pages: []mock.NextPage{
 				{Items: []models.DriveItemable{}},
 			},
 			pagerErr: errors.New("delta query error"),
@@ -519,7 +520,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 
 		{
 			name: "folder item",
-			pages: []mock.NextPage[models.DriveItemable]{
+			pages: []mock.NextPage{
 				{Items: []models.DriveItemable{
 					fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
 					driveItem("2", "folder2", "root", "root", false, true, false),
@@ -548,8 +549,8 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 					defer flush()
 
 					medi := mock.EnumerateItemsDeltaByDrive{
-						DrivePagers: map[string]mock.DriveItemsDeltaPager{
-							driveID: mock.DriveItemsDeltaPager{
+						DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+							driveID: {
 								Pages:       test.pages,
 								Err:         test.pagerErr,
 								DeltaUpdate: api.DeltaUpdate{URL: deltaString},

--- a/src/internal/m365/collection/drive/url_cache_test.go
+++ b/src/internal/m365/collection/drive/url_cache_test.go
@@ -2,6 +2,7 @@ package drive
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"math/rand"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -91,10 +93,22 @@ func (suite *URLCacheIntegrationSuite) TestURLCacheBasic() {
 		api.NewDriveItem(newFolderName, true),
 		control.Copy)
 	require.NoError(t, err, clues.ToCore(err))
-
 	require.NotNil(t, newFolder.GetId())
 
 	nfid := ptr.Val(newFolder.GetId())
+	ch := make(chan api.NextPage[models.DriveItemable], 1)
+
+	go func() {
+		for {
+			// no-op, we just need the previous delta
+			// but also need to drain the channel to
+			// prevent deadlock.
+			_, ok := <-ch
+			if !ok {
+				return
+			}
+		}
+	}()
 
 	// Get the previous delta to feed into url cache
 	_, du, err := ac.EnumerateDriveItemsDelta(
@@ -196,16 +210,18 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 
 	table := []struct {
 		name              string
-		pagerItems        map[string][]models.DriveItemable
-		pagerErr          map[string]error
+		pages             []api.NextPage[models.DriveItemable]
+		pagerErr          error
 		expectedItemProps map[string]itemProps
-		expectedErr       require.ErrorAssertionFunc
-		cacheAssert       func(*urlCache, time.Time)
+		expectErr         assert.ErrorAssertionFunc
+		expect            func(*testing.T, *urlCache, time.Time)
 	}{
 		{
 			name: "single item in cache",
-			pagerItems: map[string][]models.DriveItemable{
-				driveID: {fileItem("1", "file1", "root", "root", "https://dummy1.com", false)},
+			pages: []api.NextPage[models.DriveItemable]{
+				{Items: []models.DriveItemable{
+					fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
+				}},
 			},
 			expectedItemProps: map[string]itemProps{
 				"1": {
@@ -213,22 +229,121 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 					isDeleted:   false,
 				},
 			},
-			expectedErr: require.NoError,
-			cacheAssert: func(uc *urlCache, startTime time.Time) {
-				require.Greater(suite.T(), uc.lastRefreshTime, startTime)
-				require.Equal(suite.T(), 1, uc.deltaQueryCount)
-				require.Equal(suite.T(), 1, len(uc.idToProps))
+			expectErr: assert.NoError,
+			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
+				assert.Greater(t, uc.lastRefreshTime, startTime)
+				assert.Equal(t, 1, uc.deltaQueryCount)
+				assert.Equal(t, 1, len(uc.idToProps))
 			},
 		},
 		{
 			name: "multiple items in cache",
-			pagerItems: map[string][]models.DriveItemable{
-				driveID: {
+			pages: []api.NextPage[models.DriveItemable]{
+				{Items: []models.DriveItemable{
 					fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
 					fileItem("2", "file2", "root", "root", "https://dummy2.com", false),
 					fileItem("3", "file3", "root", "root", "https://dummy3.com", false),
 					fileItem("4", "file4", "root", "root", "https://dummy4.com", false),
 					fileItem("5", "file5", "root", "root", "https://dummy5.com", false),
+				}},
+			},
+			expectedItemProps: map[string]itemProps{
+				"1": {
+					downloadURL: "https://dummy1.com",
+					isDeleted:   false,
+				},
+				"2": {
+					downloadURL: "https://dummy2.com",
+					isDeleted:   false,
+				},
+				"3": {
+					downloadURL: "https://dummy3.com",
+					isDeleted:   false,
+				},
+				"4": {
+					downloadURL: "https://dummy4.com",
+					isDeleted:   false,
+				},
+				"5": {
+					downloadURL: "https://dummy5.com",
+					isDeleted:   false,
+				},
+			},
+			expectErr: assert.NoError,
+			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
+				assert.Greater(t, uc.lastRefreshTime, startTime)
+				assert.Equal(t, 1, uc.deltaQueryCount)
+				assert.Equal(t, 5, len(uc.idToProps))
+			},
+		},
+		{
+			name: "multiple pages",
+			pages: []api.NextPage[models.DriveItemable]{
+				{Items: []models.DriveItemable{
+					fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
+					fileItem("2", "file2", "root", "root", "https://dummy2.com", false),
+					fileItem("3", "file3", "root", "root", "https://dummy3.com", false),
+				}},
+				{Items: []models.DriveItemable{
+					fileItem("4", "file4", "root", "root", "https://dummy4.com", false),
+					fileItem("5", "file5", "root", "root", "https://dummy5.com", false),
+				}},
+			},
+			expectedItemProps: map[string]itemProps{
+				"1": {
+					downloadURL: "https://dummy1.com",
+					isDeleted:   false,
+				},
+				"2": {
+					downloadURL: "https://dummy2.com",
+					isDeleted:   false,
+				},
+				"3": {
+					downloadURL: "https://dummy3.com",
+					isDeleted:   false,
+				},
+				"4": {
+					downloadURL: "https://dummy4.com",
+					isDeleted:   false,
+				},
+				"5": {
+					downloadURL: "https://dummy5.com",
+					isDeleted:   false,
+				},
+			},
+			expectErr: assert.NoError,
+			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
+				assert.Greater(t, uc.lastRefreshTime, startTime)
+				assert.Equal(t, 2, uc.deltaQueryCount)
+				assert.Equal(t, 5, len(uc.idToProps))
+			},
+		},
+		{
+			name: "multiple pages with resets",
+			pages: []api.NextPage[models.DriveItemable]{
+				{
+					Items: []models.DriveItemable{
+						fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
+						fileItem("2", "file2", "root", "root", "https://dummy2.com", false),
+						fileItem("3", "file3", "root", "root", "https://dummy3.com", false),
+					},
+				},
+				{
+					Items: []models.DriveItemable{},
+					Reset: true,
+				},
+				{
+					Items: []models.DriveItemable{
+						fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
+						fileItem("2", "file2", "root", "root", "https://dummy2.com", false),
+						fileItem("3", "file3", "root", "root", "https://dummy3.com", false),
+					},
+				},
+				{
+					Items: []models.DriveItemable{
+						fileItem("4", "file4", "root", "root", "https://dummy4.com", false),
+						fileItem("5", "file5", "root", "root", "https://dummy5.com", false),
+					},
 				},
 			},
 			expectedItemProps: map[string]itemProps{
@@ -253,23 +368,77 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 					isDeleted:   false,
 				},
 			},
-			expectedErr: require.NoError,
-			cacheAssert: func(uc *urlCache, startTime time.Time) {
-				require.Greater(suite.T(), uc.lastRefreshTime, startTime)
-				require.Equal(suite.T(), 1, uc.deltaQueryCount)
-				require.Equal(suite.T(), 5, len(uc.idToProps))
+			expectErr: assert.NoError,
+			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
+				assert.Greater(t, uc.lastRefreshTime, startTime)
+				assert.Equal(t, 4, uc.deltaQueryCount)
+				assert.Equal(t, 5, len(uc.idToProps))
+			},
+		},
+		{
+			name: "multiple pages with resets and combo reset+items in page",
+			pages: []api.NextPage[models.DriveItemable]{
+				{
+					Items: []models.DriveItemable{
+						fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
+						fileItem("2", "file2", "root", "root", "https://dummy2.com", false),
+						fileItem("3", "file3", "root", "root", "https://dummy3.com", false),
+					},
+				},
+				{
+					Items: []models.DriveItemable{
+						fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
+						fileItem("2", "file2", "root", "root", "https://dummy2.com", false),
+						fileItem("3", "file3", "root", "root", "https://dummy3.com", false),
+					},
+					Reset: true,
+				},
+				{
+					Items: []models.DriveItemable{
+						fileItem("4", "file4", "root", "root", "https://dummy4.com", false),
+						fileItem("5", "file5", "root", "root", "https://dummy5.com", false),
+					},
+				},
+			},
+			expectedItemProps: map[string]itemProps{
+				"1": {
+					downloadURL: "https://dummy1.com",
+					isDeleted:   false,
+				},
+				"2": {
+					downloadURL: "https://dummy2.com",
+					isDeleted:   false,
+				},
+				"3": {
+					downloadURL: "https://dummy3.com",
+					isDeleted:   false,
+				},
+				"4": {
+					downloadURL: "https://dummy4.com",
+					isDeleted:   false,
+				},
+				"5": {
+					downloadURL: "https://dummy5.com",
+					isDeleted:   false,
+				},
+			},
+			expectErr: assert.NoError,
+			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
+				assert.Greater(t, uc.lastRefreshTime, startTime)
+				assert.Equal(t, 3, uc.deltaQueryCount)
+				assert.Equal(t, 5, len(uc.idToProps))
 			},
 		},
 		{
 			name: "duplicate items with potentially new urls",
-			pagerItems: map[string][]models.DriveItemable{
-				driveID: {
+			pages: []api.NextPage[models.DriveItemable]{
+				{Items: []models.DriveItemable{
 					fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
 					fileItem("2", "file2", "root", "root", "https://dummy2.com", false),
 					fileItem("3", "file3", "root", "root", "https://dummy3.com", false),
 					fileItem("1", "file1", "root", "root", "https://test1.com", false),
 					fileItem("2", "file2", "root", "root", "https://test2.com", false),
-				},
+				}},
 			},
 			expectedItemProps: map[string]itemProps{
 				"1": {
@@ -285,21 +454,21 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 					isDeleted:   false,
 				},
 			},
-			expectedErr: require.NoError,
-			cacheAssert: func(uc *urlCache, startTime time.Time) {
-				require.Greater(suite.T(), uc.lastRefreshTime, startTime)
-				require.Equal(suite.T(), 1, uc.deltaQueryCount)
-				require.Equal(suite.T(), 3, len(uc.idToProps))
+			expectErr: assert.NoError,
+			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
+				assert.Greater(t, uc.lastRefreshTime, startTime)
+				assert.Equal(t, 1, uc.deltaQueryCount)
+				assert.Equal(t, 3, len(uc.idToProps))
 			},
 		},
 		{
 			name: "deleted items",
-			pagerItems: map[string][]models.DriveItemable{
-				driveID: {
+			pages: []api.NextPage[models.DriveItemable]{
+				{Items: []models.DriveItemable{
 					fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
 					fileItem("2", "file2", "root", "root", "https://dummy2.com", false),
 					fileItem("1", "file1", "root", "root", "https://dummy1.com", true),
-				},
+				}},
 			},
 			expectedItemProps: map[string]itemProps{
 				"1": {
@@ -311,111 +480,122 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 					isDeleted:   false,
 				},
 			},
-			expectedErr: require.NoError,
-			cacheAssert: func(uc *urlCache, startTime time.Time) {
-				require.Greater(suite.T(), uc.lastRefreshTime, startTime)
-				require.Equal(suite.T(), 1, uc.deltaQueryCount)
-				require.Equal(suite.T(), 2, len(uc.idToProps))
+			expectErr: assert.NoError,
+			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
+				assert.Greater(t, uc.lastRefreshTime, startTime)
+				assert.Equal(t, 1, uc.deltaQueryCount)
+				assert.Equal(t, 2, len(uc.idToProps))
 			},
 		},
 		{
 			name: "item not found in cache",
-			pagerItems: map[string][]models.DriveItemable{
-				driveID: {fileItem("1", "file1", "root", "root", "https://dummy1.com", false)},
+			pages: []api.NextPage[models.DriveItemable]{
+				{Items: []models.DriveItemable{
+					fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
+				}},
 			},
 			expectedItemProps: map[string]itemProps{
 				"2": {},
 			},
-			expectedErr: require.Error,
-			cacheAssert: func(uc *urlCache, startTime time.Time) {
-				require.Greater(suite.T(), uc.lastRefreshTime, startTime)
-				require.Equal(suite.T(), 1, uc.deltaQueryCount)
-				require.Equal(suite.T(), 1, len(uc.idToProps))
+			expectErr: assert.Error,
+			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
+				assert.Greater(t, uc.lastRefreshTime, startTime)
+				assert.Equal(t, 1, uc.deltaQueryCount)
+				assert.Equal(t, 1, len(uc.idToProps))
 			},
 		},
 		{
-			name:       "delta query error",
-			pagerItems: map[string][]models.DriveItemable{},
-			pagerErr: map[string]error{
-				driveID: errors.New("delta query error"),
+			name: "delta query error",
+			pages: []api.NextPage[models.DriveItemable]{
+				{Items: []models.DriveItemable{}},
 			},
+			pagerErr: errors.New("delta query error"),
 			expectedItemProps: map[string]itemProps{
 				"1": {},
 				"2": {},
 			},
-			expectedErr: require.Error,
-			cacheAssert: func(uc *urlCache, _ time.Time) {
-				require.Equal(suite.T(), time.Time{}, uc.lastRefreshTime)
-				require.Equal(suite.T(), 0, uc.deltaQueryCount)
-				require.Equal(suite.T(), 0, len(uc.idToProps))
+			expectErr: assert.Error,
+			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
+				assert.Equal(t, time.Time{}, uc.lastRefreshTime)
+				assert.NotZero(t, uc.deltaQueryCount)
+				assert.Equal(t, 0, len(uc.idToProps))
 			},
 		},
 
 		{
 			name: "folder item",
-			pagerItems: map[string][]models.DriveItemable{
-				driveID: {
+			pages: []api.NextPage[models.DriveItemable]{
+				{Items: []models.DriveItemable{
 					fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
 					driveItem("2", "folder2", "root", "root", false, true, false),
-				},
+				}},
 			},
 			expectedItemProps: map[string]itemProps{
 				"2": {},
 			},
-			expectedErr: require.Error,
-			cacheAssert: func(uc *urlCache, startTime time.Time) {
-				require.Greater(suite.T(), uc.lastRefreshTime, startTime)
-				require.Equal(suite.T(), 1, uc.deltaQueryCount)
-				require.Equal(suite.T(), 1, len(uc.idToProps))
+			expectErr: assert.Error,
+			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
+				assert.Greater(t, uc.lastRefreshTime, startTime)
+				assert.Equal(t, 1, uc.deltaQueryCount)
+				assert.Equal(t, 1, len(uc.idToProps))
 			},
 		},
 	}
 
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			t := suite.T()
-			ctx, flush := tester.NewContext(t)
-			defer flush()
+			for _, numConcurrentReqs := range []int{1, 2, 32} {
+				crTestName := fmt.Sprintf("%d_concurrent_reqs", numConcurrentReqs)
+				suite.Run(crTestName, func() {
+					t := suite.T()
 
-			medi := mock.EnumeratesDriveItemsDelta{
-				Items:       test.pagerItems,
-				Err:         test.pagerErr,
-				DeltaUpdate: map[string]api.DeltaUpdate{driveID: {URL: deltaString}},
-			}
+					ctx, flush := tester.NewContext(t)
+					defer flush()
 
-			cache, err := newURLCache(
-				driveID,
-				"",
-				1*time.Hour,
-				&medi,
-				fault.New(true))
-
-			require.NoError(suite.T(), err, clues.ToCore(err))
-
-			numConcurrentReq := 100
-			var wg sync.WaitGroup
-			wg.Add(numConcurrentReq)
-
-			startTime := time.Now()
-
-			for i := 0; i < numConcurrentReq; i++ {
-				go func() {
-					defer wg.Done()
-
-					for id, expected := range test.expectedItemProps {
-						time.Sleep(time.Duration(rand.Intn(100)) * time.Millisecond)
-
-						props, err := cache.getItemProperties(ctx, id)
-
-						test.expectedErr(suite.T(), err, clues.ToCore(err))
-						require.Equal(suite.T(), expected, props)
+					medi := mock.EnumeratesDriveItemsDelta[models.DriveItemable]{
+						Pages: map[string][]api.NextPage[models.DriveItemable]{
+							driveID: test.pages,
+						},
+						Err: map[string]error{
+							driveID: test.pagerErr,
+						},
+						DeltaUpdate: map[string]api.DeltaUpdate{
+							driveID: {URL: deltaString},
+						},
 					}
-				}()
+
+					cache, err := newURLCache(
+						driveID,
+						"",
+						1*time.Hour,
+						&medi,
+						fault.New(true))
+					require.NoError(t, err, clues.ToCore(err))
+
+					var wg sync.WaitGroup
+					wg.Add(numConcurrentReqs)
+
+					startTime := time.Now()
+
+					for i := 0; i < numConcurrentReqs; i++ {
+						go func(ti int) {
+							defer wg.Done()
+
+							for id, expected := range test.expectedItemProps {
+								time.Sleep(time.Duration(rand.Intn(100)) * time.Millisecond)
+
+								props, err := cache.getItemProperties(ctx, id)
+								test.expectErr(t, err, clues.ToCore(err))
+								assert.Equal(t, expected, props)
+							}
+						}(i)
+					}
+
+					wg.Wait()
+
+					test.expect(t, cache, startTime)
+				})
 			}
-
-			wg.Wait()
-
-			test.cacheAssert(cache, startTime)
 		})
 	}
 }
@@ -432,7 +612,7 @@ func (suite *URLCacheUnitSuite) TestNeedsRefresh() {
 		driveID,
 		"",
 		refreshInterval,
-		&mock.EnumeratesDriveItemsDelta{},
+		&mock.EnumeratesDriveItemsDelta[models.DriveItemable]{},
 		fault.New(true))
 
 	require.NoError(t, err, clues.ToCore(err))
@@ -456,44 +636,44 @@ func (suite *URLCacheUnitSuite) TestNeedsRefresh() {
 
 func (suite *URLCacheUnitSuite) TestNewURLCache() {
 	table := []struct {
-		name        string
-		driveID     string
-		refreshInt  time.Duration
-		itemPager   EnumerateDriveItemsDeltaer
-		errors      *fault.Bus
-		expectedErr require.ErrorAssertionFunc
+		name       string
+		driveID    string
+		refreshInt time.Duration
+		itemPager  EnumerateDriveItemsDeltaer
+		errors     *fault.Bus
+		expectErr  require.ErrorAssertionFunc
 	}{
 		{
-			name:        "invalid driveID",
-			driveID:     "",
-			refreshInt:  1 * time.Hour,
-			itemPager:   &mock.EnumeratesDriveItemsDelta{},
-			errors:      fault.New(true),
-			expectedErr: require.Error,
+			name:       "invalid driveID",
+			driveID:    "",
+			refreshInt: 1 * time.Hour,
+			itemPager:  &mock.EnumeratesDriveItemsDelta[models.DriveItemable]{},
+			errors:     fault.New(true),
+			expectErr:  require.Error,
 		},
 		{
-			name:        "invalid refresh interval",
-			driveID:     "drive1",
-			refreshInt:  100 * time.Millisecond,
-			itemPager:   &mock.EnumeratesDriveItemsDelta{},
-			errors:      fault.New(true),
-			expectedErr: require.Error,
+			name:       "invalid refresh interval",
+			driveID:    "drive1",
+			refreshInt: 100 * time.Millisecond,
+			itemPager:  &mock.EnumeratesDriveItemsDelta[models.DriveItemable]{},
+			errors:     fault.New(true),
+			expectErr:  require.Error,
 		},
 		{
-			name:        "invalid item enumerator",
-			driveID:     "drive1",
-			refreshInt:  1 * time.Hour,
-			itemPager:   nil,
-			errors:      fault.New(true),
-			expectedErr: require.Error,
+			name:       "invalid item enumerator",
+			driveID:    "drive1",
+			refreshInt: 1 * time.Hour,
+			itemPager:  nil,
+			errors:     fault.New(true),
+			expectErr:  require.Error,
 		},
 		{
-			name:        "valid",
-			driveID:     "drive1",
-			refreshInt:  1 * time.Hour,
-			itemPager:   &mock.EnumeratesDriveItemsDelta{},
-			errors:      fault.New(true),
-			expectedErr: require.NoError,
+			name:       "valid",
+			driveID:    "drive1",
+			refreshInt: 1 * time.Hour,
+			itemPager:  &mock.EnumeratesDriveItemsDelta[models.DriveItemable]{},
+			errors:     fault.New(true),
+			expectErr:  require.NoError,
 		},
 	}
 
@@ -507,7 +687,7 @@ func (suite *URLCacheUnitSuite) TestNewURLCache() {
 				test.itemPager,
 				test.errors)
 
-			test.expectedErr(t, err, clues.ToCore(err))
+			test.expectErr(t, err, clues.ToCore(err))
 		})
 	}
 }

--- a/src/internal/m365/collection/drive/url_cache_test.go
+++ b/src/internal/m365/collection/drive/url_cache_test.go
@@ -183,7 +183,7 @@ func (suite *URLCacheIntegrationSuite) TestURLCacheBasic() {
 	wg.Wait()
 
 	// Validate that exactly 1 delta query was made by url cache
-	require.Equal(t, 1, uc.deltaQueryCount)
+	require.Equal(t, 1, uc.refreshCount)
 }
 
 // ---------------------------------------------------------------------------
@@ -226,7 +226,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			expectErr: assert.NoError,
 			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
 				assert.Greater(t, uc.lastRefreshTime, startTime)
-				assert.Equal(t, 1, uc.deltaQueryCount)
+				assert.Equal(t, 1, uc.refreshCount)
 				assert.Equal(t, 1, len(uc.idToProps))
 			},
 		},
@@ -266,7 +266,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			expectErr: assert.NoError,
 			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
 				assert.Greater(t, uc.lastRefreshTime, startTime)
-				assert.Equal(t, 1, uc.deltaQueryCount)
+				assert.Equal(t, 1, uc.refreshCount)
 				assert.Equal(t, 5, len(uc.idToProps))
 			},
 		},
@@ -308,7 +308,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			expectErr: assert.NoError,
 			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
 				assert.Greater(t, uc.lastRefreshTime, startTime)
-				assert.Equal(t, 2, uc.deltaQueryCount)
+				assert.Equal(t, 2, uc.refreshCount)
 				assert.Equal(t, 5, len(uc.idToProps))
 			},
 		},
@@ -328,6 +328,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 				},
 				{
 					Items: []models.DriveItemable{
+						fileItem("0", "file1", "root", "root", "https://dummy0.com", false),
 						fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
 						fileItem("2", "file2", "root", "root", "https://dummy2.com", false),
 						fileItem("3", "file3", "root", "root", "https://dummy3.com", false),
@@ -365,7 +366,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			expectErr: assert.NoError,
 			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
 				assert.Greater(t, uc.lastRefreshTime, startTime)
-				assert.Equal(t, 4, uc.deltaQueryCount)
+				assert.Equal(t, 4, uc.refreshCount)
 				assert.Equal(t, 5, len(uc.idToProps))
 			},
 		},
@@ -419,7 +420,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			expectErr: assert.NoError,
 			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
 				assert.Greater(t, uc.lastRefreshTime, startTime)
-				assert.Equal(t, 3, uc.deltaQueryCount)
+				assert.Equal(t, 3, uc.refreshCount)
 				assert.Equal(t, 5, len(uc.idToProps))
 			},
 		},
@@ -451,7 +452,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			expectErr: assert.NoError,
 			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
 				assert.Greater(t, uc.lastRefreshTime, startTime)
-				assert.Equal(t, 1, uc.deltaQueryCount)
+				assert.Equal(t, 1, uc.refreshCount)
 				assert.Equal(t, 3, len(uc.idToProps))
 			},
 		},
@@ -477,7 +478,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			expectErr: assert.NoError,
 			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
 				assert.Greater(t, uc.lastRefreshTime, startTime)
-				assert.Equal(t, 1, uc.deltaQueryCount)
+				assert.Equal(t, 1, uc.refreshCount)
 				assert.Equal(t, 2, len(uc.idToProps))
 			},
 		},
@@ -494,7 +495,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			expectErr: assert.Error,
 			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
 				assert.Greater(t, uc.lastRefreshTime, startTime)
-				assert.Equal(t, 1, uc.deltaQueryCount)
+				assert.Equal(t, 1, uc.refreshCount)
 				assert.Equal(t, 1, len(uc.idToProps))
 			},
 		},
@@ -511,7 +512,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			expectErr: assert.Error,
 			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
 				assert.Equal(t, time.Time{}, uc.lastRefreshTime)
-				assert.NotZero(t, uc.deltaQueryCount)
+				assert.NotZero(t, uc.refreshCount)
 				assert.Equal(t, 0, len(uc.idToProps))
 			},
 		},
@@ -530,7 +531,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			expectErr: assert.Error,
 			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
 				assert.Greater(t, uc.lastRefreshTime, startTime)
-				assert.Equal(t, 1, uc.deltaQueryCount)
+				assert.Equal(t, 1, uc.refreshCount)
 				assert.Equal(t, 1, len(uc.idToProps))
 			},
 		},

--- a/src/internal/m365/service/onedrive/mock/handlers.go
+++ b/src/internal/m365/service/onedrive/mock/handlers.go
@@ -292,20 +292,20 @@ func (m GetsItem) GetItem(
 // Enumerates Drive Items
 // ---------------------------------------------------------------------------
 
-type NextPage[T any] struct {
-	Items []T
+type NextPage struct {
+	Items []models.DriveItemable
 	Reset bool
 }
 
 type EnumerateItemsDeltaByDrive struct {
-	DrivePagers map[string]DriveItemsDeltaPager
+	DrivePagers map[string]*DriveItemsDeltaPager
 }
 
 var _ api.NextPageResulter[models.DriveItemable] = &DriveItemsDeltaPager{}
 
 type DriveItemsDeltaPager struct {
 	Idx         int
-	Pages       []NextPage[models.DriveItemable]
+	Pages       []NextPage
 	DeltaUpdate api.DeltaUpdate
 	Err         error
 }
@@ -316,7 +316,7 @@ func (edibd EnumerateItemsDeltaByDrive) EnumerateDriveItemsDelta(
 	_ api.CallConfig,
 ) api.NextPageResulter[models.DriveItemable] {
 	didp := edibd.DrivePagers[driveID]
-	return &didp
+	return didp
 }
 
 func (edi *DriveItemsDeltaPager) NextPage() ([]models.DriveItemable, bool, bool) {
@@ -325,7 +325,7 @@ func (edi *DriveItemsDeltaPager) NextPage() ([]models.DriveItemable, bool, bool)
 	}
 
 	np := edi.Pages[edi.Idx]
-	edi.Idx++
+	edi.Idx = edi.Idx + 1
 
 	return np.Items, np.Reset, false
 }

--- a/src/internal/m365/service/sharepoint/backup_test.go
+++ b/src/internal/m365/service/sharepoint/backup_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive"
 	odConsts "github.com/alcionai/corso/src/internal/m365/service/onedrive/consts"
+	"github.com/alcionai/corso/src/internal/m365/service/onedrive/mock"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -90,16 +91,29 @@ func (suite *LibrariesBackupUnitSuite) TestUpdateCollections() {
 			defer flush()
 
 			var (
-				paths     = map[string]string{}
-				currPaths = map[string]string{}
-				excluded  = map[string]struct{}{}
-				collMap   = map[string]map[string]*drive.Collection{
+				mbh = mock.DefaultSharePointBH(siteID)
+				du  = api.DeltaUpdate{
+					URL:   "notempty",
+					Reset: false,
+				}
+				paths    = map[string]string{}
+				excluded = map[string]struct{}{}
+				collMap  = map[string]map[string]*drive.Collection{
 					driveID: {},
 				}
 			)
 
+			mbh.DriveItemEnumeration = mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID: {
+						Pages:       []mock.NextPage{{Items: test.items}},
+						DeltaUpdate: du,
+					},
+				},
+			}
+
 			c := drive.NewCollections(
-				drive.NewLibraryBackupHandler(api.Drives{}, siteID, test.scope, path.SharePointService),
+				mbh,
 				tenantID,
 				idname.NewProvider(siteID, siteID),
 				nil,
@@ -107,15 +121,13 @@ func (suite *LibrariesBackupUnitSuite) TestUpdateCollections() {
 
 			c.CollectionMap = collMap
 
-			_, err := c.UpdateCollections(
+			_, _, err := c.PopulateDriveCollections(
 				ctx,
 				driveID,
 				"General",
-				test.items,
 				paths,
-				currPaths,
 				excluded,
-				true,
+				"",
 				fault.New(true))
 
 			test.expect(t, err, clues.ToCore(err))

--- a/src/pkg/fault/skipped.go
+++ b/src/pkg/fault/skipped.go
@@ -1,8 +1,16 @@
 package fault
 
 import (
+	"context"
+
 	"github.com/alcionai/corso/src/cli/print"
 )
+
+// AddSkipper presents an interface that allows callers to
+// write additional skipped items to the complying struct.
+type AddSkipper interface {
+	AddSkip(ctx context.Context, s *Skipped)
+}
 
 // skipCause identifies the well-known conditions to Skip an item.  It is
 // important that skip cause enumerations do not overlap with general error

--- a/src/pkg/services/m365/api/client.go
+++ b/src/pkg/services/m365/api/client.go
@@ -136,6 +136,7 @@ func (c Client) Post(
 
 type CallConfig struct {
 	Expand []string
+	Select []string
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/services/m365/api/drive_pager.go
+++ b/src/pkg/services/m365/api/drive_pager.go
@@ -133,7 +133,7 @@ type DriveItemDeltaPageCtrl struct {
 
 func (c Drives) newDriveItemDeltaPager(
 	driveID, prevDeltaLink string,
-	selectProps ...string,
+	cc CallConfig,
 ) *DriveItemDeltaPageCtrl {
 	preferHeaderItems := []string{
 		"deltashowremovedasdeleted",
@@ -147,8 +147,8 @@ func (c Drives) newDriveItemDeltaPager(
 		QueryParameters: &drives.ItemItemsItemDeltaRequestBuilderGetQueryParameters{},
 	}
 
-	if len(selectProps) > 0 {
-		options.QueryParameters.Select = selectProps
+	if len(cc.Select) > 0 {
+		options.QueryParameters.Select = cc.Select
 	}
 
 	builder := c.Stable.
@@ -203,12 +203,12 @@ func (c Drives) EnumerateDriveItemsDelta(
 	ctx context.Context,
 	driveID string,
 	prevDeltaLink string,
-	selectProps []string,
+	cc CallConfig,
 ) NextPageResulter[models.DriveItemable] {
 	deltaPager := c.newDriveItemDeltaPager(
 		driveID,
 		prevDeltaLink,
-		selectProps...)
+		cc)
 
 	npr := &nextPageResults[models.DriveItemable]{
 		pages: make(chan nextPage[models.DriveItemable]),

--- a/src/pkg/services/m365/api/drive_pager_test.go
+++ b/src/pkg/services/m365/api/drive_pager_test.go
@@ -199,7 +199,7 @@ func (suite *DrivePagerIntgSuite) TestEnumerateDriveItems() {
 				Select: api.DefaultDriveItemProps(),
 			})
 
-	for page, reset, done := pager.NextPage(); !done; {
+	for page, reset, done := pager.NextPage(); !done; page, reset, done = pager.NextPage() {
 		items = append(items, page...)
 
 		assert.False(t, reset, "should not reset")

--- a/src/pkg/services/m365/api/drive_pager_test.go
+++ b/src/pkg/services/m365/api/drive_pager_test.go
@@ -191,7 +191,13 @@ func (suite *DrivePagerIntgSuite) TestEnumerateDriveItems() {
 	pager := suite.its.
 		ac.
 		Drives().
-		EnumerateDriveItemsDelta(ctx, suite.its.user.driveID, "", api.DefaultDriveItemProps())
+		EnumerateDriveItemsDelta(
+			ctx,
+			suite.its.user.driveID,
+			"",
+			api.CallConfig{
+				Select: api.DefaultDriveItemProps(),
+			})
 
 	for page, reset, done := pager.NextPage(); !done; {
 		items = append(items, page...)

--- a/src/pkg/services/m365/api/item_pager.go
+++ b/src/pkg/services/m365/api/item_pager.go
@@ -223,8 +223,8 @@ func batchEnumerateItems[T any](
 
 	go enumerateItems[T](ctx, pager, &npr)
 
-	for is, _, done := npr.NextPage(); !done; {
-		items = append(items, is...)
+	for page, _, done := npr.NextPage(); !done; page, _, done = npr.NextPage() {
+		items = append(items, page...)
 	}
 
 	_, err := npr.Results()
@@ -346,12 +346,12 @@ func batchDeltaEnumerateItems[T any](
 
 	go deltaEnumerateItems[T](ctx, pager, &npr, prevDeltaLink)
 
-	for is, reset, done := npr.NextPage(); !done; {
+	for page, reset, done := npr.NextPage(); !done; page, reset, done = npr.NextPage() {
 		if reset {
 			results = []T{}
 		}
 
-		results = append(results, is...)
+		results = append(results, page...)
 	}
 
 	du, err := npr.Results()


### PR DESCRIPTION
updates the url cache item enumeration with stream processing
using channels.  Plus other changes to accomodate the
new pattern such as mock and interface updates. 

This is the second of a multipart update that has been separated
for ease of review.  CI is not expected to pass until the final
PR.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
