### PR TITLE
add groups sanity test support

### DIFF
--- a/.github/actions/backup-restore-test/action.yml
+++ b/.github/actions/backup-restore-test/action.yml
@@ -7,6 +7,9 @@ inputs:
   kind:
     description: Kind of test
     required: true
+  backup-id:
+    description: Backup to retrieve data out of
+    required: false
   backup-args:
     description: Arguments to pass for backup
     required: false
@@ -15,12 +18,9 @@ inputs:
     description: Arguments to pass for restore; restore is skipped when missing.
     required: false
     default: ""
-  test-folder:
+  restore-container:
     description: Folder to use for testing
     required: true
-  base-backup:
-    description: Base backup to use for testing
-    required: false
   log-dir:
     description: Folder to store test log files
     required: true
@@ -88,11 +88,9 @@ runs:
       shell: bash
       working-directory: src
       env:
-        SANITY_TEST_KIND: restore
-        SANITY_TEST_FOLDER: ${{ steps.restore.outputs.result }}
-        SANITY_TEST_SERVICE: ${{ inputs.service }}
-        SANITY_TEST_DATA: ${{ inputs.test-folder }}
-        SANITY_BASE_BACKUP: ${{ inputs.base-backup }}
+        SANITY_TEST_RESTORE_CONTAINER: ${{ steps.restore.outputs.result }}
+        SANITY_TEST_SOURCE_CONTAINER: ${{ inputs.restore-container }}
+        SANITY_BACKUP_ID: ${{ inputs.backup-id }}
       run: |
         echo "---------------------------"
         echo Sanity Test Restore ${{ inputs.service }} ${{ inputs.kind }}
@@ -125,11 +123,9 @@ runs:
       shell: bash
       working-directory: src
       env:
-        SANITY_TEST_KIND: export
-        SANITY_TEST_FOLDER: /tmp/export-${{ inputs.service }}-${{inputs.kind }}
-        SANITY_TEST_SERVICE: ${{ inputs.service }}
-        SANITY_TEST_DATA: ${{ inputs.test-folder }}
-        SANITY_BASE_BACKUP: ${{ inputs.base-backup }}
+        SANITY_TEST_RESTORE_CONTAINER: /tmp/export-${{ inputs.service }}-${{inputs.kind }}
+        SANITY_TEST_SOURCE_CONTAINER: ${{ inputs.restore-container }}
+        SANITY_BACKUP_ID: ${{ inputs.backup-id }}
       run: |
         echo "---------------------------"
         echo Sanity-Test Export ${{ inputs.service }} ${{ inputs.kind }}
@@ -165,11 +161,9 @@ runs:
       shell: bash
       working-directory: src
       env:
