### PR TITLE
Consolidate pager tests while adding more coverage

### DIFF
--- a/src/pkg/services/m365/api/pagers/pagers_test.go
+++ b/src/pkg/services/m365/api/pagers/pagers_test.go
@@ -702,8 +702,7 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs_FallbackPagers() {
 							},
 						},
 						validModTimes: validModTimes,
-					},
-				)
+					})
 			},
 			expect: expected{
 				errCheck: assert.NoError,
@@ -746,8 +745,7 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs_FallbackPagers() {
 							{},
 						},
 						validModTimes: validModTimes,
-					},
-				)
+					})
 			},
 			expect: expected{
 				errCheck: assert.NoError,
@@ -792,8 +790,7 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs_FallbackPagers() {
 							},
 						},
 						validModTimes: validModTimes,
-					},
-				)
+					})
 			},
 			expect: expected{
 				errCheck: assert.NoError,
@@ -848,8 +845,7 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs_FallbackPagers() {
 							},
 						},
 						validModTimes: validModTimes,
-					},
-				)
+					})
 			},
 			expect: expected{
 				errCheck: assert.NoError,


### PR DESCRIPTION
Rewrite the pager tests to more uniformly test the different outcomes
when various pagers/configurations are used

This PR splits tests into two main categories: those that deal with
getting results from a single pager with no resets etc and those that
deal with resets, fallbacks, and other similar things

All tests now check for correctness when the pager does and doesn't
support returning mod times

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
