### PR TITLE
move service api to client methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Change file extension of messages export to json to match the content
+- SDK consumption of the /services/m365 package has shifted from independent functions to a client-based api.
+- SDK consumers can now configure the /services/m365 graph api client configuration when constructing a new m365 client.
 
 ### Fixed
 - Handle OneDrive folders being deleted and recreated midway through a backup

--- a/src/cli/backup/groups.go
+++ b/src/cli/backup/groups.go
@@ -156,7 +156,12 @@ func createGroupsCmd(cmd *cobra.Command, args []string) error {
 	// TODO: log/print recoverable errors
 	errs := fault.New(false)
 
-	ins, err := m365.GroupsMap(ctx, *acct, errs)
+	svcCli, err := m365.NewM365Client(ctx, *acct)
+	if err != nil {
+		return Only(ctx, clues.Stack(err))
+	}
+
+	ins, err := svcCli.GroupsMap(ctx, errs)
 	if err != nil {
 		return Only(ctx, clues.Wrap(err, "Failed to retrieve M365 groups"))
 	}

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -157,7 +157,12 @@ func createSharePointCmd(cmd *cobra.Command, args []string) error {
 	// TODO: log/print recoverable errors
 	errs := fault.New(false)
 
-	ins, err := m365.SitesMap(ctx, *acct, errs)
+	svcCli, err := m365.NewM365Client(ctx, *acct)
+	if err != nil {
+		return Only(ctx, clues.Stack(err))
+	}
+
+	ins, err := svcCli.SitesMap(ctx, errs)
 	if err != nil {
 		return Only(ctx, clues.Wrap(err, "Failed to retrieve M365 sites"))
 	}

--- a/src/pkg/services/m365/api/client.go
+++ b/src/pkg/services/m365/api/client.go
@@ -51,8 +51,9 @@ func NewClient(
 	creds account.M365Config,
 	co control.Options,
 	counter *count.Bus,
+	opts ...graph.Option,
 ) (Client, error) {
-	s, err := NewService(creds, counter)
+	s, err := NewService(creds, counter, opts...)
 	if err != nil {
 		return Client{}, err
 	}

--- a/src/pkg/services/m365/groups_test.go
+++ b/src/pkg/services/m365/groups_test.go
@@ -35,8 +35,6 @@ func (suite *GroupsIntgSuite) SetupSuite() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	graph.InitializeConcurrencyLimiter(ctx, true, 4)
-
 	acct := tconfig.NewM365Account(t)
 
 	var err error
@@ -51,8 +49,6 @@ func (suite *GroupsIntgSuite) TestGroupByID() {
 
 	ctx, flush := tester.NewContext(t)
 	defer flush()
-
-	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
 	gid := tconfig.M365TeamID(t)
 
@@ -69,8 +65,6 @@ func (suite *GroupsIntgSuite) TestGroupByID_ByEmail() {
 
 	ctx, flush := tester.NewContext(t)
 	defer flush()
-
-	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
 	gid := tconfig.M365TeamID(t)
 
@@ -96,8 +90,6 @@ func (suite *GroupsIntgSuite) TestGroupByID_notFound() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	graph.InitializeConcurrencyLimiter(ctx, true, 4)
-
 	group, err := suite.cli.GroupByID(ctx, uuid.NewString())
 	require.Nil(t, group)
 	require.ErrorIs(t, err, graph.ErrResourceOwnerNotFound, clues.ToCore(err))
@@ -109,8 +101,6 @@ func (suite *GroupsIntgSuite) TestGroups() {
 
 	ctx, flush := tester.NewContext(t)
 	defer flush()
-
-	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
 	groups, err := suite.cli.Groups(ctx, fault.New(true))
 	assert.NoError(t, err, clues.ToCore(err))
@@ -137,8 +127,6 @@ func (suite *GroupsIntgSuite) TestSitesInGroup() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	graph.InitializeConcurrencyLimiter(ctx, true, 4)
-
 	gid := tconfig.M365TeamID(t)
 
 	sites, err := suite.cli.SitesInGroup(ctx, gid, fault.New(true))
@@ -151,8 +139,6 @@ func (suite *GroupsIntgSuite) TestGroupsMap() {
 
 	ctx, flush := tester.NewContext(t)
 	defer flush()
-
-	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
 	gm, err := suite.cli.GroupsMap(ctx, fault.New(true))
 	assert.NoError(t, err, clues.ToCore(err))

--- a/src/pkg/services/m365/m365.go
+++ b/src/pkg/services/m365/m365.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
+	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
 type client struct {
@@ -20,8 +21,9 @@ type client struct {
 func NewM365Client(
 	ctx context.Context,
 	acct account.Account,
+	opts ...graph.Option,
 ) (client, error) {
-	ac, err := makeAC(ctx, acct)
+	ac, err := makeAC(ctx, acct, opts...)
 	return client{ac}, clues.Stack(err).OrNil()
 }
 
@@ -40,6 +42,7 @@ type getAller[T any] interface {
 func makeAC(
 	ctx context.Context,
 	acct account.Account,
+	opts ...graph.Option,
 ) (api.Client, error) {
 	// exchange service inits a limit to concurrency.
 	api.InitConcurrencyLimit(ctx, path.ExchangeService)

--- a/src/pkg/services/m365/m365.go
+++ b/src/pkg/services/m365/m365.go
@@ -13,6 +13,18 @@ import (
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
 
+type client struct {
+	ac api.Client
+}
+
+func NewM365Client(
+	ctx context.Context,
+	acct account.Account,
+) (client, error) {
+	ac, err := makeAC(ctx, acct)
+	return client{ac}, clues.Stack(err).OrNil()
+}
+
 // ---------------------------------------------------------------------------
 // interfaces & structs
 // ---------------------------------------------------------------------------
@@ -28,9 +40,9 @@ type getAller[T any] interface {
 func makeAC(
 	ctx context.Context,
 	acct account.Account,
-	pst path.ServiceType,
 ) (api.Client, error) {
-	api.InitConcurrencyLimit(ctx, pst)
+	// exchange service inits a limit to concurrency.
+	api.InitConcurrencyLimit(ctx, path.ExchangeService)
 
 	creds, err := acct.M365Config()
 	if err != nil {
@@ -43,6 +55,11 @@ func makeAC(
 		count.New())
 	if err != nil {
 		return api.Client{}, clues.WrapWC(ctx, err, "constructing api client")
+	}
+
+	// run a test to ensure credentials work for the client
+	if err := cli.Access().GetToken(ctx); err != nil {
+		return api.Client{}, clues.Wrap(err, "checking client connection")
 	}
 
 	return cli, nil

--- a/src/pkg/services/m365/m365_test.go
+++ b/src/pkg/services/m365/m365_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 
 	"github.com/alcionai/clues"
-	"github.com/alcionai/corso/src/internal/tester"
-	"github.com/alcionai/corso/src/pkg/account"
-	"github.com/alcionai/corso/src/pkg/credentials"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
+	"github.com/alcionai/corso/src/pkg/account"
 )
 
 type M365IntgSuite struct {
@@ -32,18 +32,7 @@ func (suite *userIntegrationSuite) TestNewM365Client_invalidCredentials() {
 		{
 			name: "Invalid Credentials",
 			acct: func(t *testing.T) account.Account {
-				a, err := account.NewAccount(
-					account.ProviderM365,
-					account.M365Config{
-						M365: credentials.M365{
-							AzureClientID:     "Test",
-							AzureClientSecret: "without",
-						},
-						AzureTenantID: "creds",
-					})
-				require.NoError(t, err, clues.ToCore(err))
-
-				return a
+				return tconfig.NewFakeM365Account(t)
 			},
 		},
 	}

--- a/src/pkg/services/m365/m365_test.go
+++ b/src/pkg/services/m365/m365_test.go
@@ -1,0 +1,62 @@
+package m365
+
+import (
+	"testing"
+
+	"github.com/alcionai/clues"
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/account"
+	"github.com/alcionai/corso/src/pkg/credentials"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type M365IntgSuite struct {
+	tester.Suite
+}
+
+func TestM365IntgSuite(t *testing.T) {
+	suite.Run(t, &M365IntgSuite{
+		Suite: tester.NewIntegrationSuite(
+			t,
+			[][]string{}),
+	})
+}
+
+func (suite *userIntegrationSuite) TestNewM365Client_invalidCredentials() {
+	table := []struct {
+		name string
+		acct func(t *testing.T) account.Account
+	}{
+		{
+			name: "Invalid Credentials",
+			acct: func(t *testing.T) account.Account {
+				a, err := account.NewAccount(
+					account.ProviderM365,
+					account.M365Config{
+						M365: credentials.M365{
+							AzureClientID:     "Test",
+							AzureClientSecret: "without",
+						},
+						AzureTenantID: "creds",
+					})
+				require.NoError(t, err, clues.ToCore(err))
+
+				return a
+			},
+		},
+	}
+
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			_, err := NewM365Client(ctx, test.acct(t))
+			assert.Error(t, err, clues.ToCore(err))
+		})
+	}
+}

--- a/src/pkg/services/m365/m365_test.go
+++ b/src/pkg/services/m365/m365_test.go
@@ -24,6 +24,16 @@ func TestM365IntgSuite(t *testing.T) {
 	})
 }
 
+func (suite *userIntegrationSuite) TestNewM365Client() {
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	_, err := NewM365Client(ctx, tconfig.NewM365Account(t))
+	assert.NoError(t, err, clues.ToCore(err))
+}
+
 func (suite *userIntegrationSuite) TestNewM365Client_invalidCredentials() {
 	table := []struct {
 		name string

--- a/src/pkg/services/m365/sites_test.go
+++ b/src/pkg/services/m365/sites_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
-	"github.com/alcionai/corso/src/pkg/account"
-	"github.com/alcionai/corso/src/pkg/credentials"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
@@ -87,52 +85,6 @@ func (suite *siteIntegrationSuite) TestSites_GetByID() {
 			assert.NotEmpty(t, site.WebURL)
 			assert.NotEmpty(t, site.ID)
 			assert.NotEmpty(t, site.OwnerType)
-		})
-	}
-}
-
-func (suite *siteIntegrationSuite) TestSites_InvalidCredentials() {
-	table := []struct {
-		name string
-		acct func(t *testing.T) account.Account
-	}{
-		{
-			name: "Invalid Credentials",
-			acct: func(t *testing.T) account.Account {
-				a, err := account.NewAccount(
-					account.ProviderM365,
-					account.M365Config{
-						M365: credentials.M365{
-							AzureClientID:     "Test",
-							AzureClientSecret: "without",
-						},
-						AzureTenantID: "data",
-					})
-				require.NoError(t, err, clues.ToCore(err))
-
-				return a
-			},
-		},
-		{
-			name: "Empty Credentials",
-			acct: func(t *testing.T) account.Account {
-				// intentionally swallowing the error here
-				a, _ := account.NewAccount(account.ProviderM365)
-				return a
-			},
-		},
-	}
-
-	for _, test := range table {
-		suite.Run(test.name, func() {
-			t := suite.T()
-
-			ctx, flush := tester.NewContext(t)
-			defer flush()
-
-			sites, err := suite.cli.Sites(ctx, fault.New(true))
-			assert.Empty(t, sites, "returned some sites")
-			assert.NotNil(t, err)
 		})
 	}
 }

--- a/src/pkg/services/m365/sites_test.go
+++ b/src/pkg/services/m365/sites_test.go
@@ -24,6 +24,7 @@ import (
 
 type siteIntegrationSuite struct {
 	tester.Suite
+	cli client
 }
 
 func TestSiteIntegrationSuite(t *testing.T) {
@@ -35,10 +36,18 @@ func TestSiteIntegrationSuite(t *testing.T) {
 }
 
 func (suite *siteIntegrationSuite) SetupSuite() {
-	ctx, flush := tester.NewContext(suite.T())
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	graph.InitializeConcurrencyLimiter(ctx, true, 4)
+	acct := tconfig.NewM365Account(t)
+
+	var err error
+
+	// will init the concurrency limiter
+	suite.cli, err = NewM365Client(ctx, acct)
+	require.NoError(t, err, clues.ToCore(err))
 }
 
 func (suite *siteIntegrationSuite) TestSites() {
@@ -47,9 +56,7 @@ func (suite *siteIntegrationSuite) TestSites() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	acct := tconfig.NewM365Account(t)
-
-	sites, err := Sites(ctx, acct, fault.New(true))
+	sites, err := suite.cli.Sites(ctx, fault.New(true))
 	assert.NoError(t, err, clues.ToCore(err))
 	assert.NotEmpty(t, sites)
 
@@ -68,16 +75,14 @@ func (suite *siteIntegrationSuite) TestSites_GetByID() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	acct := tconfig.NewM365Account(t)
-
-	sites, err := Sites(ctx, acct, fault.New(true))
+	sites, err := suite.cli.Sites(ctx, fault.New(true))
 	assert.NoError(t, err, clues.ToCore(err))
 	assert.NotEmpty(t, sites)
 
 	for _, s := range sites {
 		suite.Run("site_"+s.ID, func() {
 			t := suite.T()
-			site, err := SiteByID(ctx, acct, s.ID)
+			site, err := suite.cli.SiteByID(ctx, s.ID)
 			require.NoError(t, err, clues.ToCore(err))
 			assert.NotEmpty(t, site.WebURL)
 			assert.NotEmpty(t, site.ID)
@@ -125,7 +130,7 @@ func (suite *siteIntegrationSuite) TestSites_InvalidCredentials() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			sites, err := Sites(ctx, test.acct(t), fault.New(true))
+			sites, err := suite.cli.Sites(ctx, fault.New(true))
 			assert.Empty(t, sites, "returned some sites")
 			assert.NotNil(t, err)
 		})

--- a/src/pkg/services/m365/users_test.go
+++ b/src/pkg/services/m365/users_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
-	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
 type userIntegrationSuite struct {
@@ -48,8 +47,6 @@ func (suite *userIntegrationSuite) TestUsersCompat_HasNoInfo() {
 
 	ctx, flush := tester.NewContext(t)
 	defer flush()
-
-	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
 	users, err := suite.cli.UsersCompatNoInfo(ctx)
 	assert.NoError(t, err, clues.ToCore(err))
@@ -204,7 +201,6 @@ func (suite *userIntegrationSuite) TestUserGetMailboxInfo() {
 func (suite *userIntegrationSuite) TestUserAssignedLicenses() {
 	t := suite.T()
 	ctx, flush := tester.NewContext(t)
-	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
 	defer flush()
 

--- a/src/pkg/services/m365/users_test.go
+++ b/src/pkg/services/m365/users_test.go
@@ -11,15 +11,13 @@ import (
 
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
-	"github.com/alcionai/corso/src/pkg/account"
-	"github.com/alcionai/corso/src/pkg/credentials"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
 type userIntegrationSuite struct {
 	tester.Suite
-	acct account.Account
+	cli client
 }
 
 func TestUserIntegrationSuite(t *testing.T) {
@@ -31,12 +29,18 @@ func TestUserIntegrationSuite(t *testing.T) {
 }
 
 func (suite *userIntegrationSuite) SetupSuite() {
-	ctx, flush := tester.NewContext(suite.T())
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	graph.InitializeConcurrencyLimiter(ctx, true, 4)
+	acct := tconfig.NewM365Account(t)
 
-	suite.acct = tconfig.NewM365Account(suite.T())
+	var err error
+
+	// will init the concurrency limiter
+	suite.cli, err = NewM365Client(ctx, acct)
+	require.NoError(t, err, clues.ToCore(err))
 }
 
 func (suite *userIntegrationSuite) TestUsersCompat_HasNoInfo() {
@@ -47,9 +51,7 @@ func (suite *userIntegrationSuite) TestUsersCompat_HasNoInfo() {
 
 	graph.InitializeConcurrencyLimiter(ctx, true, 4)
 
-	acct := tconfig.NewM365Account(suite.T())
-
-	users, err := UsersCompatNoInfo(ctx, acct)
+	users, err := suite.cli.UsersCompatNoInfo(ctx)
 	assert.NoError(t, err, clues.ToCore(err))
 	assert.NotEmpty(t, users)
 
@@ -66,7 +68,6 @@ func (suite *userIntegrationSuite) TestUsersCompat_HasNoInfo() {
 
 func (suite *userIntegrationSuite) TestUserHasMailbox() {
 	t := suite.T()
-	acct := tconfig.NewM365Account(t)
 	userID := tconfig.M365UserID(t)
 
 	table := []struct {
@@ -92,7 +93,7 @@ func (suite *userIntegrationSuite) TestUserHasMailbox() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			enabled, err := UserHasMailbox(ctx, acct, test.user)
+			enabled, err := suite.cli.UserHasMailbox(ctx, test.user)
 			require.NoError(t, err, clues.ToCore(err))
 			assert.Equal(t, test.expect, enabled)
 		})
@@ -101,7 +102,6 @@ func (suite *userIntegrationSuite) TestUserHasMailbox() {
 
 func (suite *userIntegrationSuite) TestUserHasDrive() {
 	t := suite.T()
-	acct := tconfig.NewM365Account(t)
 	userID := tconfig.M365UserID(t)
 
 	table := []struct {
@@ -130,7 +130,7 @@ func (suite *userIntegrationSuite) TestUserHasDrive() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			enabled, err := UserHasDrives(ctx, acct, test.user)
+			enabled, err := suite.cli.UserHasDrives(ctx, test.user)
 			test.expectErr(t, err, clues.ToCore(err))
 			assert.Equal(t, test.expect, enabled)
 		})
@@ -139,7 +139,6 @@ func (suite *userIntegrationSuite) TestUserHasDrive() {
 
 func (suite *userIntegrationSuite) TestUserGetMailboxInfo() {
 	t := suite.T()
-	acct := tconfig.NewM365Account(t)
 	userID := tconfig.M365UserID(t)
 
 	table := []struct {
@@ -195,47 +194,9 @@ func (suite *userIntegrationSuite) TestUserGetMailboxInfo() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			info, err := UserGetMailboxInfo(ctx, acct, test.user)
+			info, err := suite.cli.UserGetMailboxInfo(ctx, test.user)
 			test.expectErr(t, err, clues.ToCore(err))
 			test.expect(t, info)
-		})
-	}
-}
-
-func (suite *userIntegrationSuite) TestUsers_InvalidCredentials() {
-	table := []struct {
-		name string
-		acct func(t *testing.T) account.Account
-	}{
-		{
-			name: "Invalid Credentials",
-			acct: func(t *testing.T) account.Account {
-				a, err := account.NewAccount(
-					account.ProviderM365,
-					account.M365Config{
-						M365: credentials.M365{
-							AzureClientID:     "Test",
-							AzureClientSecret: "without",
-						},
-						AzureTenantID: "data",
-					})
-				require.NoError(t, err, clues.ToCore(err))
-
-				return a
-			},
-		},
-	}
-
-	for _, test := range table {
-		suite.Run(test.name, func() {
-			t := suite.T()
-
-			ctx, flush := tester.NewContext(t)
-			defer flush()
-
-			users, err := UsersCompatNoInfo(ctx, test.acct(t))
-			assert.Empty(t, users, "returned some users")
-			assert.NotNil(t, err)
 		})
 	}
 }
@@ -275,10 +236,7 @@ func (suite *userIntegrationSuite) TestUserAssignedLicenses() {
 
 	for _, run := range runs {
 		t.Run(run.name, func(t *testing.T) {
-			user, err := UserAssignedLicenses(
-				ctx,
-				suite.acct,
-				run.userID)
+			user, err := suite.cli.UserAssignedLicenses(ctx, run.userID)
 			run.expectErr(t, err, clues.ToCore(err))
 			assert.Equal(t, run.expect, user)
 		})


### PR DESCRIPTION
sdk consumers need a way to configure the graph api client options when using the services api.  This is the first in a two-part change to expose those options.  This step moves the api to a client-based set of methods instead of free functions.  The next step will add client configuration to the service client.

---

#### Does this PR need a docs update or release note?

- [x] :clock1: Yes, but in a later PR

#### Type of change

- [x] :sunflower: Feature

#### Test Plan

- [x] :green_heart: E2E
