### PR TITLE
Test error return values from pagers

### DIFF
--- a/src/pkg/services/m365/api/pagers/pagers.go
+++ b/src/pkg/services/m365/api/pagers/pagers.go
@@ -532,7 +532,10 @@ func GetAddedAndRemovedItemIDs[T any](
 		}
 
 		if err != nil && !graph.IsErrInvalidDelta(err) && !graph.IsErrDeltaNotSupported(err) {
-			return AddedAndRemoved{}, graph.Stack(ctx, err)
+			return AddedAndRemoved{
+				DU:            DeltaUpdate{Reset: true},
+				ValidModTimes: deltaPager.ValidModTimes(),
+			}, graph.Stack(ctx, err)
 		} else if err == nil {
 			return aar, graph.Stack(ctx, err).OrNil()
 		}

--- a/src/pkg/services/m365/api/pagers/pagers_test.go
+++ b/src/pkg/services/m365/api/pagers/pagers_test.go
@@ -628,6 +628,26 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs() {
 			},
 		},
 		{
+			name: "ErrorDeletedInFlight",
+			pagerGetter: func(t *testing.T, validModTimes bool) *testIDsNonDeltaMultiPager {
+				return &testIDsNonDeltaMultiPager{
+					t: t,
+					pages: []pageResult{
+						{
+							err: graph.ErrDeletedInFlight,
+						},
+					},
+					validModTimes: validModTimes,
+				}
+			},
+			expect: expected{
+				errCheck:     assert.Error,
+				maxGetterIdx: 1,
+				noDelta:      true,
+				deltaReset:   true,
+			},
+		},
+		{
 			name: "FourValidPages OnlyPartOfSecondPage",
 			pagerGetter: func(
 				t *testing.T,

--- a/src/pkg/services/m365/api/pagers/pagers_test.go
+++ b/src/pkg/services/m365/api/pagers/pagers_test.go
@@ -474,8 +474,8 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs() {
 		// maxGetterIdx is the maximum index for the item page getter. Helps ensure
 		// we're stopping enumeration when we reach the item limit.
 		maxGetterIdx int
-		// expectNoDelta should be set if we exit enumeration early due to the item
-		// limit so we don't get a delta token.
+		// noDelta should be set if we exit enumeration early due to the item limit
+		// so we don't get a delta token.
 		noDelta bool
 	}
 
@@ -792,7 +792,7 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs() {
 			) *testIDsNonDeltaMultiPager {
 				return &testIDsNonDeltaMultiPager{
 					t:             t,
-					validModTimes: true,
+					validModTimes: validModTimes,
 					pages: []pageResult{
 						{
 							items: []testItem{


### PR DESCRIPTION
Some code (e.x. Exchange) continues to use the results from a pager even
in the event some errors occur. These tests help ensure we have
consistent return values when we see an error during enumeration

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
