### PR TITLE
standardize getIDs pager signature

### DIFF
--- a/src/internal/m365/collection/exchange/backup_test.go
+++ b/src/internal/m365/collection/exchange/backup_test.go
@@ -74,18 +74,11 @@ type (
 func (mg mockGetter) GetAddedAndRemovedItemIDs(
 	ctx context.Context,
 	userID, cID, prevDelta string,
-	_ bool,
-	_ bool,
-) (
-	map[string]time.Time,
-	bool,
-	[]string,
-	pagers.DeltaUpdate,
-	error,
-) {
+	_ api.CallConfig,
+) (pagers.AddedAndRemoved, error) {
 	results, ok := mg.results[cID]
 	if !ok {
-		return nil, false, nil, pagers.DeltaUpdate{}, clues.New("mock not found for " + cID)
+		return pagers.AddedAndRemoved{}, clues.New("mock not found for " + cID)
 	}
 
 	delta := results.newDelta
@@ -98,7 +91,14 @@ func (mg mockGetter) GetAddedAndRemovedItemIDs(
 		resAdded[add] = time.Time{}
 	}
 
-	return resAdded, false, results.removed, delta, results.err
+	aar := pagers.AddedAndRemoved{
+		Added:         resAdded,
+		Removed:       results.removed,
+		ValidModTimes: false,
+		DU:            delta,
+	}
+
+	return aar, results.err
 }
 
 var _ graph.ContainerResolver = &mockResolver{}

--- a/src/internal/m365/collection/exchange/handlers.go
+++ b/src/internal/m365/collection/exchange/handlers.go
@@ -2,7 +2,6 @@ package exchange
 
 import (
 	"context"
-	"time"
 
 	"github.com/microsoft/kiota-abstractions-go/serialization"
 
@@ -30,9 +29,8 @@ type addedAndRemovedItemGetter interface {
 	GetAddedAndRemovedItemIDs(
 		ctx context.Context,
 		user, containerID, oldDeltaToken string,
-		immutableIDs bool,
-		canMakeDeltaQueries bool,
-	) (map[string]time.Time, bool, []string, pagers.DeltaUpdate, error)
+		cc api.CallConfig,
+	) (pagers.AddedAndRemoved, error)
 }
 
 type itemGetterSerializer interface {

--- a/src/internal/m365/collection/groups/backup_test.go
+++ b/src/internal/m365/collection/groups/backup_test.go
@@ -57,15 +57,22 @@ func (bh mockBackupHandler) getContainers(context.Context) ([]models.Channelable
 func (bh mockBackupHandler) getContainerItemIDs(
 	_ context.Context,
 	_, _ string,
-	_ bool,
-) (map[string]time.Time, bool, []string, pagers.DeltaUpdate, error) {
+	_ api.CallConfig,
+) (pagers.AddedAndRemoved, error) {
 	idRes := make(map[string]time.Time, len(bh.messageIDs))
 
 	for _, id := range bh.messageIDs {
 		idRes[id] = time.Time{}
 	}
 
-	return idRes, true, bh.deletedMsgIDs, pagers.DeltaUpdate{}, bh.messagesErr
+	aar := pagers.AddedAndRemoved{
+		Added:         idRes,
+		Removed:       bh.deletedMsgIDs,
+		ValidModTimes: true,
+		DU:            pagers.DeltaUpdate{},
+	}
+
+	return aar, bh.messagesErr
 }
 
 func (bh mockBackupHandler) includeContainer(

--- a/src/internal/m365/collection/groups/channel_handler.go
+++ b/src/internal/m365/collection/groups/channel_handler.go
@@ -2,7 +2,6 @@ package groups
 
 import (
 	"context"
-	"time"
 
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
@@ -41,9 +40,9 @@ func (bh channelsBackupHandler) getContainers(
 func (bh channelsBackupHandler) getContainerItemIDs(
 	ctx context.Context,
 	channelID, prevDelta string,
-	canMakeDeltaQueries bool,
-) (map[string]time.Time, bool, []string, pagers.DeltaUpdate, error) {
-	return bh.ac.GetChannelMessageIDs(ctx, bh.protectedResource, channelID, prevDelta, canMakeDeltaQueries)
+	cc api.CallConfig,
+) (pagers.AddedAndRemoved, error) {
+	return bh.ac.GetChannelMessageIDs(ctx, bh.protectedResource, channelID, prevDelta, cc)
 }
 
 func (bh channelsBackupHandler) includeContainer(

--- a/src/internal/m365/collection/groups/handlers.go
+++ b/src/internal/m365/collection/groups/handlers.go
@@ -2,7 +2,6 @@ package groups
 
 import (
 	"context"
-	"time"
 
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/pagers"
 )
 
@@ -25,8 +25,8 @@ type backupHandler interface {
 	getContainerItemIDs(
 		ctx context.Context,
 		containerID, prevDelta string,
-		canMakeDeltaQueries bool,
-	) (map[string]time.Time, bool, []string, pagers.DeltaUpdate, error)
+		cc api.CallConfig,
+	) (pagers.AddedAndRemoved, error)
 
 	// includeContainer evaluates whether the container is included
 	// in the provided scope.

--- a/src/internal/m365/graph/cache_container.go
+++ b/src/internal/m365/graph/cache_container.go
@@ -11,29 +11,10 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 )
 
-// Idable represents objects that implement msgraph-sdk-go/models.entityable
-// and have the concept of an ID.
-type Idable interface {
-	GetId() *string
-}
-
-// Descendable represents objects that implement msgraph-sdk-go/models.entityable
-// and have the concept of a "parent folder".
-type Descendable interface {
-	Idable
-	GetParentFolderId() *string
-}
-
-// Displayable represents objects that implement msgraph-sdk-go/models.entityable
-// and have the concept of a display name.
-type Displayable interface {
-	Idable
-	GetDisplayName() *string
-}
-
 type Container interface {
-	Descendable
-	Displayable
+	GetIDer
+	GetParentFolderIDer
+	GetDisplayNamer
 }
 
 // CachedContainer is used for local unit tests but also makes it so that this
@@ -41,10 +22,12 @@ type Container interface {
 // reuse logic in IDToPath.
 type CachedContainer interface {
 	Container
+
 	// Location contains either the display names for the dirs (if this is a calendar)
 	// or nil
 	Location() *path.Builder
 	SetLocation(*path.Builder)
+
 	// Path contains either the ids for the dirs (if this is a calendar)
 	// or the display names for the dirs
 	Path() *path.Builder

--- a/src/internal/m365/graph/interfaces.go
+++ b/src/internal/m365/graph/interfaces.go
@@ -1,0 +1,29 @@
+package graph
+
+import (
+	"time"
+)
+
+type GetIDer interface {
+	GetId() *string
+}
+
+type GetLastModifiedDateTimer interface {
+	GetLastModifiedDateTime() *time.Time
+}
+
+type GetAdditionalDataer interface {
+	GetAdditionalData() map[string]any
+}
+
+type GetDeletedDateTimer interface {
+	GetDeletedDateTime() *time.Time
+}
+
+type GetDisplayNamer interface {
+	GetDisplayName() *string
+}
+
+type GetParentFolderIDer interface {
+	GetParentFolderId() *string
+}

--- a/src/internal/operations/test/exchange_test.go
+++ b/src/internal/operations/test/exchange_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -35,6 +34,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
+	"github.com/alcionai/corso/src/pkg/services/m365/api/pagers"
 	storeTD "github.com/alcionai/corso/src/pkg/storage/testdata"
 )
 
@@ -484,37 +484,38 @@ func testExchangeContinuousBackups(suite *ExchangeBackupIntgSuite, toggles contr
 		require.True(t, ok, "dir %s found in %s cache", locRef.String(), category)
 
 		var (
-			err   error
-			items map[string]time.Time
+			err error
+			aar pagers.AddedAndRemoved
+			cc  = api.CallConfig{
+				UseImmutableIDs:     toggles.ExchangeImmutableIDs,
+				CanMakeDeltaQueries: true,
+			}
 		)
 
 		switch category {
 		case path.EmailCategory:
-			items, _, _, _, err = ac.Mail().GetAddedAndRemovedItemIDs(
+			aar, err = ac.Mail().GetAddedAndRemovedItemIDs(
 				ctx,
 				uidn.ID(),
 				containerID,
 				"",
-				toggles.ExchangeImmutableIDs,
-				true)
+				cc)
 
 		case path.EventsCategory:
-			items, _, _, _, err = ac.Events().GetAddedAndRemovedItemIDs(
+			aar, err = ac.Events().GetAddedAndRemovedItemIDs(
 				ctx,
 				uidn.ID(),
 				containerID,
 				"",
-				toggles.ExchangeImmutableIDs,
-				true)
+				cc)
 
 		case path.ContactsCategory:
-			items, _, _, _, err = ac.Contacts().GetAddedAndRemovedItemIDs(
+			aar, err = ac.Contacts().GetAddedAndRemovedItemIDs(
 				ctx,
 				uidn.ID(),
 				containerID,
 				"",
-				toggles.ExchangeImmutableIDs,
-				true)
+				cc)
 		}
 
 		require.NoError(
@@ -523,6 +524,8 @@ func testExchangeContinuousBackups(suite *ExchangeBackupIntgSuite, toggles contr
 			"getting items for category %s, container %s",
 			category,
 			locRef.String())
+
+		items := aar.Added
 
 		dest := dataset[category].dests[destName]
 		dest.locRef = locRef.String()

--- a/src/pkg/services/m365/api/channels_pager.go
+++ b/src/pkg/services/m365/api/channels_pager.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"time"
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -186,18 +185,18 @@ func filterOutSystemMessages(cm models.ChatMessageable) bool {
 func (c Channels) GetChannelMessageIDs(
 	ctx context.Context,
 	teamID, channelID, prevDeltaLink string,
-	canMakeDeltaQueries bool,
-) (map[string]time.Time, bool, []string, pagers.DeltaUpdate, error) {
-	added, validModTimes, removed, du, err := pagers.GetAddedAndRemovedItemIDs[models.ChatMessageable](
+	cc CallConfig,
+) (pagers.AddedAndRemoved, error) {
+	aar, err := pagers.GetAddedAndRemovedItemIDs[models.ChatMessageable](
 		ctx,
 		c.NewChannelMessagePager(teamID, channelID, CallConfig{}),
 		c.NewChannelMessageDeltaPager(teamID, channelID, prevDeltaLink),
 		prevDeltaLink,
-		canMakeDeltaQueries,
+		cc.CanMakeDeltaQueries,
 		pagers.AddedAndRemovedByDeletedDateTime[models.ChatMessageable],
 		filterOutSystemMessages)
 
-	return added, validModTimes, removed, du, clues.Stack(err).OrNil()
+	return aar, clues.Stack(err).OrNil()
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/services/m365/api/client.go
+++ b/src/pkg/services/m365/api/client.go
@@ -135,8 +135,10 @@ func (c Client) Post(
 // ---------------------------------------------------------------------------
 
 type CallConfig struct {
-	Expand []string
-	Select []string
+	Expand              []string
+	Select              []string
+	CanMakeDeltaQueries bool
+	UseImmutableIDs     bool
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/services/m365/api/contacts_pager.go
+++ b/src/pkg/services/m365/api/contacts_pager.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"time"
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -250,9 +249,8 @@ func (p *contactDeltaPager) ValidModTimes() bool {
 func (c Contacts) GetAddedAndRemovedItemIDs(
 	ctx context.Context,
 	userID, containerID, prevDeltaLink string,
-	immutableIDs bool,
-	canMakeDeltaQueries bool,
-) (map[string]time.Time, bool, []string, pagers.DeltaUpdate, error) {
+	cc CallConfig,
+) (pagers.AddedAndRemoved, error) {
 	ctx = clues.Add(
 		ctx,
 		"data_category", path.ContactsCategory,
@@ -263,12 +261,12 @@ func (c Contacts) GetAddedAndRemovedItemIDs(
 		userID,
 		containerID,
 		prevDeltaLink,
-		immutableIDs,
+		cc.UseImmutableIDs,
 		idAnd(lastModifiedDateTime)...)
 	pager := c.NewContactsPager(
 		userID,
 		containerID,
-		immutableIDs,
+		cc.UseImmutableIDs,
 		idAnd(lastModifiedDateTime)...)
 
 	return pagers.GetAddedAndRemovedItemIDs[models.Contactable](
@@ -276,6 +274,6 @@ func (c Contacts) GetAddedAndRemovedItemIDs(
 		pager,
 		deltaPager,
 		prevDeltaLink,
-		canMakeDeltaQueries,
+		cc.CanMakeDeltaQueries,
 		pagers.AddedAndRemovedByAddtlData[models.Contactable])
 }

--- a/src/pkg/services/m365/api/conversations_pager.go
+++ b/src/pkg/services/m365/api/conversations_pager.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"time"
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/groups"
@@ -237,10 +236,10 @@ func (c Conversations) GetConversationThreadPostIDs(
 	ctx context.Context,
 	groupID, conversationID, threadID string,
 	cc CallConfig,
-) (map[string]time.Time, bool, []string, pagers.DeltaUpdate, error) {
+) (pagers.AddedAndRemoved, error) {
 	canMakeDeltaQueries := false
 
-	added, validModTimes, removed, du, err := pagers.GetAddedAndRemovedItemIDs[models.Postable](
+	aarh, err := pagers.GetAddedAndRemovedItemIDs[models.Postable](
 		ctx,
 		c.NewConversationThreadPostsPager(groupID, conversationID, threadID, CallConfig{}),
 		nil,
@@ -249,5 +248,5 @@ func (c Conversations) GetConversationThreadPostIDs(
 		pagers.AddedAndRemovedAddAll[models.Postable],
 		pagers.FilterIncludeAll[models.Postable])
 
-	return added, validModTimes, removed, du, clues.Stack(err).OrNil()
+	return aarh, clues.Stack(err).OrNil()
 }

--- a/src/pkg/services/m365/api/conversations_pager_test.go
+++ b/src/pkg/services/m365/api/conversations_pager_test.go
@@ -50,17 +50,17 @@ func (suite *ConversationsPagerIntgSuite) TestEnumerateConversations_withThreads
 		for _, thread := range threads {
 			posts := testEnumerateConvPosts(suite, conv, thread)
 
-			added, valid, removed, du, err := ac.GetConversationThreadPostIDs(
+			aar, err := ac.GetConversationThreadPostIDs(
 				ctx,
 				suite.its.group.id,
 				ptr.Val(conv.GetId()),
 				ptr.Val(thread.GetId()),
 				CallConfig{})
 			require.NoError(t, err, clues.ToCore(err))
-			require.Equal(t, len(posts), len(added), "added the same number of ids and posts")
-			assert.True(t, valid, "mod times should be valid")
-			assert.Empty(t, removed, "no items should get removed")
-			assert.Empty(t, du.URL, "no delta update token should be provided")
+			require.Equal(t, len(posts), len(aar.Added), "added the same number of ids and posts")
+			assert.True(t, aar.ValidModTimes, "mod times should be valid")
+			assert.Empty(t, aar.Removed, "no items should get removed")
+			assert.Empty(t, aar.DU.URL, "no delta update token should be provided")
 
 			for _, post := range posts {
 				testGetPostByID(suite, conv, thread, post)

--- a/src/pkg/services/m365/api/events_pager.go
+++ b/src/pkg/services/m365/api/events_pager.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -245,9 +244,8 @@ func (p *eventDeltaPager) ValidModTimes() bool {
 func (c Events) GetAddedAndRemovedItemIDs(
 	ctx context.Context,
 	userID, containerID, prevDeltaLink string,
-	immutableIDs bool,
-	canMakeDeltaQueries bool,
-) (map[string]time.Time, bool, []string, pagers.DeltaUpdate, error) {
+	cc CallConfig,
+) (pagers.AddedAndRemoved, error) {
 	ctx = clues.Add(
 		ctx,
 		"data_category", path.EventsCategory,
@@ -258,12 +256,12 @@ func (c Events) GetAddedAndRemovedItemIDs(
 		userID,
 		containerID,
 		prevDeltaLink,
-		immutableIDs,
+		cc.UseImmutableIDs,
 		idAnd()...)
 	pager := c.NewEventsPager(
 		userID,
 		containerID,
-		immutableIDs,
+		cc.UseImmutableIDs,
 		idAnd(lastModifiedDateTime)...)
 
 	return pagers.GetAddedAndRemovedItemIDs[models.Eventable](
@@ -271,6 +269,6 @@ func (c Events) GetAddedAndRemovedItemIDs(
 		pager,
 		deltaPager,
 		prevDeltaLink,
-		canMakeDeltaQueries,
+		cc.CanMakeDeltaQueries,
 		pagers.AddedAndRemovedByAddtlData[models.Eventable])
 }

--- a/src/pkg/services/m365/api/mail_pager.go
+++ b/src/pkg/services/m365/api/mail_pager.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -247,9 +246,8 @@ func (p *mailDeltaPager) ValidModTimes() bool {
 func (c Mail) GetAddedAndRemovedItemIDs(
 	ctx context.Context,
 	userID, containerID, prevDeltaLink string,
-	immutableIDs bool,
-	canMakeDeltaQueries bool,
-) (map[string]time.Time, bool, []string, pagers.DeltaUpdate, error) {
+	cc CallConfig,
+) (pagers.AddedAndRemoved, error) {
 	ctx = clues.Add(
 		ctx,
 		"data_category", path.EmailCategory,
@@ -260,12 +258,12 @@ func (c Mail) GetAddedAndRemovedItemIDs(
 		userID,
 		containerID,
 		prevDeltaLink,
-		immutableIDs,
+		cc.UseImmutableIDs,
 		idAnd(lastModifiedDateTime)...)
 	pager := c.NewMailPager(
 		userID,
 		containerID,
-		immutableIDs,
+		cc.UseImmutableIDs,
 		idAnd(lastModifiedDateTime)...)
 
 	return pagers.GetAddedAndRemovedItemIDs[models.Messageable](
@@ -273,6 +271,6 @@ func (c Mail) GetAddedAndRemovedItemIDs(
 		pager,
 		deltaPager,
 		prevDeltaLink,
-		canMakeDeltaQueries,
+		cc.CanMakeDeltaQueries,
 		pagers.AddedAndRemovedByAddtlData[models.Messageable])
 }

--- a/src/pkg/services/m365/api/pagers/pagers.go
+++ b/src/pkg/services/m365/api/pagers/pagers.go
@@ -440,13 +440,9 @@ func GetAddedAndRemovedItemIDs[T any](
 	return aar, graph.Stack(ctx, err).OrNil()
 }
 
-type getIDer interface {
-	GetId() *string
-}
-
 type getIDAndModDateTimer interface {
-	getIDer
-	getLastModifiedDateTimer
+	graph.GetIDer
+	graph.GetLastModifiedDateTimer
 }
 
 // AddedAndRemovedAddAll indiscriminately adds every item to the added list, deleting nothing.
@@ -482,16 +478,9 @@ func AddedAndRemovedAddAll[T any](
 // for added and removed by additionalData[@removed]
 
 type getIDModAndAddtler interface {
-	getIDer
-	getLastModifiedDateTimer
-	GetAdditionalData() map[string]any
-}
-
-// for types that are non-compliant with this interface,
-// pagers will need to wrap the return value in a struct
-// that provides this compliance.
-type getLastModifiedDateTimer interface {
-	GetLastModifiedDateTime() *time.Time
+	graph.GetIDer
+	graph.GetLastModifiedDateTimer
+	graph.GetAdditionalDataer
 }
 
 func AddedAndRemovedByAddtlData[T any](
@@ -524,7 +513,11 @@ func AddedAndRemovedByAddtlData[T any](
 		if giaa.GetAdditionalData()[graph.AddtlDataRemoved] == nil {
 			var modTime time.Time
 
-			if mt, ok := giaa.(getLastModifiedDateTimer); ok {
+			// not all items comply with last modified date time, and not all
+			// items can be wrapped in a way that produces a valid value for
+			// the func.  That's why this isn't packed in to the expected
+			// interfaace composition.
+			if mt, ok := giaa.(graph.GetLastModifiedDateTimer); ok {
 				// Make sure to get a non-zero mod time if the item doesn't have one for
 				// some reason. Otherwise we can hit an issue where kopia has a
 				// different mod time for the file than the details does. This occurs
@@ -548,9 +541,9 @@ func AddedAndRemovedByAddtlData[T any](
 // for added and removed by GetDeletedDateTime()
 
 type getIDModAndDeletedDateTimer interface {
-	getIDer
-	getLastModifiedDateTimer
-	GetDeletedDateTime() *time.Time
+	graph.GetIDer
+	graph.GetLastModifiedDateTimer
+	graph.GetDeletedDateTimer
 }
 
 func AddedAndRemovedByDeletedDateTime[T any](
@@ -580,7 +573,11 @@ func AddedAndRemovedByDeletedDateTime[T any](
 		if giaddt.GetDeletedDateTime() == nil {
 			var modTime time.Time
 
-			if mt, ok := giaddt.(getLastModifiedDateTimer); ok {
+			// not all items comply with last modified date time, and not all
+			// items can be wrapped in a way that produces a valid value for
+			// the func.  That's why this isn't packed in to the expected
+			// interfaace composition.
+			if mt, ok := giaddt.(graph.GetLastModifiedDateTimer); ok {
 				// Make sure to get a non-zero mod time if the item doesn't have one for
 				// some reason. Otherwise we can hit an issue where kopia has a
 				// different mod time for the file than the details does. This occurs

--- a/src/pkg/services/m365/api/pagers/pagers_test.go
+++ b/src/pkg/services/m365/api/pagers/pagers_test.go
@@ -520,7 +520,7 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs() {
 				filters = append(filters, test.filter)
 			}
 
-			added, validModTimes, removed, deltaUpdate, err := GetAddedAndRemovedItemIDs[testItem](
+			aar, err := GetAddedAndRemovedItemIDs[testItem](
 				ctx,
 				test.pagerGetter(t),
 				test.deltaPagerGetter(t),
@@ -530,18 +530,18 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs() {
 				filters...)
 
 			require.NoErrorf(t, err, "getting added and removed item IDs: %+v", clues.ToCore(err))
-			if validModTimes {
-				assert.Equal(t, test.expect.added, added, "added item IDs and mod times")
+			if aar.ValidModTimes {
+				assert.Equal(t, test.expect.added, aar.Added, "added item IDs and mod times")
 			} else {
-				assert.ElementsMatch(t, maps.Keys(test.expect.added), maps.Keys(added), "added item IDs")
-				for _, modtime := range added {
+				assert.ElementsMatch(t, maps.Keys(test.expect.added), maps.Keys(aar.Added), "added item IDs")
+				for _, modtime := range aar.Added {
 					assert.True(t, modtime.After(epoch), "mod time after epoch")
 					assert.False(t, modtime.Equal(time.Time{}), "non-zero mod time")
 				}
 			}
-			assert.Equal(t, test.expect.validModTimes, validModTimes, "valid mod times")
-			assert.EqualValues(t, test.expect.removed, removed, "removed item IDs")
-			assert.Equal(t, test.expect.deltaUpdate, deltaUpdate, "delta update")
+			assert.Equal(t, test.expect.validModTimes, aar.ValidModTimes, "valid mod times")
+			assert.EqualValues(t, test.expect.removed, aar.Removed, "removed item IDs")
+			assert.Equal(t, test.expect.deltaUpdate, aar.DU, "delta update")
 		})
 	}
 }


### PR DESCRIPTION
creates a more standard method signature for the
api pager pattern for the getItemIDs delta query.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #4536

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
