### PR TITLE
Don't allow merge bases for preview backups

### DIFF
--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -397,6 +397,23 @@ func (op *BackupOperation) do(
 		}
 	}
 
+	// Drop merge bases if we're doing a preview backup. Preview backups may use
+	// different delta token parameters so we need to ensure we do a token
+	// refresh. This could eventually be pushed down the stack if we track token
+	// versions.
+	//
+	// TODO(ashmrtn): Until we use token versions to determine this, refactor
+	// input params to produceManifestsAndMetadata and do this in that function
+	// instead of here.
+	if op.Options.ToggleFeatures.PreviewBackup {
+		logger.Ctx(ctx).Info("disabling merge bases for preview backup")
+
+		mans.DisableMergeBases()
+
+		canUseMetadata = false
+		mdColls = nil
+	}
+
 	ctx = clues.Add(
 		ctx,
 		"can_use_metadata", canUseMetadata,


### PR DESCRIPTION
Preview backups may use different delta token query parameters
and we don't want them to get only changes from the last possible
backup. Avoid fine-grained tracking of this sort of stuff by just
discarding all merge bases

Keeping the bases as assist bases is fine because they'll only source
unchanged data when possible

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
