### PR TITLE
Add progress logging to uploader

### DIFF
--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -57,6 +57,7 @@ type corsoProgress struct {
 	toMerge    *mergeDetails
 	mu         sync.RWMutex
 	totalBytes int64
+	totalFiles int64
 	errs       *fault.Bus
 	counter    *count.Bus
 	// expectedIgnoredErrors is a count of error cases caught in the Error wrapper
@@ -89,6 +90,13 @@ func (cp *corsoProgress) FinishedFile(relativePath string, err error) {
 
 	if err != nil {
 		return
+	}
+
+	atomic.AddInt64(&cp.totalFiles, 1)
+
+	// Log every 1000 items uploaded
+	if cp.totalFiles%1000 == 0 {
+		logger.Ctx(cp.ctx).Infow("finishedfile", "count", cp.totalFiles, "size", cp.totalBytes)
 	}
 
 	d := cp.get(relativePath)

--- a/src/internal/kopia/upload.go
+++ b/src/internal/kopia/upload.go
@@ -96,7 +96,7 @@ func (cp *corsoProgress) FinishedFile(relativePath string, err error) {
 
 	// Log every 1000 items uploaded
 	if cp.totalFiles%1000 == 0 {
-		logger.Ctx(cp.ctx).Infow("finishedfile", "count", cp.totalFiles, "size", cp.totalBytes)
+		logger.Ctx(cp.ctx).Infow("finishedfile", "totalFiles", cp.totalFiles, "totalBytes", cp.totalBytes)
 	}
 
 	d := cp.get(relativePath)


### PR DESCRIPTION
Adds a progress log in the kopia upload that logs every 10000 files that have been uploaded.

This is useful to track progress of large backups.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #4670 

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
