### PR TITLE
Fix export stalling when run with progressbars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - SharePoint backup would fail if any site had an empty display name
+- Fix a bug with exports hanging post completion
 
 ## [v0.14.2] (beta) - 2023-10-17
 

--- a/src/cli/export/export.go
+++ b/src/cli/export/export.go
@@ -104,9 +104,15 @@ func runExport(
 	// It would be better to give a progressbar than a spinner, but we
 	// have any way of knowing how many files are available as of now.
 	diskWriteComplete := observe.MessageWithCompletion(ctx, "Writing data to disk")
-	defer close(diskWriteComplete)
 
 	err = export.ConsumeExportCollections(ctx, exportLocation, expColl, eo.Errors)
+
+	// The progressbar has to be closed before we move on as the Infof
+	// below flushes progressbar to prevent clobbering the output and
+	// that causes the entire export operation to stall indefinitely.
+	// https://github.com/alcionai/corso/blob/8102523dc62c001b301cd2ab4e799f86146ab1a0/src/cli/print/print.go#L151
+	close(diskWriteComplete)
+
 	if err != nil {
 		return Only(ctx, err)
 	}


### PR DESCRIPTION
Exports were stalling when run with progressbars. Most of our tests(except for longevity tests) did not catch this as they were running without progressbars. This should fix that.

First introduced in 040257f8be95f924fce3adcb1159422a1f22b45c

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
