### PR TITLE
Add logging like in exchange backup path

### DIFF
--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -787,6 +787,10 @@ type pagerLimiter struct {
 	limits control.PreviewItemLimits
 }
 
+func (l pagerLimiter) effectiveLimits() control.PreviewItemLimits {
+	return l.limits
+}
+
 func (l pagerLimiter) enabled() bool {
 	return l.limits.Enabled
 }
@@ -863,7 +867,10 @@ func (c *Collections) PopulateDriveCollections(
 	)
 
 	ctx = clues.Add(ctx, "invalid_prev_delta", invalidPrevDelta)
-	logger.Ctx(ctx).Infow("running backup with limiter", "limiter", limiter)
+	logger.Ctx(ctx).Infow(
+		"running backup",
+		"limits", c.ctrl.PreviewLimits,
+		"effective_limits", limiter.effectiveLimits())
 
 	if !invalidPrevDelta {
 		maps.Copy(newPrevPaths, oldPrevPaths)


### PR DESCRIPTION
Log both the given limits and the effective limits so we can figure out if something went wrong.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
