### PR TITLE
catch and sentinel resource locked error case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Skips graph calls for expired item download URLs.
 
+### Fixed
+- Catch and report cases where a protected resource is locked out of access.  SDK consumers have a new errs sentinel that allows them to check for this case.
+
 ## [v0.14.0] (beta) - 2023-10-09
 
 ### Added

--- a/src/internal/m365/controller.go
+++ b/src/internal/m365/controller.go
@@ -263,6 +263,10 @@ func (r resourceClient) GetResourceIDAndNameFrom(
 			return nil, clues.Stack(graph.ErrResourceOwnerNotFound, err)
 		}
 
+		if graph.IsErrResourceLocked(err) {
+			return nil, clues.Stack(graph.ErrResourceLocked, err)
+		}
+
 		return nil, err
 	}
 

--- a/src/internal/m365/graph/errors.go
+++ b/src/internal/m365/graph/errors.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/internal/common/str"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/filters"
 )
@@ -50,6 +51,7 @@ const (
 	// nameAlreadyExists occurs when a request with
 	// @microsoft.graph.conflictBehavior=fail finds a conflicting file.
 	nameAlreadyExists       errorCode = "nameAlreadyExists"
+	NotAllowed              errorCode = "notAllowed"
 	noResolvedUsers         errorCode = "noResolvedUsers"
 	QuotaExceeded           errorCode = "ErrorQuotaExceeded"
 	RequestResourceNotFound errorCode = "Request_ResourceNotFound"
@@ -59,6 +61,11 @@ const (
 	syncFolderNotFound errorCode = "ErrorSyncFolderNotFound"
 	syncStateInvalid   errorCode = "SyncStateInvalid"
 	syncStateNotFound  errorCode = "SyncStateNotFound"
+)
+
+// inner error codes
+const (
+	ResourceLocked errorCode = "resourceLocked"
 )
 
 type errorMessage string
@@ -112,6 +119,11 @@ var (
 	// of the call results.  If it's possible to opportunistically select one of the many
 	// replies, no error should get returned.
 	ErrMultipleResultsMatchIdentifier = clues.New("multiple results match the identifier")
+
+	// ErrResourceLocked occurs when a resource has had its access locked.
+	// Example case: https://learn.microsoft.com/en-us/sharepoint/manage-lock-status
+	// This makes the resource inaccessible for any Corso operations.
+	ErrResourceLocked = clues.New("resource has been locked and must be unlocked by an administrator")
 
 	// ErrServiceNotEnabled identifies that a resource owner does not have
 	// access to a given service.
@@ -267,6 +279,12 @@ func IsErrSiteNotFound(err error) bool {
 	return hasErrorMessage(err, requestedSiteCouldNotBeFound)
 }
 
+func IsErrResourceLocked(err error) bool {
+	return errors.Is(err, ErrResourceLocked) ||
+		hasInnerErrorCode(err, ResourceLocked) ||
+		hasErrorCode(err, NotAllowed)
+}
+
 // ---------------------------------------------------------------------------
 // error parsers
 // ---------------------------------------------------------------------------
@@ -283,6 +301,34 @@ func hasErrorCode(err error, codes ...errorCode) bool {
 
 	code, ok := ptr.ValOK(oDataError.GetErrorEscaped().GetCode())
 	if !ok {
+		return false
+	}
+
+	cs := make([]string, len(codes))
+	for i, c := range codes {
+		cs[i] = string(c)
+	}
+
+	return filters.Equal(cs).Compare(code)
+}
+
+func hasInnerErrorCode(err error, codes ...errorCode) bool {
+	if err == nil {
+		return false
+	}
+
+	var oDataError odataerrors.ODataErrorable
+	if !errors.As(err, &oDataError) {
+		return false
+	}
+
+	inner := oDataError.GetErrorEscaped().GetInnerError()
+	if inner == nil {
+		return false
+	}
+
+	code, err := str.AnyValueToString("code", inner.GetAdditionalData())
+	if err != nil {
 		return false
 	}
 

--- a/src/internal/m365/service/onedrive/enabled.go
+++ b/src/internal/m365/service/onedrive/enabled.go
@@ -30,6 +30,10 @@ func IsServiceEnabled(
 			return false, clues.Stack(graph.ErrResourceOwnerNotFound, err)
 		}
 
+		if graph.IsErrResourceLocked(err) {
+			return false, clues.Stack(graph.ErrResourceLocked, err)
+		}
+
 		return false, clues.Stack(err)
 	}
 

--- a/src/internal/m365/service/onedrive/enabled_test.go
+++ b/src/internal/m365/service/onedrive/enabled_test.go
@@ -106,6 +106,17 @@ func (suite *EnabledUnitSuite) TestIsServiceEnabled() {
 			},
 		},
 		{
+			name: "resource locked",
+			mock: func(ctx context.Context) getDefaultDriver {
+				odErr := odErrMsg(string(graph.NotAllowed), "resource")
+				return mockDGDD{nil, graph.Stack(ctx, odErr)}
+			},
+			expect: assert.False,
+			expectErr: func(t *testing.T, err error) {
+				assert.Error(t, err, clues.ToCore(err))
+			},
+		},
+		{
 			name: "arbitrary error",
 			mock: func(ctx context.Context) getDefaultDriver {
 				odErr := odErrMsg("code", "message")

--- a/src/pkg/errs/errs.go
+++ b/src/pkg/errs/errs.go
@@ -16,6 +16,7 @@ const (
 	ApplicationThrottled  errEnum = "application-throttled"
 	BackupNotFound        errEnum = "backup-not-found"
 	RepoAlreadyExists     errEnum = "repository-already-exists"
+	ResourceNotAccessible errEnum = "resource-not-accesible"
 	ResourceOwnerNotFound errEnum = "resource-owner-not-found"
 	ServiceNotEnabled     errEnum = "service-not-enabled"
 )
@@ -27,6 +28,7 @@ var internalToExternal = map[errEnum][]error{
 	ApplicationThrottled:  {graph.ErrApplicationThrottled},
 	BackupNotFound:        {repository.ErrorBackupNotFound},
 	RepoAlreadyExists:     {repository.ErrorRepoAlreadyExists},
+	ResourceNotAccessible: {graph.ErrResourceLocked},
 	ResourceOwnerNotFound: {graph.ErrResourceOwnerNotFound},
 	ServiceNotEnabled:     {graph.ErrServiceNotEnabled},
 }

--- a/src/pkg/errs/errs_test.go
+++ b/src/pkg/errs/errs_test.go
@@ -29,6 +29,7 @@ func (suite *ErrUnitSuite) TestInternal() {
 		{BackupNotFound, []error{repository.ErrorBackupNotFound}},
 		{ServiceNotEnabled, []error{graph.ErrServiceNotEnabled}},
 		{ResourceOwnerNotFound, []error{graph.ErrResourceOwnerNotFound}},
+		{ResourceNotAccessible, []error{graph.ErrResourceLocked}},
 	}
 	for _, test := range table {
 		suite.Run(string(test.get), func() {
@@ -46,6 +47,7 @@ func (suite *ErrUnitSuite) TestIs() {
 		{BackupNotFound, repository.ErrorBackupNotFound},
 		{ServiceNotEnabled, graph.ErrServiceNotEnabled},
 		{ResourceOwnerNotFound, graph.ErrResourceOwnerNotFound},
+		{ResourceNotAccessible, graph.ErrResourceLocked},
 	}
 	for _, test := range table {
 		suite.Run(string(test.target), func() {

--- a/src/pkg/services/m365/api/users.go
+++ b/src/pkg/services/m365/api/users.go
@@ -184,6 +184,10 @@ func EvaluateMailboxError(err error) error {
 		return clues.Stack(graph.ErrResourceOwnerNotFound, err)
 	}
 
+	if graph.IsErrResourceLocked(err) {
+		return clues.Stack(graph.ErrResourceLocked, err)
+	}
+
 	if graph.IsErrExchangeMailFolderNotFound(err) || graph.IsErrAuthenticationError(err) {
 		return nil
 	}

--- a/src/pkg/services/m365/api/users_test.go
+++ b/src/pkg/services/m365/api/users_test.go
@@ -86,6 +86,13 @@ func (suite *UsersUnitSuite) TestEvaluateMailboxError() {
 			},
 		},
 		{
+			name: "mail inbox err - resoruceLocked",
+			err:  odErr(string(graph.NotAllowed)),
+			expect: func(t *testing.T, err error) {
+				assert.ErrorIs(t, err, graph.ErrResourceLocked, clues.ToCore(err))
+			},
+		},
+		{
 			name: "mail inbox err - user not found",
 			err:  odErr(string(graph.MailboxNotEnabledForRESTAPI)),
 			expect: func(t *testing.T, err error) {


### PR DESCRIPTION
handle cases where a resource is found, but is not accessible due to being locked out by an administrator or msoft process.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included

#### Type of change

- [x] :bug: Bugfix

#### Issue(s)

* #4464

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
