### PR TITLE
introduce debug commands

### DIFF
--- a/src/cli/debug/debug.go
+++ b/src/cli/debug/debug.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/alcionai/corso/src/cli/flags"
 	. "github.com/alcionai/corso/src/cli/print"
 	"github.com/alcionai/corso/src/cli/utils"
 	"github.com/alcionai/corso/src/pkg/selectors"
@@ -31,6 +32,8 @@ func AddCommands(cmd *cobra.Command) {
 
 		for _, addTo := range debugCommands {
 			addTo(subCommand)
+			flags.AddAllProviderFlags(subCommand)
+			flags.AddAllStorageFlags(subCommand)
 		}
 	}
 }

--- a/src/cli/debug/debug.go
+++ b/src/cli/debug/debug.go
@@ -1,0 +1,102 @@
+package debug
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	. "github.com/alcionai/corso/src/cli/print"
+	"github.com/alcionai/corso/src/cli/utils"
+	"github.com/alcionai/corso/src/pkg/selectors"
+)
+
+var subCommandFuncs = []func() *cobra.Command{
+	metadataFilesCmd,
+}
+
+var debugCommands = []func(cmd *cobra.Command) *cobra.Command{
+	addOneDriveCommands,
+	addSharePointCommands,
+	addGroupsCommands,
+	addExchangeCommands,
+}
+
+// AddCommands attaches all `corso debug * *` commands to the parent.
+func AddCommands(cmd *cobra.Command) {
+	debugC, _ := utils.AddCommand(cmd, debugCmd(), utils.MarkDebugCommand())
+
+	for _, sc := range subCommandFuncs {
+		subCommand := sc()
+		utils.AddCommand(debugC, subCommand, utils.MarkDebugCommand())
+
+		for _, addBackupTo := range debugCommands {
+			addBackupTo(subCommand)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+const debugCommand = "debug"
+
+// The debug category of commands.
+// `corso debug [<subcommand>] [<flag>...]`
+func debugCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   debugCommand,
+		Short: "debug your service data",
+		Long:  `debug the data stored in one of your M365 services.`,
+		RunE:  handledebugCmd,
+		Args:  cobra.NoArgs,
+	}
+}
+
+// Handler for flat calls to `corso debug`.
+// Produces the same output as `corso debug --help`.
+func handledebugCmd(cmd *cobra.Command, args []string) error {
+	return cmd.Help()
+}
+
+// The backup metadataFiles subcommand.
+// `corso backup metadata-files <service> [<flag>...]`
+var metadataFilesCommand = "metadata-files"
+
+func metadataFilesCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   metadataFilesCommand,
+		Short: "Display all the metadata file contents stored by the service",
+		RunE:  handleMetadataFilesCmd,
+		Args:  cobra.NoArgs,
+	}
+}
+
+// Handler for calls to `corso backup metadata-files`.
+// Produces the same output as `corso backup metadata-files --help`.
+func handleMetadataFilesCmd(cmd *cobra.Command, args []string) error {
+	return cmd.Help()
+}
+
+// ---------------------------------------------------------------------------
+// runners
+// ---------------------------------------------------------------------------
+
+func runMetadataFiles(
+	ctx context.Context,
+	cmd *cobra.Command,
+	args []string,
+	sel selectors.Selector,
+	backupID, serviceName string,
+) error {
+	r, _, err := utils.GetAccountAndConnect(ctx, cmd, sel.PathService())
+	if err != nil {
+		return Only(ctx, err)
+	}
+
+	defer utils.CloseRepo(ctx, r)
+
+	// TODO: read and print out all metadata files in the backup
+
+	return nil
+}

--- a/src/cli/debug/debug.go
+++ b/src/cli/debug/debug.go
@@ -29,8 +29,8 @@ func AddCommands(cmd *cobra.Command) {
 		subCommand := sc()
 		utils.AddCommand(debugC, subCommand, utils.MarkDebugCommand())
 
-		for _, addBackupTo := range debugCommands {
-			addBackupTo(subCommand)
+		for _, addTo := range debugCommands {
+			addTo(subCommand)
 		}
 	}
 }
