### PR TITLE
Add logic to check if the JWT token has expired

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -79,7 +79,6 @@ require (
 	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/src/go.mod
+++ b/src/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/armon/go-metrics v0.4.1
 	github.com/aws/aws-xray-sdk-go v1.8.1
 	github.com/cenkalti/backoff/v4 v4.2.1
+	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/google/uuid v1.3.1
 	github.com/h2non/gock v1.2.0
 	github.com/kopia/kopia v0.13.0
@@ -46,7 +47,6 @@ require (
 	github.com/aws/aws-sdk-go v1.45.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
-	github.com/golang-jwt/jwt/v5 v5.0.0 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
 	github.com/hashicorp/cronexpr v1.1.2 // indirect

--- a/src/go.mod
+++ b/src/go.mod
@@ -79,6 +79,7 @@ require (
 	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -138,6 +138,8 @@ github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
 github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=

--- a/src/go.sum
+++ b/src/go.sum
@@ -138,8 +138,6 @@ github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
 github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=

--- a/src/internal/common/jwt/jwt.go
+++ b/src/internal/common/jwt/jwt.go
@@ -1,0 +1,29 @@
+package jwt
+
+import (
+	"github.com/alcionai/clues"
+	jwt "github.com/golang-jwt/jwt"
+)
+
+// IsJWTExpired checks if the JWT token is past expiry by analyzing the
+// "exp" claim present in the token. Token is considered alive if :
+// 1. time.now <= "exp" claim.
+// 2. "exp" claim is missing.
+// An error is returned if the supplied token is malformed.
+func IsJWTExpired(
+	rawToken string,
+) (bool, error) {
+	// Note: Call to ParseUnverified is intentional since token verification is
+	// not our objective. We assume the token signature is valid & verified
+	// by caller stack. We only care about the embed claims in the token.
+	token, _, err := new(jwt.Parser).ParseUnverified(rawToken, jwt.MapClaims{})
+	if err != nil {
+		return false, clues.Wrap(err, "invalid jwt")
+	}
+
+	claims, _ := token.Claims.(jwt.MapClaims)
+	// If "exp" claim is missing, token is considered alive.
+	expired := !claims.VerifyExpiresAt(jwt.TimeFunc().Unix(), false)
+
+	return expired, nil
+}

--- a/src/internal/common/jwt/jwt.go
+++ b/src/internal/common/jwt/jwt.go
@@ -17,8 +17,8 @@ func IsJWTExpired(
 	p := jwt.NewParser()
 
 	// Note: Call to ParseUnverified is intentional since token verification is
-	// not our objective. We assume the token signature is valid & verified
-	// by caller stack. We only care about the embed claims in the token.
+	// not our objective. We only care about the embed claims in the token.
+	// We assume the token signature is valid & verified by caller stack.
 	token, _, err := p.ParseUnverified(rawToken, &jwt.RegisteredClaims{})
 	if err != nil {
 		return false, clues.Wrap(err, "invalid jwt")

--- a/src/internal/common/jwt/jwt.go
+++ b/src/internal/common/jwt/jwt.go
@@ -33,7 +33,7 @@ func IsJWTExpired(
 		return false, nil
 	}
 
-	expired := t.Time.Unix() < time.Now().Unix()
+	expired := t.Before(time.Now())
 
 	return expired, nil
 }

--- a/src/internal/common/jwt/jwt.go
+++ b/src/internal/common/jwt/jwt.go
@@ -19,14 +19,12 @@ func IsJWTExpired(
 	// Note: Call to ParseUnverified is intentional since token verification is
 	// not our objective. We assume the token signature is valid & verified
 	// by caller stack. We only care about the embed claims in the token.
-	token, _, err := p.ParseUnverified(rawToken, jwt.MapClaims{})
+	token, _, err := p.ParseUnverified(rawToken, &jwt.RegisteredClaims{})
 	if err != nil {
 		return false, clues.Wrap(err, "invalid jwt")
 	}
 
-	claims, _ := token.Claims.(jwt.MapClaims)
-
-	t, err := claims.GetExpirationTime()
+	t, err := token.Claims.GetExpirationTime()
 	if err != nil {
 		return false, clues.Wrap(err, "getting token expiry time")
 	}

--- a/src/internal/common/jwt/jwt_test.go
+++ b/src/internal/common/jwt/jwt_test.go
@@ -22,7 +22,7 @@ func TestJWTUnitSuite(t *testing.T) {
 
 // createJWTToken creates a JWT token with the specified expiration time.
 func createJWTToken(
-	claims jwt.MapClaims,
+	claims jwt.RegisteredClaims,
 ) (string, error) {
 	// build claims from map
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
@@ -51,8 +51,8 @@ func (suite *JWTUnitSuite) TestIsJWTExpired() {
 			name: "alive token",
 			getToken: func() (string, error) {
 				return createJWTToken(
-					jwt.MapClaims{
-						"exp": time.Now().Add(time.Hour).Unix(),
+					jwt.RegisteredClaims{
+						ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
 					})
 			},
 			expect:    false,
@@ -62,8 +62,8 @@ func (suite *JWTUnitSuite) TestIsJWTExpired() {
 			name: "expired token",
 			getToken: func() (string, error) {
 				return createJWTToken(
-					jwt.MapClaims{
-						"exp": time.Now().Add(-time.Hour).Unix(),
+					jwt.RegisteredClaims{
+						ExpiresAt: jwt.NewNumericDate(time.Now().Add(-time.Hour)),
 					})
 			},
 			expect:    true,
@@ -81,7 +81,7 @@ func (suite *JWTUnitSuite) TestIsJWTExpired() {
 		{
 			name: "alive token, missing exp claim",
 			getToken: func() (string, error) {
-				return createJWTToken(jwt.MapClaims{})
+				return createJWTToken(jwt.RegisteredClaims{})
 			},
 			expect:    false,
 			expectErr: assert.NoError,

--- a/src/internal/common/jwt/jwt_test.go
+++ b/src/internal/common/jwt/jwt_test.go
@@ -22,7 +22,6 @@ func TestJWTUnitSuite(t *testing.T) {
 
 // createJWTToken creates a JWT token with the specified expiration time.
 func createJWTToken(
-	expiration time.Time,
 	claims jwt.MapClaims,
 ) (string, error) {
 	// build claims from map
@@ -52,7 +51,6 @@ func (suite *JWTUnitSuite) TestIsJWTExpired() {
 			name: "alive token",
 			getToken: func() (string, error) {
 				return createJWTToken(
-					time.Now().Add(time.Hour),
 					jwt.MapClaims{
 						"exp": time.Now().Add(time.Hour).Unix(),
 					})
@@ -64,7 +62,6 @@ func (suite *JWTUnitSuite) TestIsJWTExpired() {
 			name: "expired token",
 			getToken: func() (string, error) {
 				return createJWTToken(
-					time.Now().Add(time.Hour),
 					jwt.MapClaims{
 						"exp": time.Now().Add(-time.Hour).Unix(),
 					})
@@ -74,7 +71,7 @@ func (suite *JWTUnitSuite) TestIsJWTExpired() {
 		},
 		// Test with a raw token which is not generated with go-jwt lib.
 		{
-			name: "raw token",
+			name: "alive raw token",
 			getToken: func() (string, error) {
 				return rawToken, nil
 			},
@@ -84,7 +81,7 @@ func (suite *JWTUnitSuite) TestIsJWTExpired() {
 		{
 			name: "alive token, missing exp claim",
 			getToken: func() (string, error) {
-				return createJWTToken(time.Now().Add(time.Hour), jwt.MapClaims{})
+				return createJWTToken(jwt.MapClaims{})
 			},
 			expect:    false,
 			expectErr: assert.NoError,

--- a/src/internal/common/jwt/jwt_test.go
+++ b/src/internal/common/jwt/jwt_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/src/internal/common/jwt/jwt_test.go
+++ b/src/internal/common/jwt/jwt_test.go
@@ -31,6 +31,16 @@ func createJWTToken(
 	return token.SignedString([]byte(""))
 }
 
+const (
+	// Raw test token valid for 100 years.
+	rawToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9." +
+		"eyJuYmYiOiIxNjkxODE5NTc5IiwiZXhwIjoiMzk0NTUyOTE3OSIsImVuZHBvaW50dXJsTGVuZ3RoIjoiMTYw" +
+		"IiwiaXNsb29wYmFjayI6IlRydWUiLCJ2ZXIiOiJoYXNoZWRwcm9vZnRva2VuIiwicm9sZXMiOiJhbGxmaWxl" +
+		"cy53cml0ZSBhbGxzaXRlcy5mdWxsY29udHJvbCBhbGxwcm9maWxlcy5yZWFkIiwidHQiOiIxIiwiYWxnIjoi" +
+		"SFMyNTYifQ" +
+		".signature"
+)
+
 func (suite *JWTUnitSuite) TestIsJWTExpired() {
 	table := []struct {
 		name      string
@@ -60,6 +70,15 @@ func (suite *JWTUnitSuite) TestIsJWTExpired() {
 					})
 			},
 			expect:    true,
+			expectErr: assert.NoError,
+		},
+		// Test with a raw token which is not generated with go-jwt lib.
+		{
+			name: "raw token",
+			getToken: func() (string, error) {
+				return rawToken, nil
+			},
+			expect:    false,
 			expectErr: assert.NoError,
 		},
 		{

--- a/src/internal/common/jwt/jwt_test.go
+++ b/src/internal/common/jwt/jwt_test.go
@@ -1,0 +1,99 @@
+package jwt
+
+import (
+	"testing"
+	"time"
+
+	jwt "github.com/golang-jwt/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/tester"
+)
+
+type JWTUnitSuite struct {
+	tester.Suite
+}
+
+func TestJWTUnitSuite(t *testing.T) {
+	suite.Run(t, &JWTUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+// createJWTToken creates a JWT token with the specified expiration time.
+func createJWTToken(
+	expiration time.Time,
+	claims jwt.MapClaims,
+) (string, error) {
+	// build claims from map
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+
+	return token.SignedString([]byte(""))
+}
+
+func (suite *JWTUnitSuite) TestIsJWTExpired() {
+	table := []struct {
+		name      string
+		expect    bool
+		getToken  func() (string, error)
+		expectErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "alive token",
+			getToken: func() (string, error) {
+				return createJWTToken(
+					time.Now().Add(time.Hour),
+					jwt.MapClaims{
+						"exp": time.Now().Add(time.Hour).Unix(),
+					})
+			},
+			expect:    false,
+			expectErr: assert.NoError,
+		},
+		{
+			name: "expired token",
+			getToken: func() (string, error) {
+				return createJWTToken(
+					time.Now().Add(time.Hour),
+					jwt.MapClaims{
+						"exp": time.Now().Add(-time.Hour).Unix(),
+					})
+			},
+			expect:    true,
+			expectErr: assert.NoError,
+		},
+		{
+			name: "alive token, missing exp claim",
+			getToken: func() (string, error) {
+				return createJWTToken(time.Now().Add(time.Hour), jwt.MapClaims{})
+			},
+			expect:    false,
+			expectErr: assert.NoError,
+		},
+		{
+			name: "malformed token",
+			getToken: func() (string, error) {
+				return "header.claims.signature", nil
+			},
+			expect:    false,
+			expectErr: assert.Error,
+		},
+	}
+
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			_, flush := tester.NewContext(t)
+			defer flush()
+
+			token, err := test.getToken()
+			require.NoError(t, err)
+
+			expired, err := IsJWTExpired(token)
+			test.expectErr(t, err)
+
+			assert.Equal(t, test.expect, expired)
+		})
+	}
+}

--- a/src/internal/common/url.go
+++ b/src/internal/common/url.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	"net/url"
+
+	"github.com/alcionai/clues"
+)
+
+// GetQueryParamFromURL parses an URL and returns value of the specified
+// query parameter.
+func GetQueryParamFromURL(
+	rawURL, queryParam string,
+) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", clues.Wrap(err, "parsing url")
+	}
+
+	qp := u.Query()
+
+	val := qp.Get(queryParam)
+	if len(val) == 0 {
+		return "", clues.New("query param not found").With("query_param", queryParam)
+	}
+
+	return val, nil
+}

--- a/src/internal/common/url_test.go
+++ b/src/internal/common/url_test.go
@@ -1,0 +1,72 @@
+package common_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/tester"
+)
+
+type URLUnitSuite struct {
+	tester.Suite
+}
+
+func TestURLUnitSuite(t *testing.T) {
+	suite.Run(t, &URLUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *URLUnitSuite) TestGetQueryParamFromURL() {
+	qp := "tempauth"
+	table := []struct {
+		name           string
+		rawURL         string
+		queryParam     string
+		expectedResult string
+		expect         assert.ErrorAssertionFunc
+	}{
+		{
+			name:           "valid",
+			rawURL:         "http://localhost:8080?" + qp + "=h.c.s&other=val",
+			queryParam:     qp,
+			expectedResult: "h.c.s",
+			expect:         assert.NoError,
+		},
+		{
+			name:       "query param not found",
+			rawURL:     "http://localhost:8080?other=val",
+			queryParam: qp,
+			expect:     assert.Error,
+		},
+		{
+			name:       "empty query param",
+			rawURL:     "http://localhost:8080?" + qp + "=h.c.s&other=val",
+			queryParam: "",
+			expect:     assert.Error,
+		},
+		// In case of multiple occurrences, the first occurrence of param is returned.
+		{
+			name:           "multiple occurrences",
+			rawURL:         "http://localhost:8080?" + qp + "=h.c.s&other=val&" + qp + "=h1.c1.s1",
+			queryParam:     qp,
+			expectedResult: "h.c.s",
+			expect:         assert.NoError,
+		},
+	}
+
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			_, flush := tester.NewContext(t)
+			defer flush()
+
+			token, err := common.GetQueryParamFromURL(test.rawURL, test.queryParam)
+			test.expect(t, err)
+
+			assert.Equal(t, test.expectedResult, token)
+		})
+	}
+}


### PR DESCRIPTION
<!-- PR description-->
**Changes**
* Introduce jwt expiry checks, to be used in a later PR. Based off @vkamra's idea. 
* Add an url parsing helper func to extract the value of specified query param(e.g. `tempauth`).
* Unit tests for both above.


---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [x] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup
- [x] Optimization

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* internal

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
