### PR TITLE
Unexport functions and fields in api package

### DIFF
--- a/src/pkg/services/m365/api/access_test.go
+++ b/src/pkg/services/m365/api/access_test.go
@@ -1,4 +1,4 @@
-package api_test
+package api
 
 import (
 	"testing"
@@ -11,7 +11,6 @@ import (
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
-	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type AccessAPIIntgSuite struct {
@@ -110,7 +109,7 @@ func (suite *AccessAPIIntgSuite) TestGetToken() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			ac, err := api.NewClient(suite.its.ac.Credentials, control.DefaultOptions())
+			ac, err := NewClient(suite.its.ac.Credentials, control.DefaultOptions())
 			require.NoError(t, err, clues.ToCore(err))
 
 			ac.Credentials = test.creds()

--- a/src/pkg/services/m365/api/channels.go
+++ b/src/pkg/services/m365/api/channels.go
@@ -128,7 +128,7 @@ func (c Channels) GetChannelMessage(
 
 	message.SetReplies(replies)
 
-	info := ChannelMessageInfo(message)
+	info := channelMessageInfo(message)
 
 	return message, info, nil
 }
@@ -137,7 +137,7 @@ func (c Channels) GetChannelMessage(
 // Helpers
 // ---------------------------------------------------------------------------
 
-func ChannelMessageInfo(
+func channelMessageInfo(
 	msg models.ChatMessageable,
 ) *details.GroupsInfo {
 	var (

--- a/src/pkg/services/m365/api/channels_pager.go
+++ b/src/pkg/services/m365/api/channels_pager.go
@@ -167,7 +167,7 @@ func (c Channels) NewChannelMessageDeltaPager(
 // unknownFutureValue.
 const channelMessageSystemMessageContent = "<systemEventMessage/>"
 
-func FilterOutSystemMessages(cm models.ChatMessageable) bool {
+func filterOutSystemMessages(cm models.ChatMessageable) bool {
 	if ptr.Val(cm.GetMessageType()) == models.SYSTEMEVENTMESSAGE_CHATMESSAGETYPE {
 		return false
 	}
@@ -196,7 +196,7 @@ func (c Channels) GetChannelMessageIDs(
 		prevDeltaLink,
 		canMakeDeltaQueries,
 		pagers.AddedAndRemovedByDeletedDateTime[models.ChatMessageable],
-		FilterOutSystemMessages)
+		filterOutSystemMessages)
 
 	return added, validModTimes, removed, du, clues.Stack(err).OrNil()
 }

--- a/src/pkg/services/m365/api/channels_pager_test.go
+++ b/src/pkg/services/m365/api/channels_pager_test.go
@@ -195,7 +195,7 @@ func (suite *ChannelsPagerIntgSuite) TestFilterOutSystemMessages() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			test.expect(suite.T(), FilterOutSystemMessages(test.cm))
+			test.expect(suite.T(), filterOutSystemMessages(test.cm))
 		})
 	}
 }

--- a/src/pkg/services/m365/api/channels_pager_test.go
+++ b/src/pkg/services/m365/api/channels_pager_test.go
@@ -1,4 +1,4 @@
-package api_test
+package api
 
 import (
 	"testing"
@@ -14,7 +14,6 @@ import (
 	"github.com/alcionai/corso/src/internal/common/str"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
-	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type ChannelsPagerIntgSuite struct {
@@ -94,7 +93,7 @@ func (suite *ChannelsPagerIntgSuite) TestEnumerateChannelMessages() {
 
 func testEnumerateChannelMessageReplies(
 	t *testing.T,
-	ac api.Channels,
+	ac Channels,
 	groupID, channelID, messageID string,
 ) {
 	ctx, flush := tester.NewContext(t)
@@ -196,7 +195,7 @@ func (suite *ChannelsPagerIntgSuite) TestFilterOutSystemMessages() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			test.expect(suite.T(), api.FilterOutSystemMessages(test.cm))
+			test.expect(suite.T(), FilterOutSystemMessages(test.cm))
 		})
 	}
 }

--- a/src/pkg/services/m365/api/channels_test.go
+++ b/src/pkg/services/m365/api/channels_test.go
@@ -1,4 +1,4 @@
-package api_test
+package api
 
 import (
 	"testing"
@@ -11,7 +11,6 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/backup/details"
-	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type ChannelsAPIUnitSuite struct {
@@ -235,7 +234,7 @@ func (suite *ChannelsAPIUnitSuite) TestChannelMessageInfo() {
 	for _, test := range tests {
 		suite.Run(test.name, func() {
 			chMsg, expected := test.msgAndInfo()
-			assert.Equal(suite.T(), expected, api.ChannelMessageInfo(chMsg))
+			assert.Equal(suite.T(), expected, ChannelMessageInfo(chMsg))
 		})
 	}
 }

--- a/src/pkg/services/m365/api/channels_test.go
+++ b/src/pkg/services/m365/api/channels_test.go
@@ -234,7 +234,7 @@ func (suite *ChannelsAPIUnitSuite) TestChannelMessageInfo() {
 	for _, test := range tests {
 		suite.Run(test.name, func() {
 			chMsg, expected := test.msgAndInfo()
-			assert.Equal(suite.T(), expected, ChannelMessageInfo(chMsg))
+			assert.Equal(suite.T(), expected, channelMessageInfo(chMsg))
 		})
 	}
 }

--- a/src/pkg/services/m365/api/contacts_pager_test.go
+++ b/src/pkg/services/m365/api/contacts_pager_test.go
@@ -1,4 +1,4 @@
-package api_test
+package api
 
 import (
 	"testing"
@@ -12,7 +12,6 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
-	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type ContactsPagerIntgSuite struct {
@@ -56,7 +55,7 @@ func (suite *ContactsPagerIntgSuite) TestContacts_GetItemsInContainerByCollision
 	expectM := map[string]struct{}{}
 
 	for _, c := range cs {
-		expectM[api.ContactCollisionKey(c)] = struct{}{}
+		expectM[ContactCollisionKey(c)] = struct{}{}
 	}
 
 	expect := maps.Keys(expectM)
@@ -91,7 +90,7 @@ func (suite *ContactsPagerIntgSuite) TestContacts_GetItemsIDsInContainer() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	container, err := ac.GetContainerByID(ctx, suite.its.user.id, api.DefaultContacts)
+	container, err := ac.GetContainerByID(ctx, suite.its.user.id, DefaultContacts)
 	require.NoError(t, err, clues.ToCore(err))
 
 	msgs, err := ac.Stable.
@@ -112,7 +111,7 @@ func (suite *ContactsPagerIntgSuite) TestContacts_GetItemsIDsInContainer() {
 	}
 
 	results, err := suite.its.ac.Contacts().
-		GetItemIDsInContainer(ctx, suite.its.user.id, api.DefaultContacts)
+		GetItemIDsInContainer(ctx, suite.its.user.id, DefaultContacts)
 	require.NoError(t, err, clues.ToCore(err))
 	require.Less(t, 0, len(results), "requires at least one result")
 	require.Equal(t, len(expect), len(results), "must have same count of items")

--- a/src/pkg/services/m365/api/contacts_test.go
+++ b/src/pkg/services/m365/api/contacts_test.go
@@ -1,4 +1,4 @@
-package api_test
+package api
 
 import (
 	"testing"
@@ -16,7 +16,6 @@ import (
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
-	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type ContactsAPIUnitSuite struct {
@@ -73,7 +72,7 @@ func (suite *ContactsAPIUnitSuite) TestContactInfo() {
 	for _, test := range tests {
 		suite.Run(test.name, func() {
 			contact, expected := test.contactAndRP()
-			assert.Equal(suite.T(), expected, api.ContactInfo(contact))
+			assert.Equal(suite.T(), expected, ContactInfo(contact))
 		})
 	}
 }
@@ -108,7 +107,7 @@ func (suite *ContactsAPIUnitSuite) TestBytesToContactable() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			result, err := api.BytesToContactable(test.byteArray)
+			result, err := BytesToContactable(test.byteArray)
 			test.checkError(t, err, clues.ToCore(err))
 			test.isNil(t, result)
 		})

--- a/src/pkg/services/m365/api/drive_pager_test.go
+++ b/src/pkg/services/m365/api/drive_pager_test.go
@@ -1,4 +1,4 @@
-package api_test
+package api
 
 import (
 	"testing"
@@ -12,7 +12,6 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
-	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type DrivePagerIntgSuite struct {
@@ -70,7 +69,7 @@ func (suite *DrivePagerIntgSuite) TestDrives_GetItemsInContainerByCollisionKey()
 			require.NoError(t, err, clues.ToCore(err))
 
 			ims := items.GetValue()
-			expect := make([]api.DriveItemIDType, 0, len(ims))
+			expect := make([]DriveItemIDType, 0, len(ims))
 
 			assert.NotEmptyf(
 				t,
@@ -144,7 +143,7 @@ func (suite *DrivePagerIntgSuite) TestDrives_GetItemIDsInContainer() {
 			require.NoError(t, err, clues.ToCore(err))
 
 			igv := items.GetValue()
-			expect := map[string]api.DriveItemIDType{}
+			expect := map[string]DriveItemIDType{}
 
 			assert.NotEmptyf(
 				t,
@@ -153,7 +152,7 @@ func (suite *DrivePagerIntgSuite) TestDrives_GetItemIDsInContainer() {
 				suite.its.user.id, test.driveID, test.rootFolderID)
 
 			for _, itm := range igv {
-				expect[ptr.Val(itm.GetId())] = api.DriveItemIDType{
+				expect[ptr.Val(itm.GetId())] = DriveItemIDType{
 					ItemID:   ptr.Val(itm.GetId()),
 					IsFolder: itm.GetFolder() != nil,
 				}
@@ -195,8 +194,8 @@ func (suite *DrivePagerIntgSuite) TestEnumerateDriveItems() {
 			ctx,
 			suite.its.user.driveID,
 			"",
-			api.CallConfig{
-				Select: api.DefaultDriveItemProps(),
+			CallConfig{
+				Select: DefaultDriveItemProps(),
 			})
 
 	for page, reset, done := pager.NextPage(); !done; page, reset, done = pager.NextPage() {

--- a/src/pkg/services/m365/api/drive_test.go
+++ b/src/pkg/services/m365/api/drive_test.go
@@ -1,4 +1,4 @@
-package api_test
+package api
 
 import (
 	"fmt"
@@ -18,7 +18,6 @@ import (
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
-	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type DriveAPIIntgSuite struct {
@@ -66,12 +65,12 @@ func (suite *DriveAPIIntgSuite) TestDrives_PostItemInContainer() {
 		ctx,
 		suite.its.user.driveID,
 		suite.its.user.driveRootFolderID,
-		api.NewDriveItem(rc.Location, true),
+		NewDriveItem(rc.Location, true),
 		control.Replace)
 	require.NoError(t, err, clues.ToCore(err))
 
 	// generate a folder to use for collision testing
-	folder := api.NewDriveItem("collision", true)
+	folder := NewDriveItem("collision", true)
 	origFolder, err := acd.PostItemInContainer(
 		ctx,
 		suite.its.user.driveID,
@@ -81,7 +80,7 @@ func (suite *DriveAPIIntgSuite) TestDrives_PostItemInContainer() {
 	require.NoError(t, err, clues.ToCore(err))
 
 	// generate an item to use for collision testing
-	file := api.NewDriveItem("collision.txt", false)
+	file := NewDriveItem("collision.txt", false)
 	origFile, err := acd.PostItemInContainer(
 		ctx,
 		suite.its.user.driveID,
@@ -265,7 +264,7 @@ func (suite *DriveAPIIntgSuite) TestDrives_PostItemInContainer_replaceFolderRegr
 		ctx,
 		suite.its.user.driveID,
 		suite.its.user.driveRootFolderID,
-		api.NewDriveItem(rc.Location, true),
+		NewDriveItem(rc.Location, true),
 		// skip instead of replace here to get
 		// an ErrItemAlreadyExistsConflict, just in case.
 		control.Skip)
@@ -273,7 +272,7 @@ func (suite *DriveAPIIntgSuite) TestDrives_PostItemInContainer_replaceFolderRegr
 
 	// generate items within that folder
 	for i := 0; i < 5; i++ {
-		file := api.NewDriveItem(fmt.Sprintf("collision_%d.txt", i), false)
+		file := NewDriveItem(fmt.Sprintf("collision_%d.txt", i), false)
 		f, err := acd.PostItemInContainer(
 			ctx,
 			suite.its.user.driveID,
@@ -289,7 +288,7 @@ func (suite *DriveAPIIntgSuite) TestDrives_PostItemInContainer_replaceFolderRegr
 		ctx,
 		suite.its.user.driveID,
 		ptr.Val(folder.GetParentReference().GetId()),
-		api.NewDriveItem(rc.Location, true),
+		NewDriveItem(rc.Location, true),
 		control.Replace)
 	require.NoError(t, err, clues.ToCore(err))
 	require.NotEmpty(t, ptr.Val(resultFolder.GetId()))

--- a/src/pkg/services/m365/api/events_pager_test.go
+++ b/src/pkg/services/m365/api/events_pager_test.go
@@ -1,4 +1,4 @@
-package api_test
+package api
 
 import (
 	"testing"
@@ -12,7 +12,6 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
-	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type EventsPagerIntgSuite struct {
@@ -56,7 +55,7 @@ func (suite *EventsPagerIntgSuite) TestEvents_GetItemsInContainerByCollisionKey(
 	expectM := map[string]struct{}{}
 
 	for _, e := range es {
-		expectM[api.EventCollisionKey(e)] = struct{}{}
+		expectM[EventCollisionKey(e)] = struct{}{}
 	}
 
 	expect := maps.Keys(expectM)

--- a/src/pkg/services/m365/api/events_test.go
+++ b/src/pkg/services/m365/api/events_test.go
@@ -363,7 +363,7 @@ func (suite *EventsAPIIntgSuite) TestEvents_GetContainerByName_mocked() {
 		{
 			name: "zero",
 			results: func(t *testing.T) map[string]any {
-				return parseableToMap(t, models.NewCalendarCollectionResponse())
+				return requireParseableToMap(t, models.NewCalendarCollectionResponse())
 			},
 			expectErr: assert.Error,
 		},
@@ -373,7 +373,7 @@ func (suite *EventsAPIIntgSuite) TestEvents_GetContainerByName_mocked() {
 				mfcr := models.NewCalendarCollectionResponse()
 				mfcr.SetValue([]models.Calendarable{c})
 
-				return parseableToMap(t, mfcr)
+				return requireParseableToMap(t, mfcr)
 			},
 			expectErr: assert.NoError,
 		},
@@ -383,7 +383,7 @@ func (suite *EventsAPIIntgSuite) TestEvents_GetContainerByName_mocked() {
 				mfcr := models.NewCalendarCollectionResponse()
 				mfcr.SetValue([]models.Calendarable{c, c})
 
-				return parseableToMap(t, mfcr)
+				return requireParseableToMap(t, mfcr)
 			},
 			expectErr: assert.NoError,
 		},

--- a/src/pkg/services/m365/api/events_test.go
+++ b/src/pkg/services/m365/api/events_test.go
@@ -1,4 +1,4 @@
-package api_test
+package api
 
 import (
 	"testing"
@@ -18,7 +18,6 @@ import (
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
-	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type EventsAPIUnitSuite struct {
@@ -131,7 +130,7 @@ func (suite *EventsAPIUnitSuite) TestEventInfo() {
 					future       = time.Now().UTC().AddDate(0, 0, 1)
 					eventTime    = time.Date(future.Year(), future.Month(), future.Day(), future.Hour(), 0, 0, 0, time.UTC)
 					eventEndTime = eventTime.Add(30 * time.Minute)
-					event, err   = api.BytesToEventable(bytes)
+					event, err   = BytesToEventable(bytes)
 				)
 
 				require.NoError(suite.T(), err, clues.ToCore(err))
@@ -151,7 +150,7 @@ func (suite *EventsAPIUnitSuite) TestEventInfo() {
 			t := suite.T()
 
 			event, expected := test.evtAndRP()
-			result := api.EventInfo(event)
+			result := EventInfo(event)
 
 			assert.Equal(t, expected.Subject, result.Subject, "subject")
 			assert.Equal(t, expected.Sender, result.Sender, "sender")
@@ -211,7 +210,7 @@ func (suite *EventsAPIUnitSuite) TestBytesToEventable() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			result, err := api.BytesToEventable(test.byteArray)
+			result, err := BytesToEventable(test.byteArray)
 			test.checkError(t, err, clues.ToCore(err))
 			test.isNil(t, result)
 		})
@@ -304,7 +303,7 @@ func (suite *EventsAPIIntgSuite) TestEvents_canFindNonStandardFolder() {
 	containers, err := ac.EnumerateContainers(
 		ctx,
 		suite.its.user.id,
-		api.DefaultCalendar,
+		DefaultCalendar,
 		false)
 	require.NoError(t, err, clues.ToCore(err))
 

--- a/src/pkg/services/m365/api/groups.go
+++ b/src/pkg/services/m365/api/groups.go
@@ -79,7 +79,7 @@ func getGroups(
 			return false
 		}
 
-		err := ValidateGroup(item)
+		err := validateGroup(item)
 		if err != nil {
 			el.AddRecoverable(ctx, graph.Wrap(ctx, err, "validating groups"))
 		} else {
@@ -315,9 +315,9 @@ func (c Groups) GetRootSite(
 // helpers
 // ---------------------------------------------------------------------------
 
-// ValidateGroup ensures the item is a Groupable, and contains the necessary
+// validateGroup ensures the item is a Groupable, and contains the necessary
 // identifiers that we handle with all groups.
-func ValidateGroup(item models.Groupable) error {
+func validateGroup(item models.Groupable) error {
 	if item.GetId() == nil {
 		return clues.New("missing ID")
 	}

--- a/src/pkg/services/m365/api/groups_test.go
+++ b/src/pkg/services/m365/api/groups_test.go
@@ -1,4 +1,4 @@
-package api_test
+package api
 
 import (
 	"testing"
@@ -14,7 +14,6 @@ import (
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/fault"
-	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type GroupUnitSuite struct {
@@ -70,7 +69,7 @@ func (suite *GroupUnitSuite) TestValidateGroup() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			err := api.ValidateGroup(test.args)
+			err := ValidateGroup(test.args)
 			test.expectErr(t, err, clues.ToCore(err))
 
 			if test.errIsSkippable {
@@ -144,9 +143,9 @@ func (suite *GroupsIntgSuite) TestGetAllSitesNonTeam() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	group, err := suite.its.ac.Groups().GetByID(ctx, suite.its.nonTeamGroup.id, api.CallConfig{})
+	group, err := suite.its.ac.Groups().GetByID(ctx, suite.its.nonTeamGroup.id, CallConfig{})
 	require.NoError(t, err)
-	require.False(t, api.IsTeam(ctx, group), "group should not be a team for this test")
+	require.False(t, IsTeam(ctx, group), "group should not be a team for this test")
 
 	sites, err := suite.its.ac.
 		Groups().
@@ -167,7 +166,7 @@ func (suite *GroupsIntgSuite) TestGroups_GetByID() {
 		groupsAPI   = suite.its.ac.Groups()
 	)
 
-	grp, err := groupsAPI.GetByID(ctx, groupID, api.CallConfig{})
+	grp, err := groupsAPI.GetByID(ctx, groupID, CallConfig{})
 	require.NoError(t, err, clues.ToCore(err))
 
 	table := []struct {
@@ -208,7 +207,7 @@ func (suite *GroupsIntgSuite) TestGroups_GetByID() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			_, err := groupsAPI.GetByID(ctx, test.id, api.CallConfig{})
+			_, err := groupsAPI.GetByID(ctx, test.id, CallConfig{})
 			test.expectErr(t, err, clues.ToCore(err))
 		})
 	}

--- a/src/pkg/services/m365/api/groups_test.go
+++ b/src/pkg/services/m365/api/groups_test.go
@@ -69,7 +69,7 @@ func (suite *GroupUnitSuite) TestValidateGroup() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			err := ValidateGroup(test.args)
+			err := validateGroup(test.args)
 			test.expectErr(t, err, clues.ToCore(err))
 
 			if test.errIsSkippable {

--- a/src/pkg/services/m365/api/groups_test.go
+++ b/src/pkg/services/m365/api/groups_test.go
@@ -30,10 +30,9 @@ func (suite *GroupUnitSuite) TestValidateGroup() {
 	group.SetId(ptr.To("testID"))
 
 	tests := []struct {
-		name           string
-		args           models.Groupable
-		expectErr      assert.ErrorAssertionFunc
-		errIsSkippable bool
+		name      string
+		args      models.Groupable
+		expectErr assert.ErrorAssertionFunc
 	}{
 		{
 			name: "Valid group ",
@@ -71,10 +70,6 @@ func (suite *GroupUnitSuite) TestValidateGroup() {
 
 			err := validateGroup(test.args)
 			test.expectErr(t, err, clues.ToCore(err))
-
-			if test.errIsSkippable {
-				assert.ErrorIs(t, err, api.ErrKnownSkippableCase)
-			}
 		})
 	}
 }

--- a/src/pkg/services/m365/api/helper_test.go
+++ b/src/pkg/services/m365/api/helper_test.go
@@ -80,7 +80,7 @@ func odErrMsg(code, message string) *odataerrors.ODataError {
 	return odErr
 }
 
-func parseableToMap(t *testing.T, thing serialization.Parsable) map[string]any {
+func requireParseableToMap(t *testing.T, thing serialization.Parsable) map[string]any {
 	sw := kjson.NewJsonSerializationWriter()
 
 	err := sw.WriteObjectValue("", thing)

--- a/src/pkg/services/m365/api/helper_test.go
+++ b/src/pkg/services/m365/api/helper_test.go
@@ -1,4 +1,4 @@
-package api_test
+package api
 
 import (
 	"encoding/json"
@@ -19,7 +19,6 @@ import (
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/control"
-	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 // ---------------------------------------------------------------------------
@@ -28,18 +27,18 @@ import (
 
 // GockClient produces a new exchange api client that can be
 // mocked using gock.
-func gockClient(creds account.M365Config) (api.Client, error) {
+func gockClient(creds account.M365Config) (Client, error) {
 	s, err := gmock.NewService(creds)
 	if err != nil {
-		return api.Client{}, err
+		return Client{}, err
 	}
 
 	li, err := gmock.NewService(creds, graph.NoTimeout())
 	if err != nil {
-		return api.Client{}, err
+		return Client{}, err
 	}
 
-	return api.Client{
+	return Client{
 		Credentials: creds,
 		Stable:      s,
 		LargeItem:   li,
@@ -109,8 +108,8 @@ type ids struct {
 }
 
 type intgTesterSetup struct {
-	ac           api.Client
-	gockAC       api.Client
+	ac           Client
+	gockAC       Client
 	user         ids
 	site         ids
 	group        ids
@@ -129,7 +128,7 @@ func newIntegrationTesterSetup(t *testing.T) intgTesterSetup {
 	creds, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
-	its.ac, err = api.NewClient(creds, control.DefaultOptions())
+	its.ac, err = NewClient(creds, control.DefaultOptions())
 	require.NoError(t, err, clues.ToCore(err))
 
 	its.gockAC, err = gockClient(creds)

--- a/src/pkg/services/m365/api/item_serialization_test.go
+++ b/src/pkg/services/m365/api/item_serialization_test.go
@@ -1,4 +1,4 @@
-package api_test
+package api
 
 import (
 	"context"
@@ -13,7 +13,6 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type ItemSerializationUnitSuite struct {
@@ -43,13 +42,13 @@ func (suite *ItemSerializationUnitSuite) TestConcurrentItemSerialization() {
 				item := models.NewMessage()
 				item.SetSubject(&subject)
 
-				bs, err := api.Mail{}.Serialize(ctx, item, user, subject)
+				bs, err := Mail{}.Serialize(ctx, item, user, subject)
 				require.NoError(t, err, clues.ToCore(err))
 
 				return bs
 			},
 			deserializeAndGetField: func(t *testing.T, bs []byte) string {
-				item, err := api.BytesToMessageable(bs)
+				item, err := BytesToMessageable(bs)
 				require.NoError(
 					t,
 					err,
@@ -68,13 +67,13 @@ func (suite *ItemSerializationUnitSuite) TestConcurrentItemSerialization() {
 				item := models.NewEvent()
 				item.SetSubject(&subject)
 
-				bs, err := api.Events{}.Serialize(ctx, item, user, subject)
+				bs, err := Events{}.Serialize(ctx, item, user, subject)
 				require.NoError(t, err, clues.ToCore(err))
 
 				return bs
 			},
 			deserializeAndGetField: func(t *testing.T, bs []byte) string {
-				item, err := api.BytesToEventable(bs)
+				item, err := BytesToEventable(bs)
 				require.NoError(
 					t,
 					err,
@@ -93,13 +92,13 @@ func (suite *ItemSerializationUnitSuite) TestConcurrentItemSerialization() {
 				item := models.NewContact()
 				item.SetGivenName(&name)
 
-				bs, err := api.Contacts{}.Serialize(ctx, item, user, name)
+				bs, err := Contacts{}.Serialize(ctx, item, user, name)
 				require.NoError(t, err, clues.ToCore(err))
 
 				return bs
 			},
 			deserializeAndGetField: func(t *testing.T, bs []byte) string {
-				item, err := api.BytesToContactable(bs)
+				item, err := BytesToContactable(bs)
 				require.NoError(
 					t,
 					err,

--- a/src/pkg/services/m365/api/lists_test.go
+++ b/src/pkg/services/m365/api/lists_test.go
@@ -1,4 +1,4 @@
-package api_test
+package api
 
 import (
 	"testing"

--- a/src/pkg/services/m365/api/mail.go
+++ b/src/pkg/services/m365/api/mail.go
@@ -565,7 +565,7 @@ func (c Mail) Serialize(
 
 func MailInfo(msg models.Messageable, size int64) *details.ExchangeInfo {
 	var (
-		sender     = UnwrapEmailAddress(msg.GetSender())
+		sender     = unwrapEmailAddress(msg.GetSender())
 		subject    = ptr.Val(msg.GetSubject())
 		received   = ptr.Val(msg.GetReceivedDateTime())
 		created    = ptr.Val(msg.GetCreatedDateTime())
@@ -575,7 +575,7 @@ func MailInfo(msg models.Messageable, size int64) *details.ExchangeInfo {
 	if msg.GetToRecipients() != nil {
 		ppl := msg.GetToRecipients()
 		for _, entry := range ppl {
-			temp := UnwrapEmailAddress(entry)
+			temp := unwrapEmailAddress(entry)
 			if len(temp) > 0 {
 				recipients = append(recipients, temp)
 			}
@@ -594,7 +594,7 @@ func MailInfo(msg models.Messageable, size int64) *details.ExchangeInfo {
 	}
 }
 
-func UnwrapEmailAddress(contact models.Recipientable) string {
+func unwrapEmailAddress(contact models.Recipientable) string {
 	var empty string
 	if contact == nil || contact.GetEmailAddress() == nil {
 		return empty

--- a/src/pkg/services/m365/api/mail_pager_test.go
+++ b/src/pkg/services/m365/api/mail_pager_test.go
@@ -1,4 +1,4 @@
-package api_test
+package api
 
 import (
 	"testing"
@@ -13,7 +13,6 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
-	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type MailPagerIntgSuite struct {
@@ -40,7 +39,7 @@ func (suite *MailPagerIntgSuite) TestMail_GetItemsInContainerByCollisionKey() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	container, err := ac.GetContainerByID(ctx, suite.its.user.id, api.MailInbox)
+	container, err := ac.GetContainerByID(ctx, suite.its.user.id, MailInbox)
 	require.NoError(t, err, clues.ToCore(err))
 
 	msgs, err := ac.Stable.
@@ -57,12 +56,12 @@ func (suite *MailPagerIntgSuite) TestMail_GetItemsInContainerByCollisionKey() {
 	expectM := map[string]struct{}{}
 
 	for _, m := range ms {
-		expectM[api.MailCollisionKey(m)] = struct{}{}
+		expectM[MailCollisionKey(m)] = struct{}{}
 	}
 
 	expect := maps.Keys(expectM)
 
-	results, err := suite.its.ac.Mail().GetItemsInContainerByCollisionKey(ctx, suite.its.user.id, api.MailInbox)
+	results, err := suite.its.ac.Mail().GetItemsInContainerByCollisionKey(ctx, suite.its.user.id, MailInbox)
 	require.NoError(t, err, clues.ToCore(err))
 	require.Less(t, 0, len(results), "requires at least one result")
 
@@ -103,7 +102,7 @@ func (suite *MailPagerIntgSuite) TestMail_GetItemsIDsInContainer() {
 		Users().
 		ByUserId(suite.its.user.id).
 		MailFolders().
-		ByMailFolderId(api.MailInbox).
+		ByMailFolderId(MailInbox).
 		Messages().
 		Get(ctx, config)
 	require.NoError(t, err, clues.ToCore(err))
@@ -116,7 +115,7 @@ func (suite *MailPagerIntgSuite) TestMail_GetItemsIDsInContainer() {
 	}
 
 	results, err := suite.its.ac.Mail().
-		GetItemIDsInContainer(ctx, suite.its.user.id, api.MailInbox)
+		GetItemIDsInContainer(ctx, suite.its.user.id, MailInbox)
 	require.NoError(t, err, clues.ToCore(err))
 	require.Less(t, 0, len(results), "requires at least one result")
 	require.Equal(t, len(expect), len(results), "must have same count of items")

--- a/src/pkg/services/m365/api/mail_test.go
+++ b/src/pkg/services/m365/api/mail_test.go
@@ -1,4 +1,4 @@
-package api_test
+package api
 
 import (
 	"testing"
@@ -18,7 +18,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/fault"
-	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type MailAPIUnitSuite struct {
@@ -150,7 +149,7 @@ func (suite *MailAPIUnitSuite) TestMailInfo() {
 	for _, tt := range tests {
 		suite.Run(tt.name, func() {
 			msg, expected := tt.msgAndRP()
-			assert.Equal(suite.T(), expected, api.MailInfo(msg, 0))
+			assert.Equal(suite.T(), expected, MailInfo(msg, 0))
 		})
 	}
 }
@@ -179,7 +178,7 @@ func (suite *MailAPIUnitSuite) TestBytesToMessagable() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			result, err := api.BytesToMessageable(test.byteArray)
+			result, err := BytesToMessageable(test.byteArray)
 			test.checkError(t, err, clues.ToCore(err))
 			test.checkObject(t, result)
 		})
@@ -380,7 +379,7 @@ func (suite *MailAPIIntgSuite) TestMail_RestoreLargeAttachment() {
 
 	folderName := testdata.DefaultRestoreConfig("maillargeattachmenttest").Location
 	msgs := suite.its.ac.Mail()
-	mailfolder, err := msgs.CreateContainer(ctx, userID, api.MsgFolderRoot, folderName)
+	mailfolder, err := msgs.CreateContainer(ctx, userID, MsgFolderRoot, folderName)
 	require.NoError(t, err, clues.ToCore(err))
 
 	msg := models.NewMessage()
@@ -419,7 +418,7 @@ func (suite *MailAPIIntgSuite) TestMail_GetContainerByName() {
 		expectErr         assert.ErrorAssertionFunc
 	}{
 		{
-			name:      api.MailInbox,
+			name:      MailInbox,
 			expectErr: assert.NoError,
 		},
 		{

--- a/src/pkg/services/m365/api/mail_test.go
+++ b/src/pkg/services/m365/api/mail_test.go
@@ -224,7 +224,7 @@ func (suite *MailAPIIntgSuite) TestHugeAttachmentListDownload() {
 
 				interceptV1Path("users", "user", "messages", mid).
 					Reply(200).
-					JSON(parseableToMap(suite.T(), mitem))
+					JSON(requireParseableToMap(suite.T(), mitem))
 			},
 			expect: assert.NoError,
 		},
@@ -237,7 +237,7 @@ func (suite *MailAPIIntgSuite) TestHugeAttachmentListDownload() {
 
 				interceptV1Path("users", "user", "messages", mid).
 					Reply(200).
-					JSON(parseableToMap(suite.T(), email))
+					JSON(requireParseableToMap(suite.T(), email))
 
 				atts := models.NewAttachmentCollectionResponse()
 				attch := models.NewAttachment()
@@ -248,7 +248,7 @@ func (suite *MailAPIIntgSuite) TestHugeAttachmentListDownload() {
 
 				interceptV1Path("users", "user", "messages", mid, "attachments").
 					Reply(200).
-					JSON(parseableToMap(suite.T(), atts))
+					JSON(requireParseableToMap(suite.T(), atts))
 			},
 			attachmentCount: 1,
 			size:            50,
@@ -263,7 +263,7 @@ func (suite *MailAPIIntgSuite) TestHugeAttachmentListDownload() {
 
 				interceptV1Path("users", "user", "messages", mid).
 					Reply(200).
-					JSON(parseableToMap(suite.T(), email))
+					JSON(requireParseableToMap(suite.T(), email))
 
 				atts := models.NewAttachmentCollectionResponse()
 				attch := models.NewAttachment()
@@ -279,11 +279,11 @@ func (suite *MailAPIIntgSuite) TestHugeAttachmentListDownload() {
 
 				interceptV1Path("users", "user", "messages", mid, "attachments").
 					Reply(200).
-					JSON(parseableToMap(suite.T(), atts))
+					JSON(requireParseableToMap(suite.T(), atts))
 
 				interceptV1Path("users", "user", "messages", mid, "attachments", aid).
 					Reply(200).
-					JSON(parseableToMap(suite.T(), attch))
+					JSON(requireParseableToMap(suite.T(), attch))
 			},
 			attachmentCount: 1,
 			size:            200,
@@ -299,7 +299,7 @@ func (suite *MailAPIIntgSuite) TestHugeAttachmentListDownload() {
 
 				interceptV1Path("users", "user", "messages", mid).
 					Reply(200).
-					JSON(parseableToMap(suite.T(), email))
+					JSON(requireParseableToMap(suite.T(), email))
 
 				atts := models.NewAttachmentCollectionResponse()
 				attch := models.NewAttachment()
@@ -315,12 +315,12 @@ func (suite *MailAPIIntgSuite) TestHugeAttachmentListDownload() {
 
 				interceptV1Path("users", "user", "messages", mid, "attachments").
 					Reply(200).
-					JSON(parseableToMap(suite.T(), atts))
+					JSON(requireParseableToMap(suite.T(), atts))
 
 				for i := 0; i < 5; i++ {
 					interceptV1Path("users", "user", "messages", mid, "attachments", aid).
 						Reply(200).
-						JSON(parseableToMap(suite.T(), attch))
+						JSON(requireParseableToMap(suite.T(), attch))
 				}
 			},
 			attachmentCount: 5,
@@ -478,7 +478,7 @@ func (suite *MailAPIIntgSuite) TestMail_GetContainerByName_mocked() {
 		{
 			name: "zero",
 			results: func(t *testing.T) map[string]any {
-				return parseableToMap(t, models.NewMailFolderCollectionResponse())
+				return requireParseableToMap(t, models.NewMailFolderCollectionResponse())
 			},
 			expectErr: assert.Error,
 		},
@@ -488,7 +488,7 @@ func (suite *MailAPIIntgSuite) TestMail_GetContainerByName_mocked() {
 				mfcr := models.NewMailFolderCollectionResponse()
 				mfcr.SetValue([]models.MailFolderable{mf})
 
-				return parseableToMap(t, mfcr)
+				return requireParseableToMap(t, mfcr)
 			},
 			expectErr: assert.NoError,
 		},
@@ -498,7 +498,7 @@ func (suite *MailAPIIntgSuite) TestMail_GetContainerByName_mocked() {
 				mfcr := models.NewMailFolderCollectionResponse()
 				mfcr.SetValue([]models.MailFolderable{mf, mf})
 
-				return parseableToMap(t, mfcr)
+				return requireParseableToMap(t, mfcr)
 			},
 			expectErr: assert.Error,
 		},

--- a/src/pkg/services/m365/api/sites.go
+++ b/src/pkg/services/m365/api/sites.go
@@ -84,7 +84,7 @@ func (c Sites) GetAll(ctx context.Context, errs *fault.Bus) ([]models.Siteable, 
 			return false
 		}
 
-		err := ValidateSite(item)
+		err := validateSite(item)
 		if errors.Is(err, ErrKnownSkippableCase) {
 			// safe to no-op
 			return true
@@ -259,10 +259,10 @@ var ErrKnownSkippableCase = clues.New("case is known and skippable")
 
 const PersonalSitePath = "sharepoint.com/personal/"
 
-// ValidateSite ensures the item is a Siteable, and contains the necessary
+// validateSite ensures the item is a Siteable, and contains the necessary
 // identifiers that we handle with all users.
 // returns the item as a Siteable model.
-func ValidateSite(item models.Siteable) error {
+func validateSite(item models.Siteable) error {
 	id := ptr.Val(item.GetId())
 	if len(id) == 0 {
 		return clues.New("missing ID")

--- a/src/pkg/services/m365/api/sites_test.go
+++ b/src/pkg/services/m365/api/sites_test.go
@@ -1,4 +1,4 @@
-package api_test
+package api
 
 import (
 	"strings"
@@ -16,7 +16,6 @@ import (
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/fault"
-	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type SitesUnitSuite struct {
@@ -79,7 +78,7 @@ func (suite *SitesUnitSuite) TestValidateSite() {
 			args: func() *models.Site {
 				s := models.NewSite()
 				s.SetId(ptr.To("id"))
-				s.SetWebUrl(ptr.To("https://" + api.PersonalSitePath + "/someone's/onedrive"))
+				s.SetWebUrl(ptr.To("https://" + PersonalSitePath + "/someone's/onedrive"))
 				return s
 			}(),
 			errCheck:       assert.Error,
@@ -95,11 +94,11 @@ func (suite *SitesUnitSuite) TestValidateSite() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			err := api.ValidateSite(test.args)
+			err := ValidateSite(test.args)
 			test.errCheck(t, err, clues.ToCore(err))
 
 			if test.errIsSkippable {
-				assert.ErrorIs(t, err, api.ErrKnownSkippableCase)
+				assert.ErrorIs(t, err, ErrKnownSkippableCase)
 			}
 		})
 	}
@@ -135,7 +134,7 @@ func (suite *SitesIntgSuite) TestGetAll() {
 	require.NotZero(t, len(sites), "must have at least one site")
 
 	for _, site := range sites {
-		assert.NotContains(t, ptr.Val(site.GetWebUrl()), api.PersonalSitePath, "must not return onedrive sites")
+		assert.NotContains(t, ptr.Val(site.GetWebUrl()), PersonalSitePath, "must not return onedrive sites")
 		assert.NotContains(t, ptr.Val(site.GetWebUrl()), "sharepoint.com/search", "must not return search site")
 	}
 }
@@ -233,7 +232,7 @@ func (suite *SitesIntgSuite) TestSites_GetByID() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			cc := api.CallConfig{
+			cc := CallConfig{
 				Expand: []string{"drive"},
 			}
 
@@ -257,7 +256,7 @@ func (suite *SitesIntgSuite) TestGetRoot() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	result, err := suite.its.ac.Sites().GetRoot(ctx, api.CallConfig{Expand: []string{"drive"}})
+	result, err := suite.its.ac.Sites().GetRoot(ctx, CallConfig{Expand: []string{"drive"}})
 	require.NoError(t, err)
 	require.NotNil(t, result, "must find the root site")
 	require.NotEmpty(t, ptr.Val(result.GetId()), "must have an id")

--- a/src/pkg/services/m365/api/sites_test.go
+++ b/src/pkg/services/m365/api/sites_test.go
@@ -94,7 +94,7 @@ func (suite *SitesUnitSuite) TestValidateSite() {
 		suite.Run(test.name, func() {
 			t := suite.T()
 
-			err := ValidateSite(test.args)
+			err := validateSite(test.args)
 			test.errCheck(t, err, clues.ToCore(err))
 
 			if test.errIsSkippable {

--- a/src/pkg/services/m365/api/users.go
+++ b/src/pkg/services/m365/api/users.go
@@ -95,7 +95,7 @@ func (c Users) GetAll(
 			return false
 		}
 
-		err := ValidateUser(item)
+		err := validateUser(item)
 		if err != nil {
 			el.AddRecoverable(ctx, graph.Wrap(ctx, err, "validating user"))
 		} else {
@@ -297,9 +297,9 @@ func (c Users) GetFirstInboxMessage(
 // helpers
 // ---------------------------------------------------------------------------
 
-// ValidateUser ensures the item is a Userable, and contains the necessary
+// validateUser ensures the item is a Userable, and contains the necessary
 // identifiers that we handle with all users.
-func ValidateUser(item models.Userable) error {
+func validateUser(item models.Userable) error {
 	if item.GetId() == nil {
 		return clues.New("missing ID")
 	}

--- a/src/pkg/services/m365/api/users_test.go
+++ b/src/pkg/services/m365/api/users_test.go
@@ -1,4 +1,4 @@
-package api_test
+package api
 
 import (
 	"testing"
@@ -10,7 +10,6 @@ import (
 
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type UsersUnitSuite struct {
@@ -59,7 +58,7 @@ func (suite *UsersUnitSuite) TestValidateUser() {
 		suite.Run(tt.name, func() {
 			t := suite.T()
 
-			err := api.ValidateUser(tt.args)
+			err := ValidateUser(tt.args)
 			tt.errCheck(t, err, clues.ToCore(err))
 		})
 	}
@@ -116,7 +115,7 @@ func (suite *UsersUnitSuite) TestEvaluateMailboxError() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			test.expect(suite.T(), api.EvaluateMailboxError(test.err))
+			test.expect(suite.T(), EvaluateMailboxError(test.err))
 		})
 	}
 }
@@ -136,7 +135,7 @@ func (suite *UsersUnitSuite) TestIsAnyErrMailboxNotFound() {
 			name: "mailbox not found error",
 			errs: []error{
 				clues.New("an error"),
-				api.ErrMailBoxNotFound,
+				ErrMailBoxNotFound,
 				clues.New("an error"),
 			},
 			expect: true,
@@ -145,7 +144,7 @@ func (suite *UsersUnitSuite) TestIsAnyErrMailboxNotFound() {
 			name: "other errors",
 			errs: []error{
 				clues.New("an error"),
-				api.ErrMailBoxSettingsAccessDenied,
+				ErrMailBoxSettingsAccessDenied,
 				clues.New("an error"),
 			},
 			expect: false,
@@ -153,7 +152,7 @@ func (suite *UsersUnitSuite) TestIsAnyErrMailboxNotFound() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			assert.Equal(suite.T(), test.expect, api.IsAnyErrMailboxNotFound(test.errs))
+			assert.Equal(suite.T(), test.expect, IsAnyErrMailboxNotFound(test.errs))
 		})
 	}
 }

--- a/src/pkg/services/m365/api/users_test.go
+++ b/src/pkg/services/m365/api/users_test.go
@@ -58,7 +58,7 @@ func (suite *UsersUnitSuite) TestValidateUser() {
 		suite.Run(tt.name, func() {
 			t := suite.T()
 
-			err := ValidateUser(tt.args)
+			err := validateUser(tt.args)
 			tt.errCheck(t, err, clues.ToCore(err))
 		})
 	}

--- a/src/pkg/services/m365/sites_test.go
+++ b/src/pkg/services/m365/sites_test.go
@@ -58,7 +58,6 @@ func (suite *siteIntegrationSuite) TestSites() {
 			t := suite.T()
 			assert.NotEmpty(t, s.WebURL)
 			assert.NotEmpty(t, s.ID)
-			assert.NotEmpty(t, s.DisplayName)
 		})
 	}
 }
@@ -82,7 +81,6 @@ func (suite *siteIntegrationSuite) TestSites_GetByID() {
 			assert.NoError(t, err, clues.ToCore(err))
 			assert.NotEmpty(t, site.WebURL)
 			assert.NotEmpty(t, site.ID)
-			assert.NotEmpty(t, site.DisplayName)
 			assert.NotEmpty(t, site.OwnerType)
 		})
 	}
@@ -242,7 +240,6 @@ func (suite *siteUnitSuite) TestGetSites() {
 			expectSite: func(t *testing.T, site *Site) {
 				assert.NotEmpty(t, site.ID)
 				assert.NotEmpty(t, site.WebURL)
-				assert.NotEmpty(t, site.DisplayName)
 				assert.Empty(t, site.OwnerID)
 			},
 		},
@@ -257,7 +254,6 @@ func (suite *siteUnitSuite) TestGetSites() {
 			expectSite: func(t *testing.T, site *Site) {
 				assert.NotEmpty(t, site.ID)
 				assert.NotEmpty(t, site.WebURL)
-				assert.NotEmpty(t, site.DisplayName)
 				assert.Equal(t, site.OwnerID, "userid")
 				assert.Equal(t, site.OwnerEmail, "useremail")
 				assert.Equal(t, site.OwnerType, SiteOwnerUser)
@@ -274,7 +270,6 @@ func (suite *siteUnitSuite) TestGetSites() {
 			expectSite: func(t *testing.T, site *Site) {
 				assert.NotEmpty(t, site.ID)
 				assert.NotEmpty(t, site.WebURL)
-				assert.NotEmpty(t, site.DisplayName)
 				assert.Equal(t, SiteOwnerGroup, site.OwnerType)
 				assert.Equal(t, "groupid", site.OwnerID)
 				assert.Equal(t, "groupemail", site.OwnerEmail)
@@ -291,7 +286,6 @@ func (suite *siteUnitSuite) TestGetSites() {
 			expectSite: func(t *testing.T, site *Site) {
 				assert.NotEmpty(t, site.ID)
 				assert.NotEmpty(t, site.WebURL)
-				assert.NotEmpty(t, site.DisplayName)
 				assert.Equal(t, SiteOwnerGroup, site.OwnerType)
 				assert.Equal(t, "", site.OwnerID)
 				assert.Equal(t, "groupemail", site.OwnerEmail)


### PR DESCRIPTION
Unexport a bunch of stuff that isn't used outside the
package. Also use the same package for tests

Mostly renaming with some minor dead code cleanup

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