@@ -46,8 +46,8 @@ const debugCommand = "debug"
 func debugCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   debugCommand,
-		Short: "debug your service data",
-		Long:  `debug the data stored in one of your M365 services.`,
+		Short: "debugging & troubleshooting utilities",
+		Long:  `debug the data stored in corso.`,
 		RunE:  handledebugCmd,
 		Args:  cobra.NoArgs,
 	}
@@ -59,21 +59,21 @@ func handledebugCmd(cmd *cobra.Command, args []string) error {
 	return cmd.Help()
 }
 
-// The backup metadataFiles subcommand.
-// `corso backup metadata-files <service> [<flag>...]`
+// The debug metadataFiles subcommand.
+// `corso debug metadata-files <service> [<flag>...]`
 var metadataFilesCommand = "metadata-files"
 
 func metadataFilesCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   metadataFilesCommand,
-		Short: "Display all the metadata file contents stored by the service",
+		Short: "display all the metadata file contents stored by the service",
 		RunE:  handleMetadataFilesCmd,
 		Args:  cobra.NoArgs,
 	}
 }
 
-// Handler for calls to `corso backup metadata-files`.
-// Produces the same output as `corso backup metadata-files --help`.
+// Handler for calls to `corso debug metadata-files`.
+// Produces the same output as `corso debug metadata-files --help`.
 func handleMetadataFilesCmd(cmd *cobra.Command, args []string) error {
 	return cmd.Help()
 }
@@ -87,7 +87,7 @@ func runMetadataFiles(
 	cmd *cobra.Command,
 	args []string,
 	sel selectors.Selector,
-	backupID, serviceName string,
+	debugID, serviceName string,
 ) error {
 	r, _, err := utils.GetAccountAndConnect(ctx, cmd, sel.PathService())
 	if err != nil {
@@ -96,7 +96,7 @@ func runMetadataFiles(
 
 	defer utils.CloseRepo(ctx, r)
 
-	// TODO: read and print out all metadata files in the backup
+	// TODO: read and print out all metadata files in the debug
 
 	return nil
 }

--- a/src/cli/debug/exchange.go
+++ b/src/cli/debug/exchange.go
@@ -1,0 +1,73 @@
+package debug
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/alcionai/corso/src/cli/flags"
+	"github.com/alcionai/corso/src/cli/utils"
+	"github.com/alcionai/corso/src/pkg/selectors"
+)
+
+// called by debug.go to map subcommands to provider-specific handling.
+func addExchangeCommands(cmd *cobra.Command) *cobra.Command {
+	var (
+		c  *cobra.Command
+		fs *pflag.FlagSet
+	)
+
+	switch cmd.Use {
+	case metadataFilesCommand:
+		c, fs = utils.AddCommand(cmd, exchangeMetadataFilesCmd(), utils.MarkDebugCommand())
+
+		c.Use = c.Use + " " + exchangeServiceCommandUseSuffix
+
+		// Flags addition ordering should follow the order we want them to appear in help and docs:
+		// More generic (ex: --user) and more frequently used flags take precedence.
+		fs.SortFlags = false
+
+		flags.AddBackupIDFlag(c, true)
+		flags.AddCorsoPassphaseFlags(c)
+		flags.AddAWSCredsFlags(c)
+	}
+
+	return c
+}
+
+const (
+	exchangeServiceCommand          = "exchange"
+	exchangeServiceCommandUseSuffix = "--backup <backupId>"
+
+	//nolint:lll
+	exchangeServiceCommandDebugExamples = `# Display file contents for backup 1234abcd
+corso debug metadata-files exchange --backup 1234abcd-12ab-cd34-56de-1234abcd`
+)
+
+// `corso debug metadata-files exchange [<flag>...] <destination>`
+func exchangeMetadataFilesCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     exchangeServiceCommand,
+		Short:   "Display exchange metadata file content",
+		RunE:    metadataFilesExchangeCmd,
+		Args:    cobra.NoArgs,
+		Example: exchangeServiceCommandDebugExamples,
+	}
+}
+
+func metadataFilesExchangeCmd(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	if utils.HasNoFlagsAndShownHelp(cmd) {
+		return nil
+	}
+
+	// opts := utils.MakeExchangeOpts(cmd)
+
+	if flags.RunModeFV == flags.RunModeFlagTest {
+		return nil
+	}
+
+	sel := selectors.NewExchangeBackup([]string{"me"})
+
+	return runMetadataFiles(ctx, cmd, args, sel.Selector, flags.BackupIDFV, "Exchange")
+}

