### PR TITLE
Log the categories participating in an operation

### DIFF
--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/alcionai/clues"
 	"github.com/google/uuid"
-	"golang.org/x/exp/slices"
 
 	"github.com/alcionai/corso/src/internal/common/crash"
 	"github.com/alcionai/corso/src/internal/common/dttm"
@@ -238,22 +237,12 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 
 	op.Results.BackupID = model.StableID(uuid.NewString())
 
-	var cats []string
-
-	allCats, err := op.Selectors.AllPathCategories()
+	cats, err := op.Selectors.AllHumanPathCategories()
 	if err != nil {
 		// No need to exit over this, we'll just be missing a bit of info in the
 		// log.
 		logger.CtxErr(ctx, err).Info("getting categories for backup")
-	} else {
-		for _, cat := range allCats {
-			cats = append(cats, cat.HumanString())
-		}
 	}
-
-	// Sort so that it's the same across backups in case we need to do something
-	// like bin the service/category types across multiple backups.
-	slices.Sort(cats)
 
 	ctx = clues.Add(
 		ctx,

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/alcionai/clues"
 	"github.com/google/uuid"
+	"golang.org/x/exp/slices"
 
 	"github.com/alcionai/corso/src/internal/common/crash"
 	"github.com/alcionai/corso/src/internal/common/dttm"
@@ -237,6 +238,23 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 
 	op.Results.BackupID = model.StableID(uuid.NewString())
 
+	var cats []string
+
+	allCats, err := op.Selectors.AllPathCategories()
+	if err != nil {
+		// No need to exit over this, we'll just be missing a bit of info in the
+		// log.
+		logger.CtxErr(ctx, err).Info("getting categories for backup")
+	} else {
+		for _, cat := range allCats {
+			cats = append(cats, cat.HumanString())
+		}
+	}
+
+	// Sort so that it's the same across backups in case we need to do something
+	// like bin the service/category types across multiple backups.
+	slices.Sort(cats)
+
 	ctx = clues.Add(
 		ctx,
 		"tenant_id", clues.Hide(op.account.ID()),
@@ -244,6 +262,7 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 		"resource_owner_name", clues.Hide(op.ResourceOwner.Name()),
 		"backup_id", op.Results.BackupID,
 		"service", op.Selectors.Service,
+		"categories", cats,
 		"incremental", op.incremental,
 		"disable_assist_backup", op.disableAssistBackup)
 

--- a/src/internal/operations/export.go
+++ b/src/internal/operations/export.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/alcionai/clues"
 	"github.com/google/uuid"
-	"golang.org/x/exp/slices"
 
 	"github.com/alcionai/corso/src/internal/archive"
 	"github.com/alcionai/corso/src/internal/common/crash"
@@ -138,22 +137,12 @@ func (op *ExportOperation) Run(ctx context.Context) (
 	ctx, flushMetrics := events.NewMetrics(ctx, logger.Writer{Ctx: ctx})
 	defer flushMetrics()
 
-	var cats []string
-
-	allCats, err := op.Selectors.AllPathCategories()
+	cats, err := op.Selectors.AllHumanPathCategories()
 	if err != nil {
 		// No need to exit over this, we'll just be missing a bit of info in the
 		// log.
 		logger.CtxErr(ctx, err).Info("getting categories for export")
-	} else {
-		for _, cat := range allCats {
-			cats = append(cats, cat.HumanString())
-		}
 	}
-
-	// Sort so that it's the same across backups in case we need to do something
-	// like bin the service/category types across multiple exports.
-	slices.Sort(cats)
 
 	ctx = clues.Add(
 		ctx,

--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/alcionai/clues"
 	"github.com/google/uuid"
-	"golang.org/x/exp/slices"
 
 	"github.com/alcionai/corso/src/internal/common/crash"
 	"github.com/alcionai/corso/src/internal/common/dttm"
@@ -139,22 +138,12 @@ func (op *RestoreOperation) Run(ctx context.Context) (restoreDetails *details.De
 
 	ctx = count.Embed(ctx, op.Counter)
 
-	var cats []string
-
-	allCats, err := op.Selectors.AllPathCategories()
+	cats, err := op.Selectors.AllHumanPathCategories()
 	if err != nil {
 		// No need to exit over this, we'll just be missing a bit of info in the
 		// log.
 		logger.CtxErr(ctx, err).Info("getting categories for restore")
-	} else {
-		for _, cat := range allCats {
-			cats = append(cats, cat.HumanString())
-		}
 	}
-
-	// Sort so that it's the same across backups in case we need to do something
-	// like bin the service/category types across multiple restores.
-	slices.Sort(cats)
 
 	ctx = clues.Add(
 		ctx,

--- a/src/pkg/selectors/selectors.go
+++ b/src/pkg/selectors/selectors.go
@@ -293,6 +293,27 @@ func (s Selector) PathCategories() (selectorPathCategories, error) {
 	return ro.PathCategories(), nil
 }
 
+// AllPathCategories returns the sets of include and filter path categories
+// across all scope sets.
+func (s Selector) AllPathCategories() ([]path.CategoryType, error) {
+	all, err := s.PathCategories()
+	if err != nil {
+		return nil, clues.Stack(err)
+	}
+
+	res := map[string]path.CategoryType{}
+
+	for _, cat := range all.Includes {
+		res[cat.String()] = cat
+	}
+
+	for _, cat := range all.Filters {
+		res[cat.String()] = cat
+	}
+
+	return maps.Values(res), nil
+}
+
 // Reasons returns a deduplicated set of the backup reasons produced
 // using the selector's discrete owner and each scopes' service and
 // category types.

--- a/src/pkg/selectors/selectors.go
+++ b/src/pkg/selectors/selectors.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/alcionai/clues"
 	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 
 	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/pkg/backup/details"
@@ -293,25 +294,30 @@ func (s Selector) PathCategories() (selectorPathCategories, error) {
 	return ro.PathCategories(), nil
 }
 
-// AllPathCategories returns the sets of include and filter path categories
-// across all scope sets.
-func (s Selector) AllPathCategories() ([]path.CategoryType, error) {
+// AllHumanPathCategories returns the sets of include and filter path categories
+// across all scope sets. This is good for logging because it returns the
+// string version of the categories and sorts the slice so the category set is
+// easier to search for or bin across multiple logs.
+func (s Selector) AllHumanPathCategories() ([]string, error) {
 	all, err := s.PathCategories()
 	if err != nil {
 		return nil, clues.Stack(err)
 	}
 
-	res := map[string]path.CategoryType{}
+	allCats := map[path.CategoryType]string{}
 
 	for _, cat := range all.Includes {
-		res[cat.String()] = cat
+		allCats[cat] = cat.HumanString()
 	}
 
 	for _, cat := range all.Filters {
-		res[cat.String()] = cat
+		allCats[cat] = cat.HumanString()
 	}
 
-	return maps.Values(res), nil
+	res := maps.Values(allCats)
+	slices.Sort(res)
+
+	return res, nil
 }
 
 // Reasons returns a deduplicated set of the backup reasons produced


### PR DESCRIPTION
To assist in debugging via logs, add the set of
categories an operation is acting on to the
clues set in the context

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
