### PR TITLE
Standardize naming for preview default limits

### DIFF
--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -32,11 +32,11 @@ import (
 const (
 	restrictedDirectory = "Site Pages"
 
-	defaultPreviewNumContainers              = 5
-	defaultPreviewNumItemsPerContainer       = 10
-	defaultPreviewNumItems                   = defaultPreviewNumContainers * defaultPreviewNumItemsPerContainer
-	defaultPreviewNumBytes             int64 = 100 * 1024 * 1024
-	defaultPreviewNumPages                   = 50
+	defaultPreviewMaxContainers              = 5
+	defaultPreviewMaxItemsPerContainer       = 10
+	defaultPreviewMaxItems                   = defaultPreviewMaxContainers * defaultPreviewMaxItemsPerContainer
+	defaultPreviewMaxBytes             int64 = 100 * 1024 * 1024
+	defaultPreviewMaxPages                   = 50
 )
 
 // Collections is used to retrieve drive data for a
@@ -761,23 +761,23 @@ func newPagerLimiter(opts control.Options) *pagerLimiter {
 	res := &pagerLimiter{limits: opts.PreviewLimits}
 
 	if res.limits.MaxContainers == 0 {
-		res.limits.MaxContainers = defaultPreviewNumContainers
+		res.limits.MaxContainers = defaultPreviewMaxContainers
 	}
 
 	if res.limits.MaxItemsPerContainer == 0 {
-		res.limits.MaxItemsPerContainer = defaultPreviewNumItemsPerContainer
+		res.limits.MaxItemsPerContainer = defaultPreviewMaxItemsPerContainer
 	}
 
 	if res.limits.MaxItems == 0 {
-		res.limits.MaxItems = defaultPreviewNumItems
+		res.limits.MaxItems = defaultPreviewMaxItems
 	}
 
 	if res.limits.MaxBytes == 0 {
-		res.limits.MaxBytes = defaultPreviewNumBytes
+		res.limits.MaxBytes = defaultPreviewMaxBytes
 	}
 
 	if res.limits.MaxPages == 0 {
-		res.limits.MaxPages = defaultPreviewNumPages
+		res.limits.MaxPages = defaultPreviewMaxPages
 	}
 
 	return res

--- a/src/internal/m365/collection/drive/collections_test.go
+++ b/src/internal/m365/collection/drive/collections_test.go
@@ -4271,11 +4271,11 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits_Defaults() {
 	require.LessOrEqual(
 		suite.T(),
 		int64(1024*1024),
-		defaultPreviewNumBytes,
+		defaultPreviewMaxBytes,
 		"default number of bytes changed; DefaultNumBytes test case may need updating!")
 	require.Zero(
 		suite.T(),
-		defaultPreviewNumBytes%(1024*1024),
+		defaultPreviewMaxBytes%(1024*1024),
 		"default number of bytes isn't divisible by 1MB; DefaultNumBytes test case may need updating!")
 
 	// The number of pages returned can be indirectly tested by checking how many
@@ -4311,7 +4311,7 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits_Defaults() {
 		{
 			name:                 "DefaultNumItems",
 			numContainers:        1,
-			numItemsPerContainer: defaultPreviewNumItems + 1,
+			numItemsPerContainer: defaultPreviewMaxItems + 1,
 			limits: control.PreviewItemLimits{
 				Enabled:              true,
 				MaxItemsPerContainer: 99999999,
@@ -4320,14 +4320,14 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits_Defaults() {
 				MaxPages:             99999999,
 			},
 			expect: expected{
-				numItems:             defaultPreviewNumItems,
+				numItems:             defaultPreviewMaxItems,
 				numContainers:        1,
-				numItemsPerContainer: defaultPreviewNumItems,
+				numItemsPerContainer: defaultPreviewMaxItems,
 			},
 		},
 		{
 			name:                 "DefaultNumContainers",
-			numContainers:        defaultPreviewNumContainers + 1,
+			numContainers:        defaultPreviewMaxContainers + 1,
 			numItemsPerContainer: 1,
 			limits: control.PreviewItemLimits{
 				Enabled:              true,
@@ -4339,15 +4339,15 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits_Defaults() {
 			expect: expected{
 				// Root is counted as a container in the code but won't be counted or
 				// have items in the test.
-				numItems:             defaultPreviewNumContainers - 1,
-				numContainers:        defaultPreviewNumContainers - 1,
+				numItems:             defaultPreviewMaxContainers - 1,
+				numContainers:        defaultPreviewMaxContainers - 1,
 				numItemsPerContainer: 1,
 			},
 		},
 		{
 			name:                 "DefaultNumItemsPerContainer",
 			numContainers:        1,
-			numItemsPerContainer: defaultPreviewNumItemsPerContainer + 1,
+			numItemsPerContainer: defaultPreviewMaxItemsPerContainer + 1,
 			limits: control.PreviewItemLimits{
 				Enabled:       true,
 				MaxItems:      99999999,
@@ -4356,14 +4356,14 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits_Defaults() {
 				MaxPages:      99999999,
 			},
 			expect: expected{
-				numItems:             defaultPreviewNumItemsPerContainer,
+				numItems:             defaultPreviewMaxItemsPerContainer,
 				numContainers:        1,
-				numItemsPerContainer: defaultPreviewNumItemsPerContainer,
+				numItemsPerContainer: defaultPreviewMaxItemsPerContainer,
 			},
 		},
 		{
 			name:                 "DefaultNumPages",
-			numContainers:        defaultPreviewNumPages + 1,
+			numContainers:        defaultPreviewMaxPages + 1,
 			numItemsPerContainer: 1,
 			limits: control.PreviewItemLimits{
 				Enabled:              true,
@@ -4373,15 +4373,15 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits_Defaults() {
 				MaxBytes:             99999999,
 			},
 			expect: expected{
-				numItems:             defaultPreviewNumPages,
-				numContainers:        defaultPreviewNumPages,
+				numItems:             defaultPreviewMaxPages,
+				numContainers:        defaultPreviewMaxPages,
 				numItemsPerContainer: 1,
 			},
 		},
 		{
 			name:                 "DefaultNumBytes",
 			numContainers:        1,
-			numItemsPerContainer: int(defaultPreviewNumBytes/1024/1024) + 1,
+			numItemsPerContainer: int(defaultPreviewMaxBytes/1024/1024) + 1,
 			itemSize:             1024 * 1024,
 			limits: control.PreviewItemLimits{
 				Enabled:              true,
@@ -4391,9 +4391,9 @@ func (suite *CollectionsUnitSuite) TestGet_PreviewLimits_Defaults() {
 				MaxPages:             99999999,
 			},
 			expect: expected{
-				numItems:             int(defaultPreviewNumBytes) / 1024 / 1024,
+				numItems:             int(defaultPreviewMaxBytes) / 1024 / 1024,
 				numContainers:        1,
-				numItemsPerContainer: int(defaultPreviewNumBytes) / 1024 / 1024,
+				numItemsPerContainer: int(defaultPreviewMaxBytes) / 1024 / 1024,
 			},
 		},
 	}

--- a/src/internal/m365/collection/exchange/backup.go
+++ b/src/internal/m365/collection/exchange/backup.go
@@ -25,9 +25,9 @@ import (
 )
 
 const (
-	defaultPreviewContainerLimit         = 5
-	defaultPreviewItemsPerContainerLimit = 10
-	defaultPreviewItemLimit              = defaultPreviewContainerLimit * defaultPreviewItemsPerContainerLimit
+	defaultPreviewMaxContainers        = 5
+	defaultPreviewMaxItemsPerContainer = 10
+	defaultPreviewMaxItems             = defaultPreviewMaxContainers * defaultPreviewMaxItemsPerContainer
 )
 
 func CreateCollections(
@@ -167,15 +167,15 @@ func populateCollections(
 
 		// Configure limits with reasonable defaults if they're not set.
 		if effectiveLimits.MaxContainers == 0 {
-			effectiveLimits.MaxContainers = defaultPreviewContainerLimit
+			effectiveLimits.MaxContainers = defaultPreviewMaxContainers
 		}
 
 		if effectiveLimits.MaxItemsPerContainer == 0 {
-			effectiveLimits.MaxItemsPerContainer = defaultPreviewItemsPerContainerLimit
+			effectiveLimits.MaxItemsPerContainer = defaultPreviewMaxItemsPerContainer
 		}
 
 		if effectiveLimits.MaxItems == 0 {
-			effectiveLimits.MaxItems = defaultPreviewItemLimit
+			effectiveLimits.MaxItems = defaultPreviewMaxItems
 		}
 	}
 

--- a/src/internal/m365/collection/exchange/backup_test.go
+++ b/src/internal/m365/collection/exchange/backup_test.go
@@ -2212,7 +2212,7 @@ func (suite *CollectionPopulationSuite) TestFilterContainersAndFillCollections_P
 		{
 			name:                 "DefaultMaxItems",
 			numContainers:        1,
-			numItemsPerContainer: defaultPreviewItemLimit + 1,
+			numItemsPerContainer: defaultPreviewMaxItems + 1,
 			limits: control.PreviewItemLimits{
 				Enabled:              true,
 				MaxItemsPerContainer: 999,
@@ -2220,13 +2220,13 @@ func (suite *CollectionPopulationSuite) TestFilterContainersAndFillCollections_P
 			},
 			expect: expected{
 				numContainers:        1,
-				numItemsPerContainer: defaultPreviewItemLimit,
-				numItems:             defaultPreviewItemLimit,
+				numItemsPerContainer: defaultPreviewMaxItems,
+				numItems:             defaultPreviewMaxItems,
 			},
 		},
 		{
 			name:                 "DefaultMaxContainers",
-			numContainers:        defaultPreviewContainerLimit + 1,
+			numContainers:        defaultPreviewMaxContainers + 1,
 			numItemsPerContainer: 1,
 			limits: control.PreviewItemLimits{
 				Enabled:              true,
@@ -2234,15 +2234,15 @@ func (suite *CollectionPopulationSuite) TestFilterContainersAndFillCollections_P
 				MaxItems:             999,
 			},
 			expect: expected{
-				numContainers:        defaultPreviewContainerLimit,
+				numContainers:        defaultPreviewMaxContainers,
 				numItemsPerContainer: 1,
-				numItems:             defaultPreviewContainerLimit,
+				numItems:             defaultPreviewMaxContainers,
 			},
 		},
 		{
 			name:                 "DefaultMaxItemsPerContainer",
 			numContainers:        5,
-			numItemsPerContainer: defaultPreviewItemsPerContainerLimit,
+			numItemsPerContainer: defaultPreviewMaxItemsPerContainer,
 			limits: control.PreviewItemLimits{
 				Enabled:       true,
 				MaxItems:      999,
@@ -2250,8 +2250,8 @@ func (suite *CollectionPopulationSuite) TestFilterContainersAndFillCollections_P
 			},
 			expect: expected{
 				numContainers:        5,
-				numItemsPerContainer: defaultPreviewItemsPerContainerLimit,
-				numItems:             5 * defaultPreviewItemsPerContainerLimit,
+				numItemsPerContainer: defaultPreviewMaxItemsPerContainer,
+				numItems:             5 * defaultPreviewMaxItemsPerContainer,
 			},
 		},
 	}


### PR DESCRIPTION
#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