--- a/src/cli/debug/exchange.go
+++ b/src/cli/debug/exchange.go
@@ -27,8 +27,6 @@ func addExchangeCommands(cmd *cobra.Command) *cobra.Command {
 		fs.SortFlags = false
 
 		flags.AddBackupIDFlag(c, true)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
 	}
 
 	return c

--- a/src/cli/debug/exchange.go
+++ b/src/cli/debug/exchange.go
@@ -67,7 +67,7 @@ func metadataFilesExchangeCmd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	sel := selectors.NewExchangeBackup([]string{"me"})
+	sel := selectors.NewExchangeBackup([]string{"unused-placeholder"})
 
 	return runMetadataFiles(ctx, cmd, args, sel.Selector, flags.BackupIDFV, "Exchange")
 }

--- a/src/cli/debug/exchange_test.go
+++ b/src/cli/debug/exchange_test.go
@@ -1,0 +1,77 @@
+package debug
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/cli/flags"
+	flagsTD "github.com/alcionai/corso/src/cli/flags/testdata"
+	cliTD "github.com/alcionai/corso/src/cli/testdata"
+	"github.com/alcionai/corso/src/internal/tester"
+)
+
+type ExchangeUnitSuite struct {
+	tester.Suite
+}
+
+func TestExchangeUnitSuite(t *testing.T) {
+	suite.Run(t, &ExchangeUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *ExchangeUnitSuite) TestAddExchangeCommands() {
+	expectUse := exchangeServiceCommand + " " + exchangeServiceCommandUseSuffix
+
+	table := []struct {
+		name        string
+		use         string
+		expectUse   string
+		expectShort string
+		expectRunE  func(*cobra.Command, []string) error
+	}{
+		{
+			name:        "metdata-files exchange",
+			use:         metadataFilesCommand,
+			expectUse:   expectUse,
+			expectShort: exchangeMetadataFilesCmd().Short,
+			expectRunE:  metadataFilesExchangeCmd,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+			parent := &cobra.Command{Use: metadataFilesCommand}
+
+			cmd := cliTD.SetUpCmdHasFlags(
+				t,
+				parent,
+				addExchangeCommands,
+				[]cliTD.UseCobraCommandFn{
+					flags.AddAllProviderFlags,
+					flags.AddAllStorageFlags,
+				},
+				flagsTD.WithFlags(
+					exchangeServiceCommand,
+					[]string{
+						flagsTD.RestoreDestination,
+						"--" + flags.RunModeFN, flags.RunModeFlagTest,
+						"--" + flags.BackupFN, flagsTD.BackupInput,
+					},
+					flagsTD.PreparedProviderFlags(),
+					flagsTD.PreparedStorageFlags()))
+
+			cliTD.CheckCmdChild(
+				t,
+				parent,
+				3,
+				test.expectUse,
+				test.expectShort,
+				test.expectRunE)
+
+			assert.Equal(t, flagsTD.BackupInput, flags.BackupIDFV)
+			flagsTD.AssertStorageFlags(t, cmd)
+		})
+	}
+}

--- a/src/cli/debug/exchange_test.go
+++ b/src/cli/debug/exchange_test.go
@@ -21,7 +21,7 @@ func TestExchangeUnitSuite(t *testing.T) {
 	suite.Run(t, &ExchangeUnitSuite{Suite: tester.NewUnitSuite(t)})
 }
 
