### PR TITLE
Move Reasoner implementation to identity package

### DIFF
--- a/src/internal/kopia/backup_bases_test.go
+++ b/src/internal/kopia/backup_bases_test.go
@@ -270,7 +270,7 @@ func (suite *BackupBasesUnitSuite) TestMergeBackupBases() {
 			reasons := make([]identity.Reasoner, 0, len(i.cat))
 
 			for _, c := range i.cat {
-				reasons = append(reasons, NewReason("", ro, path.ExchangeService, c))
+				reasons = append(reasons, identity.NewReason("", ro, path.ExchangeService, c))
 			}
 
 			m := makeManifest(baseID, "", "b"+baseID, reasons...)
@@ -294,7 +294,7 @@ func (suite *BackupBasesUnitSuite) TestMergeBackupBases() {
 			reasons := make([]identity.Reasoner, 0, len(i.cat))
 
 			for _, c := range i.cat {
-				reasons = append(reasons, NewReason("", ro, path.ExchangeService, c))
+				reasons = append(reasons, identity.NewReason("", ro, path.ExchangeService, c))
 			}
 
 			m := makeManifest(baseID, "", "a"+baseID, reasons...)
@@ -529,7 +529,7 @@ func (suite *BackupBasesUnitSuite) TestFixupAndVerify() {
 	ro := "resource_owner"
 
 	makeMan := func(pct path.CategoryType, id, incmpl, bID string) ManifestEntry {
-		r := NewReason("", ro, path.ExchangeService, pct)
+		r := identity.NewReason("", ro, path.ExchangeService, pct)
 		return makeManifest(id, incmpl, bID, r)
 	}
 
@@ -727,11 +727,11 @@ func (suite *BackupBasesUnitSuite) TestFixupAndVerify() {
 				res := validMail1()
 				res.mergeBases[0].Reasons = append(
 					res.mergeBases[0].Reasons,
-					NewReason("", ro, path.ExchangeService, path.ContactsCategory))
+					identity.NewReason("", ro, path.ExchangeService, path.ContactsCategory))
 
 				res.assistBases[0].Reasons = append(
 					res.assistBases[0].Reasons,
-					NewReason("", ro, path.ExchangeService, path.ContactsCategory))
+					identity.NewReason("", ro, path.ExchangeService, path.ContactsCategory))
 
 				return res
 			}(),
@@ -739,11 +739,11 @@ func (suite *BackupBasesUnitSuite) TestFixupAndVerify() {
 				res := validMail1()
 				res.mergeBases[0].Reasons = append(
 					res.mergeBases[0].Reasons,
-					NewReason("", ro, path.ExchangeService, path.ContactsCategory))
+					identity.NewReason("", ro, path.ExchangeService, path.ContactsCategory))
 
 				res.assistBases[0].Reasons = append(
 					res.assistBases[0].Reasons,
-					NewReason("", ro, path.ExchangeService, path.ContactsCategory))
+					identity.NewReason("", ro, path.ExchangeService, path.ContactsCategory))
 
 				return res
 			}(),

--- a/src/internal/kopia/base_finder.go
+++ b/src/internal/kopia/base_finder.go
@@ -30,55 +30,6 @@ const (
 	userTagPrefix = "tag:"
 )
 
