### PR TITLE
filter out system messages

### DIFF
--- a/src/pkg/services/m365/api/channels.go
+++ b/src/pkg/services/m365/api/channels.go
@@ -170,7 +170,7 @@ func ChannelMessageInfo(
 		LastReplyAt:    lastReply,
 		Modified:       modTime,
 		MessageCreator: GetChatMessageFrom(msg),
-		MessagePreview: str.Preview(content, 16),
+		MessagePreview: str.Preview(content, 128),
 		ReplyCount:     len(msg.GetReplies()),
 		Size:           int64(len(content)),
 	}

--- a/src/pkg/services/m365/api/item_pager_test.go
+++ b/src/pkg/services/m365/api/item_pager_test.go
@@ -313,7 +313,7 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs() {
 			*testing.T,
 		) DeltaPager[testItem]
 		prevDelta     string
-		filter        func(a any) bool
+		filter        func(a testItem) bool
 		expect        expected
 		canDelta      bool
 		validModTimes bool
@@ -457,10 +457,10 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs() {
 		},
 		{
 			name: "no prev delta and fail all filter",
-			pagerGetter: func(t *testing.T) Pager[any] {
+			pagerGetter: func(t *testing.T) Pager[testItem] {
 				return nil
 			},
-			deltaPagerGetter: func(t *testing.T) DeltaPager[any] {
+			deltaPagerGetter: func(t *testing.T) DeltaPager[testItem] {
 				return &testIDsDeltaPager{
 					t: t,
 					added: map[string]time.Time{
@@ -471,7 +471,7 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs() {
 					validModTimes: true,
 				}
 			},
-			filter: func(any) bool { return false },
+			filter: func(testItem) bool { return false },
 			expect: expected{
 				added:         map[string]time.Time{},
 				removed:       []string{},
@@ -482,10 +482,10 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs() {
 		},
 		{
 			name: "with prev delta and fail all filter",
-			pagerGetter: func(t *testing.T) Pager[any] {
+			pagerGetter: func(t *testing.T) Pager[testItem] {
 				return nil
 			},
-			deltaPagerGetter: func(t *testing.T) DeltaPager[any] {
+			deltaPagerGetter: func(t *testing.T) DeltaPager[testItem] {
 				return &testIDsDeltaPager{
 					t: t,
 					added: map[string]time.Time{
@@ -496,7 +496,7 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs() {
 					validModTimes: true,
 				}
 			},
-			filter:    func(any) bool { return false },
+			filter:    func(testItem) bool { return false },
 			prevDelta: "delta",
 			expect: expected{
 				added:         map[string]time.Time{},
@@ -515,7 +515,7 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			filters := []func(any) bool{}
+			filters := []func(testItem) bool{}
 			if test.filter != nil {
 				filters = append(filters, test.filter)
 			}


### PR DESCRIPTION
adds a filter that removes system messages from
channel message backups.

Also extends the preview size from 16 to 128 characters.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #3988

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