-func (suite *ExchangeUnitSuite) TestAddExchangeCommands() {
+func (suite *ExchangeUnitSuite) TestExchangeCommands() {
 	expectUse := exchangeServiceCommand + " " + exchangeServiceCommandUseSuffix
 
 	table := []struct {
@@ -55,7 +55,6 @@ func (suite *ExchangeUnitSuite) TestAddExchangeCommands() {
 				flagsTD.WithFlags(
 					exchangeServiceCommand,
 					[]string{
-						flagsTD.RestoreDestination,
 						"--" + flags.RunModeFN, flags.RunModeFlagTest,
 						"--" + flags.BackupFN, flagsTD.BackupInput,
 					},
@@ -71,6 +70,7 @@ func (suite *ExchangeUnitSuite) TestAddExchangeCommands() {
 				test.expectRunE)
 
 			assert.Equal(t, flagsTD.BackupInput, flags.BackupIDFV)
+			flagsTD.AssertProviderFlags(t, cmd)
 			flagsTD.AssertStorageFlags(t, cmd)
 		})
 	}

--- a/src/cli/debug/groups.go
+++ b/src/cli/debug/groups.go
@@ -27,8 +27,6 @@ func addGroupsCommands(cmd *cobra.Command) *cobra.Command {
 		fs.SortFlags = false
 
 		flags.AddBackupIDFlag(c, true)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
 	}
 
 	return c

--- a/src/cli/debug/groups.go
+++ b/src/cli/debug/groups.go
@@ -68,7 +68,7 @@ func metadataFilesGroupsCmd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	sel := selectors.NewGroupsBackup([]string{"me"})
+	sel := selectors.NewGroupsBackup([]string{"unused-placeholder"})
 
 	return runMetadataFiles(ctx, cmd, args, sel.Selector, flags.BackupIDFV, "Groups")
 }

--- a/src/cli/debug/groups.go
+++ b/src/cli/debug/groups.go
@@ -1,0 +1,74 @@
+package debug
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/alcionai/corso/src/cli/flags"
+	"github.com/alcionai/corso/src/cli/utils"
+	"github.com/alcionai/corso/src/pkg/selectors"
+)
+
+// called by debug.go to map subcommands to provider-specific handling.
+func addGroupsCommands(cmd *cobra.Command) *cobra.Command {
+	var (
+		c  *cobra.Command
+		fs *pflag.FlagSet
+	)
+
+	switch cmd.Use {
+	case metadataFilesCommand:
+		c, fs = utils.AddCommand(cmd, groupsMetadataFilesCmd(), utils.MarkDebugCommand())
+
+		c.Use = c.Use + " " + groupsServiceCommandUseSuffix
+
+		// Flags addition ordering should follow the order we want them to appear in help and docs:
+		// More generic (ex: --user) and more frequently used flags take precedence.
+		fs.SortFlags = false
+
+		flags.AddBackupIDFlag(c, true)
+		flags.AddCorsoPassphaseFlags(c)
+		flags.AddAWSCredsFlags(c)
+	}
+
+	return c
+}
+
+// TODO: correct examples
+const (
+	groupsServiceCommand          = "groups"
+	groupsServiceCommandUseSuffix = "--backup <backupId>"
+
+	//nolint:lll
+	groupsServiceCommandDebugExamples = `# Display file contents for backup 1234abcd
+	corso debug metadata-files groups --backup 1234abcd-12ab-cd34-56de-1234abcd`
+)
+
+// `corso debug metadata-files groups [<flag>...] <destination>`
+func groupsMetadataFilesCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     groupsServiceCommand,
+		Short:   "Display groups metadata file content",
+		RunE:    metadataFilesGroupsCmd,
+		Args:    cobra.NoArgs,
+		Example: groupsServiceCommandDebugExamples,
+	}
+}
+
+func metadataFilesGroupsCmd(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	if utils.HasNoFlagsAndShownHelp(cmd) {
+		return nil
+	}
+
+	// opts := utils.MakeGroupsOpts(cmd)
+
+	if flags.RunModeFV == flags.RunModeFlagTest {
+		return nil
+	}
+
+	sel := selectors.NewGroupsBackup([]string{"me"})
+
+	return runMetadataFiles(ctx, cmd, args, sel.Selector, flags.BackupIDFV, "Groups")
+}

