### PR TITLE
Temporarily disable restoring to alternate resource for Groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - Teams Channels that cannot support delta tokens (those without messages) fall back to non-delta enumeration and no longer fail a backup.
 
+### Known issues
+- Restoring the data into a different Group from the one it was backed up from is not currently supported
+
 ## [v0.13.0] (beta) - 2023-09-18
 
 ### Added

--- a/src/cli/flags/restore_config.go
+++ b/src/cli/flags/restore_config.go
@@ -19,7 +19,7 @@ var (
 )
 
 // AddRestoreConfigFlags adds the restore config flag set.
-func AddRestoreConfigFlags(cmd *cobra.Command) {
+func AddRestoreConfigFlags(cmd *cobra.Command, canRestoreToAlternate bool) {
 	fs := cmd.Flags()
 	fs.StringVar(
 		&CollisionsFV, CollisionsFN, string(control.Skip),
@@ -28,7 +28,10 @@ func AddRestoreConfigFlags(cmd *cobra.Command) {
 	fs.StringVar(
 		&DestinationFV, DestinationFN, "",
 		"Overrides the folder where items get restored; '/' places items into their original location")
-	fs.StringVar(
-		&ToResourceFV, ToResourceFN, "",
-		"Overrides the protected resource (mailbox, site, user, etc) where data gets restored")
+
+	if canRestoreToAlternate {
+		fs.StringVar(
+			&ToResourceFV, ToResourceFN, "",
+			"Overrides the protected resource (mailbox, site, user, etc) where data gets restored")
+	}
 }

--- a/src/cli/restore/exchange.go
+++ b/src/cli/restore/exchange.go
@@ -28,7 +28,7 @@ func addExchangeCommands(cmd *cobra.Command) *cobra.Command {
 
 		flags.AddBackupIDFlag(c, true)
 		flags.AddExchangeDetailsAndRestoreFlags(c)
-		flags.AddRestoreConfigFlags(c)
+		flags.AddRestoreConfigFlags(c, true)
 		flags.AddFailFastFlag(c)
 	}
 

--- a/src/cli/restore/groups.go
+++ b/src/cli/restore/groups.go
@@ -30,7 +30,7 @@ func addGroupsCommands(cmd *cobra.Command) *cobra.Command {
 		flags.AddNoPermissionsFlag(c)
 		flags.AddSharePointDetailsAndRestoreFlags(c) // for sp restores
 		flags.AddSiteIDFlag(c)
-		flags.AddRestoreConfigFlags(c)
+		flags.AddRestoreConfigFlags(c, false)
 		flags.AddFailFastFlag(c)
 	}
 

--- a/src/cli/restore/groups_test.go
+++ b/src/cli/restore/groups_test.go
@@ -65,7 +65,7 @@ func (suite *GroupsUnitSuite) TestAddGroupsCommands() {
 						"--" + flags.PageFolderFN, flagsTD.FlgInputs(flagsTD.PageFolderInput),
 						"--" + flags.CollisionsFN, flagsTD.Collisions,
 						"--" + flags.DestinationFN, flagsTD.Destination,
-						"--" + flags.ToResourceFN, flagsTD.ToResource,
+						// "--" + flags.ToResourceFN, flagsTD.ToResource,
 						"--" + flags.NoPermissionsFN,
 					},
 					flagsTD.PreparedProviderFlags(),
@@ -91,7 +91,7 @@ func (suite *GroupsUnitSuite) TestAddGroupsCommands() {
 			assert.Equal(t, flagsTD.FileModifiedBeforeInput, opts.FileModifiedBefore)
 			assert.Equal(t, flagsTD.Collisions, opts.RestoreCfg.Collisions)
 			assert.Equal(t, flagsTD.Destination, opts.RestoreCfg.Destination)
-			assert.Equal(t, flagsTD.ToResource, opts.RestoreCfg.ProtectedResource)
+			// assert.Equal(t, flagsTD.ToResource, opts.RestoreCfg.ProtectedResource)
 			assert.True(t, flags.NoPermissionsFV)
 			flagsTD.AssertProviderFlags(t, cmd)
 			flagsTD.AssertStorageFlags(t, cmd)

--- a/src/cli/restore/onedrive.go
+++ b/src/cli/restore/onedrive.go
@@ -29,7 +29,7 @@ func addOneDriveCommands(cmd *cobra.Command) *cobra.Command {
 		flags.AddBackupIDFlag(c, true)
 		flags.AddOneDriveDetailsAndRestoreFlags(c)
 		flags.AddNoPermissionsFlag(c)
-		flags.AddRestoreConfigFlags(c)
+		flags.AddRestoreConfigFlags(c, true)
 		flags.AddFailFastFlag(c)
 	}
 

--- a/src/cli/restore/sharepoint.go
+++ b/src/cli/restore/sharepoint.go
@@ -29,7 +29,7 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 		flags.AddBackupIDFlag(c, true)
 		flags.AddSharePointDetailsAndRestoreFlags(c)
 		flags.AddNoPermissionsFlag(c)
-		flags.AddRestoreConfigFlags(c)
+		flags.AddRestoreConfigFlags(c, true)
 		flags.AddFailFastFlag(c)
 	}
 

--- a/src/internal/operations/test/group_test.go
+++ b/src/internal/operations/test/group_test.go
@@ -226,18 +226,18 @@ func (suite *GroupsRestoreNightlyIntgSuite) TestRestore_Run_groupsWithAdvancedOp
 		suite.its.group.RootSite.DriveRootFolderID)
 }
 
-func (suite *GroupsRestoreNightlyIntgSuite) TestRestore_Run_groupsAlternateProtectedResource() {
-	sel := selectors.NewGroupsBackup([]string{suite.its.group.ID})
-	sel.Include(selTD.GroupsBackupLibraryFolderScope(sel))
-	sel.Filter(sel.Library("documents"))
-	sel.DiscreteOwner = suite.its.group.ID
+// func (suite *GroupsRestoreNightlyIntgSuite) TestRestore_Run_groupsAlternateProtectedResource() {
+// 	sel := selectors.NewGroupsBackup([]string{suite.its.group.ID})
+// 	sel.Include(selTD.GroupsBackupLibraryFolderScope(sel))
+// 	sel.Filter(sel.Library("documents"))
+// 	sel.DiscreteOwner = suite.its.group.ID
 
-	runDriveRestoreToAlternateProtectedResource(
-		suite.T(),
-		suite,
-		suite.its.ac,
-		sel.Selector,
-		suite.its.group.RootSite,
-		suite.its.secondaryGroup.RootSite,
-		suite.its.secondaryGroup.ID)
-}
+// 	runDriveRestoreToAlternateProtectedResource(
+// 		suite.T(),
+// 		suite,
+// 		suite.its.ac,
+// 		sel.Selector,
+// 		suite.its.group.RootSite,
+// 		suite.its.secondaryGroup.RootSite,
+// 		suite.its.secondaryGroup.ID)
+// }

--- a/website/docs/support/known-issues.md
+++ b/website/docs/support/known-issues.md
@@ -34,4 +34,4 @@ Below is a list of known Corso issues and limitations:
 
 * Groups and Teams support is available in an early-access status, and may be subject to breaking changes.
 
-* Restoring the data into a different Group from the one it was backed up from is not currently supported
+* Restoring the data into a different Group from the one it was backed up from isn't currently supported

--- a/website/docs/support/known-issues.md
+++ b/website/docs/support/known-issues.md
@@ -33,3 +33,5 @@ Below is a list of known Corso issues and limitations:
 * Teams messages don't support Restore due to limited Graph API support for message creation.
 
 * Groups and Teams support is available in an early-access status, and may be subject to breaking changes.
+
+* Restoring the data into a different Group from the one it was backed up from is not currently supported


### PR DESCRIPTION
<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
