### PR TITLE
make exchange comply with moved interface

### DIFF
--- a/src/internal/m365/collection/exchange/backup_test.go
+++ b/src/internal/m365/collection/exchange/backup_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/account"
+	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/backup/metadata"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -47,8 +48,13 @@ type mockBackupHandler struct {
 	userID   string
 }
 
-func (bh mockBackupHandler) itemEnumerator() addedAndRemovedItemGetter { return bh.mg }
-func (bh mockBackupHandler) itemHandler() itemGetterSerializer         { return nil }
+func (bh mockBackupHandler) itemEnumerator() addedAndRemovedItemGetter {
+	return bh.mg
+}
+
+func (bh mockBackupHandler) itemHandler() api.GetAndSerializeItemer[details.ExchangeInfo] {
+	return nil
+}
 
 func (bh mockBackupHandler) NewContainerCache(
 	userID string,

--- a/src/internal/m365/collection/exchange/collection.go
+++ b/src/internal/m365/collection/exchange/collection.go
@@ -22,6 +22,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 var (
@@ -63,7 +64,7 @@ func updateStatus(
 
 func getItemAndInfo(
 	ctx context.Context,
-	getter itemGetterSerializer,
+	getter api.GetAndSerializeItemer[details.ExchangeInfo],
 	userID string,
 	id string,
 	useImmutableIDs bool,
@@ -106,7 +107,7 @@ func getItemAndInfo(
 func NewCollection(
 	bc data.BaseCollection,
 	user string,
-	items itemGetterSerializer,
+	items api.GetAndSerializeItemer[details.ExchangeInfo],
 	origAdded map[string]time.Time,
 	origRemoved []string,
 	validModTimes bool,
@@ -161,7 +162,7 @@ type prefetchCollection struct {
 	// removed is a list of item IDs that were deleted from, or moved out, of a container
 	removed map[string]struct{}
 
-	getter itemGetterSerializer
+	getter api.GetAndSerializeItemer[details.ExchangeInfo]
 
 	statusUpdater support.StatusUpdater
 }
@@ -328,7 +329,7 @@ type lazyFetchCollection struct {
 	// removed is a list of item IDs that were deleted from, or moved out, of a container
 	removed map[string]struct{}
 
-	getter itemGetterSerializer
+	getter api.GetAndSerializeItemer[details.ExchangeInfo]
 
 	statusUpdater support.StatusUpdater
 }
@@ -426,7 +427,7 @@ func (col *lazyFetchCollection) streamItems(
 }
 
 type lazyItemGetter struct {
-	getter       itemGetterSerializer
+	getter       api.GetAndSerializeItemer[details.ExchangeInfo]
 	userID       string
 	itemID       string
 	parentPath   string

--- a/src/internal/m365/collection/exchange/collection_test.go
+++ b/src/internal/m365/collection/exchange/collection_test.go
@@ -333,8 +333,7 @@ type mockLazyItemGetterSerializer struct {
 
 func (mlg *mockLazyItemGetterSerializer) GetItem(
 	ctx context.Context,
-	user string,
-	itemID string,
+	user, itemID string,
 	immutableIDs bool,
 	errs *fault.Bus,
 ) (serialization.Parsable, *details.ExchangeInfo, error) {
@@ -342,7 +341,10 @@ func (mlg *mockLazyItemGetterSerializer) GetItem(
 	return mlg.ItemGetSerialize.GetItem(ctx, user, itemID, immutableIDs, errs)
 }
 
-func (mlg *mockLazyItemGetterSerializer) check(t *testing.T, expectIDs []string) {
+func (mlg *mockLazyItemGetterSerializer) check(
+	t *testing.T,
+	expectIDs []string,
+) {
 	assert.ElementsMatch(t, expectIDs, mlg.callIDs)
 }
 

--- a/src/internal/m365/collection/exchange/contacts_backup.go
+++ b/src/internal/m365/collection/exchange/contacts_backup.go
@@ -2,6 +2,7 @@ package exchange
 
 import (
 	"github.com/alcionai/corso/src/internal/m365/graph"
+	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
@@ -25,7 +26,7 @@ func (h contactBackupHandler) itemEnumerator() addedAndRemovedItemGetter {
 	return h.ac
 }
 
-func (h contactBackupHandler) itemHandler() itemGetterSerializer {
+func (h contactBackupHandler) itemHandler() api.GetAndSerializeItemer[details.ExchangeInfo] {
 	return h.ac
 }
 

--- a/src/internal/m365/collection/exchange/events_backup.go
+++ b/src/internal/m365/collection/exchange/events_backup.go
@@ -2,6 +2,7 @@ package exchange
 
 import (
 	"github.com/alcionai/corso/src/internal/m365/graph"
+	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
@@ -25,7 +26,7 @@ func (h eventBackupHandler) itemEnumerator() addedAndRemovedItemGetter {
 	return h.ac
 }
 
-func (h eventBackupHandler) itemHandler() itemGetterSerializer {
+func (h eventBackupHandler) itemHandler() api.GetAndSerializeItemer[details.ExchangeInfo] {
 	return h.ac
 }
 

--- a/src/internal/m365/collection/exchange/handlers.go
+++ b/src/internal/m365/collection/exchange/handlers.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/microsoft/kiota-abstractions-go/serialization"
-
 	"github.com/alcionai/corso/src/internal/m365/graph"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control"
@@ -22,7 +20,7 @@ import (
 
 type backupHandler interface {
 	itemEnumerator() addedAndRemovedItemGetter
-	itemHandler() itemGetterSerializer
+	itemHandler() api.GetAndSerializeItemer[details.ExchangeInfo]
 	NewContainerCache(userID string) (string, graph.ContainerResolver)
 }
 
@@ -33,20 +31,6 @@ type addedAndRemovedItemGetter interface {
 		immutableIDs bool,
 		canMakeDeltaQueries bool,
 	) (map[string]time.Time, bool, []string, pagers.DeltaUpdate, error)
-}
-
-type itemGetterSerializer interface {
-	GetItem(
-		ctx context.Context,
-		user, itemID string,
-		immutableIDs bool,
-		errs *fault.Bus,
-	) (serialization.Parsable, *details.ExchangeInfo, error)
-	Serialize(
-		ctx context.Context,
-		item serialization.Parsable,
-		user, itemID string,
-	) ([]byte, error)
 }
 
 func BackupHandlers(ac api.Client) map[path.CategoryType]backupHandler {

--- a/src/internal/m365/collection/exchange/mail_backup.go
+++ b/src/internal/m365/collection/exchange/mail_backup.go
@@ -2,6 +2,7 @@ package exchange
 
 import (
 	"github.com/alcionai/corso/src/internal/m365/graph"
+	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
@@ -25,7 +26,7 @@ func (h mailBackupHandler) itemEnumerator() addedAndRemovedItemGetter {
 	return h.ac
 }
 
-func (h mailBackupHandler) itemHandler() itemGetterSerializer {
+func (h mailBackupHandler) itemHandler() api.GetAndSerializeItemer[details.ExchangeInfo] {
 	return h.ac
 }
 

--- a/src/pkg/services/m365/api/interfaces.go
+++ b/src/pkg/services/m365/api/interfaces.go
@@ -16,8 +16,8 @@ type GetAndSerializeItemer[INFO any] interface {
 type GetItemer[INFO any] interface {
 	GetItem(
 		ctx context.Context,
-		user, itemID string,
-		immutableIDs bool,
+		protectedResource, itemID string,
+		useImmutableIDs bool,
 		errs *fault.Bus,
 	) (serialization.Parsable, *INFO, error)
 }


### PR DESCRIPTION
swap out the exchange itemGetterSerializer interface with the api package GetAndSerializeItemer.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #4536

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
