### PR TITLE
Allow callers to request multiple limiter tokens

### DIFF
--- a/src/internal/common/limiters/limiter.go
+++ b/src/internal/common/limiters/limiter.go
@@ -4,6 +4,6 @@ import "context"
 
 type Limiter interface {
 	Wait(ctx context.Context) error
-	WaitN(ctx context.Context, N int) error
+	WaitN(ctx context.Context, n int) error
 	Shutdown()
 }

--- a/src/internal/common/limiters/limiter.go
+++ b/src/internal/common/limiters/limiter.go
@@ -4,5 +4,6 @@ import "context"
 
 type Limiter interface {
 	Wait(ctx context.Context) error
+	WaitN(ctx context.Context, N int) error
 	Shutdown()
 }

--- a/src/internal/common/limiters/sliding_window.go
+++ b/src/internal/common/limiters/sliding_window.go
@@ -89,8 +89,13 @@ func (s *slidingWindow) Wait(ctx context.Context) error {
 	return s.WaitN(ctx, 1)
 }
 
-// Wait blocks a request until N tokens are available or the context gets
-// cancelled.
+// WaitN blocks a request until n tokens are available or the context gets
+// cancelled. WaitN should be called with n <= capacity otherwise it will block
+// forever.
+//
+// TODO(pandeyabs): Enforce n <= capacity check. Not adding it right now because
+// we are relying on capacity = 0 for ctx cancellation test, which would need
+// some refactoring.
 func (s *slidingWindow) WaitN(ctx context.Context, n int) error {
 	for i := 0; i < n; i++ {
 		select {

--- a/src/internal/common/limiters/sliding_window.go
+++ b/src/internal/common/limiters/sliding_window.go
@@ -91,8 +91,8 @@ func (s *slidingWindow) Wait(ctx context.Context) error {
 
 // Wait blocks a request until N tokens are available or the context gets
 // cancelled.
-func (s *slidingWindow) WaitN(ctx context.Context, N int) error {
-	for i := 0; i < N; i++ {
+func (s *slidingWindow) WaitN(ctx context.Context, n int) error {
+	for i := 0; i < n; i++ {
 		select {
 		case <-ctx.Done():
 			return clues.Stack(ctx.Err())

--- a/src/internal/common/limiters/sliding_window_test.go
+++ b/src/internal/common/limiters/sliding_window_test.go
@@ -89,23 +89,23 @@ func (suite *SlidingWindowUnitTestSuite) TestWaitSliding() {
 		slideInterval time.Duration
 		capacity      int
 		numRequests   int
-		N             int
+		n             int
 	}{
 		{
-			Name:          "Request 1 token",
+			Name:          "Request 1 token each",
 			windowSize:    1 * time.Second,
 			slideInterval: 10 * time.Millisecond,
 			capacity:      100,
 			numRequests:   200,
-			N:             1,
+			n:             1,
 		},
 		{
-			Name:          "Request 5 tokens",
+			Name:          "Request 5 tokens each",
 			windowSize:    1 * time.Second,
 			slideInterval: 10 * time.Millisecond,
 			capacity:      100,
 			numRequests:   100,
-			N:             5,
+			n:             5,
 		},
 	}
 
@@ -136,7 +136,7 @@ func (suite *SlidingWindowUnitTestSuite) TestWaitSliding() {
 					// of the 2 windows. Rest of the intervals will be empty.
 					time.Sleep(time.Duration(rand.Intn(1500)) * time.Millisecond)
 
-					err := s.WaitN(ctx, test.N)
+					err := s.WaitN(ctx, test.n)
 					require.NoError(t, err)
 				}()
 			}

--- a/src/internal/common/limiters/sliding_window_test.go
+++ b/src/internal/common/limiters/sliding_window_test.go
@@ -81,57 +81,81 @@ func (suite *SlidingWindowUnitTestSuite) TestWaitBasic() {
 }
 
 // TestWaitSliding tests the sliding window functionality of the limiter with
-// time distributed Wait() calls.
+// time distributed WaitN() calls.
 func (suite *SlidingWindowUnitTestSuite) TestWaitSliding() {
-	var (
-		t             = suite.T()
-		windowSize    = 1 * time.Second
-		slideInterval = 10 * time.Millisecond
-		capacity      = 100
-		// Test will run for duration of 2 windowSize.
-		numRequests = 2 * capacity
-		wg          sync.WaitGroup
-	)
-
-	defer goleak.VerifyNone(t)
-
-	ctx, flush := tester.NewContext(t)
-	defer flush()
-
-	s, err := NewSlidingWindowLimiter(windowSize, slideInterval, capacity)
-	require.NoError(t, err)
-
-	// Make concurrent requests to the limiter
-	for i := 0; i < numRequests; i++ {
-		wg.Add(1)
-
-		go func() {
-			defer wg.Done()
-
-			// Sleep for a random duration to spread out requests over multiple slide
-			// intervals & windows, so that we can test the sliding window logic better.
-			// Without this, the requests will be bunched up in the very first intervals
-			// of the 2 windows. Rest of the intervals will be empty.
-			time.Sleep(time.Duration(rand.Intn(1500)) * time.Millisecond)
-
-			err := s.Wait(ctx)
-			require.NoError(t, err)
-		}()
+	tests := []struct {
+		Name          string
+		windowSize    time.Duration
+		slideInterval time.Duration
+		capacity      int
+		numRequests   int
+		N             int
+	}{
+		{
+			Name:          "Request 1 token",
+			windowSize:    1 * time.Second,
+			slideInterval: 10 * time.Millisecond,
+			capacity:      100,
+			numRequests:   200,
+			N:             1,
+		},
+		{
+			Name:          "Request 5 tokens",
+			windowSize:    1 * time.Second,
+			slideInterval: 10 * time.Millisecond,
+			capacity:      100,
+			numRequests:   100,
+			N:             5,
+		},
 	}
-	wg.Wait()
 
-	// Shutdown the ticker before accessing the internal limiter state.
-	s.Shutdown()
+	for _, test := range tests {
+		suite.Run(test.Name, func() {
+			t := suite.T()
 
-	// Verify that number of requests allowed in each window is less than or equal
-	// to window capacity
-	sw := s.(*slidingWindow)
-	data := append(sw.prev.count, sw.curr.count...)
+			defer goleak.VerifyNone(t)
 
-	sums := slidingSums(data, sw.numIntervals)
+			ctx, flush := tester.NewContext(t)
+			defer flush()
 
-	for _, sum := range sums {
-		require.True(t, sum <= capacity, "sum: %d, capacity: %d", sum, capacity)
+			s, err := NewSlidingWindowLimiter(test.windowSize, test.slideInterval, test.capacity)
+			require.NoError(t, err)
+
+			var wg sync.WaitGroup
+
+			// Make concurrent requests to the limiter
+			for i := 0; i < test.numRequests; i++ {
+				wg.Add(1)
+
+				go func() {
+					defer wg.Done()
+
+					// Sleep for a random duration to spread out requests over multiple slide
+					// intervals & windows, so that we can test the sliding window logic better.
+					// Without this, the requests will be bunched up in the very first intervals
+					// of the 2 windows. Rest of the intervals will be empty.
+					time.Sleep(time.Duration(rand.Intn(1500)) * time.Millisecond)
+
+					err := s.WaitN(ctx, test.N)
+					require.NoError(t, err)
+				}()
+			}
+			wg.Wait()
+
+			// Shutdown the ticker before accessing the internal limiter state.
+			s.Shutdown()
+
+			// Verify that number of requests allowed in each window is less than or equal
+			// to window capacity
+			sw := s.(*slidingWindow)
+			data := append(sw.prev.count, sw.curr.count...)
+
+			sums := slidingSums(data, sw.numIntervals)
+
+			for _, sum := range sums {
+				require.True(t, sum <= test.capacity, "sum: %d, capacity: %d", sum, test.capacity)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!-- PR description-->

Adds `WaitN` support in sliding window limiter. `WaitN` blocks the request until all `N` tokens are acquired.  It won't be used for exchange service since exchange doesn't assign weights to API requests. 

This is mostly for interface conformance right now, so that we can support various limiter types behind the same `limiter` interface. 

`WaitN` might be useful for onedrive/sharepoint if we decide to use sliding window limiter for those services. Although the value add is debatable since limits are per min. It doesn't help us much perf-wise to front load requests for a minute long window. 

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [x] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