--- a/src/cli/debug/groups_test.go
+++ b/src/cli/debug/groups_test.go
@@ -55,7 +55,6 @@ func (suite *GroupsUnitSuite) TestAddGroupsCommands() {
 				flagsTD.WithFlags(
 					groupsServiceCommand,
 					[]string{
-						flagsTD.RestoreDestination,
 						"--" + flags.RunModeFN, flags.RunModeFlagTest,
 						"--" + flags.BackupFN, flagsTD.BackupInput,
 					},

--- a/src/cli/debug/groups_test.go
+++ b/src/cli/debug/groups_test.go
@@ -1,0 +1,77 @@
+package debug
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/cli/flags"
+	flagsTD "github.com/alcionai/corso/src/cli/flags/testdata"
+	cliTD "github.com/alcionai/corso/src/cli/testdata"
+	"github.com/alcionai/corso/src/internal/tester"
+)
+
+type GroupsUnitSuite struct {
+	tester.Suite
+}
+
+func TestGroupsUnitSuite(t *testing.T) {
+	suite.Run(t, &GroupsUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *GroupsUnitSuite) TestAddGroupsCommands() {
+	expectUse := groupsServiceCommand + " " + groupsServiceCommandUseSuffix
+
+	table := []struct {
+		name        string
+		use         string
+		expectUse   string
+		expectShort string
+		expectRunE  func(*cobra.Command, []string) error
+	}{
+		{
+			name:        "metdata-files groups",
+			use:         metadataFilesCommand,
+			expectUse:   expectUse,
+			expectShort: groupsMetadataFilesCmd().Short,
+			expectRunE:  metadataFilesGroupsCmd,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+			parent := &cobra.Command{Use: metadataFilesCommand}
+
+			cmd := cliTD.SetUpCmdHasFlags(
+				t,
+				parent,
+				addGroupsCommands,
+				[]cliTD.UseCobraCommandFn{
+					flags.AddAllProviderFlags,
+					flags.AddAllStorageFlags,
+				},
+				flagsTD.WithFlags(
+					groupsServiceCommand,
+					[]string{
+						flagsTD.RestoreDestination,
+						"--" + flags.RunModeFN, flags.RunModeFlagTest,
+						"--" + flags.BackupFN, flagsTD.BackupInput,
+					},
+					flagsTD.PreparedProviderFlags(),
+					flagsTD.PreparedStorageFlags()))
+
+			cliTD.CheckCmdChild(
+				t,
+				parent,
+				3,
+				test.expectUse,
+				test.expectShort,
+				test.expectRunE)
+
+			assert.Equal(t, flagsTD.BackupInput, flags.BackupIDFV)
+			flagsTD.AssertStorageFlags(t, cmd)
+		})
+	}
+}

--- a/src/cli/debug/onedrive.go
+++ b/src/cli/debug/onedrive.go
@@ -27,8 +27,6 @@ func addOneDriveCommands(cmd *cobra.Command) *cobra.Command {
 		fs.SortFlags = false
 
 		flags.AddBackupIDFlag(c, true)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
 	}
 
 	return c

--- a/src/cli/debug/onedrive.go
+++ b/src/cli/debug/onedrive.go
@@ -1,0 +1,73 @@
+package debug
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/alcionai/corso/src/cli/flags"
+	"github.com/alcionai/corso/src/cli/utils"
+	"github.com/alcionai/corso/src/pkg/selectors"
+)
+
+// called by debug.go to map subcommands to provider-specific handling.
+func addOneDriveCommands(cmd *cobra.Command) *cobra.Command {
+	var (
+		c  *cobra.Command
+		fs *pflag.FlagSet
+	)
+
+	switch cmd.Use {
+	case metadataFilesCommand:
+		c, fs = utils.AddCommand(cmd, oneDriveMetadataFilesCmd(), utils.MarkDebugCommand())
+
+		c.Use = c.Use + " " + oneDriveServiceCommandUseSuffix
+
+		// Flags addition ordering should follow the order we want them to appear in help and docs:
+		// More generic (ex: --user) and more frequently used flags take precedence.
+		fs.SortFlags = false
+
+		flags.AddBackupIDFlag(c, true)
+		flags.AddCorsoPassphaseFlags(c)
+		flags.AddAWSCredsFlags(c)
+	}
+
+	return c
+}
+
+const (
+	oneDriveServiceCommand          = "onedrive"
+	oneDriveServiceCommandUseSuffix = "--backup <backupId>"
+
+	//nolint:lll
+	oneDriveServiceCommandDebugExamples = `# Display file contents for backup 1234abcd
+	corso debug metadata-files onedrive --backup 1234abcd-12ab-cd34-56de-1234abcd`
+)
+
+// `corso debug metadata-files onedrive [<flag>...] <destination>`
+func oneDriveMetadataFilesCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     oneDriveServiceCommand,
+		Short:   "Display onedrive metadata file content",
+		RunE:    metadataFilesOneDriveCmd,
+		Args:    cobra.NoArgs,
+		Example: oneDriveServiceCommandDebugExamples,
+	}
+}
+
+func metadataFilesOneDriveCmd(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	if utils.HasNoFlagsAndShownHelp(cmd) {
+		return nil
+	}
+
+	// opts := utils.MakeOneDriveOpts(cmd)
+
+	if flags.RunModeFV == flags.RunModeFlagTest {
+		return nil
+	}
+
+	sel := selectors.NewOneDriveBackup([]string{"me"})
+
+	return runMetadataFiles(ctx, cmd, args, sel.Selector, flags.BackupIDFV, "OneDrive")
+}

