### PR TITLE
extract container transforms from the api layer

### DIFF
--- a/src/internal/m365/collection/exchange/backup.go
+++ b/src/internal/m365/collection/exchange/backup.go
@@ -21,9 +21,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
-// CreateCollections - utility function that retrieves M365
-// IDs through Microsoft Graph API. The selectors.ExchangeScope
-// determines the type of collections that are retrieved.
 func CreateCollections(
 	ctx context.Context,
 	bpc inject.BackupProducerConfig,

--- a/src/internal/m365/collection/exchange/contacts_container_cache.go
+++ b/src/internal/m365/collection/exchange/contacts_container_cache.go
@@ -113,9 +113,9 @@ func (cfc *contactContainerCache) Populate(
 			return el.Failure()
 		}
 
-		gncf := graph.NewCacheFolder(c, nil, nil)
+		cacheFolder := graph.NewCacheFolder(c, nil, nil)
 
-		err := cfc.addFolder(&gncf)
+		err := cfc.addFolder(&cacheFolder)
 		if err != nil {
 			errs.AddRecoverable(
 				ctx,

--- a/src/internal/m365/collection/exchange/container_resolver.go
+++ b/src/internal/m365/collection/exchange/container_resolver.go
@@ -23,14 +23,12 @@ type containerGetter interface {
 	) (graph.Container, error)
 }
 
-type containersEnumerator interface {
+type containersEnumerator[T any] interface {
 	EnumerateContainers(
 		ctx context.Context,
 		userID, baseDirID string,
 		immutableIDs bool,
-		fn func(graph.CachedContainer) error,
-		errs *fault.Bus,
-	) error
+	) ([]T, error)
 }
 
 type containerRefresher interface {

--- a/src/internal/m365/collection/exchange/events_container_cache.go
+++ b/src/internal/m365/collection/exchange/events_container_cache.go
@@ -87,12 +87,12 @@ func (ecc *eventContainerCache) Populate(
 			return el.Failure()
 		}
 
-		gncf := graph.NewCacheFolder(
+		cacheFolder := graph.NewCacheFolder(
 			api.CalendarDisplayable{Calendarable: c},
 			path.Builder{}.Append(ptr.Val(c.GetId())),
 			path.Builder{}.Append(ptr.Val(c.GetName())))
 
-		err := ecc.addFolder(&gncf)
+		err := ecc.addFolder(&cacheFolder)
 		if err != nil {
 			errs.AddRecoverable(
 				ctx,

--- a/src/internal/m365/collection/exchange/events_container_cache.go
+++ b/src/internal/m365/collection/exchange/events_container_cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/alcionai/clues"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/graph"
@@ -16,7 +17,7 @@ var _ graph.ContainerResolver = &eventContainerCache{}
 
 type eventContainerCache struct {
 	*containerResolver
-	enumer containersEnumerator
+	enumer containersEnumerator[models.Calendarable]
 	getter containerGetter
 	userID string
 }
@@ -70,22 +71,40 @@ func (ecc *eventContainerCache) Populate(
 		return clues.Wrap(err, "initializing")
 	}
 
-	err := ecc.enumer.EnumerateContainers(
+	el := errs.Local()
+
+	containers, err := ecc.enumer.EnumerateContainers(
 		ctx,
 		ecc.userID,
 		"",
-		false,
-		ecc.addFolder,
-		errs)
+		false)
 	if err != nil {
 		return clues.Wrap(err, "enumerating containers")
 	}
 
-	if err := ecc.populatePaths(ctx, errs); err != nil {
-		return clues.Wrap(err, "establishing calendar paths")
+	for _, c := range containers {
+		if el.Failure() != nil {
+			return el.Failure()
+		}
+
+		gncf := graph.NewCacheFolder(
+			api.CalendarDisplayable{Calendarable: c},
+			path.Builder{}.Append(ptr.Val(c.GetId())),
+			path.Builder{}.Append(ptr.Val(c.GetName())))
+
+		err := ecc.addFolder(&gncf)
+		if err != nil {
+			errs.AddRecoverable(
+				ctx,
+				graph.Stack(ctx, err).Label(fault.LabelForceNoBackupCreation))
+		}
 	}
 
-	return nil
+	if err := ecc.populatePaths(ctx, errs); err != nil {
+		return clues.Wrap(err, "populating paths")
+	}
+
+	return el.Failure()
 }
 
 // AddToCache adds container to map in field 'cache'

--- a/src/internal/m365/collection/exchange/mail_container_cache.go
+++ b/src/internal/m365/collection/exchange/mail_container_cache.go
@@ -117,9 +117,9 @@ func (mc *mailContainerCache) Populate(
 			return el.Failure()
 		}
 
-		gncf := graph.NewCacheFolder(c, nil, nil)
+		cacheFolder := graph.NewCacheFolder(c, nil, nil)
 
-		err := mc.addFolder(&gncf)
+		err := mc.addFolder(&cacheFolder)
 		if err != nil {
 			errs.AddRecoverable(
 				ctx,

--- a/src/internal/m365/collection/exchange/mail_container_cache.go
+++ b/src/internal/m365/collection/exchange/mail_container_cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/alcionai/clues"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -40,7 +41,7 @@ func (r *mailRefresher) refreshContainer(
 // nameLookup map: Key: DisplayName Value: ID
 type mailContainerCache struct {
 	*containerResolver
-	enumer containersEnumerator
+	enumer containersEnumerator[models.MailFolderable]
 	getter containerGetter
 	userID string
 }
@@ -100,20 +101,35 @@ func (mc *mailContainerCache) Populate(
 		return clues.Wrap(err, "initializing")
 	}
 
-	err := mc.enumer.EnumerateContainers(
+	el := errs.Local()
+
+	containers, err := mc.enumer.EnumerateContainers(
 		ctx,
 		mc.userID,
 		"",
-		false,
-		mc.addFolder,
-		errs)
+		false)
 	if err != nil {
 		return clues.Wrap(err, "enumerating containers")
+	}
+
+	for _, c := range containers {
+		if el.Failure() != nil {
+			return el.Failure()
+		}
+
+		gncf := graph.NewCacheFolder(c, nil, nil)
+
+		err := mc.addFolder(&gncf)
+		if err != nil {
+			errs.AddRecoverable(
+				ctx,
+				graph.Stack(ctx, err).Label(fault.LabelForceNoBackupCreation))
+		}
 	}
 
 	if err := mc.populatePaths(ctx, errs); err != nil {
 		return clues.Wrap(err, "populating paths")
 	}
 
-	return nil
+	return el.Failure()
 }

--- a/src/pkg/services/m365/api/contacts_pager.go
+++ b/src/pkg/services/m365/api/contacts_pager.go
@@ -66,7 +66,7 @@ func (p *contactsFoldersPageCtrl) ValidModTimes() bool {
 	return true
 }
 
-// EnumerateContainers retrieves all of the users current contact folders.
+// EnumerateContainers retrieves all of the user's current contact folders.
 func (c Contacts) EnumerateContainers(
 	ctx context.Context,
 	userID, baseContainerID string,

--- a/src/pkg/services/m365/api/events_pager.go
+++ b/src/pkg/services/m365/api/events_pager.go
@@ -67,7 +67,7 @@ func (p *eventsCalendarsPageCtrl) ValidModTimes() bool {
 	return true
 }
 
-// EnumerateContainers retrieves all of the users current mail folders.
+// EnumerateContainers retrieves all of the user's current mail folders.
 func (c Events) EnumerateContainers(
 	ctx context.Context,
 	userID, _ string, // baseContainerID not needed here

--- a/src/pkg/services/m365/api/events_test.go
+++ b/src/pkg/services/m365/api/events_test.go
@@ -309,7 +309,8 @@ func (suite *EventsAPIIntgSuite) TestEvents_canFindNonStandardFolder() {
 	require.NoError(t, err, clues.ToCore(err))
 
 	for _, c := range containers {
-		findContainer(c)
+		err := findContainer(c)
+		require.NoError(t, err, clues.ToCore(err))
 	}
 
 	require.True(

--- a/src/pkg/services/m365/api/events_test.go
+++ b/src/pkg/services/m365/api/events_test.go
@@ -13,13 +13,11 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/common/ptr"
-	"github.com/alcionai/corso/src/internal/m365/graph"
 	exchMock "github.com/alcionai/corso/src/internal/m365/service/exchange/mock"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
-	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
@@ -294,8 +292,8 @@ func (suite *EventsAPIIntgSuite) TestEvents_canFindNonStandardFolder() {
 	var (
 		found         bool
 		calID         = ptr.Val(cal.GetId())
-		findContainer = func(gcc graph.CachedContainer) error {
-			if ptr.Val(gcc.GetId()) == calID {
+		findContainer = func(mc models.Calendarable) error {
+			if ptr.Val(mc.GetId()) == calID {
 				found = true
 			}
 
@@ -303,14 +301,17 @@ func (suite *EventsAPIIntgSuite) TestEvents_canFindNonStandardFolder() {
 		}
 	)
 
-	err = ac.EnumerateContainers(
+	containers, err := ac.EnumerateContainers(
 		ctx,
 		suite.its.user.id,
 		api.DefaultCalendar,
-		false,
-		findContainer,
-		fault.New(true))
+		false)
 	require.NoError(t, err, clues.ToCore(err))
+
+	for _, c := range containers {
+		findContainer(c)
+	}
+
 	require.True(
 		t,
 		found,

--- a/src/pkg/services/m365/api/mail_pager.go
+++ b/src/pkg/services/m365/api/mail_pager.go
@@ -63,7 +63,7 @@ func (p *mailFoldersPageCtrl) ValidModTimes() bool {
 	return true
 }
 
-// EnumerateContainers retrieves all of the users current mail folders.
+// EnumerateContainers retrieves all of the user's current mail folders.
 func (c Mail) EnumerateContainers(
 	ctx context.Context,
 	userID, _ string, // baseContainerID not needed here


### PR DESCRIPTION
removes the cache container transformation funcs
from the exchange api container enumeration params. This ensures a cleaner separation of ownership where the api is only responsible for enumerating containers, and the caller is responsible for transforming them.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [ ] :broom: Tech Debt/Cleanup


#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
