### PR TITLE
Enhance OneNote skip check 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix a case where missing item LastModifiedTimes could cause incremental backups to fail.
 - Email size metadata was incorrectly set to the size of the last attachment.  Emails will now correctly report the size of the mail content plus the size of all attachments.
 - Improves the filtering capabilities for Groups restore and backup
+- Improve check to skip OneNote files that cannot be downloaded.
 
 ### Changed
 - Groups restore now expects the site whose backup we should restore

--- a/src/internal/m365/collection/drive/collection_test.go
+++ b/src/internal/m365/collection/drive/collection_test.go
@@ -531,11 +531,12 @@ func (suite *GetDriveItemUnitTestSuite) TestGetDriveItem_error() {
 	strval := "not-important"
 
 	table := []struct {
-		name     string
-		colScope collectionScope
-		itemSize int64
-		labels   []string
-		err      error
+		name         string
+		colScope     collectionScope
+		itemSize     int64
+		itemMimeType string
+		labels       []string
+		err          error
 	}{
 		{
 			name:     "Simple item fetch no error",
@@ -570,6 +571,14 @@ func (suite *GetDriveItemUnitTestSuite) TestGetDriveItem_error() {
 			itemSize: 10,
 			err:      clues.New("small onenote error").Label(graph.LabelStatus(http.StatusServiceUnavailable)),
 			labels:   []string{graph.LabelStatus(http.StatusServiceUnavailable), graph.LabelsSkippable},
+		},
+		{
+			name:         "small OneNote file",
+			colScope:     CollectionScopeFolder,
+			itemMimeType: oneNoteMimeType,
+			itemSize:     10,
+			err:          clues.New("small onenote error").Label(graph.LabelStatus(http.StatusServiceUnavailable)),
+			labels:       []string{graph.LabelStatus(http.StatusServiceUnavailable), graph.LabelsSkippable},
 		},
 		{
 			name:     "big OneNote file",
@@ -609,6 +618,8 @@ func (suite *GetDriveItemUnitTestSuite) TestGetDriveItem_error() {
 				now,
 				true,
 				false)
+
+			stubItem.GetFile().SetMimeType(&test.itemMimeType)
 
 			mbh := mock.DefaultOneDriveBH("a-user")
 			mbh.GI = mock.GetsItem{Item: stubItem}


### PR DESCRIPTION
This enhances the check that allows skipping OneNote files that cannot be downloaded
with a mime type check.

This handles cases where the folder the item is in does not have the `package` facet.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
