### PR TITLE
Update log statements for base finder

### DIFF
--- a/src/internal/kopia/base_finder.go
+++ b/src/internal/kopia/base_finder.go
@@ -183,18 +183,19 @@ func (b *baseFinder) findBasesInSet(
 			continue
 		}
 
+		ictx = clues.Add(ictx, "search_backup_id", bup.ID)
+
 		ssid := bup.StreamStoreID
 		if len(ssid) == 0 {
 			ssid = bup.DetailsID
 		}
 
 		if len(ssid) == 0 {
-			logger.Ctx(ictx).Debugw(
-				"empty backup stream store ID",
-				"search_backup_id", bup.ID)
-
+			logger.Ctx(ictx).Debug("empty backup stream store ID")
 			continue
 		}
+
+		ictx = clues.Add(ictx, "ssid", ssid)
 
 		// If we've made it to this point then we're considering the backup
 		// complete as it has both an item data snapshot and a backup details
@@ -215,21 +216,14 @@ func (b *baseFinder) findBasesInSet(
 					Reasons:          []identity.Reasoner{reason},
 				}
 
-				logger.Ctx(ictx).Infow(
-					"found assist base",
-					"search_backup_id", bup.ID,
-					"search_snapshot_id", meta.ID,
-					"ssid", ssid)
+				logger.Ctx(ictx).Info("found assist base")
 			}
 
 			// Skip if an assist base has already been selected.
 			continue
 		}
 
-		logger.Ctx(ictx).Infow("found merge base",
-			"search_backup_id", bup.ID,
-			"search_snapshot_id", meta.ID,
-			"ssid", ssid)
+		logger.Ctx(ictx).Info("found merge base")
 
 		mergeBase = &BackupBase{
 			Backup:           bup,


### PR DESCRIPTION
Store more info in the context so that log statements need to add fewer additional fields.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup


#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
