### PR TITLE
Minor cleanup for drive backup code

### DIFF
--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -980,12 +980,11 @@ func (c *Collections) processItem(
 			return clues.NewWC(ctx, "item seen before parent folder")
 		}
 
-
 		// This will only kick in if the file was moved multiple times
 		// within a single delta query.  We delete the file from the previous
 		// collection so that it doesn't appear in two places.
-		prevParentContainerID, prevAdded := currPrevPaths[itemID]
-		if prevAdded {
+		prevParentContainerID, alreadyAdded := currPrevPaths[itemID]
+		if alreadyAdded {
 			prevColl, found := c.CollectionMap[driveID][prevParentContainerID]
 			if !found {
 				return clues.NewWC(ctx, "previous collection not found").
@@ -1002,7 +1001,7 @@ func (c *Collections) processItem(
 
 		// Only increment counters if the file didn't already get counted (i.e. it's
 		// not an item that was either updated or moved during the delta query).
-		if collection.Add(item) && !prevAdded {
+		if collection.Add(item) && !alreadyAdded {
 			c.NumItems++
 			c.NumFiles++
 		}


### PR DESCRIPTION
Just a few minor updates to stats logic to reset the counters if the delta is reset and also only count items if they weren't previously seen and counted.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
