### PR TITLE
Add tests on assist bases for drive-backed services for groups bump

### DIFF
--- a/src/internal/operations/test/group_test.go
+++ b/src/internal/operations/test/group_test.go
@@ -186,6 +186,15 @@ func (suite *GroupsBackupIntgSuite) TestBackup_Run_groupsBasic_groups9VersionBum
 		"items written")
 }
 
+func (suite *GroupsBackupIntgSuite) TestBackup_Run_groupsBasic_assistBackup_groups9VersionBump() {
+	sel := selectors.NewGroupsBackup([]string{suite.its.group.ID})
+	sel.Include(
+		selTD.GroupsBackupLibraryFolderScope(sel),
+		selTD.GroupsBackupChannelScope(sel))
+
+	runDriveAssistBaseGroupsUpdate(suite, sel.Selector, false)
+}
+
 func (suite *GroupsBackupIntgSuite) TestBackup_Run_groupsBasic() {
 	t := suite.T()
 

--- a/src/internal/operations/test/group_test.go
+++ b/src/internal/operations/test/group_test.go
@@ -186,7 +186,7 @@ func (suite *GroupsBackupIntgSuite) TestBackup_Run_groupsBasic_groups9VersionBum
 		"items written")
 }
 
-func (suite *GroupsBackupIntgSuite) TestBackup_Run_groupsBasic_assistBackup_groups9VersionBump() {
+func (suite *GroupsBackupIntgSuite) TestBackup_Run_groupsVersion9AssistBases() {
 	sel := selectors.NewGroupsBackup([]string{suite.its.group.ID})
 	sel.Include(
 		selTD.GroupsBackupLibraryFolderScope(sel),

--- a/src/internal/operations/test/onedrive_test.go
+++ b/src/internal/operations/test/onedrive_test.go
@@ -215,6 +215,13 @@ func (suite *OneDriveBackupIntgSuite) TestBackup_Run_oneDriveBasic_groups9Versio
 		"items written")
 }
 
+//func (suite *OneDriveBackupIntgSuite) TestBackup_Run_oneDriveBasic_assistBackup_groups9VersionBump() {
+//	sel := selectors.NewOneDriveBackup([]string{tconfig.SecondaryM365UserID(suite.T())})
+//	sel.Include(selTD.OneDriveBackupFolderScope(sel))
+//
+//	runDriveAssistBaseGroupsUpdate(suite, sel.Selector, true)
+//}
+
 func (suite *OneDriveBackupIntgSuite) TestBackup_Run_incrementalOneDrive() {
 	sel := selectors.NewOneDriveRestore([]string{suite.its.user.ID})
 

--- a/src/internal/operations/test/sharepoint_test.go
+++ b/src/internal/operations/test/sharepoint_test.go
@@ -150,6 +150,13 @@ func (suite *SharePointBackupIntgSuite) TestBackup_Run_sharePointBasic_groups9Ve
 		"items written")
 }
 
+func (suite *SharePointBackupIntgSuite) TestBackup_Run_sharePointBasic_assistBackup_groups9VersionBump() {
+	sel := selectors.NewSharePointBackup([]string{suite.its.site.ID})
+	sel.Include(selTD.SharePointBackupFolderScope(sel))
+
+	runDriveAssistBaseGroupsUpdate(suite, sel.Selector, true)
+}
+
 func (suite *SharePointBackupIntgSuite) TestBackup_Run_incrementalSharePoint() {
 	sel := selectors.NewSharePointRestore([]string{suite.its.site.ID})
 

--- a/src/internal/operations/test/sharepoint_test.go
+++ b/src/internal/operations/test/sharepoint_test.go
@@ -150,7 +150,7 @@ func (suite *SharePointBackupIntgSuite) TestBackup_Run_sharePointBasic_groups9Ve
 		"items written")
 }
 
-func (suite *SharePointBackupIntgSuite) TestBackup_Run_sharePointBasic_assistBackup_groups9VersionBump() {
+func (suite *SharePointBackupIntgSuite) TestBackup_Run_sharePointVersion9AssistBases() {
 	sel := selectors.NewSharePointBackup([]string{suite.its.site.ID})
 	sel.Include(selTD.SharePointBackupFolderScope(sel))
 


### PR DESCRIPTION
We need to make sure we don't use old assist bases
for the groups bump this adds automated tests for
that

The OneDrive test is currently disabled because
it's not making an assist base as expected. This
can be debugged later

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* #4569

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
