### PR TITLE
Consolidate Reasoner implementations

### DIFF
--- a/src/pkg/selectors/reasons.go
+++ b/src/pkg/selectors/reasons.go
@@ -8,45 +8,11 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
-// ---------------------------------------------------------------------------
-// reasoner interface compliance
-// ---------------------------------------------------------------------------
-
-var _ identity.Reasoner = &backupReason{}
-
-type backupReason struct {
-	category path.CategoryType
-	resource string
-	service  path.ServiceType
-	tenant   string
-}
-
-func (br backupReason) Tenant() string {
-	return br.tenant
-}
-
-func (br backupReason) ProtectedResource() string {
-	return br.resource
-}
-
-func (br backupReason) Service() path.ServiceType {
-	return br.service
-}
-
-func (br backupReason) Category() path.CategoryType {
-	return br.category
-}
-
-func (br backupReason) SubtreePath() (path.Path, error) {
-	return path.BuildPrefix(
-		br.tenant,
-		br.resource,
-		br.service,
-		br.category)
-}
-
-func (br backupReason) key() string {
-	return br.category.String() + br.resource + br.service.String() + br.tenant
+func key(br identity.Reasoner) string {
+	return br.Category().String() +
+		br.ProtectedResource() +
+		br.Service().String() +
+		br.Tenant()
 }
 
 // ---------------------------------------------------------------------------
@@ -76,14 +42,8 @@ func reasonsFor(
 
 	for _, sl := range [][]path.CategoryType{pc.Includes, pc.Filters} {
 		for _, cat := range sl {
-			br := backupReason{
-				category: cat,
-				resource: resource,
-				service:  service,
-				tenant:   tenantID,
-			}
-
-			reasons[br.key()] = br
+			br := identity.NewReason(tenantID, resource, service, cat)
+			reasons[key(br)] = br
 		}
 	}
 


### PR DESCRIPTION
Remove other implementation of Reasoner in the
selector package since it's a duplicate of the
one that's in the identity package

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
