### PR TITLE
add getPostIDs in conversations pager

### DIFF
--- a/src/cli/utils/groups_test.go
+++ b/src/cli/utils/groups_test.go
@@ -42,28 +42,28 @@ func (suite *GroupsUtilsSuite) TestIncludeGroupsRestoreDataSelectors() {
 		{
 			name:             "no inputs",
 			opts:             utils.GroupsOpts{},
-			expectIncludeLen: 2,
+			expectIncludeLen: 3,
 		},
 		{
 			name: "empty",
 			opts: utils.GroupsOpts{
 				Groups: empty,
 			},
-			expectIncludeLen: 2,
+			expectIncludeLen: 3,
 		},
 		{
 			name: "single inputs",
 			opts: utils.GroupsOpts{
 				Groups: single,
 			},
-			expectIncludeLen: 2,
+			expectIncludeLen: 3,
 		},
 		{
 			name: "multi inputs",
 			opts: utils.GroupsOpts{
 				Groups: multi,
 			},
-			expectIncludeLen: 2,
+			expectIncludeLen: 3,
 		},
 		// sharepoint
 		{
@@ -120,7 +120,7 @@ func (suite *GroupsUtilsSuite) TestIncludeGroupsRestoreDataSelectors() {
 				FileName:   empty,
 				FolderPath: empty,
 			},
-			expectIncludeLen: 2,
+			expectIncludeLen: 3,
 		},
 		{
 			name: "library folder suffixes and contains",
@@ -128,7 +128,7 @@ func (suite *GroupsUtilsSuite) TestIncludeGroupsRestoreDataSelectors() {
 				FileName:   empty,
 				FolderPath: empty,
 			},
-			expectIncludeLen: 2,
+			expectIncludeLen: 3,
 		},
 		{
 			name: "Page Folder",
@@ -389,7 +389,7 @@ func (suite *GroupsUtilsSuite) TestAddGroupsCategories() {
 		{
 			name:           "none",
 			cats:           []string{},
-			expectScopeLen: 2,
+			expectScopeLen: 3,
 		},
 		{
 			name:           "libraries",

--- a/src/internal/m365/collection/exchange/backup_test.go
+++ b/src/internal/m365/collection/exchange/backup_test.go
@@ -75,18 +75,11 @@ type (
 func (mg mockGetter) GetAddedAndRemovedItemIDs(
 	ctx context.Context,
 	userID, cID, prevDelta string,
-	_ bool,
-	_ bool,
-) (
-	map[string]time.Time,
-	bool,
-	[]string,
-	pagers.DeltaUpdate,
-	error,
-) {
+	_ api.CallConfig,
+) (pagers.AddedAndRemoved, error) {
 	results, ok := mg.results[cID]
 	if !ok {
-		return nil, false, nil, pagers.DeltaUpdate{}, clues.New("mock not found for " + cID)
+		return pagers.AddedAndRemoved{}, clues.New("mock not found for " + cID)
 	}
 
 	delta := results.newDelta
@@ -99,7 +92,14 @@ func (mg mockGetter) GetAddedAndRemovedItemIDs(
 		resAdded[add] = time.Time{}
 	}
 
-	return resAdded, false, results.removed, delta, results.err
+	aar := pagers.AddedAndRemoved{
+		Added:         resAdded,
+		Removed:       results.removed,
+		ValidModTimes: false,
+		DU:            delta,
+	}
+
+	return aar, results.err
 }
 
 var _ graph.ContainerResolver = &mockResolver{}

--- a/src/internal/m365/collection/exchange/handlers.go
+++ b/src/internal/m365/collection/exchange/handlers.go
@@ -2,7 +2,6 @@ package exchange
 
 import (
 	"context"
-	"time"
 
 	"github.com/microsoft/kiota-abstractions-go/serialization"
 
@@ -30,9 +29,8 @@ type addedAndRemovedItemGetter interface {
 	GetAddedAndRemovedItemIDs(
 		ctx context.Context,
 		user, containerID, oldDeltaToken string,
-		immutableIDs bool,
-		canMakeDeltaQueries bool,
-	) (map[string]time.Time, bool, []string, pagers.DeltaUpdate, error)
+		cc api.CallConfig,
+	) (pagers.AddedAndRemoved, error)
 }
 
 type itemGetterSerializer interface {

--- a/src/internal/m365/collection/groups/backup_test.go
+++ b/src/internal/m365/collection/groups/backup_test.go
@@ -58,15 +58,22 @@ func (bh mockBackupHandler) getContainers(context.Context) ([]models.Channelable
 func (bh mockBackupHandler) getContainerItemIDs(
 	_ context.Context,
 	_, _ string,
-	_ bool,
-) (map[string]time.Time, bool, []string, pagers.DeltaUpdate, error) {
+	_ api.CallConfig,
+) (pagers.AddedAndRemoved, error) {
 	idRes := make(map[string]time.Time, len(bh.messageIDs))
 
 	for _, id := range bh.messageIDs {
 		idRes[id] = time.Time{}
 	}
 
-	return idRes, true, bh.deletedMsgIDs, pagers.DeltaUpdate{}, bh.messagesErr
+	aar := pagers.AddedAndRemoved{
+		Added:         idRes,
+		Removed:       bh.deletedMsgIDs,
+		ValidModTimes: true,
+		DU:            pagers.DeltaUpdate{},
+	}
+
+	return aar, bh.messagesErr
 }
 
 func (bh mockBackupHandler) includeContainer(

--- a/src/internal/m365/collection/groups/channel_handler.go
+++ b/src/internal/m365/collection/groups/channel_handler.go
@@ -2,7 +2,6 @@ package groups
 
 import (
 	"context"
-	"time"
 
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
@@ -41,9 +40,9 @@ func (bh channelsBackupHandler) getContainers(
 func (bh channelsBackupHandler) getContainerItemIDs(
 	ctx context.Context,
 	channelID, prevDelta string,
-	canMakeDeltaQueries bool,
-) (map[string]time.Time, bool, []string, pagers.DeltaUpdate, error) {
-	return bh.ac.GetChannelMessageIDs(ctx, bh.protectedResource, channelID, prevDelta, canMakeDeltaQueries)
+	cc api.CallConfig,
+) (pagers.AddedAndRemoved, error) {
+	return bh.ac.GetChannelMessageIDs(ctx, bh.protectedResource, channelID, prevDelta, cc)
 }
 
 func (bh channelsBackupHandler) includeContainer(

--- a/src/internal/m365/collection/groups/handlers.go
+++ b/src/internal/m365/collection/groups/handlers.go
@@ -2,7 +2,6 @@ package groups
 
 import (
 	"context"
-	"time"
 
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/pagers"
 )
 
@@ -25,8 +25,8 @@ type backupHandler interface {
 	getContainerItemIDs(
 		ctx context.Context,
 		containerID, prevDelta string,
-		canMakeDeltaQueries bool,
-	) (map[string]time.Time, bool, []string, pagers.DeltaUpdate, error)
+		cc api.CallConfig,
+	) (pagers.AddedAndRemoved, error)
 
 	// includeContainer evaluates whether the container is included
 	// in the provided scope.

--- a/src/internal/m365/graph/cache_container.go
+++ b/src/internal/m365/graph/cache_container.go
@@ -11,29 +11,10 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
-// Idable represents objects that implement msgraph-sdk-go/models.entityable
-// and have the concept of an ID.
-type Idable interface {
-	GetId() *string
-}
-
-// Descendable represents objects that implement msgraph-sdk-go/models.entityable
-// and have the concept of a "parent folder".
-type Descendable interface {
-	Idable
-	GetParentFolderId() *string
-}
-
-// Displayable represents objects that implement msgraph-sdk-go/models.entityable
-// and have the concept of a display name.
-type Displayable interface {
-	Idable
-	GetDisplayName() *string
-}
-
 type Container interface {
-	Descendable
-	Displayable
+	GetIDer
+	GetParentFolderIDer
+	GetDisplayNamer
 }
 
 // CachedContainer is used for local unit tests but also makes it so that this
@@ -41,10 +22,12 @@ type Container interface {
 // reuse logic in IDToPath.
 type CachedContainer interface {
 	Container
+
 	// Location contains either the display names for the dirs (if this is a calendar)
 	// or nil
 	Location() *path.Builder
 	SetLocation(*path.Builder)
+
 	// Path contains either the ids for the dirs (if this is a calendar)
 	// or the display names for the dirs
 	Path() *path.Builder

--- a/src/internal/m365/graph/interfaces.go
+++ b/src/internal/m365/graph/interfaces.go
@@ -1,0 +1,29 @@
+package graph
+
+import (
+	"time"
+)
+
+type GetIDer interface {
+	GetId() *string
+}
+
+type GetLastModifiedDateTimer interface {
+	GetLastModifiedDateTime() *time.Time
+}
+
+type GetAdditionalDataer interface {
+	GetAdditionalData() map[string]any
+}
+
+type GetDeletedDateTimer interface {
+	GetDeletedDateTime() *time.Time
+}
+
+type GetDisplayNamer interface {
+	GetDisplayName() *string
+}
+
+type GetParentFolderIDer interface {
+	GetParentFolderId() *string
+}

--- a/src/pkg/path/category_type.go
+++ b/src/pkg/path/category_type.go
@@ -17,28 +17,30 @@ type CategoryType int
 
 //go:generate stringer -type=CategoryType -linecomment
 const (
-	UnknownCategory         CategoryType = 0
-	EmailCategory           CategoryType = 1 // email
-	ContactsCategory        CategoryType = 2 // contacts
-	EventsCategory          CategoryType = 3 // events
-	FilesCategory           CategoryType = 4 // files
-	ListsCategory           CategoryType = 5 // lists
-	LibrariesCategory       CategoryType = 6 // libraries
-	PagesCategory           CategoryType = 7 // pages
-	DetailsCategory         CategoryType = 8 // details
-	ChannelMessagesCategory CategoryType = 9 // channelMessages
+	UnknownCategory           CategoryType = 0
+	EmailCategory             CategoryType = 1  // email
+	ContactsCategory          CategoryType = 2  // contacts
+	EventsCategory            CategoryType = 3  // events
+	FilesCategory             CategoryType = 4  // files
+	ListsCategory             CategoryType = 5  // lists
+	LibrariesCategory         CategoryType = 6  // libraries
+	PagesCategory             CategoryType = 7  // pages
+	DetailsCategory           CategoryType = 8  // details
+	ChannelMessagesCategory   CategoryType = 9  // channelMessages
+	ConversationPostsCategory CategoryType = 10 // conversationPosts
 )
 
 var strToCat = map[string]CategoryType{
-	strings.ToLower(EmailCategory.String()):           EmailCategory,
-	strings.ToLower(ContactsCategory.String()):        ContactsCategory,
-	strings.ToLower(EventsCategory.String()):          EventsCategory,
-	strings.ToLower(FilesCategory.String()):           FilesCategory,
-	strings.ToLower(LibrariesCategory.String()):       LibrariesCategory,
-	strings.ToLower(ListsCategory.String()):           ListsCategory,
-	strings.ToLower(PagesCategory.String()):           PagesCategory,
-	strings.ToLower(DetailsCategory.String()):         DetailsCategory,
-	strings.ToLower(ChannelMessagesCategory.String()): ChannelMessagesCategory,
+	strings.ToLower(EmailCategory.String()):             EmailCategory,
+	strings.ToLower(ContactsCategory.String()):          ContactsCategory,
+	strings.ToLower(EventsCategory.String()):            EventsCategory,
+	strings.ToLower(FilesCategory.String()):             FilesCategory,
+	strings.ToLower(LibrariesCategory.String()):         LibrariesCategory,
+	strings.ToLower(ListsCategory.String()):             ListsCategory,
+	strings.ToLower(PagesCategory.String()):             PagesCategory,
+	strings.ToLower(DetailsCategory.String()):           DetailsCategory,
+	strings.ToLower(ChannelMessagesCategory.String()):   ChannelMessagesCategory,
+	strings.ToLower(ConversationPostsCategory.String()): ConversationPostsCategory,
 }
 
 func ToCategoryType(s string) CategoryType {
@@ -51,15 +53,16 @@ func ToCategoryType(s string) CategoryType {
 }
 
 var catToHuman = map[CategoryType]string{
-	EmailCategory:           "Emails",
-	ContactsCategory:        "Contacts",
-	EventsCategory:          "Events",
-	FilesCategory:           "Files",
-	LibrariesCategory:       "Libraries",
-	ListsCategory:           "Lists",
-	PagesCategory:           "Pages",
-	DetailsCategory:         "Details",
-	ChannelMessagesCategory: "Messages",
+	EmailCategory:             "Emails",
+	ContactsCategory:          "Contacts",
+	EventsCategory:            "Events",
+	FilesCategory:             "Files",
+	LibrariesCategory:         "Libraries",
+	ListsCategory:             "Lists",
+	PagesCategory:             "Pages",
+	DetailsCategory:           "Details",
+	ChannelMessagesCategory:   "Messages",
+	ConversationPostsCategory: "Posts",
 }
 
 // HumanString produces a more human-readable string version of the category.
@@ -93,8 +96,9 @@ var serviceCategories = map[ServiceType]map[CategoryType]struct{}{
 		PagesCategory:     {},
 	},
 	GroupsService: {
-		ChannelMessagesCategory: {},
-		LibrariesCategory:       {},
+		ChannelMessagesCategory:   {},
+		ConversationPostsCategory: {},
+		LibrariesCategory:         {},
 	},
 }
 

--- a/src/pkg/path/category_type_test.go
+++ b/src/pkg/path/category_type_test.go
@@ -34,6 +34,7 @@ func (suite *CategoryTypeUnitSuite) TestToCategoryType() {
 		{input: "pages", expect: 7},
 		{input: "details", expect: 8},
 		{input: "channelmessages", expect: 9},
+		{input: "conversationposts", expect: 10},
 	}
 	for _, test := range table {
 		suite.Run(test.input, func() {
@@ -60,6 +61,7 @@ func (suite *CategoryTypeUnitSuite) TestHumanString() {
 		{input: 7, expect: "Pages"},
 		{input: 8, expect: "Details"},
 		{input: 9, expect: "Messages"},
+		{input: 10, expect: "Posts"},
 	}
 	for _, test := range table {
 		suite.Run(test.input.String(), func() {

--- a/src/pkg/path/categorytype_string.go
+++ b/src/pkg/path/categorytype_string.go
@@ -18,11 +18,12 @@ func _() {
 	_ = x[PagesCategory-7]
 	_ = x[DetailsCategory-8]
 	_ = x[ChannelMessagesCategory-9]
+	_ = x[ConversationPostsCategory-10]
 }
 
-const _CategoryType_name = "UnknownCategoryemailcontactseventsfileslistslibrariespagesdetailschannelMessages"
+const _CategoryType_name = "UnknownCategoryemailcontactseventsfileslistslibrariespagesdetailschannelMessagesconversationPosts"
 
-var _CategoryType_index = [...]uint8{0, 15, 20, 28, 34, 39, 44, 53, 58, 65, 80}
+var _CategoryType_index = [...]uint8{0, 15, 20, 28, 34, 39, 44, 53, 58, 65, 80, 97}
 
 func (i CategoryType) String() string {
 	if i < 0 || i >= CategoryType(len(_CategoryType_index)-1) {

--- a/src/pkg/services/m365/api/channels_pager.go
+++ b/src/pkg/services/m365/api/channels_pager.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"time"
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -186,18 +185,18 @@ func filterOutSystemMessages(cm models.ChatMessageable) bool {
 func (c Channels) GetChannelMessageIDs(
 	ctx context.Context,
 	teamID, channelID, prevDeltaLink string,
-	canMakeDeltaQueries bool,
-) (map[string]time.Time, bool, []string, pagers.DeltaUpdate, error) {
-	added, validModTimes, removed, du, err := pagers.GetAddedAndRemovedItemIDs[models.ChatMessageable](
+	cc CallConfig,
+) (pagers.AddedAndRemoved, error) {
+	aar, err := pagers.GetAddedAndRemovedItemIDs[models.ChatMessageable](
 		ctx,
 		c.NewChannelMessagePager(teamID, channelID, CallConfig{}),
 		c.NewChannelMessageDeltaPager(teamID, channelID, prevDeltaLink),
 		prevDeltaLink,
-		canMakeDeltaQueries,
+		cc.CanMakeDeltaQueries,
 		pagers.AddedAndRemovedByDeletedDateTime[models.ChatMessageable],
 		filterOutSystemMessages)
 
-	return added, validModTimes, removed, du, clues.Stack(err).OrNil()
+	return aar, clues.Stack(err).OrNil()
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/services/m365/api/client.go
+++ b/src/pkg/services/m365/api/client.go
@@ -159,8 +159,10 @@ func (c Client) Post(
 // ---------------------------------------------------------------------------
 
 type CallConfig struct {
-	Expand []string
-	Select []string
+	Expand              []string
+	Select              []string
+	CanMakeDeltaQueries bool
+	UseImmutableIDs     bool
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/services/m365/api/contacts_pager.go
+++ b/src/pkg/services/m365/api/contacts_pager.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"time"
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -250,9 +249,8 @@ func (p *contactDeltaPager) ValidModTimes() bool {
 func (c Contacts) GetAddedAndRemovedItemIDs(
 	ctx context.Context,
 	userID, containerID, prevDeltaLink string,
-	immutableIDs bool,
-	canMakeDeltaQueries bool,
-) (map[string]time.Time, bool, []string, pagers.DeltaUpdate, error) {
+	cc CallConfig,
+) (pagers.AddedAndRemoved, error) {
 	ctx = clues.Add(
 		ctx,
 		"data_category", path.ContactsCategory,
@@ -263,12 +261,12 @@ func (c Contacts) GetAddedAndRemovedItemIDs(
 		userID,
 		containerID,
 		prevDeltaLink,
-		immutableIDs,
+		cc.UseImmutableIDs,
 		idAnd(lastModifiedDateTime)...)
 	pager := c.NewContactsPager(
 		userID,
 		containerID,
-		immutableIDs,
+		cc.UseImmutableIDs,
 		idAnd(lastModifiedDateTime)...)
 
 	return pagers.GetAddedAndRemovedItemIDs[models.Contactable](
@@ -276,6 +274,6 @@ func (c Contacts) GetAddedAndRemovedItemIDs(
 		pager,
 		deltaPager,
 		prevDeltaLink,
-		canMakeDeltaQueries,
+		cc.CanMakeDeltaQueries,
 		pagers.AddedAndRemovedByAddtlData[models.Contactable])
 }

--- a/src/pkg/services/m365/api/conversations_pager.go
+++ b/src/pkg/services/m365/api/conversations_pager.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"time"
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/groups"
@@ -237,10 +236,10 @@ func (c Conversations) GetConversationThreadPostIDs(
 	ctx context.Context,
 	groupID, conversationID, threadID string,
 	cc CallConfig,
-) (map[string]time.Time, bool, []string, pagers.DeltaUpdate, error) {
+) (pagers.AddedAndRemoved, error) {
 	canMakeDeltaQueries := false
 
-	added, validModTimes, removed, du, err := pagers.GetAddedAndRemovedItemIDs[models.Postable](
+	aarh, err := pagers.GetAddedAndRemovedItemIDs[models.Postable](
 		ctx,
 		c.NewConversationThreadPostsPager(groupID, conversationID, threadID, CallConfig{}),
 		nil,
@@ -249,5 +248,5 @@ func (c Conversations) GetConversationThreadPostIDs(
 		pagers.AddedAndRemovedAddAll[models.Postable],
 		pagers.FilterIncludeAll[models.Postable])
 
-	return added, validModTimes, removed, du, clues.Stack(err).OrNil()
+	return aarh, clues.Stack(err).OrNil()
 }

--- a/src/pkg/services/m365/api/conversations_pager_test.go
+++ b/src/pkg/services/m365/api/conversations_pager_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -48,6 +49,18 @@ func (suite *ConversationsPagerIntgSuite) TestEnumerateConversations_withThreads
 
 		for _, thread := range threads {
 			posts := testEnumerateConvPosts(suite, conv, thread)
+
+			added, valid, removed, du, err := ac.GetConversationThreadPostIDs(
+				ctx,
+				suite.its.group.id,
+				ptr.Val(conv.GetId()),
+				ptr.Val(thread.GetId()),
+				CallConfig{})
+			require.NoError(t, err, clues.ToCore(err))
+			require.Equal(t, len(posts), len(added), "added the same number of ids and posts")
+			assert.True(t, valid, "mod times should be valid")
+			assert.Empty(t, removed, "no items should get removed")
+			assert.Empty(t, du.URL, "no delta update token should be provided")
 
 			for _, post := range posts {
 				testGetPostByID(suite, conv, thread, post)

--- a/src/pkg/services/m365/api/conversations_pager_test.go
+++ b/src/pkg/services/m365/api/conversations_pager_test.go
@@ -50,17 +50,17 @@ func (suite *ConversationsPagerIntgSuite) TestEnumerateConversations_withThreads
 		for _, thread := range threads {
 			posts := testEnumerateConvPosts(suite, conv, thread)
 
-			added, valid, removed, du, err := ac.GetConversationThreadPostIDs(
+			aar, err := ac.GetConversationThreadPostIDs(
 				ctx,
 				suite.its.group.id,
 				ptr.Val(conv.GetId()),
 				ptr.Val(thread.GetId()),
 				CallConfig{})
 			require.NoError(t, err, clues.ToCore(err))
-			require.Equal(t, len(posts), len(added), "added the same number of ids and posts")
-			assert.True(t, valid, "mod times should be valid")
-			assert.Empty(t, removed, "no items should get removed")
-			assert.Empty(t, du.URL, "no delta update token should be provided")
+			require.Equal(t, len(posts), len(aar.Added), "added the same number of ids and posts")
+			assert.True(t, aar.ValidModTimes, "mod times should be valid")
+			assert.Empty(t, aar.Removed, "no items should get removed")
+			assert.Empty(t, aar.DU.URL, "no delta update token should be provided")
 
 			for _, post := range posts {
 				testGetPostByID(suite, conv, thread, post)

--- a/src/pkg/services/m365/api/events_pager.go
+++ b/src/pkg/services/m365/api/events_pager.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -245,9 +244,8 @@ func (p *eventDeltaPager) ValidModTimes() bool {
 func (c Events) GetAddedAndRemovedItemIDs(
 	ctx context.Context,
 	userID, containerID, prevDeltaLink string,
-	immutableIDs bool,
-	canMakeDeltaQueries bool,
-) (map[string]time.Time, bool, []string, pagers.DeltaUpdate, error) {
+	cc CallConfig,
+) (pagers.AddedAndRemoved, error) {
 	ctx = clues.Add(
 		ctx,
 		"data_category", path.EventsCategory,
@@ -258,12 +256,12 @@ func (c Events) GetAddedAndRemovedItemIDs(
 		userID,
 		containerID,
 		prevDeltaLink,
-		immutableIDs,
+		cc.UseImmutableIDs,
 		idAnd()...)
 	pager := c.NewEventsPager(
 		userID,
 		containerID,
-		immutableIDs,
+		cc.UseImmutableIDs,
 		idAnd(lastModifiedDateTime)...)
 
 	return pagers.GetAddedAndRemovedItemIDs[models.Eventable](
@@ -271,6 +269,6 @@ func (c Events) GetAddedAndRemovedItemIDs(
 		pager,
 		deltaPager,
 		prevDeltaLink,
-		canMakeDeltaQueries,
+		cc.CanMakeDeltaQueries,
 		pagers.AddedAndRemovedByAddtlData[models.Eventable])
 }

--- a/src/pkg/services/m365/api/interfaces.go
+++ b/src/pkg/services/m365/api/interfaces.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"context"
+
+	"github.com/microsoft/kiota-abstractions-go/serialization"
+
+	"github.com/alcionai/corso/src/pkg/fault"
+)
+
+type GetAndSerializeItemer[INFO any] interface {
+	GetItemer[INFO]
+	Serializer
+}
+
+type GetItemer[INFO any] interface {
+	GetItem(
+		ctx context.Context,
+		user, itemID string,
+		immutableIDs bool,
+		errs *fault.Bus,
+	) (serialization.Parsable, *INFO, error)
+}
+
+type Serializer interface {
+	Serialize(
+		ctx context.Context,
+		item serialization.Parsable,
+		protectedResource, itemID string,
+	) ([]byte, error)
+}

--- a/src/pkg/services/m365/api/mail_pager.go
+++ b/src/pkg/services/m365/api/mail_pager.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -247,9 +246,8 @@ func (p *mailDeltaPager) ValidModTimes() bool {
 func (c Mail) GetAddedAndRemovedItemIDs(
 	ctx context.Context,
 	userID, containerID, prevDeltaLink string,
-	immutableIDs bool,
-	canMakeDeltaQueries bool,
-) (map[string]time.Time, bool, []string, pagers.DeltaUpdate, error) {
+	cc CallConfig,
+) (pagers.AddedAndRemoved, error) {
 	ctx = clues.Add(
 		ctx,
 		"data_category", path.EmailCategory,
@@ -260,12 +258,12 @@ func (c Mail) GetAddedAndRemovedItemIDs(
 		userID,
 		containerID,
 		prevDeltaLink,
-		immutableIDs,
+		cc.UseImmutableIDs,
 		idAnd(lastModifiedDateTime)...)
 	pager := c.NewMailPager(
 		userID,
 		containerID,
-		immutableIDs,
+		cc.UseImmutableIDs,
 		idAnd(lastModifiedDateTime)...)
 
 	return pagers.GetAddedAndRemovedItemIDs[models.Messageable](
@@ -273,6 +271,6 @@ func (c Mail) GetAddedAndRemovedItemIDs(
 		pager,
 		deltaPager,
 		prevDeltaLink,
-		canMakeDeltaQueries,
+		cc.CanMakeDeltaQueries,
 		pagers.AddedAndRemovedByAddtlData[models.Messageable])
 }

--- a/src/pkg/services/m365/api/pagers/pagers.go
+++ b/src/pkg/services/m365/api/pagers/pagers.go
@@ -378,6 +378,13 @@ func FilterIncludeAll[T any](_ T) bool {
 // shared enumeration runner funcs
 // ---------------------------------------------------------------------------
 
+type AddedAndRemoved struct {
+	Added         map[string]time.Time
+	Removed       []string
+	DU            DeltaUpdate
+	ValidModTimes bool
+}
+
 type addedAndRemovedHandler[T any] func(
 	items []T,
 	filters ...func(T) bool,
@@ -395,16 +402,23 @@ func GetAddedAndRemovedItemIDs[T any](
 	canMakeDeltaQueries bool,
 	aarh addedAndRemovedHandler[T],
 	filters ...func(T) bool,
-) (map[string]time.Time, bool, []string, DeltaUpdate, error) {
+) (AddedAndRemoved, error) {
 	if canMakeDeltaQueries {
 		ts, du, err := batchDeltaEnumerateItems[T](ctx, deltaPager, prevDeltaLink)
 		if err != nil && !graph.IsErrInvalidDelta(err) && !graph.IsErrDeltaNotSupported(err) {
-			return nil, false, nil, DeltaUpdate{}, graph.Stack(ctx, err)
+			return AddedAndRemoved{}, graph.Stack(ctx, err)
 		}
 
 		if err == nil {
 			a, r, err := aarh(ts, filters...)
-			return a, deltaPager.ValidModTimes(), r, du, graph.Stack(ctx, err).OrNil()
+			aar := AddedAndRemoved{
+				Added:         a,
+				Removed:       r,
+				DU:            du,
+				ValidModTimes: deltaPager.ValidModTimes(),
+			}
+
+			return aar, graph.Stack(ctx, err).OrNil()
 		}
 	}
 
@@ -412,21 +426,23 @@ func GetAddedAndRemovedItemIDs[T any](
 
 	ts, err := BatchEnumerateItems(ctx, pager)
 	if err != nil {
-		return nil, false, nil, DeltaUpdate{}, graph.Stack(ctx, err)
+		return AddedAndRemoved{}, graph.Stack(ctx, err)
 	}
 
 	a, r, err := aarh(ts, filters...)
+	aar := AddedAndRemoved{
+		Added:         a,
+		Removed:       r,
+		DU:            du,
+		ValidModTimes: pager.ValidModTimes(),
+	}
 
-	return a, pager.ValidModTimes(), r, du, graph.Stack(ctx, err).OrNil()
-}
-
-type getIDer interface {
-	GetId() *string
+	return aar, graph.Stack(ctx, err).OrNil()
 }
 
 type getIDAndModDateTimer interface {
-	getIDer
-	getLastModifiedDateTimer
+	graph.GetIDer
+	graph.GetLastModifiedDateTimer
 }
 
 // AddedAndRemovedAddAll indiscriminately adds every item to the added list, deleting nothing.
@@ -462,16 +478,9 @@ func AddedAndRemovedAddAll[T any](
 // for added and removed by additionalData[@removed]
 
 type getIDModAndAddtler interface {
-	getIDer
-	getLastModifiedDateTimer
-	GetAdditionalData() map[string]any
-}
-
-// for types that are non-compliant with this interface,
-// pagers will need to wrap the return value in a struct
-// that provides this compliance.
-type getLastModifiedDateTimer interface {
-	GetLastModifiedDateTime() *time.Time
+	graph.GetIDer
+	graph.GetLastModifiedDateTimer
+	graph.GetAdditionalDataer
 }
 
 func AddedAndRemovedByAddtlData[T any](
@@ -504,7 +513,11 @@ func AddedAndRemovedByAddtlData[T any](
 		if giaa.GetAdditionalData()[graph.AddtlDataRemoved] == nil {
 			var modTime time.Time
 
-			if mt, ok := giaa.(getLastModifiedDateTimer); ok {
+			// not all items comply with last modified date time, and not all
+			// items can be wrapped in a way that produces a valid value for
+			// the func.  That's why this isn't packed in to the expected
+			// interfaace composition.
+			if mt, ok := giaa.(graph.GetLastModifiedDateTimer); ok {
 				// Make sure to get a non-zero mod time if the item doesn't have one for
 				// some reason. Otherwise we can hit an issue where kopia has a
 				// different mod time for the file than the details does. This occurs
@@ -528,9 +541,9 @@ func AddedAndRemovedByAddtlData[T any](
 // for added and removed by GetDeletedDateTime()
 
 type getIDModAndDeletedDateTimer interface {
-	getIDer
-	getLastModifiedDateTimer
-	GetDeletedDateTime() *time.Time
+	graph.GetIDer
+	graph.GetLastModifiedDateTimer
+	graph.GetDeletedDateTimer
 }
 
 func AddedAndRemovedByDeletedDateTime[T any](
@@ -560,7 +573,11 @@ func AddedAndRemovedByDeletedDateTime[T any](
 		if giaddt.GetDeletedDateTime() == nil {
 			var modTime time.Time
 
-			if mt, ok := giaddt.(getLastModifiedDateTimer); ok {
+			// not all items comply with last modified date time, and not all
+			// items can be wrapped in a way that produces a valid value for
+			// the func.  That's why this isn't packed in to the expected
+			// interfaace composition.
+			if mt, ok := giaddt.(graph.GetLastModifiedDateTimer); ok {
 				// Make sure to get a non-zero mod time if the item doesn't have one for
 				// some reason. Otherwise we can hit an issue where kopia has a
 				// different mod time for the file than the details does. This occurs

--- a/src/pkg/services/m365/api/pagers/pagers.go
+++ b/src/pkg/services/m365/api/pagers/pagers.go
@@ -370,9 +370,6 @@ func batchDeltaEnumerateItems[T any](
 // filter funcs
 // ---------------------------------------------------------------------------
 
-// false -> remove, true -> keep
-type filterer[T any] func(T) bool
-
 func FilterIncludeAll[T any](_ T) bool {
 	return true
 }
@@ -383,7 +380,7 @@ func FilterIncludeAll[T any](_ T) bool {
 
 type addedAndRemovedHandler[T any] func(
 	items []T,
-	filters ...filterer[T],
+	filters ...func(T) bool,
 ) (
 	map[string]time.Time,
 	[]string,
@@ -397,7 +394,7 @@ func GetAddedAndRemovedItemIDs[T any](
 	prevDeltaLink string,
 	canMakeDeltaQueries bool,
 	aarh addedAndRemovedHandler[T],
-	filters ...filterer[T],
+	filters ...func(T) bool,
 ) (map[string]time.Time, bool, []string, DeltaUpdate, error) {
 	if canMakeDeltaQueries {
 		ts, du, err := batchDeltaEnumerateItems[T](ctx, deltaPager, prevDeltaLink)
@@ -435,7 +432,7 @@ type getIDAndModDateTimer interface {
 // AddedAndRemovedAddAll indiscriminately adds every item to the added list, deleting nothing.
 func AddedAndRemovedAddAll[T any](
 	items []T,
-	filters ...filterer[T],
+	filters ...func(T) bool,
 ) (map[string]time.Time, []string, error) {
 	added := map[string]time.Time{}
 
@@ -479,7 +476,7 @@ type getLastModifiedDateTimer interface {
 
 func AddedAndRemovedByAddtlData[T any](
 	items []T,
-	filters ...filterer[T],
+	filters ...func(T) bool,
 ) (map[string]time.Time, []string, error) {
 	added := map[string]time.Time{}
 	removed := []string{}
@@ -538,7 +535,7 @@ type getIDModAndDeletedDateTimer interface {
 
 func AddedAndRemovedByDeletedDateTime[T any](
 	items []T,
-	filters ...filterer[T],
+	filters ...func(T) bool,
 ) (map[string]time.Time, []string, error) {
 	added := map[string]time.Time{}
 	removed := []string{}

--- a/src/pkg/services/m365/api/pagers/pagers_test.go
+++ b/src/pkg/services/m365/api/pagers/pagers_test.go
@@ -520,7 +520,7 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs() {
 				filters = append(filters, test.filter)
 			}
 
-			added, validModTimes, removed, deltaUpdate, err := GetAddedAndRemovedItemIDs[testItem](
+			aar, err := GetAddedAndRemovedItemIDs[testItem](
 				ctx,
 				test.pagerGetter(t),
 				test.deltaPagerGetter(t),
@@ -530,18 +530,18 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs() {
 				filters...)
 
 			require.NoErrorf(t, err, "getting added and removed item IDs: %+v", clues.ToCore(err))
-			if validModTimes {
-				assert.Equal(t, test.expect.added, added, "added item IDs and mod times")
+			if aar.ValidModTimes {
+				assert.Equal(t, test.expect.added, aar.Added, "added item IDs and mod times")
 			} else {
-				assert.ElementsMatch(t, maps.Keys(test.expect.added), maps.Keys(added), "added item IDs")
-				for _, modtime := range added {
+				assert.ElementsMatch(t, maps.Keys(test.expect.added), maps.Keys(aar.Added), "added item IDs")
+				for _, modtime := range aar.Added {
 					assert.True(t, modtime.After(epoch), "mod time after epoch")
 					assert.False(t, modtime.Equal(time.Time{}), "non-zero mod time")
 				}
 			}
-			assert.Equal(t, test.expect.validModTimes, validModTimes, "valid mod times")
-			assert.EqualValues(t, test.expect.removed, removed, "removed item IDs")
-			assert.Equal(t, test.expect.deltaUpdate, deltaUpdate, "delta update")
+			assert.Equal(t, test.expect.validModTimes, aar.ValidModTimes, "valid mod times")
+			assert.EqualValues(t, test.expect.removed, aar.Removed, "removed item IDs")
+			assert.Equal(t, test.expect.deltaUpdate, aar.DU, "delta update")
 		})
 	}
 }


### PR DESCRIPTION
adds the getPostIDs func to ensure conversations
complies with standard data paging patterns

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #4536

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
