### PR TITLE
Minor refactor for checking backup type when finding bases

### DIFF
--- a/src/internal/kopia/base_finder.go
+++ b/src/internal/kopia/base_finder.go
@@ -257,42 +257,6 @@ func (b *baseFinder) findBasesInSet(
 	return mergeBase, assistBase, nil
 }
 
-// isAssistBackupModel checks if the provided backup is an assist backup.
-func (b *baseFinder) isAssistBackupModel(
-	ctx context.Context,
-	bup *backup.Backup,
-) bool {
-	allTags := map[string]string{
-		model.BackupTypeTag: model.AssistBackup,
-	}
-
-	for k, v := range allTags {
-		if bup.Tags[k] != v {
-			// This is not an assist backup so we can just exit here.
-			logger.Ctx(ctx).Debugw(
-				"assist backup model missing tags",
-				"backup_id", bup.ID,
-				"tag", k,
-				"expected_value", v,
-				"actual_value", bup.Tags[k])
-
-			return false
-		}
-	}
-
-	// Check if it has a valid streamstore id and snapshot id.
-	if len(bup.StreamStoreID) == 0 || len(bup.SnapshotID) == 0 {
-		logger.Ctx(ctx).Infow(
-			"nil ssid or snapshot id in assist base",
-			"ssid", bup.StreamStoreID,
-			"snapshot_id", bup.SnapshotID)
-
-		return false
-	}
-
-	return true
-}
-
 func (b *baseFinder) getBase(
 	ctx context.Context,
 	r identity.Reasoner,

--- a/src/internal/kopia/base_finder.go
+++ b/src/internal/kopia/base_finder.go
@@ -199,8 +199,8 @@ func (b *baseFinder) findBasesInSet(
 
 		if bup.SnapshotID != string(man.ID) {
 			logger.Ctx(ictx).Infow(
-				"backup has empty or different snapshot ID",
-				"got_snapshot_id", bup.SnapshotID)
+				"retrieved backup has empty or different snapshot ID from provided manifest",
+				"backup_snapshot_id", bup.SnapshotID)
 
 			continue
 		}

--- a/src/internal/kopia/base_finder_test.go
+++ b/src/internal/kopia/base_finder_test.go
@@ -279,6 +279,13 @@ func (builder *baseInfoBuilder) legacyBackupDetails() *baseInfoBuilder {
 	return builder
 }
 
+func (builder *baseInfoBuilder) setBackupItemSnapshotID(
+	id string,
+) *baseInfoBuilder {
+	builder.info.backup.b.SnapshotID = id
+	return builder
+}
+
 func (builder *baseInfoBuilder) clearBackupDetails() *baseInfoBuilder {
 	builder.info.backup.b.DetailsID = ""
 	builder.info.backup.b.StreamStoreID = ""
@@ -436,6 +443,20 @@ func (suite *BaseFinderUnitSuite) TestGetBases() {
 			data: []baseInfo{
 				newBaseInfoBuilder(2, testT2, testUser1Mail...).
 					clearBackupDetails().
+					build(),
+				newBaseInfoBuilder(1, testT1, testUser1Mail...).
+					build(),
+			},
+			expectedMergeReasons: map[int][]identity.Reasoner{
+				1: testUser1Mail,
+			},
+		},
+		{
+			name:  "Return Older Base If Snapshot ID Mismatch",
+			input: testUser1Mail,
+			data: []baseInfo{
+				newBaseInfoBuilder(2, testT2, testUser1Mail...).
+					setBackupItemSnapshotID("foo").
 					build(),
 				newBaseInfoBuilder(1, testT1, testUser1Mail...).
 					build(),


### PR DESCRIPTION
Use the new helper function to get the backup type and rewrite logic
to streamline checks/actions on the backup type

Hoists a check on the backup's snapshot ID higher in the code and
adds a test case for that

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
