### PR TITLE
expose sitesInGroup to sdk consumers

### DIFF
--- a/src/pkg/services/m365/groups.go
+++ b/src/pkg/services/m365/groups.go
@@ -36,7 +36,7 @@ func GroupByID(
 ) (*Group, error) {
 	ac, err := makeAC(ctx, acct, path.GroupsService)
 	if err != nil {
-		return nil, clues.Stack(err).WithClues(ctx)
+		return nil, clues.Stack(err)
 	}
 
 	cc := api.CallConfig{}
@@ -69,7 +69,7 @@ func Groups(
 ) ([]*Group, error) {
 	ac, err := makeAC(ctx, acct, path.GroupsService)
 	if err != nil {
-		return nil, clues.Stack(err).WithClues(ctx)
+		return nil, clues.Stack(err)
 	}
 
 	return getAllGroups(ctx, ac.Groups())
@@ -96,6 +96,31 @@ func getAllGroups(
 	}
 
 	return ret, nil
+}
+
+func SitesInGroup(
+	ctx context.Context,
+	acct account.Account,
+	groupID string,
+	errs *fault.Bus,
+) ([]*Site, error) {
+	ac, err := makeAC(ctx, acct, path.GroupsService)
+	if err != nil {
+		return nil, clues.Stack(err)
+	}
+
+	sites, err := ac.Groups().GetAllSites(ctx, groupID, errs)
+	if err != nil {
+		return nil, clues.Stack(err)
+	}
+
+	result := make([]*Site, 0, len(sites))
+
+	for _, site := range sites {
+		result = append(result, ParseSite(site))
+	}
+
+	return result, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/services/m365/m365.go
+++ b/src/pkg/services/m365/m365.go
@@ -33,12 +33,12 @@ func makeAC(
 
 	creds, err := acct.M365Config()
 	if err != nil {
-		return api.Client{}, clues.Wrap(err, "getting m365 account creds")
+		return api.Client{}, clues.Wrap(err, "getting m365 account creds").WithClues(ctx)
 	}
 
 	cli, err := api.NewClient(creds, control.DefaultOptions())
 	if err != nil {
-		return api.Client{}, clues.Wrap(err, "constructing api client")
+		return api.Client{}, clues.Wrap(err, "constructing api client").WithClues(ctx)
 	}
 
 	return cli, nil

--- a/src/pkg/services/m365/sites.go
+++ b/src/pkg/services/m365/sites.go
@@ -56,7 +56,7 @@ func SiteByID(
 ) (*Site, error) {
 	ac, err := makeAC(ctx, acct, path.SharePointService)
 	if err != nil {
-		return nil, clues.Stack(err).WithClues(ctx)
+		return nil, clues.Stack(err)
 	}
 
 	cc := api.CallConfig{
@@ -75,7 +75,7 @@ func SiteByID(
 func Sites(ctx context.Context, acct account.Account, errs *fault.Bus) ([]*Site, error) {
 	ac, err := makeAC(ctx, acct, path.SharePointService)
 	if err != nil {
-		return nil, clues.Stack(err).WithClues(ctx)
+		return nil, clues.Stack(err)
 	}
 
 	return getAllSites(ctx, ac.Sites())

--- a/src/pkg/services/m365/users.go
+++ b/src/pkg/services/m365/users.go
@@ -42,7 +42,7 @@ func UsersCompatNoInfo(ctx context.Context, acct account.Account) ([]*UserNoInfo
 func UserHasMailbox(ctx context.Context, acct account.Account, userID string) (bool, error) {
 	ac, err := makeAC(ctx, acct, path.ExchangeService)
 	if err != nil {
-		return false, clues.Stack(err).WithClues(ctx)
+		return false, clues.Stack(err)
 	}
 
 	return exchange.IsServiceEnabled(ctx, ac.Users(), userID)
@@ -55,7 +55,7 @@ func UserGetMailboxInfo(
 ) (api.MailboxInfo, error) {
 	ac, err := makeAC(ctx, acct, path.ExchangeService)
 	if err != nil {
-		return api.MailboxInfo{}, clues.Stack(err).WithClues(ctx)
+		return api.MailboxInfo{}, clues.Stack(err)
 	}
 
 	return exchange.GetMailboxInfo(ctx, ac.Users(), userID)
@@ -66,7 +66,7 @@ func UserGetMailboxInfo(
 func UserHasDrives(ctx context.Context, acct account.Account, userID string) (bool, error) {
 	ac, err := makeAC(ctx, acct, path.OneDriveService)
 	if err != nil {
-		return false, clues.Stack(err).WithClues(ctx)
+		return false, clues.Stack(err)
 	}
 
 	return onedrive.IsServiceEnabled(ctx, ac.Users(), userID)
@@ -76,7 +76,7 @@ func UserHasDrives(ctx context.Context, acct account.Account, userID string) (bo
 func usersNoInfo(ctx context.Context, acct account.Account, errs *fault.Bus) ([]*UserNoInfo, error) {
 	ac, err := makeAC(ctx, acct, path.UnknownService)
 	if err != nil {
-		return nil, clues.Stack(err).WithClues(ctx)
+		return nil, clues.Stack(err)
 	}
 
 	us, err := ac.Users().GetAll(ctx, errs)


### PR DESCRIPTION
exposes the m365 api call to get all sites in a group to the sdk service interface.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
