### PR TITLE
Create and tag preview backups

### DIFF
--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -934,9 +934,11 @@ func (op *BackupOperation) createBackupModels(
 		model.ServiceTag: op.Selectors.PathService().String(),
 	}
 
-	// Add tags to mark this backup as either assist or merge. This is used to:
+	// Add tags to mark this backup as preview, assist, or merge. This is used to:
 	// 1. Filter assist backups by tag during base selection process
 	// 2. Differentiate assist backups, merge backups, and preview backups.
+	//
+	// model.BackupTypeTag has more info about how these tags are used.
 	switch {
 	case op.Options.ToggleFeatures.PreviewBackup:
 		// Preview backups need to be successful and without errors to be considered
@@ -968,7 +970,8 @@ func (op *BackupOperation) createBackupModels(
 		tags[model.BackupTypeTag] = model.AssistBackup
 
 	default:
-		return clues.New("backup is neither assist nor merge").WithClues(ctx)
+		return clues.New("unable to determine backup type due to operation errors").
+			WithClues(ctx)
 	}
 
 	// Additional defensive check to make sure we tag things as expected above.

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -936,22 +936,44 @@ func (op *BackupOperation) createBackupModels(
 
 	// Add tags to mark this backup as either assist or merge. This is used to:
 	// 1. Filter assist backups by tag during base selection process
-	// 2. Differentiate assist backups from merge backups
-	if isMergeBackup(
+	// 2. Differentiate assist backups, merge backups, and preview backups.
+	switch {
+	case op.Options.ToggleFeatures.PreviewBackup:
+		// Preview backups need to be successful and without errors to be considered
+		// valid. Just reuse the merge base check for that since it has the same
+		// requirements.
+		if !isMergeBackup(
+			snapID,
+			ssid,
+			op.Options.FailureHandling,
+			op.Errors) {
+			return clues.New("failed preview backup").WithClues(ctx)
+		}
+
+		tags[model.BackupTypeTag] = model.PreviewBackup
+
+	case isMergeBackup(
 		snapID,
 		ssid,
 		op.Options.FailureHandling,
-		op.Errors) {
+		op.Errors):
 		tags[model.BackupTypeTag] = model.MergeBackup
-	} else if isAssistBackup(
+
+	case isAssistBackup(
 		opStats.hasNewDetailEntries,
 		snapID,
 		ssid,
 		op.Options.FailureHandling,
-		op.Errors) {
+		op.Errors):
 		tags[model.BackupTypeTag] = model.AssistBackup
-	} else {
+
+	default:
 		return clues.New("backup is neither assist nor merge").WithClues(ctx)
+	}
+
+	// Additional defensive check to make sure we tag things as expected above.
+	if len(tags[model.BackupTypeTag]) == 0 {
+		return clues.New("empty backup type tag").WithClues(ctx)
 	}
 
 	ctx = clues.Add(ctx, model.BackupTypeTag, tags[model.BackupTypeTag])

--- a/src/pkg/control/options.go
+++ b/src/pkg/control/options.go
@@ -86,4 +86,9 @@ type Toggles struct {
 	// DisableConcurrencyLimiter removes concurrency limits when communicating with
 	// graph API. This flag is only relevant for exchange backups for now
 	DisableConcurrencyLimiter bool `json:"disableConcurrencyLimiter,omitempty"`
+
+	// PreviewBackup denotes that this backup contains a subset of information for
+	// the protected resource. PreviewBackups are used to demonstrate value by
+	// being quick to create.
+	PreviewBackup bool `json:"previewBackup"`
 }


### PR DESCRIPTION
Add an option to request a preview backup and tag the resulting backup
as a preview if the flag is set. Preview backups must complete
successfully with no errors in order to be tagged

This does not update the item selection logic, so right now preview
backups will contain all items that normal backups do. Item selection
will be refined in upcoming PRs

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
