### PR TITLE
Add connection timeout retries to item retry handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handle OneDrive folders being deleted and recreated midway through a backup
 - Automatically re-run a full delta query on incremental if the prior backup is found to have malformed prior-state information.
 - Retry drive item permission downloads during long-running backups after the jwt token expires and refreshes.
+- Retry item downloads during connection timeouts.
 
 ## [v0.15.0] (beta) - 2023-10-31
 

--- a/src/internal/common/readers/retry_handler.go
+++ b/src/internal/common/readers/retry_handler.go
@@ -41,8 +41,7 @@ func isTimeoutErr(err error) bool {
 		return err.Timeout()
 	}
 
-	return errors.Is(err, context.Canceled) ||
-		errors.Is(err, context.DeadlineExceeded) ||
+	return errors.Is(err, os.ErrDeadlineExceeded) ||
 		errors.Is(err, http.ErrHandlerTimeout) ||
 		os.IsTimeout(err)
 }

--- a/src/internal/common/readers/retry_handler.go
+++ b/src/internal/common/readers/retry_handler.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
+	"os"
 	"syscall"
 	"time"
 
@@ -29,6 +32,19 @@ const (
 var retryErrs = []error{
 	syscall.ECONNRESET,
 	io.ErrUnexpectedEOF,
+}
+
+// TODO(pandeyabs): Consolidate error funcs with retryErrs slice.
+func isTimeoutErr(err error) bool {
+	switch err := err.(type) {
+	case *url.Error:
+		return err.Timeout()
+	}
+
+	return errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, http.ErrHandlerTimeout) ||
+		os.IsTimeout(err)
 }
 
 type Getter interface {
@@ -91,7 +107,8 @@ func isRetriable(err error) bool {
 		}
 	}
 
-	return false
+	// Retry on read connection timeouts.
+	return isTimeoutErr(err)
 }
 
 func (rrh *resetRetryHandler) Read(p []byte) (int, error) {

--- a/src/internal/common/readers/retry_handler_test.go
+++ b/src/internal/common/readers/retry_handler_test.go
@@ -573,16 +573,6 @@ func (suite *ResetRetryHandlerUnitSuite) TestIsRetriable() {
 			expect: true,
 		},
 		{
-			name:   "Timeout - deadline exceeded",
-			err:    func() error { return context.DeadlineExceeded },
-			expect: true,
-		},
-		{
-			name:   "Timeout - ctx canceled",
-			err:    func() error { return context.Canceled },
-			expect: true,
-		},
-		{
 			name:   "Timeout - http timeout",
 			err:    func() error { return http.ErrHandlerTimeout },
 			expect: true,
@@ -590,7 +580,7 @@ func (suite *ResetRetryHandlerUnitSuite) TestIsRetriable() {
 		{
 			name: "Timeout - url error",
 			err: func() error {
-				return &url.Error{Err: context.DeadlineExceeded}
+				return &url.Error{Err: os.ErrDeadlineExceeded}
 			},
 			expect: true,
 		},


### PR DESCRIPTION
We were missing a retry for connection timeout issues. Adding it.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
