### PR TITLE
Use microsecond granularity for exchange tests

### DIFF
--- a/src/internal/m365/controller_test.go
+++ b/src/internal/m365/controller_test.go
@@ -1073,7 +1073,7 @@ func (suite *ControllerIntegrationSuite) TestRestoreAndBackup_core() {
 				suite.ctrl.tenant,
 				[]string{suite.user},
 				control.DefaultOptions(),
-				control.DefaultRestoreConfig(dttm.HumanReadableDriveItem))
+				control.DefaultRestoreConfig(dttm.SafeForTesting))
 		})
 	}
 }
@@ -1242,7 +1242,7 @@ func (suite *ControllerIntegrationSuite) TestMultiFolderBackupDifferentNames() {
 
 			t.Log("Backup enumeration complete")
 
-			restoreCfg := control.DefaultRestoreConfig(dttm.HumanReadableDriveItem)
+			restoreCfg := control.DefaultRestoreConfig(dttm.SafeForTesting)
 			restoreCfg.IncludePermissions = true
 
 			ci := stub.ConfigInfo{
@@ -1285,7 +1285,7 @@ func (suite *ControllerIntegrationSuite) TestRestoreAndBackup_largeMailAttachmen
 		},
 	}
 
-	restoreCfg := control.DefaultRestoreConfig(dttm.HumanReadableDriveItem)
+	restoreCfg := control.DefaultRestoreConfig(dttm.SafeForTesting)
 	restoreCfg.IncludePermissions = true
 
 	runRestoreBackupTest(

--- a/src/internal/m365/onedrive_test.go
+++ b/src/internal/m365/onedrive_test.go
@@ -1355,7 +1355,7 @@ func testRestoreFolderNamedFolderRegression(
 				collectionsLatest:   expected,
 			}
 
-			restoreCfg := control.DefaultRestoreConfig(dttm.HumanReadableDriveItem)
+			restoreCfg := control.DefaultRestoreConfig(dttm.SafeForTesting)
 			restoreCfg.IncludePermissions = true
 
 			runRestoreTestWithVersion(


### PR DESCRIPTION
Switch the folder name granularity to microseconds instead of seconds to avoid collisions with other concurrent CI test runs.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [x] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