--- a/src/cli/debug/onedrive.go
+++ b/src/cli/debug/onedrive.go
@@ -67,7 +67,7 @@ func metadataFilesOneDriveCmd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	sel := selectors.NewOneDriveBackup([]string{"me"})
+	sel := selectors.NewOneDriveBackup([]string{"unused-placeholder"})
 
 	return runMetadataFiles(ctx, cmd, args, sel.Selector, flags.BackupIDFV, "OneDrive")
 }

--- a/src/cli/debug/onedrive_test.go
+++ b/src/cli/debug/onedrive_test.go
@@ -55,7 +55,6 @@ func (suite *OneDriveUnitSuite) TestAddOneDriveCommands() {
 				flagsTD.WithFlags(
 					oneDriveServiceCommand,
 					[]string{
-						flagsTD.RestoreDestination,
 						"--" + flags.RunModeFN, flags.RunModeFlagTest,
 						"--" + flags.BackupFN, flagsTD.BackupInput,
 					},

--- a/src/cli/debug/onedrive_test.go
+++ b/src/cli/debug/onedrive_test.go
@@ -1,0 +1,77 @@
+package debug
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/cli/flags"
+	flagsTD "github.com/alcionai/corso/src/cli/flags/testdata"
+	cliTD "github.com/alcionai/corso/src/cli/testdata"
+	"github.com/alcionai/corso/src/internal/tester"
+)
+
+type OneDriveUnitSuite struct {
+	tester.Suite
+}
+
+func TestOneDriveUnitSuite(t *testing.T) {
+	suite.Run(t, &OneDriveUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *OneDriveUnitSuite) TestAddOneDriveCommands() {
+	expectUse := oneDriveServiceCommand + " " + oneDriveServiceCommandUseSuffix
+
+	table := []struct {
+		name        string
+		use         string
+		expectUse   string
+		expectShort string
+		expectRunE  func(*cobra.Command, []string) error
+	}{
+		{
+			name:        "metadata-files onedrive",
+			use:         metadataFilesCommand,
+			expectUse:   expectUse,
+			expectShort: oneDriveMetadataFilesCmd().Short,
+			expectRunE:  metadataFilesOneDriveCmd,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+			parent := &cobra.Command{Use: metadataFilesCommand}
+
+			cmd := cliTD.SetUpCmdHasFlags(
+				t,
+				parent,
+				addOneDriveCommands,
+				[]cliTD.UseCobraCommandFn{
+					flags.AddAllProviderFlags,
+					flags.AddAllStorageFlags,
+				},
+				flagsTD.WithFlags(
+					oneDriveServiceCommand,
+					[]string{
+						flagsTD.RestoreDestination,
+						"--" + flags.RunModeFN, flags.RunModeFlagTest,
+						"--" + flags.BackupFN, flagsTD.BackupInput,
+					},
+					flagsTD.PreparedProviderFlags(),
+					flagsTD.PreparedStorageFlags()))
+
+			cliTD.CheckCmdChild(
+				t,
+				parent,
+				3,
+				test.expectUse,
+				test.expectShort,
+				test.expectRunE)
+
+			assert.Equal(t, flagsTD.BackupInput, flags.BackupIDFV)
+			flagsTD.AssertStorageFlags(t, cmd)
+		})
+	}
+}

--- a/src/cli/debug/sharepoint.go
+++ b/src/cli/debug/sharepoint.go
@@ -27,8 +27,6 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 		fs.SortFlags = false
 
 		flags.AddBackupIDFlag(c, true)
-		flags.AddCorsoPassphaseFlags(c)
-		flags.AddAWSCredsFlags(c)
 	}
 
 	return c

