### PR TITLE
bump xsync to v3

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/microsoftgraph/msgraph-sdk-go v1.25.0
 	github.com/microsoftgraph/msgraph-sdk-go-core v1.0.0
 	github.com/pkg/errors v0.9.1
+	github.com/puzpuzpuz/xsync/v3 v3.0.2
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible
 	github.com/spatialcurrent/go-lazy v0.0.0-20211115014721-47315cc003d1
 	github.com/spf13/cast v1.5.1
@@ -63,7 +64,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
-	github.com/puzpuzpuz/xsync/v3 v3.0.2 // indirect
 	github.com/sagikazarmark/locafero v0.3.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect

--- a/src/go.mod
+++ b/src/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/microsoftgraph/msgraph-sdk-go v1.25.0
 	github.com/microsoftgraph/msgraph-sdk-go-core v1.0.0
 	github.com/pkg/errors v0.9.1
-	github.com/puzpuzpuz/xsync/v2 v2.5.1
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible
 	github.com/spatialcurrent/go-lazy v0.0.0-20211115014721-47315cc003d1
 	github.com/spf13/cast v1.5.1
@@ -64,6 +63,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
+	github.com/puzpuzpuz/xsync/v3 v3.0.2 // indirect
 	github.com/sagikazarmark/locafero v0.3.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -379,6 +379,8 @@ github.com/prometheus/procfs v0.11.1 h1:xRC8Iq1yyca5ypa9n1EZnWZkt7dwcoRPQwX/5gwa
 github.com/prometheus/procfs v0.11.1/go.mod h1:eesXgaPo1q7lBpVMoMy0ZOFTth9hBn4W/y0/p/ScXhY=
 github.com/puzpuzpuz/xsync/v2 v2.5.1 h1:mVGYAvzDSu52+zaGyNjC+24Xw2bQi3kTr4QJ6N9pIIU=
 github.com/puzpuzpuz/xsync/v2 v2.5.1/go.mod h1:gD2H2krq/w52MfPLE+Uy64TzJDVY7lP2znR9qmR35kU=
+github.com/puzpuzpuz/xsync/v3 v3.0.2 h1:3yESHrRFYr6xzkz61LLkvNiPFXxJEAABanTQpKbAaew=
+github.com/puzpuzpuz/xsync/v3 v3.0.2/go.mod h1:VjzYrABPabuM4KyBh1Ftq6u8nhwY5tBPKP9jpmh0nnA=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/src/go.sum
+++ b/src/go.sum
@@ -377,8 +377,6 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.11.1 h1:xRC8Iq1yyca5ypa9n1EZnWZkt7dwcoRPQwX/5gwaUuI=
 github.com/prometheus/procfs v0.11.1/go.mod h1:eesXgaPo1q7lBpVMoMy0ZOFTth9hBn4W/y0/p/ScXhY=
-github.com/puzpuzpuz/xsync/v2 v2.5.1 h1:mVGYAvzDSu52+zaGyNjC+24Xw2bQi3kTr4QJ6N9pIIU=
-github.com/puzpuzpuz/xsync/v2 v2.5.1/go.mod h1:gD2H2krq/w52MfPLE+Uy64TzJDVY7lP2znR9qmR35kU=
 github.com/puzpuzpuz/xsync/v3 v3.0.2 h1:3yESHrRFYr6xzkz61LLkvNiPFXxJEAABanTQpKbAaew=
 github.com/puzpuzpuz/xsync/v3 v3.0.2/go.mod h1:VjzYrABPabuM4KyBh1Ftq6u8nhwY5tBPKP9jpmh0nnA=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/src/internal/common/syncd/map.go
