### PR TITLE
Preview backup for drive-backed services

### DIFF
--- a/src/internal/m365/collection/drive/collection.go
+++ b/src/internal/m365/collection/drive/collection.go
@@ -223,7 +223,7 @@ func (oc Collection) ContainsItem(item models.DriveItemable) bool {
 }
 
 // AddedItems returns the number of non-deleted items in the collection.
-func (oc Collection) AddedItems() int {
+func (oc Collection) CountAddedItems() int {
 	// Subtract one since the folder is added to the collection so we get folder
 	// metadata. The collection of the root folder of the drive doesn't have its
 	// own folder reference since it doesn't have permissions the user can change,

--- a/src/internal/m365/collection/drive/collection.go
+++ b/src/internal/m365/collection/drive/collection.go
@@ -215,6 +215,22 @@ func (oc *Collection) IsEmpty() bool {
 	return len(oc.driveItems) == 0
 }
 
+// ContainsItem returns true if the collection has the given item as one of its
+// children.
+func (oc Collection) ContainsItem(item models.DriveItemable) bool {
+	_, ok := oc.driveItems[ptr.Val(item.GetId())]
+	return ok
+}
+
+// AddedItems returns the number of non-deleted items in the collection.
+func (oc Collection) AddedItems() int {
+	// Subtract one since the folder is added to the collection so we get folder
+	// metadata. The collection of the root folder of the drive doesn't have its
+	// own folder reference since it doesn't have permissions the user can change,
+	// but it's close enough for our purposes.
+	return len(oc.driveItems) - 1
+}
+
 // Items() returns the channel containing M365 Exchange objects
 func (oc *Collection) Items(
 	ctx context.Context,

--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -913,20 +913,18 @@ func (c *Collections) PopulateDriveCollections(
 
 			// Check if we got the max number of containers we're looking for and also
 			// processed items for the final container.
-			if limiter.enabled() {
-				if item.GetFolder() != nil || item.GetPackageEscaped() != nil {
-					id := ptr.Val(item.GetId())
+			if item.GetFolder() != nil || item.GetPackageEscaped() != nil {
+				id := ptr.Val(item.GetId())
 
-					// Don't check for containers we've already seen.
-					if _, ok := c.CollectionMap[driveID][id]; !ok {
-						if id != lastContainerID {
-							if limiter.atLimit(stats) {
-								break
-							}
-
-							lastContainerID = id
-							stats.numContainers++
+				// Don't check for containers we've already seen.
+				if _, ok := c.CollectionMap[driveID][id]; !ok {
+					if id != lastContainerID {
+						if limiter.atLimit(stats) {
+							break
 						}
+
+						lastContainerID = id
+						stats.numContainers++
 					}
 				}
 			}

--- a/src/internal/m365/collection/drive/collections_test.go
+++ b/src/internal/m365/collection/drive/collections_test.go
@@ -4199,7 +4199,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 				tenant,
 				idname.NewProvider(user, user),
 				func(*support.ControllerOperationStatus) {},
-				opts)
+				opts,
+				count.New())
 
 			errs := fault.New(true)
 

--- a/src/internal/m365/collection/drive/collections_test.go
+++ b/src/internal/m365/collection/drive/collections_test.go
@@ -3611,9 +3611,9 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 						Pages: []mock.NextPage{{
 							Items: []models.DriveItemable{
 								driveRootItem(rootID), // will be present, not needed
-								driveItemWithSize(idx("1", "f"), namex("1", "f"), parent(1), rootID, 7, isFile),
-								driveItemWithSize(idx("2", "f"), namex("2", "f"), parent(1), rootID, 1, isFile),
-								driveItemWithSize(idx("3", "f"), namex("3", "f"), parent(1), rootID, 1, isFile),
+								driveItemWithSize(idx(file, 1), namex(file, 1), parent(1), rootID, 7, isFile),
+								driveItemWithSize(idx(file, 2), namex(file, 2), parent(1), rootID, 1, isFile),
+								driveItemWithSize(idx(file, 3), namex(file, 3), parent(1), rootID, 1, isFile),
 							},
 						}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
@@ -3621,7 +3621,7 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 				},
 			},
 			expectedCollections: map[string][]string{
-				fullPath(1): {idx("2", "f"), idx("3", "f")},
+				fullPath(1): {idx(file, 2), idx(file, 3)},
 			},
 		},
 		{
@@ -3641,9 +3641,9 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 						Pages: []mock.NextPage{{
 							Items: []models.DriveItemable{
 								driveRootItem(rootID), // will be present, not needed
-								driveItemWithSize(idx("1", "f"), namex("1", "f"), parent(1), rootID, 1, isFile),
-								driveItemWithSize(idx("2", "f"), namex("2", "f"), parent(1), rootID, 2, isFile),
-								driveItemWithSize(idx("3", "f"), namex("3", "f"), parent(1), rootID, 1, isFile),
+								driveItemWithSize(idx(file, 1), namex(file, 1), parent(1), rootID, 1, isFile),
+								driveItemWithSize(idx(file, 2), namex(file, 2), parent(1), rootID, 2, isFile),
+								driveItemWithSize(idx(file, 3), namex(file, 3), parent(1), rootID, 1, isFile),
 							},
 						}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
@@ -3651,7 +3651,7 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 				},
 			},
 			expectedCollections: map[string][]string{
-				fullPath(1): {idx("1", "f"), idx("2", "f")},
+				fullPath(1): {idx(file, 1), idx(file, 2)},
 			},
 		},
 		{
@@ -3671,10 +3671,10 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 						Pages: []mock.NextPage{{
 							Items: []models.DriveItemable{
 								driveRootItem(rootID), // will be present, not needed
-								driveItemWithSize(idx("1", "f"), namex("1", "f"), parent(1), rootID, 1, isFile),
-								driveItemWithSize(idx("1", "d"), namex("1", "d"), parent(1), rootID, 1, isFolder),
-								driveItemWithSize(idx("2", "f"), namex("2", "f"), parent(1, namex("1", "d")), idx("1", "d"), 2, isFile),
-								driveItemWithSize(idx("3", "f"), namex("3", "f"), parent(1, namex("1", "d")), idx("1", "d"), 1, isFile),
+								driveItemWithSize(idx(file, 1), namex(file, 1), parent(1), rootID, 1, isFile),
+								driveItemWithSize(idx(folder, 1), namex(folder, 1), parent(1), rootID, 1, isFolder),
+								driveItemWithSize(idx(file, 2), namex(file, 2), parent(1, namex(folder, 1)), idx(folder, 1), 2, isFile),
+								driveItemWithSize(idx(file, 3), namex(file, 3), parent(1, namex(folder, 1)), idx(folder, 1), 1, isFile),
 							},
 						}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
@@ -3682,8 +3682,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 				},
 			},
 			expectedCollections: map[string][]string{
-				fullPath(1):                  {idx("1", "f")},
-				fullPath(1, namex("1", "d")): {idx("1", "d"), idx("2", "f")},
+				fullPath(1):                   {idx(file, 1)},
+				fullPath(1, namex(folder, 1)): {idx(folder, 1), idx(file, 2)},
 			},
 		},
 		{
@@ -3703,12 +3703,12 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 						Pages: []mock.NextPage{{
 							Items: []models.DriveItemable{
 								driveRootItem(rootID), // will be present, not needed
-								driveItem(idx("1", "f"), namex("1", "f"), parent(1), rootID, isFile),
-								driveItem(idx("2", "f"), namex("2", "f"), parent(1), rootID, isFile),
-								driveItem(idx("3", "f"), namex("3", "f"), parent(1), rootID, isFile),
-								driveItem(idx("4", "f"), namex("4", "f"), parent(1), rootID, isFile),
-								driveItem(idx("5", "f"), namex("5", "f"), parent(1), rootID, isFile),
-								driveItem(idx("6", "f"), namex("6", "f"), parent(1), rootID, isFile),
+								driveItem(idx(file, 1), namex(file, 1), parent(1), rootID, isFile),
+								driveItem(idx(file, 2), namex(file, 2), parent(1), rootID, isFile),
+								driveItem(idx(file, 3), namex(file, 3), parent(1), rootID, isFile),
+								driveItem(idx(file, 4), namex(file, 4), parent(1), rootID, isFile),
+								driveItem(idx(file, 5), namex(file, 5), parent(1), rootID, isFile),
+								driveItem(idx(file, 6), namex(file, 6), parent(1), rootID, isFile),
 							},
 						}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
@@ -3716,7 +3716,7 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 				},
 			},
 			expectedCollections: map[string][]string{
-				fullPath(1): {idx("1", "f"), idx("2", "f"), idx("3", "f")},
+				fullPath(1): {idx(file, 1), idx(file, 2), idx(file, 3)},
 			},
 		},
 		{
@@ -3737,19 +3737,19 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 							{
 								Items: []models.DriveItemable{
 									driveRootItem(rootID), // will be present, not needed
-									driveItem(idx("1", "f"), namex("1", "f"), parent(1), rootID, isFile),
-									driveItem(idx("2", "f"), namex("2", "f"), parent(1), rootID, isFile),
+									driveItem(idx(file, 1), namex(file, 1), parent(1), rootID, isFile),
+									driveItem(idx(file, 2), namex(file, 2), parent(1), rootID, isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
 									// Repeated items shouldn't count against the limit.
-									driveItem(idx("1", "f"), namex("1", "f"), parent(1), rootID, isFile),
-									driveItem(idx("1", "d"), namex("1", "d"), parent(1), rootID, isFolder),
-									driveItem(idx("3", "f"), namex("3", "f"), parent(1, namex("1", "d")), idx("1", "d"), isFile),
-									driveItem(idx("4", "f"), namex("4", "f"), parent(1, namex("1", "d")), idx("1", "d"), isFile),
-									driveItem(idx("5", "f"), namex("5", "f"), parent(1, namex("1", "d")), idx("1", "d"), isFile),
-									driveItem(idx("6", "f"), namex("6", "f"), parent(1, namex("1", "d")), idx("1", "d"), isFile),
+									driveItem(idx(file, 1), namex(file, 1), parent(1), rootID, isFile),
+									driveItem(idx(folder, 1), namex(folder, 1), parent(1), rootID, isFolder),
+									driveItem(idx(file, 3), namex(file, 3), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
+									driveItem(idx(file, 4), namex(file, 4), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
+									driveItem(idx(file, 5), namex(file, 5), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
+									driveItem(idx(file, 6), namex(file, 6), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
 								},
 							},
 						},
@@ -3758,8 +3758,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 				},
 			},
 			expectedCollections: map[string][]string{
-				fullPath(1):                  {idx("1", "f"), idx("2", "f")},
-				fullPath(1, namex("1", "d")): {idx("1", "d"), idx("3", "f")},
+				fullPath(1):                   {idx(file, 1), idx(file, 2)},
+				fullPath(1, namex(folder, 1)): {idx(folder, 1), idx(file, 3)},
 			},
 		},
 		{
@@ -3780,18 +3780,18 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 							{
 								Items: []models.DriveItemable{
 									driveRootItem(rootID), // will be present, not needed
-									driveItem(idx("1", "f"), namex("1", "f"), parent(1), rootID, isFile),
-									driveItem(idx("2", "f"), namex("2", "f"), parent(1), rootID, isFile),
+									driveItem(idx(file, 1), namex(file, 1), parent(1), rootID, isFile),
+									driveItem(idx(file, 2), namex(file, 2), parent(1), rootID, isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
 									driveRootItem(rootID), // will be present, not needed
-									driveItem(idx("1", "d"), namex("1", "d"), parent(1), rootID, isFolder),
-									driveItem(idx("3", "f"), namex("3", "f"), parent(1, namex("1", "d")), idx("1", "d"), isFile),
-									driveItem(idx("4", "f"), namex("4", "f"), parent(1, namex("1", "d")), idx("1", "d"), isFile),
-									driveItem(idx("5", "f"), namex("5", "f"), parent(1, namex("1", "d")), idx("1", "d"), isFile),
-									driveItem(idx("6", "f"), namex("6", "f"), parent(1, namex("1", "d")), idx("1", "d"), isFile),
+									driveItem(idx(folder, 1), namex(folder, 1), parent(1), rootID, isFolder),
+									driveItem(idx(file, 3), namex(file, 3), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
+									driveItem(idx(file, 4), namex(file, 4), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
+									driveItem(idx(file, 5), namex(file, 5), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
+									driveItem(idx(file, 6), namex(file, 6), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
 								},
 							},
 						},
@@ -3800,7 +3800,7 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 				},
 			},
 			expectedCollections: map[string][]string{
-				fullPath(1): {idx("1", "f"), idx("2", "f")},
+				fullPath(1): {idx(file, 1), idx(file, 2)},
 			},
 		},
 		{
@@ -3821,17 +3821,17 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 							{
 								Items: []models.DriveItemable{
 									driveRootItem(rootID), // will be present, not needed
-									driveItem(idx("1", "f"), namex("1", "f"), parent(1), rootID, isFile),
-									driveItem(idx("2", "f"), namex("2", "f"), parent(1), rootID, isFile),
-									driveItem(idx("3", "f"), namex("3", "f"), parent(1), rootID, isFile),
+									driveItem(idx(file, 1), namex(file, 1), parent(1), rootID, isFile),
+									driveItem(idx(file, 2), namex(file, 2), parent(1), rootID, isFile),
+									driveItem(idx(file, 3), namex(file, 3), parent(1), rootID, isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
 									driveRootItem(rootID), // will be present, not needed
-									driveItem(idx("1", "d"), namex("1", "d"), parent(1), rootID, isFolder),
-									driveItem(idx("4", "f"), namex("4", "f"), parent(1, namex("1", "d")), idx("1", "d"), isFile),
-									driveItem(idx("5", "f"), namex("5", "f"), parent(1, namex("1", "d")), idx("1", "d"), isFile),
+									driveItem(idx(folder, 1), namex(folder, 1), parent(1), rootID, isFolder),
+									driveItem(idx(file, 4), namex(file, 4), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
+									driveItem(idx(file, 5), namex(file, 5), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
 								},
 							},
 						},
@@ -3842,8 +3842,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 			expectedCollections: map[string][]string{
 				// Root has an additional item. It's hard to fix that in the code
 				// though.
-				fullPath(1):                  {idx("1", "f"), idx("2", "f")},
-				fullPath(1, namex("1", "d")): {idx("1", "d"), idx("4", "f")},
+				fullPath(1):                   {idx(file, 1), idx(file, 2)},
+				fullPath(1, namex(folder, 1)): {idx(folder, 1), idx(file, 4)},
 			},
 		},
 		{
@@ -3864,19 +3864,19 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 							{
 								Items: []models.DriveItemable{
 									driveRootItem(rootID), // will be present, not needed
-									driveItem(idx("0", "d"), namex("0", "d"), parent(1), rootID, isFolder),
-									driveItem(idx("1", "f"), namex("1", "f"), parent(1, namex("0", "d")), idx("0", "d"), isFile),
-									driveItem(idx("2", "f"), namex("2", "f"), parent(1, namex("0", "d")), idx("0", "d"), isFile),
+									driveItem(idx(folder, 0), namex(folder, 0), parent(1), rootID, isFolder),
+									driveItem(idx(file, 1), namex(file, 1), parent(1, namex(folder, 0)), idx(folder, 0), isFile),
+									driveItem(idx(file, 2), namex(file, 2), parent(1, namex(folder, 0)), idx(folder, 0), isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
 									driveRootItem(rootID), // will be present, not needed
-									driveItem(idx("0", "d"), namex("0", "d"), parent(1), rootID, isFolder),
+									driveItem(idx(folder, 0), namex(folder, 0), parent(1), rootID, isFolder),
 									// Updated item that shouldn't count against the limit a second time.
-									driveItem(idx("2", "f"), namex("2", "f"), parent(1, namex("0", "d")), idx("0", "d"), isFile),
-									driveItem(idx("3", "f"), namex("3", "f"), parent(1, namex("0", "d")), idx("0", "d"), isFile),
-									driveItem(idx("4", "f"), namex("4", "f"), parent(1, namex("0", "d")), idx("0", "d"), isFile),
+									driveItem(idx(file, 2), namex(file, 2), parent(1, namex(folder, 0)), idx(folder, 0), isFile),
+									driveItem(idx(file, 3), namex(file, 3), parent(1, namex(folder, 0)), idx(folder, 0), isFile),
+									driveItem(idx(file, 4), namex(file, 4), parent(1, namex(folder, 0)), idx(folder, 0), isFile),
 								},
 							},
 						},
@@ -3885,8 +3885,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 				},
 			},
 			expectedCollections: map[string][]string{
-				fullPath(1):                  {},
-				fullPath(1, namex("0", "d")): {idx("0", "d"), idx("1", "f"), idx("2", "f"), idx("3", "f")},
+				fullPath(1):                   {},
+				fullPath(1, namex(folder, 0)): {idx(folder, 0), idx(file, 1), idx(file, 2), idx(file, 3)},
 			},
 		},
 		{
@@ -3907,20 +3907,20 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 							{
 								Items: []models.DriveItemable{
 									driveRootItem(rootID), // will be present, not needed
-									driveItem(idx("1", "f"), namex("1", "f"), parent(1), rootID, isFile),
-									driveItem(idx("2", "f"), namex("2", "f"), parent(1), rootID, isFile),
+									driveItem(idx(file, 1), namex(file, 1), parent(1), rootID, isFile),
+									driveItem(idx(file, 2), namex(file, 2), parent(1), rootID, isFile),
 									// Put folder 0 at limit.
-									driveItem(idx("0", "d"), namex("0", "d"), parent(1), rootID, isFolder),
-									driveItem(idx("3", "f"), namex("3", "f"), parent(1, namex("0", "d")), idx("0", "d"), isFile),
-									driveItem(idx("4", "f"), namex("4", "f"), parent(1, namex("0", "d")), idx("0", "d"), isFile),
+									driveItem(idx(folder, 0), namex(folder, 0), parent(1), rootID, isFolder),
+									driveItem(idx(file, 3), namex(file, 3), parent(1, namex(folder, 0)), idx(folder, 0), isFile),
+									driveItem(idx(file, 4), namex(file, 4), parent(1, namex(folder, 0)), idx(folder, 0), isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
 									driveRootItem(rootID), // will be present, not needed
-									driveItem(idx("0", "d"), namex("0", "d"), parent(1), rootID, isFolder),
+									driveItem(idx(folder, 0), namex(folder, 0), parent(1), rootID, isFolder),
 									// Try to move item from root to folder 0 which is already at the limit.
-									driveItem(idx("1", "f"), namex("1", "f"), parent(1, namex("0", "d")), idx("0", "d"), isFile),
+									driveItem(idx(file, 1), namex(file, 1), parent(1, namex(folder, 0)), idx(folder, 0), isFile),
 								},
 							},
 						},
@@ -3929,8 +3929,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 				},
 			},
 			expectedCollections: map[string][]string{
-				fullPath(1):                  {idx("1", "f"), idx("2", "f")},
-				fullPath(1, namex("0", "d")): {idx("0", "d"), idx("3", "f"), idx("4", "f")},
+				fullPath(1):                   {idx(file, 1), idx(file, 2)},
+				fullPath(1, namex(folder, 0)): {idx(folder, 0), idx(file, 3), idx(file, 4)},
 			},
 		},
 		{
@@ -3951,23 +3951,23 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 							{
 								Items: []models.DriveItemable{
 									driveRootItem(rootID), // will be present, not needed
-									driveItem(idx("1", "f"), namex("1", "f"), parent(1), rootID, isFile),
-									driveItem(idx("2", "f"), namex("2", "f"), parent(1), rootID, isFile),
-									driveItem(idx("3", "f"), namex("3", "f"), parent(1), rootID, isFile),
+									driveItem(idx(file, 1), namex(file, 1), parent(1), rootID, isFile),
+									driveItem(idx(file, 2), namex(file, 2), parent(1), rootID, isFile),
+									driveItem(idx(file, 3), namex(file, 3), parent(1), rootID, isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
 									driveRootItem(rootID), // will be present, not needed
-									driveItem(idx("1", "d"), namex("1", "d"), parent(1), rootID, isFolder),
-									driveItem(idx("4", "f"), namex("4", "f"), parent(1, namex("1", "d")), idx("1", "d"), isFile),
+									driveItem(idx(folder, 1), namex(folder, 1), parent(1), rootID, isFolder),
+									driveItem(idx(file, 4), namex(file, 4), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
 									driveRootItem(rootID), // will be present, not needed
-									driveItem(idx("1", "d"), namex("1", "d"), parent(1), rootID, isFolder),
-									driveItem(idx("5", "f"), namex("5", "f"), parent(1, namex("1", "d")), idx("1", "d"), isFile),
+									driveItem(idx(folder, 1), namex(folder, 1), parent(1), rootID, isFolder),
+									driveItem(idx(file, 5), namex(file, 5), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
 								},
 							},
 						},
@@ -3976,8 +3976,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 				},
 			},
 			expectedCollections: map[string][]string{
-				fullPath(1):                  {idx("1", "f"), idx("2", "f"), idx("3", "f")},
-				fullPath(1, namex("1", "d")): {idx("1", "d"), idx("4", "f"), idx("5", "f")},
+				fullPath(1):                   {idx(file, 1), idx(file, 2), idx(file, 3)},
+				fullPath(1, namex(folder, 1)): {idx(folder, 1), idx(file, 4), idx(file, 5)},
 			},
 		},
 		{
@@ -3998,22 +3998,22 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 							{
 								Items: []models.DriveItemable{
 									driveRootItem(rootID), // will be present, not needed
-									driveItem(idx("1", "f"), namex("1", "f"), parent(1), rootID, isFile),
-									driveItem(idx("2", "f"), namex("2", "f"), parent(1), rootID, isFile),
-									driveItem(idx("3", "f"), namex("3", "f"), parent(1), rootID, isFile),
+									driveItem(idx(file, 1), namex(file, 1), parent(1), rootID, isFile),
+									driveItem(idx(file, 2), namex(file, 2), parent(1), rootID, isFile),
+									driveItem(idx(file, 3), namex(file, 3), parent(1), rootID, isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
 									driveRootItem(rootID), // will be present, not needed
-									driveItem(idx("1", "d"), namex("1", "d"), parent(1), rootID, isFolder),
-									driveItem(idx("4", "f"), namex("4", "f"), parent(1, namex("1", "d")), idx("1", "d"), isFile),
-									driveItem(idx("5", "f"), namex("5", "f"), parent(1, namex("1", "d")), idx("1", "d"), isFile),
+									driveItem(idx(folder, 1), namex(folder, 1), parent(1), rootID, isFolder),
+									driveItem(idx(file, 4), namex(file, 4), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
+									driveItem(idx(file, 5), namex(file, 5), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
 									// This container shouldn't be returned.
-									driveItem(idx("2", "d"), namex("2", "d"), parent(1), rootID, isFolder),
-									driveItem(idx("7", "f"), namex("7", "f"), parent(1, namex("2", "d")), idx("2", "d"), isFile),
-									driveItem(idx("8", "f"), namex("8", "f"), parent(1, namex("2", "d")), idx("2", "d"), isFile),
-									driveItem(idx("9", "f"), namex("9", "f"), parent(1, namex("2", "d")), idx("2", "d"), isFile),
+									driveItem(idx(folder, 2), namex(folder, 2), parent(1), rootID, isFolder),
+									driveItem(idx(file, 7), namex(file, 7), parent(1, namex(folder, 2)), idx(folder, 2), isFile),
+									driveItem(idx(file, 8), namex(file, 8), parent(1, namex(folder, 2)), idx(folder, 2), isFile),
+									driveItem(idx(file, 9), namex(file, 9), parent(1, namex(folder, 2)), idx(folder, 2), isFile),
 								},
 							},
 						},
@@ -4022,8 +4022,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 				},
 			},
 			expectedCollections: map[string][]string{
-				fullPath(1):                  {idx("1", "f"), idx("2", "f"), idx("3", "f")},
-				fullPath(1, namex("1", "d")): {idx("1", "d"), idx("4", "f"), idx("5", "f")},
+				fullPath(1):                   {idx(file, 1), idx(file, 2), idx(file, 3)},
+				fullPath(1, namex(folder, 1)): {idx(folder, 1), idx(file, 4), idx(file, 5)},
 			},
 		},
 		{
@@ -4044,27 +4044,27 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 							{
 								Items: []models.DriveItemable{
 									driveRootItem(rootID), // will be present, not needed
-									driveItem(idx("1", "f"), namex("1", "f"), parent(1), rootID, isFile),
-									driveItem(idx("2", "f"), namex("2", "f"), parent(1), rootID, isFile),
-									driveItem(idx("3", "f"), namex("3", "f"), parent(1), rootID, isFile),
+									driveItem(idx(file, 1), namex(file, 1), parent(1), rootID, isFile),
+									driveItem(idx(file, 2), namex(file, 2), parent(1), rootID, isFile),
+									driveItem(idx(file, 3), namex(file, 3), parent(1), rootID, isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
 									driveRootItem(rootID), // will be present, not needed
-									driveItem(idx("1", "d"), namex("1", "d"), parent(1), rootID, isFolder),
-									driveItem(idx("4", "f"), namex("4", "f"), parent(1, namex("1", "d")), idx("1", "d"), isFile),
-									driveItem(idx("5", "f"), namex("5", "f"), parent(1, namex("1", "d")), idx("1", "d"), isFile),
+									driveItem(idx(folder, 1), namex(folder, 1), parent(1), rootID, isFolder),
+									driveItem(idx(file, 4), namex(file, 4), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
+									driveItem(idx(file, 5), namex(file, 5), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
 									driveRootItem(rootID), // will be present, not needed
 									// This container shouldn't be returned.
-									driveItem(idx("2", "d"), namex("2", "d"), parent(1), rootID, isFolder),
-									driveItem(idx("7", "f"), namex("7", "f"), parent(1, namex("2", "d")), idx("2", "d"), isFile),
-									driveItem(idx("8", "f"), namex("8", "f"), parent(1, namex("2", "d")), idx("2", "d"), isFile),
-									driveItem(idx("9", "f"), namex("9", "f"), parent(1, namex("2", "d")), idx("2", "d"), isFile),
+									driveItem(idx(folder, 2), namex(folder, 2), parent(1), rootID, isFolder),
+									driveItem(idx(file, 7), namex(file, 7), parent(1, namex(folder, 2)), idx(folder, 2), isFile),
+									driveItem(idx(file, 8), namex(file, 8), parent(1, namex(folder, 2)), idx(folder, 2), isFile),
+									driveItem(idx(file, 9), namex(file, 9), parent(1, namex(folder, 2)), idx(folder, 2), isFile),
 								},
 							},
 						},
@@ -4073,8 +4073,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 				},
 			},
 			expectedCollections: map[string][]string{
-				fullPath(1):                  {idx("1", "f"), idx("2", "f"), idx("3", "f")},
-				fullPath(1, namex("1", "d")): {idx("1", "d"), idx("4", "f"), idx("5", "f")},
+				fullPath(1):                   {idx(file, 1), idx(file, 2), idx(file, 3)},
+				fullPath(1, namex(folder, 1)): {idx(folder, 1), idx(file, 4), idx(file, 5)},
 			},
 		},
 		{
@@ -4095,11 +4095,11 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 							{
 								Items: []models.DriveItemable{
 									driveRootItem(rootID), // will be present, not needed
-									driveItem(idx("1", "f"), namex("1", "f"), parent(1), rootID, isFile),
-									driveItem(idx("2", "f"), namex("2", "f"), parent(1), rootID, isFile),
-									driveItem(idx("3", "f"), namex("3", "f"), parent(1), rootID, isFile),
-									driveItem(idx("4", "f"), namex("4", "f"), parent(1), rootID, isFile),
-									driveItem(idx("5", "f"), namex("5", "f"), parent(1), rootID, isFile),
+									driveItem(idx(file, 1), namex(file, 1), parent(1), rootID, isFile),
+									driveItem(idx(file, 2), namex(file, 2), parent(1), rootID, isFile),
+									driveItem(idx(file, 3), namex(file, 3), parent(1), rootID, isFile),
+									driveItem(idx(file, 4), namex(file, 4), parent(1), rootID, isFile),
+									driveItem(idx(file, 5), namex(file, 5), parent(1), rootID, isFile),
 								},
 							},
 						},
@@ -4110,11 +4110,11 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 							{
 								Items: []models.DriveItemable{
 									driveRootItem(rootID), // will be present, not needed
-									driveItem(idx("1", "f"), namex("1", "f"), parent(2), rootID, isFile),
-									driveItem(idx("2", "f"), namex("2", "f"), parent(2), rootID, isFile),
-									driveItem(idx("3", "f"), namex("3", "f"), parent(2), rootID, isFile),
-									driveItem(idx("4", "f"), namex("4", "f"), parent(2), rootID, isFile),
-									driveItem(idx("5", "f"), namex("5", "f"), parent(2), rootID, isFile),
+									driveItem(idx(file, 1), namex(file, 1), parent(2), rootID, isFile),
+									driveItem(idx(file, 2), namex(file, 2), parent(2), rootID, isFile),
+									driveItem(idx(file, 3), namex(file, 3), parent(2), rootID, isFile),
+									driveItem(idx(file, 4), namex(file, 4), parent(2), rootID, isFile),
+									driveItem(idx(file, 5), namex(file, 5), parent(2), rootID, isFile),
 								},
 							},
 						},
@@ -4123,8 +4123,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 				},
 			},
 			expectedCollections: map[string][]string{
-				fullPath(1): {idx("1", "f"), idx("2", "f"), idx("3", "f")},
-				fullPath(2): {idx("1", "f"), idx("2", "f"), idx("3", "f")},
+				fullPath(1): {idx(file, 1), idx(file, 2), idx(file, 3)},
+				fullPath(2): {idx(file, 1), idx(file, 2), idx(file, 3)},
 			},
 		},
 		{
@@ -4144,23 +4144,23 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 							{
 								Items: []models.DriveItemable{
 									driveRootItem(rootID), // will be present, not needed
-									driveItem(idx("1", "f"), namex("1", "f"), parent(1), rootID, isFile),
-									driveItem(idx("2", "f"), namex("2", "f"), parent(1), rootID, isFile),
-									driveItem(idx("3", "f"), namex("3", "f"), parent(1), rootID, isFile),
+									driveItem(idx(file, 1), namex(file, 1), parent(1), rootID, isFile),
+									driveItem(idx(file, 2), namex(file, 2), parent(1), rootID, isFile),
+									driveItem(idx(file, 3), namex(file, 3), parent(1), rootID, isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
 									driveRootItem(rootID), // will be present, not needed
-									driveItem(idx("1", "d"), namex("1", "d"), parent(1), rootID, isFolder),
-									driveItem(idx("4", "f"), namex("4", "f"), parent(1, namex("1", "d")), idx("1", "d"), isFile),
+									driveItem(idx(folder, 1), namex(folder, 1), parent(1), rootID, isFolder),
+									driveItem(idx(file, 4), namex(file, 4), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
 									driveRootItem(rootID), // will be present, not needed
-									driveItem(idx("1", "d"), namex("1", "d"), parent(1), rootID, isFolder),
-									driveItem(idx("5", "f"), namex("5", "f"), parent(1, namex("1", "d")), idx("1", "d"), isFile),
+									driveItem(idx(folder, 1), namex(folder, 1), parent(1), rootID, isFolder),
+									driveItem(idx(file, 5), namex(file, 5), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
 								},
 							},
 						},
@@ -4169,8 +4169,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 				},
 			},
 			expectedCollections: map[string][]string{
-				fullPath(1):                  {idx("1", "f"), idx("2", "f"), idx("3", "f")},
-				fullPath(1, namex("1", "d")): {idx("1", "d"), idx("4", "f"), idx("5", "f")},
+				fullPath(1):                   {idx(file, 1), idx(file, 2), idx(file, 3)},
+				fullPath(1, namex(folder, 1)): {idx(folder, 1), idx(file, 4), idx(file, 5)},
 			},
 		},
 	}

