### PR TITLE
Cleaner way to disable merge bases during preview

### DIFF
--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -412,23 +412,6 @@ func (op *BackupOperation) do(
 		}
 	}
 
-	// Drop merge bases if we're doing a preview backup. Preview backups may use
-	// different delta token parameters so we need to ensure we do a token
-	// refresh. This could eventually be pushed down the stack if we track token
-	// versions.
-	//
-	// TODO(ashmrtn): Until we use token versions to determine this, refactor
-	// input params to produceManifestsAndMetadata and do this in that function
-	// instead of here.
-	if op.Options.PreviewLimits.Enabled {
-		logger.Ctx(ctx).Info("disabling merge bases for preview backup")
-
-		mans.DisableMergeBases()
-
-		canUseMetadata = false
-		mdColls = nil
-	}
-
 	ctx = clues.Add(
 		ctx,
 		"can_use_metadata", canUseMetadata,
@@ -515,7 +498,11 @@ func makeFallbackReasons(tenant string, sel selectors.Selector) ([]identity.Reas
 // checker to see if conditions are correct for incremental backup behavior such as
 // retrieving metadata like delta tokens and previous paths.
 func useIncrementalBackup(sel selectors.Selector, opts control.Options) bool {
-	return !opts.ToggleFeatures.DisableIncrementals
+	// Drop merge bases if we're doing a preview backup. Preview backups may use
+	// different delta token parameters so we need to ensure we do a token
+	// refresh. This could eventually be pushed down the stack if we track token
+	// versions.
+	return !opts.ToggleFeatures.DisableIncrementals && !opts.PreviewLimits.Enabled
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Switch to a cleaner way of disabling merge bases when making a preview backup. This sets the flag to not find merge bases instead of finding them and then dropping them.

Manually tested running a backup with `--preview` (local dev flag) and
`--disable-incrementals` and verified in the log that merge bases were
dropped 

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
