### PR TITLE
Fail backups if we see an item has a zero mod time

### DIFF
--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -148,6 +148,10 @@ func (cp *corsoProgress) FinishedFile(relativePath string, err error) {
 			Label(fault.LabelForceNoBackupCreation))
 
 		return
+	} else if info.Modified().IsZero() {
+		cp.errs.AddRecoverable(ctx, clues.New("mod time of zero").
+			WithClues(ctx).
+			Label(fault.LabelForceNoBackupCreation))
 	}
 
 	err = cp.deets.Add(d.repoPath, d.locationPath, info)

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -149,7 +149,7 @@ func (cp *corsoProgress) FinishedFile(relativePath string, err error) {
 
 		return
 	} else if info.Modified().IsZero() {
-		cp.errs.AddRecoverable(ctx, clues.New("mod time of zero").
+		cp.errs.AddRecoverable(ctx, clues.New("zero-valued mod time").
 			WithClues(ctx).
 			Label(fault.LabelForceNoBackupCreation))
 	}

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -1310,20 +1310,25 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_ReaderError() {
 	loc2 := path.Builder{}.Append(suite.storePath2.Folders()...)
 	r := identity.NewReason(testTenant, testUser, path.ExchangeService, path.EmailCategory)
 
+	info := exchMock.StubMailInfo()
+	info.Exchange.Modified = time.Now()
+
 	collections := []data.BackupCollection{
 		&dataMock.Collection{
 			Path: suite.storePath1,
 			Loc:  loc1,
 			ItemData: []data.Item{
 				&dataMock.Item{
-					ItemID:   testFileName,
-					Reader:   io.NopCloser(bytes.NewReader(testFileData)),
-					ItemInfo: exchMock.StubMailInfo(),
+					ItemID:       testFileName,
+					Reader:       io.NopCloser(bytes.NewReader(testFileData)),
+					ModifiedTime: info.Modified(),
+					ItemInfo:     info,
 				},
 				&dataMock.Item{
-					ItemID:   testFileName2,
-					Reader:   io.NopCloser(bytes.NewReader(testFileData2)),
-					ItemInfo: exchMock.StubMailInfo(),
+					ItemID:       testFileName2,
+					Reader:       io.NopCloser(bytes.NewReader(testFileData2)),
+					ModifiedTime: info.Modified(),
+					ItemInfo:     info,
 				},
 			},
 		},
@@ -1332,24 +1337,28 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_ReaderError() {
 			Loc:  loc2,
 			ItemData: []data.Item{
 				&dataMock.Item{
-					ItemID:   testFileName3,
-					Reader:   io.NopCloser(bytes.NewReader(testFileData3)),
-					ItemInfo: exchMock.StubMailInfo(),
+					ItemID:       testFileName3,
+					Reader:       io.NopCloser(bytes.NewReader(testFileData3)),
+					ModifiedTime: info.Modified(),
+					ItemInfo:     info,
 				},
 				&dataMock.Item{
-					ItemID:   testFileName4,
-					ReadErr:  assert.AnError,
-					ItemInfo: exchMock.StubMailInfo(),
+					ItemID:       testFileName4,
+					ReadErr:      assert.AnError,
+					ModifiedTime: info.Modified(),
+					ItemInfo:     info,
 				},
 				&dataMock.Item{
-					ItemID:   testFileName5,
-					Reader:   io.NopCloser(bytes.NewReader(testFileData5)),
-					ItemInfo: exchMock.StubMailInfo(),
+					ItemID:       testFileName5,
+					Reader:       io.NopCloser(bytes.NewReader(testFileData5)),
+					ModifiedTime: info.Modified(),
+					ItemInfo:     info,
 				},
 				&dataMock.Item{
-					ItemID:   testFileName6,
-					Reader:   io.NopCloser(bytes.NewReader(testFileData6)),
-					ItemInfo: exchMock.StubMailInfo(),
+					ItemID:       testFileName6,
+					Reader:       io.NopCloser(bytes.NewReader(testFileData6)),
+					ModifiedTime: info.Modified(),
+					ItemInfo:     info,
 				},
 			},
 		},

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -1067,6 +1067,7 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_NoDetailsForMeta() {
 		DriveID:   "drive-id",
 		DriveName: "drive-name",
 		ItemName:  "item",
+		Modified:  time.Now(),
 	}
 
 	// tags that are supplied by the caller. This includes basic tags to support
@@ -1124,10 +1125,11 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_NoDetailsForMeta() {
 					info.ItemName = name
 
 					ms := &dataMock.Item{
-						ItemID:   name,
-						Reader:   io.NopCloser(&bytes.Buffer{}),
-						ItemSize: 0,
-						ItemInfo: details.ItemInfo{OneDrive: &info},
+						ItemID:       name,
+						Reader:       io.NopCloser(&bytes.Buffer{}),
+						ItemSize:     0,
+						ItemInfo:     details.ItemInfo{OneDrive: &info},
+						ModifiedTime: info.Modified,
 					}
 
 					streams = append(streams, ms)
@@ -1152,12 +1154,15 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections_NoDetailsForMeta() {
 			cols: func() []data.BackupCollection {
 				info := baseOneDriveItemInfo
 				info.ItemName = testFileName
+				// Update the mod time so it's not counted as cached.
+				info.Modified = info.Modified.Add(time.Hour)
 
 				ms := &dataMock.Item{
-					ItemID:   testFileName,
-					Reader:   io.NopCloser(&bytes.Buffer{}),
-					ItemSize: 0,
-					ItemInfo: details.ItemInfo{OneDrive: &info},
+					ItemID:       testFileName,
+					Reader:       io.NopCloser(&bytes.Buffer{}),
+					ItemSize:     0,
+					ItemInfo:     details.ItemInfo{OneDrive: &info},
+					ModifiedTime: info.Modified,
 				}
 
 				mc := &dataMock.Collection{


### PR DESCRIPTION
This is a big hammer solution to keep bad state from getting into the repo. It will keep us getting into a situation in which we've made a backup that was marked as a successful backup (and thus a merge base) but has items which we won't be able to do details merging on if we do use it as a merge base.

Long term, we should probably tag these backups with some sort of special tag that says they shouldn't be used as bases at all since we'll fail to merge details. We'll fail details merging even if the base is used as an assist base.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
