### PR TITLE
Check if user provided webURL before trying to access it

### DIFF
--- a/src/cli/utils/groups.go
+++ b/src/cli/utils/groups.go
@@ -272,11 +272,11 @@ func FilterGroupsRestoreInfoSelectors(
 ) {
 	var site string
 
+	// It is possible that neither exists as this filter is only
+	// mandatory for restore and not for export.
 	if len(opts.SiteID) > 0 {
 		site = opts.SiteID[0]
-	} else {
-		// using else instead of else if so that it would have a hard
-		// fail in case we somehow miss checking this earlier
+	} else if len(opts.WebURL) > 0 {
 		site = opts.WebURL[0]
 	}
 


### PR DESCRIPTION
The check should have already happened in the CLI layer. And we cannot do the check here this function is also shared with export which might not have a filter.

Follow up to https://github.com/alcionai/corso/pull/4496

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
