### PR TITLE
add graph options to services client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Change file extension of messages export to json to match the content
+- SDK consumption of the /services/m365 package has shifted from independent functions to a client-based api.
+- SDK consumers can now configure the /services/m365 graph api client configuration when constructing a new m365 client.
 
 ### Fixed
 - Handle OneDrive folders being deleted and recreated midway through a backup

--- a/src/pkg/services/m365/api/client.go
+++ b/src/pkg/services/m365/api/client.go
@@ -51,8 +51,9 @@ func NewClient(
 	creds account.M365Config,
 	co control.Options,
 	counter *count.Bus,
+	opts ...graph.Option,
 ) (Client, error) {
-	s, err := NewService(creds, counter)
+	s, err := NewService(creds, counter, opts...)
 	if err != nil {
 		return Client{}, err
 	}

--- a/src/pkg/services/m365/m365.go
+++ b/src/pkg/services/m365/m365.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
+	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
 type client struct {
@@ -20,8 +21,9 @@ type client struct {
 func NewM365Client(
 	ctx context.Context,
 	acct account.Account,
+	opts ...graph.Option,
 ) (client, error) {
-	ac, err := makeAC(ctx, acct)
+	ac, err := makeAC(ctx, acct, opts...)
 	return client{ac}, clues.Stack(err).OrNil()
 }
 
@@ -40,6 +42,7 @@ type getAller[T any] interface {
 func makeAC(
 	ctx context.Context,
 	acct account.Account,
+	opts ...graph.Option,
 ) (api.Client, error) {
 	// exchange service inits a limit to concurrency.
 	api.InitConcurrencyLimit(ctx, path.ExchangeService)

--- a/src/pkg/services/m365/m365_test.go
+++ b/src/pkg/services/m365/m365_test.go
@@ -24,6 +24,16 @@ func TestM365IntgSuite(t *testing.T) {
 	})
 }
 
+func (suite *userIntegrationSuite) TestNewM365Client() {
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	_, err := NewM365Client(ctx, tconfig.NewM365Account(t))
+	assert.NoError(t, err, clues.ToCore(err))
+}
+
 func (suite *userIntegrationSuite) TestNewM365Client_invalidCredentials() {
 	table := []struct {
 		name string


### PR DESCRIPTION
allows sdk callers to configure the client behavior when using the services/m365 package.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

#### Type of change

- [x] :sunflower: Feature


#### Test Plan

- [x] :green_heart: E2E