--- a/src/cli/debug/sharepoint.go
+++ b/src/cli/debug/sharepoint.go
@@ -1,0 +1,73 @@
+package debug
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/alcionai/corso/src/cli/flags"
+	"github.com/alcionai/corso/src/cli/utils"
+	"github.com/alcionai/corso/src/pkg/selectors"
+)
+
+// called by debug.go to map subcommands to provider-specific handling.
+func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
+	var (
+		c  *cobra.Command
+		fs *pflag.FlagSet
+	)
+
+	switch cmd.Use {
+	case metadataFilesCommand:
+		c, fs = utils.AddCommand(cmd, sharePointMetadataFilesCmd(), utils.MarkDebugCommand())
+
+		c.Use = c.Use + " " + sharePointServiceCommandUseSuffix
+
+		// Flags addition ordering should follow the order we want them to appear in help and docs:
+		// More generic (ex: --user) and more frequently used flags take precedence.
+		fs.SortFlags = false
+
+		flags.AddBackupIDFlag(c, true)
+		flags.AddCorsoPassphaseFlags(c)
+		flags.AddAWSCredsFlags(c)
+	}
+
+	return c
+}
+
+const (
+	sharePointServiceCommand          = "sharepoint"
+	sharePointServiceCommandUseSuffix = "--backup <backupId>"
+
+	//nolint:lll
+	sharePointServiceCommandDebugExamples = `# Display file contents for backup 1234abcd
+	corso debug metadata-files sharepoint --backup 1234abcd-12ab-cd34-56de-1234abcd`
+)
+
+// `corso debug metadata-files sharepoint [<flag>...] <destination>`
+func sharePointMetadataFilesCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     sharePointServiceCommand,
+		Short:   "Display sharepoint metadata file content",
+		RunE:    metadataFilesSharePointCmd,
+		Args:    cobra.NoArgs,
+		Example: sharePointServiceCommandDebugExamples,
+	}
+}
+
+func metadataFilesSharePointCmd(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	if utils.HasNoFlagsAndShownHelp(cmd) {
+		return nil
+	}
+
+	// opts := utils.MakeSharePointOpts(cmd)
+
+	if flags.RunModeFV == flags.RunModeFlagTest {
+		return nil
+	}
+
+	sel := selectors.NewSharePointBackup([]string{"me"})
+
+	return runMetadataFiles(ctx, cmd, args, sel.Selector, flags.BackupIDFV, "SharePoint")
+}

--- a/src/cli/debug/sharepoint.go
+++ b/src/cli/debug/sharepoint.go
@@ -67,7 +67,7 @@ func metadataFilesSharePointCmd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	sel := selectors.NewSharePointBackup([]string{"me"})
+	sel := selectors.NewSharePointBackup([]string{"unused-placeholder"})
 
 	return runMetadataFiles(ctx, cmd, args, sel.Selector, flags.BackupIDFV, "SharePoint")
 }