--- a/src/internal/m365/collection/drive/collections_test.go
+++ b/src/internal/m365/collection/drive/collections_test.go
@@ -3586,12 +3586,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 	drive2.SetName(ptr.To(namex(drive, 2)))
 
 	table := []struct {
-		name string
-		// notPreview denotes that this preview should set the PreviewBackup flag to
-		// false. Using the negation here since most tests *are* checking backup
-		// preview with limits enabled.
-		notPreview bool
-		limits     control.Limits
+		name       string
+		limits     control.PreviewItemLimits
 		drives     []models.Driveable
 		enumerator mock.EnumerateItemsDeltaByDrive
 		// Collection name -> set of item IDs. We can't check item data because
@@ -3600,7 +3596,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 	}{
 		{
 			name: "OneDrive SinglePage ExcludeItemsOverMaxSize",
-			limits: control.Limits{
+			limits: control.PreviewItemLimits{
+				Enabled:              true,
 				MaxItems:             999,
 				MaxItemsPerContainer: 999,
 				MaxContainers:        999,
@@ -3629,7 +3626,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 		},
 		{
 			name: "OneDrive SinglePage SingleFolder ExcludeCombinedItemsOverMaxSize",
-			limits: control.Limits{
+			limits: control.PreviewItemLimits{
+				Enabled:              true,
 				MaxItems:             999,
 				MaxItemsPerContainer: 999,
 				MaxContainers:        999,
@@ -3658,7 +3656,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 		},
 		{
 			name: "OneDrive SinglePage MultipleFolders ExcludeCombinedItemsOverMaxSize",
-			limits: control.Limits{
+			limits: control.PreviewItemLimits{
+				Enabled:              true,
 				MaxItems:             999,
 				MaxItemsPerContainer: 999,
 				MaxContainers:        999,
@@ -3689,7 +3688,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 		},
 		{
 			name: "OneDrive SinglePage SingleFolder ItemLimit",
-			limits: control.Limits{
+			limits: control.PreviewItemLimits{
+				Enabled:              true,
 				MaxItems:             3,
 				MaxItemsPerContainer: 999,
 				MaxContainers:        999,
@@ -3721,7 +3721,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 		},
 		{
 			name: "OneDrive MultiplePages MultipleFolders ItemLimit WithRepeatedItem",
-			limits: control.Limits{
+			limits: control.PreviewItemLimits{
+				Enabled:              true,
 				MaxItems:             3,
 				MaxItemsPerContainer: 999,
 				MaxContainers:        999,
@@ -3763,7 +3764,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 		},
 		{
 			name: "OneDrive MultiplePages PageLimit",
-			limits: control.Limits{
+			limits: control.PreviewItemLimits{
+				Enabled:              true,
 				MaxItems:             999,
 				MaxItemsPerContainer: 999,
 				MaxContainers:        999,
@@ -3803,7 +3805,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 		},
 		{
 			name: "OneDrive MultiplePages PerContainerItemLimit",
-			limits: control.Limits{
+			limits: control.PreviewItemLimits{
+				Enabled:              true,
 				MaxItems:             999,
 				MaxItemsPerContainer: 1,
 				MaxContainers:        999,
@@ -3845,7 +3848,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 		},
 		{
 			name: "OneDrive MultiplePages PerContainerItemLimit ItemUpdated",
-			limits: control.Limits{
+			limits: control.PreviewItemLimits{
+				Enabled:              true,
 				MaxItems:             999,
 				MaxItemsPerContainer: 3,
 				MaxContainers:        999,
@@ -3887,7 +3891,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 		},
 		{
 			name: "OneDrive MultiplePages PerContainerItemLimit MoveItemBetweenFolders",
-			limits: control.Limits{
+			limits: control.PreviewItemLimits{
+				Enabled:              true,
 				MaxItems:             999,
 				MaxItemsPerContainer: 2,
 				MaxContainers:        999,
@@ -3930,7 +3935,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 		},
 		{
 			name: "OneDrive MultiplePages ContainerLimit LastContainerSplitAcrossPages",
-			limits: control.Limits{
+			limits: control.PreviewItemLimits{
+				Enabled:              true,
 				MaxItems:             999,
 				MaxItemsPerContainer: 999,
 				MaxContainers:        2,
@@ -3976,7 +3982,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 		},
 		{
 			name: "OneDrive MultiplePages ContainerLimit NextContainerOnSamePage",
-			limits: control.Limits{
+			limits: control.PreviewItemLimits{
+				Enabled:              true,
 				MaxItems:             999,
 				MaxItemsPerContainer: 999,
 				MaxContainers:        2,
@@ -4021,7 +4028,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 		},
 		{
 			name: "OneDrive MultiplePages ContainerLimit NextContainerOnNextPage",
-			limits: control.Limits{
+			limits: control.PreviewItemLimits{
+				Enabled:              true,
 				MaxItems:             999,
 				MaxItemsPerContainer: 999,
 				MaxContainers:        2,
@@ -4071,7 +4079,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 		},
 		{
 			name: "TwoDrives SeparateLimitAccounting",
-			limits: control.Limits{
+			limits: control.PreviewItemLimits{
+				Enabled:              true,
 				MaxItems:             3,
 				MaxItemsPerContainer: 999,
 				MaxContainers:        999,
@@ -4119,9 +4128,8 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 			},
 		},
 		{
-			name:       "OneDrive PreviewDisabled MinimumLimitsIgnored",
-			notPreview: true,
-			limits: control.Limits{
+			name: "OneDrive PreviewDisabled MinimumLimitsIgnored",
+			limits: control.PreviewItemLimits{
 				MaxItems:             1,
 				MaxItemsPerContainer: 1,
 				MaxContainers:        1,
@@ -4184,8 +4192,7 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits() {
 			mbh.DriveItemEnumeration = test.enumerator
 
 			opts := control.DefaultOptions()
-			opts.ToggleFeatures.PreviewBackup = !test.notPreview
-			opts.ItemLimits = test.limits
+			opts.PreviewLimits = test.limits
 
 			c := NewCollections(
 				mbh,

--- a/src/internal/m365/service/onedrive/mock/handlers.go
+++ b/src/internal/m365/service/onedrive/mock/handlers.go
@@ -331,6 +331,8 @@ func (edi *DriveItemsDeltaPager) NextPage() ([]models.DriveItemable, bool, bool)
 	return np.Items, np.Reset, false
 }
 
+func (edi *DriveItemsDeltaPager) Cancel() {}
+
 func (edi *DriveItemsDeltaPager) Results() (pagers.DeltaUpdate, error) {
 	return edi.DeltaUpdate, edi.Err
 }

--- a/src/pkg/control/options.go
+++ b/src/pkg/control/options.go
@@ -43,7 +43,8 @@ type PreviewItemLimits struct {
 	MaxItems             int
 	MaxItemsPerContainer int
 	MaxContainers        int
-	MaxBytes             int
+	MaxBytes             int64
+	MaxPages             int
 	Enabled              bool
 }
 

--- a/src/pkg/services/m365/api/pagers/pagers.go
+++ b/src/pkg/services/m365/api/pagers/pagers.go
@@ -51,6 +51,7 @@ type nextPage[T any] struct {
 type NextPageResulter[T any] interface {
 	NextPager[T]
 
+	Cancel()
 	Results() (DeltaUpdate, error)
 }
 


### PR DESCRIPTION
Add logic and tests for preview backups in drive-backed services.
Does slightly change a few of the options for preview backup limits

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
