### PR TITLE
Return details from restore function

### DIFF
--- a/src/internal/m365/restore.go
+++ b/src/internal/m365/restore.go
@@ -44,49 +44,45 @@ func (ctrl *Controller) ConsumeRestoreCollections(
 	var (
 		service = rcc.Selector.PathService()
 		status  *support.ControllerOperationStatus
-		deets   = &details.Builder{}
+		deets   *details.Details
 		err     error
 	)
 
 	switch service {
 	case path.ExchangeService:
-		status, err = exchange.ConsumeRestoreCollections(
+		deets, status, err = exchange.ConsumeRestoreCollections(
 			ctx,
 			ctrl.AC,
 			rcc,
 			dcs,
-			deets,
 			errs,
 			ctr)
 	case path.OneDriveService:
-		status, err = onedrive.ConsumeRestoreCollections(
+		deets, status, err = onedrive.ConsumeRestoreCollections(
 			ctx,
 			drive.NewUserDriveRestoreHandler(ctrl.AC),
 			rcc,
 			ctrl.backupDriveIDNames,
 			dcs,
-			deets,
 			errs,
 			ctr)
 	case path.SharePointService:
-		status, err = sharepoint.ConsumeRestoreCollections(
+		deets, status, err = sharepoint.ConsumeRestoreCollections(
 			ctx,
 			rcc,
 			ctrl.AC,
 			ctrl.backupDriveIDNames,
 			dcs,
-			deets,
 			errs,
 			ctr)
 	case path.GroupsService:
-		status, err = groups.ConsumeRestoreCollections(
+		deets, status, err = groups.ConsumeRestoreCollections(
 			ctx,
 			rcc,
 			ctrl.AC,
 			ctrl.backupDriveIDNames,
 			ctrl.backupSiteIDWebURL,
 			dcs,
-			deets,
 			errs,
 			ctr)
 	default:
@@ -96,5 +92,5 @@ func (ctrl *Controller) ConsumeRestoreCollections(
 	ctrl.incrementAwaitingMessages()
 	ctrl.UpdateStatus(status)
 
-	return deets.Details(), err
+	return deets, err
 }

--- a/src/internal/m365/service/groups/restore_test.go
+++ b/src/internal/m365/service/groups/restore_test.go
@@ -53,14 +53,13 @@ func (suite *GroupsUnitSuite) TestConsumeRestoreCollections_noErrorOnGroups() {
 		mock.Collection{Path: pth},
 	}
 
-	_, err = ConsumeRestoreCollections(
+	_, _, err = ConsumeRestoreCollections(
 		ctx,
 		rcc,
 		api.Client{},
 		idname.NewCache(map[string]string{}),
 		idname.NewCache(map[string]string{}),
 		dcs,
-		nil,
 		fault.New(false),
 		nil)
 	assert.NoError(t, err, "Groups Channels restore")

--- a/src/internal/m365/service/onedrive/restore.go
+++ b/src/internal/m365/service/onedrive/restore.go
@@ -26,11 +26,11 @@ func ConsumeRestoreCollections(
 	rcc inject.RestoreConsumerConfig,
 	backupDriveIDNames idname.Cacher,
 	dcs []data.RestoreCollection,
-	deets *details.Builder,
 	errs *fault.Bus,
 	ctr *count.Bus,
-) (*support.ControllerOperationStatus, error) {
+) (*details.Details, *support.ControllerOperationStatus, error) {
 	var (
+		deets             = &details.Builder{}
 		restoreMetrics    support.CollectionMetrics
 		el                = errs.Local()
 		caches            = drive.NewRestoreCaches(backupDriveIDNames)
@@ -41,7 +41,7 @@ func ConsumeRestoreCollections(
 
 	err := caches.Populate(ctx, rh, rcc.ProtectedResource.ID())
 	if err != nil {
-		return nil, clues.Wrap(err, "initializing restore caches")
+		return nil, nil, clues.Wrap(err, "initializing restore caches")
 	}
 
 	// Reorder collections so that the parents directories are created
@@ -91,7 +91,7 @@ func ConsumeRestoreCollections(
 		restoreMetrics,
 		rcc.RestoreConfig.Location)
 
-	return status, el.Failure()
+	return deets.Details(), status, el.Failure()
 }
 
 // Augment restore path to add extra files(meta) needed for restore as


### PR DESCRIPTION
Minor cleanup that will also help reduce diff for future changes.

Instead of taking in a details builder and adding to it during
restore, just create a local details builder and return the built
details to the caller

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #4254

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
