### PR TITLE
Add functions used for restore to existing service-level handlers

### DIFF
--- a/src/internal/m365/export.go
+++ b/src/internal/m365/export.go
@@ -21,13 +21,13 @@ func (ctrl *Controller) NewServiceHandler(
 
 	switch service {
 	case path.OneDriveService:
-		return onedrive.NewOneDriveHandler(opts), nil
+		return onedrive.NewOneDriveHandler(opts, ctrl.AC, ctrl.resourceHandler), nil
 
 	case path.SharePointService:
-		return sharepoint.NewSharePointHandler(opts), nil
+		return sharepoint.NewSharePointHandler(opts, ctrl.AC, ctrl.resourceHandler), nil
 
 	case path.GroupsService:
-		return groups.NewGroupsHandler(opts), nil
+		return groups.NewGroupsHandler(opts, ctrl.AC, ctrl.resourceHandler), nil
 	}
 
 	return nil, clues.New("unrecognized service").

--- a/src/internal/m365/resource/resource.go
+++ b/src/internal/m365/resource/resource.go
@@ -1,5 +1,9 @@
 package resource
 
+import "github.com/alcionai/clues"
+
+var ErrNoResourceLookup = clues.New("missing resource lookup client")
+
 type Category string
 
 const (

--- a/src/internal/m365/service/groups/export.go
+++ b/src/internal/m365/service/groups/export.go
@@ -26,7 +26,7 @@ var _ inject.ServiceHandler = &groupsHandler{}
 func NewGroupsHandler(
 	opts control.Options,
 	apiClient api.Client,
-	resourceClient idname.GetResourceIDAndNamer,
+	resourceGetter idname.GetResourceIDAndNamer,
 ) *groupsHandler {
 	return &groupsHandler{
 		baseGroupsHandler: baseGroupsHandler{
@@ -35,7 +35,7 @@ func NewGroupsHandler(
 			backupSiteIDWebURL: idname.NewCache(nil),
 		},
 		apiClient:      apiClient,
-		resourceClient: resourceClient,
+		resourceGetter: resourceGetter,
 	}
 }
 
@@ -159,7 +159,7 @@ func (h *baseGroupsHandler) ProduceExportCollections(
 type groupsHandler struct {
 	baseGroupsHandler
 	apiClient      api.Client
-	resourceClient idname.GetResourceIDAndNamer
+	resourceGetter idname.GetResourceIDAndNamer
 }
 
 func (h *groupsHandler) IsServiceEnabled(
@@ -176,11 +176,11 @@ func (h *groupsHandler) PopulateProtectedResourceIDAndName(
 	resource string, // Can be either ID or name.
 	ins idname.Cacher,
 ) (idname.Provider, error) {
-	if h.resourceClient == nil {
+	if h.resourceGetter == nil {
 		return nil, clues.Stack(graph.ErrNoResourceLookup).WithClues(ctx)
 	}
 
-	pr, err := h.resourceClient.GetResourceIDAndNameFrom(ctx, resource, ins)
+	pr, err := h.resourceGetter.GetResourceIDAndNameFrom(ctx, resource, ins)
 
 	return pr, clues.Wrap(err, "identifying resource owner").OrNil()
 }

--- a/src/internal/m365/service/groups/export.go
+++ b/src/internal/m365/service/groups/export.go
@@ -177,7 +177,7 @@ func (h *groupsHandler) PopulateProtectedResourceIDAndName(
 	ins idname.Cacher,
 ) (idname.Provider, error) {
 	if h.resourceGetter == nil {
-		return nil, clues.Stack(resource.ErrNoResourceLookup).WithClues(ctx)
+		return nil, clues.StackWC(ctx, resource.ErrNoResourceLookup)
 	}
 
 	pr, err := h.resourceGetter.GetResourceIDAndNameFrom(ctx, resourceID, ins)

--- a/src/internal/m365/service/groups/export.go
+++ b/src/internal/m365/service/groups/export.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive"
 	"github.com/alcionai/corso/src/internal/m365/collection/groups"
+	"github.com/alcionai/corso/src/internal/m365/resource"
 	"github.com/alcionai/corso/src/internal/operations/inject"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control"
@@ -18,7 +19,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
-	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
 var _ inject.ServiceHandler = &groupsHandler{}
@@ -164,23 +164,23 @@ type groupsHandler struct {
 
 func (h *groupsHandler) IsServiceEnabled(
 	ctx context.Context,
-	resource string,
+	resourceID string,
 ) (bool, error) {
 	// TODO(ashmrtn): Move free function implementation to this function.
-	res, err := IsServiceEnabled(ctx, h.apiClient.Groups(), resource)
+	res, err := IsServiceEnabled(ctx, h.apiClient.Groups(), resourceID)
 	return res, clues.Stack(err).OrNil()
 }
 
 func (h *groupsHandler) PopulateProtectedResourceIDAndName(
 	ctx context.Context,
-	resource string, // Can be either ID or name.
+	resourceID string, // Can be either ID or name.
 	ins idname.Cacher,
 ) (idname.Provider, error) {
 	if h.resourceGetter == nil {
-		return nil, clues.Stack(graph.ErrNoResourceLookup).WithClues(ctx)
+		return nil, clues.Stack(resource.ErrNoResourceLookup).WithClues(ctx)
 	}
 
-	pr, err := h.resourceGetter.GetResourceIDAndNameFrom(ctx, resource, ins)
+	pr, err := h.resourceGetter.GetResourceIDAndNameFrom(ctx, resourceID, ins)
 
 	return pr, clues.Wrap(err, "identifying resource owner").OrNil()
 }

--- a/src/internal/m365/service/groups/export_test.go
+++ b/src/internal/m365/service/groups/export_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/export"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type ExportUnitSuite struct {
@@ -96,7 +97,7 @@ func (suite *ExportUnitSuite) TestExportRestoreCollections_messages() {
 
 	stats := data.ExportStats{}
 
-	ecs, err := NewGroupsHandler(control.DefaultOptions()).
+	ecs, err := NewGroupsHandler(control.DefaultOptions(), api.Client{}, nil).
 		ProduceExportCollections(
 			ctx,
 			int(version.Backup),
@@ -196,7 +197,7 @@ func (suite *ExportUnitSuite) TestExportRestoreCollections_libraries() {
 		},
 	}
 
-	handler := NewGroupsHandler(control.DefaultOptions())
+	handler := NewGroupsHandler(control.DefaultOptions(), api.Client{}, nil)
 	handler.CacheItemInfo(dii)
 
 	stats := data.ExportStats{}

--- a/src/internal/m365/service/onedrive/export.go
+++ b/src/internal/m365/service/onedrive/export.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alcionai/clues"
 
+	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive"
 	"github.com/alcionai/corso/src/internal/operations/inject"
@@ -13,27 +14,49 @@ import (
 	"github.com/alcionai/corso/src/pkg/export"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
-var _ inject.ServiceHandler = &baseOnedriveHandler{}
+var _ inject.ServiceHandler = &onedriveHandler{}
 
 func NewOneDriveHandler(
 	opts control.Options,
-) *baseOnedriveHandler {
-	return &baseOnedriveHandler{
-		opts: opts,
+	apiClient api.Client,
+	resourceClient idname.GetResourceIDAndNamer,
+) *onedriveHandler {
+	return &onedriveHandler{
+		baseOneDriveHandler: baseOneDriveHandler{
+			opts:               opts,
+			backupDriveIDNames: idname.NewCache(nil),
+		},
+		apiClient:      apiClient,
+		resourceClient: resourceClient,
 	}
 }
 
-type baseOnedriveHandler struct {
-	opts control.Options
+// ========================================================================== //
+//                            baseOneDriveHandler
+// ========================================================================== //
+
+// baseOneDriveHandler contains logic for tracking data and doing operations
+// (e.x. export) that don't require contact with external M356 services.
+type baseOneDriveHandler struct {
+	opts               control.Options
+	backupDriveIDNames idname.CacheBuilder
 }
 
-func (h *baseOnedriveHandler) CacheItemInfo(v details.ItemInfo) {}
+func (h *baseOneDriveHandler) CacheItemInfo(v details.ItemInfo) {
+	if v.OneDrive == nil {
+		return
+	}
+
+	h.backupDriveIDNames.Add(v.OneDrive.DriveID, v.OneDrive.DriveName)
+}
 
 // ProduceExportCollections will create the export collections for the
 // given restore collections.
-func (h *baseOnedriveHandler) ProduceExportCollections(
+func (h *baseOneDriveHandler) ProduceExportCollections(
 	ctx context.Context,
 	backupVersion int,
 	exportCfg control.ExportConfig,
@@ -64,4 +87,40 @@ func (h *baseOnedriveHandler) ProduceExportCollections(
 	}
 
 	return ec, el.Failure()
+}
+
+// ========================================================================== //
+//                              onedriveHandler
+// ========================================================================== //
+
+// onedriveHandler contains logic for handling data and performing operations
+// (e.x. restore) regardless of whether they require contact with external M365
+// services or not.
+type onedriveHandler struct {
+	baseOneDriveHandler
+	apiClient      api.Client
+	resourceClient idname.GetResourceIDAndNamer
+}
+
+func (h *onedriveHandler) IsServiceEnabled(
+	ctx context.Context,
+	resource string,
+) (bool, error) {
+	// TODO(ashmrtn): Move free function implementation to this function.
+	res, err := IsServiceEnabled(ctx, h.apiClient.Users(), resource)
+	return res, clues.Stack(err).OrNil()
+}
+
+func (h *onedriveHandler) PopulateProtectedResourceIDAndName(
+	ctx context.Context,
+	resource string, // Can be either ID or name.
+	ins idname.Cacher,
+) (idname.Provider, error) {
+	if h.resourceClient == nil {
+		return nil, clues.Stack(graph.ErrNoResourceLookup).WithClues(ctx)
+	}
+
+	pr, err := h.resourceClient.GetResourceIDAndNameFrom(ctx, resource, ins)
+
+	return pr, clues.Wrap(err, "identifying resource owner").OrNil()
 }

--- a/src/internal/m365/service/onedrive/export.go
+++ b/src/internal/m365/service/onedrive/export.go
@@ -23,7 +23,7 @@ var _ inject.ServiceHandler = &onedriveHandler{}
 func NewOneDriveHandler(
 	opts control.Options,
 	apiClient api.Client,
-	resourceClient idname.GetResourceIDAndNamer,
+	resourceGetter idname.GetResourceIDAndNamer,
 ) *onedriveHandler {
 	return &onedriveHandler{
 		baseOneDriveHandler: baseOneDriveHandler{
@@ -31,7 +31,7 @@ func NewOneDriveHandler(
 			backupDriveIDNames: idname.NewCache(nil),
 		},
 		apiClient:      apiClient,
-		resourceClient: resourceClient,
+		resourceGetter: resourceGetter,
 	}
 }
 
@@ -99,7 +99,7 @@ func (h *baseOneDriveHandler) ProduceExportCollections(
 type onedriveHandler struct {
 	baseOneDriveHandler
 	apiClient      api.Client
-	resourceClient idname.GetResourceIDAndNamer
+	resourceGetter idname.GetResourceIDAndNamer
 }
 
 func (h *onedriveHandler) IsServiceEnabled(
@@ -116,11 +116,11 @@ func (h *onedriveHandler) PopulateProtectedResourceIDAndName(
 	resource string, // Can be either ID or name.
 	ins idname.Cacher,
 ) (idname.Provider, error) {
-	if h.resourceClient == nil {
+	if h.resourceGetter == nil {
 		return nil, clues.Stack(graph.ErrNoResourceLookup).WithClues(ctx)
 	}
 
-	pr, err := h.resourceClient.GetResourceIDAndNameFrom(ctx, resource, ins)
+	pr, err := h.resourceGetter.GetResourceIDAndNameFrom(ctx, resource, ins)
 
 	return pr, clues.Wrap(err, "identifying resource owner").OrNil()
 }

--- a/src/internal/m365/service/onedrive/export.go
+++ b/src/internal/m365/service/onedrive/export.go
@@ -117,7 +117,7 @@ func (h *onedriveHandler) PopulateProtectedResourceIDAndName(
 	ins idname.Cacher,
 ) (idname.Provider, error) {
 	if h.resourceGetter == nil {
-		return nil, clues.Stack(resource.ErrNoResourceLookup).WithClues(ctx)
+		return nil, clues.StackWC(ctx, resource.ErrNoResourceLookup)
 	}
 
 	pr, err := h.resourceGetter.GetResourceIDAndNameFrom(ctx, resourceID, ins)

--- a/src/internal/m365/service/onedrive/export.go
+++ b/src/internal/m365/service/onedrive/export.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive"
+	"github.com/alcionai/corso/src/internal/m365/resource"
 	"github.com/alcionai/corso/src/internal/operations/inject"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control"
@@ -15,7 +16,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
-	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
 var _ inject.ServiceHandler = &onedriveHandler{}
@@ -104,23 +104,23 @@ type onedriveHandler struct {
 
 func (h *onedriveHandler) IsServiceEnabled(
 	ctx context.Context,
-	resource string,
+	resourceID string,
 ) (bool, error) {
 	// TODO(ashmrtn): Move free function implementation to this function.
-	res, err := IsServiceEnabled(ctx, h.apiClient.Users(), resource)
+	res, err := IsServiceEnabled(ctx, h.apiClient.Users(), resourceID)
 	return res, clues.Stack(err).OrNil()
 }
 
 func (h *onedriveHandler) PopulateProtectedResourceIDAndName(
 	ctx context.Context,
-	resource string, // Can be either ID or name.
+	resourceID string, // Can be either ID or name.
 	ins idname.Cacher,
 ) (idname.Provider, error) {
 	if h.resourceGetter == nil {
-		return nil, clues.Stack(graph.ErrNoResourceLookup).WithClues(ctx)
+		return nil, clues.Stack(resource.ErrNoResourceLookup).WithClues(ctx)
 	}
 
-	pr, err := h.resourceGetter.GetResourceIDAndNameFrom(ctx, resource, ins)
+	pr, err := h.resourceGetter.GetResourceIDAndNameFrom(ctx, resourceID, ins)
 
 	return pr, clues.Wrap(err, "identifying resource owner").OrNil()
 }

--- a/src/internal/m365/service/onedrive/export_test.go
+++ b/src/internal/m365/service/onedrive/export_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/export"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type ExportUnitSuite struct {
@@ -341,7 +342,7 @@ func (suite *ExportUnitSuite) TestExportRestoreCollections() {
 
 	stats := data.ExportStats{}
 
-	ecs, err := NewOneDriveHandler(control.DefaultOptions()).
+	ecs, err := NewOneDriveHandler(control.DefaultOptions(), api.Client{}, nil).
 		ProduceExportCollections(
 			ctx,
 			int(version.Backup),

--- a/src/internal/m365/service/sharepoint/export.go
+++ b/src/internal/m365/service/sharepoint/export.go
@@ -131,7 +131,7 @@ func (h *sharepointHandler) PopulateProtectedResourceIDAndName(
 	ins idname.Cacher,
 ) (idname.Provider, error) {
 	if h.resourceGetter == nil {
-		return nil, clues.Stack(resource.ErrNoResourceLookup).WithClues(ctx)
+		return nil, clues.StackWC(ctx, resource.ErrNoResourceLookup)
 	}
 
 	pr, err := h.resourceGetter.GetResourceIDAndNameFrom(ctx, resourceID, ins)

--- a/src/internal/m365/service/sharepoint/export.go
+++ b/src/internal/m365/service/sharepoint/export.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive"
+	"github.com/alcionai/corso/src/internal/m365/resource"
 	"github.com/alcionai/corso/src/internal/operations/inject"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/control"
@@ -16,7 +17,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
-	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
 var _ inject.ServiceHandler = &sharepointHandler{}
@@ -118,23 +118,23 @@ type sharepointHandler struct {
 
 func (h *sharepointHandler) IsServiceEnabled(
 	ctx context.Context,
-	resource string,
+	resourceID string,
 ) (bool, error) {
 	// TODO(ashmrtn): Move free function implementation to this function.
-	res, err := IsServiceEnabled(ctx, h.apiClient.Sites(), resource)
+	res, err := IsServiceEnabled(ctx, h.apiClient.Sites(), resourceID)
 	return res, clues.Stack(err).OrNil()
 }
 
 func (h *sharepointHandler) PopulateProtectedResourceIDAndName(
 	ctx context.Context,
-	resource string, // Can be either ID or name.
+	resourceID string, // Can be either ID or name.
 	ins idname.Cacher,
 ) (idname.Provider, error) {
 	if h.resourceGetter == nil {
-		return nil, clues.Stack(graph.ErrNoResourceLookup).WithClues(ctx)
+		return nil, clues.Stack(resource.ErrNoResourceLookup).WithClues(ctx)
 	}
 
-	pr, err := h.resourceGetter.GetResourceIDAndNameFrom(ctx, resource, ins)
+	pr, err := h.resourceGetter.GetResourceIDAndNameFrom(ctx, resourceID, ins)
 
 	return pr, clues.Wrap(err, "identifying resource owner").OrNil()
 }

--- a/src/internal/m365/service/sharepoint/export.go
+++ b/src/internal/m365/service/sharepoint/export.go
@@ -24,7 +24,7 @@ var _ inject.ServiceHandler = &sharepointHandler{}
 func NewSharePointHandler(
 	opts control.Options,
 	apiClient api.Client,
-	resourceClient idname.GetResourceIDAndNamer,
+	resourceGetter idname.GetResourceIDAndNamer,
 ) *sharepointHandler {
 	return &sharepointHandler{
 		baseSharePointHandler: baseSharePointHandler{
@@ -32,7 +32,7 @@ func NewSharePointHandler(
 			backupDriveIDNames: idname.NewCache(nil),
 		},
 		apiClient:      apiClient,
-		resourceClient: resourceClient,
+		resourceGetter: resourceGetter,
 	}
 }
 
@@ -113,7 +113,7 @@ func (h *baseSharePointHandler) ProduceExportCollections(
 type sharepointHandler struct {
 	baseSharePointHandler
 	apiClient      api.Client
-	resourceClient idname.GetResourceIDAndNamer
+	resourceGetter idname.GetResourceIDAndNamer
 }
 
 func (h *sharepointHandler) IsServiceEnabled(
@@ -130,11 +130,11 @@ func (h *sharepointHandler) PopulateProtectedResourceIDAndName(
 	resource string, // Can be either ID or name.
 	ins idname.Cacher,
 ) (idname.Provider, error) {
-	if h.resourceClient == nil {
+	if h.resourceGetter == nil {
 		return nil, clues.Stack(graph.ErrNoResourceLookup).WithClues(ctx)
 	}
 
-	pr, err := h.resourceClient.GetResourceIDAndNameFrom(ctx, resource, ins)
+	pr, err := h.resourceGetter.GetResourceIDAndNameFrom(ctx, resource, ins)
 
 	return pr, clues.Wrap(err, "identifying resource owner").OrNil()
 }

--- a/src/internal/m365/service/sharepoint/export_test.go
+++ b/src/internal/m365/service/sharepoint/export_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/export"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
 type ExportUnitSuite struct {
@@ -125,7 +126,7 @@ func (suite *ExportUnitSuite) TestExportRestoreCollections() {
 				},
 			}
 
-			handler := NewSharePointHandler(control.DefaultOptions())
+			handler := NewSharePointHandler(control.DefaultOptions(), api.Client{}, nil)
 			handler.CacheItemInfo(test.itemInfo)
 
 			stats := data.ExportStats{}

--- a/src/pkg/services/m365/api/graph/errors.go
+++ b/src/pkg/services/m365/api/graph/errors.go
@@ -138,8 +138,6 @@ var (
 	ErrResourceOwnerNotFound = clues.New("resource owner not found in tenant")
 
 	ErrTokenExpired = clues.New("jwt token expired")
-
-	ErrNoResourceLookup = clues.New("missing resource lookup client")
 )
 
 func IsErrApplicationThrottled(err error) bool {

--- a/src/pkg/services/m365/api/graph/errors.go
+++ b/src/pkg/services/m365/api/graph/errors.go
@@ -138,6 +138,8 @@ var (
 	ErrResourceOwnerNotFound = clues.New("resource owner not found in tenant")
 
 	ErrTokenExpired = clues.New("jwt token expired")
+
+	ErrNoResourceLookup = clues.New("missing resource lookup client")
 )
 
 func IsErrApplicationThrottled(err error) bool {


### PR DESCRIPTION
This continues the push towards having service-level handlers that know
how to perform different operations. It adds the helper functions that
will be used during restore operations to the existing handler code

This logic is not currently used nor does this PR change the restore
call path

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #4254

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
