### PR TITLE
Don't update prev delta url

### DIFF
--- a/src/internal/m365/collection/drive/url_cache.go
+++ b/src/internal/m365/collection/drive/url_cache.go
@@ -176,7 +176,7 @@ func (uc *urlCache) refreshCache(
 		}
 	}
 
-	du, err := pager.Results()
+	_, err := pager.Results()
 	if err != nil {
 		return clues.Stack(err)
 	}
@@ -185,7 +185,6 @@ func (uc *urlCache) refreshCache(
 
 	// Update last refresh time
 	uc.lastRefreshTime = time.Now()
-	uc.prevDelta = du.URL
 
 	return nil
 }


### PR DESCRIPTION
<!-- PR description-->

URL cache should use the same delta token base used by `ProduceCollections`. This is because we want to update URLs for the set of items which was discovered by `ProduceCollections`. Otherwise, we'll have url cache misses & we'll have to resort to doing GetItem graph calls for each item which means we lose all goodness of the url cacche.

This reverts a change introduced in a recent [PR](https://github.com/alcionai/corso/commit/5215e907b05c25415e738c21a1292d33f74e3419#diff-f79ab9c9b31db3600d4e14b6df4d4c679b4356e32c3a68eaeaeb934c1c5a13a7R175) where we are updating cache's delta token base to a newer one. 

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