-        SANITY_TEST_KIND: export
-        SANITY_TEST_FOLDER: /tmp/export-${{ inputs.service }}-${{inputs.kind }}-unzipped
-        SANITY_TEST_SERVICE: ${{ inputs.service }}
-        SANITY_TEST_DATA: ${{ inputs.test-folder }}
-        SANITY_BASE_BACKUP: ${{ inputs.base-backup }}
+        SANITY_TEST_RESTORE_CONTAINER: /tmp/export-${{ inputs.service }}-${{inputs.kind }}-unzipped
+        SANITY_TEST_SOURCE_CONTAINER: ${{ inputs.restore-container }}
+        SANITY_BACKUP_ID: ${{ inputs.backup-id }}
       run: |
         echo "---------------------------"
         echo Sanity-Test Export Archive ${{ inputs.service }} ${{ inputs.kind }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,6 @@ jobs:
           CORSO_SECONDARY_M365_TEST_USER_ID: ${{ vars.CORSO_SECONDARY_M365_TEST_USER_ID }}
           CORSO_PASSPHRASE: ${{ secrets.INTEGRATION_TEST_CORSO_PASSPHRASE }}
           S3_BUCKET: ${{ secrets.CI_TESTS_S3_BUCKET }}
-          CORSO_ENABLE_GROUPS: true
         run: |
           set -euo pipefail
           go test       \
@@ -243,7 +242,6 @@ jobs:
           CORSO_SECONDARY_M365_TEST_USER_ID: ${{ vars.CORSO_SECONDARY_M365_TEST_USER_ID }}
           CORSO_PASSPHRASE: ${{ secrets.INTEGRATION_TEST_CORSO_PASSPHRASE }}
           S3_BUCKET: ${{ secrets.CI_RETENTION_TESTS_S3_BUCKET }}
-          CORSO_ENABLE_GROUPS: true
         run: |
           set -euo pipefail
           go test       \
@@ -277,7 +275,6 @@ jobs:
     env:
       CORSO_LOG_FILE: ${{ github.workspace }}/src/testlog/run-unit.log
       LOG_GRAPH_REQUESTS: true
-      CORSO_ENABLE_GROUPS: true
     steps:
       - uses: actions/checkout@v4
 
@@ -332,7 +329,6 @@ jobs:
     env:
       CORSO_LOG_FILE: ${{ github.workspace }}/testlog/run-fork.log
       LOG_GRAPH_REQUESTS: true
-      CORSO_ENABLE_GROUPS: true
     steps:
       - name: Fail check if not repository_dispatch
         if: github.event_name != 'repository_dispatch'

--- a/.github/workflows/nightly_test.yml
+++ b/.github/workflows/nightly_test.yml
@@ -59,7 +59,6 @@ jobs:
       AZURE_CLIENT_ID_NAME: ${{ needs.SetM365App.outputs.client_id_env }}
       AZURE_CLIENT_SECRET_NAME: ${{ needs.SetM365App.outputs.client_secret_env }}
       CLIENT_APP_SLOT: ${{ needs.SetM365App.outputs.client_app_slot }}
-      CORSO_ENABLE_GROUPS: true
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - add-groups-sanity-tests
   workflow_dispatch:
     inputs:
       user:

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - sanity-refactor-for-gropus
+      - add-groups-sanity-tests
   workflow_dispatch:
     inputs:
       user:

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -39,7 +39,6 @@ jobs:
       CORSO_LOG_FILE: ${{ github.workspace }}/src/testlog/run-sanity.log
       RESTORE_DEST_PFX: Corso_Test_Sanity_
       TEST_USER: ${{ github.event.inputs.user != '' && github.event.inputs.user || secrets.CORSO_M365_TEST_USER_ID }}
-      CORSO_ENABLE_GROUPS: true
 
     defaults:
       run:
@@ -184,7 +183,7 @@ jobs:
           kind: first-backup
           backup-args: '--mailbox "${{ env.TEST_USER }}" --data "email"'
           restore-args: '--email-folder ${{ env.RESTORE_DEST_PFX }}${{ steps.repo-init.outputs.result }}'
-          test-folder: '${{ env.RESTORE_DEST_PFX }}${{ steps.repo-init.outputs.result }}'
+          restore-container: '${{ env.RESTORE_DEST_PFX }}${{ steps.repo-init.outputs.result }}'
           log-dir: ${{ env.CORSO_LOG_DIR }}
 
       - name: Exchange - Incremental backup
@@ -195,8 +194,8 @@ jobs:
           kind: incremental
           backup-args: '--mailbox "${{ env.TEST_USER }}" --data "email"'
           restore-args: '--email-folder ${{ env.RESTORE_DEST_PFX }}${{ steps.repo-init.outputs.result }}'
-          test-folder: '${{ env.RESTORE_DEST_PFX }}${{ steps.repo-init.outputs.result }}'
-          base-backup: ${{ steps.exchange-backup.outputs.backup-id }}
+          restore-container: '${{ env.RESTORE_DEST_PFX }}${{ steps.repo-init.outputs.result }}'
+          backup-id: ${{ steps.exchange-backup.outputs.backup-id }}
           log-dir: ${{ env.CORSO_LOG_DIR }}
 
       - name: Exchange - Non delta backup
@@ -207,8 +206,8 @@ jobs:
           kind: non-delta
           backup-args: '--mailbox "${{ env.TEST_USER }}" --data "email" --disable-delta'
           restore-args: '--email-folder ${{ env.RESTORE_DEST_PFX }}${{ steps.repo-init.outputs.result }}'
-          test-folder: '${{ env.RESTORE_DEST_PFX }}${{ steps.repo-init.outputs.result }}'
-          base-backup: ${{ steps.exchange-backup.outputs.backup-id }}
+          restore-container: '${{ env.RESTORE_DEST_PFX }}${{ steps.repo-init.outputs.result }}'
+          backup-id: ${{ steps.exchange-backup.outputs.backup-id }}
           log-dir: ${{ env.CORSO_LOG_DIR }}
 
       - name: Exchange - Incremental backup after non-delta
@@ -219,8 +218,8 @@ jobs:
           kind: non-delta-incremental
           backup-args: '--mailbox "${{ env.TEST_USER }}" --data "email"'
           restore-args: '--email-folder ${{ env.RESTORE_DEST_PFX }}${{ steps.repo-init.outputs.result }}'
-          test-folder: '${{ env.RESTORE_DEST_PFX }}${{ steps.repo-init.outputs.result }}'
-          base-backup: ${{ steps.exchange-backup.outputs.backup-id }}
+          restore-container: '${{ env.RESTORE_DEST_PFX }}${{ steps.repo-init.outputs.result }}'
+          backup-id: ${{ steps.exchange-backup.outputs.backup-id }}
           log-dir: ${{ env.CORSO_LOG_DIR }}
 
 
@@ -252,7 +251,7 @@ jobs:
           kind: first-backup
           backup-args: '--user "${{ env.TEST_USER }}"'
           restore-args: '--folder ${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-onedrive.outputs.result }}'
-          test-folder: '${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-onedrive.outputs.result }}'
+          restore-container: '${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-onedrive.outputs.result }}'
           log-dir: ${{ env.CORSO_LOG_DIR }}
           with-export: true
 
@@ -275,7 +274,7 @@ jobs:
           kind: incremental
           backup-args: '--user "${{ env.TEST_USER }}"'
           restore-args: '--folder ${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-onedrive.outputs.result }}'
-          test-folder: '${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-onedrive.outputs.result }}'
+          restore-container: '${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-onedrive.outputs.result }}'
           log-dir: ${{ env.CORSO_LOG_DIR }}
           with-export: true
 
@@ -308,7 +307,7 @@ jobs:
           kind: first-backup
           backup-args: '--site "${{ secrets.CORSO_M365_TEST_SITE_URL }}"'
           restore-args: '--folder ${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-sharepoint.outputs.result }}'
-          test-folder: '${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-sharepoint.outputs.result }}'
+          restore-container: '${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-sharepoint.outputs.result }}'
           log-dir: ${{ env.CORSO_LOG_DIR }}
           with-export: true
 
@@ -332,7 +331,7 @@ jobs:
           kind: incremental
           backup-args: '--site "${{ secrets.CORSO_M365_TEST_SITE_URL }}"'
           restore-args: '--folder ${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-sharepoint.outputs.result }}'
-          test-folder: '${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-sharepoint.outputs.result }}'
+          restore-container: '${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-sharepoint.outputs.result }}'
           log-dir: ${{ env.CORSO_LOG_DIR }}
           with-export: true
 
@@ -364,32 +363,33 @@ jobs:
           service: groups
           kind: first-backup
           backup-args: '--group "${{ vars.CORSO_M365_TEST_TEAM_ID }}"'
-          test-folder: '${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-groups.outputs.result }}'
+          restore-container: '${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-groups.outputs.result }}'
           log-dir: ${{ env.CORSO_LOG_DIR }}
+          with-export: true
 
       # generate some more enteries for incremental check
-      # - name: Groups - Create new data (for incremental)
-      #   working-directory: ./src/cmd/factory
-      #   run: |
-      #     go run . sharepoint files  \
-      #       --site ${{ secrets.CORSO_M365_TEST_GROUPS_SITE_URL }} \
-      #       --user ${{ env.TEST_USER }} \
-      #       --secondaryuser  ${{ env.CORSO_SECONDARY_M365_TEST_USER_ID }} \
-      #       --tenant ${{ secrets.TENANT_ID }} \
-      #       --destination ${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-groups.outputs.result }} \
-      #       --count 4
+      - name: Groups - Create new data (for incremental)
+        working-directory: ./src/cmd/factory
+        run: |
+          go run . sharepoint files  \
+            --site ${{ env.CORSO_M365_TEST_GROUPS_SITE_URL }} \
+            --user ${{ env.TEST_USER }} \
+            --secondaryuser  ${{ env.CORSO_SECONDARY_M365_TEST_USER_ID }} \
+            --tenant ${{ secrets.TENANT_ID }} \
+            --destination ${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-groups.outputs.result }} \
+            --count 4
 
