### PR TITLE
Add a control option to disable sliding window limiter

### DIFF
--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -84,6 +84,7 @@ func addExchangeCommands(cmd *cobra.Command) *cobra.Command {
 		flags.AddEnableImmutableIDFlag(c)
 		flags.AddDeltaPageSizeFlag(c)
 		flags.AddGenericBackupFlags(c)
+		flags.AddDisableSlidingWindowLimiterFlag(c)
 
 	case listCommand:
 		c, fs = utils.AddCommand(cmd, exchangeListCmd())

--- a/src/cli/backup/exchange_test.go
+++ b/src/cli/backup/exchange_test.go
@@ -108,6 +108,7 @@ func (suite *ExchangeUnitSuite) TestBackupCreateFlags() {
 				// bool flags
 				"--" + flags.DisableDeltaFN,
 				"--" + flags.EnableImmutableIDFN,
+				"--" + flags.DisableSlidingWindowLimiterFN,
 			},
 			flagsTD.PreparedGenericBackupFlags(),
 			flagsTD.PreparedProviderFlags(),
@@ -124,6 +125,7 @@ func (suite *ExchangeUnitSuite) TestBackupCreateFlags() {
 	assert.True(t, co.ToggleFeatures.ForceItemDataDownload)
 	assert.True(t, co.ToggleFeatures.DisableDelta)
 	assert.True(t, co.ToggleFeatures.ExchangeImmutableIDs)
+	assert.True(t, co.ToggleFeatures.DisableSlidingWindowLimiter)
 	flagsTD.AssertGenericBackupFlags(t, cmd)
 	flagsTD.AssertProviderFlags(t, cmd)
 	flagsTD.AssertStorageFlags(t, cmd)

--- a/src/cli/flags/options.go
+++ b/src/cli/flags/options.go
@@ -5,21 +5,22 @@ import (
 )
 
 const (
-	AlertsFN                = "alerts"
-	DeltaPageSizeFN         = "delta-page-size"
-	DisableDeltaFN          = "disable-delta"
-	DisableIncrementalsFN   = "disable-incrementals"
-	ForceItemDataDownloadFN = "force-item-data-download"
-	EnableImmutableIDFN     = "enable-immutable-id"
-	FailFastFN              = "fail-fast"
-	FailedItemsFN           = "failed-items"
-	FetchParallelismFN      = "fetch-parallelism"
-	NoStatsFN               = "no-stats"
-	RecoveredErrorsFN       = "recovered-errors"
-	NoPermissionsFN         = "no-permissions"
-	RunModeFN               = "run-mode"
-	SkippedItemsFN          = "skipped-items"
-	SkipReduceFN            = "skip-reduce"
+	AlertsFN                      = "alerts"
+	DeltaPageSizeFN               = "delta-page-size"
+	DisableSlidingWindowLimiterFN = "disable-sliding-window-limiter"
+	DisableDeltaFN                = "disable-delta"
+	DisableIncrementalsFN         = "disable-incrementals"
+	ForceItemDataDownloadFN       = "force-item-data-download"
+	EnableImmutableIDFN           = "enable-immutable-id"
+	FailFastFN                    = "fail-fast"
+	FailedItemsFN                 = "failed-items"
+	FetchParallelismFN            = "fetch-parallelism"
+	NoStatsFN                     = "no-stats"
+	RecoveredErrorsFN             = "recovered-errors"
+	NoPermissionsFN               = "no-permissions"
+	RunModeFN                     = "run-mode"
+	SkippedItemsFN                = "skipped-items"
+	SkipReduceFN                  = "skip-reduce"
 )
 
 var (
@@ -37,9 +38,10 @@ var (
 	NoStatsFV               bool
 	// RunMode describes the type of run, such as:
 	// flagtest, dry, run.  Should default to 'run'.
-	RunModeFV       string
-	NoPermissionsFV bool
-	SkipReduceFV    bool
+	RunModeFV                     string
+	NoPermissionsFV               bool
+	SkipReduceFV                  bool
+	DisableSlidingWindowLimiterFV bool
 )
 
 // well-known flag values
@@ -158,4 +160,19 @@ func AddRunModeFlag(cmd *cobra.Command, persistent bool) {
 
 	fs.StringVar(&RunModeFV, RunModeFN, "run", "What mode to run: dry, test, run.  Defaults to run.")
 	cobra.CheckErr(fs.MarkHidden(RunModeFN))
+}
+
+// AddDisableSlidingWindowLimiterFN disables the experimental sliding window rate
+// limiter for graph API requests. This is only relevant for exchange backups.
+// Exchange restores continue to use the default token bucket rate limiter.
+// Setting this flag switches exchange backups to use the default token bucket
+// rate limiter.
+func AddDisableSlidingWindowLimiterFlag(cmd *cobra.Command) {
+	fs := cmd.Flags()
+	fs.BoolVar(
+		&DisableSlidingWindowLimiterFV,
+		DisableSlidingWindowLimiterFN,
+		false,
+		"Disable sliding window rate limiter. Default: false")
+	cobra.CheckErr(fs.MarkHidden(DisableSlidingWindowLimiterFN))
 }

--- a/src/cli/flags/options.go
+++ b/src/cli/flags/options.go
@@ -7,9 +7,9 @@ import (
 const (
 	AlertsFN                      = "alerts"
 	DeltaPageSizeFN               = "delta-page-size"
-	DisableSlidingWindowLimiterFN = "disable-sliding-window-limiter"
 	DisableDeltaFN                = "disable-delta"
 	DisableIncrementalsFN         = "disable-incrementals"
+	DisableSlidingWindowLimiterFN = "disable-sliding-window-limiter"
 	ForceItemDataDownloadFN       = "force-item-data-download"
 	EnableImmutableIDFN           = "enable-immutable-id"
 	FailFastFN                    = "fail-fast"
@@ -24,24 +24,24 @@ const (
 )
 
 var (
-	DeltaPageSizeFV         int
-	DisableDeltaFV          bool
-	DisableIncrementalsFV   bool
-	ForceItemDataDownloadFV bool
-	EnableImmutableIDFV     bool
-	FailFastFV              bool
-	FetchParallelismFV      int
-	ListAlertsFV            string
-	ListFailedItemsFV       string
-	ListSkippedItemsFV      string
-	ListRecoveredErrorsFV   string
-	NoStatsFV               bool
+	DeltaPageSizeFV               int
+	DisableDeltaFV                bool
+	DisableIncrementalsFV         bool
+	DisableSlidingWindowLimiterFV bool
+	ForceItemDataDownloadFV       bool
+	EnableImmutableIDFV           bool
+	FailFastFV                    bool
+	FetchParallelismFV            int
+	ListAlertsFV                  string
+	ListFailedItemsFV             string
+	ListSkippedItemsFV            string
+	ListRecoveredErrorsFV         string
+	NoStatsFV                     bool
 	// RunMode describes the type of run, such as:
 	// flagtest, dry, run.  Should default to 'run'.
-	RunModeFV                     string
-	NoPermissionsFV               bool
-	SkipReduceFV                  bool
-	DisableSlidingWindowLimiterFV bool
+	RunModeFV       string
+	NoPermissionsFV bool
+	SkipReduceFV    bool
 )
 
 // well-known flag values
@@ -173,6 +173,6 @@ func AddDisableSlidingWindowLimiterFlag(cmd *cobra.Command) {
 		&DisableSlidingWindowLimiterFV,
 		DisableSlidingWindowLimiterFN,
 		false,
-		"Disable sliding window rate limiter. Default: false")
+		"Disable sliding window rate limiter.")
 	cobra.CheckErr(fs.MarkHidden(DisableSlidingWindowLimiterFN))
 }

--- a/src/cli/utils/options.go
+++ b/src/cli/utils/options.go
@@ -26,6 +26,7 @@ func Control() control.Options {
 	opt.ToggleFeatures.ForceItemDataDownload = flags.ForceItemDataDownloadFV
 	opt.ToggleFeatures.DisableDelta = flags.DisableDeltaFV
 	opt.ToggleFeatures.ExchangeImmutableIDs = flags.EnableImmutableIDFV
+	opt.ToggleFeatures.DisableSlidingWindowLimiter = flags.DisableSlidingWindowLimiterFV
 	opt.Parallelism.ItemFetch = flags.FetchParallelismFV
 
 	return opt

--- a/src/cli/utils/options.go
+++ b/src/cli/utils/options.go
@@ -25,8 +25,8 @@ func Control() control.Options {
 	opt.ToggleFeatures.DisableIncrementals = flags.DisableIncrementalsFV
 	opt.ToggleFeatures.ForceItemDataDownload = flags.ForceItemDataDownloadFV
 	opt.ToggleFeatures.DisableDelta = flags.DisableDeltaFV
-	opt.ToggleFeatures.ExchangeImmutableIDs = flags.EnableImmutableIDFV
 	opt.ToggleFeatures.DisableSlidingWindowLimiter = flags.DisableSlidingWindowLimiterFV
+	opt.ToggleFeatures.ExchangeImmutableIDs = flags.EnableImmutableIDFV
 	opt.Parallelism.ItemFetch = flags.FetchParallelismFV
 
 	return opt

--- a/src/cli/utils/options_test.go
+++ b/src/cli/utils/options_test.go
@@ -36,6 +36,7 @@ func (suite *OptionsUnitSuite) TestAddExchangeCommands() {
 			assert.True(t, flags.SkipReduceFV, flags.SkipReduceFN)
 			assert.Equal(t, 2, flags.FetchParallelismFV, flags.FetchParallelismFN)
 			assert.Equal(t, 499, flags.DeltaPageSizeFV, flags.DeltaPageSizeFN)
+			assert.True(t, flags.DisableSlidingWindowLimiterFV, flags.DisableSlidingWindowLimiterFN)
 		},
 	}
 
@@ -50,6 +51,7 @@ func (suite *OptionsUnitSuite) TestAddExchangeCommands() {
 	flags.AddSkipReduceFlag(cmd)
 	flags.AddFetchParallelismFlag(cmd)
 	flags.AddDeltaPageSizeFlag(cmd)
+	flags.AddDisableSlidingWindowLimiterFlag(cmd)
 
 	// Test arg parsing for few args
 	cmd.SetArgs([]string{
@@ -63,6 +65,7 @@ func (suite *OptionsUnitSuite) TestAddExchangeCommands() {
 		"--" + flags.SkipReduceFN,
 		"--" + flags.FetchParallelismFN, "2",
 		"--" + flags.DeltaPageSizeFN, "499",
+		"--" + flags.DisableSlidingWindowLimiterFN,
 	})
 
 	err := cmd.Execute()

--- a/src/pkg/control/options.go
+++ b/src/pkg/control/options.go
@@ -90,8 +90,7 @@ type Toggles struct {
 
 	// DisableSlidingWindowLimiter disables the experimental sliding window rate
 	// limiter for graph API requests. This is only relevant for exchange backups.
-	// Exchange restores continue to use the default token bucket rate limiter.
-	// Setting this flag switches exchange backups to use the default token bucket
-	// rate limiter.
+	// Setting this flag switches exchange backups to fallback to the default token
+	// bucket rate limiter.
 	DisableSlidingWindowLimiter bool `json:"disableSlidingWindowLimiter"`
 }

--- a/src/pkg/control/options.go
+++ b/src/pkg/control/options.go
@@ -87,4 +87,11 @@ type Toggles struct {
 	// the protected resource. PreviewBackups are used to demonstrate value by
 	// being quick to create.
 	PreviewBackup bool `json:"previewBackup"`
+
+	// DisableSlidingWindowLimiter disables the experimental sliding window rate
+	// limiter for graph API requests. This is only relevant for exchange backups.
+	// Exchange restores continue to use the default token bucket rate limiter.
+	// Setting this flag switches exchange backups to use the default token bucket
+	// rate limiter.
+	DisableSlidingWindowLimiter bool `json:"disableSlidingWindowLimiter"`
 }


### PR DESCRIPTION
<!-- PR description-->

Add a killswitch for sliding window limiter.  This is only relevant for exchange backups  Setting this flag switches exchange backups to use the default token bucket rate limiter.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
