### PR TITLE
Add stats to export operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Skips graph calls for expired item download URLs.
+- Export operation now shows the stats at the end of the run
 
 ### Fixed
 - Catch and report cases where a protected resource is locked out of access.  SDK consumers have a new errs sentinel that allows them to check for this case.

--- a/src/cli/export/export.go
+++ b/src/cli/export/export.go
@@ -14,7 +14,6 @@ import (
 	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/observe"
-	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/export"
 	"github.com/alcionai/corso/src/pkg/selectors"
@@ -118,22 +117,7 @@ func runExport(
 	}
 
 	for k, s := range stats {
-		kind := ""
-
-		switch k {
-		case details.OneDriveItem:
-			kind = "Files"
-		case details.GroupsChannelMessage:
-			kind = "Messages"
-		case details.ExchangeContact:
-			kind = "Contacts"
-		case details.ExchangeEvent:
-			kind = "Events"
-		case details.ExchangeMail:
-			kind = "Emails"
-		}
-
-		Infof(ctx, "%s: %d items (%s)", kind, s.ResourceCount, humanize.Bytes(uint64(s.BytesRead)))
+		Infof(ctx, "%s: %d items (%s)", k.HumanString(), s.ResourceCount, humanize.Bytes(uint64(s.BytesRead)))
 	}
 
 	return nil

--- a/src/cli/export/export.go
+++ b/src/cli/export/export.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/alcionai/clues"
+	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
 	"github.com/alcionai/corso/src/cli/flags"
@@ -13,6 +14,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/observe"
+	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/export"
 	"github.com/alcionai/corso/src/pkg/selectors"
@@ -108,6 +110,30 @@ func runExport(
 	err = export.ConsumeExportCollections(ctx, exportLocation, expColl, eo.Errors)
 	if err != nil {
 		return Only(ctx, err)
+	}
+
+	stats := eo.GetStats()
+	if len(stats) > 0 {
+		Infof(ctx, "\nExport details")
+	}
+
+	for k, s := range stats {
+		kind := ""
+
+		switch k {
+		case details.OneDriveItem:
+			kind = "Files"
+		case details.GroupsChannelMessage:
+			kind = "Messages"
+		case details.ExchangeContact:
+			kind = "Contacts"
+		case details.ExchangeEvent:
+			kind = "Events"
+		case details.ExchangeMail:
+			kind = "Emails"
+		}
+
+		Infof(ctx, "%s: %d items (%s)", kind, s.ResourceCount, humanize.Bytes(uint64(s.BytesRead)))
 	}
 
 	return nil

--- a/src/internal/data/metrics.go
+++ b/src/internal/data/metrics.go
@@ -82,6 +82,10 @@ func ReaderWithStats(
 	kind details.ItemType,
 	stats *ExportStats,
 ) io.ReadCloser {
+	if reader == nil {
+		return nil
+	}
+
 	return &statsReader{
 		reader: reader,
 		kind:   kind,

--- a/src/internal/data/metrics.go
+++ b/src/internal/data/metrics.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"sync/atomic"
 
-	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/path"
 )
 
 type CollectionStats struct {
@@ -30,13 +30,12 @@ type KindStats struct {
 
 type ExportStats struct {
 	// data is kept private so that we can enforce atomic int updates
-	// TODO(meain): Should we be exposing details.ItemType?
-	data map[details.ItemType]KindStats
+	data map[path.CategoryType]KindStats
 }
 
-func (es *ExportStats) UpdateBytes(kind details.ItemType, bytesRead int64) {
+func (es *ExportStats) UpdateBytes(kind path.CategoryType, bytesRead int64) {
 	if es.data == nil {
-		es.data = map[details.ItemType]KindStats{}
+		es.data = map[path.CategoryType]KindStats{}
 	}
 
 	ks := es.data[kind]
@@ -44,9 +43,9 @@ func (es *ExportStats) UpdateBytes(kind details.ItemType, bytesRead int64) {
 	es.data[kind] = ks
 }
 
-func (es *ExportStats) UpdateResourceCount(kind details.ItemType) {
+func (es *ExportStats) UpdateResourceCount(kind path.CategoryType) {
 	if es.data == nil {
-		es.data = map[details.ItemType]KindStats{}
+		es.data = map[path.CategoryType]KindStats{}
 	}
 
 	ks := es.data[kind]
@@ -54,7 +53,7 @@ func (es *ExportStats) UpdateResourceCount(kind details.ItemType) {
 	es.data[kind] = ks
 }
 
-func (es *ExportStats) GetStats() map[details.ItemType]KindStats {
+func (es *ExportStats) GetStats() map[path.CategoryType]KindStats {
 	return es.data
 }
 
@@ -79,7 +78,7 @@ func (sr *statsReader) Close() error {
 // will update the stats
 func ReaderWithStats(
 	reader io.ReadCloser,
-	kind details.ItemType,
+	kind path.CategoryType,
 	stats *ExportStats,
 ) io.ReadCloser {
 	if reader == nil {

--- a/src/internal/data/metrics.go
+++ b/src/internal/data/metrics.go
@@ -58,20 +58,16 @@ func (es *ExportStats) GetStats() map[path.CategoryType]KindStats {
 }
 
 type statsReader struct {
-	reader io.ReadCloser
-	kind   details.ItemType
-	stats  *ExportStats
+	io.ReadCloser
+	kind  path.CategoryType
+	stats *ExportStats
 }
 
-func (sr *statsReader) Read(p []byte) (n int, err error) {
-	n, err = sr.reader.Read(p)
+func (sr *statsReader) Read(p []byte) (int, error) {
+	n, err := sr.ReadCloser.Read(p)
 	sr.stats.UpdateBytes(sr.kind, int64(n))
 
-	return
-}
-
-func (sr *statsReader) Close() error {
-	return sr.reader.Close()
+	return n, err
 }
 
 // Create a function that will take a reader and return a reader that
@@ -86,8 +82,8 @@ func ReaderWithStats(
 	}
 
 	return &statsReader{
-		reader: reader,
-		kind:   kind,
-		stats:  stats,
+		ReadCloser: reader,
+		kind:       kind,
+		stats:      stats,
 	}
 }

--- a/src/internal/data/metrics.go
+++ b/src/internal/data/metrics.go
@@ -1,5 +1,12 @@
 package data
 
+import (
+	"io"
+	"sync/atomic"
+
+	"github.com/alcionai/corso/src/pkg/backup/details"
+)
+
 type CollectionStats struct {
 	Folders,
 	Objects,
@@ -14,4 +21,70 @@ func (cs CollectionStats) IsZero() bool {
 
 func (cs CollectionStats) String() string {
 	return cs.Details
+}
+
+type KindStats struct {
+	BytesRead     int64
+	ResourceCount int64
+}
+
+type ExportStats struct {
+	// data is kept private so that we can enforce atomic int updates
+	// TODO(meain): Should we be exposing details.ItemType?
+	data map[details.ItemType]KindStats
+}
+
+func (es *ExportStats) UpdateBytes(kind details.ItemType, bytesRead int64) {
+	if es.data == nil {
+		es.data = map[details.ItemType]KindStats{}
+	}
+
+	ks := es.data[kind]
+	atomic.AddInt64(&ks.BytesRead, bytesRead)
+	es.data[kind] = ks
+}
+
+func (es *ExportStats) UpdateResourceCount(kind details.ItemType) {
+	if es.data == nil {
+		es.data = map[details.ItemType]KindStats{}
+	}
+
+	ks := es.data[kind]
+	atomic.AddInt64(&ks.ResourceCount, 1)
+	es.data[kind] = ks
+}
+
+func (es *ExportStats) GetStats() map[details.ItemType]KindStats {
+	return es.data
+}
+
+type statsReader struct {
+	reader io.ReadCloser
+	kind   details.ItemType
+	stats  *ExportStats
+}
+
+func (sr *statsReader) Read(p []byte) (n int, err error) {
+	n, err = sr.reader.Read(p)
+	sr.stats.UpdateBytes(sr.kind, int64(n))
+
+	return
+}
+
+func (sr *statsReader) Close() error {
+	return sr.reader.Close()
+}
+
+// Create a function that will take a reader and return a reader that
+// will update the stats
+func ReaderWithStats(
+	reader io.ReadCloser,
+	kind details.ItemType,
+	stats *ExportStats,
+) io.ReadCloser {
+	return &statsReader{
+		reader: reader,
+		kind:   kind,
+		stats:  stats,
+	}
 }

--- a/src/internal/m365/collection/drive/export.go
+++ b/src/internal/m365/collection/drive/export.go
@@ -9,10 +9,10 @@ import (
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive/metadata"
 	"github.com/alcionai/corso/src/internal/version"
-	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/export"
 	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/path"
 )
 
 func NewExportCollection(
@@ -60,8 +60,8 @@ func streamItems(
 				continue
 			}
 
-			stats.UpdateResourceCount(details.OneDriveItem)
-			body := data.ReaderWithStats(item.ToReader(), details.OneDriveItem, stats)
+			stats.UpdateResourceCount(path.FilesCategory)
+			body := data.ReaderWithStats(item.ToReader(), path.FilesCategory, stats)
 
 			ch <- export.Item{
 				ID:    itemUUID,

--- a/src/internal/m365/collection/drive/export.go
+++ b/src/internal/m365/collection/drive/export.go
@@ -51,6 +51,14 @@ func streamItems(
 			}
 
 			name, err := getItemName(ctx, itemUUID, backupVersion, rc)
+			if err != nil {
+				ch <- export.Item{
+					ID:    itemUUID,
+					Error: err,
+				}
+
+				continue
+			}
 
 			stats.UpdateResourceCount(details.OneDriveItem)
 			body := data.ReaderWithStats(item.ToReader(), details.OneDriveItem, stats)

--- a/src/internal/m365/collection/groups/export.go
+++ b/src/internal/m365/collection/groups/export.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/data"
+	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/export"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -40,6 +41,7 @@ func streamItems(
 	backupVersion int,
 	cec control.ExportConfig,
 	ch chan<- export.Item,
+	stats *data.ExportStats,
 ) {
 	defer close(ch)
 
@@ -54,6 +56,9 @@ func streamItems(
 					Error: err,
 				}
 			} else {
+				stats.UpdateResourceCount(details.GroupsChannelMessage)
+				body = data.ReaderWithStats(body, details.GroupsChannelMessage, stats)
+
 				ch <- export.Item{
 					ID: item.ID(),
 					// channel message items have no name

--- a/src/internal/m365/collection/groups/export.go
+++ b/src/internal/m365/collection/groups/export.go
@@ -24,6 +24,7 @@ func NewExportCollection(
 	backingCollections []data.RestoreCollection,
 	backupVersion int,
 	cec control.ExportConfig,
+	stats *data.ExportStats,
 ) export.Collectioner {
 	return export.BaseCollection{
 		BaseDir:           baseDir,
@@ -31,6 +32,7 @@ func NewExportCollection(
 		BackupVersion:     backupVersion,
 		Cfg:               cec,
 		Stream:            streamItems,
+		Stats:             stats,
 	}
 }
 

--- a/src/internal/m365/collection/groups/export.go
+++ b/src/internal/m365/collection/groups/export.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/data"
-	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/export"
 	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
@@ -58,8 +58,8 @@ func streamItems(
 					Error: err,
 				}
 			} else {
-				stats.UpdateResourceCount(details.GroupsChannelMessage)
-				body = data.ReaderWithStats(body, details.GroupsChannelMessage, stats)
+				stats.UpdateResourceCount(path.ChannelMessagesCategory)
+				body = data.ReaderWithStats(body, path.ChannelMessagesCategory, stats)
 
 				ch <- export.Item{
 					ID: item.ID(),

--- a/src/internal/m365/collection/groups/export_test.go
+++ b/src/internal/m365/collection/groups/export_test.go
@@ -90,7 +90,8 @@ func (suite *ExportUnitSuite) TestStreamItems() {
 				[]data.RestoreCollection{test.backingColl},
 				version.NoBackup,
 				control.DefaultExportConfig(),
-				ch)
+				ch,
+				&data.ExportStats{})
 
 			var (
 				itm export.Item

--- a/src/internal/m365/export.go
+++ b/src/internal/m365/export.go
@@ -27,6 +27,7 @@ func (ctrl *Controller) ProduceExportCollections(
 	exportCfg control.ExportConfig,
 	opts control.Options,
 	dcs []data.RestoreCollection,
+	stats *data.ExportStats,
 	errs *fault.Bus,
 ) ([]export.Collectioner, error) {
 	ctx, end := diagnostics.Span(ctx, "m365:export")
@@ -51,6 +52,7 @@ func (ctrl *Controller) ProduceExportCollections(
 			opts,
 			dcs,
 			deets,
+			stats,
 			errs)
 	case selectors.ServiceSharePoint:
 		expCollections, err = sharepoint.ProduceExportCollections(
@@ -61,6 +63,7 @@ func (ctrl *Controller) ProduceExportCollections(
 			dcs,
 			ctrl.backupDriveIDNames,
 			deets,
+			stats,
 			errs)
 	case selectors.ServiceGroups:
 		expCollections, err = groups.ProduceExportCollections(
@@ -72,6 +75,7 @@ func (ctrl *Controller) ProduceExportCollections(
 			ctrl.backupDriveIDNames,
 			ctrl.backupSiteIDWebURL,
 			deets,
+			stats,
 			errs)
 
 	default:

--- a/src/internal/m365/mock/connector.go
+++ b/src/internal/m365/mock/connector.go
@@ -90,6 +90,7 @@ func (ctrl Controller) ProduceExportCollections(
 	_ control.ExportConfig,
 	_ control.Options,
 	_ []data.RestoreCollection,
+	_ *data.ExportStats,
 	_ *fault.Bus,
 ) ([]export.Collectioner, error) {
 	return nil, ctrl.Err

--- a/src/internal/m365/service/groups/export.go
+++ b/src/internal/m365/service/groups/export.go
@@ -29,6 +29,7 @@ func ProduceExportCollections(
 	backupDriveIDNames idname.Cacher,
 	backupSiteIDWebURL idname.Cacher,
 	deets *details.Builder,
+	stats *data.ExportStats,
 	errs *fault.Bus,
 ) ([]export.Collectioner, error) {
 	var (
@@ -91,7 +92,8 @@ func ProduceExportCollections(
 			coll = drive.NewExportCollection(
 				baseDir.String(),
 				[]data.RestoreCollection{restoreColl},
-				backupVersion)
+				backupVersion,
+				stats)
 		default:
 			el.AddRecoverable(
 				ctx,

--- a/src/internal/m365/service/groups/export.go
+++ b/src/internal/m365/service/groups/export.go
@@ -53,7 +53,8 @@ func ProduceExportCollections(
 				path.Builder{}.Append(folders...).String(),
 				[]data.RestoreCollection{restoreColl},
 				backupVersion,
-				exportCfg)
+				exportCfg,
+				stats)
 		case path.LibrariesCategory:
 			drivePath, err := path.ToDrivePath(restoreColl.FullPath())
 			if err != nil {

--- a/src/internal/m365/service/groups/export_test.go
+++ b/src/internal/m365/service/groups/export_test.go
@@ -19,7 +19,6 @@ import (
 	odStub "github.com/alcionai/corso/src/internal/m365/service/onedrive/stub"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/version"
-	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/export"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -136,8 +135,8 @@ func (suite *ExportUnitSuite) TestExportRestoreCollections_messages() {
 	assert.Equal(t, expectedItems, fitems, "items")
 
 	expectedStats := data.ExportStats{}
-	expectedStats.UpdateBytes(details.GroupsChannelMessage, int64(size))
-	expectedStats.UpdateResourceCount(details.GroupsChannelMessage)
+	expectedStats.UpdateBytes(path.ChannelMessagesCategory, int64(size))
+	expectedStats.UpdateResourceCount(path.ChannelMessagesCategory)
 	assert.Equal(t, expectedStats, stats, "stats")
 }
 
@@ -237,7 +236,7 @@ func (suite *ExportUnitSuite) TestExportRestoreCollections_libraries() {
 	assert.Equal(t, expectedItems, fitems, "items")
 
 	expectedStats := data.ExportStats{}
-	expectedStats.UpdateBytes(details.OneDriveItem, int64(size))
-	expectedStats.UpdateResourceCount(details.OneDriveItem)
+	expectedStats.UpdateBytes(path.FilesCategory, int64(size))
+	expectedStats.UpdateResourceCount(path.FilesCategory)
 	assert.Equal(t, expectedStats, stats, "stats")
 }

--- a/src/internal/m365/service/groups/export_test.go
+++ b/src/internal/m365/service/groups/export_test.go
@@ -98,7 +98,6 @@ func (suite *ExportUnitSuite) TestExportRestoreCollections_messages() {
 		},
 	}
 
-	// TODO(meain)
 	stats := data.ExportStats{}
 
 	ecs, err := ProduceExportCollections(

--- a/src/internal/m365/service/onedrive/export.go
+++ b/src/internal/m365/service/onedrive/export.go
@@ -23,6 +23,7 @@ func ProduceExportCollections(
 	opts control.Options,
 	dcs []data.RestoreCollection,
 	deets *details.Builder,
+	stats *data.ExportStats,
 	errs *fault.Bus,
 ) ([]export.Collectioner, error) {
 	var (
@@ -43,7 +44,8 @@ func ProduceExportCollections(
 			drive.NewExportCollection(
 				baseDir.String(),
 				[]data.RestoreCollection{dc},
-				backupVersion))
+				backupVersion,
+				stats))
 	}
 
 	return ec, el.Failure()

--- a/src/internal/m365/service/onedrive/export_test.go
+++ b/src/internal/m365/service/onedrive/export_test.go
@@ -17,10 +17,10 @@ import (
 	odStub "github.com/alcionai/corso/src/internal/m365/service/onedrive/stub"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/version"
-	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/export"
 	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/path"
 )
 
 type ExportUnitSuite struct {
@@ -292,10 +292,10 @@ func (suite *ExportUnitSuite) TestGetItems() {
 
 			if size+count > 0 { // it is only initialized if we have something
 				expectedStats = data.ExportStats{}
-				expectedStats.UpdateBytes(details.OneDriveItem, int64(size))
+				expectedStats.UpdateBytes(path.FilesCategory, int64(size))
 
 				for i := 0; i < count; i++ {
-					expectedStats.UpdateResourceCount(details.OneDriveItem)
+					expectedStats.UpdateResourceCount(path.FilesCategory)
 				}
 			}
 
@@ -376,7 +376,7 @@ func (suite *ExportUnitSuite) TestExportRestoreCollections() {
 	assert.Equal(t, expectedItems, fitems, "items")
 
 	expectedStats := data.ExportStats{}
-	expectedStats.UpdateBytes(details.OneDriveItem, int64(size))
-	expectedStats.UpdateResourceCount(details.OneDriveItem)
+	expectedStats.UpdateBytes(path.FilesCategory, int64(size))
+	expectedStats.UpdateResourceCount(path.FilesCategory)
 	assert.Equal(t, expectedStats, stats, "stats")
 }

--- a/src/internal/m365/service/onedrive/export_test.go
+++ b/src/internal/m365/service/onedrive/export_test.go
@@ -248,7 +248,8 @@ func (suite *ExportUnitSuite) TestGetItems() {
 			ec := drive.NewExportCollection(
 				"",
 				[]data.RestoreCollection{test.backingCollection},
-				test.version)
+				test.version,
+				&data.ExportStats{})
 
 			items := ec.Items(ctx)
 

--- a/src/internal/m365/service/sharepoint/export.go
+++ b/src/internal/m365/service/sharepoint/export.go
@@ -26,6 +26,7 @@ func ProduceExportCollections(
 	dcs []data.RestoreCollection,
 	backupDriveIDNames idname.CacheBuilder,
 	deets *details.Builder,
+	stats *data.ExportStats,
 	errs *fault.Bus,
 ) ([]export.Collectioner, error) {
 	var (
@@ -56,7 +57,8 @@ func ProduceExportCollections(
 			drive.NewExportCollection(
 				baseDir.String(),
 				[]data.RestoreCollection{dc},
-				backupVersion))
+				backupVersion,
+				stats))
 	}
 
 	return ec, el.Failure()

--- a/src/internal/m365/service/sharepoint/export_test.go
+++ b/src/internal/m365/service/sharepoint/export_test.go
@@ -18,7 +18,6 @@ import (
 	odStub "github.com/alcionai/corso/src/internal/m365/service/onedrive/stub"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/version"
-	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/export"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -135,7 +134,7 @@ func (suite *ExportUnitSuite) TestExportRestoreCollections() {
 	assert.Equal(t, expectedItems, fitems, "items")
 
 	expectedStats := data.ExportStats{}
-	expectedStats.UpdateBytes(details.OneDriveItem, int64(size))
-	expectedStats.UpdateResourceCount(details.OneDriveItem)
+	expectedStats.UpdateBytes(path.FilesCategory, int64(size))
+	expectedStats.UpdateResourceCount(path.FilesCategory)
 	assert.Equal(t, expectedStats, stats, "stats")
 }

--- a/src/internal/m365/service/sharepoint/export_test.go
+++ b/src/internal/m365/service/sharepoint/export_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/alcionai/clues"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
@@ -17,6 +18,7 @@ import (
 	odStub "github.com/alcionai/corso/src/internal/m365/service/onedrive/stub"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/version"
+	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/export"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -98,6 +100,8 @@ func (suite *ExportUnitSuite) TestExportRestoreCollections() {
 		},
 	}
 
+	stats := data.ExportStats{}
+
 	ecs, err := ProduceExportCollections(
 		ctx,
 		int(version.Backup),
@@ -106,6 +110,7 @@ func (suite *ExportUnitSuite) TestExportRestoreCollections() {
 		dcs,
 		cache,
 		nil,
+		&stats,
 		fault.New(true))
 	assert.NoError(t, err, "export collections error")
 	assert.Len(t, ecs, 1, "num of collections")
@@ -113,9 +118,24 @@ func (suite *ExportUnitSuite) TestExportRestoreCollections() {
 	assert.Equal(t, expectedPath, ecs[0].BasePath(), "base dir")
 
 	fitems := []export.Item{}
+	size := 0
+
 	for item := range ecs[0].Items(ctx) {
+		// unwrap the body from stats reader
+		b, err := io.ReadAll(item.Body)
+		assert.NoError(t, err, clues.ToCore(err))
+
+		size += len(b)
+		bitem := io.NopCloser(bytes.NewBuffer(b))
+		item.Body = bitem
+
 		fitems = append(fitems, item)
 	}
 
 	assert.Equal(t, expectedItems, fitems, "items")
+
+	expectedStats := data.ExportStats{}
+	expectedStats.UpdateBytes(details.OneDriveItem, int64(size))
+	expectedStats.UpdateResourceCount(details.OneDriveItem)
+	assert.Equal(t, expectedStats, stats, "stats")
 }

--- a/src/internal/operations/export.go
+++ b/src/internal/operations/export.go
@@ -247,7 +247,7 @@ func (op *ExportOperation) do(
 	opStats.resourceCount = 1
 	opStats.cs = dcs
 
-	expCollections, err := exportRestoreCollections(
+	expCollections, err := produceExportCollections(
 		ctx,
 		op.ec,
 		bup.Version,
@@ -314,7 +314,7 @@ func (op *ExportOperation) finalizeMetrics(
 // Exporter funcs
 // ---------------------------------------------------------------------------
 
-func exportRestoreCollections(
+func produceExportCollections(
 	ctx context.Context,
 	ec inject.ExportConsumer,
 	backupVersion int,

--- a/src/internal/operations/export.go
+++ b/src/internal/operations/export.go
@@ -22,12 +22,12 @@ import (
 	"github.com/alcionai/corso/src/internal/stats"
 	"github.com/alcionai/corso/src/internal/streamstore"
 	"github.com/alcionai/corso/src/pkg/account"
-	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/count"
 	"github.com/alcionai/corso/src/pkg/export"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
+	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/store"
 )
@@ -328,7 +328,7 @@ func (op *ExportOperation) finalizeMetrics(
 //	    Contacts data.KindStats
 //	    ...
 //	}
-func (op *ExportOperation) GetStats() map[details.ItemType]data.KindStats {
+func (op *ExportOperation) GetStats() map[path.CategoryType]data.KindStats {
 	return op.stats.GetStats()
 }
 

--- a/src/internal/operations/export.go
+++ b/src/internal/operations/export.go
@@ -320,14 +320,6 @@ func (op *ExportOperation) finalizeMetrics(
 // be calling this once the export collections have been read and process
 // as the data that will be available here will be the data that was read
 // and processed.
-// TODO(meain): Should we convert the data to a different format?
-// Something like below:
-//
-//	type ExportStats struct {
-//	    Files    data.KindStats
-//	    Contacts data.KindStats
-//	    ...
-//	}
 func (op *ExportOperation) GetStats() map[path.CategoryType]data.KindStats {
 	return op.stats.GetStats()
 }

--- a/src/internal/operations/inject/inject.go
+++ b/src/internal/operations/inject/inject.go
@@ -88,6 +88,7 @@ type (
 			exportCfg control.ExportConfig,
 			opts control.Options,
 			dcs []data.RestoreCollection,
+			stats *data.ExportStats,
 			errs *fault.Bus,
 		) ([]export.Collectioner, error)
 

--- a/src/pkg/export/export.go
+++ b/src/pkg/export/export.go
@@ -28,7 +28,8 @@ type itemStreamer func(
 	backingColls []data.RestoreCollection,
 	backupVersion int,
 	cfg control.ExportConfig,
-	ch chan<- Item)
+	ch chan<- Item,
+	stats *data.ExportStats)
 
 // BaseCollection holds the foundational details of an export collection.
 type BaseCollection struct {
@@ -45,6 +46,8 @@ type BaseCollection struct {
 	Cfg control.ExportConfig
 
 	Stream itemStreamer
+
+	Stats *data.ExportStats
 }
 
 func (bc BaseCollection) BasePath() string {
@@ -53,7 +56,7 @@ func (bc BaseCollection) BasePath() string {
 
 func (bc BaseCollection) Items(ctx context.Context) <-chan Item {
 	ch := make(chan Item)
-	go bc.Stream(ctx, bc.BackingCollection, bc.BackupVersion, bc.Cfg, ch)
+	go bc.Stream(ctx, bc.BackingCollection, bc.BackupVersion, bc.Cfg, ch, bc.Stats)
 
 	return ch
 }


### PR DESCRIPTION
Have a way to gather stats about the exported data.

Users can now call `ExportOperation.GetStats()` at the end of the run to get the stats for the operations. The data will be in the format `map[path.CategoryType]data.KindStats` whre `KindStats` is:

```go
type KindStats struct {
	BytesRead     int64
	ResourceCount int64
}
```
---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* https://github.com/alcionai/corso/issues/4311

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
