### PR TITLE
modify onenote skip, clues add collection scope

### DIFF
--- a/src/internal/m365/collection/drive/collection.go
+++ b/src/internal/m365/collection/drive/collection.go
@@ -273,9 +273,9 @@ func (oc *Collection) getDriveItemContent(
 
 		// Skip big OneNote files as they can't be downloaded
 		if clues.HasLabel(err, graph.LabelStatus(http.StatusServiceUnavailable)) &&
+			// oc.scope == CollectionScopePackage && *item.GetSize() >= MaxOneNoteFileSize {
 			// TODO: We've removed the file size check because it looks like we've seen persistent
 			// 503's with smaller OneNote files also.
-			// oc.scope == CollectionScopePackage && *item.GetSize() >= MaxOneNoteFileSize {
 			oc.scope == CollectionScopePackage {
 			// FIXME: It is possible that in case of a OneNote file we
 			// will end up just backing up the `onetoc2` file without
@@ -283,10 +283,18 @@ func (oc *Collection) getDriveItemContent(
 			// "item". This will have to be handled during the
 			// restore, or we have to handle it separately by somehow
 			// deleting the entire collection.
-			logger.CtxErr(ctx, err).With("skipped_reason", fault.SkipBigOneNote).Info("max OneNote file size exceeded")
-			errs.AddSkip(ctx, fault.FileSkip(fault.SkipBigOneNote, driveID, itemID, itemName, graph.ItemInfo(item)))
+			logger.
+				CtxErr(ctx, err).
+				With("skipped_reason", fault.SkipOneNote).
+				Info("inaccessible one note file")
+			errs.AddSkip(ctx, fault.FileSkip(
+				fault.SkipOneNote,
+				driveID,
+				itemID,
+				itemName,
+				graph.ItemInfo(item)))
 
-			return nil, clues.Wrap(err, "max oneNote item").Label(graph.LabelsSkippable)
+			return nil, clues.Wrap(err, "inaccesible oneNote item").Label(graph.LabelsSkippable)
 		}
 
 		errs.AddRecoverable(

--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -813,6 +813,8 @@ func (c *Collections) UpdateCollections(
 				colScope = CollectionScopePackage
 			}
 
+			ictx = clues.Add(ictx, "collection_scope", colScope)
+
 			col, err := NewCollection(
 				c.handler,
 				c.protectedResource,

--- a/src/pkg/backup/backup.go
+++ b/src/pkg/backup/backup.go
@@ -102,7 +102,7 @@ func New(
 		switch true {
 		case s.HasCause(fault.SkipMalware):
 			malware++
-		case s.HasCause(fault.SkipBigOneNote):
+		case s.HasCause(fault.SkipOneNote):
 			invalidONFile++
 		default:
 			otherSkips++

--- a/src/pkg/fault/skipped.go
+++ b/src/pkg/fault/skipped.go
@@ -18,12 +18,12 @@ const (
 	// permanently fail any attempts to backup or restore.
 	SkipMalware skipCause = "malware_detected"
 
-	// SkipBigOneNote identifies that a file was skipped because it
-	// was big OneNote file and we can only download OneNote files which
-	// are less that 2GB in size.
+	// SkipOneNote identifies that a file was skipped because it
+	// was a OneNote file that remains inaccessible (503 server response)
+	// regardless of the number of retries.
 	//nolint:lll
 	// https://support.microsoft.com/en-us/office/restrictions-and-limitations-in-onedrive-and-sharepoint-64883a5d-228e-48f5-b3d2-eb39e07630fa#onenotenotebooks
-	SkipBigOneNote skipCause = "big_one_note_file"
+	SkipOneNote skipCause = "inaccessible_one_note_file"
 )
 
 var _ print.Printable = &Skipped{}


### PR DESCRIPTION
some additional logging context for collection scope.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Supportability/Tests


#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
