### PR TITLE
Fix backup of Groups without an associated Team

### DIFF
--- a/src/cli/backup/groups_e2e_test.go
+++ b/src/cli/backup/groups_e2e_test.go
@@ -517,7 +517,7 @@ func (suite *BackupDeleteGroupsE2ESuite) SetupSuite() {
 
 	suite.dpnd = prepM365Test(t, ctx, path.GroupsService)
 
-	m365GroupID := tconfig.M365GroupID(t)
+	m365GroupID := tconfig.M365TeamID(t)
 	groups := []string{m365GroupID}
 
 	// some tests require an existing backup

--- a/src/internal/m365/backup_test.go
+++ b/src/internal/m365/backup_test.go
@@ -511,7 +511,7 @@ func (suite *GroupsCollectionIntgSuite) TestCreateGroupsCollection_SharePoint() 
 	defer flush()
 
 	var (
-		groupID  = tconfig.M365GroupID(t)
+		groupID  = tconfig.M365TeamID(t)
 		ctrl     = newController(ctx, t, path.GroupsService)
 		groupIDs = []string{groupID}
 	)
@@ -585,7 +585,7 @@ func (suite *GroupsCollectionIntgSuite) TestCreateGroupsCollection_SharePoint_In
 	defer flush()
 
 	var (
-		groupID  = tconfig.M365GroupID(t)
+		groupID  = tconfig.M365TeamID(t)
 		ctrl     = newController(ctx, t, path.GroupsService)
 		groupIDs = []string{groupID}
 	)

--- a/src/internal/m365/collection/groups/backup_test.go
+++ b/src/internal/m365/collection/groups/backup_test.go
@@ -470,7 +470,7 @@ func (suite *BackupIntgSuite) SetupSuite() {
 
 func (suite *BackupIntgSuite) TestCreateCollections() {
 	var (
-		protectedResource = tconfig.M365GroupID(suite.T())
+		protectedResource = tconfig.M365TeamID(suite.T())
 		resources         = []string{protectedResource}
 		handler           = NewChannelBackupHandler(protectedResource, suite.ac.Channels())
 	)

--- a/src/internal/tester/tconfig/config.go
+++ b/src/internal/tester/tconfig/config.go
@@ -184,13 +184,13 @@ func ReadTestConfig() (map[string]string, error) {
 		TestCfgGroupID,
 		os.Getenv(EnvCorsoM365TestGroupID),
 		vpr.GetString(TestCfgGroupID),
-		"6f24b40d-b13d-4752-980f-f5fb9fba7aa0")
+		"87d622a5-fb64-4fa4-a324-3dd620afe0bd") // CINonTeamGroup (create one without teams)
 	fallbackTo(
 		testEnv,
 		TestCfgSecondaryGroupID,
 		os.Getenv(EnvCorsoSecondaryM365TestGroupID),
 		vpr.GetString(TestCfgSecondaryGroupID),
-		"20cda3c0-6f9a-4286-9f2f-bb284e1f79c9")
+		"cd260eff-834f-4cc3-b3bf-0aad1c9b8b7e") // CINonTeamGroup2 (create one without teams)
 	fallbackTo(
 		testEnv,
 		TestCfgSiteURL,

--- a/src/internal/tester/tconfig/protected_resources.go
+++ b/src/internal/tester/tconfig/protected_resources.go
@@ -278,9 +278,10 @@ func SecondaryM365TeamID(t *testing.T) string {
 // by either the env var CORSO_M365_TEST_GROUP_ID, the corso_test.toml config
 // file or the default value (in that order of priority).  The default is a
 // last-attempt fallback that will only work on alcion's testing org.
+// NOTE: This Group will not have a Team associated with it.
 func M365GroupID(t *testing.T) string {
 	cfg, err := ReadTestConfig()
 	require.NoError(t, err, "retrieving m365 group id from test configuration: %+v", clues.ToCore(err))
 
-	return strings.ToLower(cfg[TestCfgTeamID])
+	return strings.ToLower(cfg[TestCfgGroupID])
 }

--- a/src/pkg/services/m365/api/groups.go
+++ b/src/pkg/services/m365/api/groups.go
@@ -182,6 +182,19 @@ func (c Groups) GetAllSites(
 
 	sites := []models.Siteable{root}
 
+	group, err := c.Groups().GetByID(
+		ctx,
+		identifier,
+		CallConfig{})
+	if err != nil {
+		return nil, clues.Wrap(err, "getting group").WithClues(ctx)
+	}
+
+	isTeam := IsTeam(ctx, group)
+	if !isTeam {
+		return sites, nil
+	}
+
 	channels, err := Channels(c).GetChannels(ctx, identifier)
 	if err != nil {
 		return nil, clues.Wrap(err, "getting channels")

--- a/src/pkg/services/m365/api/groups_test.go
+++ b/src/pkg/services/m365/api/groups_test.go
@@ -137,6 +137,24 @@ func (suite *GroupsIntgSuite) TestGetAllSites() {
 	require.Equal(t, siteCount, len(sites), "incorrect number of sites")
 }
 
+// GetAllSites for Groups that are not Teams should return just the root site
+func (suite *GroupsIntgSuite) TestGetAllSitesNonTeam() {
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	group, err := suite.its.ac.Groups().GetByID(ctx, suite.its.nonTeamGroup.id, api.CallConfig{})
+	require.NoError(t, err)
+	require.False(t, api.IsTeam(ctx, group), "group should not be a team for this test")
+
+	sites, err := suite.its.ac.
+		Groups().
+		GetAllSites(ctx, suite.its.nonTeamGroup.id, fault.New(true))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(sites), "incorrect number of sites")
+}
+
 func (suite *GroupsIntgSuite) TestGroups_GetByID() {
 	t := suite.T()
 

--- a/src/pkg/services/m365/api/helper_test.go
+++ b/src/pkg/services/m365/api/helper_test.go
@@ -83,11 +83,12 @@ type ids struct {
 }
 
 type intgTesterSetup struct {
-	ac     api.Client
-	gockAC api.Client
-	user   ids
-	site   ids
-	group  ids
+	ac           api.Client
+	gockAC       api.Client
+	user         ids
+	site         ids
+	group        ids
+	nonTeamGroup ids // group which does not have an associated team
 }
 
 func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
@@ -141,6 +142,8 @@ func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
 	// use of the TeamID is intentional here, so that we are assured
 	// the group has full usage of the teams api.
 	its.group.id = tconfig.M365TeamID(t)
+
+	its.nonTeamGroup.id = tconfig.M365GroupID(t)
 
 	channel, err := its.ac.Channels().
 		GetChannelByName(


### PR DESCRIPTION
Previously we were trying to fetch channels of Groups without channels.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
