### PR TITLE
Helper function to add common backup flags

### DIFF
--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -80,13 +80,11 @@ func addExchangeCommands(cmd *cobra.Command) *cobra.Command {
 		flags.AddMailBoxFlag(c)
 		flags.AddDataFlag(c, []string{dataEmail, dataContacts, dataEvents}, false)
 		flags.AddFetchParallelismFlag(c)
-		flags.AddFailFastFlag(c)
-		flags.AddDisableIncrementalsFlag(c)
-		flags.AddForceItemDataDownloadFlag(c)
 		flags.AddDisableDeltaFlag(c)
 		flags.AddEnableImmutableIDFlag(c)
 		flags.AddDisableConcurrencyLimiterFlag(c)
 		flags.AddDeltaPageSizeFlag(c)
+		flags.AddGenericBackupFlags(c)
 
 	case listCommand:
 		c, fs = utils.AddCommand(cmd, exchangeListCmd())

--- a/src/cli/backup/groups.go
+++ b/src/cli/backup/groups.go
@@ -73,10 +73,8 @@ func addGroupsCommands(cmd *cobra.Command) *cobra.Command {
 		flags.AddGroupFlag(c)
 		flags.AddDataFlag(c, []string{flags.DataLibraries, flags.DataMessages}, false)
 		flags.AddFetchParallelismFlag(c)
-		flags.AddFailFastFlag(c)
 		flags.AddDisableDeltaFlag(c)
-		flags.AddDisableIncrementalsFlag(c)
-		flags.AddForceItemDataDownloadFlag(c)
+		flags.AddGenericBackupFlags(c)
 
 	case listCommand:
 		c, fs = utils.AddCommand(cmd, groupsListCmd(), utils.MarkPreviewCommand())

--- a/src/cli/backup/onedrive.go
+++ b/src/cli/backup/onedrive.go
@@ -66,9 +66,7 @@ func addOneDriveCommands(cmd *cobra.Command) *cobra.Command {
 		c.Example = oneDriveServiceCommandCreateExamples
 
 		flags.AddUserFlag(c)
-		flags.AddFailFastFlag(c)
-		flags.AddDisableIncrementalsFlag(c)
-		flags.AddForceItemDataDownloadFlag(c)
+		flags.AddGenericBackupFlags(c)
 
 	case listCommand:
 		c, fs = utils.AddCommand(cmd, oneDriveListCmd())

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -79,9 +79,7 @@ func addSharePointCommands(cmd *cobra.Command) *cobra.Command {
 		flags.AddSiteFlag(c, true)
 		flags.AddSiteIDFlag(c, true)
 		flags.AddDataFlag(c, []string{flags.DataLibraries}, true)
-		flags.AddFailFastFlag(c)
-		flags.AddDisableIncrementalsFlag(c)
-		flags.AddForceItemDataDownloadFlag(c)
+		flags.AddGenericBackupFlags(c)
 
 	case listCommand:
 		c, fs = utils.AddCommand(cmd, sharePointListCmd())

--- a/src/cli/flags/backup_create.go
+++ b/src/cli/flags/backup_create.go
@@ -1,0 +1,11 @@
+package flags
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func AddGenericBackupFlags(cmd *cobra.Command) {
+	AddFailFastFlag(cmd)
+	AddDisableIncrementalsFlag(cmd)
+	AddForceItemDataDownloadFlag(cmd)
+}


### PR DESCRIPTION
Helps ensure that all services implement the same standard flag set and allows easily expanding said flag set.

Existing tests check flags are added as expected

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
