### PR TITLE
Allow restore data from sites in groups backup to different site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Skips graph calls for expired item download URLs.
 - Export operation now shows the stats at the end of the run
+- Group backup data can now be restored to a different resource than the one it was backed up from
 
 ### Fixed
 - Catch and report cases where a protected resource is locked out of access.  SDK consumers have a new errs sentinel that allows them to check for this case.

--- a/src/cli/flags/restore_config.go
+++ b/src/cli/flags/restore_config.go
@@ -19,7 +19,7 @@ var (
 )
 
 // AddRestoreConfigFlags adds the restore config flag set.
-func AddRestoreConfigFlags(cmd *cobra.Command, canRestoreToAlternate bool) {
+func AddRestoreConfigFlags(cmd *cobra.Command) {
 	fs := cmd.Flags()
 	fs.StringVar(
 		&CollisionsFV, CollisionsFN, string(control.Skip),
@@ -29,9 +29,7 @@ func AddRestoreConfigFlags(cmd *cobra.Command, canRestoreToAlternate bool) {
 		&DestinationFV, DestinationFN, "",
 		"Overrides the folder where items get restored; '/' places items into their original location")
 
-	if canRestoreToAlternate {
-		fs.StringVar(
-			&ToResourceFV, ToResourceFN, "",
-			"Overrides the protected resource (mailbox, site, user, etc) where data gets restored")
-	}
+	fs.StringVar(
+		&ToResourceFV, ToResourceFN, "",
+		"Overrides the protected resource (mailbox, site, user, etc) where data gets restored")
 }

--- a/src/cli/restore/exchange.go
+++ b/src/cli/restore/exchange.go
@@ -28,7 +28,7 @@ func addExchangeCommands(cmd *cobra.Command) *cobra.Command {
 
 		flags.AddBackupIDFlag(c, true)
 		flags.AddExchangeDetailsAndRestoreFlags(c)
-		flags.AddRestoreConfigFlags(c, true)
+		flags.AddRestoreConfigFlags(c)
 		flags.AddFailFastFlag(c)
 	}
 

--- a/src/cli/restore/groups.go
+++ b/src/cli/restore/groups.go
@@ -31,7 +31,7 @@ func addGroupsCommands(cmd *cobra.Command) *cobra.Command {
 		flags.AddSiteIDFlag(c, false)
 		flags.AddNoPermissionsFlag(c)
 		flags.AddSharePointDetailsAndRestoreFlags(c)
-		flags.AddRestoreConfigFlags(c, false)
+		flags.AddRestoreConfigFlags(c)
 		flags.AddFailFastFlag(c)
 	}
 

--- a/src/cli/restore/groups_test.go
+++ b/src/cli/restore/groups_test.go
@@ -66,7 +66,7 @@ func (suite *GroupsUnitSuite) TestAddGroupsCommands() {
 						"--" + flags.PageFolderFN, flagsTD.FlgInputs(flagsTD.PageFolderInput),
 						"--" + flags.CollisionsFN, flagsTD.Collisions,
 						"--" + flags.DestinationFN, flagsTD.Destination,
-						// "--" + flags.ToResourceFN, flagsTD.ToResource,
+						"--" + flags.ToResourceFN, flagsTD.ToResource,
 						"--" + flags.NoPermissionsFN,
 					},
 					flagsTD.PreparedProviderFlags(),
@@ -83,6 +83,7 @@ func (suite *GroupsUnitSuite) TestAddGroupsCommands() {
 			opts := utils.MakeGroupsOpts(cmd)
 
 			assert.Equal(t, flagsTD.BackupInput, flags.BackupIDFV)
+			assert.Equal(t, flagsTD.SiteInput, opts.Site)
 			assert.Equal(t, flagsTD.LibraryInput, opts.Library)
 			assert.ElementsMatch(t, flagsTD.FileNameInput, opts.FileName)
 			assert.ElementsMatch(t, flagsTD.FolderPathInput, opts.FolderPath)
@@ -92,7 +93,7 @@ func (suite *GroupsUnitSuite) TestAddGroupsCommands() {
 			assert.Equal(t, flagsTD.FileModifiedBeforeInput, opts.FileModifiedBefore)
 			assert.Equal(t, flagsTD.Collisions, opts.RestoreCfg.Collisions)
 			assert.Equal(t, flagsTD.Destination, opts.RestoreCfg.Destination)
-			// assert.Equal(t, flagsTD.ToResource, opts.RestoreCfg.ProtectedResource)
+			assert.Equal(t, flagsTD.ToResource, opts.RestoreCfg.ProtectedResource)
 			assert.True(t, flags.NoPermissionsFV)
 			flagsTD.AssertProviderFlags(t, cmd)
 			flagsTD.AssertStorageFlags(t, cmd)

--- a/src/cli/restore/groups_test.go
+++ b/src/cli/restore/groups_test.go
@@ -53,6 +53,7 @@ func (suite *GroupsUnitSuite) TestAddGroupsCommands() {
 						"--" + flags.RunModeFN, flags.RunModeFlagTest,
 						"--" + flags.BackupFN, flagsTD.BackupInput,
 						"--" + flags.SiteFN, flagsTD.SiteInput,
+						"--" + flags.SiteIDFN, flagsTD.SiteInput,
 						"--" + flags.LibraryFN, flagsTD.LibraryInput,
 						"--" + flags.FileFN, flagsTD.FlgInputs(flagsTD.FileNameInput),
 						"--" + flags.FolderFN, flagsTD.FlgInputs(flagsTD.FolderPathInput),
@@ -83,7 +84,8 @@ func (suite *GroupsUnitSuite) TestAddGroupsCommands() {
 			opts := utils.MakeGroupsOpts(cmd)
 
 			assert.Equal(t, flagsTD.BackupInput, flags.BackupIDFV)
-			assert.Equal(t, flagsTD.SiteInput, opts.Site)
+			assert.Equal(t, flagsTD.SiteInput, opts.SiteID[0])
+			assert.Equal(t, flagsTD.SiteInput, opts.WebURL[0])
 			assert.Equal(t, flagsTD.LibraryInput, opts.Library)
 			assert.ElementsMatch(t, flagsTD.FileNameInput, opts.FileName)
 			assert.ElementsMatch(t, flagsTD.FolderPathInput, opts.FolderPath)

--- a/src/cli/restore/onedrive.go
+++ b/src/cli/restore/onedrive.go
@@ -29,7 +29,7 @@ func addOneDriveCommands(cmd *cobra.Command) *cobra.Command {
 		flags.AddBackupIDFlag(c, true)
 		flags.AddOneDriveDetailsAndRestoreFlags(c)
 		flags.AddNoPermissionsFlag(c)
-		flags.AddRestoreConfigFlags(c, true)
+		flags.AddRestoreConfigFlags(c)
 		flags.AddFailFastFlag(c)
 	}
 

--- a/src/cli/restore/sharepoint.go
+++ b/src/cli/restore/sharepoint.go
@@ -29,7 +29,7 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 		flags.AddBackupIDFlag(c, true)
 		flags.AddSharePointDetailsAndRestoreFlags(c)
 		flags.AddNoPermissionsFlag(c)
-		flags.AddRestoreConfigFlags(c, true)
+		flags.AddRestoreConfigFlags(c)
 		flags.AddFailFastFlag(c)
 	}
 

--- a/src/cli/utils/exchange.go
+++ b/src/cli/utils/exchange.go
@@ -59,7 +59,7 @@ func MakeExchangeOpts(cmd *cobra.Command) ExchangeOpts {
 		EventStartsBefore: flags.EventStartsBeforeFV,
 		EventSubject:      flags.EventSubjectFV,
 
-		RestoreCfg: makeRestoreCfgOpts(cmd),
+		RestoreCfg: makeBaseRestoreCfgOpts(cmd),
 
 		// populated contains the list of flags that appear in the
 		// command, according to pflags.  Use this to differentiate

--- a/src/cli/utils/groups.go
+++ b/src/cli/utils/groups.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/alcionai/corso/src/cli/flags"
+	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 )
 
@@ -67,6 +68,10 @@ func AddGroupsCategories(sel *selectors.GroupsBackup, cats []string) *selectors.
 }
 
 func MakeGroupsOpts(cmd *cobra.Command) GroupsOpts {
+	restoreCfg := makeBaseRestoreCfgOpts(cmd)
+	restoreCfg.SubServiceType = path.SharePointService                   // this is the only possibility as of now
+	restoreCfg.SubService = append(flags.SiteIDFV, flags.WebURLFV...)[0] // we should always have just one
+
 	return GroupsOpts{
 		Groups:   flags.GroupFV,
 		Channels: flags.ChannelFV,
@@ -92,7 +97,7 @@ func MakeGroupsOpts(cmd *cobra.Command) GroupsOpts {
 		Page:       flags.PageFV,
 		PageFolder: flags.PageFolderFV,
 
-		RestoreCfg: makeRestoreCfgOpts(cmd),
+		RestoreCfg: restoreCfg,
 		ExportCfg:  makeExportCfgOpts(cmd),
 
 		// populated contains the list of flags that appear in the

--- a/src/cli/utils/groups.go
+++ b/src/cli/utils/groups.go
@@ -69,7 +69,8 @@ func AddGroupsCategories(sel *selectors.GroupsBackup, cats []string) *selectors.
 
 func MakeGroupsOpts(cmd *cobra.Command) GroupsOpts {
 	restoreCfg := makeBaseRestoreCfgOpts(cmd)
-	restoreCfg.SubServiceType = path.SharePointService                   // this is the only possibility as of now
+	restoreCfg.SubServiceType = path.SharePointService // this is the only possibility as of now
+
 	restoreCfg.SubService = append(flags.SiteIDFV, flags.WebURLFV...)[0] // we should always have just one
 
 	return GroupsOpts{

--- a/src/cli/utils/groups.go
+++ b/src/cli/utils/groups.go
@@ -72,7 +72,7 @@ func MakeGroupsOpts(cmd *cobra.Command) GroupsOpts {
 
 	sites := append(flags.SiteIDFV, flags.WebURLFV...)
 	if len(sites) > 0 {
-		// There will either be zero or one sites, this is ensured by ValidateGroupsRestoreFlags
+		// There will either be zero or one site, this is ensured by ValidateGroupsRestoreFlags
 		restoreCfg.SubServiceType = path.SharePointService
 		restoreCfg.SubService = sites[0]
 	}
@@ -119,7 +119,7 @@ func ValidateGroupsRestoreFlags(backupID string, opts GroupsOpts, isRestore bool
 	}
 
 	// When restoring the user has to select a single site to
-	// restore. During exports or other operation, they can either select
+	// restore. During exports or other operations, they can either select
 	// the entire backup or just a single site.
 	if isRestore && len(opts.WebURL)+len(opts.SiteID) == 0 {
 		return clues.New("web URL of the site to restore is required. Use --" + flags.SiteFN + " to provide one.")

--- a/src/cli/utils/onedrive.go
+++ b/src/cli/utils/onedrive.go
@@ -35,7 +35,7 @@ func MakeOneDriveOpts(cmd *cobra.Command) OneDriveOpts {
 		FileModifiedAfter:  flags.FileModifiedAfterFV,
 		FileModifiedBefore: flags.FileModifiedBeforeFV,
 
-		RestoreCfg: makeRestoreCfgOpts(cmd),
+		RestoreCfg: makeBaseRestoreCfgOpts(cmd),
 		ExportCfg:  makeExportCfgOpts(cmd),
 
 		// populated contains the list of flags that appear in the

--- a/src/cli/utils/restore_config.go
+++ b/src/cli/utils/restore_config.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/path"
 )
 
 type RestoreCfgOpts struct {
@@ -23,10 +24,18 @@ type RestoreCfgOpts struct {
 	ProtectedResource string
 	SkipPermissions   bool
 
+	// SubService is useful when we are trying to restore Groups where
+	// the user can only restore a single service at any point instead of
+	// the entire backup.
+	SubServiceType path.ServiceType
+	SubService     string
+
 	Populated flags.PopulatedFlags
 }
 
-func makeRestoreCfgOpts(cmd *cobra.Command) RestoreCfgOpts {
+// makeBaseRestoreCfgOpts fills in all RestoreCfgOpts except for sub
+// service details. That is filled by the caller.
+func makeBaseRestoreCfgOpts(cmd *cobra.Command) RestoreCfgOpts {
 	return RestoreCfgOpts{
 		Collisions:        flags.CollisionsFV,
 		Destination:       flags.DestinationFV,
@@ -73,6 +82,9 @@ func MakeRestoreConfig(
 
 	restoreCfg.ProtectedResource = opts.ProtectedResource
 	restoreCfg.IncludePermissions = !opts.SkipPermissions
+
+	restoreCfg.SubService.Type = opts.SubServiceType
+	restoreCfg.SubService.ID = opts.SubService
 
 	Infof(ctx, "Restoring to folder %s", restoreCfg.Location)
 

--- a/src/cli/utils/sharepoint.go
+++ b/src/cli/utils/sharepoint.go
@@ -56,7 +56,7 @@ func MakeSharePointOpts(cmd *cobra.Command) SharePointOpts {
 		Page:       flags.PageFV,
 		PageFolder: flags.PageFolderFV,
 
-		RestoreCfg: makeRestoreCfgOpts(cmd),
+		RestoreCfg: makeBaseRestoreCfgOpts(cmd),
 		ExportCfg:  makeExportCfgOpts(cmd),
 
 		// populated contains the list of flags that appear in the

--- a/src/internal/m365/controller.go
+++ b/src/internal/m365/controller.go
@@ -110,9 +110,9 @@ func NewController(
 	ctrl := Controller{
 		AC:           ac,
 		IDNameLookup: idname.NewCache(nil),
-		ownerLookup:  rCli,
 
 		credentials:        creds,
+		ownerLookup:        rCli,
 		tenant:             acct.ID(),
 		wg:                 &sync.WaitGroup{},
 		backupDriveIDNames: idname.NewCache(nil),

--- a/src/internal/m365/controller_test.go
+++ b/src/internal/m365/controller_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/m365/mock"
 	"github.com/alcionai/corso/src/internal/m365/resource"
+	"github.com/alcionai/corso/src/internal/m365/service/common"
 	exchMock "github.com/alcionai/corso/src/internal/m365/service/exchange/mock"
 	"github.com/alcionai/corso/src/internal/m365/stub"
 	"github.com/alcionai/corso/src/internal/m365/support"
@@ -57,18 +58,18 @@ func (suite *ControllerUnitSuite) TestPopulateOwnerIDAndNamesFrom() {
 	var (
 		itn    = map[string]string{id: name}
 		nti    = map[string]string{name: id}
-		lookup = &ResourceClient{
-			enum:   resource.Users,
-			getter: &mock.IDNameGetter{ID: id, Name: name},
+		lookup = &common.ResourceClient{
+			Enum:   resource.Users,
+			Getter: &mock.IDNameGetter{ID: id, Name: name},
 		}
-		noLookup = &ResourceClient{enum: resource.Users, getter: &mock.IDNameGetter{}}
+		noLookup = &common.ResourceClient{Enum: resource.Users, Getter: &mock.IDNameGetter{}}
 	)
 
 	table := []struct {
 		name              string
 		protectedResource string
 		ins               inMock.Cache
-		rc                *ResourceClient
+		rc                *common.ResourceClient
 		expectID          string
 		expectName        string
 		expectErr         require.ErrorAssertionFunc

--- a/src/internal/m365/controller_test.go
+++ b/src/internal/m365/controller_test.go
@@ -57,18 +57,18 @@ func (suite *ControllerUnitSuite) TestPopulateOwnerIDAndNamesFrom() {
 	var (
 		itn    = map[string]string{id: name}
 		nti    = map[string]string{name: id}
-		lookup = &resourceClient{
+		lookup = &ResourceClient{
 			enum:   resource.Users,
 			getter: &mock.IDNameGetter{ID: id, Name: name},
 		}
-		noLookup = &resourceClient{enum: resource.Users, getter: &mock.IDNameGetter{}}
+		noLookup = &ResourceClient{enum: resource.Users, getter: &mock.IDNameGetter{}}
 	)
 
 	table := []struct {
 		name              string
 		protectedResource string
 		ins               inMock.Cache
-		rc                *resourceClient
+		rc                *ResourceClient
 		expectID          string
 		expectName        string
 		expectErr         require.ErrorAssertionFunc

--- a/src/internal/m365/mock/connector.go
+++ b/src/internal/m365/mock/connector.go
@@ -50,6 +50,15 @@ func (ctrl Controller) ProduceBackupCollections(
 	return ctrl.Collections, ctrl.Exclude, ctrl.Err == nil, ctrl.Err
 }
 
+func (ctrl Controller) GetRestoreResource(
+	ctx context.Context,
+	service path.ServiceType,
+	rc control.RestoreConfig,
+	orig idname.Provider,
+) (path.ServiceType, idname.Provider, error) {
+	return service, orig, nil
+}
+
 func (ctrl *Controller) GetMetadataPaths(
 	ctx context.Context,
 	r kinject.RestoreProducer,

--- a/src/internal/m365/restore.go
+++ b/src/internal/m365/restore.go
@@ -53,6 +53,7 @@ func (ctrl *Controller) GetRestoreResource(
 	}
 
 	ctrl.IDNameLookup = idname.NewCache(map[string]string{pr.ID(): pr.Name()})
+
 	return svc, pr, nil
 }
 

--- a/src/internal/m365/service/common/lookup.go
+++ b/src/internal/m365/service/common/lookup.go
@@ -1,0 +1,94 @@
+package common
+
+import (
+	"context"
+
+	"github.com/alcionai/clues"
+
+	"github.com/alcionai/corso/src/internal/common/idname"
+	"github.com/alcionai/corso/src/internal/m365/graph"
+	"github.com/alcionai/corso/src/internal/m365/resource"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+)
+
+// ---------------------------------------------------------------------------
+// Resource Lookup Handling
+// ---------------------------------------------------------------------------
+
+func GetResourceClient(rc resource.Category, ac api.Client) (*resourceClient, error) {
+	switch rc {
+	case resource.Users:
+		return &resourceClient{enum: rc, getter: ac.Users()}, nil
+	case resource.Sites:
+		return &resourceClient{enum: rc, getter: ac.Sites()}, nil
+	case resource.Groups:
+		return &resourceClient{enum: rc, getter: ac.Groups()}, nil
+	default:
+		return nil, clues.New("unrecognized owner resource type").With("resource_enum", rc)
+	}
+}
+
+type resourceClient struct {
+	enum   resource.Category
+	getter getIDAndNamer
+}
+
+type getIDAndNamer interface {
+	GetIDAndName(
+		ctx context.Context,
+		owner string,
+		cc api.CallConfig,
+	) (
+		ownerID string,
+		ownerName string,
+		err error,
+	)
+}
+
+var _ idname.GetResourceIDAndNamer = &resourceClient{}
+
+// GetResourceIDAndNameFrom looks up the resource's canonical id and display name.
+// If the resource is present in the idNameSwapper, then that interface's id and
+// name values are returned.  As a fallback, the resource calls the discovery
+// api to fetch the user or site using the resource value. This fallback assumes
+// that the resource is a well formed ID or display name of appropriate design
+// (PrincipalName for users, WebURL for sites).
+func (r resourceClient) GetResourceIDAndNameFrom(
+	ctx context.Context,
+	owner string,
+	ins idname.Cacher,
+) (idname.Provider, error) {
+	if ins != nil {
+		if n, ok := ins.NameOf(owner); ok {
+			return idname.NewProvider(owner, n), nil
+		} else if i, ok := ins.IDOf(owner); ok {
+			return idname.NewProvider(i, owner), nil
+		}
+	}
+
+	ctx = clues.Add(ctx, "owner_identifier", owner)
+
+	var (
+		id, name string
+		err      error
+	)
+
+	id, name, err = r.getter.GetIDAndName(ctx, owner, api.CallConfig{})
+	if err != nil {
+		if graph.IsErrUserNotFound(err) {
+			return nil, clues.Stack(graph.ErrResourceOwnerNotFound, err)
+		}
+
+		if graph.IsErrResourceLocked(err) {
+			return nil, clues.Stack(graph.ErrResourceLocked, err)
+		}
+
+		return nil, err
+	}
+
+	if len(id) == 0 || len(name) == 0 {
+		return nil, clues.Stack(graph.ErrResourceOwnerNotFound)
+	}
+
+	return idname.NewProvider(id, name), nil
+}

--- a/src/internal/m365/service/common/lookup.go
+++ b/src/internal/m365/service/common/lookup.go
@@ -15,22 +15,22 @@ import (
 // Resource Lookup Handling
 // ---------------------------------------------------------------------------
 
-func GetResourceClient(rc resource.Category, ac api.Client) (*resourceClient, error) {
+func GetResourceClient(rc resource.Category, ac api.Client) (*ResourceClient, error) {
 	switch rc {
 	case resource.Users:
-		return &resourceClient{enum: rc, getter: ac.Users()}, nil
+		return &ResourceClient{Enum: rc, Getter: ac.Users()}, nil
 	case resource.Sites:
-		return &resourceClient{enum: rc, getter: ac.Sites()}, nil
+		return &ResourceClient{Enum: rc, Getter: ac.Sites()}, nil
 	case resource.Groups:
-		return &resourceClient{enum: rc, getter: ac.Groups()}, nil
+		return &ResourceClient{Enum: rc, Getter: ac.Groups()}, nil
 	default:
 		return nil, clues.New("unrecognized owner resource type").With("resource_enum", rc)
 	}
 }
 
-type resourceClient struct {
-	enum   resource.Category
-	getter getIDAndNamer
+type ResourceClient struct {
+	Enum   resource.Category
+	Getter getIDAndNamer
 }
 
 type getIDAndNamer interface {
@@ -45,7 +45,7 @@ type getIDAndNamer interface {
 	)
 }
 
-var _ idname.GetResourceIDAndNamer = &resourceClient{}
+var _ idname.GetResourceIDAndNamer = &ResourceClient{}
 
 // GetResourceIDAndNameFrom looks up the resource's canonical id and display name.
 // If the resource is present in the idNameSwapper, then that interface's id and
@@ -53,7 +53,7 @@ var _ idname.GetResourceIDAndNamer = &resourceClient{}
 // api to fetch the user or site using the resource value. This fallback assumes
 // that the resource is a well formed ID or display name of appropriate design
 // (PrincipalName for users, WebURL for sites).
-func (r resourceClient) GetResourceIDAndNameFrom(
+func (r ResourceClient) GetResourceIDAndNameFrom(
 	ctx context.Context,
 	owner string,
 	ins idname.Cacher,
@@ -73,7 +73,7 @@ func (r resourceClient) GetResourceIDAndNameFrom(
 		err      error
 	)
 
-	id, name, err = r.getter.GetIDAndName(ctx, owner, api.CallConfig{})
+	id, name, err = r.Getter.GetIDAndName(ctx, owner, api.CallConfig{})
 	if err != nil {
 		if graph.IsErrUserNotFound(err) {
 			return nil, clues.Stack(graph.ErrResourceOwnerNotFound, err)

--- a/src/internal/m365/service/exchange/restore_test.go
+++ b/src/internal/m365/service/exchange/restore_test.go
@@ -1,0 +1,84 @@
+package exchange
+
+import (
+	"testing"
+
+	"github.com/alcionai/clues"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/common/dttm"
+	"github.com/alcionai/corso/src/internal/common/idname"
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+)
+
+type ExchangeRestoreUnitSuite struct {
+	tester.Suite
+}
+
+func TestExchangeRestoreUnitSuite(t *testing.T) {
+	suite.Run(t, &ExchangeRestoreUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *ExchangeRestoreUnitSuite) TestGetRestoreResource() {
+	var (
+		id        = "id"
+		name      = "name"
+		cfgWithPR = control.DefaultRestoreConfig(dttm.HumanReadable)
+	)
+
+	cfgWithPR.ProtectedResource = id
+
+	table := []struct {
+		name           string
+		cfg            control.RestoreConfig
+		orig           idname.Provider
+		cache          map[string]string
+		expectErr      assert.ErrorAssertionFunc
+		expectProvider assert.ValueAssertionFunc
+		expectID       string
+		expectName     string
+	}{
+		{
+			name:       "use original",
+			cfg:        control.DefaultRestoreConfig(dttm.HumanReadable),
+			orig:       idname.NewProvider("oid", "oname"),
+			expectErr:  assert.NoError,
+			expectID:   "oid",
+			expectName: "oname",
+		},
+		{
+			name:       "use new",
+			cfg:        cfgWithPR,
+			orig:       idname.NewProvider("oid", "oname"),
+			cache:      map[string]string{id: name},
+			expectErr:  assert.NoError,
+			expectID:   id,
+			expectName: name,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			svc, result, err := GetRestoreResource(
+				ctx,
+				api.Client{},
+				test.cfg,
+				idname.NewCache(test.cache),
+				test.orig)
+			test.expectErr(t, err, clues.ToCore(err))
+			require.NotNil(t, result)
+			assert.Equal(t, path.ExchangeService, svc)
+			assert.Equal(t, test.expectID, result.ID())
+			assert.Equal(t, test.expectName, result.Name())
+		})
+	}
+}

--- a/src/internal/m365/service/groups/restore.go
+++ b/src/internal/m365/service/groups/restore.go
@@ -43,6 +43,10 @@ func GetRestoreResource(
 	}
 
 	if len(rc.ProtectedResource) == 0 {
+		if len(rc.SubService.ID) == 0 {
+			return path.UnknownService, nil, errors.New("missing subservice id for restore")
+		}
+
 		pr, err := res.GetResourceIDAndNameFrom(ctx, rc.SubService.ID, ins)
 		if err != nil {
 			return path.UnknownService, nil, clues.Wrap(err, "identifying resource owner")

--- a/src/internal/m365/service/onedrive/restore_test.go
+++ b/src/internal/m365/service/onedrive/restore_test.go
@@ -8,9 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/common/dttm"
+	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/version"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type RestoreUnitSuite struct {
@@ -312,6 +316,65 @@ func (suite *RestoreUnitSuite) TestAugmentRestorePaths_DifferentRestorePath() {
 			// Ordering of paths matter here as we need dirmeta files
 			// to show up before file in dir
 			assert.Equal(t, outPaths, actual, "augmented paths")
+		})
+	}
+}
+
+func (suite *RestoreUnitSuite) TestGetRestoreResource() {
+	var (
+		id        = "id"
+		name      = "name"
+		cfgWithPR = control.DefaultRestoreConfig(dttm.HumanReadable)
+	)
+
+	cfgWithPR.ProtectedResource = id
+
+	table := []struct {
+		name           string
+		cfg            control.RestoreConfig
+		orig           idname.Provider
+		cache          map[string]string
+		expectErr      assert.ErrorAssertionFunc
+		expectProvider assert.ValueAssertionFunc
+		expectID       string
+		expectName     string
+	}{
+		{
+			name:       "use original",
+			cfg:        control.DefaultRestoreConfig(dttm.HumanReadable),
+			orig:       idname.NewProvider("oid", "oname"),
+			expectErr:  assert.NoError,
+			expectID:   "oid",
+			expectName: "oname",
+		},
+		{
+			name:       "use new",
+			cfg:        cfgWithPR,
+			orig:       idname.NewProvider("oid", "oname"),
+			cache:      map[string]string{id: name},
+			expectErr:  assert.NoError,
+			expectID:   id,
+			expectName: name,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			svc, result, err := GetRestoreResource(
+				ctx,
+				api.Client{},
+				test.cfg,
+				idname.NewCache(test.cache),
+				test.orig)
+			test.expectErr(t, err, clues.ToCore(err))
+			require.NotNil(t, result)
+			assert.Equal(t, path.OneDriveService, svc)
+			assert.Equal(t, test.expectID, result.ID())
+			assert.Equal(t, test.expectName, result.Name())
 		})
 	}
 }

--- a/src/internal/m365/service/sharepoint/restore_test.go
+++ b/src/internal/m365/service/sharepoint/restore_test.go
@@ -1,0 +1,84 @@
+package sharepoint
+
+import (
+	"testing"
+
+	"github.com/alcionai/clues"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/common/dttm"
+	"github.com/alcionai/corso/src/internal/common/idname"
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+)
+
+type SharepointRestoreUnitSuite struct {
+	tester.Suite
+}
+
+func TestSharepointRestoreUnitSuite(t *testing.T) {
+	suite.Run(t, &SharepointRestoreUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *SharepointRestoreUnitSuite) TestGetRestoreResource() {
+	var (
+		id        = "id"
+		name      = "name"
+		cfgWithPR = control.DefaultRestoreConfig(dttm.HumanReadable)
+	)
+
+	cfgWithPR.ProtectedResource = id
+
+	table := []struct {
+		name           string
+		cfg            control.RestoreConfig
+		orig           idname.Provider
+		cache          map[string]string
+		expectErr      assert.ErrorAssertionFunc
+		expectProvider assert.ValueAssertionFunc
+		expectID       string
+		expectName     string
+	}{
+		{
+			name:       "use original",
+			cfg:        control.DefaultRestoreConfig(dttm.HumanReadable),
+			orig:       idname.NewProvider("oid", "oname"),
+			expectErr:  assert.NoError,
+			expectID:   "oid",
+			expectName: "oname",
+		},
+		{
+			name:       "use new",
+			cfg:        cfgWithPR,
+			orig:       idname.NewProvider("oid", "oname"),
+			cache:      map[string]string{id: name},
+			expectErr:  assert.NoError,
+			expectID:   id,
+			expectName: name,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			svc, result, err := GetRestoreResource(
+				ctx,
+				api.Client{},
+				test.cfg,
+				idname.NewCache(test.cache),
+				test.orig)
+			test.expectErr(t, err, clues.ToCore(err))
+			require.NotNil(t, result)
+			assert.Equal(t, path.SharePointService, svc)
+			assert.Equal(t, test.expectID, result.ID())
+			assert.Equal(t, test.expectName, result.Name())
+		})
+	}
+}

--- a/src/internal/operations/inject/inject.go
+++ b/src/internal/operations/inject/inject.go
@@ -45,6 +45,12 @@ type (
 	}
 
 	RestoreConsumer interface {
+		GetRestoreResource(
+			ctx context.Context,
+			service path.ServiceType,
+			rc control.RestoreConfig,
+			orig idname.Provider,
+		) (path.ServiceType, idname.Provider, error)
 		ConsumeRestoreCollections(
 			ctx context.Context,
 			rcc RestoreConsumerConfig,

--- a/src/internal/operations/restore_test.go
+++ b/src/internal/operations/restore_test.go
@@ -196,7 +196,7 @@ func (suite *RestoreOpUnitSuite) TestChooseRestoreResource() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			result, err := chooseRestoreResource(ctx, test.ctrl, test.cfg, test.orig)
+			svc, result, err := chooseRestoreResource(ctx, test.ctrl, test.cfg, test.orig)
 			test.expectErr(t, err, clues.ToCore(err))
 			require.NotNil(t, result)
 			assert.Equal(t, test.expectID, result.ID())

--- a/src/internal/operations/test/group_test.go
+++ b/src/internal/operations/test/group_test.go
@@ -42,6 +42,8 @@ func (suite *GroupsBackupIntgSuite) SetupSuite() {
 func (suite *GroupsBackupIntgSuite) TestBackup_Run_incrementalGroups() {
 	sel := selectors.NewGroupsRestore([]string{suite.its.group.ID})
 
+	// sel.Filter(sel.Site(suite.its.group.RootSite.ID))
+
 	ic := func(cs []string) selectors.Selector {
 		sel.Include(sel.LibraryFolders(cs, selectors.PrefixMatch()))
 		return sel.Selector

--- a/src/internal/operations/test/group_test.go
+++ b/src/internal/operations/test/group_test.go
@@ -199,7 +199,7 @@ type GroupsRestoreNightlyIntgSuite struct {
 	its intgTesterSetup
 }
 
-func TestGroupsRestoreIntgSuite(t *testing.T) {
+func TestGroupsRestoreNightlyIntgSuite(t *testing.T) {
 	suite.Run(t, &GroupsRestoreNightlyIntgSuite{
 		Suite: tester.NewNightlySuite(
 			t,
@@ -226,18 +226,18 @@ func (suite *GroupsRestoreNightlyIntgSuite) TestRestore_Run_groupsWithAdvancedOp
 		suite.its.group.RootSite.DriveRootFolderID)
 }
 
-// func (suite *GroupsRestoreNightlyIntgSuite) TestRestore_Run_groupsAlternateProtectedResource() {
-// 	sel := selectors.NewGroupsBackup([]string{suite.its.group.ID})
-// 	sel.Include(selTD.GroupsBackupLibraryFolderScope(sel))
-// 	sel.Filter(sel.Library("documents"))
-// 	sel.DiscreteOwner = suite.its.group.ID
+func (suite *GroupsRestoreNightlyIntgSuite) TestRestore_Run_groupsAlternateProtectedResource() {
+	sel := selectors.NewGroupsBackup([]string{suite.its.group.ID})
+	sel.Include(selTD.GroupsBackupLibraryFolderScope(sel))
+	sel.Filter(sel.Library("documents"))
+	sel.DiscreteOwner = suite.its.group.ID
 
-// 	runDriveRestoreToAlternateProtectedResource(
-// 		suite.T(),
-// 		suite,
-// 		suite.its.ac,
-// 		sel.Selector,
-// 		suite.its.group.RootSite,
-// 		suite.its.secondaryGroup.RootSite,
-// 		suite.its.secondaryGroup.ID)
-// }
+	runDriveRestoreToAlternateProtectedResource(
+		suite.T(),
+		suite,
+		suite.its.ac,
+		sel.Selector,
+		suite.its.group.RootSite,
+		suite.its.secondaryGroup.RootSite,
+		suite.its.secondaryGroup.ID)
+}

--- a/src/internal/operations/test/group_test.go
+++ b/src/internal/operations/test/group_test.go
@@ -239,5 +239,5 @@ func (suite *GroupsRestoreNightlyIntgSuite) TestRestore_Run_groupsAlternateProte
 		sel.Selector,
 		suite.its.group.RootSite,
 		suite.its.secondaryGroup.RootSite,
-		suite.its.secondaryGroup.ID)
+		suite.its.secondaryGroup.RootSite.ID)
 }

--- a/src/internal/operations/test/group_test.go
+++ b/src/internal/operations/test/group_test.go
@@ -222,8 +222,7 @@ func (suite *GroupsRestoreNightlyIntgSuite) TestRestore_Run_groupsWithAdvancedOp
 		suite,
 		suite.its.ac,
 		sel.Selector,
-		suite.its.group.RootSite.DriveID,
-		suite.its.group.RootSite.DriveRootFolderID)
+		suite.its.group.RootSite)
 }
 
 func (suite *GroupsRestoreNightlyIntgSuite) TestRestore_Run_groupsAlternateProtectedResource() {

--- a/src/internal/operations/test/onedrive_test.go
+++ b/src/internal/operations/test/onedrive_test.go
@@ -1050,6 +1050,12 @@ func runDriveRestoreWithAdvancedOptions(
 		acd                 = ac.Drives()
 	)
 
+	// Groups restore needs subservice information
+	if sel.Service == selectors.ServiceGroups {
+		restoreCfg.SubService.Type = path.SharePointService
+		restoreCfg.SubService.ID = driveID
+	}
+
 	// initial restore
 
 	suite.Run("baseline", func() {
@@ -1320,8 +1326,13 @@ func runDriveRestoreToAlternateProtectedResource(
 		acd               = ac.Drives()
 	)
 
-	// first restore to the 'from' resource
+	// Groups restore needs subservice information
+	if sel.Service == selectors.ServiceGroups {
+		restoreCfg.SubService.Type = path.SharePointService
+		restoreCfg.SubService.ID = driveFrom.ID
+	}
 
+	// first restore to the 'from' resource
 	suite.Run("restore original resource", func() {
 		mb = evmock.NewBus()
 		fromCtr := count.New()

--- a/src/internal/operations/test/sharepoint_test.go
+++ b/src/internal/operations/test/sharepoint_test.go
@@ -209,8 +209,7 @@ func (suite *SharePointRestoreNightlyIntgSuite) TestRestore_Run_sharepointWithAd
 		suite,
 		suite.its.ac,
 		sel.Selector,
-		suite.its.site.DriveID,
-		suite.its.site.DriveRootFolderID)
+		suite.its.site)
 }
 
 func (suite *SharePointRestoreNightlyIntgSuite) TestRestore_Run_sharepointAlternateProtectedResource() {

--- a/src/pkg/control/restore.go
+++ b/src/pkg/control/restore.go
@@ -38,6 +38,11 @@ func IsValidCollisionPolicy(cp CollisionPolicy) bool {
 
 const RootLocation = "/"
 
+type RestoreConfigSubService struct {
+	ID   string
+	Type path.ServiceType
+}
+
 // RestoreConfig contains
 type RestoreConfig struct {
 	// Defines the per-item collision handling policy.
@@ -48,6 +53,11 @@ type RestoreConfig struct {
 	// If empty, restores to the same resource that was backed up.
 	// Defaults to empty.
 	ProtectedResource string `json:"protectedResource"`
+
+	// SubService specifies the sub-service which we are restoring in
+	// case of services that are constructed out of multiple services
+	// like Groups.
+	SubService RestoreConfigSubService
 
 	// Location specifies the container into which the data will be restored.
 	// Only accepts container names, does not accept IDs.

--- a/src/pkg/control/restore_test.go
+++ b/src/pkg/control/restore_test.go
@@ -116,15 +116,18 @@ func (suite *RestoreUnitSuite) TestRestoreConfig_piiHandling() {
 		expectPlain string
 	}{
 		{
-			name:        "empty",
-			expectSafe:  `{"onCollision":"","protectedResource":"","location":"","drive":"","includePermissions":false}`,
-			expectPlain: `{"onCollision":"","protectedResource":"","location":"","drive":"","includePermissions":false}`,
+			name: "empty",
+			expectSafe: `{"onCollision":"","protectedResource":"","SubService":{"ID":"","Type":0}` +
+				`,"location":"","drive":"","includePermissions":false}`,
+			expectPlain: `{"onCollision":"","protectedResource":"","SubService":{"ID":"","Type":0}` +
+				`,"location":"","drive":"","includePermissions":false}`,
 		},
 		{
-			name:       "defaults",
-			rc:         cdrc,
-			expectSafe: `{"onCollision":"skip","protectedResource":"","location":"***","drive":"","includePermissions":false}`,
-			expectPlain: `{"onCollision":"skip","protectedResource":"","location":"` +
+			name: "defaults",
+			rc:   cdrc,
+			expectSafe: `{"onCollision":"skip","protectedResource":"","SubService":{"ID":"","Type":0}` +
+				`,"location":"***","drive":"","includePermissions":false}`,
+			expectPlain: `{"onCollision":"skip","protectedResource":"","SubService":{"ID":"","Type":0},"location":"` +
 				cdrc.Location + `","drive":"","includePermissions":false}`,
 		},
 		{
@@ -136,9 +139,11 @@ func (suite *RestoreUnitSuite) TestRestoreConfig_piiHandling() {
 				Drive:              "somedriveid",
 				IncludePermissions: true,
 			},
-			expectSafe: `{"onCollision":"copy","protectedResource":"***","location":"***/exchange/***/email/***/***/***",` +
+			expectSafe: `{"onCollision":"copy","protectedResource":"***","SubService":{"ID":"","Type":0}` +
+				`,"location":"***/exchange/***/email/***/***/***",` +
 				`"drive":"***","includePermissions":true}`,
-			expectPlain: `{"onCollision":"copy","protectedResource":"snoob","location":"tid/exchange/ro/email/foo/bar/baz",` +
+			expectPlain: `{"onCollision":"copy","protectedResource":"snoob","SubService":{"ID":"","Type":0}` +
+				`,"location":"tid/exchange/ro/email/foo/bar/baz",` +
 				`"drive":"somedriveid","includePermissions":true}`,
 		},
 	}

--- a/website/docs/support/known-issues.md
+++ b/website/docs/support/known-issues.md
@@ -33,5 +33,3 @@ Below is a list of known Corso issues and limitations:
 * Teams messages don't support Restore due to limited Graph API support for message creation.
 
 * Groups and Teams support is available in an early-access status, and may be subject to breaking changes.
-
-* Restoring the data into a different Group from the one it was backed up from isn't currently supported


### PR DESCRIPTION
This adds the option restore a site to a different one from the one that it was backed up from.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* fixes https://github.com/alcionai/corso/issues/4511

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
