### PR TITLE
Refactor drive handler logic

### DIFF
--- a/src/internal/m365/collection/drive/collections_test.go
+++ b/src/internal/m365/collection/drive/collections_test.go
@@ -740,7 +740,13 @@ func (suite *OneDriveCollectionsUnitSuite) TestUpdateCollections() {
 			maps.Copy(currPrevPaths, test.inputFolderMap)
 
 			c := NewCollections(
-				&itemBackupHandler{api.Drives{}, user, test.scope},
+				&itemBackupHandler{
+					baseItemHandler: baseItemHandler{
+						ac: api.Drives{},
+					},
+					userID: user,
+					scope:  test.scope,
+				},
 				tenant,
 				idname.NewProvider(user, user),
 				nil,
@@ -2462,7 +2468,13 @@ func (suite *OneDriveCollectionsUnitSuite) TestAddURLCacheToDriveCollections() {
 			// Add a few collections
 			for i := 0; i < collCount; i++ {
 				coll, err := NewCollection(
-					&itemBackupHandler{api.Drives{}, "test-user", anyFolder},
+					&itemBackupHandler{
+						baseItemHandler: baseItemHandler{
+							ac: api.Drives{},
+						},
+						userID: "test-user",
+						scope:  anyFolder,
+					},
 					idname.NewProvider("", ""),
 					nil,
 					nil,

--- a/src/internal/m365/collection/drive/group_handler.go
+++ b/src/internal/m365/collection/drive/group_handler.go
@@ -2,8 +2,12 @@ package drive
 
 import (
 	"github.com/alcionai/clues"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
+	"github.com/alcionai/corso/src/internal/common/idname"
+	"github.com/alcionai/corso/src/internal/common/ptr"
 	odConsts "github.com/alcionai/corso/src/internal/m365/service/onedrive/consts"
+	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
@@ -24,7 +28,9 @@ func NewGroupBackupHandler(
 ) groupBackupHandler {
 	return groupBackupHandler{
 		libraryBackupHandler{
-			ac:     ac,
+			baseLibraryHandler: baseLibraryHandler{
+				ac: ac,
+			},
 			siteID: siteID,
 			// Not adding scope here. Anything that needs scope has to
 			// be from group handler
@@ -94,6 +100,39 @@ func (h groupBackupHandler) SitePathPrefix(tenantID string) (path.Path, error) {
 		false,
 		odConsts.SitesPathDir,
 		h.siteID)
+}
+
+func (h groupBackupHandler) AugmentItemInfo(
+	dii details.ItemInfo,
+	resource idname.Provider,
+	item models.DriveItemable,
+	size int64,
+	parentPath *path.Builder,
+) details.ItemInfo {
+	var pps string
+
+	if parentPath != nil {
+		pps = parentPath.String()
+	}
+
+	driveName, driveID := getItemDriveInfo(item)
+
+	dii.Extension = &details.ExtensionData{}
+	dii.Groups = &details.GroupsInfo{
+		Created:    ptr.Val(item.GetCreatedDateTime()),
+		DriveID:    driveID,
+		DriveName:  driveName,
+		ItemName:   ptr.Val(item.GetName()),
+		ItemType:   details.SharePointLibrary,
+		Modified:   ptr.Val(item.GetLastModifiedDateTime()),
+		Owner:      getItemCreator(item),
+		ParentPath: pps,
+		SiteID:     resource.ID(),
+		Size:       size,
+		WebURL:     resource.Name(),
+	}
+
+	return dii
 }
 
 func (h groupBackupHandler) IsAllPass() bool {

--- a/src/internal/m365/collection/drive/handler_utils.go
+++ b/src/internal/m365/collection/drive/handler_utils.go
@@ -5,10 +5,7 @@ import (
 
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
-	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/common/ptr"
-	"github.com/alcionai/corso/src/pkg/backup/details"
-	"github.com/alcionai/corso/src/pkg/path"
 )
 
 func getItemCreator(item models.DriveItemable) string {
@@ -41,92 +38,4 @@ func getItemDriveInfo(item models.DriveItemable) (string, string) {
 	driveID := ptr.Val(item.GetParentReference().GetDriveId())
 
 	return driveName, driveID
-}
-
-func augmentItemInfo(
-	dii details.ItemInfo,
-	resource idname.Provider,
-	service path.ServiceType,
-	item models.DriveItemable,
-	size int64,
-	parentPath *path.Builder,
-) details.ItemInfo {
-	var driveName, driveID, creatorEmail string
-
-	// TODO: we rely on this info for details/restore lookups,
-	// so if it's nil we have an issue, and will need an alternative
-	// way to source the data.
-
-	if item.GetCreatedBy() != nil && item.GetCreatedBy().GetUser() != nil {
-		// User is sometimes not available when created via some
-		// external applications (like backup/restore solutions)
-		additionalData := item.GetCreatedBy().GetUser().GetAdditionalData()
-
-		ed, ok := additionalData["email"]
-		if !ok {
-			ed = additionalData["displayName"]
-		}
-
-		if ed != nil {
-			creatorEmail = *ed.(*string)
-		}
-	}
-
-	if item.GetParentReference() != nil {
-		driveID = ptr.Val(item.GetParentReference().GetDriveId())
-		driveName = strings.TrimSpace(ptr.Val(item.GetParentReference().GetName()))
-	}
-
-	var pps string
-	if parentPath != nil {
-		pps = parentPath.String()
-	}
-
-	switch service {
-	case path.OneDriveService:
-		dii.OneDrive = &details.OneDriveInfo{
-			Created:    ptr.Val(item.GetCreatedDateTime()),
-			DriveID:    driveID,
-			DriveName:  driveName,
-			ItemName:   ptr.Val(item.GetName()),
-			ItemType:   details.OneDriveItem,
-			Modified:   ptr.Val(item.GetLastModifiedDateTime()),
-			Owner:      creatorEmail,
-			ParentPath: pps,
-			Size:       size,
-		}
-	case path.SharePointService:
-		dii.SharePoint = &details.SharePointInfo{
-			Created:    ptr.Val(item.GetCreatedDateTime()),
-			DriveID:    driveID,
-			DriveName:  driveName,
-			ItemName:   ptr.Val(item.GetName()),
-			ItemType:   details.SharePointLibrary,
-			Modified:   ptr.Val(item.GetLastModifiedDateTime()),
-			Owner:      creatorEmail,
-			ParentPath: pps,
-			SiteID:     resource.ID(),
-			Size:       size,
-			WebURL:     resource.Name(),
-		}
-
-	case path.GroupsService:
-		dii.Groups = &details.GroupsInfo{
-			Created:    ptr.Val(item.GetCreatedDateTime()),
-			DriveID:    driveID,
-			DriveName:  driveName,
-			ItemName:   ptr.Val(item.GetName()),
-			ItemType:   details.SharePointLibrary,
-			Modified:   ptr.Val(item.GetLastModifiedDateTime()),
-			Owner:      creatorEmail,
-			ParentPath: pps,
-			SiteID:     resource.ID(),
-			Size:       size,
-			WebURL:     resource.Name(),
-		}
-	}
-
-	dii.Extension = &details.ExtensionData{}
-
-	return dii
 }

--- a/src/internal/m365/collection/drive/handler_utils.go
+++ b/src/internal/m365/collection/drive/handler_utils.go
@@ -26,6 +26,7 @@ func getItemCreator(item models.DriveItemable) string {
 		return ""
 	}
 
+	// TODO(ashmrtn): Replace with str package with fallbacks.
 	return *ed.(*string)
 }
 

--- a/src/internal/m365/collection/drive/handler_utils.go
+++ b/src/internal/m365/collection/drive/handler_utils.go
@@ -11,6 +11,38 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
+func getItemCreator(item models.DriveItemable) string {
+	if item.GetCreatedBy() == nil || item.GetCreatedBy().GetUser() == nil {
+		return ""
+	}
+
+	// User is sometimes not available when created via some
+	// external applications (like backup/restore solutions)
+	additionalData := item.GetCreatedBy().GetUser().GetAdditionalData()
+
+	ed, ok := additionalData["email"]
+	if !ok {
+		ed = additionalData["displayName"]
+	}
+
+	if ed == nil {
+		return ""
+	}
+
+	return *ed.(*string)
+}
+
+func getItemDriveInfo(item models.DriveItemable) (string, string) {
+	if item.GetParentReference() == nil {
+		return "", ""
+	}
+
+	driveName := strings.TrimSpace(ptr.Val(item.GetParentReference().GetName()))
+	driveID := ptr.Val(item.GetParentReference().GetDriveId())
+
+	return driveName, driveID
+}
+
 func augmentItemInfo(
 	dii details.ItemInfo,
 	resource idname.Provider,

--- a/src/internal/m365/collection/drive/item_collector_test.go
+++ b/src/internal/m365/collection/drive/item_collector_test.go
@@ -266,7 +266,13 @@ func (suite *OneDriveIntgSuite) TestOneDriveNewCollections() {
 			)
 
 			colls := NewCollections(
-				&itemBackupHandler{suite.ac.Drives(), test.user, scope},
+				&itemBackupHandler{
+					baseItemHandler: baseItemHandler{
+						ac: suite.ac.Drives(),
+					},
+					userID: test.user,
+					scope:  scope,
+				},
 				creds.AzureTenantID,
 				idname.NewProvider(test.user, test.user),
 				service.updateStatus,

--- a/src/internal/m365/collection/drive/item_handler.go
+++ b/src/internal/m365/collection/drive/item_handler.go
@@ -27,7 +27,8 @@ type baseItemHandler struct {
 }
 
 func (h baseItemHandler) NewDrivePager(
-	resourceOwner string, fields []string,
+	resourceOwner string,
+	fields []string,
 ) api.Pager[models.Driveable] {
 	return h.ac.NewUserDrivePager(resourceOwner, fields)
 }

--- a/src/internal/m365/collection/drive/library_handler.go
+++ b/src/internal/m365/collection/drive/library_handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
 	"github.com/alcionai/corso/src/internal/common/idname"
+	"github.com/alcionai/corso/src/internal/common/ptr"
 	odConsts "github.com/alcionai/corso/src/internal/m365/service/onedrive/consts"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control"
@@ -16,6 +17,50 @@ import (
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
+
+type baseLibraryHandler struct {
+	ac api.Drives
+}
+
+func (h baseLibraryHandler) NewDrivePager(
+	resourceOwner string,
+	fields []string,
+) api.Pager[models.Driveable] {
+	return h.ac.NewSiteDrivePager(resourceOwner, fields)
+}
+
+func (h baseLibraryHandler) AugmentItemInfo(
+	dii details.ItemInfo,
+	resource idname.Provider,
+	item models.DriveItemable,
+	size int64,
+	parentPath *path.Builder,
+) details.ItemInfo {
+	var pps string
+
+	if parentPath != nil {
+		pps = parentPath.String()
+	}
+
+	driveName, driveID := getItemDriveInfo(item)
+
+	dii.Extension = &details.ExtensionData{}
+	dii.SharePoint = &details.SharePointInfo{
+		Created:    ptr.Val(item.GetCreatedDateTime()),
+		DriveID:    driveID,
+		DriveName:  driveName,
+		ItemName:   ptr.Val(item.GetName()),
+		ItemType:   details.SharePointLibrary,
+		Modified:   ptr.Val(item.GetLastModifiedDateTime()),
+		Owner:      getItemCreator(item),
+		ParentPath: pps,
+		SiteID:     resource.ID(),
+		Size:       size,
+		WebURL:     resource.Name(),
+	}
+
+	return dii
+}
 
 var _ BackupHandler = &libraryBackupHandler{}
 


### PR DESCRIPTION
Do a couple of high-level things with drive handlers:
* pull out generic functionality into a base handler
* use handler-specific implementations of AugmentItemInfo
* remove old switch-based augmentItemInfo

Overall goal is to reduce places we use service type
comparisons to handle behavior differences

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #4254

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