-      # - name: Groups - Incremental backup
-      #   id: groups-incremental
-      #   uses: ./.github/actions/backup-restore-test
-      #   with:
-      #     service: groups
-      #     kind: incremental
-      #     backup-args: '--site "${{ secrets.CORSO_M365_TEST_GROUPS_SITE_URL }}"'
-      #     restore-args: '--folder ${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-groups.outputs.result }}'
-      #     test-folder: '${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-groups.outputs.result }}'
-      #     log-dir: ${{ env.CORSO_LOG_DIR }}
-      #     with-export: true
+      - name: Groups - Incremental backup
+        id: groups-incremental
+        uses: ./.github/actions/backup-restore-test
+        with:
+          service: groups
+          kind: incremental
+          backup-args: '--site "${{ env.CORSO_M365_TEST_GROUPS_SITE_URL }}"'
+          restore-args: '--folder ${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-groups.outputs.result }}'
+          restore-container: '${{ env.RESTORE_DEST_PFX }}${{ steps.new-data-creation-groups.outputs.result }}'
+          log-dir: ${{ env.CORSO_LOG_DIR }}
+          with-export: true
 
 ##########################################################################################################################################
 

--- a/src/cmd/sanity_test/common/common.go
+++ b/src/cmd/sanity_test/common/common.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
@@ -19,36 +18,30 @@ type PermissionInfo struct {
 }
 
 const (
-	sanityBaseBackup  = "SANITY_BASE_BACKUP"
-	sanityTestData    = "SANITY_TEST_DATA"
-	sanityTestFolder  = "SANITY_TEST_FOLDER"
-	sanityTestService = "SANITY_TEST_SERVICE"
-	sanityTestUser    = "SANITY_TEST_USER"
+	sanityBackupID             = "SANITY_BACKUP_ID"
+	sanityTestSourceContainer  = "SANITY_TEST_SOURCE_CONTAINER"
+	sanityTestRestoreContainer = "SANITY_TEST_RESTORE_CONTAINER"
+	sanityTestUser             = "SANITY_TEST_USER"
 )
 
 type Envs struct {
-	BaseBackupFolder string
-	DataFolder       string
-	FolderName       string
+	BackupID         string
+	SourceContainer  string
+	RestoreContainer string
 	GroupID          string
-	Service          string
 	SiteID           string
-	StartTime        time.Time
 	UserID           string
 }
 
 func EnvVars(ctx context.Context) Envs {
-	folder := strings.TrimSpace(os.Getenv(sanityTestFolder))
-	startTime, _ := MustGetTimeFromName(ctx, folder)
+	folder := strings.TrimSpace(os.Getenv(sanityTestRestoreContainer))
 
 	e := Envs{
-		BaseBackupFolder: os.Getenv(sanityBaseBackup),
-		DataFolder:       os.Getenv(sanityTestData),
-		FolderName:       folder,
+		BackupID:         os.Getenv(sanityBackupID),
+		SourceContainer:  os.Getenv(sanityTestSourceContainer),
+		RestoreContainer: folder,
 		GroupID:          tconfig.GetM365TeamID(ctx),
 		SiteID:           tconfig.GetM365SiteID(ctx),
-		Service:          os.Getenv(sanityTestService),
-		StartTime:        startTime,
 		UserID:           tconfig.GetM365UserID(ctx),
 	}
 

--- a/src/cmd/sanity_test/common/common.go
+++ b/src/cmd/sanity_test/common/common.go
@@ -30,6 +30,7 @@ type Envs struct {
 	BaseBackupFolder string
 	DataFolder       string
 	FolderName       string
+	GroupID          string
 	Service          string
 	SiteID           string
 	StartTime        time.Time
@@ -44,6 +45,7 @@ func EnvVars(ctx context.Context) Envs {
 		BaseBackupFolder: os.Getenv(sanityBaseBackup),
 		DataFolder:       os.Getenv(sanityTestData),
 		FolderName:       folder,
+		GroupID:          tconfig.GetM365TeamID(ctx),
 		SiteID:           tconfig.GetM365SiteID(ctx),
 		Service:          os.Getenv(sanityTestService),
 		StartTime:        startTime,

--- a/src/cmd/sanity_test/common/filepath.go
+++ b/src/cmd/sanity_test/common/filepath.go
@@ -12,8 +12,8 @@ import (
 func BuildFilepathSanitree(
 	ctx context.Context,
 	rootDir string,
-) *Sanitree[fs.FileInfo] {
-	var root *Sanitree[fs.FileInfo]
+) *Sanitree[fs.FileInfo, fs.FileInfo] {
+	var root *Sanitree[fs.FileInfo, fs.FileInfo]
 
 	walker := func(
 		p string,
@@ -34,12 +34,12 @@ func BuildFilepathSanitree(
 		}
 
 		if root == nil {
-			root = &Sanitree[fs.FileInfo]{
+			root = &Sanitree[fs.FileInfo, fs.FileInfo]{
 				Self:     info,
 				ID:       info.Name(),
 				Name:     info.Name(),
-				Leaves:   map[string]*Sanileaf[fs.FileInfo]{},
-				Children: map[string]*Sanitree[fs.FileInfo]{},
+				Leaves:   map[string]*Sanileaf[fs.FileInfo, fs.FileInfo]{},
+				Children: map[string]*Sanitree[fs.FileInfo, fs.FileInfo]{},
 			}
 
 			return nil
@@ -49,16 +49,16 @@ func BuildFilepathSanitree(
 		node := root.NodeAt(ctx, elems[:len(elems)-1])
 
 		if info.IsDir() {
-			node.Children[info.Name()] = &Sanitree[fs.FileInfo]{
+			node.Children[info.Name()] = &Sanitree[fs.FileInfo, fs.FileInfo]{
 				Parent:   node,
 				Self:     info,
 				ID:       info.Name(),
 				Name:     info.Name(),
-				Leaves:   map[string]*Sanileaf[fs.FileInfo]{},
-				Children: map[string]*Sanitree[fs.FileInfo]{},
+				Leaves:   map[string]*Sanileaf[fs.FileInfo, fs.FileInfo]{},
+				Children: map[string]*Sanitree[fs.FileInfo, fs.FileInfo]{},
 			}
 		} else {
-			node.Leaves[info.Name()] = &Sanileaf[fs.FileInfo]{
+			node.Leaves[info.Name()] = &Sanileaf[fs.FileInfo, fs.FileInfo]{
 				Parent: node,
 				Self:   info,
 				ID:     info.Name(),

--- a/src/cmd/sanity_test/common/sanitree.go
+++ b/src/cmd/sanity_test/common/sanitree.go
@@ -106,6 +106,8 @@ func AssertEqualTrees[ET, EL, RT, RL any](
 		return
 	}
 
+	Debugf(ctx, "comparing trees at path: %+v", expect.Path())
+
 	checkChildrenAndLeaves(ctx, expect, result)
 	ctx = clues.Add(ctx, "container_name", expect.Name)
 
@@ -159,6 +161,8 @@ func CompareDiffTrees[ET, EL, RT, RL any](
 		return
 	}
 
+	Debugf(ctx, "comparing tree at path: %+v", expect.Path())
+
 	checkChildrenAndLeaves(ctx, expect, result)
 	ctx = clues.Add(ctx, "container_name", expect.Name)
 
@@ -181,7 +185,7 @@ func CompareDiffTrees[ET, EL, RT, RL any](
 }
 
 // ---------------------------------------------------------------------------
-// Checking hierarcy likeness
+// Checking hierarchy likeness
 // ---------------------------------------------------------------------------
 
 func checkChildrenAndLeaves[ET, EL, RT, RL any](
@@ -191,9 +195,16 @@ func checkChildrenAndLeaves[ET, EL, RT, RL any](
 ) {
 	Assert(
 		ctx,
-		func() bool { return expect != nil && result != nil },
-		"non nil nodes",
-		expect,
+		func() bool { return expect != nil },
+		"expected stree is nil",
+		"not nil",
+		expect)
+
+	Assert(
+		ctx,
+		func() bool { return result != nil },
+		"result stree is nil",
+		"not nil",
 		result)
 
 	ctx = clues.Add(ctx, "container_name", expect.Name)

--- a/src/cmd/sanity_test/driveish/driveish.go
+++ b/src/cmd/sanity_test/driveish/driveish.go
@@ -2,7 +2,6 @@ package driveish
 
 import (
 	"context"
-	"time"
 
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
@@ -20,8 +19,7 @@ func populateSanitree(
 	ctx context.Context,
 	ac api.Client,
 	driveID string,
-	startTime time.Time,
-) *common.Sanitree[models.DriveItemable] {
+) *common.Sanitree[models.DriveItemable, models.DriveItemable] {
 	common.Infof(ctx, "building sanitree for drive: %s", driveID)
 
 	root, err := ac.Drives().GetRootFolder(ctx, driveID)
@@ -29,12 +27,12 @@ func populateSanitree(
 		common.Fatal(ctx, "getting drive root folder", err)
 	}
 
-	stree := &common.Sanitree[models.DriveItemable]{
+	stree := &common.Sanitree[models.DriveItemable, models.DriveItemable]{
 		Self:     root,
 		ID:       ptr.Val(root.GetId()),
 		Name:     ptr.Val(root.GetName()),
-		Leaves:   map[string]*common.Sanileaf[models.DriveItemable]{},
-		Children: map[string]*common.Sanitree[models.DriveItemable]{},
+		Leaves:   map[string]*common.Sanileaf[models.DriveItemable, models.DriveItemable]{},
+		Children: map[string]*common.Sanitree[models.DriveItemable, models.DriveItemable]{},
 	}
 
 	recursivelyBuildTree(
@@ -42,8 +40,7 @@ func populateSanitree(
 		ac,
 		driveID,
 		stree.Name+"/",
-		stree,
-		startTime)
+		stree)
 
 	return stree
 }
@@ -52,8 +49,7 @@ func recursivelyBuildTree(
 	ctx context.Context,
 	ac api.Client,
 	driveID, location string,
-	stree *common.Sanitree[models.DriveItemable],
-	startTime time.Time,
+	stree *common.Sanitree[models.DriveItemable, models.DriveItemable],
 ) {
 	common.Debugf(ctx, "adding: %s", location)
 
@@ -76,7 +72,7 @@ func recursivelyBuildTree(
 				continue
 			}
 
-			branch := &common.Sanitree[models.DriveItemable]{
+			branch := &common.Sanitree[models.DriveItemable, models.DriveItemable]{
 				Parent: stree,
 				Self:   driveItem,
 				ID:     itemID,
@@ -84,8 +80,8 @@ func recursivelyBuildTree(
 				Expand: map[string]any{
 					expandPermissions: permissionIn(ctx, ac, driveID, itemID),
 				},
-				Leaves:   map[string]*common.Sanileaf[models.DriveItemable]{},
-				Children: map[string]*common.Sanitree[models.DriveItemable]{},
+				Leaves:   map[string]*common.Sanileaf[models.DriveItemable, models.DriveItemable]{},
+				Children: map[string]*common.Sanitree[models.DriveItemable, models.DriveItemable]{},
 			}
 
 			stree.Children[itemName] = branch
@@ -95,12 +91,11 @@ func recursivelyBuildTree(
 				ac,
 				driveID,
 				location+branch.Name+"/",
-				branch,
-				startTime)
+				branch)
 		}
 
 		if driveItem.GetFile() != nil {
-			stree.Leaves[itemName] = &common.Sanileaf[models.DriveItemable]{
+			stree.Leaves[itemName] = &common.Sanileaf[models.DriveItemable, models.DriveItemable]{
 				Parent: stree,
 				Self:   driveItem,
 				ID:     itemID,

--- a/src/cmd/sanity_test/driveish/export.go
+++ b/src/cmd/sanity_test/driveish/export.go
@@ -2,7 +2,6 @@ package driveish
 
 import (
 	"context"
-	"fmt"
 	"io/fs"
 
 	"github.com/alcionai/clues"
@@ -58,5 +57,5 @@ func CheckExport(
 		fpTree.Children[envs.DataFolder],
 		comparator)
 
-	fmt.Println("Success")
+	common.Infof(ctx, "Success")
 }

--- a/src/cmd/sanity_test/driveish/export.go
+++ b/src/cmd/sanity_test/driveish/export.go
@@ -33,15 +33,15 @@ func CheckExport(
 		ac,
 		driveID)
 
-	dataTree, ok := root.Children[envs.DataFolder]
+	sourceTree, ok := root.Children[envs.SourceContainer]
 	common.Assert(
 		ctx,
 		func() bool { return ok },
-		"should find root-level data folder",
-		envs.DataFolder,
+		"should find root-level source data folder",
+		envs.SourceContainer,
 		"not found")
 
-	fpTree := common.BuildFilepathSanitree(ctx, envs.FolderName)
+	fpTree := common.BuildFilepathSanitree(ctx, envs.RestoreContainer)
 
 	comparator := func(
 		ctx context.Context,
@@ -53,8 +53,8 @@ func CheckExport(
 
 	common.CompareDiffTrees(
 		ctx,
-		dataTree,
-		fpTree.Children[envs.DataFolder],
+		sourceTree,
+		fpTree.Children[envs.SourceContainer],
 		comparator)
 
 	common.Infof(ctx, "Success")

--- a/src/cmd/sanity_test/driveish/export.go
+++ b/src/cmd/sanity_test/driveish/export.go
@@ -32,8 +32,7 @@ func CheckExport(
 	root := populateSanitree(
 		ctx,
 		ac,
-		driveID,
-		envs.StartTime)
+		driveID)
 
 	dataTree, ok := root.Children[envs.DataFolder]
 	common.Assert(
@@ -47,8 +46,8 @@ func CheckExport(
 
 	comparator := func(
 		ctx context.Context,
-		expect *common.Sanitree[models.DriveItemable],
-		result *common.Sanitree[fs.FileInfo],
+		expect *common.Sanitree[models.DriveItemable, models.DriveItemable],
+		result *common.Sanitree[fs.FileInfo, fs.FileInfo],
 	) {
 		common.CompareLeaves(ctx, expect.Leaves, result.Leaves, nil)
 	}

--- a/src/cmd/sanity_test/driveish/restore.go
+++ b/src/cmd/sanity_test/driveish/restore.go
@@ -46,7 +46,7 @@ func CheckRestoration(
 		"drive_id", driveID,
 		"drive_name", driveName)
 
-	root := populateSanitree(ctx, ac, driveID, envs.StartTime)
+	root := populateSanitree(ctx, ac, driveID)
 
 	dataTree, ok := root.Children[envs.DataFolder]
 	common.Assert(
@@ -64,7 +64,10 @@ func CheckRestoration(
 		envs.FolderName,
 		"not found")
 
-	var permissionCheck common.ContainerComparatorFn[models.DriveItemable, models.DriveItemable]
+	var permissionCheck common.ContainerComparatorFn[
+		models.DriveItemable, models.DriveItemable,
+		models.DriveItemable, models.DriveItemable]
+
 	if permissionsComparator != nil {
 		permissionCheck = checkRestoredDriveItemPermissions(permissionsComparator)
 	}
@@ -127,7 +130,10 @@ func permissionIn(
 
 func checkRestoredDriveItemPermissions(
 	comparator func(expect, result []common.PermissionInfo) func() bool,
-) common.ContainerComparatorFn[models.DriveItemable, models.DriveItemable] {
+) common.ContainerComparatorFn[
+	models.DriveItemable, models.DriveItemable,
+	models.DriveItemable, models.DriveItemable,
+] {
 	/**
 		TODO: replace this check with testElementsMatch
 		from internal/connecter/graph_connector_helper_test.go
@@ -135,7 +141,7 @@ func checkRestoredDriveItemPermissions(
 
 	return func(
 		ctx context.Context,
-		expect, result *common.Sanitree[models.DriveItemable],
+		expect, result *common.Sanitree[models.DriveItemable, models.DriveItemable],
 	) {
 		expectPerms, err := tform.AnyValueToT[[]common.PermissionInfo](
 			expandPermissions,

--- a/src/cmd/sanity_test/driveish/restore.go
+++ b/src/cmd/sanity_test/driveish/restore.go
@@ -2,7 +2,6 @@ package driveish
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/alcionai/clues"
@@ -79,7 +78,7 @@ func CheckRestoration(
 		permissionCheck,
 		nil)
 
-	fmt.Println("Success")
+	common.Infof(ctx, "Success")
 }
 
 func permissionIn(

--- a/src/cmd/sanity_test/driveish/restore.go
+++ b/src/cmd/sanity_test/driveish/restore.go
@@ -47,20 +47,20 @@ func CheckRestoration(
 
 	root := populateSanitree(ctx, ac, driveID)
 
-	dataTree, ok := root.Children[envs.DataFolder]
+	sourceTree, ok := root.Children[envs.SourceContainer]
 	common.Assert(
 		ctx,
 		func() bool { return ok },
-		"should find root-level data folder",
-		envs.DataFolder,
+		"should find root-level source data folder",
+		envs.SourceContainer,
 		"not found")
 
-	restoreTree, ok := root.Children[envs.FolderName]
+	restoreTree, ok := root.Children[envs.RestoreContainer]
 	common.Assert(
 		ctx,
 		func() bool { return ok },
 		"should find root-level restore folder",
-		envs.FolderName,
+		envs.RestoreContainer,
 		"not found")
 
 	var permissionCheck common.ContainerComparatorFn[
@@ -73,8 +73,8 @@ func CheckRestoration(
 
 	common.AssertEqualTrees[models.DriveItemable](
 		ctx,
-		dataTree,
-		restoreTree.Children[envs.DataFolder],
+		sourceTree,
+		restoreTree.Children[envs.SourceContainer],
 		permissionCheck,
 		nil)
 

--- a/src/cmd/sanity_test/driveish/restore.go
+++ b/src/cmd/sanity_test/driveish/restore.go
@@ -127,17 +127,16 @@ func permissionIn(
 	return pi
 }
 
+/*
+TODO: replace this check with testElementsMatch
+from internal/connecter/graph_connector_helper_test.go
+*/
 func checkRestoredDriveItemPermissions(
 	comparator func(expect, result []common.PermissionInfo) func() bool,
 ) common.ContainerComparatorFn[
 	models.DriveItemable, models.DriveItemable,
 	models.DriveItemable, models.DriveItemable,
 ] {
-	/**
-		TODO: replace this check with testElementsMatch
-		from internal/connecter/graph_connector_helper_test.go
-	**/
-
 	return func(
 		ctx context.Context,
 		expect, result *common.Sanitree[models.DriveItemable, models.DriveItemable],

--- a/src/cmd/sanity_test/export/groups.go
+++ b/src/cmd/sanity_test/export/groups.go
@@ -43,12 +43,12 @@ func checkChannelMessagesExport(
 	ac api.Client,
 	envs common.Envs,
 ) {
-	dataTree := populateMessagesSanitree(
+	sourceTree := populateMessagesSanitree(
 		ctx,
 		ac,
 		envs.GroupID)
 
-	fpTree := common.BuildFilepathSanitree(ctx, envs.FolderName)
+	fpTree := common.BuildFilepathSanitree(ctx, envs.RestoreContainer)
 
 	comparator := func(
 		ctx context.Context,
@@ -60,7 +60,7 @@ func checkChannelMessagesExport(
 
 	common.CompareDiffTrees(
 		ctx,
-		dataTree,
+		sourceTree,
 		fpTree.Children["Messages"],
 		comparator)
 

--- a/src/cmd/sanity_test/export/groups.go
+++ b/src/cmd/sanity_test/export/groups.go
@@ -2,8 +2,15 @@ package export
 
 import (
 	"context"
+	"fmt"
+	"io/fs"
+
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
 	"github.com/alcionai/corso/src/cmd/sanity_test/common"
+	"github.com/alcionai/corso/src/cmd/sanity_test/driveish"
+	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
@@ -12,5 +19,109 @@ func CheckGroupsExport(
 	ac api.Client,
 	envs common.Envs,
 ) {
-	// TODO
+	// assumes we only need to sanity check the default site.
+	// should we expand this to check all sites in the group?
+	// are we backing up / restoring more than the default site?
+	drive, err := ac.Sites().GetDefaultDrive(ctx, envs.SiteID)
+	if err != nil {
+		common.Fatal(ctx, "getting the drive:", err)
+	}
+
+	driveish.CheckExport(
+		ctx,
+		ac,
+		drive,
+		envs)
+
+	checkChannelMessagesExport(
+		ctx,
+		ac,
+		envs)
+}
+
+func checkChannelMessagesExport(
+	ctx context.Context,
+	ac api.Client,
+	envs common.Envs,
+) {
+	dataTree := populateMessagesSanitree(
+		ctx,
+		ac,
+		envs.GroupID)
+
+	fpTree := common.BuildFilepathSanitree(ctx, envs.FolderName)
+
+	comparator := func(
+		ctx context.Context,
+		expect *common.Sanitree[models.Channelable, models.ChatMessageable],
+		result *common.Sanitree[fs.FileInfo, fs.FileInfo],
+	) {
+		common.CompareLeaves(ctx, expect.Leaves, result.Leaves, nil)
+	}
+
+	common.CompareDiffTrees(
+		ctx,
+		dataTree,
+		fpTree.Children["Messages"],
+		comparator)
+
+	fmt.Println("Success")
+}
+
+func populateMessagesSanitree(
+	ctx context.Context,
+	ac api.Client,
+	groupID string,
+) *common.Sanitree[models.Channelable, models.ChatMessageable] {
+	root := &common.Sanitree[models.Channelable, models.ChatMessageable]{
+		ID:   groupID,
+		Name: path.ChannelMessagesCategory.HumanString(),
+		// group should not have leaves
+		Children: map[string]*common.Sanitree[models.Channelable, models.ChatMessageable]{},
+	}
+
+	channels, err := ac.Channels().GetChannels(ctx, groupID)
+	if err != nil {
+		common.Fatal(ctx, "getting channels", err)
+	}
+
+	for _, ch := range channels {
+		child := &common.Sanitree[
+			models.Channelable, models.ChatMessageable,
+		]{
+			Parent: root,
+			ID:     ptr.Val(ch.GetId()),
+			Name:   ptr.Val(ch.GetDisplayName()),
+			Leaves: map[string]*common.Sanileaf[models.Channelable, models.ChatMessageable]{},
+			// no children in channels
+		}
+
+		msgs, err := ac.Channels().GetChannelMessages(
+			ctx,
+			groupID,
+			ptr.Val(ch.GetId()),
+			api.CallConfig{
+				// include all nessage replies in each message
+				Expand: []string{"replies"},
+			})
+		if err != nil {
+			common.Fatal(ctx, "getting channel messages", err)
+		}
+
+		for _, msg := range msgs {
+			child.Leaves[ptr.Val(msg.GetId())] = &common.Sanileaf[
+				models.Channelable,
+				models.ChatMessageable,
+			]{
+				Self: msg,
+				ID:   ptr.Val(msg.GetId()),
+				Name: ptr.Val(msg.GetId()),         // channel messages have no display name
+				Size: int64(len(msg.GetReplies())), // size is the count of replies
+			}
+		}
+
+		root.Children[ptr.Val(ch.GetDisplayName())] = child
+	}
+
+	return root
 }

--- a/src/cmd/sanity_test/export/groups.go
+++ b/src/cmd/sanity_test/export/groups.go
@@ -2,7 +2,6 @@ package export
 
 import (
 	"context"
-	"fmt"
 	"io/fs"
 
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -65,7 +64,7 @@ func checkChannelMessagesExport(
 		fpTree.Children["Messages"],
 		comparator)
 
-	fmt.Println("Success")
+	common.Infof(ctx, "Success")
 }
 
 func populateMessagesSanitree(

--- a/src/cmd/sanity_test/restore/exchange.go
+++ b/src/cmd/sanity_test/restore/exchange.go
@@ -19,20 +19,20 @@ func CheckEmailRestoration(
 	ac api.Client,
 	envs common.Envs,
 ) {
-	restoredTree := buildSanitree(ctx, ac, envs.UserID, envs.FolderName)
-	dataTree := buildSanitree(ctx, ac, envs.UserID, envs.DataFolder)
+	restoredTree := buildSanitree(ctx, ac, envs.UserID, envs.RestoreContainer)
+	sourceTree := buildSanitree(ctx, ac, envs.UserID, envs.SourceContainer)
 
 	ctx = clues.Add(
 		ctx,
-		"restore_folder_id", restoredTree.ID,
-		"restore_folder_name", restoredTree.Name,
-		"original_folder_id", dataTree.ID,
-		"original_folder_name", dataTree.Name)
+		"restore_container_id", restoredTree.ID,
+		"restore_container_name", restoredTree.Name,
+		"source_container_id", sourceTree.ID,
+		"source_container_name", sourceTree.Name)
 
 	common.AssertEqualTrees[models.MailFolderable, any](
 		ctx,
-		dataTree,
-		restoredTree.Children[envs.DataFolder],
+		sourceTree,
+		restoredTree.Children[envs.SourceContainer],
 		nil,
 		nil)
 

--- a/src/cmd/sanity_test/restore/exchange.go
+++ b/src/cmd/sanity_test/restore/exchange.go
@@ -36,7 +36,7 @@ func CheckEmailRestoration(
 
 	verifyEmailData(ctx, folderNameToRestoreItemCount, folderNameToItemCount)
 
-	common.AssertEqualTrees[models.MailFolderable](
+	common.AssertEqualTrees[models.MailFolderable, any](
 		ctx,
 		dataTree,
 		restoredTree.Children[envs.DataFolder],
@@ -61,7 +61,7 @@ func buildSanitree(
 	ctx context.Context,
 	ac api.Client,
 	userID, folderName string,
-) *common.Sanitree[models.MailFolderable] {
+) *common.Sanitree[models.MailFolderable, any] {
 	gcc, err := ac.Mail().GetContainerByName(
 		ctx,
 		userID,
@@ -82,12 +82,12 @@ func buildSanitree(
 			clues.New("casting "+*gcc.GetDisplayName()+" to models.MailFolderable"))
 	}
 
-	root := &common.Sanitree[models.MailFolderable]{
+	root := &common.Sanitree[models.MailFolderable, any]{
 		Self:        mmf,
 		ID:          ptr.Val(mmf.GetId()),
 		Name:        ptr.Val(mmf.GetDisplayName()),
 		CountLeaves: int(ptr.Val(mmf.GetTotalItemCount())),
-		Children:    map[string]*common.Sanitree[models.MailFolderable]{},
+		Children:    map[string]*common.Sanitree[models.MailFolderable, any]{},
 	}
 
 	recurseSubfolders(ctx, ac, root, userID)
@@ -98,7 +98,7 @@ func buildSanitree(
 func recurseSubfolders(
 	ctx context.Context,
 	ac api.Client,
-	parent *common.Sanitree[models.MailFolderable],
+	parent *common.Sanitree[models.MailFolderable, any],
 	userID string,
 ) {
 	childFolders, err := ac.Mail().GetContainerChildren(
@@ -110,13 +110,13 @@ func recurseSubfolders(
 	}
 
 	for _, child := range childFolders {
-		c := &common.Sanitree[models.MailFolderable]{
+		c := &common.Sanitree[models.MailFolderable, any]{
 			Parent:      parent,
 			Self:        child,
 			ID:          ptr.Val(child.GetId()),
 			Name:        ptr.Val(child.GetDisplayName()),
 			CountLeaves: int(ptr.Val(child.GetTotalItemCount())),
-			Children:    map[string]*common.Sanitree[models.MailFolderable]{},
+			Children:    map[string]*common.Sanitree[models.MailFolderable, any]{},
 		}
 
 		parent.Children[c.Name] = c

--- a/src/cmd/sanity_test/restore/groups.go
+++ b/src/cmd/sanity_test/restore/groups.go
@@ -4,13 +4,27 @@ import (
 	"context"
 
 	"github.com/alcionai/corso/src/cmd/sanity_test/common"
+	"github.com/alcionai/corso/src/cmd/sanity_test/driveish"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
+// only checks drive restoration.  channel messages are not
+// supported for restore actions.
 func CheckGroupsRestoration(
 	ctx context.Context,
 	ac api.Client,
 	envs common.Envs,
 ) {
-	// TODO
+	drive, err := ac.Sites().GetDefaultDrive(ctx, envs.SiteID)
+	if err != nil {
+		common.Fatal(ctx, "getting site's default drive:", err)
+	}
+
+	driveish.CheckRestoration(
+		ctx,
+		ac,
+		drive,
+		envs,
+		// skip permissions tests
+		nil)
 }

--- a/src/cmd/sanity_test/restore/onedrive.go
+++ b/src/cmd/sanity_test/restore/onedrive.go
@@ -8,8 +8,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
-const ()
-
 func CheckOneDriveRestoration(
 	ctx context.Context,
 	ac api.Client,

--- a/src/internal/tester/tconfig/protected_resources.go
+++ b/src/internal/tester/tconfig/protected_resources.go
@@ -185,14 +185,14 @@ func M365SiteURL(t *testing.T) string {
 	return strings.ToLower(cfg[TestCfgSiteURL])
 }
 
-// GetM365SiteID returns a siteID string representing the m365SitteID described
+// GetM365SiteID returns a siteID string representing the m365SiteID described
 // by either the env var CORSO_M365_TEST_SITE_ID, the corso_test.toml config
 // file or the default value (in that order of priority).  The default is a
 // last-attempt fallback that will only work on alcion's testing org.
 func GetM365SiteID(ctx context.Context) string {
 	cfg, err := ReadTestConfig()
 	if err != nil {
-		logger.Ctx(ctx).Error(err, "retrieving m365 user id from test configuration")
+		logger.Ctx(ctx).Error(err, "retrieving m365 site id from test configuration")
 	}
 
 	return strings.ToLower(cfg[TestCfgSiteID])
@@ -207,6 +207,19 @@ func SecondaryM365SiteID(t *testing.T) string {
 	require.NoError(t, err, "retrieving secondary m365 site id from test configuration: %+v", clues.ToCore(err))
 
 	return strings.ToLower(cfg[TestCfgSecondarySiteID])
+}
+
+// GetM365TeamID returns a groupID string representing the m365TeamID described
+// by either the env var CORSO_M365_TEST_TEAM_ID, the corso_test.toml config
+// file or the default value (in that order of priority).  The default is a
+// last-attempt fallback that will only work on alcion's testing org.
+func GetM365TeamID(ctx context.Context) string {
+	cfg, err := ReadTestConfig()
+	if err != nil {
+		logger.Ctx(ctx).Error(err, "retrieving m365 team id from test configuration")
+	}
+
+	return strings.ToLower(cfg[TestCfgTeamID])
 }
 
 // UnlicensedM365UserID returns an userID string representing the m365UserID

--- a/src/pkg/services/m365/api/channels_pager.go
+++ b/src/pkg/services/m365/api/channels_pager.go
@@ -42,7 +42,7 @@ func (p *channelMessagePageCtrl) ValidModTimes() bool {
 
 func (c Channels) NewChannelMessagePager(
 	teamID, channelID string,
-	selectProps ...string,
+	cc CallConfig,
 ) *channelMessagePageCtrl {
 	builder := c.Stable.
 		Client().
@@ -57,8 +57,12 @@ func (c Channels) NewChannelMessagePager(
 		Headers:         newPreferHeaders(preferPageSize(maxNonDeltaPageSize)),
 	}
 
-	if len(selectProps) > 0 {
-		options.QueryParameters.Select = selectProps
+	if len(cc.Props) > 0 {
+		options.QueryParameters.Select = cc.Props
+	}
+
+	if len(cc.Expand) > 0 {
+		options.QueryParameters.Expand = cc.Expand
 	}
 
 	return &channelMessagePageCtrl{
@@ -68,6 +72,20 @@ func (c Channels) NewChannelMessagePager(
 		gs:         c.Stable,
 		options:    options,
 	}
+}
+
+// GetChannelMessages fetches a delta of all messages in the channel.
+// returns two maps: addedItems, deletedItems
+func (c Channels) GetChannelMessages(
+	ctx context.Context,
+	teamID, channelID string,
+	cc CallConfig,
+) ([]models.ChatMessageable, error) {
+	ctx = clues.Add(ctx, "channel_id", channelID)
+	pager := c.NewChannelMessagePager(teamID, channelID, cc)
+	items, err := enumerateItems(ctx, pager)
+
+	return items, graph.Stack(ctx, err).OrNil()
 }
 
 // ---------------------------------------------------------------------------
@@ -144,7 +162,7 @@ func (c Channels) NewChannelMessageDeltaPager(
 	}
 }
 
-// GetChannelMessageIDsDelta fetches a delta of all messages in the channel.
+// GetChannelMessageIDs fetches a delta of all messages in the channel.
 // returns two maps: addedItems, deletedItems
 func (c Channels) GetChannelMessageIDs(
 	ctx context.Context,
@@ -153,7 +171,7 @@ func (c Channels) GetChannelMessageIDs(
 ) (map[string]time.Time, bool, []string, DeltaUpdate, error) {
 	added, validModTimes, removed, du, err := getAddedAndRemovedItemIDs[models.ChatMessageable](
 		ctx,
-		c.NewChannelMessagePager(teamID, channelID),
+		c.NewChannelMessagePager(teamID, channelID, CallConfig{}),
 		c.NewChannelMessageDeltaPager(teamID, channelID, prevDeltaLink),
 		prevDeltaLink,
 		canMakeDeltaQueries,

--- a/src/pkg/services/m365/api/channels_pager.go
+++ b/src/pkg/services/m365/api/channels_pager.go
@@ -83,7 +83,7 @@ func (c Channels) GetChannelMessages(
 ) ([]models.ChatMessageable, error) {
 	ctx = clues.Add(ctx, "channel_id", channelID)
 	pager := c.NewChannelMessagePager(teamID, channelID, cc)
-	items, err := enumerateItems(ctx, pager)
+	items, err := enumerateItems[models.ChatMessageable](ctx, pager)
 
 	return items, graph.Stack(ctx, err).OrNil()
 }

--- a/src/pkg/services/m365/api/client.go
+++ b/src/pkg/services/m365/api/client.go
@@ -136,6 +136,7 @@ func (c Client) Post(
 
 type CallConfig struct {
 	Expand []string
+	Props  []string
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds test support for groups in sanity testing.
Sharepoint support is a straightforward plugin.
Channels messages includes the following additions:
1/ channel message sanitree builder
2/ splitting sanitree and sanileaf data types
3/ adding a ChannelMessages enumerator in the api.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Supportability/Tests

#### Issue(s)

* #3988

#### Test Plan

- [x] :muscle: Manual
- [x] :green_heart: E2E
