### PR TITLE
clean up unused graph error sentinels

### DIFF
--- a/src/internal/m365/collection/drive/item_collector_test.go
+++ b/src/internal/m365/collection/drive/item_collector_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/alcionai/clues"
 	"github.com/google/uuid"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
-	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -22,6 +21,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
+	graphTD "github.com/alcionai/corso/src/pkg/services/m365/api/graph/testdata"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/mock"
 )
 
@@ -38,15 +38,6 @@ const (
 	userMysiteNotFound    = "ResourceNotFound User's mysite not found"
 )
 
-func odErr(code string) *odataerrors.ODataError {
-	odErr := odataerrors.NewODataError()
-	merr := odataerrors.NewMainError()
-	merr.SetCode(&code)
-	odErr.SetErrorEscaped(merr)
-
-	return odErr
-}
-
 func (suite *ItemCollectorUnitSuite) TestDrives() {
 	t := suite.T()
 
@@ -60,8 +51,8 @@ func (suite *ItemCollectorUnitSuite) TestDrives() {
 	// These errors won't be the "correct" format when compared to what graph
 	// returns, but they're close enough to have the same info when the inner
 	// details are extracted via support package.
-	mySiteURLNotFound := odErr(userMysiteURLNotFound)
-	mySiteNotFound := odErr(userMysiteNotFound)
+	mySiteURLNotFound := graphTD.ODataErr(userMysiteURLNotFound)
+	mySiteNotFound := graphTD.ODataErr(userMysiteNotFound)
 
 	resultDrives := make([]models.Driveable, 0, numDriveResults)
 

--- a/src/internal/m365/service/exchange/enabled_test.go
+++ b/src/internal/m365/service/exchange/enabled_test.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
-	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
+	graphTD "github.com/alcionai/corso/src/pkg/services/m365/api/graph/testdata"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/mock"
 )
 
@@ -46,19 +46,6 @@ func (m mockGMB) GetFirstInboxMessage(context.Context, string, string) error {
 	return m.inboxMessageErr
 }
 
-// TODO(pandeyabs): Duplicate of graph/errors_test.go. Remove
-// this and identical funcs in od/sp and use the one in graph/errors_test.go
-// instead.
-func odErrMsg(code, message string) *odataerrors.ODataError {
-	odErr := odataerrors.NewODataError()
-	merr := odataerrors.NewMainError()
-	merr.SetCode(&code)
-	merr.SetMessage(&message)
-	odErr.SetErrorEscaped(merr)
-
-	return odErr
-}
-
 func (suite *EnabledUnitSuite) TestIsServiceEnabled() {
 	table := []struct {
 		name      string
@@ -79,7 +66,7 @@ func (suite *EnabledUnitSuite) TestIsServiceEnabled() {
 		{
 			name: "user has no mailbox",
 			mock: func(ctx context.Context) getMailInboxer {
-				odErr := odErrMsg(string(graph.ResourceNotFound), "message")
+				odErr := graphTD.ODataErrWithMsg(string(graph.ResourceNotFound), "message")
 
 				return mockGMB{
 					mailboxErr: graph.Stack(ctx, odErr),
@@ -91,7 +78,7 @@ func (suite *EnabledUnitSuite) TestIsServiceEnabled() {
 		{
 			name: "user not found",
 			mock: func(ctx context.Context) getMailInboxer {
-				odErr := odErrMsg(string(graph.RequestResourceNotFound), "message")
+				odErr := graphTD.ODataErrWithMsg(string(graph.RequestResourceNotFound), "message")
 
 				return mockGMB{
 					mailboxErr: graph.Stack(ctx, odErr),
@@ -103,7 +90,7 @@ func (suite *EnabledUnitSuite) TestIsServiceEnabled() {
 		{
 			name: "overlapping resourcenotfound",
 			mock: func(ctx context.Context) getMailInboxer {
-				odErr := odErrMsg(string(graph.ResourceNotFound), "User not found")
+				odErr := graphTD.ODataErrWithMsg(string(graph.ResourceNotFound), "User not found")
 
 				return mockGMB{
 					mailboxErr: graph.Stack(ctx, odErr),
@@ -115,7 +102,7 @@ func (suite *EnabledUnitSuite) TestIsServiceEnabled() {
 		{
 			name: "arbitrary error",
 			mock: func(ctx context.Context) getMailInboxer {
-				odErr := odErrMsg("code", "message")
+				odErr := graphTD.ODataErrWithMsg("code", "message")
 
 				return mockGMB{
 					mailboxErr: graph.Stack(ctx, odErr),
@@ -166,7 +153,7 @@ func (suite *EnabledUnitSuite) TestGetMailboxInfo() {
 		{
 			name: "user has no mailbox",
 			mock: func(ctx context.Context) getMailboxer {
-				err := odErrMsg(string(graph.ResourceNotFound), "message")
+				err := graphTD.ODataErrWithMsg(string(graph.ResourceNotFound), "message")
 
 				return mockGMB{
 					mailboxErr: graph.Stack(ctx, err),
@@ -187,7 +174,7 @@ func (suite *EnabledUnitSuite) TestGetMailboxInfo() {
 		{
 			name: "settings access denied",
 			mock: func(ctx context.Context) getMailboxer {
-				err := odErrMsg(string(graph.ErrorAccessDenied), "message")
+				err := graphTD.ODataErrWithMsg(string(graph.ErrorAccessDenied), "message")
 
 				return mockGMB{
 					mailbox:     models.NewMailFolder(),
@@ -226,7 +213,7 @@ func (suite *EnabledUnitSuite) TestGetMailboxInfo() {
 		{
 			name: "mailbox quota exceeded",
 			mock: func(ctx context.Context) getMailboxer {
-				err := odErrMsg(string(graph.QuotaExceeded), "message")
+				err := graphTD.ODataErrWithMsg(string(graph.QuotaExceeded), "message")
 				return mockGMB{
 					mailbox:         models.NewMailFolder(),
 					settings:        mock.UserSettings(),

--- a/src/internal/m365/service/groups/enabled_test.go
+++ b/src/internal/m365/service/groups/enabled_test.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
-	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
+	graphTD "github.com/alcionai/corso/src/pkg/services/m365/api/graph/testdata"
 )
 
 type EnabledUnitSuite struct {
@@ -36,19 +36,6 @@ func (m mockGBI) GetByID(
 	_ api.CallConfig,
 ) (models.Groupable, error) {
 	return m.group, m.err
-}
-
-// TODO(pandeyabs): Duplicate of graph/errors_test.go. Remove
-// this and identical funcs in od/sp and use the one in graph/errors_test.go
-// instead.
-func odErrMsg(code, message string) *odataerrors.ODataError {
-	odErr := odataerrors.NewODataError()
-	merr := odataerrors.NewMainError()
-	merr.SetCode(&code)
-	merr.SetMessage(&message)
-	odErr.SetErrorEscaped(merr)
-
-	return odErr
 }
 
 func (suite *EnabledUnitSuite) TestIsServiceEnabled() {
@@ -89,7 +76,7 @@ func (suite *EnabledUnitSuite) TestIsServiceEnabled() {
 			name: "group not found",
 			mock: func(ctx context.Context) api.GetByIDer[models.Groupable] {
 				return mockGBI{
-					err: graph.Stack(ctx, odErrMsg(string(graph.RequestResourceNotFound), "message")),
+					err: graph.Stack(ctx, graphTD.ODataErrWithMsg(string(graph.RequestResourceNotFound), "message")),
 				}
 			},
 			expect:    assert.False,

--- a/src/internal/m365/service/onedrive/enabled_test.go
+++ b/src/internal/m365/service/onedrive/enabled_test.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
-	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
+	graphTD "github.com/alcionai/corso/src/pkg/services/m365/api/graph/testdata"
 )
 
 type EnabledUnitSuite struct {
@@ -31,17 +31,6 @@ type mockDGDD struct {
 
 func (m mockDGDD) GetDefaultDrive(context.Context, string) (models.Driveable, error) {
 	return m.response, m.err
-}
-
-// Copied from src/pkg/services/m365/api/graph/errors_test.go
-func odErrMsg(code, message string) *odataerrors.ODataError {
-	odErr := odataerrors.NewODataError()
-	merr := odataerrors.NewMainError()
-	merr.SetCode(&code)
-	merr.SetMessage(&message)
-	odErr.SetErrorEscaped(merr)
-
-	return odErr
 }
 
 func (suite *EnabledUnitSuite) TestIsServiceEnabled() {
@@ -64,7 +53,7 @@ func (suite *EnabledUnitSuite) TestIsServiceEnabled() {
 		{
 			name: "mysite not found",
 			mock: func(ctx context.Context) getDefaultDriver {
-				odErr := odErrMsg("code", string(graph.MysiteNotFound))
+				odErr := graphTD.ODataErrWithMsg("code", string(graph.MysiteNotFound))
 				return mockDGDD{nil, graph.Stack(ctx, odErr)}
 			},
 			expect: assert.False,
@@ -75,7 +64,7 @@ func (suite *EnabledUnitSuite) TestIsServiceEnabled() {
 		{
 			name: "mysite URL not found",
 			mock: func(ctx context.Context) getDefaultDriver {
-				odErr := odErrMsg("code", string(graph.MysiteURLNotFound))
+				odErr := graphTD.ODataErrWithMsg("code", string(graph.MysiteURLNotFound))
 				return mockDGDD{nil, graph.Stack(ctx, odErr)}
 			},
 			expect: assert.False,
@@ -86,7 +75,7 @@ func (suite *EnabledUnitSuite) TestIsServiceEnabled() {
 		{
 			name: "no sharepoint license",
 			mock: func(ctx context.Context) getDefaultDriver {
-				odErr := odErrMsg("code", string(graph.NoSPLicense))
+				odErr := graphTD.ODataErrWithMsg("code", string(graph.NoSPLicense))
 				return mockDGDD{nil, graph.Stack(ctx, odErr)}
 			},
 			expect: assert.False,
@@ -97,7 +86,7 @@ func (suite *EnabledUnitSuite) TestIsServiceEnabled() {
 		{
 			name: "user not found",
 			mock: func(ctx context.Context) getDefaultDriver {
-				odErr := odErrMsg(string(graph.RequestResourceNotFound), "message")
+				odErr := graphTD.ODataErrWithMsg(string(graph.RequestResourceNotFound), "message")
 				return mockDGDD{nil, graph.Stack(ctx, odErr)}
 			},
 			expect: assert.False,
@@ -108,7 +97,7 @@ func (suite *EnabledUnitSuite) TestIsServiceEnabled() {
 		{
 			name: "resource locked",
 			mock: func(ctx context.Context) getDefaultDriver {
-				odErr := odErrMsg(string(graph.NotAllowed), "resource")
+				odErr := graphTD.ODataErrWithMsg(string(graph.NotAllowed), "resource")
 				return mockDGDD{nil, graph.Stack(ctx, odErr)}
 			},
 			expect: assert.False,
@@ -119,7 +108,7 @@ func (suite *EnabledUnitSuite) TestIsServiceEnabled() {
 		{
 			name: "arbitrary error",
 			mock: func(ctx context.Context) getDefaultDriver {
-				odErr := odErrMsg("code", "message")
+				odErr := graphTD.ODataErrWithMsg("code", "message")
 				return mockDGDD{nil, graph.Stack(ctx, odErr)}
 			},
 			expect: assert.False,

--- a/src/internal/m365/service/sharepoint/enabled_test.go
+++ b/src/internal/m365/service/sharepoint/enabled_test.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
-	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
+	graphTD "github.com/alcionai/corso/src/pkg/services/m365/api/graph/testdata"
 )
 
 type EnabledUnitSuite struct {
@@ -37,16 +37,6 @@ func (m mockGSR) GetRoot(
 	return m.response, m.err
 }
 
-func odErrMsg(code, message string) *odataerrors.ODataError {
-	odErr := odataerrors.NewODataError()
-	merr := odataerrors.NewMainError()
-	merr.SetCode(&code)
-	merr.SetMessage(&message)
-	odErr.SetErrorEscaped(merr)
-
-	return odErr
-}
-
 func (suite *EnabledUnitSuite) TestIsServiceEnabled() {
 	table := []struct {
 		name      string
@@ -67,7 +57,7 @@ func (suite *EnabledUnitSuite) TestIsServiceEnabled() {
 		{
 			name: "no sharepoint license",
 			mock: func(ctx context.Context) getSiteRooter {
-				odErr := odErrMsg("code", string(graph.NoSPLicense))
+				odErr := graphTD.ODataErrWithMsg("code", string(graph.NoSPLicense))
 
 				return mockGSR{nil, graph.Stack(ctx, odErr)}
 			},
@@ -79,7 +69,7 @@ func (suite *EnabledUnitSuite) TestIsServiceEnabled() {
 		{
 			name: "arbitrary error",
 			mock: func(ctx context.Context) getSiteRooter {
-				odErr := odErrMsg("code", "message")
+				odErr := graphTD.ODataErrWithMsg("code", "message")
 
 				return mockGSR{nil, graph.Stack(ctx, odErr)}
 			},

--- a/src/pkg/services/m365/api/conversations_test.go
+++ b/src/pkg/services/m365/api/conversations_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	graphTD "github.com/alcionai/corso/src/pkg/services/m365/api/graph/testdata"
 )
 
 // called by the pager test, since it is already enumerating
@@ -161,7 +162,7 @@ func (suite *ConversationAPIIntgSuite) TestConversations_attachmentListDownload(
 					"posts",
 					pid).
 					Reply(200).
-					JSON(requireParseableToMap(suite.T(), itm))
+					JSON(graphTD.ParseableToMap(suite.T(), itm))
 			},
 			expect: assert.NoError,
 		},
@@ -187,7 +188,7 @@ func (suite *ConversationAPIIntgSuite) TestConversations_attachmentListDownload(
 					"posts",
 					pid).
 					Reply(200).
-					JSON(requireParseableToMap(suite.T(), itm))
+					JSON(graphTD.ParseableToMap(suite.T(), itm))
 			},
 			attachmentCount: 1,
 			size:            50,
@@ -217,7 +218,7 @@ func (suite *ConversationAPIIntgSuite) TestConversations_attachmentListDownload(
 					"posts",
 					pid).
 					Reply(200).
-					JSON(requireParseableToMap(suite.T(), itm))
+					JSON(graphTD.ParseableToMap(suite.T(), itm))
 			},
 			attachmentCount: 5,
 			size:            1000,

--- a/src/pkg/services/m365/api/events_test.go
+++ b/src/pkg/services/m365/api/events_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
+	graphTD "github.com/alcionai/corso/src/pkg/services/m365/api/graph/testdata"
 )
 
 type EventsAPIUnitSuite struct {
@@ -362,7 +363,7 @@ func (suite *EventsAPIIntgSuite) TestEvents_GetContainerByName_mocked() {
 		{
 			name: "zero",
 			results: func(t *testing.T) map[string]any {
-				return requireParseableToMap(t, models.NewCalendarCollectionResponse())
+				return graphTD.ParseableToMap(t, models.NewCalendarCollectionResponse())
 			},
 			expectErr: assert.Error,
 		},
@@ -372,7 +373,7 @@ func (suite *EventsAPIIntgSuite) TestEvents_GetContainerByName_mocked() {
 				mfcr := models.NewCalendarCollectionResponse()
 				mfcr.SetValue([]models.Calendarable{c})
 
-				return requireParseableToMap(t, mfcr)
+				return graphTD.ParseableToMap(t, mfcr)
 			},
 			expectErr: assert.NoError,
 		},
@@ -382,7 +383,7 @@ func (suite *EventsAPIIntgSuite) TestEvents_GetContainerByName_mocked() {
 				mfcr := models.NewCalendarCollectionResponse()
 				mfcr.SetValue([]models.Calendarable{c, c})
 
-				return requireParseableToMap(t, mfcr)
+				return graphTD.ParseableToMap(t, mfcr)
 			},
 			expectErr: assert.NoError,
 		},

--- a/src/pkg/services/m365/api/graph/errors.go
+++ b/src/pkg/services/m365/api/graph/errors.go
@@ -226,8 +226,7 @@ func IsErrUnauthorizedOrBadToken(err error) bool {
 }
 
 func IsErrBadJWTToken(err error) bool {
-	return hasErrorCode(err, invalidAuthenticationToken) ||
-		errors.Is(err, ErrTokenExpired)
+	return hasErrorCode(err, invalidAuthenticationToken)
 }
 
 func IsErrItemAlreadyExistsConflict(err error) bool {

--- a/src/pkg/services/m365/api/graph/errors.go
+++ b/src/pkg/services/m365/api/graph/errors.go
@@ -78,7 +78,7 @@ const (
 	MysiteURLNotFound               errorMessage = "unable to retrieve user's mysite url"
 	MysiteNotFound                  errorMessage = "user's mysite not found"
 	NoSPLicense                     errorMessage = "Tenant does not have a SPO license"
-	parameterDeltaTokenNotSupported errorMessage = "Parameter 'DeltaToken' not supported for this request"
+	ParameterDeltaTokenNotSupported errorMessage = "Parameter 'DeltaToken' not supported for this request"
 	usersCannotBeResolved           errorMessage = "One or more users could not be resolved"
 	requestedSiteCouldNotBeFound    errorMessage = "Requested site could not be found"
 )
@@ -100,15 +100,6 @@ var (
 	// The folder or item was deleted between the time we identified
 	// it and when we tried to fetch data for it.
 	ErrDeletedInFlight = clues.New("deleted in flight")
-
-	// Delta tokens can be desycned or expired.  In either case, the token
-	// becomes invalid, and cannot be used again.
-	// https://learn.microsoft.com/en-us/graph/errors#code-property
-	ErrInvalidDelta = clues.New("invalid delta token")
-
-	// Not all systems support delta queries.  This must be handled separately
-	// from invalid delta token cases.
-	ErrDeltaNotSupported = clues.New("delta not supported")
 
 	// ErrItemAlreadyExistsConflict denotes that a post or put attempted to create
 	// an item which already exists by some unique identifier.  The identifier is
@@ -132,16 +123,9 @@ var (
 	// access to a given service.
 	ErrServiceNotEnabled = clues.New("service is not enabled for that resource owner")
 
-	// Timeout errors are identified for tracking the need to retry calls.
-	// Other delay errors, like throttling, are already handled by the
-	// graph client's built-in retries.
-	// https://github.com/microsoftgraph/msgraph-sdk-go/issues/302
-	ErrTimeout = clues.New("communication timeout")
-
 	ErrResourceOwnerNotFound = clues.New("resource owner not found in tenant")
 
 	ErrTokenExpired = clues.New("jwt token expired")
-	ErrTokenInvalid = clues.New("jwt token invalid")
 )
 
 func IsErrApplicationThrottled(err error) bool {
@@ -174,13 +158,11 @@ func IsErrItemNotFound(err error) bool {
 }
 
 func IsErrInvalidDelta(err error) bool {
-	return errors.Is(err, ErrInvalidDelta) ||
-		hasErrorCode(err, syncStateNotFound, resyncRequired, syncStateInvalid)
+	return hasErrorCode(err, syncStateNotFound, resyncRequired, syncStateInvalid)
 }
 
 func IsErrDeltaNotSupported(err error) bool {
-	return errors.Is(err, ErrDeltaNotSupported) ||
-		hasErrorMessage(err, parameterDeltaTokenNotSupported)
+	return hasErrorMessage(err, ParameterDeltaTokenNotSupported)
 }
 
 func IsErrQuotaExceeded(err error) bool {
@@ -227,8 +209,7 @@ func IsErrTimeout(err error) bool {
 		return err.Timeout()
 	}
 
-	return errors.Is(err, ErrTimeout) ||
-		errors.Is(err, context.Canceled) ||
+	return errors.Is(err, context.Canceled) ||
 		errors.Is(err, context.DeadlineExceeded) ||
 		errors.Is(err, http.ErrHandlerTimeout) ||
 		os.IsTimeout(err)
@@ -241,14 +222,12 @@ func IsErrConnectionReset(err error) bool {
 func IsErrUnauthorizedOrBadToken(err error) bool {
 	return clues.HasLabel(err, LabelStatus(http.StatusUnauthorized)) ||
 		hasErrorCode(err, invalidAuthenticationToken) ||
-		errors.Is(err, ErrTokenExpired) ||
-		errors.Is(err, ErrTokenInvalid)
+		errors.Is(err, ErrTokenExpired)
 }
 
 func IsErrBadJWTToken(err error) bool {
 	return hasErrorCode(err, invalidAuthenticationToken) ||
-		errors.Is(err, ErrTokenExpired) ||
-		errors.Is(err, ErrTokenInvalid)
+		errors.Is(err, ErrTokenExpired)
 }
 
 func IsErrItemAlreadyExistsConflict(err error) bool {

--- a/src/pkg/services/m365/api/graph/errors_test.go
+++ b/src/pkg/services/m365/api/graph/errors_test.go
@@ -478,7 +478,7 @@ func (suite *GraphErrorsUnitSuite) TestIsErrIsErrBadJWTToken() {
 		{
 			name:   "err token expired",
 			err:    clues.Stack(assert.AnError, ErrTokenExpired),
-			expect: assert.True,
+			expect: assert.False,
 		},
 		{
 			name:   "oDataErr code invalid auth token ",

--- a/src/pkg/services/m365/api/graph/middleware_test.go
+++ b/src/pkg/services/m365/api/graph/middleware_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/account"
 	"github.com/alcionai/corso/src/pkg/count"
 	"github.com/alcionai/corso/src/pkg/path"
+	graphTD "github.com/alcionai/corso/src/pkg/services/m365/api/graph/testdata"
 )
 
 type mwReturns struct {
@@ -304,8 +305,8 @@ func (suite *RetryMWIntgSuite) TestRetryMiddleware_RetryResponse_maintainBodyAft
 
 	InitializeConcurrencyLimiter(ctx, false, -1)
 
-	odem := odErrMsg("SystemDown", "The System, Is Down, bah-dup-da-woo-woo!")
-	m := parseableToMap(t, odem)
+	odem := graphTD.ODataErrWithMsg("SystemDown", "The System, Is Down, bah-dup-da-woo-woo!")
+	m := graphTD.ParseableToMap(t, odem)
 
 	body, err := json.Marshal(m)
 	require.NoError(t, err, clues.ToCore(err))

--- a/src/pkg/services/m365/api/graph/testdata/errors.go
+++ b/src/pkg/services/m365/api/graph/testdata/errors.go
@@ -1,0 +1,62 @@
+package testdata
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/microsoft/kiota-abstractions-go/serialization"
+	kjson "github.com/microsoft/kiota-serialization-json-go"
+	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
+	"github.com/stretchr/testify/require"
+)
+
+func ODataErr(code string) *odataerrors.ODataError {
+	odErr := odataerrors.NewODataError()
+	merr := odataerrors.NewMainError()
+	merr.SetCode(&code)
+	// graph sdk expects the message to be available
+	merr.SetMessage(&code)
+	odErr.SetErrorEscaped(merr)
+
+	return odErr
+}
+
+func ODataErrWithMsg(code, message string) *odataerrors.ODataError {
+	odErr := odataerrors.NewODataError()
+	merr := odataerrors.NewMainError()
+	merr.SetCode(&code)
+	merr.SetMessage(&message)
+	odErr.SetErrorEscaped(merr)
+
+	return odErr
+}
+
+func ParseableToMap(t *testing.T, thing serialization.Parsable) map[string]any {
+	sw := kjson.NewJsonSerializationWriter()
+
+	err := sw.WriteObjectValue("", thing)
+	require.NoError(t, err, "serialize parsable")
+
+	content, err := sw.GetSerializedContent()
+	require.NoError(t, err, "deserialize parsable")
+
+	var out map[string]any
+	err = json.Unmarshal([]byte(content), &out)
+	require.NoError(t, err, "unmarshal parsable")
+
+	return out
+}
+
+func ParseableToReader(t *testing.T, thing serialization.Parsable) (int64, io.ReadCloser) {
+	sw := kjson.NewJsonSerializationWriter()
+
+	err := sw.WriteObjectValue("", thing)
+	require.NoError(t, err, "serialize parsable")
+
+	content, err := sw.GetSerializedContent()
+	require.NoError(t, err, "deserialize parsable")
+
+	return int64(len(content)), io.NopCloser(bytes.NewReader(content))
+}

--- a/src/pkg/services/m365/api/helper_test.go
+++ b/src/pkg/services/m365/api/helper_test.go
@@ -1,15 +1,11 @@
 package api
 
 import (
-	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/alcionai/clues"
 	"github.com/h2non/gock"
-	"github.com/microsoft/kiota-abstractions-go/serialization"
-	kjson "github.com/microsoft/kiota-serialization-json-go"
-	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
@@ -58,42 +54,6 @@ func v1APIURLPath(parts ...string) string {
 
 func interceptV1Path(pathParts ...string) *gock.Request {
 	return gock.New(graphAPIHostURL).Get(v1APIURLPath(pathParts...))
-}
-
-func odErr(code string) *odataerrors.ODataError {
-	odErr := odataerrors.NewODataError()
-	merr := odataerrors.NewMainError()
-	merr.SetCode(&code)
-	merr.SetMessage(&code) // sdk expect message to be available
-	odErr.SetErrorEscaped(merr)
-
-	return odErr
-}
-
-func odErrMsg(code, message string) *odataerrors.ODataError {
-	odErr := odataerrors.NewODataError()
-	merr := odataerrors.NewMainError()
-	merr.SetCode(&code)
-	merr.SetMessage(&message)
-	odErr.SetErrorEscaped(merr)
-
-	return odErr
-}
-
-func requireParseableToMap(t *testing.T, thing serialization.Parsable) map[string]any {
-	sw := kjson.NewJsonSerializationWriter()
-
-	err := sw.WriteObjectValue("", thing)
-	require.NoError(t, err, "serialize")
-
-	content, err := sw.GetSerializedContent()
-	require.NoError(t, err, "deserialize")
-
-	var out map[string]any
-	err = json.Unmarshal([]byte(content), &out)
-	require.NoError(t, err, "unmarshall")
-
-	return out
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/services/m365/api/mail_test.go
+++ b/src/pkg/services/m365/api/mail_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/fault"
+	graphTD "github.com/alcionai/corso/src/pkg/services/m365/api/graph/testdata"
 )
 
 type MailAPIUnitSuite struct {
@@ -223,7 +224,7 @@ func (suite *MailAPIIntgSuite) TestMail_attachmentListDownload() {
 
 				interceptV1Path("users", "user", "messages", mid).
 					Reply(200).
-					JSON(requireParseableToMap(suite.T(), mitem))
+					JSON(graphTD.ParseableToMap(suite.T(), mitem))
 			},
 			expect: assert.NoError,
 		},
@@ -236,7 +237,7 @@ func (suite *MailAPIIntgSuite) TestMail_attachmentListDownload() {
 
 				interceptV1Path("users", "user", "messages", mid).
 					Reply(200).
-					JSON(requireParseableToMap(suite.T(), email))
+					JSON(graphTD.ParseableToMap(suite.T(), email))
 
 				atts := models.NewAttachmentCollectionResponse()
 				attch := models.NewAttachment()
@@ -247,7 +248,7 @@ func (suite *MailAPIIntgSuite) TestMail_attachmentListDownload() {
 
 				interceptV1Path("users", "user", "messages", mid, "attachments").
 					Reply(200).
-					JSON(requireParseableToMap(suite.T(), atts))
+					JSON(graphTD.ParseableToMap(suite.T(), atts))
 			},
 			attachmentCount: 1,
 			size:            50,
@@ -262,7 +263,7 @@ func (suite *MailAPIIntgSuite) TestMail_attachmentListDownload() {
 
 				interceptV1Path("users", "user", "messages", mid).
 					Reply(200).
-					JSON(requireParseableToMap(suite.T(), email))
+					JSON(graphTD.ParseableToMap(suite.T(), email))
 
 				atts := models.NewAttachmentCollectionResponse()
 				attch := models.NewAttachment()
@@ -278,11 +279,11 @@ func (suite *MailAPIIntgSuite) TestMail_attachmentListDownload() {
 
 				interceptV1Path("users", "user", "messages", mid, "attachments").
 					Reply(200).
-					JSON(requireParseableToMap(suite.T(), atts))
+					JSON(graphTD.ParseableToMap(suite.T(), atts))
 
 				interceptV1Path("users", "user", "messages", mid, "attachments", aid).
 					Reply(200).
-					JSON(requireParseableToMap(suite.T(), attch))
+					JSON(graphTD.ParseableToMap(suite.T(), attch))
 			},
 			attachmentCount: 1,
 			size:            200,
@@ -298,7 +299,7 @@ func (suite *MailAPIIntgSuite) TestMail_attachmentListDownload() {
 
 				interceptV1Path("users", "user", "messages", mid).
 					Reply(200).
-					JSON(requireParseableToMap(suite.T(), email))
+					JSON(graphTD.ParseableToMap(suite.T(), email))
 
 				atts := models.NewAttachmentCollectionResponse()
 				attch := models.NewAttachment()
@@ -314,12 +315,12 @@ func (suite *MailAPIIntgSuite) TestMail_attachmentListDownload() {
 
 				interceptV1Path("users", "user", "messages", mid, "attachments").
 					Reply(200).
-					JSON(requireParseableToMap(suite.T(), atts))
+					JSON(graphTD.ParseableToMap(suite.T(), atts))
 
 				for i := 0; i < 5; i++ {
 					interceptV1Path("users", "user", "messages", mid, "attachments", aid).
 						Reply(200).
-						JSON(requireParseableToMap(suite.T(), attch))
+						JSON(graphTD.ParseableToMap(suite.T(), attch))
 				}
 			},
 			attachmentCount: 5,
@@ -477,7 +478,7 @@ func (suite *MailAPIIntgSuite) TestMail_GetContainerByName_mocked() {
 		{
 			name: "zero",
 			results: func(t *testing.T) map[string]any {
-				return requireParseableToMap(t, models.NewMailFolderCollectionResponse())
+				return graphTD.ParseableToMap(t, models.NewMailFolderCollectionResponse())
 			},
 			expectErr: assert.Error,
 		},
@@ -487,7 +488,7 @@ func (suite *MailAPIIntgSuite) TestMail_GetContainerByName_mocked() {
 				mfcr := models.NewMailFolderCollectionResponse()
 				mfcr.SetValue([]models.MailFolderable{mf})
 
-				return requireParseableToMap(t, mfcr)
+				return graphTD.ParseableToMap(t, mfcr)
 			},
 			expectErr: assert.NoError,
 		},
@@ -497,7 +498,7 @@ func (suite *MailAPIIntgSuite) TestMail_GetContainerByName_mocked() {
 				mfcr := models.NewMailFolderCollectionResponse()
 				mfcr.SetValue([]models.MailFolderable{mf, mf})
 
-				return requireParseableToMap(t, mfcr)
+				return graphTD.ParseableToMap(t, mfcr)
 			},
 			expectErr: assert.Error,
 		},

--- a/src/pkg/services/m365/api/pagers/pagers_test.go
+++ b/src/pkg/services/m365/api/pagers/pagers_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
+	graphTD "github.com/alcionai/corso/src/pkg/services/m365/api/graph/testdata"
 )
 
 // ---------------------------------------------------------------------------
@@ -1057,7 +1058,10 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs_FallbackPagers() {
 						t: t,
 						pages: []pageResult{
 							{
-								err:        graph.ErrDeltaNotSupported,
+								err: graphTD.ODataErrWithMsg(
+									string(graph.ParameterDeltaTokenNotSupported),
+									string(graph.ParameterDeltaTokenNotSupported),
+								),
 								needsReset: true,
 							},
 						},
@@ -1168,7 +1172,10 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs_FallbackPagers() {
 								},
 							},
 							{
-								err:        graph.ErrDeltaNotSupported,
+								err: graphTD.ODataErrWithMsg(
+									string(graph.ParameterDeltaTokenNotSupported),
+									string(graph.ParameterDeltaTokenNotSupported),
+								),
 								needsReset: true,
 							},
 						},
@@ -1283,7 +1290,10 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs_FallbackPagers() {
 								},
 							},
 							{
-								err:        graph.ErrDeltaNotSupported,
+								err: graphTD.ODataErrWithMsg(
+									string(graph.ParameterDeltaTokenNotSupported),
+									string(graph.ParameterDeltaTokenNotSupported),
+								),
 								needsReset: true,
 							},
 						},

--- a/src/pkg/services/m365/api/pagers/pagers_test.go
+++ b/src/pkg/services/m365/api/pagers/pagers_test.go
@@ -1058,10 +1058,7 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs_FallbackPagers() {
 						t: t,
 						pages: []pageResult{
 							{
-								err: graphTD.ODataErrWithMsg(
-									string(graph.ParameterDeltaTokenNotSupported),
-									string(graph.ParameterDeltaTokenNotSupported),
-								),
+								err:        graphTD.ODataErr(string(graph.ParameterDeltaTokenNotSupported)),
 								needsReset: true,
 							},
 						},
@@ -1115,7 +1112,7 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs_FallbackPagers() {
 						t: t,
 						pages: []pageResult{
 							{
-								err:        graph.ErrDeltaNotSupported,
+								err:        graphTD.ODataErr(string(graph.ParameterDeltaTokenNotSupported)),
 								needsReset: true,
 							},
 						},
@@ -1172,10 +1169,7 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs_FallbackPagers() {
 								},
 							},
 							{
-								err: graphTD.ODataErrWithMsg(
-									string(graph.ParameterDeltaTokenNotSupported),
-									string(graph.ParameterDeltaTokenNotSupported),
-								),
+								err:        graphTD.ODataErr(string(graph.ParameterDeltaTokenNotSupported)),
 								needsReset: true,
 							},
 						},
@@ -1290,10 +1284,7 @@ func (suite *PagerUnitSuite) TestGetAddedAndRemovedItemIDs_FallbackPagers() {
 								},
 							},
 							{
-								err: graphTD.ODataErrWithMsg(
-									string(graph.ParameterDeltaTokenNotSupported),
-									string(graph.ParameterDeltaTokenNotSupported),
-								),
+								err:        graphTD.ODataErr(string(graph.ParameterDeltaTokenNotSupported)),
 								needsReset: true,
 							},
 						},

--- a/src/pkg/services/m365/api/users_test.go
+++ b/src/pkg/services/m365/api/users_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
+	graphTD "github.com/alcionai/corso/src/pkg/services/m365/api/graph/testdata"
 )
 
 type UsersUnitSuite struct {
@@ -79,35 +80,35 @@ func (suite *UsersUnitSuite) TestEvaluateMailboxError() {
 		},
 		{
 			name: "mail inbox err - user not found",
-			err:  odErr(string(graph.RequestResourceNotFound)),
+			err:  graphTD.ODataErr(string(graph.RequestResourceNotFound)),
 			expect: func(t *testing.T, err error) {
 				assert.ErrorIs(t, err, graph.ErrResourceOwnerNotFound, clues.ToCore(err))
 			},
 		},
 		{
 			name: "mail inbox err - resoruceLocked",
-			err:  odErr(string(graph.NotAllowed)),
+			err:  graphTD.ODataErr(string(graph.NotAllowed)),
 			expect: func(t *testing.T, err error) {
 				assert.ErrorIs(t, err, graph.ErrResourceLocked, clues.ToCore(err))
 			},
 		},
 		{
 			name: "mail inbox err - user not found",
-			err:  odErr(string(graph.MailboxNotEnabledForRESTAPI)),
+			err:  graphTD.ODataErr(string(graph.MailboxNotEnabledForRESTAPI)),
 			expect: func(t *testing.T, err error) {
 				assert.NoError(t, err, clues.ToCore(err))
 			},
 		},
 		{
 			name: "mail inbox err - authenticationError",
-			err:  odErr(string(graph.AuthenticationError)),
+			err:  graphTD.ODataErr(string(graph.AuthenticationError)),
 			expect: func(t *testing.T, err error) {
 				assert.NoError(t, err, clues.ToCore(err))
 			},
 		},
 		{
 			name: "mail inbox err - other error",
-			err:  odErrMsg("somecode", "somemessage"),
+			err:  graphTD.ODataErrWithMsg("somecode", "somemessage"),
 			expect: func(t *testing.T, err error) {
 				assert.Error(t, err, clues.ToCore(err))
 			},


### PR DESCRIPTION
A handful of the error sentinel values in graph/errors.go were only around to comply with an old expectation that IsErr funcs have a matching sentinel.  That assumption is out of date, and there's no point in keeping around unused sentinels.

This PR makes three changes to clean up that issue:
1. remove unused sentinels (unused is qualifed as "not produced").
2. fix external pacakges which referenced those errors in tests alone by replacing those sentinels with odata errors.
3. centralize odata error test code to help support upstream package odata error creation.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
