### PR TITLE
retry item downloads on invalid token error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Handle OneDrive folders being deleted and recreated midway through a backup
 - Automatically re-run a full delta query on incrmental if the prior backup is found to have malformed prior-state information.
+- Retry drive item permission downloads during long-running backups after the jwt token expires and refreshes.
 
 ## [v0.15.0] (beta) - 2023-10-31
 

--- a/src/internal/m365/collection/drive/collection.go
+++ b/src/internal/m365/collection/drive/collection.go
@@ -341,7 +341,7 @@ func downloadContent(
 	content, err := downloadItem(ctx, iaag, item)
 	if err == nil {
 		return content, nil
-	} else if !graph.IsErrUnauthorized(err) {
+	} else if !graph.IsErrUnauthorizedOrBadToken(err) {
 		return nil, err
 	}
 
@@ -397,7 +397,7 @@ func readItemContents(
 	}
 
 	rc, err := downloadFile(ctx, iaag, props.downloadURL)
-	if graph.IsErrUnauthorized(err) {
+	if graph.IsErrUnauthorizedOrBadToken(err) {
 		logger.CtxErr(ctx, err).Info("stale item in cache")
 	}
 

--- a/src/internal/m365/collection/drive/item_test.go
+++ b/src/internal/m365/collection/drive/item_test.go
@@ -158,10 +158,9 @@ func (suite *ItemIntegrationSuite) TestIsURLExpired() {
 		}
 	}
 
-	expired, err := isURLExpired(ctx, url)
+	expired, err := graph.IsURLExpired(ctx, url)
 	require.NoError(t, err, clues.ToCore(err))
-
-	require.False(t, expired)
+	require.NoError(t, expired, clues.ToCore(err))
 }
 
 // TestItemWriter is an integration test for uploading data to OneDrive

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -198,12 +198,12 @@ func (op *BackupOperation) Run(ctx context.Context) (err error) {
 	}()
 
 	ctx, end := diagnostics.Span(ctx, "operations:backup:run")
-	defer func() {
-		end()
-	}()
+	defer end()
 
 	ctx, flushMetrics := events.NewMetrics(ctx, logger.Writer{Ctx: ctx})
 	defer flushMetrics()
+
+	ctx = clues.AddTrace(ctx)
 
 	// Check if the protected resource has the service enabled in order for us
 	// to run a backup.

