### PR TITLE
start centralizing intg test setup

### DIFF
--- a/src/internal/tester/tsetup/m365.go
+++ b/src/internal/tester/tsetup/m365.go
@@ -1,0 +1,130 @@
+package tsetup
+
+import (
+	"testing"
+
+	"github.com/alcionai/clues"
+	"github.com/stretchr/testify/require"
+
+	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/internal/m365/graph"
+	"github.com/alcionai/corso/src/internal/m365/graph/mock"
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
+	"github.com/alcionai/corso/src/pkg/account"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+)
+
+// ---------------------------------------------------------------------------
+// Gockable client
+// ---------------------------------------------------------------------------
+
+// GockClient produces a new exchange api client that can be
+// mocked using gock.
+func gockClient(creds account.M365Config) (api.Client, error) {
+	s, err := mock.NewService(creds)
+	if err != nil {
+		return api.Client{}, err
+	}
+
+	li, err := mock.NewService(creds, graph.NoTimeout())
+	if err != nil {
+		return api.Client{}, err
+	}
+
+	return api.Client{
+		Credentials: creds,
+		Stable:      s,
+		LargeItem:   li,
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Suite Setup
+// ---------------------------------------------------------------------------
+
+type m365IDs struct {
+	ID                string
+	Email             string
+	DriveID           string
+	DriveRootFolderID string
+	TestContainerID   string
+}
+
+type M365 struct {
+	AC           api.Client
+	GockAC       api.Client
+	User         m365IDs
+	Site         m365IDs
+	Group        m365IDs
+	NonTeamGroup m365IDs // group which does not have an associated team
+}
+
+func NewM365IntegrationTester(t *testing.T) M365 {
+	mit := M365{}
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	graph.InitializeConcurrencyLimiter(ctx, true, 4)
+
+	a := tconfig.NewM365Account(t)
+	creds, err := a.M365Config()
+	require.NoError(t, err, clues.ToCore(err))
+
+	mit.AC, err = api.NewClient(creds, control.DefaultOptions())
+	require.NoError(t, err, clues.ToCore(err))
+
+	mit.GockAC, err = gockClient(creds)
+	require.NoError(t, err, clues.ToCore(err))
+
+	// user drive
+
+	mit.User.ID = tconfig.M365UserID(t)
+
+	userDrive, err := mit.AC.Users().GetDefaultDrive(ctx, mit.User.ID)
+	require.NoError(t, err, clues.ToCore(err))
+
+	mit.User.DriveID = ptr.Val(userDrive.GetId())
+
+	userDriveRootFolder, err := mit.AC.Drives().GetRootFolder(ctx, mit.User.DriveID)
+	require.NoError(t, err, clues.ToCore(err))
+
+	mit.User.DriveRootFolderID = ptr.Val(userDriveRootFolder.GetId())
+
+	// site
+
+	mit.Site.ID = tconfig.M365SiteID(t)
+
+	siteDrive, err := mit.AC.Sites().GetDefaultDrive(ctx, mit.Site.ID)
+	require.NoError(t, err, clues.ToCore(err))
+
+	mit.Site.DriveID = ptr.Val(siteDrive.GetId())
+
+	siteDriveRootFolder, err := mit.AC.Drives().GetRootFolder(ctx, mit.Site.DriveID)
+	require.NoError(t, err, clues.ToCore(err))
+
+	mit.Site.DriveRootFolderID = ptr.Val(siteDriveRootFolder.GetId())
+
+	// groups/teams
+
+	// use of the TeamID is intentional here, so that we are assured
+	// the group has full usage of the teams api.
+	mit.Group.ID = tconfig.M365TeamID(t)
+	mit.Group.Email = tconfig.M365TeamEmail(t)
+
+	mit.NonTeamGroup.ID = tconfig.M365GroupID(t)
+
+	channel, err := mit.AC.Channels().
+		GetChannelByName(
+			ctx,
+			mit.Group.ID,
+			"Test")
+	require.NoError(t, err, clues.ToCore(err))
+	require.Equal(t, "Test", ptr.Val(channel.GetDisplayName()))
+
+	mit.Group.TestContainerID = ptr.Val(channel.GetId())
+
+	return mit
+}

--- a/src/pkg/services/m365/api/access_test.go
+++ b/src/pkg/services/m365/api/access_test.go
@@ -9,13 +9,14 @@ import (
 
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
+	"github.com/alcionai/corso/src/internal/tester/tsetup"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
 )
 
 type AccessAPIIntgSuite struct {
 	tester.Suite
-	its intgTesterSetup
+	its tsetup.M365
 }
 
 func TestAccessAPIIntgSuite(t *testing.T) {
@@ -27,7 +28,7 @@ func TestAccessAPIIntgSuite(t *testing.T) {
 }
 
 func (suite *AccessAPIIntgSuite) SetupSuite() {
-	suite.its = newIntegrationTesterSetup(suite.T())
+	suite.its = tsetup.NewM365IntegrationTester(suite.T())
 }
 
 func (suite *AccessAPIIntgSuite) TestGetToken() {
@@ -38,13 +39,13 @@ func (suite *AccessAPIIntgSuite) TestGetToken() {
 	}{
 		{
 			name:      "good",
-			creds:     func() account.M365Config { return suite.its.ac.Credentials },
+			creds:     func() account.M365Config { return suite.its.AC.Credentials },
 			expectErr: require.NoError,
 		},
 		{
 			name: "bad tenant ID",
 			creds: func() account.M365Config {
-				creds := suite.its.ac.Credentials
+				creds := suite.its.AC.Credentials
 				creds.AzureTenantID = "ZIM"
 
 				return creds
@@ -54,7 +55,7 @@ func (suite *AccessAPIIntgSuite) TestGetToken() {
 		{
 			name: "missing tenant ID",
 			creds: func() account.M365Config {
-				creds := suite.its.ac.Credentials
+				creds := suite.its.AC.Credentials
 				creds.AzureTenantID = ""
 
 				return creds
@@ -64,7 +65,7 @@ func (suite *AccessAPIIntgSuite) TestGetToken() {
 		{
 			name: "bad client ID",
 			creds: func() account.M365Config {
-				creds := suite.its.ac.Credentials
+				creds := suite.its.AC.Credentials
 				creds.AzureClientID = "GIR"
 
 				return creds
@@ -74,7 +75,7 @@ func (suite *AccessAPIIntgSuite) TestGetToken() {
 		{
 			name: "missing client ID",
 			creds: func() account.M365Config {
-				creds := suite.its.ac.Credentials
+				creds := suite.its.AC.Credentials
 				creds.AzureClientID = ""
 
 				return creds
@@ -84,7 +85,7 @@ func (suite *AccessAPIIntgSuite) TestGetToken() {
 		{
 			name: "bad client secret",
 			creds: func() account.M365Config {
-				creds := suite.its.ac.Credentials
+				creds := suite.its.AC.Credentials
 				creds.AzureClientSecret = "MY TALLEST"
 
 				return creds
@@ -94,7 +95,7 @@ func (suite *AccessAPIIntgSuite) TestGetToken() {
 		{
 			name: "missing client secret",
 			creds: func() account.M365Config {
-				creds := suite.its.ac.Credentials
+				creds := suite.its.AC.Credentials
 				creds.AzureClientSecret = ""
 
 				return creds
@@ -109,7 +110,7 @@ func (suite *AccessAPIIntgSuite) TestGetToken() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			ac, err := NewClient(suite.its.ac.Credentials, control.DefaultOptions())
+			ac, err := NewClient(suite.its.AC.Credentials, control.DefaultOptions())
 			require.NoError(t, err, clues.ToCore(err))
 
 			ac.Credentials = test.creds()

--- a/src/pkg/services/m365/api/channels_pager_test.go
+++ b/src/pkg/services/m365/api/channels_pager_test.go
@@ -14,11 +14,12 @@ import (
 	"github.com/alcionai/corso/src/internal/common/str"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
+	"github.com/alcionai/corso/src/internal/tester/tsetup"
 )
 
 type ChannelsPagerIntgSuite struct {
 	tester.Suite
-	its intgTesterSetup
+	its tsetup.M365
 }
 
 func TestChannelPagerIntgSuite(t *testing.T) {
@@ -30,19 +31,19 @@ func TestChannelPagerIntgSuite(t *testing.T) {
 }
 
 func (suite *ChannelsPagerIntgSuite) SetupSuite() {
-	suite.its = newIntegrationTesterSetup(suite.T())
+	suite.its = tsetup.NewM365IntegrationTester(suite.T())
 }
 
 func (suite *ChannelsPagerIntgSuite) TestEnumerateChannels() {
 	var (
 		t  = suite.T()
-		ac = suite.its.ac.Channels()
+		ac = suite.its.AC.Channels()
 	)
 
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	chans, err := ac.GetChannels(ctx, suite.its.group.id)
+	chans, err := ac.GetChannels(ctx, suite.its.Group.ID)
 	require.NoError(t, err, clues.ToCore(err))
 	require.NotEmpty(t, chans)
 }
@@ -50,7 +51,7 @@ func (suite *ChannelsPagerIntgSuite) TestEnumerateChannels() {
 func (suite *ChannelsPagerIntgSuite) TestEnumerateChannelMessages() {
 	var (
 		t  = suite.T()
-		ac = suite.its.ac.Channels()
+		ac = suite.its.AC.Channels()
 	)
 
 	ctx, flush := tester.NewContext(t)
@@ -58,8 +59,8 @@ func (suite *ChannelsPagerIntgSuite) TestEnumerateChannelMessages() {
 
 	addedIDs, _, _, du, err := ac.GetChannelMessageIDs(
 		ctx,
-		suite.its.group.id,
-		suite.its.group.testContainerID,
+		suite.its.Group.ID,
+		suite.its.Group.TestContainerID,
 		"",
 		true)
 	require.NoError(t, err, clues.ToCore(err))
@@ -69,8 +70,8 @@ func (suite *ChannelsPagerIntgSuite) TestEnumerateChannelMessages() {
 
 	addedIDs, _, deletedIDs, du, err := ac.GetChannelMessageIDs(
 		ctx,
-		suite.its.group.id,
-		suite.its.group.testContainerID,
+		suite.its.Group.ID,
+		suite.its.Group.TestContainerID,
 		du.URL,
 		true)
 	require.NoError(t, err, clues.ToCore(err))
@@ -83,9 +84,9 @@ func (suite *ChannelsPagerIntgSuite) TestEnumerateChannelMessages() {
 		suite.Run(id+"-replies", func() {
 			testEnumerateChannelMessageReplies(
 				suite.T(),
-				suite.its.ac.Channels(),
-				suite.its.group.id,
-				suite.its.group.testContainerID,
+				suite.its.AC.Channels(),
+				suite.its.Group.ID,
+				suite.its.Group.TestContainerID,
 				id)
 		})
 	}

--- a/src/pkg/services/m365/api/contacts_pager_test.go
+++ b/src/pkg/services/m365/api/contacts_pager_test.go
@@ -12,11 +12,12 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
+	"github.com/alcionai/corso/src/internal/tester/tsetup"
 )
 
 type ContactsPagerIntgSuite struct {
 	tester.Suite
-	its intgTesterSetup
+	its tsetup.M365
 }
 
 func TestContactsPagerIntgSuite(t *testing.T) {
@@ -28,23 +29,23 @@ func TestContactsPagerIntgSuite(t *testing.T) {
 }
 
 func (suite *ContactsPagerIntgSuite) SetupSuite() {
-	suite.its = newIntegrationTesterSetup(suite.T())
+	suite.its = tsetup.NewM365IntegrationTester(suite.T())
 }
 
 func (suite *ContactsPagerIntgSuite) TestContacts_GetItemsInContainerByCollisionKey() {
 	t := suite.T()
-	ac := suite.its.ac.Contacts()
+	ac := suite.its.AC.Contacts()
 
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	container, err := ac.GetContainerByID(ctx, suite.its.user.id, "contacts")
+	container, err := ac.GetContainerByID(ctx, suite.its.User.ID, "contacts")
 	require.NoError(t, err, clues.ToCore(err))
 
 	conts, err := ac.Stable.
 		Client().
 		Users().
-		ByUserId(suite.its.user.id).
+		ByUserId(suite.its.User.ID).
 		ContactFolders().
 		ByContactFolderId(ptr.Val(container.GetId())).
 		Contacts().
@@ -60,7 +61,7 @@ func (suite *ContactsPagerIntgSuite) TestContacts_GetItemsInContainerByCollision
 
 	expect := maps.Keys(expectM)
 
-	results, err := suite.its.ac.Contacts().GetItemsInContainerByCollisionKey(ctx, suite.its.user.id, "contacts")
+	results, err := suite.its.AC.Contacts().GetItemsInContainerByCollisionKey(ctx, suite.its.User.ID, "contacts")
 	require.NoError(t, err, clues.ToCore(err))
 	require.Less(t, 0, len(results), "requires at least one result")
 
@@ -85,18 +86,18 @@ func (suite *ContactsPagerIntgSuite) TestContacts_GetItemsInContainerByCollision
 
 func (suite *ContactsPagerIntgSuite) TestContacts_GetItemsIDsInContainer() {
 	t := suite.T()
-	ac := suite.its.ac.Contacts()
+	ac := suite.its.AC.Contacts()
 
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	container, err := ac.GetContainerByID(ctx, suite.its.user.id, DefaultContacts)
+	container, err := ac.GetContainerByID(ctx, suite.its.User.ID, DefaultContacts)
 	require.NoError(t, err, clues.ToCore(err))
 
 	msgs, err := ac.Stable.
 		Client().
 		Users().
-		ByUserId(suite.its.user.id).
+		ByUserId(suite.its.User.ID).
 		ContactFolders().
 		ByContactFolderId(ptr.Val(container.GetId())).
 		Contacts().
@@ -110,8 +111,8 @@ func (suite *ContactsPagerIntgSuite) TestContacts_GetItemsIDsInContainer() {
 		expect[ptr.Val(m.GetId())] = struct{}{}
 	}
 
-	results, err := suite.its.ac.Contacts().
-		GetItemIDsInContainer(ctx, suite.its.user.id, DefaultContacts)
+	results, err := suite.its.AC.Contacts().
+		GetItemIDsInContainer(ctx, suite.its.User.ID, DefaultContacts)
 	require.NoError(t, err, clues.ToCore(err))
 	require.Less(t, 0, len(results), "requires at least one result")
 	require.Equal(t, len(expect), len(results), "must have same count of items")

--- a/src/pkg/services/m365/api/contacts_test.go
+++ b/src/pkg/services/m365/api/contacts_test.go
@@ -14,6 +14,7 @@ import (
 	exchMock "github.com/alcionai/corso/src/internal/m365/service/exchange/mock"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
+	"github.com/alcionai/corso/src/internal/tester/tsetup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 )
@@ -116,7 +117,7 @@ func (suite *ContactsAPIUnitSuite) TestBytesToContactable() {
 
 type ContactsAPIIntgSuite struct {
 	tester.Suite
-	its intgTesterSetup
+	its tsetup.M365
 }
 
 func TestContactsAPIntgSuite(t *testing.T) {
@@ -128,7 +129,7 @@ func TestContactsAPIntgSuite(t *testing.T) {
 }
 
 func (suite *ContactsAPIIntgSuite) SetupSuite() {
-	suite.its = newIntegrationTesterSetup(suite.T())
+	suite.its = tsetup.NewM365IntegrationTester(suite.T())
 }
 
 func (suite *ContactsAPIIntgSuite) TestContacts_GetContainerByName() {
@@ -142,9 +143,9 @@ func (suite *ContactsAPIIntgSuite) TestContacts_GetContainerByName() {
 
 	rc := testdata.DefaultRestoreConfig("contacts_api")
 
-	cc, err := suite.its.ac.Contacts().CreateContainer(
+	cc, err := suite.its.AC.Contacts().CreateContainer(
 		ctx,
-		suite.its.user.id,
+		suite.its.User.ID,
 		"",
 		rc.Location)
 	require.NoError(t, err, clues.ToCore(err))
@@ -169,9 +170,9 @@ func (suite *ContactsAPIIntgSuite) TestContacts_GetContainerByName() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			_, err := suite.its.ac.
+			_, err := suite.its.AC.
 				Contacts().
-				GetContainerByName(ctx, suite.its.user.id, "", test.name)
+				GetContainerByName(ctx, suite.its.User.ID, "", test.name)
 			test.expectErr(t, err, clues.ToCore(err))
 		})
 	}

--- a/src/pkg/services/m365/api/drive_pager_test.go
+++ b/src/pkg/services/m365/api/drive_pager_test.go
@@ -12,11 +12,12 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
+	"github.com/alcionai/corso/src/internal/tester/tsetup"
 )
 
 type DrivePagerIntgSuite struct {
 	tester.Suite
-	its intgTesterSetup
+	its tsetup.M365
 }
 
 func TestDrivePagerIntgSuite(t *testing.T) {
@@ -28,7 +29,7 @@ func TestDrivePagerIntgSuite(t *testing.T) {
 }
 
 func (suite *DrivePagerIntgSuite) SetupSuite() {
-	suite.its = newIntegrationTesterSetup(suite.T())
+	suite.its = tsetup.NewM365IntegrationTester(suite.T())
 }
 
 func (suite *DrivePagerIntgSuite) TestDrives_GetItemsInContainerByCollisionKey() {
@@ -39,13 +40,13 @@ func (suite *DrivePagerIntgSuite) TestDrives_GetItemsInContainerByCollisionKey()
 	}{
 		{
 			name:         "user drive",
-			driveID:      suite.its.user.driveID,
-			rootFolderID: suite.its.user.driveRootFolderID,
+			driveID:      suite.its.User.DriveID,
+			rootFolderID: suite.its.User.DriveRootFolderID,
 		},
 		{
 			name:         "site drive",
-			driveID:      suite.its.site.driveID,
-			rootFolderID: suite.its.site.driveRootFolderID,
+			driveID:      suite.its.Site.DriveID,
+			rootFolderID: suite.its.Site.DriveRootFolderID,
 		},
 	}
 	for _, test := range table {
@@ -58,7 +59,7 @@ func (suite *DrivePagerIntgSuite) TestDrives_GetItemsInContainerByCollisionKey()
 			t.Log("drive", test.driveID)
 			t.Log("rootFolder", test.rootFolderID)
 
-			items, err := suite.its.ac.Stable.
+			items, err := suite.its.AC.Stable.
 				Client().
 				Drives().
 				ByDriveId(test.driveID).
@@ -75,9 +76,9 @@ func (suite *DrivePagerIntgSuite) TestDrives_GetItemsInContainerByCollisionKey()
 				t,
 				ims,
 				"need at least one item to compare in user %s drive %s folder %s",
-				suite.its.user.id, test.driveID, test.rootFolderID)
+				suite.its.User.ID, test.driveID, test.rootFolderID)
 
-			results, err := suite.its.ac.
+			results, err := suite.its.AC.
 				Drives().
 				GetItemsInContainerByCollisionKey(ctx, test.driveID, test.rootFolderID)
 			require.NoError(t, err, clues.ToCore(err))
@@ -113,13 +114,13 @@ func (suite *DrivePagerIntgSuite) TestDrives_GetItemIDsInContainer() {
 	}{
 		{
 			name:         "user drive",
-			driveID:      suite.its.user.driveID,
-			rootFolderID: suite.its.user.driveRootFolderID,
+			driveID:      suite.its.User.DriveID,
+			rootFolderID: suite.its.User.DriveRootFolderID,
 		},
 		{
 			name:         "site drive",
-			driveID:      suite.its.site.driveID,
-			rootFolderID: suite.its.site.driveRootFolderID,
+			driveID:      suite.its.Site.DriveID,
+			rootFolderID: suite.its.Site.DriveRootFolderID,
 		},
 	}
 	for _, test := range table {
@@ -132,7 +133,7 @@ func (suite *DrivePagerIntgSuite) TestDrives_GetItemIDsInContainer() {
 			t.Log("drive", test.driveID)
 			t.Log("rootFolder", test.rootFolderID)
 
-			items, err := suite.its.ac.Stable.
+			items, err := suite.its.AC.Stable.
 				Client().
 				Drives().
 				ByDriveId(test.driveID).
@@ -149,7 +150,7 @@ func (suite *DrivePagerIntgSuite) TestDrives_GetItemIDsInContainer() {
 				t,
 				igv,
 				"need at least one item to compare in user %s drive %s folder %s",
-				suite.its.user.id, test.driveID, test.rootFolderID)
+				suite.its.User.ID, test.driveID, test.rootFolderID)
 
 			for _, itm := range igv {
 				expect[ptr.Val(itm.GetId())] = DriveItemIDType{
@@ -158,7 +159,7 @@ func (suite *DrivePagerIntgSuite) TestDrives_GetItemIDsInContainer() {
 				}
 			}
 
-			results, err := suite.its.ac.
+			results, err := suite.its.AC.
 				Drives().
 				GetItemIDsInContainer(ctx, test.driveID, test.rootFolderID)
 			require.NoError(t, err, clues.ToCore(err))
@@ -188,11 +189,11 @@ func (suite *DrivePagerIntgSuite) TestEnumerateDriveItems() {
 	items := []models.DriveItemable{}
 
 	pager := suite.its.
-		ac.
+		AC.
 		Drives().
 		EnumerateDriveItemsDelta(
 			ctx,
-			suite.its.user.driveID,
+			suite.its.User.DriveID,
 			"",
 			CallConfig{
 				Select: DefaultDriveItemProps(),

--- a/src/pkg/services/m365/api/events_pager_test.go
+++ b/src/pkg/services/m365/api/events_pager_test.go
@@ -12,11 +12,12 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
+	"github.com/alcionai/corso/src/internal/tester/tsetup"
 )
 
 type EventsPagerIntgSuite struct {
 	tester.Suite
-	its intgTesterSetup
+	its tsetup.M365
 }
 
 func TestEventsPagerIntgSuite(t *testing.T) {
@@ -28,23 +29,23 @@ func TestEventsPagerIntgSuite(t *testing.T) {
 }
 
 func (suite *EventsPagerIntgSuite) SetupSuite() {
-	suite.its = newIntegrationTesterSetup(suite.T())
+	suite.its = tsetup.NewM365IntegrationTester(suite.T())
 }
 
 func (suite *EventsPagerIntgSuite) TestEvents_GetItemsInContainerByCollisionKey() {
 	t := suite.T()
-	ac := suite.its.ac.Events()
+	ac := suite.its.AC.Events()
 
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	container, err := ac.GetContainerByID(ctx, suite.its.user.id, "calendar")
+	container, err := ac.GetContainerByID(ctx, suite.its.User.ID, "calendar")
 	require.NoError(t, err, clues.ToCore(err))
 
 	evts, err := ac.Stable.
 		Client().
 		Users().
-		ByUserId(suite.its.user.id).
+		ByUserId(suite.its.User.ID).
 		Calendars().
 		ByCalendarId(ptr.Val(container.GetId())).
 		Events().
@@ -60,9 +61,9 @@ func (suite *EventsPagerIntgSuite) TestEvents_GetItemsInContainerByCollisionKey(
 
 	expect := maps.Keys(expectM)
 
-	results, err := suite.its.ac.
+	results, err := suite.its.AC.
 		Events().
-		GetItemsInContainerByCollisionKey(ctx, suite.its.user.id, "calendar")
+		GetItemsInContainerByCollisionKey(ctx, suite.its.User.ID, "calendar")
 	require.NoError(t, err, clues.ToCore(err))
 	require.Less(t, 0, len(results), "requires at least one result")
 

--- a/src/pkg/services/m365/api/events_test.go
+++ b/src/pkg/services/m365/api/events_test.go
@@ -16,6 +16,7 @@ import (
 	exchMock "github.com/alcionai/corso/src/internal/m365/service/exchange/mock"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
+	"github.com/alcionai/corso/src/internal/tester/tsetup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 )
@@ -219,7 +220,7 @@ func (suite *EventsAPIUnitSuite) TestBytesToEventable() {
 
 type EventsAPIIntgSuite struct {
 	tester.Suite
-	its intgTesterSetup
+	its tsetup.M365
 }
 
 func TestEventsAPIIntgSuite(t *testing.T) {
@@ -231,7 +232,7 @@ func TestEventsAPIIntgSuite(t *testing.T) {
 }
 
 func (suite *EventsAPIIntgSuite) SetupSuite() {
-	suite.its = newIntegrationTesterSetup(suite.T())
+	suite.its = tsetup.NewM365IntegrationTester(suite.T())
 }
 
 func (suite *EventsAPIIntgSuite) TestEvents_RestoreLargeAttachment() {
@@ -243,7 +244,7 @@ func (suite *EventsAPIIntgSuite) TestEvents_RestoreLargeAttachment() {
 	userID := tconfig.M365UserID(suite.T())
 
 	folderName := testdata.DefaultRestoreConfig("eventlargeattachmenttest").Location
-	evts := suite.its.ac.Events()
+	evts := suite.its.AC.Events()
 	calendar, err := evts.CreateContainer(ctx, userID, "", folderName)
 	require.NoError(t, err, clues.ToCore(err))
 
@@ -282,10 +283,10 @@ func (suite *EventsAPIIntgSuite) TestEvents_canFindNonStandardFolder() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	ac := suite.its.ac.Events()
+	ac := suite.its.AC.Events()
 	rc := testdata.DefaultRestoreConfig("api_calendar_discovery")
 
-	cal, err := ac.CreateContainer(ctx, suite.its.user.id, "", rc.Location)
+	cal, err := ac.CreateContainer(ctx, suite.its.User.ID, "", rc.Location)
 	require.NoError(t, err, clues.ToCore(err))
 
 	var (
@@ -302,7 +303,7 @@ func (suite *EventsAPIIntgSuite) TestEvents_canFindNonStandardFolder() {
 
 	containers, err := ac.EnumerateContainers(
 		ctx,
-		suite.its.user.id,
+		suite.its.User.ID,
 		DefaultCalendar,
 		false)
 	require.NoError(t, err, clues.ToCore(err))
@@ -341,9 +342,9 @@ func (suite *EventsAPIIntgSuite) TestEvents_GetContainerByName() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			_, err := suite.its.ac.
+			_, err := suite.its.AC.
 				Events().
-				GetContainerByName(ctx, suite.its.user.id, "", test.name)
+				GetContainerByName(ctx, suite.its.User.ID, "", test.name)
 			test.expectErr(t, err, clues.ToCore(err))
 		})
 	}
@@ -399,7 +400,7 @@ func (suite *EventsAPIIntgSuite) TestEvents_GetContainerByName_mocked() {
 				Reply(200).
 				JSON(test.results(t))
 
-			_, err := suite.its.gockAC.
+			_, err := suite.its.GockAC.
 				Events().
 				GetContainerByName(ctx, "u", "", test.name)
 			test.expectErr(t, err, clues.ToCore(err))

--- a/src/pkg/services/m365/api/groups_test.go
+++ b/src/pkg/services/m365/api/groups_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
+	"github.com/alcionai/corso/src/internal/tester/tsetup"
 	"github.com/alcionai/corso/src/pkg/fault"
 )
 
@@ -76,7 +77,7 @@ func (suite *GroupUnitSuite) TestValidateGroup() {
 
 type GroupsIntgSuite struct {
 	tester.Suite
-	its intgTesterSetup
+	its tsetup.M365
 }
 
 func TestGroupsIntgSuite(t *testing.T) {
@@ -88,7 +89,7 @@ func TestGroupsIntgSuite(t *testing.T) {
 }
 
 func (suite *GroupsIntgSuite) SetupSuite() {
-	suite.its = newIntegrationTesterSetup(suite.T())
+	suite.its = tsetup.NewM365IntegrationTester(suite.T())
 }
 
 func (suite *GroupsIntgSuite) TestGetAll() {
@@ -97,7 +98,7 @@ func (suite *GroupsIntgSuite) TestGetAll() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	groups, err := suite.its.ac.
+	groups, err := suite.its.AC.
 		Groups().
 		GetAll(ctx, fault.New(true))
 	require.NoError(t, err)
@@ -110,8 +111,8 @@ func (suite *GroupsIntgSuite) TestGetAllSites() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	channels, err := suite.its.ac.
-		Channels().GetChannels(ctx, suite.its.group.id)
+	channels, err := suite.its.AC.
+		Channels().GetChannels(ctx, suite.its.Group.ID)
 	require.NoError(t, err, "getting channels")
 	require.NotZero(t, len(channels), "must have at least one channel")
 
@@ -123,9 +124,9 @@ func (suite *GroupsIntgSuite) TestGetAllSites() {
 		}
 	}
 
-	sites, err := suite.its.ac.
+	sites, err := suite.its.AC.
 		Groups().
-		GetAllSites(ctx, suite.its.group.id, fault.New(true))
+		GetAllSites(ctx, suite.its.Group.ID, fault.New(true))
 	require.NoError(t, err)
 	require.NotZero(t, len(sites), "must have at least one site")
 	require.Equal(t, siteCount, len(sites), "incorrect number of sites")
@@ -138,13 +139,13 @@ func (suite *GroupsIntgSuite) TestGetAllSitesNonTeam() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	group, err := suite.its.ac.Groups().GetByID(ctx, suite.its.nonTeamGroup.id, CallConfig{})
+	group, err := suite.its.AC.Groups().GetByID(ctx, suite.its.NonTeamGroup.ID, CallConfig{})
 	require.NoError(t, err)
 	require.False(t, IsTeam(ctx, group), "group should not be a team for this test")
 
-	sites, err := suite.its.ac.
+	sites, err := suite.its.AC.
 		Groups().
-		GetAllSites(ctx, suite.its.nonTeamGroup.id, fault.New(true))
+		GetAllSites(ctx, suite.its.NonTeamGroup.ID, fault.New(true))
 	require.NoError(t, err)
 	require.Equal(t, 1, len(sites), "incorrect number of sites")
 }
@@ -156,9 +157,9 @@ func (suite *GroupsIntgSuite) TestGroups_GetByID() {
 	defer flush()
 
 	var (
-		groupID     = suite.its.group.id
-		groupsEmail = suite.its.group.email
-		groupsAPI   = suite.its.ac.Groups()
+		groupID     = suite.its.Group.ID
+		groupsEmail = suite.its.Group.Email
+		groupsAPI   = suite.its.AC.Groups()
 	)
 
 	grp, err := groupsAPI.GetByID(ctx, groupID, CallConfig{})

--- a/src/pkg/services/m365/api/helper_test.go
+++ b/src/pkg/services/m365/api/helper_test.go
@@ -5,45 +5,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/alcionai/clues"
 	"github.com/h2non/gock"
 	"github.com/microsoft/kiota-abstractions-go/serialization"
 	kjson "github.com/microsoft/kiota-serialization-json-go"
 	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 	"github.com/stretchr/testify/require"
-
-	"github.com/alcionai/corso/src/internal/common/ptr"
-	"github.com/alcionai/corso/src/internal/m365/graph"
-	gmock "github.com/alcionai/corso/src/internal/m365/graph/mock"
-	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/internal/tester/tconfig"
-	"github.com/alcionai/corso/src/pkg/account"
-	"github.com/alcionai/corso/src/pkg/control"
 )
-
-// ---------------------------------------------------------------------------
-// Gockable client
-// ---------------------------------------------------------------------------
-
-// GockClient produces a new exchange api client that can be
-// mocked using gock.
-func gockClient(creds account.M365Config) (Client, error) {
-	s, err := gmock.NewService(creds)
-	if err != nil {
-		return Client{}, err
-	}
-
-	li, err := gmock.NewService(creds, graph.NoTimeout())
-	if err != nil {
-		return Client{}, err
-	}
-
-	return Client{
-		Credentials: creds,
-		Stable:      s,
-		LargeItem:   li,
-	}, nil
-}
 
 // ---------------------------------------------------------------------------
 // Intercepting calls with Gock
@@ -93,93 +60,4 @@ func requireParseableToMap(t *testing.T, thing serialization.Parsable) map[strin
 	require.NoError(t, err, "unmarshall")
 
 	return out
-}
-
-// ---------------------------------------------------------------------------
-// Suite Setup
-// ---------------------------------------------------------------------------
-
-type ids struct {
-	id                string
-	email             string
-	driveID           string
-	driveRootFolderID string
-	testContainerID   string
-}
-
-type intgTesterSetup struct {
-	ac           Client
-	gockAC       Client
-	user         ids
-	site         ids
-	group        ids
-	nonTeamGroup ids // group which does not have an associated team
-}
-
-func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
-	its := intgTesterSetup{}
-
-	ctx, flush := tester.NewContext(t)
-	defer flush()
-
-	graph.InitializeConcurrencyLimiter(ctx, true, 4)
-
-	a := tconfig.NewM365Account(t)
-	creds, err := a.M365Config()
-	require.NoError(t, err, clues.ToCore(err))
-
-	its.ac, err = NewClient(creds, control.DefaultOptions())
-	require.NoError(t, err, clues.ToCore(err))
-
-	its.gockAC, err = gockClient(creds)
-	require.NoError(t, err, clues.ToCore(err))
-
-	// user drive
-
-	its.user.id = tconfig.M365UserID(t)
-
-	userDrive, err := its.ac.Users().GetDefaultDrive(ctx, its.user.id)
-	require.NoError(t, err, clues.ToCore(err))
-
-	its.user.driveID = ptr.Val(userDrive.GetId())
-
-	userDriveRootFolder, err := its.ac.Drives().GetRootFolder(ctx, its.user.driveID)
-	require.NoError(t, err, clues.ToCore(err))
-
-	its.user.driveRootFolderID = ptr.Val(userDriveRootFolder.GetId())
-
-	// site
-
-	its.site.id = tconfig.M365SiteID(t)
-
-	siteDrive, err := its.ac.Sites().GetDefaultDrive(ctx, its.site.id)
-	require.NoError(t, err, clues.ToCore(err))
-
-	its.site.driveID = ptr.Val(siteDrive.GetId())
-
-	siteDriveRootFolder, err := its.ac.Drives().GetRootFolder(ctx, its.site.driveID)
-	require.NoError(t, err, clues.ToCore(err))
-
-	its.site.driveRootFolderID = ptr.Val(siteDriveRootFolder.GetId())
-
-	// groups/teams
-
-	// use of the TeamID is intentional here, so that we are assured
-	// the group has full usage of the teams api.
-	its.group.id = tconfig.M365TeamID(t)
-	its.group.email = tconfig.M365TeamEmail(t)
-
-	its.nonTeamGroup.id = tconfig.M365GroupID(t)
-
-	channel, err := its.ac.Channels().
-		GetChannelByName(
-			ctx,
-			its.group.id,
-			"Test")
-	require.NoError(t, err, clues.ToCore(err))
-	require.Equal(t, "Test", ptr.Val(channel.GetDisplayName()))
-
-	its.group.testContainerID = ptr.Val(channel.GetId())
-
-	return its
 }

--- a/src/pkg/services/m365/api/lists_test.go
+++ b/src/pkg/services/m365/api/lists_test.go
@@ -12,16 +12,17 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
+	"github.com/alcionai/corso/src/internal/tester/tsetup"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 )
 
 type ListsAPIIntgSuite struct {
 	tester.Suite
-	its intgTesterSetup
+	its tsetup.M365
 }
 
 func (suite *ListsAPIIntgSuite) SetupSuite() {
-	suite.its = newIntegrationTesterSetup(suite.T())
+	suite.its = tsetup.NewM365IntegrationTester(suite.T())
 }
 
 func TestListsAPIIntgSuite(t *testing.T) {
@@ -39,9 +40,9 @@ func (suite *ListsAPIIntgSuite) TestLists_PostDrive() {
 	defer flush()
 
 	var (
-		acl       = suite.its.ac.Lists()
+		acl       = suite.its.AC.Lists()
 		driveName = testdata.DefaultRestoreConfig("list_api_post_drive").Location
-		siteID    = suite.its.site.id
+		siteID    = suite.its.Site.ID
 	)
 
 	// first post, should have no errors

--- a/src/pkg/services/m365/api/mail_pager_test.go
+++ b/src/pkg/services/m365/api/mail_pager_test.go
@@ -13,11 +13,12 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
+	"github.com/alcionai/corso/src/internal/tester/tsetup"
 )
 
 type MailPagerIntgSuite struct {
 	tester.Suite
-	its intgTesterSetup
+	its tsetup.M365
 }
 
 func TestMailPagerIntgSuite(t *testing.T) {
@@ -29,23 +30,23 @@ func TestMailPagerIntgSuite(t *testing.T) {
 }
 
 func (suite *MailPagerIntgSuite) SetupSuite() {
-	suite.its = newIntegrationTesterSetup(suite.T())
+	suite.its = tsetup.NewM365IntegrationTester(suite.T())
 }
 
 func (suite *MailPagerIntgSuite) TestMail_GetItemsInContainerByCollisionKey() {
 	t := suite.T()
-	ac := suite.its.ac.Mail()
+	ac := suite.its.AC.Mail()
 
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	container, err := ac.GetContainerByID(ctx, suite.its.user.id, MailInbox)
+	container, err := ac.GetContainerByID(ctx, suite.its.User.ID, MailInbox)
 	require.NoError(t, err, clues.ToCore(err))
 
 	msgs, err := ac.Stable.
 		Client().
 		Users().
-		ByUserId(suite.its.user.id).
+		ByUserId(suite.its.User.ID).
 		MailFolders().
 		ByMailFolderId(ptr.Val(container.GetId())).
 		Messages().
@@ -61,7 +62,7 @@ func (suite *MailPagerIntgSuite) TestMail_GetItemsInContainerByCollisionKey() {
 
 	expect := maps.Keys(expectM)
 
-	results, err := suite.its.ac.Mail().GetItemsInContainerByCollisionKey(ctx, suite.its.user.id, MailInbox)
+	results, err := suite.its.AC.Mail().GetItemsInContainerByCollisionKey(ctx, suite.its.User.ID, MailInbox)
 	require.NoError(t, err, clues.ToCore(err))
 	require.Less(t, 0, len(results), "requires at least one result")
 
@@ -86,7 +87,7 @@ func (suite *MailPagerIntgSuite) TestMail_GetItemsInContainerByCollisionKey() {
 
 func (suite *MailPagerIntgSuite) TestMail_GetItemsIDsInContainer() {
 	t := suite.T()
-	ac := suite.its.ac.Mail()
+	ac := suite.its.AC.Mail()
 
 	ctx, flush := tester.NewContext(t)
 	defer flush()
@@ -100,7 +101,7 @@ func (suite *MailPagerIntgSuite) TestMail_GetItemsIDsInContainer() {
 	msgs, err := ac.Stable.
 		Client().
 		Users().
-		ByUserId(suite.its.user.id).
+		ByUserId(suite.its.User.ID).
 		MailFolders().
 		ByMailFolderId(MailInbox).
 		Messages().
@@ -114,8 +115,8 @@ func (suite *MailPagerIntgSuite) TestMail_GetItemsIDsInContainer() {
 		expect[ptr.Val(m.GetId())] = struct{}{}
 	}
 
-	results, err := suite.its.ac.Mail().
-		GetItemIDsInContainer(ctx, suite.its.user.id, MailInbox)
+	results, err := suite.its.AC.Mail().
+		GetItemIDsInContainer(ctx, suite.its.User.ID, MailInbox)
 	require.NoError(t, err, clues.ToCore(err))
 	require.Less(t, 0, len(results), "requires at least one result")
 	require.Equal(t, len(expect), len(results), "must have same count of items")

--- a/src/pkg/services/m365/api/sites_test.go
+++ b/src/pkg/services/m365/api/sites_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
+	"github.com/alcionai/corso/src/internal/tester/tsetup"
 	"github.com/alcionai/corso/src/pkg/fault"
 )
 
@@ -99,7 +100,7 @@ func (suite *SitesUnitSuite) TestValidateSite() {
 
 type SitesIntgSuite struct {
 	tester.Suite
-	its intgTesterSetup
+	its tsetup.M365
 }
 
 func TestSitesIntgSuite(t *testing.T) {
@@ -111,7 +112,7 @@ func TestSitesIntgSuite(t *testing.T) {
 }
 
 func (suite *SitesIntgSuite) SetupSuite() {
-	suite.its = newIntegrationTesterSetup(suite.T())
+	suite.its = tsetup.NewM365IntegrationTester(suite.T())
 }
 
 func (suite *SitesIntgSuite) TestGetAll() {
@@ -120,7 +121,7 @@ func (suite *SitesIntgSuite) TestGetAll() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	sites, err := suite.its.ac.
+	sites, err := suite.its.AC.
 		Sites().
 		GetAll(ctx, fault.New(true))
 	require.NoError(t, err)
@@ -146,7 +147,7 @@ func (suite *SitesIntgSuite) TestSites_GetByID() {
 		uuids = strings.Join(parts[1:], ",")
 	}
 
-	sitesAPI := suite.its.ac.Sites()
+	sitesAPI := suite.its.AC.Sites()
 
 	table := []struct {
 		name      string
@@ -249,7 +250,7 @@ func (suite *SitesIntgSuite) TestGetRoot() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	result, err := suite.its.ac.Sites().GetRoot(ctx, CallConfig{Expand: []string{"drive"}})
+	result, err := suite.its.AC.Sites().GetRoot(ctx, CallConfig{Expand: []string{"drive"}})
 	require.NoError(t, err)
 	require.NotNil(t, result, "must find the root site")
 	require.NotEmpty(t, ptr.Val(result.GetId()), "must have an id")


### PR DESCRIPTION
we duplicate a lot of boilerplate code in integration tests involving the creation of an api client and the aggregation of external IDs.  In some packages we've begun
to add quality-of-life structs to aggregate these setup details. This change begins moving those structs to a singular package so that we can clear out the common setup boilerplate found elsewhere in the code.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Supportability/Tests
- [x] :broom: Tech Debt/Cleanup
