### PR TITLE
verify previous path state before backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Handle OneDrive folders being deleted and recreated midway through a backup
-- Automatically re-run a full delta query on incrmental if the prior backup is found to have malformed prior-state heuristics.
+- Automatically re-run a full delta query on incrmental if the prior backup is found to have malformed prior-state information.
 
 ## [v0.15.0] (beta) - 2023-10-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Handle OneDrive folders being deleted and recreated midway through a backup
+- Automatically re-run a full delta query on incrmental if the prior backup is found to have malformed prior-state heuristics.
 
 ## [v0.15.0] (beta) - 2023-10-31
 

--- a/src/internal/m365/collection/drive/collections_test.go
+++ b/src/internal/m365/collection/drive/collections_test.go
@@ -1375,6 +1375,77 @@ func (suite *OneDriveCollectionsUnitSuite) TestDeserializeMetadata() {
 			canUsePreviousBackup: false,
 			errCheck:             assert.NoError,
 		},
+		{
+			name: "DuplicatePreviousPaths",
+			cols: []func() []graph.MetadataCollectionEntry{
+				func() []graph.MetadataCollectionEntry {
+					return []graph.MetadataCollectionEntry{
+						graph.NewMetadataEntry(
+							bupMD.DeltaURLsFileName,
+							map[string]string{driveID1: deltaURL1}),
+						graph.NewMetadataEntry(
+							bupMD.PreviousPathFileName,
+							map[string]map[string]string{
+								driveID1: {
+									folderID1: path1,
+									folderID2: path1,
+								},
+							}),
+					}
+				},
+			},
+			expectedDeltas:       map[string]string{},
+			expectedPaths:        map[string]map[string]string{},
+			canUsePreviousBackup: false,
+			errCheck:             assert.NoError,
+		},
+		{
+			name: "DuplicatePreviousPaths_separateDrives",
+			cols: []func() []graph.MetadataCollectionEntry{
+				func() []graph.MetadataCollectionEntry {
+					return []graph.MetadataCollectionEntry{
+						graph.NewMetadataEntry(
+							bupMD.DeltaURLsFileName,
+							map[string]string{driveID1: deltaURL1}),
+						graph.NewMetadataEntry(
+							bupMD.PreviousPathFileName,
+							map[string]map[string]string{
+								driveID1: {
+									folderID1: path1,
+								},
+							}),
+					}
+				},
+				func() []graph.MetadataCollectionEntry {
+					return []graph.MetadataCollectionEntry{
+						graph.NewMetadataEntry(
+							bupMD.DeltaURLsFileName,
+							map[string]string{driveID2: deltaURL2}),
+						graph.NewMetadataEntry(
+							bupMD.PreviousPathFileName,
+							map[string]map[string]string{
+								driveID2: {
+									folderID1: path1,
+								},
+							}),
+					}
+				},
+			},
+			expectedDeltas: map[string]string{
+				driveID1: deltaURL1,
+				driveID2: deltaURL2,
+			},
+			expectedPaths: map[string]map[string]string{
+				driveID1: {
+					folderID1: path1,
+				},
+				driveID2: {
+					folderID1: path1,
+				},
+			},
+			canUsePreviousBackup: true,
+			errCheck:             assert.NoError,
+		},
 	}
 
 	for _, test := range table {
@@ -1406,7 +1477,7 @@ func (suite *OneDriveCollectionsUnitSuite) TestDeserializeMetadata() {
 					data.NoFetchRestoreCollection{Collection: mc}))
 			}
 
-			deltas, paths, canUsePreviousBackup, err := deserializeMetadata(ctx, cols)
+			deltas, paths, canUsePreviousBackup, err := deserializeAndValidateMetadata(ctx, cols)
 			test.errCheck(t, err)
 			assert.Equal(t, test.canUsePreviousBackup, canUsePreviousBackup, "can use previous backup")
 
@@ -1439,7 +1510,7 @@ func (suite *OneDriveCollectionsUnitSuite) TestDeserializeMetadata_ReadFailure()
 
 	fc := failingColl{}
 
-	_, _, canUsePreviousBackup, err := deserializeMetadata(ctx, []data.RestoreCollection{fc})
+	_, _, canUsePreviousBackup, err := deserializeAndValidateMetadata(ctx, []data.RestoreCollection{fc})
 	require.NoError(t, err)
 	require.False(t, canUsePreviousBackup)
 }
@@ -2839,6 +2910,62 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 				rootFolderPath2: true,
 			},
 		},