--- a/src/cli/debug/sharepoint_test.go
+++ b/src/cli/debug/sharepoint_test.go
@@ -55,7 +55,6 @@ func (suite *SharePointUnitSuite) TestAddSharePointCommands() {
 				flagsTD.WithFlags(
 					sharePointServiceCommand,
 					[]string{
-						flagsTD.RestoreDestination,
 						"--" + flags.RunModeFN, flags.RunModeFlagTest,
 						"--" + flags.BackupFN, flagsTD.BackupInput,
 					},

--- a/src/cli/debug/sharepoint_test.go
+++ b/src/cli/debug/sharepoint_test.go
@@ -1,0 +1,77 @@
+package debug
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/cli/flags"
+	flagsTD "github.com/alcionai/corso/src/cli/flags/testdata"
+	cliTD "github.com/alcionai/corso/src/cli/testdata"
+	"github.com/alcionai/corso/src/internal/tester"
+)
+
+type SharePointUnitSuite struct {
+	tester.Suite
+}
+
+func TestSharePointUnitSuite(t *testing.T) {
+	suite.Run(t, &SharePointUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *SharePointUnitSuite) TestAddSharePointCommands() {
+	expectUse := sharePointServiceCommand + " " + sharePointServiceCommandUseSuffix
+
+	table := []struct {
+		name        string
+		use         string
+		expectUse   string
+		expectShort string
+		expectRunE  func(*cobra.Command, []string) error
+	}{
+		{
+			name:        "metdata-files sharepoint",
+			use:         metadataFilesCommand,
+			expectUse:   expectUse,
+			expectShort: sharePointMetadataFilesCmd().Short,
+			expectRunE:  metadataFilesSharePointCmd,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+			parent := &cobra.Command{Use: metadataFilesCommand}
+
+			cmd := cliTD.SetUpCmdHasFlags(
+				t,
+				parent,
+				addSharePointCommands,
+				[]cliTD.UseCobraCommandFn{
+					flags.AddAllProviderFlags,
+					flags.AddAllStorageFlags,
+				},
+				flagsTD.WithFlags(
+					sharePointServiceCommand,
+					[]string{
+						flagsTD.RestoreDestination,
+						"--" + flags.RunModeFN, flags.RunModeFlagTest,
+						"--" + flags.BackupFN, flagsTD.BackupInput,
+					},
+					flagsTD.PreparedProviderFlags(),
+					flagsTD.PreparedStorageFlags()))
+
+			cliTD.CheckCmdChild(
+				t,
+				parent,
+				3,
+				test.expectUse,
+				test.expectShort,
+				test.expectRunE)
+
+			assert.Equal(t, flagsTD.BackupInput, flags.BackupIDFV)
+			flagsTD.AssertStorageFlags(t, cmd)
+		})
+	}
+}

--- a/src/cli/flags/debug.go
+++ b/src/cli/flags/debug.go
@@ -1,0 +1,1 @@
+package flags

--- a/src/cli/flags/debug.go
+++ b/src/cli/flags/debug.go
@@ -1,1 +1,0 @@
-package flags

--- a/src/cli/flags/repo.go
+++ b/src/cli/flags/repo.go
@@ -69,7 +69,8 @@ func AddAWSCredsFlags(cmd *cobra.Command) {
 // M365 flags
 func AddCorsoPassphaseFlags(cmd *cobra.Command) {
 	fs := cmd.Flags()
-	fs.StringVar(&PassphraseFV,
+	fs.StringVar(
+		&PassphraseFV,
 		PassphraseFN,
 		"",
 		"Passphrase to protect encrypted repository contents")
@@ -78,7 +79,8 @@ func AddCorsoPassphaseFlags(cmd *cobra.Command) {
 // M365 flags
 func AddUpdatePassphraseFlags(cmd *cobra.Command, require bool) {
 	fs := cmd.Flags()
-	fs.StringVar(&NewPhasephraseFV,
+	fs.StringVar(
+		&NewPhasephraseFV,
 		NewPassphraseFN,
 		"",
 		"update Corso passphrase for repo")

--- a/src/cli/utils/debug.go
+++ b/src/cli/utils/debug.go
@@ -1,0 +1,3 @@
+package utils
+
+// TODO(keepers): something


### PR DESCRIPTION
adds the primary `debug` command to the cli as
a hidden command option.  Also includes the scaffold for
a `metadata-files` command that could be used to print
out the metadata files in the backup.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Test Plan

- [x] :zap: Unit test
