### PR TITLE
Check for no backup version

### DIFF
--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -381,7 +381,8 @@ func (op *BackupOperation) do(
 	//     by requiring knowledge of good/bad backup versions for different
 	//     services)
 	if op.Selectors.PathService() == path.GroupsService {
-		if mans.MinBackupVersion() < version.Groups9Update {
+		if mans.MinBackupVersion() != version.NoBackup &&
+			mans.MinBackupVersion() < version.Groups9Update {
 			logger.Ctx(ctx).Info("dropping merge bases due to groups version change")
 
 			mans.DisableMergeBases()
@@ -391,7 +392,8 @@ func (op *BackupOperation) do(
 			mdColls = nil
 		}
 
-		if mans.MinAssistVersion() < version.Groups9Update {
+		if mans.MinAssistVersion() != version.NoBackup &&
+			mans.MinAssistVersion() < version.Groups9Update {
 			logger.Ctx(ctx).Info("disabling assist bases due to groups version change")
 			mans.DisableAssistBases()
 		}


### PR DESCRIPTION
Only drop bases if it's actually a backup version.
This lets us use assist bases even if the merge base
is too old

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #4569

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
