### PR TITLE
Use separate config dirs for kopia in file system mode

### DIFF
--- a/src/pkg/storage/testdata/storage.go
+++ b/src/pkg/storage/testdata/storage.go
@@ -68,6 +68,9 @@ func NewFilesystemStorage(t tester.TestT) storage.Storage {
 		},
 		storage.CommonConfig{
 			Corso: GetAndInsertCorso(""),
+			// Use separate kopia configs for each instance. Place in a new folder to
+			// avoid mixing data.
+			KopiaCfgDir: t.TempDir(),
 		})
 	require.NoError(t, err, "creating storage", clues.ToCore(err))
 


### PR DESCRIPTION
Fixes possible issues of opening the
incorrect repo if tests are run in
parallel.

Integration test for this in
[model_store_test.go](https://github.com/alcionai/corso/blob/3d78183651289e2051b8690850069c9b41df6bd0/src/internal/kopia/model_store_test.go#L897)

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #4422

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
