### PR TITLE
completes basic backup support for conversations

### DIFF
--- a/src/internal/m365/collection/groups/backup.go
+++ b/src/internal/m365/collection/groups/backup.go
@@ -127,7 +127,7 @@ func populateCollections[C graph.GetIDer, I groupsItemer](
 			cl          = counter.Local()
 			cID         = ptr.Val(c.container.GetId())
 			err         error
-			dp          = dps[c.folders.String()]
+			dp          = dps[c.storageDirFolders.String()]
 			prevDelta   = dp.Delta
 			prevPathStr = dp.Path // do not log: pii; log prevPath instead
 			prevPath    path.Path
@@ -168,7 +168,7 @@ func populateCollections[C graph.GetIDer, I groupsItemer](
 			CanMakeDeltaQueries: bh.canMakeDeltaQueries() && c.canMakeDeltaQueries,
 		}
 
-		addAndRem, err := bh.getContainerItemIDs(ctx, c.folders, prevDelta, cc)
+		addAndRem, err := bh.getContainerItemIDs(ctx, c.storageDirFolders, prevDelta, cc)
 		if err != nil {
 			el.AddRecoverable(ctx, clues.Stack(err))
 			continue
@@ -181,12 +181,12 @@ func populateCollections[C graph.GetIDer, I groupsItemer](
 		cl.Add(count.ItemsRemoved, int64(len(removed)))
 
 		if len(addAndRem.DU.URL) > 0 {
-			deltaURLs[c.folders.String()] = addAndRem.DU.URL
+			deltaURLs[c.storageDirFolders.String()] = addAndRem.DU.URL
 		} else if !addAndRem.DU.Reset {
 			logger.Ctx(ictx).Info("missing delta url")
 		}
 
-		currPath, err := bh.canonicalPath(c.folders, qp.TenantID)
+		currPath, err := bh.canonicalPath(c.storageDirFolders, qp.TenantID)
 		if err != nil {
 			err = clues.StackWC(ctx, err).Label(count.BadCollPath)
 			el.AddRecoverable(ctx, err)
@@ -205,7 +205,7 @@ func populateCollections[C graph.GetIDer, I groupsItemer](
 			data.NewBaseCollection(
 				currPath,
 				prevPath,
-				c.location.Builder(),
+				c.humanLocation.Builder(),
 				ctrlOpts,
 				addAndRem.DU.Reset,
 				cl),
@@ -215,11 +215,11 @@ func populateCollections[C graph.GetIDer, I groupsItemer](
 			removed,
 			statusUpdater)
 
-		collections[c.folders.String()] = &edc
+		collections[c.storageDirFolders.String()] = &edc
 
 		// add the current path for the container ID to be used in the next backup
 		// as the "previous path", for reference in case of a rename or relocation.
-		currPaths[c.folders.String()] = currPath.String()
+		currPaths[c.storageDirFolders.String()] = currPath.String()
 	}
 
 	// A tombstone is a channel that needs to be marked for deletion.

--- a/src/internal/m365/collection/groups/backup_test.go
+++ b/src/internal/m365/collection/groups/backup_test.go
@@ -104,10 +104,10 @@ func (bh mockBackupHandler) includeContainer(
 }
 
 func (bh mockBackupHandler) canonicalPath(
-	folders path.Elements,
+	storageDirFolders path.Elements,
 	tenantID string,
 ) (path.Path, error) {
-	return folders.
+	return storageDirFolders.
 		Builder().
 		ToDataLayerPath(
 			tenantID,

--- a/src/internal/m365/collection/groups/backup_test.go
+++ b/src/internal/m365/collection/groups/backup_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	inMock "github.com/alcionai/corso/src/internal/common/idname/mock"
-	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/m365/collection/groups/testdata"
 	"github.com/alcionai/corso/src/internal/m365/support"
@@ -42,7 +41,7 @@ var _ backupHandler[models.Channelable, models.ChatMessageable] = &mockBackupHan
 
 type mockBackupHandler struct {
 	channels      []models.Channelable
-	channelsErr   error
+	containersErr error
 	messageIDs    []string
 	deletedMsgIDs []string
 	messagesErr   error
@@ -52,17 +51,31 @@ type mockBackupHandler struct {
 	doNotInclude  bool
 }
 
-func (bh mockBackupHandler) canMakeDeltaQueries(models.Channelable) bool {
+func (bh mockBackupHandler) canMakeDeltaQueries() bool {
 	return true
 }
 
-func (bh mockBackupHandler) getContainers(context.Context) ([]models.Channelable, error) {
-	return bh.channels, bh.channelsErr
+func (bh mockBackupHandler) containers() []container[models.Channelable] {
+	containers := make([]container[models.Channelable], 0, len(bh.channels))
+
+	for _, ch := range bh.channels {
+		containers = append(containers, channelContainer(ch))
+	}
+
+	return containers
+}
+
+func (bh mockBackupHandler) getContainers(
+	context.Context,
+	api.CallConfig,
+) ([]container[models.Channelable], error) {
+	return bh.containers(), bh.containersErr
 }
 
 func (bh mockBackupHandler) getContainerItemIDs(
 	_ context.Context,
-	_, _ string,
+	_ path.Elements,
+	_ string,
 	_ api.CallConfig,
 ) (pagers.AddedAndRemoved, error) {
 	idRes := make(map[string]time.Time, len(bh.messageIDs))
@@ -91,22 +104,17 @@ func (bh mockBackupHandler) includeContainer(
 }
 
 func (bh mockBackupHandler) canonicalPath(
-	folders *path.Builder,
+	folders path.Elements,
 	tenantID string,
 ) (path.Path, error) {
 	return folders.
+		Builder().
 		ToDataLayerPath(
 			tenantID,
 			"protectedResource",
 			path.GroupsService,
 			path.ChannelMessagesCategory,
 			false)
-}
-
-func (bh mockBackupHandler) locationPath(
-	c models.Channelable,
-) *path.Builder {
-	return path.Builder{}.Append(ptr.Val(c.GetDisplayName()))
 }
 
 func (bh mockBackupHandler) GetItem(
@@ -255,7 +263,7 @@ func (suite *BackupUnitSuite) TestPopulateCollections() {
 				qp,
 				test.mock,
 				statusUpdater,
-				test.mock.channels,
+				test.mock.containers(),
 				selectors.NewGroupsBackup(nil).Channels(selectors.Any())[0],
 				nil,
 				ctrlOpts,
@@ -415,7 +423,7 @@ func (suite *BackupUnitSuite) TestPopulateCollections_incremental() {
 				qp,
 				test.mock,
 				statusUpdater,
-				test.mock.channels,
+				test.mock.containers(),
 				allScope,
 				test.deltaPaths,
 				ctrlOpts,

--- a/src/internal/m365/collection/groups/channel_handler.go
+++ b/src/internal/m365/collection/groups/channel_handler.go
@@ -3,9 +3,9 @@ package groups
 import (
 	"context"
 
+	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
-	"github.com/alcionai/clues"
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -74,10 +74,10 @@ func (bh channelsBackupHandler) includeContainer(
 }
 
 func (bh channelsBackupHandler) canonicalPath(
-	folders path.Elements,
+	storageDirFolders path.Elements,
 	tenantID string,
 ) (path.Path, error) {
-	return folders.
+	return storageDirFolders.
 		Builder().
 		ToDataLayerPath(
 			tenantID,
@@ -107,8 +107,8 @@ func (bh channelsBackupHandler) GetItem(
 
 func channelContainer(ch models.Channelable) container[models.Channelable] {
 	return container[models.Channelable]{
-		folders:             path.Elements{ptr.Val(ch.GetId())},
-		location:            path.Elements{ptr.Val(ch.GetDisplayName())},
+		storageDirFolders:   path.Elements{ptr.Val(ch.GetId())},
+		humanLocation:       path.Elements{ptr.Val(ch.GetDisplayName())},
 		canMakeDeltaQueries: len(ptr.Val(ch.GetEmail())) > 0,
 		container:           ch,
 	}

--- a/src/internal/m365/collection/groups/conversation_handler.go
+++ b/src/internal/m365/collection/groups/conversation_handler.go
@@ -91,10 +91,10 @@ func (bh conversationsBackupHandler) includeContainer(
 }
 
 func (bh conversationsBackupHandler) canonicalPath(
-	folders path.Elements,
+	storageDirFolders path.Elements,
 	tenantID string,
 ) (path.Path, error) {
-	return folders.
+	return storageDirFolders.
 		Builder().
 		ToDataLayerPath(
 			tenantID,
@@ -133,8 +133,8 @@ func conversationThreadContainer(
 	t models.ConversationThreadable,
 ) container[models.Conversationable] {
 	return container[models.Conversationable]{
-		folders:             path.Elements{ptr.Val(c.GetId()), ptr.Val(t.GetId())},
-		location:            path.Elements{"TODO(keepers)"},
+		storageDirFolders:   path.Elements{ptr.Val(c.GetId()), ptr.Val(t.GetId())},
+		humanLocation:       path.Elements{"TODO(keepers)"},
 		canMakeDeltaQueries: false,
 		container:           c,
 	}

--- a/src/internal/m365/collection/groups/handlers.go
+++ b/src/internal/m365/collection/groups/handlers.go
@@ -27,12 +27,14 @@ type backupHandler[C graph.GetIDer, I groupsItemer] interface {
 	// gets all containers for the resource
 	getContainers(
 		ctx context.Context,
-	) ([]C, error)
+		cc api.CallConfig,
+	) ([]container[C], error)
 
 	// gets all item IDs (by delta, if possible) in the container
 	getContainerItemIDs(
 		ctx context.Context,
-		containerID, prevDelta string,
+		containerPath path.Elements,
+		prevDelta string,
 		cc api.CallConfig,
 	) (pagers.AddedAndRemoved, error)
 
@@ -48,15 +50,13 @@ type backupHandler[C graph.GetIDer, I groupsItemer] interface {
 	// canonicalPath constructs the service and category specific path for
 	// the given builder.
 	canonicalPath(
-		folders *path.Builder,
+		folders path.Elements,
 		tenantID string,
 	) (path.Path, error)
 
-	locationPath(c C) *path.Builder
-
-	// canMakeDeltaQueries evaluates whether the container can support a
-	// delta query when enumerating its items.
-	canMakeDeltaQueries(C) bool
+	// canMakeDeltaQueries evaluates whether the data type can support a
+	// delta query enumeration.
+	canMakeDeltaQueries() bool
 }
 
 type getItemer[I groupsItemer] interface {
@@ -66,4 +66,15 @@ type getItemer[I groupsItemer] interface {
 		containerIDs path.Elements,
 		itemID string,
 	) (I, *details.GroupsInfo, error)
+}
+
+// ---------------------------------------------------------------------------
+// Container management
+// ---------------------------------------------------------------------------
+
+type container[C graph.GetIDer] struct {
+	folders             path.Elements
+	location            path.Elements
+	canMakeDeltaQueries bool
+	container           C
 }

--- a/src/internal/m365/collection/groups/handlers.go
+++ b/src/internal/m365/collection/groups/handlers.go
@@ -50,7 +50,7 @@ type backupHandler[C graph.GetIDer, I groupsItemer] interface {
 	// canonicalPath constructs the service and category specific path for
 	// the given builder.
 	canonicalPath(
-		folders path.Elements,
+		storageDir path.Elements,
 		tenantID string,
 	) (path.Path, error)
 
@@ -73,8 +73,8 @@ type getItemer[I groupsItemer] interface {
 // ---------------------------------------------------------------------------
 
 type container[C graph.GetIDer] struct {
-	folders             path.Elements
-	location            path.Elements
+	storageDirFolders   path.Elements
+	humanLocation       path.Elements
 	canMakeDeltaQueries bool
 	container           C
 }

--- a/src/internal/m365/service/groups/backup.go
+++ b/src/internal/m365/service/groups/backup.go
@@ -73,7 +73,7 @@ func ProduceBackupCollections(
 
 		cl := counter.Local()
 		ictx := clues.AddLabelCounter(ctx, cl.PlainAdder())
-		ictx = clues.Add(ctx, "category", scope.Category().PathType())
+		ictx = clues.Add(ictx, "category", scope.Category().PathType())
 
 		var dbcs []data.BackupCollection
 

--- a/src/internal/m365/service/groups/backup.go
+++ b/src/internal/m365/service/groups/backup.go
@@ -73,12 +73,16 @@ func ProduceBackupCollections(
 
 		cl := counter.Local()
 		ictx := clues.AddLabelCounter(ctx, cl.PlainAdder())
+		ictx = clues.Add(ctx, "category", scope.Category().PathType())
 
 		var dbcs []data.BackupCollection
 
 		switch scope.Category().PathType() {
 		case path.LibrariesCategory:
-			sites, err := ac.Groups().GetAllSites(ictx, bpc.ProtectedResource.ID(), errs)
+			sites, err := ac.Groups().GetAllSites(
+				ictx,
+				bpc.ProtectedResource.ID(),
+				errs)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -157,7 +161,7 @@ func ProduceBackupCollections(
 			}
 			progressBar := observe.MessageWithCompletion(ictx, pcfg, scope.Category().PathType().HumanString())
 
-			if !api.IsTeam(ctx, group) {
+			if !api.IsTeam(ictx, group) {
 				continue
 			}
 
@@ -203,7 +207,7 @@ func ProduceBackupCollections(
 			progressBar := observe.MessageWithCompletion(ictx, pcfg, scope.Category().PathType().HumanString())
 
 			cs, canUsePreviousBackup, err := groups.CreateCollections(
-				ctx,
+				ictx,
 				bpc,
 				bh,
 				creds.AzureTenantID,
@@ -212,7 +216,7 @@ func ProduceBackupCollections(
 				counter,
 				errs)
 			if err != nil {
-				el.AddRecoverable(ctx, err)
+				el.AddRecoverable(ictx, err)
 				continue
 			}
 

--- a/src/pkg/backup/details/builder.go
+++ b/src/pkg/backup/details/builder.go
@@ -62,9 +62,10 @@ func (b *Builder) addFolderEntries(
 		b.knownFolders = map[string]Entry{}
 	}
 
-	// Need a unique location because we want to have separate folders for
-	// different drives and categories even if there's duplicate folder names in
-	// them.
+	// Unique location ensures that the location reference includes all
+	// possible hierarchy.  In many handlers, the location ref is only partially
+	// constructed (ex: drive locations do not contain the drive ID).  This
+	// transformer ensures that the location is complete and fully populated.
 	uniqueLoc, err := entry.uniqueLocation(locationRef)
 	if err != nil {
 		return clues.Wrap(err, "getting LocationIDer")

--- a/src/pkg/backup/details/groups.go
+++ b/src/pkg/backup/details/groups.go
@@ -145,6 +145,8 @@ func (i *GroupsInfo) uniqueLocation(baseLoc *path.Builder) (*uniqueLoc, error) {
 		loc, err = NewGroupsLocationIDer(path.LibrariesCategory, i.DriveID, baseLoc.Elements()...)
 	case GroupsChannelMessage:
 		loc, err = NewGroupsLocationIDer(path.ChannelMessagesCategory, "", baseLoc.Elements()...)
+	case GroupsConversationPost:
+		loc, err = NewGroupsLocationIDer(path.ConversationPostsCategory, "", baseLoc.Elements()...)
 	}
 
 	return &loc, err
@@ -156,7 +158,7 @@ func (i *GroupsInfo) updateFolder(f *FolderInfo) error {
 	switch i.ItemType {
 	case SharePointLibrary:
 		return updateFolderWithinDrive(SharePointLibrary, i.DriveName, i.DriveID, f)
-	case GroupsChannelMessage:
+	case GroupsChannelMessage, GroupsConversationPost:
 		return nil
 	}
 

--- a/src/pkg/path/elements.go
+++ b/src/pkg/path/elements.go
@@ -65,6 +65,11 @@ func NewElements(p string) Elements {
 	return Split(p)
 }
 
+// Builder produces a *Builder{} containing the elements.
+func (el Elements) Builder() *Builder {
+	return Builder{}.Append(el...)
+}
+
 // Conceal produces a concealed representation of the elements, suitable for
 // logging, storing in errors, and other output.
 func (el Elements) Conceal() string {


### PR DESCRIPTION
adds support for hierarchical storage in the groups collection processor, which allows us to insert conv posts based on both conversation and thread, while maintaining support for channel message structure.

```
corso backup create groups \
	--group 1e8f7352 \
	--data conversations

Done

  ID                                    Bytes Uploaded  Items Uploaded  Items Skipped  Errors
  fb97a204-d6d6-4e62-9f9a-d225fc095e48  0 B             0               0              0

Completed Backups:
  ID                                    Started At            Duration  Status     Resource Owner
  fb97a204-d6d6-4e62-9f9a-d225fc095e48  2023-10-31T18:24:12Z  4.27463s  Completed  Keepers-Teams-Testing
```
---

#### Does this PR need a docs update or release note?

- [x] :clock1: Yes, but in a later PR

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #4536

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
