### PR TITLE
Temporary removal of OneNote file size check

### DIFF
--- a/src/internal/m365/collection/drive/collection.go
+++ b/src/internal/m365/collection/drive/collection.go
@@ -265,7 +265,10 @@ func (oc *Collection) getDriveItemContent(
 
 		// Skip big OneNote files as they can't be downloaded
 		if clues.HasLabel(err, graph.LabelStatus(http.StatusServiceUnavailable)) &&
-			oc.scope == CollectionScopePackage && *item.GetSize() >= MaxOneNoteFileSize {
+			// TODO: We've removed the file size check because it looks like we've seen persistent
+			// 503's with smaller OneNote files also.
+			// oc.scope == CollectionScopePackage && *item.GetSize() >= MaxOneNoteFileSize {
+			oc.scope == CollectionScopePackage {
 			// FIXME: It is possible that in case of a OneNote file we
 			// will end up just backing up the `onetoc2` file without
 			// the one file which is the important part of the OneNote

--- a/src/internal/m365/collection/drive/collection_test.go
+++ b/src/internal/m365/collection/drive/collection_test.go
@@ -565,7 +565,7 @@ func (suite *GetDriveItemUnitTestSuite) TestGetDriveItem_error() {
 			colScope: CollectionScopePackage,
 			itemSize: 10,
 			err:      clues.New("small onenote error").Label(graph.LabelStatus(http.StatusServiceUnavailable)),
-			labels:   []string{graph.LabelStatus(http.StatusServiceUnavailable)},
+			labels:   []string{graph.LabelStatus(http.StatusServiceUnavailable), graph.LabelsSkippable},
 		},
 		{
 			name:     "big OneNote file",


### PR DESCRIPTION
Temporarily remove the large file size check that controls skipping a OneNote file download that failed with a
503 error.

We've observed this error condition to be persistent even with smaller OneNote files.

This allows us to unblock backup for these resources while we investigate the issue.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
