### PR TITLE
apply channels and streaming to drive collections

### DIFF
--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -672,11 +672,8 @@ func (c *Collections) getCollectionPath(
 
 // PopulateDriveCollections initializes and adds the provided drive items to Collections
 // A new collection is created for every drive folder.
-// oldPrevPaths is the unchanged data that was loaded from the metadata file.
-// This map is not modified during the call.
-// currPrevPaths starts as a copy of oldPaths and is updated as changes are found in
-// the returned results.  Items are added to this collection throughout the call.
-// newPrevPaths, ie: the items added during this call, get returned as a map.
+// Along with populating the collection items and updating the excluded item IDs, this func
+// returns the current DeltaUpdate and PreviousPaths for metadata records.
 func (c *Collections) PopulateDriveCollections(
 	ctx context.Context,
 	driveID, driveName string,

--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -707,8 +707,7 @@ func (c *Collections) PopulateDriveCollections(
 			Select: api.DefaultDriveItemProps(),
 		})
 
-	page, reset, done := pager.NextPage()
-	for ; !done; page, reset, done = pager.NextPage() {
+	for page, reset, done := pager.NextPage(); !done; page, reset, done = pager.NextPage() {
 		if el.Failure() != nil {
 			break
 		}

--- a/src/internal/m365/collection/drive/collections_test.go
+++ b/src/internal/m365/collection/drive/collections_test.go
@@ -1519,7 +1519,6 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 		{
 			name:   "OneDrive_TwoItemPages_WithReset",
 			drives: []models.Driveable{drive1},
-
 			enumerator: mock.EnumerateItemsDeltaByDrive{
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
 					driveID1: {
@@ -1529,6 +1528,7 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 									driveRootItem("root"),
 									driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
 									driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+									driveItem("file3", "file3", driveBasePath1+"/folder", "folder", true, false, false),
 								},
 							},
 							{

--- a/src/internal/m365/collection/drive/url_cache.go
+++ b/src/internal/m365/collection/drive/url_cache.go
@@ -165,7 +165,8 @@ func (uc *urlCache) refreshCache(
 			Select: api.URLCacheDriveItemProps(),
 		})
 
-	for page, reset, done := pager.NextPage(); !done; {
+	page, reset, done := pager.NextPage()
+	for ; !done; page, reset, done = pager.NextPage() {
 		err := uc.updateCache(
 			ctx,
 			page,

--- a/src/internal/m365/collection/drive/url_cache.go
+++ b/src/internal/m365/collection/drive/url_cache.go
@@ -165,8 +165,7 @@ func (uc *urlCache) refreshCache(
 			Select: api.URLCacheDriveItemProps(),
 		})
 
-	page, reset, done := pager.NextPage()
-	for ; !done; page, reset, done = pager.NextPage() {
+	for page, reset, done := pager.NextPage(); !done; page, reset, done = pager.NextPage() {
 		err := uc.updateCache(
 			ctx,
 			page,

--- a/src/internal/m365/collection/drive/url_cache_test.go
+++ b/src/internal/m365/collection/drive/url_cache_test.go
@@ -317,6 +317,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			pages: []mock.NextPage{
 				{
 					Items: []models.DriveItemable{
+						fileItem("-1", "file-1", "root", "root", "https://dummy-1.com", false),
 						fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
 						fileItem("2", "file2", "root", "root", "https://dummy2.com", false),
 						fileItem("3", "file3", "root", "root", "https://dummy3.com", false),

--- a/src/internal/m365/collection/drive/url_cache_test.go
+++ b/src/internal/m365/collection/drive/url_cache_test.go
@@ -308,7 +308,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			expectErr: assert.NoError,
 			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
 				assert.Greater(t, uc.lastRefreshTime, startTime)
-				assert.Equal(t, 2, uc.refreshCount)
+				assert.Equal(t, 1, uc.refreshCount)
 				assert.Equal(t, 5, len(uc.idToProps))
 			},
 		},
@@ -366,8 +366,8 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			expectErr: assert.NoError,
 			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
 				assert.Greater(t, uc.lastRefreshTime, startTime)
-				assert.Equal(t, 4, uc.refreshCount)
-				assert.Equal(t, 5, len(uc.idToProps))
+				assert.Equal(t, 1, uc.refreshCount)
+				assert.Equal(t, 6, len(uc.idToProps))
 			},
 		},
 		{
@@ -420,7 +420,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			expectErr: assert.NoError,
 			expect: func(t *testing.T, uc *urlCache, startTime time.Time) {
 				assert.Greater(t, uc.lastRefreshTime, startTime)
-				assert.Equal(t, 3, uc.refreshCount)
+				assert.Equal(t, 1, uc.refreshCount)
 				assert.Equal(t, 5, len(uc.idToProps))
 			},
 		},

--- a/src/internal/m365/collection/drive/url_cache_test.go
+++ b/src/internal/m365/collection/drive/url_cache_test.go
@@ -204,7 +204,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 
 	table := []struct {
 		name              string
-		pages             []mock.NextPage[models.DriveItemable]
+		pages             []mock.NextPage
 		pagerErr          error
 		expectedItemProps map[string]itemProps
 		expectErr         assert.ErrorAssertionFunc
@@ -212,7 +212,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 	}{
 		{
 			name: "single item in cache",
-			pages: []mock.NextPage[models.DriveItemable]{
+			pages: []mock.NextPage{
 				{Items: []models.DriveItemable{
 					fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
 				}},
@@ -232,7 +232,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		},
 		{
 			name: "multiple items in cache",
-			pages: []mock.NextPage[models.DriveItemable]{
+			pages: []mock.NextPage{
 				{Items: []models.DriveItemable{
 					fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
 					fileItem("2", "file2", "root", "root", "https://dummy2.com", false),
@@ -272,7 +272,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		},
 		{
 			name: "multiple pages",
-			pages: []mock.NextPage[models.DriveItemable]{
+			pages: []mock.NextPage{
 				{Items: []models.DriveItemable{
 					fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
 					fileItem("2", "file2", "root", "root", "https://dummy2.com", false),
@@ -314,7 +314,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		},
 		{
 			name: "multiple pages with resets",
-			pages: []mock.NextPage[models.DriveItemable]{
+			pages: []mock.NextPage{
 				{
 					Items: []models.DriveItemable{
 						fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
@@ -372,7 +372,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		},
 		{
 			name: "multiple pages with resets and combo reset+items in page",
-			pages: []mock.NextPage[models.DriveItemable]{
+			pages: []mock.NextPage{
 				{
 					Items: []models.DriveItemable{
 						fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
@@ -426,7 +426,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		},
 		{
 			name: "duplicate items with potentially new urls",
-			pages: []mock.NextPage[models.DriveItemable]{
+			pages: []mock.NextPage{
 				{Items: []models.DriveItemable{
 					fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
 					fileItem("2", "file2", "root", "root", "https://dummy2.com", false),
@@ -458,7 +458,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		},
 		{
 			name: "deleted items",
-			pages: []mock.NextPage[models.DriveItemable]{
+			pages: []mock.NextPage{
 				{Items: []models.DriveItemable{
 					fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
 					fileItem("2", "file2", "root", "root", "https://dummy2.com", false),
@@ -484,7 +484,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		},
 		{
 			name: "item not found in cache",
-			pages: []mock.NextPage[models.DriveItemable]{
+			pages: []mock.NextPage{
 				{Items: []models.DriveItemable{
 					fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
 				}},
@@ -501,7 +501,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		},
 		{
 			name: "delta query error",
-			pages: []mock.NextPage[models.DriveItemable]{
+			pages: []mock.NextPage{
 				{Items: []models.DriveItemable{}},
 			},
 			pagerErr: errors.New("delta query error"),
@@ -519,7 +519,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 
 		{
 			name: "folder item",
-			pages: []mock.NextPage[models.DriveItemable]{
+			pages: []mock.NextPage{
 				{Items: []models.DriveItemable{
 					fileItem("1", "file1", "root", "root", "https://dummy1.com", false),
 					driveItem("2", "folder2", "root", "root", false, true, false),
@@ -548,8 +548,8 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 					defer flush()
 
 					medi := mock.EnumerateItemsDeltaByDrive{
-						DrivePagers: map[string]mock.DriveItemsDeltaPager{
-							driveID: mock.DriveItemsDeltaPager{
+						DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+							driveID: {
 								Pages:       test.pages,
 								Err:         test.pagerErr,
 								DeltaUpdate: api.DeltaUpdate{URL: deltaString},

--- a/src/internal/m365/service/onedrive/mock/handlers.go
+++ b/src/internal/m365/service/onedrive/mock/handlers.go
@@ -292,8 +292,8 @@ func (m GetsItem) GetItem(
 // Enumerates Drive Items
 // ---------------------------------------------------------------------------
 
-type NextPage[T any] struct {
-	Items []T
+type NextPage struct {
+	Items []models.DriveItemable
 	Reset bool
 }
 
@@ -305,7 +305,7 @@ var _ api.NextPageResulter[models.DriveItemable] = &DriveItemsDeltaPager{}
 
 type DriveItemsDeltaPager struct {
 	Idx         int
-	Pages       []NextPage[models.DriveItemable]
+	Pages       []NextPage
 	DeltaUpdate api.DeltaUpdate
 	Err         error
 }

--- a/src/internal/m365/service/onedrive/mock/handlers.go
+++ b/src/internal/m365/service/onedrive/mock/handlers.go
@@ -298,7 +298,7 @@ type NextPage struct {
 }
 
 type EnumerateItemsDeltaByDrive struct {
-	DrivePagers map[string]DriveItemsDeltaPager
+	DrivePagers map[string]*DriveItemsDeltaPager
 }
 
 var _ api.NextPageResulter[models.DriveItemable] = &DriveItemsDeltaPager{}
@@ -316,7 +316,7 @@ func (edibd EnumerateItemsDeltaByDrive) EnumerateDriveItemsDelta(
 	_ api.CallConfig,
 ) api.NextPageResulter[models.DriveItemable] {
 	didp := edibd.DrivePagers[driveID]
-	return &didp
+	return didp
 }
 
 func (edi *DriveItemsDeltaPager) NextPage() ([]models.DriveItemable, bool, bool) {
@@ -325,7 +325,7 @@ func (edi *DriveItemsDeltaPager) NextPage() ([]models.DriveItemable, bool, bool)
 	}
 
 	np := edi.Pages[edi.Idx]
-	edi.Idx++
+	edi.Idx = edi.Idx + 1
 
 	return np.Items, np.Reset, false
 }

--- a/src/internal/m365/service/sharepoint/backup_test.go
+++ b/src/internal/m365/service/sharepoint/backup_test.go
@@ -104,8 +104,8 @@ func (suite *LibrariesBackupUnitSuite) TestUpdateCollections() {
 			)
 
 			mbh.DriveItemEnumeration = mock.EnumerateItemsDeltaByDrive{
-				DrivePagers: map[string]mock.DriveItemsDeltaPager{
-					driveID: mock.DriveItemsDeltaPager{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID: {
 						Pages:       []mock.NextPage{{Items: test.items}},
 						DeltaUpdate: du,
 					},

--- a/src/internal/m365/service/sharepoint/backup_test.go
+++ b/src/internal/m365/service/sharepoint/backup_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive"
 	odConsts "github.com/alcionai/corso/src/internal/m365/service/onedrive/consts"
+	"github.com/alcionai/corso/src/internal/m365/service/onedrive/mock"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -90,16 +91,29 @@ func (suite *LibrariesBackupUnitSuite) TestUpdateCollections() {
 			defer flush()
 
 			var (
-				paths     = map[string]string{}
-				currPaths = map[string]string{}
-				excluded  = map[string]struct{}{}
-				collMap   = map[string]map[string]*drive.Collection{
+				mbh = mock.DefaultSharePointBH(siteID)
+				du  = api.DeltaUpdate{
+					URL:   "notempty",
+					Reset: false,
+				}
+				paths    = map[string]string{}
+				excluded = map[string]struct{}{}
+				collMap  = map[string]map[string]*drive.Collection{
 					driveID: {},
 				}
 			)
 
+			mbh.DriveItemEnumeration = mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]mock.DriveItemsDeltaPager{
+					driveID: mock.DriveItemsDeltaPager{
+						Pages:       []mock.NextPage{{Items: test.items}},
+						DeltaUpdate: du,
+					},
+				},
+			}
+
 			c := drive.NewCollections(
-				drive.NewLibraryBackupHandler(api.Drives{}, siteID, test.scope, path.SharePointService),
+				mbh,
 				tenantID,
 				idname.NewProvider(siteID, siteID),
 				nil,
@@ -107,15 +121,13 @@ func (suite *LibrariesBackupUnitSuite) TestUpdateCollections() {
 
 			c.CollectionMap = collMap
 
-			_, err := c.UpdateCollections(
+			_, _, err := c.PopulateDriveCollections(
 				ctx,
 				driveID,
 				"General",
-				test.items,
 				paths,
-				currPaths,
 				excluded,
-				true,
+				"",
 				fault.New(true))
 
 			test.expect(t, err, clues.ToCore(err))

--- a/src/pkg/fault/skipped.go
+++ b/src/pkg/fault/skipped.go
@@ -1,8 +1,16 @@
 package fault
 
 import (
+	"context"
+
 	"github.com/alcionai/corso/src/cli/print"
 )
+
+// AddSkipper presents an interface that allows callers to
+// write additional skipped items to the complying struct.
+type AddSkipper interface {
+	AddSkip(ctx context.Context, s *Skipped)
+}
 
 // skipCause identifies the well-known conditions to Skip an item.  It is
 // important that skip cause enumerations do not overlap with general error

--- a/src/pkg/services/m365/api/drive_pager_test.go
+++ b/src/pkg/services/m365/api/drive_pager_test.go
@@ -199,8 +199,7 @@ func (suite *DrivePagerIntgSuite) TestEnumerateDriveItems() {
 				Select: api.DefaultDriveItemProps(),
 			})
 
-	page, reset, done := pager.NextPage()
-	for ; !done; page, reset, done = pager.NextPage() {
+	for page, reset, done := pager.NextPage(); !done; page, reset, done = pager.NextPage() {
 		items = append(items, page...)
 
 		assert.False(t, reset, "should not reset")

--- a/src/pkg/services/m365/api/drive_pager_test.go
+++ b/src/pkg/services/m365/api/drive_pager_test.go
@@ -199,7 +199,8 @@ func (suite *DrivePagerIntgSuite) TestEnumerateDriveItems() {
 				Select: api.DefaultDriveItemProps(),
 			})
 
-	for page, reset, done := pager.NextPage(); !done; {
+	page, reset, done := pager.NextPage()
+	for ; !done; page, reset, done = pager.NextPage() {
 		items = append(items, page...)
 
 		assert.False(t, reset, "should not reset")

--- a/src/pkg/services/m365/api/item_pager.go
+++ b/src/pkg/services/m365/api/item_pager.go
@@ -223,8 +223,7 @@ func batchEnumerateItems[T any](
 
 	go enumerateItems[T](ctx, pager, &npr)
 
-	page, _, done := npr.NextPage()
-	for ; !done; page, _, done = npr.NextPage() {
+	for page, _, done := npr.NextPage(); !done; page, _, done = npr.NextPage() {
 		items = append(items, page...)
 	}
 
@@ -347,8 +346,7 @@ func batchDeltaEnumerateItems[T any](
 
 	go deltaEnumerateItems[T](ctx, pager, &npr, prevDeltaLink)
 
-	page, reset, done := npr.NextPage()
-	for ; !done; page, reset, done = npr.NextPage() {
+	for page, reset, done := npr.NextPage(); !done; page, reset, done = npr.NextPage() {
 		if reset {
 			results = []T{}
 		}

--- a/src/pkg/services/m365/api/item_pager.go
+++ b/src/pkg/services/m365/api/item_pager.go
@@ -223,8 +223,9 @@ func batchEnumerateItems[T any](
 
 	go enumerateItems[T](ctx, pager, &npr)
 
-	for is, _, done := npr.NextPage(); !done; {
-		items = append(items, is...)
+	page, _, done := npr.NextPage()
+	for ; !done; page, _, done = npr.NextPage() {
+		items = append(items, page...)
 	}
 
 	_, err := npr.Results()
@@ -346,12 +347,13 @@ func batchDeltaEnumerateItems[T any](
 
 	go deltaEnumerateItems[T](ctx, pager, &npr, prevDeltaLink)
 
-	for is, reset, done := npr.NextPage(); !done; {
+	page, reset, done := npr.NextPage()
+	for ; !done; page, reset, done = npr.NextPage() {
 		if reset {
 			results = []T{}
 		}
 
-		results = append(results, is...)
+		results = append(results, page...)
 	}
 
 	du, err := npr.Results()


### PR DESCRIPTION
Updates drive collection processing with the new pattern of streaming pages from the api using channels.

This is the last in a multipart update that has been separated for ease of review.  Everything should now pass.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