-func NewReason(
-	tenant, resource string,
-	service path.ServiceType,
-	category path.CategoryType,
-) identity.Reasoner {
-	return reason{
-		tenant:   tenant,
-		resource: resource,
-		service:  service,
-		category: category,
-	}
-}
-
-type reason struct {
-	// tenant appears here so that when this is moved to an inject package nothing
-	// needs changed. However, kopia itself is blind to the fields in the reason
-	// struct and relies on helper functions to get the information it needs.
-	tenant   string
-	resource string
-	service  path.ServiceType
-	category path.CategoryType
-}
-
-func (r reason) Tenant() string {
-	return r.tenant
-}
-
-func (r reason) ProtectedResource() string {
-	return r.resource
-}
-
-func (r reason) Service() path.ServiceType {
-	return r.service
-}
-
-func (r reason) Category() path.CategoryType {
-	return r.category
-}
-
-func (r reason) SubtreePath() (path.Path, error) {
-	p, err := path.BuildPrefix(
-		r.Tenant(),
-		r.ProtectedResource(),
-		r.Service(),
-		r.Category())
-
-	return p, clues.Wrap(err, "building path").OrNil()
-}
-
 func tagKeys(r identity.Reasoner) []string {
 	return []string{
 		r.ProtectedResource(),

--- a/src/internal/kopia/base_finder_test.go
+++ b/src/internal/kopia/base_finder_test.go
@@ -47,22 +47,22 @@ var (
 
 	testAllUsersAllCats = []identity.Reasoner{
 		// User1 email and events.
-		NewReason("", testUser1, path.ExchangeService, path.EmailCategory),
-		NewReason("", testUser1, path.ExchangeService, path.EventsCategory),
+		identity.NewReason("", testUser1, path.ExchangeService, path.EmailCategory),
+		identity.NewReason("", testUser1, path.ExchangeService, path.EventsCategory),
 		// User2 email and events.
-		NewReason("", testUser2, path.ExchangeService, path.EmailCategory),
-		NewReason("", testUser2, path.ExchangeService, path.EventsCategory),
+		identity.NewReason("", testUser2, path.ExchangeService, path.EmailCategory),
+		identity.NewReason("", testUser2, path.ExchangeService, path.EventsCategory),
 		// User3 email and events.
-		NewReason("", testUser3, path.ExchangeService, path.EmailCategory),
-		NewReason("", testUser3, path.ExchangeService, path.EventsCategory),
+		identity.NewReason("", testUser3, path.ExchangeService, path.EmailCategory),
+		identity.NewReason("", testUser3, path.ExchangeService, path.EventsCategory),
 	}
 	testAllUsersMail = []identity.Reasoner{
-		NewReason("", testUser1, path.ExchangeService, path.EmailCategory),
-		NewReason("", testUser2, path.ExchangeService, path.EmailCategory),
-		NewReason("", testUser3, path.ExchangeService, path.EmailCategory),
+		identity.NewReason("", testUser1, path.ExchangeService, path.EmailCategory),
+		identity.NewReason("", testUser2, path.ExchangeService, path.EmailCategory),
+		identity.NewReason("", testUser3, path.ExchangeService, path.EmailCategory),
 	}
 	testUser1Mail = []identity.Reasoner{
-		NewReason("", testUser1, path.ExchangeService, path.EmailCategory),
+		identity.NewReason("", testUser1, path.ExchangeService, path.EmailCategory),
 	}
 )
 
@@ -294,7 +294,7 @@ func (suite *BaseFinderUnitSuite) TestNoResult_NoBackupsOrSnapshots() {
 		bg: mockEmptyModelGetter{},
 	}
 	reasons := []identity.Reasoner{
-		NewReason("", "a-user", path.ExchangeService, path.EmailCategory),
+		identity.NewReason("", "a-user", path.ExchangeService, path.EmailCategory),
 	}
 
 	bb := bf.FindBases(ctx, reasons, nil)
@@ -314,7 +314,7 @@ func (suite *BaseFinderUnitSuite) TestNoResult_ErrorListingSnapshots() {
 		bg: mockEmptyModelGetter{},
 	}
 	reasons := []identity.Reasoner{
-		NewReason("", "a-user", path.ExchangeService, path.EmailCategory),
+		identity.NewReason("", "a-user", path.ExchangeService, path.EmailCategory),
 	}
 
 	bb := bf.FindBases(ctx, reasons, nil)
@@ -561,14 +561,14 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 			},
 			expectedBaseReasons: map[int][]identity.Reasoner{
 				0: {
-					NewReason("", testUser1, path.ExchangeService, path.EmailCategory),
-					NewReason("", testUser2, path.ExchangeService, path.EmailCategory),
-					NewReason("", testUser3, path.ExchangeService, path.EmailCategory),
+					identity.NewReason("", testUser1, path.ExchangeService, path.EmailCategory),
+					identity.NewReason("", testUser2, path.ExchangeService, path.EmailCategory),
+					identity.NewReason("", testUser3, path.ExchangeService, path.EmailCategory),
 				},
 				1: {
-					NewReason("", testUser1, path.ExchangeService, path.EventsCategory),
-					NewReason("", testUser2, path.ExchangeService, path.EventsCategory),
-					NewReason("", testUser3, path.ExchangeService, path.EventsCategory),
+					identity.NewReason("", testUser1, path.ExchangeService, path.EventsCategory),
+					identity.NewReason("", testUser2, path.ExchangeService, path.EventsCategory),
+					identity.NewReason("", testUser3, path.ExchangeService, path.EventsCategory),
 				},
 			},
 			backupData: []backupInfo{
@@ -611,20 +611,20 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 			},
 			expectedBaseReasons: map[int][]identity.Reasoner{
 				2: {
-					NewReason("", testUser1, path.ExchangeService, path.EmailCategory),
-					NewReason("", testUser2, path.ExchangeService, path.EmailCategory),
-					NewReason("", testUser1, path.ExchangeService, path.EventsCategory),
-					NewReason("", testUser2, path.ExchangeService, path.EventsCategory),
+					identity.NewReason("", testUser1, path.ExchangeService, path.EmailCategory),
+					identity.NewReason("", testUser2, path.ExchangeService, path.EmailCategory),
+					identity.NewReason("", testUser1, path.ExchangeService, path.EventsCategory),
+					identity.NewReason("", testUser2, path.ExchangeService, path.EventsCategory),
 				},
 			},
 			expectedAssistReasons: map[int][]identity.Reasoner{
 				0: {
-					NewReason("", testUser1, path.ExchangeService, path.EventsCategory),
-					NewReason("", testUser2, path.ExchangeService, path.EventsCategory),
+					identity.NewReason("", testUser1, path.ExchangeService, path.EventsCategory),
+					identity.NewReason("", testUser2, path.ExchangeService, path.EventsCategory),
 				},
 				1: {
-					NewReason("", testUser1, path.ExchangeService, path.EmailCategory),
-					NewReason("", testUser2, path.ExchangeService, path.EmailCategory),
+					identity.NewReason("", testUser1, path.ExchangeService, path.EmailCategory),
+					identity.NewReason("", testUser2, path.ExchangeService, path.EmailCategory),
 				},
 			},
 			backupData: []backupInfo{

--- a/src/internal/kopia/cleanup_backups_test.go
+++ b/src/internal/kopia/cleanup_backups_test.go
@@ -648,13 +648,13 @@ func (suite *BackupCleanupUnitSuite) TestCleanupOrphanedData() {
 				manifestWithReasons(
 					manifestWithTime(baseTime, snapCurrent()),
 					"tenant1",
-					NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
+					identity.NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
 				manifestWithTime(baseTime, deetsCurrent()),
 
 				manifestWithReasons(
 					manifestWithTime(baseTime.Add(time.Second), snapCurrent2()),
 					"tenant1",
-					NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
+					identity.NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
 				manifestWithTime(baseTime.Add(time.Second), deetsCurrent2()),
 			},
 			backups: []backupRes{
@@ -675,19 +675,19 @@ func (suite *BackupCleanupUnitSuite) TestCleanupOrphanedData() {
 				manifestWithReasons(
 					manifestWithTime(baseTime, snapCurrent()),
 					"tenant1",
-					NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
+					identity.NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
 				manifestWithTime(baseTime, deetsCurrent()),
 
 				manifestWithReasons(
 					manifestWithTime(baseTime.Add(time.Second), snapCurrent2()),
 					"tenant1",
-					NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
+					identity.NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
 				manifestWithTime(baseTime.Add(time.Second), deetsCurrent2()),
 
 				manifestWithReasons(
 					manifestWithTime(baseTime.Add(time.Minute), snapCurrent3()),
 					"tenant1",
-					NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
+					identity.NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
 				manifestWithTime(baseTime.Add(time.Minute), deetsCurrent3()),
 			},
 			backups: []backupRes{
@@ -719,13 +719,13 @@ func (suite *BackupCleanupUnitSuite) TestCleanupOrphanedData() {
 				manifestWithReasons(
 					manifestWithTime(baseTime, snapCurrent()),
 					"tenant1",
-					NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
+					identity.NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
 				manifestWithTime(baseTime, deetsCurrent()),
 
 				manifestWithReasons(
 					manifestWithTime(baseTime.Add(time.Second), snapCurrent2()),
 					"tenant1",
-					NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
+					identity.NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
 				manifestWithTime(baseTime.Add(time.Second), deetsCurrent2()),
 			},
 			backups: []backupRes{
@@ -749,19 +749,19 @@ func (suite *BackupCleanupUnitSuite) TestCleanupOrphanedData() {
 				manifestWithReasons(
 					manifestWithTime(baseTime, snapCurrent()),
 					"tenant1",
-					NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
+					identity.NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
 				manifestWithTime(baseTime, deetsCurrent()),
 
 				manifestWithReasons(
 					manifestWithTime(baseTime.Add(time.Second), snapCurrent2()),
 					"tenant1",
-					NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
+					identity.NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
 				manifestWithTime(baseTime.Add(time.Second), deetsCurrent2()),
 
 				manifestWithReasons(
 					manifestWithTime(baseTime.Add(time.Minute), snapCurrent3()),
 					"tenant1",
-					NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
+					identity.NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
 				manifestWithTime(baseTime.Add(time.Minute), deetsCurrent3()),
 			},
 			backups: []backupRes{
@@ -786,19 +786,19 @@ func (suite *BackupCleanupUnitSuite) TestCleanupOrphanedData() {
 				manifestWithReasons(
 					manifestWithTime(baseTime, snapCurrent()),
 					"tenant1",
-					NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
+					identity.NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
 				manifestWithTime(baseTime, deetsCurrent()),
 
 				manifestWithReasons(
 					manifestWithTime(baseTime.Add(time.Minute), snapCurrent2()),
 					"tenant1",
-					NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
+					identity.NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
 				manifestWithTime(baseTime.Add(time.Minute), deetsCurrent2()),
 
 				manifestWithReasons(
 					manifestWithTime(baseTime.Add(time.Second), snapCurrent3()),
 					"tenant1",
-					NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
+					identity.NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
 				manifestWithTime(baseTime.Add(time.Second), deetsCurrent3()),
 			},
 			backups: []backupRes{
@@ -823,14 +823,14 @@ func (suite *BackupCleanupUnitSuite) TestCleanupOrphanedData() {
 				manifestWithReasons(
 					manifestWithTime(baseTime, snapCurrent()),
 					"tenant1",
-					NewReason("", "ro", path.ExchangeService, path.EmailCategory),
-					NewReason("", "ro", path.ExchangeService, path.ContactsCategory)),
+					identity.NewReason("", "ro", path.ExchangeService, path.EmailCategory),
+					identity.NewReason("", "ro", path.ExchangeService, path.ContactsCategory)),
 				manifestWithTime(baseTime, deetsCurrent()),
 
 				manifestWithReasons(
 					manifestWithTime(baseTime.Add(time.Second), snapCurrent2()),
 					"tenant1",
-					NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
+					identity.NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
 				manifestWithTime(baseTime.Add(time.Second), deetsCurrent2()),
 			},
 			backups: []backupRes{
@@ -851,13 +851,13 @@ func (suite *BackupCleanupUnitSuite) TestCleanupOrphanedData() {
 				manifestWithReasons(
 					manifestWithTime(baseTime, snapCurrent()),
 					"tenant1",
-					NewReason("", "ro1", path.ExchangeService, path.EmailCategory)),
+					identity.NewReason("", "ro1", path.ExchangeService, path.EmailCategory)),
 				manifestWithTime(baseTime, deetsCurrent()),
 
 				manifestWithReasons(
 					manifestWithTime(baseTime.Add(time.Second), snapCurrent2()),
 					"tenant1",
-					NewReason("", "ro2", path.ExchangeService, path.EmailCategory)),
+					identity.NewReason("", "ro2", path.ExchangeService, path.EmailCategory)),
 				manifestWithTime(baseTime.Add(time.Second), deetsCurrent2()),
 			},
 			backups: []backupRes{
@@ -878,13 +878,13 @@ func (suite *BackupCleanupUnitSuite) TestCleanupOrphanedData() {
 				manifestWithReasons(
 					manifestWithTime(baseTime, snapCurrent()),
 					"tenant1",
-					NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
+					identity.NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
 				manifestWithTime(baseTime, deetsCurrent()),
 
 				manifestWithReasons(
 					manifestWithTime(baseTime.Add(time.Second), snapCurrent2()),
 					"tenant2",
-					NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
+					identity.NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
 				manifestWithTime(baseTime.Add(time.Second), deetsCurrent2()),
 			},
 			backups: []backupRes{
@@ -905,19 +905,19 @@ func (suite *BackupCleanupUnitSuite) TestCleanupOrphanedData() {
 				manifestWithReasons(
 					manifestWithTime(baseTime, snapCurrent()),
 					"",
-					NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
+					identity.NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
 				manifestWithTime(baseTime, deetsCurrent()),
 
 				manifestWithReasons(
 					manifestWithTime(baseTime.Add(time.Second), snapCurrent2()),
 					"tenant1",
-					NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
+					identity.NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
 				manifestWithTime(baseTime.Add(time.Second), deetsCurrent2()),
 
 				manifestWithReasons(
 					manifestWithTime(baseTime.Add(time.Minute), snapCurrent3()),
 					"tenant1",
-					NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
+					identity.NewReason("", "ro", path.ExchangeService, path.EmailCategory)),
 				manifestWithTime(baseTime.Add(time.Minute), deetsCurrent3()),
 			},
 			backups: []backupRes{

--- a/src/internal/kopia/upload_test.go
+++ b/src/internal/kopia/upload_test.go
@@ -883,7 +883,7 @@ func makeManifestEntry(
 	var reasons []identity.Reasoner
 
 	for _, c := range categories {
-		reasons = append(reasons, NewReason(tenant, resourceOwner, service, c))
+		reasons = append(reasons, identity.NewReason(tenant, resourceOwner, service, c))
 	}
 
 	return ManifestEntry{

--- a/src/internal/kopia/wrapper_scale_test.go
+++ b/src/internal/kopia/wrapper_scale_test.go
@@ -70,7 +70,7 @@ func BenchmarkHierarchyMerge(b *testing.B) {
 	}
 
 	reasons := []identity.Reasoner{
-		NewReason(
+		identity.NewReason(
 			testTenant,
 			baseStorePath.ProtectedResource(),
 			baseStorePath.Service(),

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -811,12 +811,12 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 	}
 
 	reasons := []identity.Reasoner{
-		NewReason(
+		identity.NewReason(
 			testTenant,
 			suite.storePath1.ProtectedResource(),
 			suite.storePath1.Service(),
 			suite.storePath1.Category()),
-		NewReason(
+		identity.NewReason(
 			testTenant,
 			suite.storePath2.ProtectedResource(),
 			suite.storePath2.Service(),
@@ -1077,7 +1077,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_NoDetailsForMeta() {
 	}
 
 	reasons := []identity.Reasoner{
-		NewReason(
+		identity.NewReason(
 			testTenant,
 			storePath.ProtectedResource(),
 			storePath.Service(),
@@ -1253,7 +1253,7 @@ func (suite *KopiaIntegrationSuite) TestRestoreAfterCompressionChange() {
 
 	w := &Wrapper{k}
 
-	r := NewReason(testTenant, testUser, path.ExchangeService, path.EmailCategory)
+	r := identity.NewReason(testTenant, testUser, path.ExchangeService, path.EmailCategory)
 
 	dc1 := exchMock.NewCollection(suite.storePath1, suite.locPath1, 1)
 	dc2 := exchMock.NewCollection(suite.storePath2, suite.locPath2, 1)
@@ -1303,7 +1303,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_ReaderError() {
 
 	loc1 := path.Builder{}.Append(suite.storePath1.Folders()...)
 	loc2 := path.Builder{}.Append(suite.storePath2.Folders()...)
-	r := NewReason(testTenant, testUser, path.ExchangeService, path.EmailCategory)
+	r := identity.NewReason(testTenant, testUser, path.ExchangeService, path.EmailCategory)
 
 	collections := []data.BackupCollection{
 		&dataMock.Collection{
@@ -1585,7 +1585,7 @@ func (suite *KopiaSimpleRepoIntegrationSuite) SetupTest() {
 			dataMock.NewVersionedBackupCollection(t, collection))
 	}
 
-	r := NewReason(testTenant, testUser, path.ExchangeService, path.EmailCategory)
+	r := identity.NewReason(testTenant, testUser, path.ExchangeService, path.EmailCategory)
 
 	// Other tests check basic things about deets so not doing that again here.
 	stats, _, _, err := suite.w.ConsumeBackupCollections(
@@ -1622,7 +1622,7 @@ func (c *i64counter) Count(i int64) {
 }
 
 func (suite *KopiaSimpleRepoIntegrationSuite) TestBackupExcludeItem() {
-	r := NewReason(testTenant, testUser, path.ExchangeService, path.EmailCategory)
+	r := identity.NewReason(testTenant, testUser, path.ExchangeService, path.EmailCategory)
 
 	man, err := suite.w.c.LoadSnapshot(suite.ctx, suite.snapshotID)
 	require.NoError(suite.T(), err, "getting base snapshot: %v", clues.ToCore(err))

--- a/src/internal/m365/service/groups/backup_test.go
+++ b/src/internal/m365/service/groups/backup_test.go
@@ -85,14 +85,14 @@ func (suite *GroupsBackupUnitSuite) TestMetadataFiles() {
 	}{
 		{
 			name:      "error",
-			reason:    kopia.NewReason("tenant", "user", path.GroupsService, path.LibrariesCategory),
+			reason:    identity.NewReason("tenant", "user", path.GroupsService, path.LibrariesCategory),
 			manID:     "manifestID",
 			r:         mockRestoreProducer{err: assert.AnError},
 			expectErr: require.Error,
 		},
 		{
 			name:   "single site",
-			reason: kopia.NewReason("tenant", "user", path.GroupsService, path.LibrariesCategory),
+			reason: identity.NewReason("tenant", "user", path.GroupsService, path.LibrariesCategory),
 			manID:  "manifestID",
 			r: mockRestoreProducer{
 				rc: []data.RestoreCollection{
@@ -108,7 +108,7 @@ func (suite *GroupsBackupUnitSuite) TestMetadataFiles() {
 		},
 		{
 			name:   "multiple sites",
-			reason: kopia.NewReason("tenant", "user", path.GroupsService, path.LibrariesCategory),
+			reason: identity.NewReason("tenant", "user", path.GroupsService, path.LibrariesCategory),
 			manID:  "manifestID",
 			r: mockRestoreProducer{
 				rc: []data.RestoreCollection{

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -453,12 +453,12 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_ConsumeBackupDataCollections
 		tenant        = "a-tenant"
 		resourceOwner = "a-user"
 
-		emailReason = kopia.NewReason(
+		emailReason = identity.NewReason(
 			tenant,
 			resourceOwner,
 			path.ExchangeService,
 			path.EmailCategory)
-		contactsReason = kopia.NewReason(
+		contactsReason = identity.NewReason(
 			tenant,
 			resourceOwner,
 			path.ExchangeService,
@@ -590,12 +590,12 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 			DetailsID: "did2",
 		}
 
-		pathReason1 = kopia.NewReason(
+		pathReason1 = identity.NewReason(
 			"",
 			itemPath1.ProtectedResource(),
 			itemPath1.Service(),
 			itemPath1.Category())
-		pathReason3 = kopia.NewReason(
+		pathReason3 = identity.NewReason(
 			"",
 			itemPath3.ProtectedResource(),
 			itemPath3.Service(),
@@ -616,7 +616,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsItems
 			},
 			true)
 		exchangeLocationPath1 = path.Builder{}.Append("work-display-name")
-		exchangePathReason1   = kopia.NewReason(
+		exchangePathReason1   = identity.NewReason(
 			"",
 			exchangeItemPath1.ProtectedResource(),
 			exchangeItemPath1.Service(),
@@ -1267,7 +1267,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_MergeBackupDetails_AddsFolde
 
 		locPath1 = path.Builder{}.Append(itemPath1.Folders()...)
 
-		pathReason1 = kopia.NewReason(
+		pathReason1 = identity.NewReason(
 			"",
 			itemPath1.ProtectedResource(),
 			itemPath1.Service(),

--- a/src/internal/operations/manifests_test.go
+++ b/src/internal/operations/manifests_test.go
@@ -163,7 +163,7 @@ func (suite *OperationsManifestsUnitSuite) TestGetMetadataPaths() {
 			name:  "single reason",
 			manID: "single",
 			reasons: []identity.Reasoner{
-				kopia.NewReason(tid, ro, path.ExchangeService, path.EmailCategory),
+				identity.NewReason(tid, ro, path.ExchangeService, path.EmailCategory),
 			},
 			preFetchPaths: []string{},
 			expectPaths: func(t *testing.T, files []string) []path.Path {
@@ -183,8 +183,8 @@ func (suite *OperationsManifestsUnitSuite) TestGetMetadataPaths() {
 			name:  "multiple reasons",
 			manID: "multi",
 			reasons: []identity.Reasoner{
-				kopia.NewReason(tid, ro, path.ExchangeService, path.EmailCategory),
-				kopia.NewReason(tid, ro, path.ExchangeService, path.ContactsCategory),
+				identity.NewReason(tid, ro, path.ExchangeService, path.EmailCategory),
+				identity.NewReason(tid, ro, path.ExchangeService, path.ContactsCategory),
 			},
 			preFetchPaths: []string{},
 			expectPaths: func(t *testing.T, files []string) []path.Path {
@@ -209,7 +209,7 @@ func (suite *OperationsManifestsUnitSuite) TestGetMetadataPaths() {
 			name:  "single reason sp libraries",
 			manID: "single-sp-libraries",
 			reasons: []identity.Reasoner{
-				kopia.NewReason(tid, ro, path.SharePointService, path.LibrariesCategory),
+				identity.NewReason(tid, ro, path.SharePointService, path.LibrariesCategory),
 			},
 			preFetchPaths: []string{},
 			expectPaths: func(t *testing.T, files []string) []path.Path {
@@ -229,7 +229,7 @@ func (suite *OperationsManifestsUnitSuite) TestGetMetadataPaths() {
 			name:  "single reason groups messages",
 			manID: "single-groups-messages",
 			reasons: []identity.Reasoner{
-				kopia.NewReason(tid, ro, path.GroupsService, path.ChannelMessagesCategory),
+				identity.NewReason(tid, ro, path.GroupsService, path.ChannelMessagesCategory),
 			},
 			preFetchPaths: []string{},
 			expectPaths: func(t *testing.T, files []string) []path.Path {
@@ -249,7 +249,7 @@ func (suite *OperationsManifestsUnitSuite) TestGetMetadataPaths() {
 			name:  "single reason groups libraries",
 			manID: "single-groups-libraries",
 			reasons: []identity.Reasoner{
-				kopia.NewReason(tid, ro, path.GroupsService, path.LibrariesCategory),
+				identity.NewReason(tid, ro, path.GroupsService, path.LibrariesCategory),
 			},
 			preFetchPaths: []string{"previouspath"},
 			expectPaths: func(t *testing.T, files []string) []path.Path {
@@ -314,7 +314,7 @@ func buildReasons(
 	for _, cat := range cats {
 		reasons = append(
 			reasons,
-			kopia.NewReason(tenant, ro, service, cat))
+			identity.NewReason(tenant, ro, service, cat))
 	}
 
 	return reasons
@@ -384,7 +384,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 			},
 			rp: mockRestoreProducer{},
 			reasons: []identity.Reasoner{
-				kopia.NewReason("", ro, path.ExchangeService, path.EmailCategory),
+				identity.NewReason("", ro, path.ExchangeService, path.EmailCategory),
 			},
 			getMeta:   false,
 			assertErr: assert.NoError,
@@ -405,7 +405,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 			},
 			rp: mockRestoreProducer{},
 			reasons: []identity.Reasoner{
-				kopia.NewReason("", ro, path.ExchangeService, path.EmailCategory),
+				identity.NewReason("", ro, path.ExchangeService, path.EmailCategory),
 			},
 			getMeta:   true,
 			assertErr: assert.NoError,
@@ -431,8 +431,8 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				},
 			},
 			reasons: []identity.Reasoner{
-				kopia.NewReason("", ro, path.ExchangeService, path.EmailCategory),
-				kopia.NewReason("", ro, path.ExchangeService, path.ContactsCategory),
+				identity.NewReason("", ro, path.ExchangeService, path.EmailCategory),
+				identity.NewReason("", ro, path.ExchangeService, path.ContactsCategory),
 			},
 			getMeta:   true,
 			assertErr: assert.NoError,
@@ -475,7 +475,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				},
 			},
 			reasons: []identity.Reasoner{
-				kopia.NewReason("", ro, path.ExchangeService, path.EmailCategory),
+				identity.NewReason("", ro, path.ExchangeService, path.EmailCategory),
 			},
 			getMeta:   true,
 			assertErr: assert.NoError,
@@ -501,7 +501,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				},
 			},
 			reasons: []identity.Reasoner{
-				kopia.NewReason("", ro, path.ExchangeService, path.EmailCategory),
+				identity.NewReason("", ro, path.ExchangeService, path.EmailCategory),
 			},
 			getMeta:    true,
 			dropAssist: true,
@@ -528,7 +528,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 				},
 			},
 			reasons: []identity.Reasoner{
-				kopia.NewReason("", ro, path.ExchangeService, path.EmailCategory),
+				identity.NewReason("", ro, path.ExchangeService, path.EmailCategory),
 			},
 			getMeta:   true,
 			assertErr: assert.NoError,
@@ -548,7 +548,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata() {
 			},
 			rp: mockRestoreProducer{err: assert.AnError},
 			reasons: []identity.Reasoner{
-				kopia.NewReason("", ro, path.ExchangeService, path.EmailCategory),
+				identity.NewReason("", ro, path.ExchangeService, path.EmailCategory),
 			},
 			getMeta:    true,
 			assertErr:  assert.Error,
@@ -652,13 +652,13 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 		}
 	}
 
-	emailReason := kopia.NewReason(
+	emailReason := identity.NewReason(
 		"",
 		ro,
 		path.ExchangeService,
 		path.EmailCategory)
 
-	fbEmailReason := kopia.NewReason(
+	fbEmailReason := identity.NewReason(
 		"",
 		fbro,
 		path.ExchangeService,
@@ -928,11 +928,11 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 			},
 			reasons: []identity.Reasoner{
 				emailReason,
-				kopia.NewReason("", ro, path.ExchangeService, path.ContactsCategory),
+				identity.NewReason("", ro, path.ExchangeService, path.ContactsCategory),
 			},
 			fallbackReasons: []identity.Reasoner{
 				fbEmailReason,
-				kopia.NewReason("", fbro, path.ExchangeService, path.ContactsCategory),
+				identity.NewReason("", fbro, path.ExchangeService, path.ContactsCategory),
 			},
 			getMeta:   true,
 			assertErr: assert.NoError,
@@ -960,7 +960,7 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 			},
 			reasons: []identity.Reasoner{emailReason},
 			fallbackReasons: []identity.Reasoner{
-				kopia.NewReason("", fbro, path.ExchangeService, path.ContactsCategory),
+				identity.NewReason("", fbro, path.ExchangeService, path.ContactsCategory),
 			},
 			getMeta:   true,
 			assertErr: assert.NoError,
@@ -993,11 +993,11 @@ func (suite *OperationsManifestsUnitSuite) TestProduceManifestsAndMetadata_Fallb
 			},
 			reasons: []identity.Reasoner{
 				emailReason,
-				kopia.NewReason("", ro, path.ExchangeService, path.ContactsCategory),
+				identity.NewReason("", ro, path.ExchangeService, path.ContactsCategory),
 			},
 			fallbackReasons: []identity.Reasoner{
 				fbEmailReason,
-				kopia.NewReason("", fbro, path.ExchangeService, path.ContactsCategory),
+				identity.NewReason("", fbro, path.ExchangeService, path.ContactsCategory),
 			},
 			getMeta:   true,
 			assertErr: assert.NoError,

--- a/src/internal/operations/test/helper_test.go
+++ b/src/internal/operations/test/helper_test.go
@@ -240,7 +240,7 @@ func checkBackupIsInManifests(
 	for _, category := range categories {
 		t.Run(category.String(), func(t *testing.T) {
 			var (
-				r     = kopia.NewReason("", resourceOwner, sel.PathService(), category)
+				r     = identity.NewReason("", resourceOwner, sel.PathService(), category)
 				tags  = map[string]string{kopia.TagBackupCategory: ""}
 				found bool
 			)

--- a/src/pkg/backup/identity/identity.go
+++ b/src/pkg/backup/identity/identity.go
@@ -1,6 +1,10 @@
 package identity
 
-import "github.com/alcionai/corso/src/pkg/path"
+import (
+	"github.com/alcionai/clues"
+
+	"github.com/alcionai/corso/src/pkg/path"
+)
 
 // Reasoner describes the parts of the backup that make up its
 // data identity: the tenant, protected resources, services, and
@@ -13,4 +17,53 @@ type Reasoner interface {
 	// SubtreePath returns the path prefix for data in existing backups that have
 	// parameters (tenant, protected resourced, etc) that match this Reasoner.
 	SubtreePath() (path.Path, error)
+}
+
+func NewReason(
+	tenantID, resourceID string,
+	service path.ServiceType,
+	category path.CategoryType,
+) Reasoner {
+	return reason{
+		tenant:   tenantID,
+		resource: resourceID,
+		service:  service,
+		category: category,
+	}
+}
+
+type reason struct {
+	// tenant appears here so that when this is moved to an inject package nothing
+	// needs changed. However, kopia itself is blind to the fields in the reason
+	// struct and relies on helper functions to get the information it needs.
+	tenant   string
+	resource string
+	service  path.ServiceType
+	category path.CategoryType
+}
+
+func (r reason) Tenant() string {
+	return r.tenant
+}
+
+func (r reason) ProtectedResource() string {
+	return r.resource
+}
+
+func (r reason) Service() path.ServiceType {
+	return r.service
+}
+
+func (r reason) Category() path.CategoryType {
+	return r.category
+}
+
+func (r reason) SubtreePath() (path.Path, error) {
+	p, err := path.BuildPrefix(
+		r.Tenant(),
+		r.ProtectedResource(),
+		r.Service(),
+		r.Category())
+
+	return p, clues.Wrap(err, "building path").OrNil()
 }


### PR DESCRIPTION
Move the Reasoner implementation from the kopia package to the identity
package. This will help avoid import cycles if we want to start
persisting Reason information in the backup model.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