--- a/src/internal/operations/restore.go
+++ b/src/internal/operations/restore.go
@@ -129,12 +129,12 @@ func (op *RestoreOperation) Run(ctx context.Context) (restoreDetails *details.De
 	// -----
 
 	ctx, end := diagnostics.Span(ctx, "operations:restore:run")
-	defer func() {
-		end()
-	}()
+	defer end()
 
 	ctx, flushMetrics := events.NewMetrics(ctx, logger.Writer{Ctx: ctx})
 	defer flushMetrics()
+
+	ctx = clues.AddTrace(ctx)
 
 	cats, err := op.Selectors.AllHumanPathCategories()
 	if err != nil {

--- a/src/pkg/fault/fault.go
+++ b/src/pkg/fault/fault.go
@@ -149,7 +149,7 @@ func (e *Bus) logAndAddRecoverable(ctx context.Context, err error, skip int) {
 	isFail := e.addRecoverableErr(err)
 
 	if isFail {
-		log.Errorf("recoverable error: %v", err)
+		log.Errorf("failed on recoverable error: %v", err)
 	} else {
 		log.Infof("recoverable error: %v", err)
 	}

--- a/src/pkg/services/m365/api/drive.go
+++ b/src/pkg/services/m365/api/drive.go
@@ -266,33 +266,16 @@ func (c Drives) GetItemPermission(
 	ctx context.Context,
 	driveID, itemID string,
 ) (models.PermissionCollectionResponseable, error) {
-	var (
-		retries int
-		perm    models.PermissionCollectionResponseable
-		err     error
-	)
+	perm, err := c.Stable.
+		Client().
+		Drives().
+		ByDriveId(driveID).
+		Items().
+		ByDriveItemId(itemID).
+		Permissions().
+		Get(ctx, nil)
 
-	// jwt retry has to be handled here, since we need to re-run the
-	// full client to get the new token.
-	for i := 0; i < 3; i++ {
-		retries++
-
-		perm, err = c.Stable.
-			Client().
-			Drives().
-			ByDriveId(driveID).
-			Items().
-			ByDriveItemId(itemID).
-			Permissions().
-			Get(ctx, nil)
-		if err != nil && !graph.IsErrUnauthorizedOrBadToken(err) {
-			break
-		}
-	}
-
-	return perm, graph.Wrap(ctx, err, "getting item permissions").
-		With("api_retry_count", retries).
-		OrNil()
+	return perm, graph.Wrap(ctx, err, "getting item permissions").OrNil()
 }
 
 func (c Drives) PostItemPermissionUpdate(

--- a/src/pkg/services/m365/api/graph/errors.go
+++ b/src/pkg/services/m365/api/graph/errors.go
@@ -239,11 +239,14 @@ func IsErrConnectionReset(err error) bool {
 }
 
 func IsErrUnauthorizedOrBadToken(err error) bool {
-	// TODO: refine this investigation.  We don't currently know if
-	// a specific item download url expired, or if the full connection
-	// auth expired.
 	return clues.HasLabel(err, LabelStatus(http.StatusUnauthorized)) ||
 		hasErrorCode(err, invalidAuthenticationToken) ||
+		errors.Is(err, ErrTokenExpired) ||
+		errors.Is(err, ErrTokenInvalid)
+}
+
+func IsErrBadJWTToken(err error) bool {
+	return hasErrorCode(err, invalidAuthenticationToken) ||
 		errors.Is(err, ErrTokenExpired) ||
 		errors.Is(err, ErrTokenInvalid)
 }

--- a/src/pkg/services/m365/api/graph/errors.go
+++ b/src/pkg/services/m365/api/graph/errors.go
@@ -14,6 +14,8 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 	"github.com/pkg/errors"
 
+	"github.com/alcionai/corso/src/internal/common"
+	"github.com/alcionai/corso/src/internal/common/jwt"
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/common/str"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -45,6 +47,7 @@ const (
 	// Some datacenters are returning this when we try to get the inbox of a user
 	// that doesn't exist.
 	invalidUser                 errorCode = "ErrorInvalidUser"
+	invalidAuthenticationToken  errorCode = "InvalidAuthenticationToken"
 	itemNotFound                errorCode = "itemNotFound"
 	MailboxNotEnabledForRESTAPI errorCode = "MailboxNotEnabledForRESTAPI"
 	malwareDetected             errorCode = "malwareDetected"
@@ -138,6 +141,7 @@ var (
 	ErrResourceOwnerNotFound = clues.New("resource owner not found in tenant")
 
 	ErrTokenExpired = clues.New("jwt token expired")
+	ErrTokenInvalid = clues.New("jwt token invalid")
 )
 
 func IsErrApplicationThrottled(err error) bool {
@@ -234,12 +238,13 @@ func IsErrConnectionReset(err error) bool {
 	return errors.Is(err, syscall.ECONNRESET)
 }
 
-func IsErrUnauthorized(err error) bool {
+func IsErrUnauthorizedOrBadToken(err error) bool {
 	// TODO: refine this investigation.  We don't currently know if
 	// a specific item download url expired, or if the full connection
 	// auth expired.
 	return clues.HasLabel(err, LabelStatus(http.StatusUnauthorized)) ||
-		errors.Is(err, ErrTokenExpired)
+		errors.Is(err, ErrTokenExpired) ||
+		errors.Is(err, ErrTokenInvalid)
 }
 
 func IsErrItemAlreadyExistsConflict(err error) bool {
@@ -557,4 +562,39 @@ func ItemInfo(item models.DriveItemable) map[string]any {
 	}
 
 	return m
+}
+
+// ---------------------------------------------------------------------------
+// other helpers
+// ---------------------------------------------------------------------------
+
+// JWTQueryParam is a query param embed in graph download URLs which holds
+// JWT token.
+const JWTQueryParam = "tempauth"
+
+// IsURLExpired inspects the jwt token embed in the item download url
+// and returns true if it is expired.
+func IsURLExpired(
+	ctx context.Context,
+	url string,
+) (
+	expiredErr error,
+	err error,
+) {
+	// Extract the raw JWT string from the download url.
+	rawJWT, err := common.GetQueryParamFromURL(url, JWTQueryParam)
+	if err != nil {
+		return nil, clues.WrapWC(ctx, err, "jwt query param not found")
+	}
+
+	expired, err := jwt.IsJWTExpired(rawJWT)
+	if err != nil {
+		return nil, clues.WrapWC(ctx, err, "checking jwt expiry")
+	}
+
+	if expired {
+		return clues.StackWC(ctx, ErrTokenExpired), nil
+	}
+
+	return nil, nil
 }

--- a/src/pkg/services/m365/api/graph/errors.go
+++ b/src/pkg/services/m365/api/graph/errors.go
@@ -243,6 +243,7 @@ func IsErrUnauthorizedOrBadToken(err error) bool {
 	// a specific item download url expired, or if the full connection
 	// auth expired.
 	return clues.HasLabel(err, LabelStatus(http.StatusUnauthorized)) ||
+		hasErrorCode(err, invalidAuthenticationToken) ||
 		errors.Is(err, ErrTokenExpired) ||
 		errors.Is(err, ErrTokenInvalid)
 }
@@ -576,13 +577,13 @@ const JWTQueryParam = "tempauth"
 // and returns true if it is expired.
 func IsURLExpired(
 	ctx context.Context,
-	url string,
+	urlStr string,
 ) (
 	expiredErr error,
 	err error,
 ) {
 	// Extract the raw JWT string from the download url.
-	rawJWT, err := common.GetQueryParamFromURL(url, JWTQueryParam)
+	rawJWT, err := common.GetQueryParamFromURL(urlStr, JWTQueryParam)
 	if err != nil {
 		return nil, clues.WrapWC(ctx, err, "jwt query param not found")
 	}

--- a/src/pkg/services/m365/api/graph/errors_test.go
+++ b/src/pkg/services/m365/api/graph/errors_test.go
@@ -511,6 +511,56 @@ func (suite *GraphErrorsUnitSuite) TestIsErrUnauthorizedOrBadToken() {
 	}
 }
 
+func (suite *GraphErrorsUnitSuite) TestIsErrIsErrBadJWTToken() {
+	table := []struct {
+		name   string
+		err    error
+		expect assert.BoolAssertionFunc
+	}{
+		{
+			name:   "nil",
+			err:    nil,
+			expect: assert.False,
+		},
+		{
+			name:   "non-matching",
+			err:    assert.AnError,
+			expect: assert.False,
+		},
+		{
+			name:   "non-matching oDataErr",
+			err:    odErr("folder doesn't exist"),
+			expect: assert.False,
+		},
+		{
+			name: "graph 401",
+			err: clues.Stack(assert.AnError).
+				Label(LabelStatus(http.StatusUnauthorized)),
+			expect: assert.False,
+		},
+		{
+			name:   "err token expired",
+			err:    clues.Stack(assert.AnError, ErrTokenExpired),
+			expect: assert.True,
+		},
+		{
+			name:   "oDataErr code invalid auth token ",
+			err:    odErr(string(invalidAuthenticationToken)),
+			expect: assert.True,
+		},
+		{
+			name:   "err token invalid",
+			err:    clues.Stack(assert.AnError, ErrTokenInvalid),
+			expect: assert.True,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			test.expect(suite.T(), IsErrBadJWTToken(test.err))
+		})
+	}
+}
+
 func (suite *GraphErrorsUnitSuite) TestMalwareInfo() {
 	var (
 		i         = models.NewDriveItem()

--- a/src/pkg/services/m365/api/graph/errors_test.go
+++ b/src/pkg/services/m365/api/graph/errors_test.go
@@ -496,7 +496,7 @@ func (suite *GraphErrorsUnitSuite) TestIsErrUnauthorizedOrBadToken() {
 		{
 			name:   "oDataErr code invalid auth token ",
 			err:    odErr(string(invalidAuthenticationToken)),
-			expect: assert.False,
+			expect: assert.True,
 		},
 		{
 			name:   "err token invalid",

--- a/src/pkg/services/m365/api/graph/errors_test.go
+++ b/src/pkg/services/m365/api/graph/errors_test.go
@@ -461,7 +461,7 @@ func (suite *GraphErrorsUnitSuite) TestIsErrTimeout() {
 	}
 }
 
-func (suite *GraphErrorsUnitSuite) TestIsErrUnauthorized() {
+func (suite *GraphErrorsUnitSuite) TestIsErrUnauthorizedOrBadToken() {
 	table := []struct {
 		name   string
 		err    error
@@ -478,20 +478,35 @@ func (suite *GraphErrorsUnitSuite) TestIsErrUnauthorized() {
 			expect: assert.False,
 		},
 		{
+			name:   "non-matching oDataErr",
+			err:    odErr("folder doesn't exist"),
+			expect: assert.False,
+		},
+		{
 			name: "graph 401",
 			err: clues.Stack(assert.AnError).
 				Label(LabelStatus(http.StatusUnauthorized)),
 			expect: assert.True,
 		},
 		{
-			name:   "token expired",
+			name:   "err token expired",
 			err:    clues.Stack(assert.AnError, ErrTokenExpired),
+			expect: assert.True,
+		},
+		{
+			name:   "oDataErr code invalid auth token ",
+			err:    odErr(string(invalidAuthenticationToken)),
+			expect: assert.False,
+		},
+		{
+			name:   "err token invalid",
+			err:    clues.Stack(assert.AnError, ErrTokenInvalid),
 			expect: assert.True,
 		},
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			test.expect(suite.T(), IsErrUnauthorized(test.err))
+			test.expect(suite.T(), IsErrUnauthorizedOrBadToken(test.err))
 		})
 	}
 }

--- a/src/pkg/services/m365/api/graph/service.go
+++ b/src/pkg/services/m365/api/graph/service.go
@@ -383,6 +383,7 @@ func (aw *adapterWrap) Send(
 			logger.Ctx(ictx).Debug("http connection error")
 			events.Inc(events.APICall, "connectionerror")
 		case IsErrBadJWTToken(err):
+			logger.Ctx(ictx).Debug("bad jwt token")
 			events.Inc(events.APICall, "badjwttoken")
 		default:
 			return nil, clues.StackWC(ictx, err).WithTrace(1)
@@ -391,5 +392,5 @@ func (aw *adapterWrap) Send(
 		time.Sleep(3 * time.Second)
 	}
 
-	return sp, err
+	return sp, clues.Stack(err).OrNil()
 }

--- a/src/pkg/services/m365/api/graph/service_test.go
+++ b/src/pkg/services/m365/api/graph/service_test.go
@@ -1,12 +1,17 @@
 package graph
 
 import (
+	"bytes"
+	"io"
 	"net/http"
+	"strconv"
 	"syscall"
 	"testing"
 	"time"
 
 	"github.com/alcionai/clues"
+	"github.com/microsoft/kiota-abstractions-go/serialization"
+	kjson "github.com/microsoft/kiota-serialization-json-go"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
 	"github.com/stretchr/testify/assert"
@@ -244,4 +249,81 @@ func (suite *GraphIntgSuite) TestAdapterWrap_retriesConnectionClose() {
 	_, err = NewService(adpt).Client().Users().Get(ctx, nil)
 	require.ErrorIs(t, err, syscall.ECONNRESET, clues.ToCore(err))
 	require.Equal(t, 16, retryInc, "number of retries")
+}
+
+func requireParseableToReader(t *testing.T, thing serialization.Parsable) (int64, io.ReadCloser) {
+	sw := kjson.NewJsonSerializationWriter()
+
+	err := sw.WriteObjectValue("", thing)
+	require.NoError(t, err, "serialize")
+
+	content, err := sw.GetSerializedContent()
+	require.NoError(t, err, "deserialize")
+
+	return int64(len(content)), io.NopCloser(bytes.NewReader(content))
+}
+
+func (suite *GraphIntgSuite) TestAdapterWrap_retriesBadJWTToken() {
+	var (
+		t        = suite.T()
+		retryInc = 0
+		odErr    = odErrMsg(string(invalidAuthenticationToken), "string(invalidAuthenticationToken)")
+	)
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	// the panics should get caught and returned as errors
+	alwaysBadJWT := mwForceResp{
+		alternate: func(req *http.Request) (bool, *http.Response, error) {
+			retryInc++
+
+			l, b := requireParseableToReader(t, odErr)
+
+			header := http.Header{}
+			header.Set("Content-Length", strconv.Itoa(int(l)))
+			header.Set("Content-Type", "application/json")
+
+			resp := &http.Response{
+				Body:          b,
+				ContentLength: l,
+				Header:        header,
+				Proto:         req.Proto,
+				Request:       req,
+				// avoiding 401 for the test to escape extraneous code paths in graph client
+				StatusCode: http.StatusMethodNotAllowed,
+			}
+
+			return true, resp, nil
+		},
+	}
+
+	adpt, err := CreateAdapter(
+		suite.credentials.AzureTenantID,
+		suite.credentials.AzureClientID,
+		suite.credentials.AzureClientSecret,
+		count.New(),
+		appendMiddleware(&alwaysBadJWT))
+	require.NoError(t, err, clues.ToCore(err))
+
+	// Keeping this test in place for now as a showcase, even though
+	// it kinda proves a failure to handle the error case.  On the bright
+	// side, direct URL lookups are a rarity in corso, so the importance
+	// is not as high.
+	_, err = users.
+		NewItemCalendarsItemEventsDeltaRequestBuilder("https://graph.microsoft.com/fnords/beaux/regard", adpt).
+		Get(ctx, nil)
+	assert.ErrorContains(
+		t,
+		err,
+		"content type application/json does not have a factory registered to be parsed",
+		clues.ToCore(err))
+	assert.Equal(t, 1, retryInc, "number of retries")
+
+	retryInc = 0
+
+	// the query doesn't matter
+	_, err = NewService(adpt).Client().Users().Get(ctx, nil)
+	assert.True(t, IsErrBadJWTToken(err), clues.ToCore(err))
+	assert.Equal(t, 4, retryInc, "number of retries")
 }


### PR DESCRIPTION
this is an alternative possible response from graph api when the client is updating the token in-flight.  We normally catch this for item downloads, but are defaulting on permission downloads.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

#### Type of change

- [x] :bug: Bugfix


#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
