### PR TITLE
rename group handler interface

### DIFF
--- a/src/internal/m365/collection/groups/backup.go
+++ b/src/internal/m365/collection/groups/backup.go
@@ -58,7 +58,7 @@ func CreateCollections(
 
 	ctx = clues.Add(ctx, "can_use_previous_backup", canUsePreviousBackup)
 
-	channels, err := bh.getChannels(ctx)
+	channels, err := bh.getContainers(ctx)
 	if err != nil {
 		return nil, false, clues.Stack(err)
 	}
@@ -154,7 +154,7 @@ func populateCollections(
 		// and will return an error if a delta token is queried.
 		canMakeDeltaQueries := len(ptr.Val(c.GetEmail())) > 0
 
-		add, _, rem, du, err := bh.getChannelMessageIDs(ctx, cID, prevDelta, canMakeDeltaQueries)
+		add, _, rem, du, err := bh.getContainerItemIDs(ctx, cID, prevDelta, canMakeDeltaQueries)
 		if err != nil {
 			el.AddRecoverable(ctx, clues.Stack(err))
 			continue

--- a/src/internal/m365/collection/groups/backup_test.go
+++ b/src/internal/m365/collection/groups/backup_test.go
@@ -49,11 +49,11 @@ type mockBackupHandler struct {
 	doNotInclude  bool
 }
 
-func (bh mockBackupHandler) getChannels(context.Context) ([]models.Channelable, error) {
+func (bh mockBackupHandler) getContainers(context.Context) ([]models.Channelable, error) {
 	return bh.channels, bh.channelsErr
 }
 
-func (bh mockBackupHandler) getChannelMessageIDs(
+func (bh mockBackupHandler) getContainerItemIDs(
 	_ context.Context,
 	_, _ string,
 	_ bool,
@@ -89,7 +89,7 @@ func (bh mockBackupHandler) canonicalPath(
 			false)
 }
 
-func (bh mockBackupHandler) GetChannelMessage(
+func (bh mockBackupHandler) GetItemByID(
 	_ context.Context,
 	_, _, itemID string,
 ) (models.ChatMessageable, *details.GroupsInfo, error) {

--- a/src/internal/m365/collection/groups/channel_handler.go
+++ b/src/internal/m365/collection/groups/channel_handler.go
@@ -31,13 +31,13 @@ func NewChannelBackupHandler(
 	}
 }
 
-func (bh channelsBackupHandler) getChannels(
+func (bh channelsBackupHandler) getContainers(
 	ctx context.Context,
 ) ([]models.Channelable, error) {
 	return bh.ac.GetChannels(ctx, bh.protectedResource)
 }
 
-func (bh channelsBackupHandler) getChannelMessageIDs(
+func (bh channelsBackupHandler) getContainerItemIDs(
 	ctx context.Context,
 	channelID, prevDelta string,
 	canMakeDeltaQueries bool,
@@ -76,9 +76,9 @@ func (bh channelsBackupHandler) PathPrefix(tenantID string) (path.Path, error) {
 		false)
 }
 
-func (bh channelsBackupHandler) GetChannelMessage(
+func (bh channelsBackupHandler) GetItemByID(
 	ctx context.Context,
-	teamID, channelID, itemID string,
+	groupID, channelID, itemID string,
 ) (models.ChatMessageable, *details.GroupsInfo, error) {
-	return bh.ac.GetChannelMessage(ctx, teamID, channelID, itemID)
+	return bh.ac.GetChannelMessage(ctx, groupID, channelID, itemID)
 }

--- a/src/internal/m365/collection/groups/collection.go
+++ b/src/internal/m365/collection/groups/collection.go
@@ -35,7 +35,7 @@ type Collection struct {
 	// removed is a list of item IDs that were deleted from, or moved out, of a container
 	removed map[string]struct{}
 
-	getter getChannelMessager
+	getter getItemByIDer
 
 	statusUpdater support.StatusUpdater
 }
@@ -48,7 +48,7 @@ type Collection struct {
 // or notMoved (if they match).
 func NewCollection(
 	baseCol data.BaseCollection,
-	getter getChannelMessager,
+	getter getItemByIDer,
 	protectedResource string,
 	added map[string]struct{},
 	removed map[string]struct{},
@@ -144,7 +144,7 @@ func (col *Collection) streamItems(ctx context.Context, errs *fault.Bus) {
 			flds := col.FullPath().Folders()
 			parentFolderID := flds[len(flds)-1]
 
-			item, info, err := col.getter.GetChannelMessage(
+			item, info, err := col.getter.GetItemByID(
 				ctx,
 				col.protectedResource,
 				parentFolderID,

--- a/src/internal/m365/collection/groups/handlers.go
+++ b/src/internal/m365/collection/groups/handlers.go
@@ -14,21 +14,21 @@ import (
 )
 
 type backupHandler interface {
-	getChannelMessager
+	getItemByIDer
 
-	// gets all channels for the group
-	getChannels(
+	// gets all containers for the resource
+	getContainers(
 		ctx context.Context,
 	) ([]models.Channelable, error)
 
-	// gets all message IDs (by delta, if possible) in the channel
-	getChannelMessageIDs(
+	// gets all item IDs (by delta, if possible) in the container
+	getContainerItemIDs(
 		ctx context.Context,
-		channelID, prevDelta string,
+		containerID, prevDelta string,
 		canMakeDeltaQueries bool,
 	) (map[string]time.Time, bool, []string, api.DeltaUpdate, error)
 
-	// includeContainer evaluates whether the channel is included
+	// includeContainer evaluates whether the container is included
 	// in the provided scope.
 	includeContainer(
 		ctx context.Context,
@@ -45,9 +45,9 @@ type backupHandler interface {
 	) (path.Path, error)
 }
 
-type getChannelMessager interface {
-	GetChannelMessage(
+type getItemByIDer interface {
+	GetItemByID(
 		ctx context.Context,
-		teamID, channelID, itemID string,
+		resourceID, containerID, itemID string,
 	) (models.ChatMessageable, *details.GroupsInfo, error)
 }

--- a/src/internal/m365/collection/groups/mock/getter.go
+++ b/src/internal/m365/collection/groups/mock/getter.go
@@ -13,12 +13,12 @@ type GetChannelMessage struct {
 	Err error
 }
 
-func (m GetChannelMessage) GetChannelMessage(
+func (m GetChannelMessage) GetItemByID(
 	ctx context.Context,
-	teamID, channelID, itemID string,
+	groupID, channelID, messageID string,
 ) (models.ChatMessageable, *details.GroupsInfo, error) {
 	msg := models.NewChatMessage()
-	msg.SetId(ptr.To(itemID))
+	msg.SetId(ptr.To(messageID))
 
 	return msg, &details.GroupsInfo{}, m.Err
 }


### PR DESCRIPTION
renames methods in the group handler interface
to replace the channel-specific vocabulary with the more standard and generic "containers" and
"items" naming conventions.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
