### PR TITLE
Enforce site filter for Groups restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Catch and report cases where a protected resource is locked out of access.  SDK consumers have a new errs sentinel that allows them to check for this case.
 - Fix a case where missing item LastModifiedTimes could cause incremental backups to fail.
 - Email size metadata was incorrectly set to the size of the last attachment.  Emails will now correctly report the size of the mail content plus the size of all attachments.
+- Improves the filtering capabilities for Groups restore and backup
+
+### Changed
+- Groups restore now expects the site whose backup we should restore
 
 ## [v0.14.0] (beta) - 2023-10-09
 

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -76,8 +76,8 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 		c.Use = c.Use + " " + sharePointServiceCommandCreateUseSuffix
 		c.Example = sharePointServiceCommandCreateExamples
 
-		flags.AddSiteFlag(c)
-		flags.AddSiteIDFlag(c)
+		flags.AddSiteFlag(c, true)
+		flags.AddSiteIDFlag(c, true)
 		flags.AddDataFlag(c, []string{flags.DataLibraries}, true)
 		flags.AddFailFastFlag(c)
 		flags.AddDisableIncrementalsFlag(c)

--- a/src/cli/export/groups.go
+++ b/src/cli/export/groups.go
@@ -27,6 +27,8 @@ func addGroupsCommands(cmd *cobra.Command) *cobra.Command {
 		fs.SortFlags = false
 
 		flags.AddBackupIDFlag(c, true)
+		flags.AddSingleSiteIDFlag(c, false)
+		flags.AddSharePointDetailsAndRestoreFlags(c)
 		flags.AddGroupDetailsAndRestoreFlags(c)
 		flags.AddExportConfigFlags(c)
 		flags.AddFailFastFlag(c)
@@ -89,7 +91,7 @@ func exportGroupsCmd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	if err := utils.ValidateGroupsRestoreFlags(flags.BackupIDFV, opts); err != nil {
+	if err := utils.ValidateGroupsRestoreFlags(flags.BackupIDFV, opts, false); err != nil {
 		return err
 	}
 

--- a/src/cli/export/groups.go
+++ b/src/cli/export/groups.go
@@ -27,7 +27,8 @@ func addGroupsCommands(cmd *cobra.Command) *cobra.Command {
 		fs.SortFlags = false
 
 		flags.AddBackupIDFlag(c, true)
-		flags.AddSingleSiteIDFlag(c, false)
+		flags.AddSiteFlag(c, false)
+		flags.AddSiteIDFlag(c, false)
 		flags.AddSharePointDetailsAndRestoreFlags(c)
 		flags.AddGroupDetailsAndRestoreFlags(c)
 		flags.AddExportConfigFlags(c)

--- a/src/cli/flags/groups.go
+++ b/src/cli/flags/groups.go
@@ -7,9 +7,10 @@ import (
 const DataMessages = "messages"
 
 const (
-	ChannelFN = "channel"
-	GroupFN   = "group"
-	MessageFN = "message"
+	ChannelFN   = "channel"
+	GroupFN     = "group"
+	MessageFN   = "message"
+	GroupSiteFN = "site"
 
 	MessageCreatedAfterFN    = "message-created-after"
 	MessageCreatedBeforeFN   = "message-created-before"
@@ -22,11 +23,31 @@ var (
 	GroupFV   []string
 	MessageFV []string
 
+	// Have to create a separate one for restore to make sure we
+	// create on which accepts only one value
+	GroupSiteFV string
+
 	MessageCreatedAfterFV    string
 	MessageCreatedBeforeFV   string
 	MessageLastReplyAfterFV  string
 	MessageLastReplyBeforeFV string
 )
+
+func AddSingleSiteIDFlag(cmd *cobra.Command, required bool) {
+	cmd.Flags().StringVar(
+		&GroupSiteFV,
+		GroupSiteFN,
+		"",
+		"ID or URL of the site to restore.")
+
+	// TODO: we can move this check to runtime once we support
+	// restoring other resources from groups, ie chat messages and
+	// only cause it to fail when the user is trying to restore site
+	// data.
+	if required {
+		cobra.CheckErr(cmd.MarkFlagRequired(GroupSiteFN))
+	}
+}
 
 func AddGroupDetailsAndRestoreFlags(cmd *cobra.Command) {
 	fs := cmd.Flags()

--- a/src/cli/flags/groups.go
+++ b/src/cli/flags/groups.go
@@ -7,10 +7,9 @@ import (
 const DataMessages = "messages"
 
 const (
-	ChannelFN   = "channel"
-	GroupFN     = "group"
-	MessageFN   = "message"
-	GroupSiteFN = "site"
+	ChannelFN = "channel"
+	GroupFN   = "group"
+	MessageFN = "message"
 
 	MessageCreatedAfterFN    = "message-created-after"
 	MessageCreatedBeforeFN   = "message-created-before"
@@ -23,31 +22,11 @@ var (
 	GroupFV   []string
 	MessageFV []string
 
-	// Have to create a separate one for restore to make sure we
-	// create on which accepts only one value
-	GroupSiteFV string
-
 	MessageCreatedAfterFV    string
 	MessageCreatedBeforeFV   string
 	MessageLastReplyAfterFV  string
 	MessageLastReplyBeforeFV string
 )
-
-func AddSingleSiteIDFlag(cmd *cobra.Command, required bool) {
-	cmd.Flags().StringVar(
-		&GroupSiteFV,
-		GroupSiteFN,
-		"",
-		"ID or URL of the site to restore.")
-
-	// TODO: we can move this check to runtime once we support
-	// restoring other resources from groups, ie chat messages and
-	// only cause it to fail when the user is trying to restore site
-	// data.
-	if required {
-		cobra.CheckErr(cmd.MarkFlagRequired(GroupSiteFN))
-	}
-}
 
 func AddGroupDetailsAndRestoreFlags(cmd *cobra.Command) {
 	fs := cmd.Flags()

--- a/src/cli/flags/sharepoint.go
+++ b/src/cli/flags/sharepoint.go
@@ -95,24 +95,28 @@ func AddSharePointDetailsAndRestoreFlags(cmd *cobra.Command) {
 // AddSiteIDFlag adds the --site-id flag, which accepts site ID values.
 // This flag is hidden, since we expect users to prefer the --site url
 // and do not want to encourage confusion.
-func AddSiteIDFlag(cmd *cobra.Command) {
+func AddSiteIDFlag(cmd *cobra.Command, multiple bool) {
 	fs := cmd.Flags()
+
+	message := "ID of the site to operate on"
+	if multiple {
+		//nolint:lll
+		message += "; accepts '" + Wildcard + "' to select all sites.  Args cannot be comma-delimited and must use multiple flags."
+	}
 
 	// note string ARRAY var.  IDs naturally contain commas, so we cannot accept
 	// duplicate values within a flag declaration.  ie: --site-id a,b,c does not
 	// work.  Users must call --site-id a --site-id b --site-id c.
-	fs.StringArrayVar(
-		&SiteIDFV,
-		SiteIDFN, nil,
-		//nolint:lll
-		"Backup data by site ID; accepts '"+Wildcard+"' to select all sites.  Args cannot be comma-delimited and must use multiple flags.")
+	fs.StringArrayVar(&SiteIDFV, SiteIDFN, nil, message)
 	cobra.CheckErr(fs.MarkHidden(SiteIDFN))
 }
 
 // AddSiteFlag adds the --site flag, which accepts webURL values.
-func AddSiteFlag(cmd *cobra.Command) {
-	cmd.Flags().StringSliceVar(
-		&WebURLFV,
-		SiteFN, nil,
-		"Backup data by site URL; accepts '"+Wildcard+"' to select all sites.")
+func AddSiteFlag(cmd *cobra.Command, multiple bool) {
+	message := "Web URL of the site to operate on"
+	if multiple {
+		message += "; accepts '" + Wildcard + "' to select all sites."
+	}
+
+	cmd.Flags().StringSliceVar(&WebURLFV, SiteFN, nil, message)
 }

--- a/src/cli/flags/testdata/flags.go
+++ b/src/cli/flags/testdata/flags.go
@@ -10,6 +10,7 @@ func FlgInputs(in []string) string { return strings.Join(in, ",") }
 
 var (
 	BackupInput = "backup-id"
+	SiteInput   = "site-id"
 
 	GroupsInput  = []string{"team1", "group2"}
 	MailboxInput = []string{"mailbox1", "mailbox2"}

--- a/src/cli/restore/groups.go
+++ b/src/cli/restore/groups.go
@@ -27,9 +27,9 @@ func addGroupsCommands(cmd *cobra.Command) *cobra.Command {
 		fs.SortFlags = false
 
 		flags.AddBackupIDFlag(c, true)
+		flags.AddSingleSiteIDFlag(c, true)
 		flags.AddNoPermissionsFlag(c)
-		flags.AddSharePointDetailsAndRestoreFlags(c) // for sp restores
-		flags.AddSiteIDFlag(c)
+		flags.AddSharePointDetailsAndRestoreFlags(c)
 		flags.AddRestoreConfigFlags(c, false)
 		flags.AddFailFastFlag(c)
 	}
@@ -83,7 +83,7 @@ func restoreGroupsCmd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	if err := utils.ValidateGroupsRestoreFlags(flags.BackupIDFV, opts); err != nil {
+	if err := utils.ValidateGroupsRestoreFlags(flags.BackupIDFV, opts, true); err != nil {
 		return err
 	}
 

--- a/src/cli/restore/groups.go
+++ b/src/cli/restore/groups.go
@@ -27,7 +27,8 @@ func addGroupsCommands(cmd *cobra.Command) *cobra.Command {
 		fs.SortFlags = false
 
 		flags.AddBackupIDFlag(c, true)
-		flags.AddSingleSiteIDFlag(c, true)
+		flags.AddSiteFlag(c, false)
+		flags.AddSiteIDFlag(c, false)
 		flags.AddNoPermissionsFlag(c)
 		flags.AddSharePointDetailsAndRestoreFlags(c)
 		flags.AddRestoreConfigFlags(c, false)

--- a/src/cli/restore/groups_test.go
+++ b/src/cli/restore/groups_test.go
@@ -52,6 +52,7 @@ func (suite *GroupsUnitSuite) TestAddGroupsCommands() {
 					[]string{
 						"--" + flags.RunModeFN, flags.RunModeFlagTest,
 						"--" + flags.BackupFN, flagsTD.BackupInput,
+						"--" + flags.SiteFN, flagsTD.SiteInput,
 						"--" + flags.LibraryFN, flagsTD.LibraryInput,
 						"--" + flags.FileFN, flagsTD.FlgInputs(flagsTD.FileNameInput),
 						"--" + flags.FolderFN, flagsTD.FlgInputs(flagsTD.FolderPathInput),

--- a/src/cli/utils/groups_test.go
+++ b/src/cli/utils/groups_test.go
@@ -227,8 +227,26 @@ func (suite *GroupsUtilsSuite) TestValidateGroupsRestoreFlags() {
 		{
 			name:     "just site",
 			backupID: "id",
-			opts:     utils.GroupsOpts{Site: "site"}, // site is mandatory
+			opts:     utils.GroupsOpts{WebURL: []string{"site"}}, // site is mandatory
 			expect:   assert.NoError,
+		},
+		{
+			name:     "just siteid",
+			backupID: "id",
+			opts:     utils.GroupsOpts{SiteID: []string{"site-id"}},
+			expect:   assert.NoError,
+		},
+		{
+			name:     "multiple sites",
+			backupID: "id",
+			opts:     utils.GroupsOpts{SiteID: []string{"site-id1", "site-id2"}},
+			expect:   assert.Error,
+		},
+		{
+			name:     "site and siteid",
+			backupID: "id",
+			opts:     utils.GroupsOpts{SiteID: []string{"site-id"}, WebURL: []string{"site"}},
+			expect:   assert.Error,
 		},
 		{
 			name:     "no backupID",
@@ -240,7 +258,7 @@ func (suite *GroupsUtilsSuite) TestValidateGroupsRestoreFlags() {
 			name:     "all valid",
 			backupID: "id",
 			opts: utils.GroupsOpts{
-				Site:                   "site",
+				WebURL:                 []string{"site"},
 				FileCreatedAfter:       dttm.Now(),
 				FileCreatedBefore:      dttm.Now(),
 				FileModifiedAfter:      dttm.Now(),

--- a/src/cli/utils/groups_test.go
+++ b/src/cli/utils/groups_test.go
@@ -71,7 +71,6 @@ func (suite *GroupsUtilsSuite) TestIncludeGroupsRestoreDataSelectors() {
 			opts: utils.GroupsOpts{
 				FileName:   empty,
 				FolderPath: containsOnly,
-				Site:       empty,
 			},
 			expectIncludeLen: 1,
 		},
@@ -80,7 +79,6 @@ func (suite *GroupsUtilsSuite) TestIncludeGroupsRestoreDataSelectors() {
 			opts: utils.GroupsOpts{
 				FileName:   empty,
 				FolderPath: prefixOnly,
-				Site:       empty,
 			},
 			expectIncludeLen: 1,
 		},
@@ -89,7 +87,6 @@ func (suite *GroupsUtilsSuite) TestIncludeGroupsRestoreDataSelectors() {
 			opts: utils.GroupsOpts{
 				FileName:   empty,
 				FolderPath: containsAndPrefix,
-				Site:       empty,
 			},
 			expectIncludeLen: 2,
 		},
@@ -100,7 +97,6 @@ func (suite *GroupsUtilsSuite) TestIncludeGroupsRestoreDataSelectors() {
 				FolderPath: empty,
 				ListItem:   empty,
 				ListFolder: containsOnly,
-				Site:       empty,
 			},
 			expectIncludeLen: 1,
 		},
@@ -123,7 +119,6 @@ func (suite *GroupsUtilsSuite) TestIncludeGroupsRestoreDataSelectors() {
 			opts: utils.GroupsOpts{
 				FileName:   empty,
 				FolderPath: empty,
-				// SiteID:     empty,  // TODO(meain): Update once we support multiple sites
 			},
 			expectIncludeLen: 2,
 		},
@@ -132,7 +127,6 @@ func (suite *GroupsUtilsSuite) TestIncludeGroupsRestoreDataSelectors() {
 			opts: utils.GroupsOpts{
 				FileName:   empty,
 				FolderPath: empty,
-				// SiteID:     empty, // TODO(meain): update once we support multiple sites
 			},
 			expectIncludeLen: 2,
 		},
@@ -231,9 +225,9 @@ func (suite *GroupsUtilsSuite) TestValidateGroupsRestoreFlags() {
 		expect   assert.ErrorAssertionFunc
 	}{
 		{
-			name:     "no opts",
+			name:     "just site",
 			backupID: "id",
-			opts:     utils.GroupsOpts{},
+			opts:     utils.GroupsOpts{Site: "site"}, // site is mandatory
 			expect:   assert.NoError,
 		},
 		{
@@ -246,6 +240,7 @@ func (suite *GroupsUtilsSuite) TestValidateGroupsRestoreFlags() {
 			name:     "all valid",
 			backupID: "id",
 			opts: utils.GroupsOpts{
+				Site:                   "site",
 				FileCreatedAfter:       dttm.Now(),
 				FileCreatedBefore:      dttm.Now(),
 				FileModifiedAfter:      dttm.Now(),
@@ -362,7 +357,7 @@ func (suite *GroupsUtilsSuite) TestValidateGroupsRestoreFlags() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
-			test.expect(t, utils.ValidateGroupsRestoreFlags(test.backupID, test.opts, false))
+			test.expect(t, utils.ValidateGroupsRestoreFlags(test.backupID, test.opts, true))
 		})
 	}
 }

--- a/src/cli/utils/groups_test.go
+++ b/src/cli/utils/groups_test.go
@@ -71,7 +71,7 @@ func (suite *GroupsUtilsSuite) TestIncludeGroupsRestoreDataSelectors() {
 			opts: utils.GroupsOpts{
 				FileName:   empty,
 				FolderPath: containsOnly,
-				SiteID:     empty,
+				Site:       empty,
 			},
 			expectIncludeLen: 1,
 		},
@@ -80,7 +80,7 @@ func (suite *GroupsUtilsSuite) TestIncludeGroupsRestoreDataSelectors() {
 			opts: utils.GroupsOpts{
 				FileName:   empty,
 				FolderPath: prefixOnly,
-				SiteID:     empty,
+				Site:       empty,
 			},
 			expectIncludeLen: 1,
 		},
@@ -89,7 +89,7 @@ func (suite *GroupsUtilsSuite) TestIncludeGroupsRestoreDataSelectors() {
 			opts: utils.GroupsOpts{
 				FileName:   empty,
 				FolderPath: containsAndPrefix,
-				SiteID:     empty,
+				Site:       empty,
 			},
 			expectIncludeLen: 2,
 		},
@@ -100,7 +100,7 @@ func (suite *GroupsUtilsSuite) TestIncludeGroupsRestoreDataSelectors() {
 				FolderPath: empty,
 				ListItem:   empty,
 				ListFolder: containsOnly,
-				SiteID:     empty,
+				Site:       empty,
 			},
 			expectIncludeLen: 1,
 		},
@@ -362,7 +362,7 @@ func (suite *GroupsUtilsSuite) TestValidateGroupsRestoreFlags() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
-			test.expect(t, utils.ValidateGroupsRestoreFlags(test.backupID, test.opts))
+			test.expect(t, utils.ValidateGroupsRestoreFlags(test.backupID, test.opts, false))
 		})
 	}
 }

--- a/src/pkg/selectors/groups.go
+++ b/src/pkg/selectors/groups.go
@@ -261,6 +261,21 @@ func (s *groups) ChannelMessages(channels, messages []string, opts ...option) []
 	return scopes
 }
 
+// Sites produces one or more Groups site scopes, where the site
+// matches upon a given site by ID or URL.
+// If any slice contains selectors.Any, that slice is reduced to [selectors.Any]
+// If any slice contains selectors.None, that slice is reduced to [selectors.None]
+// If any slice is empty, it defaults to [selectors.None]
+func (s *groups) Site(site string) []GroupsScope {
+	return []GroupsScope{
+		makeInfoScope[GroupsScope](
+			GroupsLibraryItem,
+			GroupsInfoSite,
+			[]string{site},
+			filters.Equal),
+	}
+}
+
 // Library produces one or more Group library scopes, where the library
 // matches upon a given drive by ID or Name.  In order to ensure library selection
 // this should always be embedded within the Filter() set; include(Library()) will
@@ -519,6 +534,7 @@ const (
 	GroupsInfoLibraryItemModifiedBefore groupsCategory = "GroupsInfoLibraryItemModifiedBefore"
 
 	// channel and drive selection
+	GroupsInfoSite             groupsCategory = "GroupsInfoSite"
 	GroupsInfoSiteLibraryDrive groupsCategory = "GroupsInfoSiteLibraryDrive"
 
 	// data contained within details.ItemInfo
@@ -562,7 +578,7 @@ func (c groupsCategory) leafCat() categorizer {
 		GroupsInfoChannelMessageCreatedAfter, GroupsInfoChannelMessageCreatedBefore, GroupsInfoChannelMessageCreator,
 		GroupsInfoChannelMessageLastReplyAfter, GroupsInfoChannelMessageLastReplyBefore:
 		return GroupsChannelMessage
-	case GroupsLibraryFolder, GroupsLibraryItem, GroupsInfoSiteLibraryDrive,
+	case GroupsLibraryFolder, GroupsLibraryItem, GroupsInfoSite, GroupsInfoSiteLibraryDrive,
 		GroupsInfoLibraryItemCreatedAfter, GroupsInfoLibraryItemCreatedBefore,
 		GroupsInfoLibraryItemModifiedAfter, GroupsInfoLibraryItemModifiedBefore:
 		return GroupsLibraryItem
@@ -781,6 +797,18 @@ func (s GroupsScope) matchesInfo(dii details.ItemInfo) bool {
 	}
 
 	switch infoCat {
+	case GroupsInfoSite:
+		ds := []string{}
+
+		if len(info.SiteID) > 0 {
+			ds = append(ds, info.SiteID)
+		}
+
+		if len(info.WebURL) > 0 {
+			ds = append(ds, info.WebURL)
+		}
+
+		return matchesAny(s, GroupsInfoSite, ds)
 	case GroupsInfoSiteLibraryDrive:
 		ds := []string{}
 

--- a/src/pkg/selectors/groups_test.go
+++ b/src/pkg/selectors/groups_test.go
@@ -457,6 +457,7 @@ func (suite *GroupsSelectorSuite) TestCategory_PathType() {
 		{GroupsLibraryFolder, path.LibrariesCategory},
 		{GroupsLibraryItem, path.LibrariesCategory},
 		{GroupsInfoSiteLibraryDrive, path.LibrariesCategory},
+		{GroupsInfoSite, path.LibrariesCategory},
 	}
 	for _, test := range table {
 		suite.Run(test.cat.String(), func() {

--- a/src/pkg/selectors/groups_test.go
+++ b/src/pkg/selectors/groups_test.go
@@ -394,6 +394,7 @@ func (suite *GroupsSelectorSuite) TestGroupsScope_MatchesInfo() {
 		{"file modified before epoch", dspl, user, sel.ModifiedBefore(dttm.Format(now)), assert.False},
 		{"in library", dspl, user, sel.Library("included-library"), assert.True},
 		{"not in library", dspl, user, sel.Library("not-included-library"), assert.False},
+		{"site id", dspl, user, sel.Site("site1"), assert.True},
 		{"library id", dspl, user, sel.Library("1234"), assert.True},
 		{"not library id", dspl, user, sel.Library("abcd"), assert.False},
 
@@ -430,6 +431,7 @@ func (suite *GroupsSelectorSuite) TestGroupsScope_MatchesInfo() {
 					LastReplyAt:    mod,
 					DriveName:      "included-library",
 					DriveID:        "1234",
+					SiteID:         "site1",
 				},
 			}
 

--- a/src/pkg/selectors/groups_test.go
+++ b/src/pkg/selectors/groups_test.go
@@ -395,6 +395,7 @@ func (suite *GroupsSelectorSuite) TestGroupsScope_MatchesInfo() {
 		{"in library", dspl, user, sel.Library("included-library"), assert.True},
 		{"not in library", dspl, user, sel.Library("not-included-library"), assert.False},
 		{"site id", dspl, user, sel.Site("site1"), assert.True},
+		{"web url", dspl, user, sel.Site(user), assert.True},
 		{"library id", dspl, user, sel.Library("1234"), assert.True},
 		{"not library id", dspl, user, sel.Library("abcd"), assert.False},
 


### PR DESCRIPTION
This PR reworks the groups restore to and makes the site to restore to mandatory. This also updates some missing filtering capabilities in groups export.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* closes https://github.com/alcionai/corso/issues/4462

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