+		{
+			name:   "duplicate previous paths in metadata",
+			drives: []models.Driveable{drive1},
+			enumerator: mock.EnumerateItemsDeltaByDrive{
+				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+					driveID1: {
+						Pages: []mock.NextPage{{
+							Items: []models.DriveItemable{
+								driveRootItem("root"),
+								driveItem("folder", "folder", driveBasePath1, "root", false, true, false),
+								driveItem("file", "file", driveBasePath1+"/folder", "folder", true, false, false),
+								driveItem("folder2", "folder2", driveBasePath1, "root", false, true, false),
+								driveItem("file2", "file2", driveBasePath1+"/folder2", "folder2", true, false, false),
+							},
+						}},
+						DeltaUpdate: pagers.DeltaUpdate{URL: delta},
+					},
+				},
+			},
+			canUsePreviousBackup: false,
+			errCheck:             assert.NoError,
+			prevFolderPaths: map[string]map[string]string{
+				driveID1: {
+					"root":    rootFolderPath1,
+					"folder":  rootFolderPath1 + "/folder",
+					"folder2": rootFolderPath1 + "/folder",
+				},
+			},
+			expectedCollections: map[string]map[data.CollectionState][]string{
+				rootFolderPath1: {
+					data.NewState: {"folder", "folder2"},
+				},
+				rootFolderPath1 + "/folder": {
+					data.NewState: {"folder", "file"},
+				},
+				rootFolderPath1 + "/folder2": {
+					data.NewState: {"folder2", "file2"},
+				},
+			},
+			expectedDeltaURLs: map[string]string{
+				driveID1: delta,
+			},
+			expectedFolderPaths: map[string]map[string]string{
+				driveID1: {
+					"root":    rootFolderPath1,
+					"folder":  rootFolderPath1 + "/folder",
+					"folder2": rootFolderPath1 + "/folder2",
+				},
+			},
+			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
+			doNotMergeItems: map[string]bool{
+				rootFolderPath1:              true,
+				rootFolderPath1 + "/folder":  true,
+				rootFolderPath1 + "/folder2": true,
+			},
+		},
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
@@ -2912,7 +3039,7 @@ func (suite *OneDriveCollectionsUnitSuite) TestGet() {
 				}
 
 				if folderPath == metadataPath.String() {
-					deltas, paths, _, err := deserializeMetadata(
+					deltas, paths, _, err := deserializeAndValidateMetadata(
 						ctx,
 						[]data.RestoreCollection{
 							dataMock.NewUnversionedRestoreCollection(

--- a/src/internal/m365/collection/drive/debug.go
+++ b/src/internal/m365/collection/drive/debug.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/data"
 	bupMD "github.com/alcionai/corso/src/pkg/backup/metadata"
+	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/store"
 )
 
@@ -14,7 +15,7 @@ func DeserializeMetadataFiles(
 	ctx context.Context,
 	colls []data.RestoreCollection,
 ) ([]store.MetadataFile, error) {
-	deltas, prevs, _, err := deserializeMetadata(ctx, colls)
+	deltas, prevs, _, err := deserializeAndValidateMetadata(ctx, colls, fault.New(true))
 
 	files := []store.MetadataFile{
 		{

--- a/src/internal/operations/inject/inject.go
+++ b/src/internal/operations/inject/inject.go
@@ -3,6 +3,8 @@ package inject
 import (
 	"context"
 
+	"github.com/kopia/kopia/repo/manifest"
+
 	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/common/prefixmatcher"
 	"github.com/alcionai/corso/src/internal/data"
@@ -15,7 +17,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/export"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
-	"github.com/kopia/kopia/repo/manifest"
 )
 
 type (

--- a/src/internal/operations/manifests.go
+++ b/src/internal/operations/manifests.go
@@ -53,7 +53,7 @@ func produceManifestsAndMetadata(
 }
 
 // getManifestsAndMetadata calls kopia to retrieve prior backup manifests,
-// metadata collections to supply backup heuristics.
+// metadata collections to supply backup information.
 func getManifestsAndMetadata(
 	ctx context.Context,
 	bf inject.BaseFinder,

--- a/src/pkg/fault/alert.go
+++ b/src/pkg/fault/alert.go
@@ -4,6 +4,10 @@ import (
 	"github.com/alcionai/corso/src/cli/print"
 )
 
+const (
+	AlertPreviousPathCollision = "previous_path_collision"
+)
+
 var _ print.Printable = &Alert{}
 
 // Alerts are informational-only notifications.  The purpose of alerts is to

--- a/src/pkg/fault/fault.go
+++ b/src/pkg/fault/fault.go
@@ -208,7 +208,6 @@ func (e *Bus) AddAlert(ctx context.Context, a *Alert) {
 	e.logAndAddAlert(ctx, a, 1)
 }
 
-// logs the error and adds an alert.
 func (e *Bus) logAndAddAlert(ctx context.Context, a *Alert, trace int) {
 	logger.CtxStack(ctx, trace+1).
 		With("alert", a).


### PR DESCRIPTION
Drive previous paths have a prior bug or condition that allows multiple previousPath metadata folder ID entries within a single drive point to the same previous path string.
In these cases we need to treat the backup as having no prior metadata, and re-run the full delta query to correct the bad state.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

#### Type of change

- [x] :bug: Bugfix

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