+++ b/src/internal/common/syncd/map.go
@@ -1,0 +1,29 @@
+package syncd
+
+import (
+	"github.com/puzpuzpuz/xsync/v3"
+)
+
+// MapTo produces a threadsafe map[string]V
+type MapTo[V any] struct {
+	xmo *xsync.MapOf[string, V]
+}
+
+// NewMapTo produces a new threadsafe mapOf[string]V
+func NewMapTo[V any]() MapTo[V] {
+	return MapTo[V]{
+		xmo: xsync.NewMapOf[string, V](),
+	}
+}
+
+func (m MapTo[V]) Store(k string, v V) {
+	m.xmo.Store(k, v)
+}
+
+func (m MapTo[V]) Load(k string) (V, bool) {
+	return m.xmo.Load(k)
+}
+
+func (m MapTo[V]) Size() int {
+	return m.xmo.Size()
+}

--- a/src/internal/m365/collection/drive/permission.go
+++ b/src/internal/m365/collection/drive/permission.go
@@ -7,9 +7,9 @@ import (
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/drives"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
-	"github.com/puzpuzpuz/xsync/v2"
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/internal/common/syncd"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive/metadata"
 	"github.com/alcionai/corso/src/internal/version"
@@ -21,7 +21,7 @@ import (
 
 func getParentMetadata(
 	parentPath path.Path,
-	parentDirToMeta *xsync.MapOf[string, metadata.Metadata],
+	parentDirToMeta syncd.MapTo[metadata.Metadata],
 ) (metadata.Metadata, error) {
 	parentMeta, ok := parentDirToMeta.Load(parentPath.String())
 	if !ok {
@@ -91,7 +91,7 @@ func getCollectionMetadata(
 func computePreviousLinkShares(
 	ctx context.Context,
 	originDir path.Path,
-	parentMetas *xsync.MapOf[string, metadata.Metadata],
+	parentMetas syncd.MapTo[metadata.Metadata],
 ) ([]metadata.LinkShare, error) {
 	linkShares := []metadata.LinkShare{}
 	ctx = clues.Add(ctx, "origin_dir", originDir)
@@ -141,7 +141,7 @@ func computePreviousMetadata(
 	ctx context.Context,
 	originDir path.Path,
 	// map parent dir -> parent's metadata
-	parentMetas *xsync.MapOf[string, metadata.Metadata],
+	parentMetas syncd.MapTo[metadata.Metadata],
 ) (metadata.Metadata, error) {
 	var (
 		parent path.Path
@@ -194,7 +194,7 @@ func UpdatePermissions(
 	driveID string,
 	itemID string,
 	permAdded, permRemoved []metadata.Permission,
-	oldPermIDToNewID *xsync.MapOf[string, string],
+	oldPermIDToNewID syncd.MapTo[string],
 	errs *fault.Bus,
 ) error {
 	el := errs.Local()
@@ -303,7 +303,7 @@ func UpdateLinkShares(
 	driveID string,
 	itemID string,
 	lsAdded, lsRemoved []metadata.LinkShare,
-	oldLinkShareIDToNewID *xsync.MapOf[string, string],
+	oldLinkShareIDToNewID syncd.MapTo[string],
 	errs *fault.Bus,
 ) (bool, error) {
 	// You can only delete inherited sharing links the first time you

--- a/src/internal/m365/collection/drive/permission_test.go
+++ b/src/internal/m365/collection/drive/permission_test.go
@@ -4,11 +4,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/puzpuzpuz/xsync/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/common/syncd"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive/metadata"
 	odConsts "github.com/alcionai/corso/src/internal/m365/service/onedrive/consts"
 	"github.com/alcionai/corso/src/internal/tester"
@@ -157,7 +157,7 @@ func runComputeParentPermissionsTest(
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			input := xsync.NewMapOf[metadata.Metadata]()
+			input := syncd.NewMapTo[metadata.Metadata]()
 			for k, v := range test.parentPerms {
 				input.Store(k, v)
 			}

--- a/src/internal/m365/collection/drive/restore_caches.go
+++ b/src/internal/m365/collection/drive/restore_caches.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
-	"github.com/puzpuzpuz/xsync/v2"
 
 	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/internal/common/syncd"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive/metadata"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
@@ -24,12 +24,12 @@ type driveInfo struct {
 type restoreCaches struct {
 	BackupDriveIDName     idname.Cacher
 	collisionKeyToItemID  map[string]api.DriveItemIDType
-	DriveIDToDriveInfo    *xsync.MapOf[string, driveInfo]
-	DriveNameToDriveInfo  *xsync.MapOf[string, driveInfo]
+	DriveIDToDriveInfo    syncd.MapTo[driveInfo]
+	DriveNameToDriveInfo  syncd.MapTo[driveInfo]
 	Folders               *folderCache
-	OldLinkShareIDToNewID *xsync.MapOf[string, string]
-	OldPermIDToNewID      *xsync.MapOf[string, string]
-	ParentDirToMeta       *xsync.MapOf[string, metadata.Metadata]
+	OldLinkShareIDToNewID syncd.MapTo[string]
+	OldPermIDToNewID      syncd.MapTo[string]
+	ParentDirToMeta       syncd.MapTo[metadata.Metadata]
 
 	pool sync.Pool
 }
@@ -98,12 +98,12 @@ func NewRestoreCaches(
 	return &restoreCaches{
 		BackupDriveIDName:     backupDriveIDNames,
 		collisionKeyToItemID:  map[string]api.DriveItemIDType{},
-		DriveIDToDriveInfo:    xsync.NewMapOf[driveInfo](),
-		DriveNameToDriveInfo:  xsync.NewMapOf[driveInfo](),
+		DriveIDToDriveInfo:    syncd.NewMapTo[driveInfo](),
+		DriveNameToDriveInfo:  syncd.NewMapTo[driveInfo](),
 		Folders:               NewFolderCache(),
-		OldLinkShareIDToNewID: xsync.NewMapOf[string](),
-		OldPermIDToNewID:      xsync.NewMapOf[string](),
-		ParentDirToMeta:       xsync.NewMapOf[metadata.Metadata](),
+		OldLinkShareIDToNewID: syncd.NewMapTo[string](),
+		OldPermIDToNewID:      syncd.NewMapTo[string](),
+		ParentDirToMeta:       syncd.NewMapTo[metadata.Metadata](),
 		// Buffer pool for uploads
 		pool: sync.Pool{
 			New: func() any {

--- a/src/internal/operations/test/onedrive_test.go
+++ b/src/internal/operations/test/onedrive_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/drives"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
-	"github.com/puzpuzpuz/xsync/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -19,6 +18,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/dttm"
 	inMock "github.com/alcionai/corso/src/internal/common/idname/mock"
 	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/internal/common/syncd"
 	"github.com/alcionai/corso/src/internal/events"
 	evmock "github.com/alcionai/corso/src/internal/events/mock"
 	"github.com/alcionai/corso/src/internal/m365"
@@ -351,7 +351,7 @@ func runDriveIncrementalTest(
 		newFileName = "new_file.txt"
 		newFileID   string
 
-		permissionIDMappings = xsync.NewMapOf[string]()
+		permissionIDMappings = syncd.NewMapTo[string]()
 		writePerm            = metadata.Permission{
 			ID:       "perm-id",
 			Roles:    []string{"write"},

--- a/src/pkg/count/count.go
+++ b/src/pkg/count/count.go
@@ -1,7 +1,7 @@
 package count
 
 import (
-	"github.com/puzpuzpuz/xsync/v2"
+	"github.com/puzpuzpuz/xsync/v3"
 )
 
 // Bus handles threadsafe counting of arbitrarily keyed metrics.
@@ -12,7 +12,7 @@ type Bus struct {
 
 func New() *Bus {
 	return &Bus{
-		stats: xsync.NewMapOf[*xsync.Counter](),
+		stats: xsync.NewMapOf[string, *xsync.Counter](),
 	}
 }
 


### PR DESCRIPTION
three changes
1. bumps the xsync package to v3
2. creates a common package for synced maps
3. replaces all xsync MapOf imports with the new common/syncd package.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
