### PR TITLE
populate tree with folder enumeration

### DIFF
--- a/src/internal/m365/collection/drive/collections_test.go
+++ b/src/internal/m365/collection/drive/collections_test.go
@@ -1692,21 +1692,28 @@ func (suite *CollectionsUnitSuite) TestGet_treeCannotBeUsedWhileIncomplete() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	drive := models.NewDrive()
-	drive.SetId(ptr.To("id"))
-	drive.SetName(ptr.To("name"))
+	drv := models.NewDrive()
+	drv.SetId(ptr.To("id"))
+	drv.SetName(ptr.To("name"))
 
 	mbh := mock.DefaultOneDriveBH(user)
 	opts := control.DefaultOptions()
 	opts.ToggleFeatures.UseDeltaTree = true
 
-	mockDrivePager := &apiMock.Pager[models.Driveable]{
-		ToReturn: []apiMock.PagerResult[models.Driveable]{
-			{Values: []models.Driveable{drive}},
+	mbh.DrivePagerV = pagerForDrives(drv)
+	mbh.DriveItemEnumeration = mock.EnumerateItemsDeltaByDrive{
+		DrivePagers: map[string]*mock.DriveItemsDeltaPager{
+			"id": {
+				Pages: []mock.NextPage{{
+					Items: []models.DriveItemable{
+						driveRootItem(rootID), // will be present, not needed
+						delItem(id(file), parent(1), rootID, isFile),
+					},
+				}},
+				DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
+			},
 		},
 	}
-
-	mbh.DrivePagerV = mockDrivePager
 
 	c := collWithMBH(mbh)
 	c.ctrl = opts

--- a/src/internal/m365/collection/drive/collections_test.go
+++ b/src/internal/m365/collection/drive/collections_test.go
@@ -172,7 +172,7 @@ func malwareItem(
 }
 
 func driveRootItem(id string) models.DriveItemable {
-	name := "root"
+	name := rootName
 	item := models.NewDriveItem()
 	item.SetName(&name)
 	item.SetId(&id)
@@ -279,8 +279,8 @@ const (
 	malware   = "malware"
 	nav       = "nav"
 	pkg       = "package"
-	rootName  = "root"
-	rootID    = "root_id"
+	rootID    = odConsts.RootID
+	rootName  = odConsts.RootPathDir
 	subfolder = "subfolder"
 	tenant    = "t"
 	user      = "u"

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -147,6 +147,8 @@ func (c *Collections) getTree(
 	return collections, canUsePrevBackup, nil
 }
 
+var errTreeNotImplemented = clues.New("backup tree not implemented")
+
 func (c *Collections) makeDriveCollections(
 	ctx context.Context,
 	drv models.Driveable,
@@ -245,7 +247,7 @@ func (c *Collections) makeDriveCollections(
 	// 	}
 	// }
 
-	return nil, nil, du, clues.New("not yet implemented")
+	return nil, nil, du, errTreeNotImplemented
 }
 
 // populateTree constructs a new tree and populates it with items

--- a/src/internal/m365/collection/drive/collections_tree_test.go
+++ b/src/internal/m365/collection/drive/collections_tree_test.go
@@ -482,7 +482,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_GetTree() {
 
 // This test is primarily aimed exercising the full breadth of single-drive delta enumeration
 // and broad contracts.
-// mMre granular testing can be found in the lower level test functions below.
+// More granular testing can be found in the lower level test functions below.
 func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 	drv := models.NewDrive()
 	drv.SetId(ptr.To(id(drive)))

--- a/src/internal/m365/collection/drive/collections_tree_test.go
+++ b/src/internal/m365/collection/drive/collections_tree_test.go
@@ -532,12 +532,6 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 	drv.SetId(ptr.To(id(drive)))
 	drv.SetName(ptr.To(name(drive)))
 
-	basePath, err := odConsts.DriveFolderPrefixBuilder(id(drive)).ToDataLayerOneDrivePath(tenant, user, false)
-	require.NoError(suite.T(), err, clues.ToCore(err))
-
-	folderPath, err := basePath.Append(false, namex(folder, "parent"), name(folder))
-	require.NoError(suite.T(), err, clues.ToCore(err))
-
 	type expected struct {
 		counts                   countTD.Expected
 		err                      require.ErrorAssertionFunc
@@ -550,7 +544,6 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 		name       string
 		enumerator mock.EnumerateItemsDeltaByDrive
 		tree       *folderyMcFolderFace
-		prevPaths  map[string]string
 		limiter    *pagerLimiter
 		expect     expected
 	}{
@@ -565,8 +558,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 					},
 				},
 			},
-			prevPaths: map[string]string{},
-			limiter:   newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts:                   countTD.Expected{},
 				err:                      require.NoError,
@@ -586,8 +578,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 					},
 				},
 			},
-			prevPaths: map[string]string{},
-			limiter:   newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed: 1,
@@ -612,8 +603,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 					},
 				},
 			},
-			prevPaths: map[string]string{},
-			limiter:   newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed: 2,
@@ -638,8 +628,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 					},
 				},
 			},
-			prevPaths: map[string]string{},
-			limiter:   newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed: 2,
@@ -670,8 +659,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 					},
 				},
 			},
-			prevPaths: map[string]string{},
-			limiter:   newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed: 7,
@@ -698,9 +686,6 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
-			},
-			prevPaths: map[string]string{
-				id(folder): folderPath.String(),
 			},
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
@@ -729,9 +714,6 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
-			},
-			prevPaths: map[string]string{
-				id(folder): folderPath.String(),
 			},
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
@@ -764,8 +746,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 					},
 				},
 			},
-			prevPaths: map[string]string{},
-			limiter:   newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed:       3,
@@ -773,7 +754,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 					count.PagesEnumerated:             2,
 				},
 				err:      require.NoError,
-				treeSize: 1,
+				treeSize: 2,
 				treeContainsFolderIDs: []string{
 					rootID,
 				},
@@ -794,9 +775,6 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
-			},
-			prevPaths: map[string]string{
-				id(folder): folderPath.String(),
 			},
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
@@ -829,9 +807,6 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 					},
 				},
 			},
-			prevPaths: map[string]string{
-				id(folder): folderPath.String(),
-			},
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -861,8 +836,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 					},
 				},
 			},
-			prevPaths: map[string]string{},
-			limiter:   newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFoldersProcessed: 1,
@@ -894,8 +868,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 					},
 				},
 			},
-			prevPaths: map[string]string{},
-			limiter:   newPagerLimiter(minimumLimitOpts()),
+			limiter: newPagerLimiter(minimumLimitOpts()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFoldersProcessed: 0,
@@ -926,8 +899,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 					},
 				},
 			},
-			prevPaths: map[string]string{},
-			limiter:   newPagerLimiter(minimumLimitOpts()),
+			limiter: newPagerLimiter(minimumLimitOpts()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFoldersProcessed: 0,
@@ -966,7 +938,6 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 				test.limiter,
 				&driveEnumerationStats{},
 				drv,
-				test.prevPaths,
 				id(delta),
 				counter,
 				fault.New(true))
@@ -992,12 +963,6 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 	drv.SetId(ptr.To(id(drive)))
 	drv.SetName(ptr.To(name(drive)))
 
-	basePath, err := odConsts.DriveFolderPrefixBuilder(id(drive)).ToDataLayerOneDrivePath(tenant, user, false)
-	require.NoError(suite.T(), err, clues.ToCore(err))
-
-	folderPath, err := basePath.Append(false, namex(folder, "parent"), name(folder))
-	require.NoError(suite.T(), err, clues.ToCore(err))
-
 	type expected struct {
 		counts                   countTD.Expected
 		err                      require.ErrorAssertionFunc
@@ -1007,19 +972,17 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 	}
 
 	table := []struct {
-		name      string
-		tree      *folderyMcFolderFace
-		page      []models.DriveItemable
-		prevPaths map[string]string
-		limiter   *pagerLimiter
-		expect    expected
+		name    string
+		tree    *folderyMcFolderFace
+		page    []models.DriveItemable
+		limiter *pagerLimiter
+		expect  expected
 	}{
 		{
-			name:      "nil page",
-			tree:      treeWithRoot(),
-			page:      nil,
-			prevPaths: map[string]string{},
-			limiter:   newPagerLimiter(control.DefaultOptions()),
+			name:    "nil page",
+			tree:    treeWithRoot(),
+			page:    nil,
+			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts:   countTD.Expected{},
 				err:      require.NoError,
@@ -1031,11 +994,10 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			},
 		},
 		{
-			name:      "empty page",
-			tree:      treeWithRoot(),
-			page:      []models.DriveItemable{},
-			prevPaths: map[string]string{},
-			limiter:   newPagerLimiter(control.DefaultOptions()),
+			name:    "empty page",
+			tree:    treeWithRoot(),
+			page:    []models.DriveItemable{},
+			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts:   countTD.Expected{},
 				err:      require.NoError,
@@ -1047,11 +1009,10 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			},
 		},
 		{
-			name:      "root only",
-			tree:      treeWithRoot(),
-			page:      rootAnd(),
-			prevPaths: map[string]string{},
-			limiter:   newPagerLimiter(control.DefaultOptions()),
+			name:    "root only",
+			tree:    treeWithRoot(),
+			page:    rootAnd(),
+			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed: 1,
@@ -1065,11 +1026,10 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			},
 		},
 		{
-			name:      "one",
-			tree:      treeWithRoot(),
-			page:      rootAnd(driveItem(id(folder), name(folder), parent(0), rootID, isFolder)),
-			prevPaths: map[string]string{},
-			limiter:   newPagerLimiter(control.DefaultOptions()),
+			name:    "one",
+			tree:    treeWithRoot(),
+			page:    rootAnd(driveItem(id(folder), name(folder), parent(0), rootID, isFolder)),
+			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed: 2,
@@ -1090,8 +1050,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 				driveItem(id(folder), name(folder), parent(0), rootID, isFolder),
 				driveItem(idx(folder, "sib"), namex(folder, "sib"), parent(0), rootID, isFolder),
 				driveItem(idx(folder, "chld"), namex(folder, "chld"), parent(0), id(folder), isFolder)),
-			prevPaths: map[string]string{},
-			limiter:   newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed: 4,
@@ -1114,8 +1073,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 				driveItem(id(folder), name(folder), parent(0), rootID, isFolder),
 				driveItem(idx(folder, "sib"), namex(folder, "sib"), parent(0), rootID, isFolder),
 				driveItem(idx(folder, "chld"), namex(folder, "chld"), parent(0), id(folder), isFolder)),
-			prevPaths: map[string]string{},
-			limiter:   newPagerLimiter(minimumLimitOpts()),
+			limiter: newPagerLimiter(minimumLimitOpts()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed: 1,
@@ -1129,12 +1087,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			},
 		},
 		{
-			name: "tombstone",
-			tree: treeWithFolders(),
-			page: rootAnd(delItem(id(folder), parent(0), idx(folder, "parent"), isFolder)),
-			prevPaths: map[string]string{
-				id(folder): folderPath.String(),
-			},
+			name:    "tombstone",
+			tree:    treeWithFolders(),
+			page:    rootAnd(delItem(id(folder), parent(0), idx(folder, "parent"), isFolder)),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1158,15 +1113,14 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			page: rootAnd(
 				driveItem(id(folder), name(folder), parent(0), rootID, isFolder),
 				delItem(id(folder), parent(0), rootID, isFolder)),
-			prevPaths: map[string]string{},
-			limiter:   newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed:       2,
 					count.TotalDeleteFoldersProcessed: 1,
 				},
 				err:      require.NoError,
-				treeSize: 1,
+				treeSize: 2,
 				treeContainsFolderIDs: []string{
 					rootID,
 				},
@@ -1180,9 +1134,6 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 				driveItem(idx(folder, "parent"), namex(folder, "parent"), parent(0), rootID, isFolder),
 				driveItem(id(folder), namex(folder, "moved"), parent(0), idx(folder, "parent"), isFolder),
 				delItem(id(folder), parent(0), idx(folder, "parent"), isFolder)),
-			prevPaths: map[string]string{
-				id(folder): folderPath.String(),
-			},
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1206,9 +1157,6 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			page: rootAnd(
 				delItem(id(folder), parent(0), rootID, isFolder),
 				driveItem(id(folder), name(folder), parent(0), rootID, isFolder)),
-			prevPaths: map[string]string{
-				id(folder): folderPath.String(),
-			},
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1230,8 +1178,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			page: rootAnd(
 				delItem(id(folder), parent(0), rootID, isFolder),
 				driveItem(id(folder), name(folder), parent(0), rootID, isFolder)),
-			prevPaths: map[string]string{},
-			limiter:   newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed:       2,
@@ -1264,7 +1211,6 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 				&driveEnumerationStats{},
 				drv,
 				test.page,
-				test.prevPaths,
 				counter,
 				fault.New(true))
 			test.expect.err(t, err, clues.ToCore(err))
@@ -1293,12 +1239,6 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 	del := delItem(id(folder), parent(0), rootID, isFolder)
 	mal := malwareItem(idx(folder, "mal"), namex(folder, "mal"), parent(0), rootID, isFolder)
 
-	basePath, err := odConsts.DriveFolderPrefixBuilder(id(drive)).ToDataLayerOneDrivePath(tenant, user, false)
-	require.NoError(suite.T(), err, clues.ToCore(err))
-
-	folderPath, err := basePath.Append(false, name(folder))
-	require.NoError(suite.T(), err, clues.ToCore(err))
-
 	type expected struct {
 		counts             countTD.Expected
 		err                require.ErrorAssertionFunc
@@ -1307,17 +1247,15 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 	}
 
 	table := []struct {
-		name      string
-		tree      *folderyMcFolderFace
-		folder    models.DriveItemable
-		prevPaths map[string]string
-		expect    expected
+		name   string
+		tree   *folderyMcFolderFace
+		folder models.DriveItemable
+		expect expected
 	}{
 		{
-			name:      "add folder",
-			tree:      treeWithRoot(),
-			folder:    fld,
-			prevPaths: map[string]string{},
+			name:   "add folder",
+			tree:   treeWithRoot(),
+			folder: fld,
 			expect: expected{
 				err:                require.NoError,
 				counts:             countTD.Expected{count.TotalFoldersProcessed: 1},
@@ -1326,22 +1264,20 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 			},
 		},
 		{
-			name:      "re-add folder that already exists",
-			tree:      treeWithFolders(),
-			folder:    subFld,
-			prevPaths: map[string]string{},
+			name:   "re-add folder that already exists",
+			tree:   treeWithFolders(),
+			folder: subFld,
 			expect: expected{
 				err:                require.NoError,
-				counts:             countTD.Expected{count.TotalFoldersProcessed: 0},
+				counts:             countTD.Expected{count.TotalFoldersProcessed: 1},
 				treeSize:           3,
 				treeContainsFolder: assert.True,
 			},
 		},
 		{
-			name:      "add package",
-			tree:      treeWithRoot(),
-			folder:    pack,
-			prevPaths: map[string]string{},
+			name:   "add package",
+			tree:   treeWithRoot(),
+			folder: pack,
 			expect: expected{
 				err:                require.NoError,
 				counts:             countTD.Expected{count.TotalPackagesProcessed: 1},
@@ -1353,9 +1289,6 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 			name:   "add tombstone",
 			tree:   treeWithFolders(),
 			folder: del,
-			prevPaths: map[string]string{
-				id(folder): folderPath.String(),
-			},
 			expect: expected{
 				err:                require.NoError,
 				counts:             countTD.Expected{count.TotalDeleteFoldersProcessed: 1},
@@ -1367,9 +1300,6 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 			name:   "re-add tombstone that already exists",
 			tree:   treeWithTombstone(),
 			folder: del,
-			prevPaths: map[string]string{
-				id(folder): folderPath.String(),
-			},
 			expect: expected{
 				err:                require.NoError,
 				counts:             countTD.Expected{count.TotalDeleteFoldersProcessed: 1},
@@ -1378,10 +1308,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 			},
 		},
 		{
-			name:      "add malware",
-			tree:      treeWithRoot(),
-			folder:    mal,
-			prevPaths: map[string]string{},
+			name:   "add malware",
+			tree:   treeWithRoot(),
+			folder: mal,
 			expect: expected{
 				err:                require.NoError,
 				counts:             countTD.Expected{count.TotalMalwareProcessed: 1},
@@ -1406,7 +1335,6 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 				test.tree,
 				drv,
 				test.folder,
-				test.prevPaths,
 				des,
 				counter,
 				fault.New(true))
@@ -1414,89 +1342,6 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 			test.expect.counts.Compare(t, counter)
 			assert.Equal(t, test.expect.treeSize, test.tree.CountFolders(), "folders in tree")
 			test.expect.treeContainsFolder(t, test.tree.ContainsFolder(ptr.Val(test.folder.GetId())))
-		})
-	}
-}
-
-func (suite *CollectionsTreeUnitSuite) TestCollections_TombstoneOrDeleteFolder() {
-	basePath, err := odConsts.DriveFolderPrefixBuilder(id(drive)).ToDataLayerOneDrivePath(tenant, user, false)
-	require.NoError(suite.T(), err, clues.ToCore(err))
-
-	folderPath, err := basePath.Append(false, name(folder))
-	require.NoError(suite.T(), err, clues.ToCore(err))
-
-	table := []struct {
-		name           string
-		tree           *folderyMcFolderFace
-		folder         models.DriveItemable
-		prevPaths      map[string]string
-		expectErr      require.ErrorAssertionFunc
-		expectExists   assert.BoolAssertionFunc
-		expectPrevPath path.Elements
-	}{
-		{
-			name:   "tombstone folder with previous path",
-			tree:   treeWithFolders(),
-			folder: delItem(id(folder), parent(0), rootID, isFolder),
-			prevPaths: map[string]string{
-				id(folder): folderPath.String(),
-			},
-			expectErr:      require.NoError,
-			expectExists:   assert.True,
-			expectPrevPath: folderPath.Folders(),
-		},
-		{
-			name:   "delete unseen folder with previous path",
-			tree:   treeWithRoot(),
-			folder: delItem(id(folder), parent(0), rootID, isFolder),
-			prevPaths: map[string]string{
-				id(folder): folderPath.String(),
-			},
-			expectErr:      require.NoError,
-			expectExists:   assert.True,
-			expectPrevPath: folderPath.Folders(),
-		},
-		{
-			name:           "delete folder with no previous path",
-			tree:           treeWithFolders(),
-			folder:         delItem(id(folder), parent(0), rootID, isFolder),
-			prevPaths:      map[string]string{},
-			expectErr:      require.NoError,
-			expectExists:   assert.False,
-			expectPrevPath: nil,
-		},
-		{
-			name:           "delete unseen folder with no previous path",
-			tree:           treeWithRoot(),
-			folder:         delItem(id(folder), parent(0), rootID, isFolder),
-			prevPaths:      map[string]string{},
-			expectErr:      require.NoError,
-			expectExists:   assert.False,
-			expectPrevPath: nil,
-		},
-	}
-	for _, test := range table {
-		suite.Run(test.name, func() {
-			t := suite.T()
-			c := collWithMBH(mock.DefaultOneDriveBH(user))
-			fID := ptr.Val(test.folder.GetId())
-
-			ctx, flush := tester.NewContext(t)
-			defer flush()
-
-			err := c.tombstoneOrDeleteFolder(
-				ctx,
-				test.tree,
-				test.folder,
-				test.prevPaths)
-			test.expectErr(t, err, clues.ToCore(err))
-			test.expectExists(t, test.tree.ContainsFolder(fID))
-
-			if err == nil && test.expectPrevPath != nil {
-				zombey := test.tree.tombstones[fID]
-				require.NotNil(t, zombey)
-				assert.Equal(t, test.expectPrevPath, zombey.prev)
-			}
 		})
 	}
 }

--- a/src/internal/m365/collection/drive/delta_tree.go
+++ b/src/internal/m365/collection/drive/delta_tree.go
@@ -237,10 +237,6 @@ func (face *folderyMcFolderFace) SetTombstone(
 
 		delete(face.folderIDToNode, id)
 
-		if len(zombey.prev) == 0 {
-			zombey.prev = loc
-		}
-
 		zombey.parent = nil
 		face.tombstones[id] = zombey
 

--- a/src/internal/m365/collection/drive/delta_tree.go
+++ b/src/internal/m365/collection/drive/delta_tree.go
@@ -237,6 +237,10 @@ func (face *folderyMcFolderFace) SetTombstone(
 
 		delete(face.folderIDToNode, id)
 
+		if len(zombey.prev) == 0 {
+			zombey.prev = loc
+		}
+
 		zombey.parent = nil
 		face.tombstones[id] = zombey
 

--- a/src/internal/m365/collection/drive/delta_tree_test.go
+++ b/src/internal/m365/collection/drive/delta_tree_test.go
@@ -19,8 +19,8 @@ import (
 var loc = path.NewElements("root:/foo/bar/baz/qux/fnords/smarf/voi/zumba/bangles/howdyhowdyhowdy")
 
 func treeWithRoot() *folderyMcFolderFace {
-	rootey := newNodeyMcNodeFace(nil, rootID, rootName, false)
 	tree := newFolderyMcFolderFace(nil)
+	rootey := newNodeyMcNodeFace(nil, rootID, rootName, false)
 	tree.root = rootey
 	tree.folderIDToNode[rootID] = rootey
 
@@ -95,109 +95,98 @@ func (suite *DeltaTreeUnitSuite) TestNewNodeyMcNodeFace() {
 // and intentionally does not verify the resulting node tree
 func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 	table := []struct {
-		tname      string
-		tree       *folderyMcFolderFace
-		parentID   string
-		id         string
-		name       string
-		isPackage  bool
-		expectErr  assert.ErrorAssertionFunc
-		expectPrev assert.ValueAssertionFunc
+		tname     string
+		tree      *folderyMcFolderFace
+		parentID  string
+		id        string
+		name      string
+		isPackage bool
+		expectErr assert.ErrorAssertionFunc
 	}{
 		{
 			tname: "add root",
 			tree: &folderyMcFolderFace{
 				folderIDToNode: map[string]*nodeyMcNodeFace{},
 			},
-			id:         rootID,
-			name:       rootName,
-			isPackage:  true,
-			expectErr:  assert.NoError,
-			expectPrev: assert.Nil,
+			id:        rootID,
+			name:      rootName,
+			isPackage: true,
+			expectErr: assert.NoError,
 		},
 		{
-			tname:      "root already exists",
-			tree:       treeWithRoot(),
-			id:         rootID,
-			name:       rootName,
-			expectErr:  assert.NoError,
-			expectPrev: assert.Nil,
+			tname:     "root already exists",
+			tree:      treeWithRoot(),
+			id:        rootID,
+			name:      rootName,
+			expectErr: assert.NoError,
 		},
 		{
-			tname:      "add folder",
-			tree:       treeWithRoot(),
-			parentID:   rootID,
-			id:         id(folder),
-			name:       name(folder),
-			expectErr:  assert.NoError,
-			expectPrev: assert.Nil,
+			tname:     "add folder",
+			tree:      treeWithRoot(),
+			parentID:  rootID,
+			id:        id(folder),
+			name:      name(folder),
+			expectErr: assert.NoError,
 		},
 		{
-			tname:      "add package",
-			tree:       treeWithRoot(),
-			parentID:   rootID,
-			id:         id(folder),
-			name:       name(folder),
-			isPackage:  true,
-			expectErr:  assert.NoError,
-			expectPrev: assert.Nil,
+			tname:     "add package",
+			tree:      treeWithRoot(),
+			parentID:  rootID,
+			id:        id(folder),
+			name:      name(folder),
+			isPackage: true,
+			expectErr: assert.NoError,
 		},
 		{
-			tname:      "missing ID",
-			tree:       treeWithRoot(),
-			parentID:   rootID,
-			name:       name(folder),
-			isPackage:  true,
-			expectErr:  assert.Error,
-			expectPrev: assert.Nil,
+			tname:     "missing ID",
+			tree:      treeWithRoot(),
+			parentID:  rootID,
+			name:      name(folder),
+			isPackage: true,
+			expectErr: assert.Error,
 		},
 		{
-			tname:      "missing name",
-			tree:       treeWithRoot(),
-			parentID:   rootID,
-			id:         id(folder),
-			isPackage:  true,
-			expectErr:  assert.Error,
-			expectPrev: assert.Nil,
+			tname:     "missing name",
+			tree:      treeWithRoot(),
+			parentID:  rootID,
+			id:        id(folder),
+			isPackage: true,
+			expectErr: assert.Error,
 		},
 		{
-			tname:      "missing parentID",
-			tree:       treeWithRoot(),
-			id:         id(folder),
-			name:       name(folder),
-			isPackage:  true,
-			expectErr:  assert.Error,
-			expectPrev: assert.Nil,
+			tname:     "missing parentID",
+			tree:      treeWithRoot(),
+			id:        id(folder),
+			name:      name(folder),
+			isPackage: true,
+			expectErr: assert.Error,
 		},
 		{
-			tname:      "already tombstoned",
-			tree:       treeWithTombstone(),
-			parentID:   rootID,
-			id:         id(folder),
-			name:       name(folder),
-			expectErr:  assert.NoError,
-			expectPrev: assert.NotNil,
+			tname:     "already tombstoned",
+			tree:      treeWithTombstone(),
+			parentID:  rootID,
+			id:        id(folder),
+			name:      name(folder),
+			expectErr: assert.NoError,
 		},
 		{
 			tname: "add folder before parent",
 			tree: &folderyMcFolderFace{
 				folderIDToNode: map[string]*nodeyMcNodeFace{},
 			},
-			parentID:   rootID,
-			id:         id(folder),
-			name:       name(folder),
-			isPackage:  true,
-			expectErr:  assert.Error,
-			expectPrev: assert.Nil,
+			parentID:  rootID,
+			id:        id(folder),
+			name:      name(folder),
+			isPackage: true,
+			expectErr: assert.Error,
 		},
 		{
-			tname:      "folder already exists",
-			tree:       treeWithFolders(),
-			parentID:   idx(folder, "parent"),
-			id:         id(folder),
-			name:       name(folder),
-			expectErr:  assert.NoError,
-			expectPrev: assert.Nil,
+			tname:     "folder already exists",
+			tree:      treeWithFolders(),
+			parentID:  idx(folder, "parent"),
+			id:        id(folder),
+			name:      name(folder),
+			expectErr: assert.NoError,
 		},
 	}
 	for _, test := range table {
@@ -221,7 +210,6 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 
 			result := test.tree.folderIDToNode[test.id]
 			require.NotNil(t, result)
-			test.expectPrev(t, result.prev)
 			assert.Equal(t, test.id, result.id)
 			assert.Equal(t, test.name, result.name)
 			assert.Equal(t, test.isPackage, result.isPackage)
@@ -241,54 +229,35 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddTombstone() {
 	table := []struct {
 		name      string
 		id        string
-		loc       path.Elements
 		tree      *folderyMcFolderFace
 		expectErr assert.ErrorAssertionFunc
 	}{
 		{
 			name:      "add tombstone",
 			id:        id(folder),
-			loc:       loc,
 			tree:      newFolderyMcFolderFace(nil),
 			expectErr: assert.NoError,
 		},
 		{
 			name:      "duplicate tombstone",
 			id:        id(folder),
-			loc:       loc,
 			tree:      treeWithTombstone(),
 			expectErr: assert.NoError,
 		},
 		{
 			name:      "missing ID",
-			loc:       loc,
-			tree:      newFolderyMcFolderFace(nil),
-			expectErr: assert.Error,
-		},
-		{
-			name:      "missing loc",
-			id:        id(folder),
-			tree:      newFolderyMcFolderFace(nil),
-			expectErr: assert.Error,
-		},
-		{
-			name:      "empty loc",
-			id:        id(folder),
-			loc:       path.Elements{},
 			tree:      newFolderyMcFolderFace(nil),
 			expectErr: assert.Error,
 		},
 		{
 			name:      "conflict: folder alive",
 			id:        id(folder),
-			loc:       loc,
 			tree:      treeWithTombstone(),
 			expectErr: assert.NoError,
 		},
 		{
-			name:      "already tombstoned with different path",
+			name:      "already tombstoned",
 			id:        id(folder),
-			loc:       append(path.Elements{"foo"}, loc...),
 			tree:      treeWithTombstone(),
 			expectErr: assert.NoError,
 		},
@@ -309,8 +278,6 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddTombstone() {
 
 			result := test.tree.tombstones[test.id]
 			require.NotNil(t, result)
-			require.NotEmpty(t, result.prev)
-			assert.Equal(t, loc, result.prev)
 		})
 	}
 }

--- a/src/internal/m365/collection/drive/limiter_test.go
+++ b/src/internal/m365/collection/drive/limiter_test.go
@@ -26,6 +26,26 @@ import (
 	"github.com/alcionai/corso/src/pkg/services/m365/api/pagers"
 )
 
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func minimumLimitOpts() control.Options {
+	minLimitOpts := control.DefaultOptions()
+	minLimitOpts.PreviewLimits.Enabled = true
+	minLimitOpts.PreviewLimits.MaxBytes = 1
+	minLimitOpts.PreviewLimits.MaxContainers = 1
+	minLimitOpts.PreviewLimits.MaxItems = 1
+	minLimitOpts.PreviewLimits.MaxItemsPerContainer = 1
+	minLimitOpts.PreviewLimits.MaxPages = 1
+
+	return minLimitOpts
+}
+
+// ---------------------------------------------------------------------------
+// tests
+// ---------------------------------------------------------------------------
+
 type LimiterUnitSuite struct {
 	tester.Suite
 }

--- a/src/pkg/count/keys.go
+++ b/src/pkg/count/keys.go
@@ -66,6 +66,12 @@ const (
 	StreamItemsErrored            Key = "stream-items-errored"
 	StreamItemsFound              Key = "stream-items-found"
 	StreamItemsRemoved            Key = "stream-items-removed"
+	Tombstones                    Key = "tombstones"
+	TotalContainersSkipped        Key = "total-containers-skipped"
+	TotalDeleteFoldersProcessed   Key = "total-delete-folders-processed"
+	TotalFoldersProcessed         Key = "total-folders-processed"
+	TotalMalwareProcessed         Key = "total-malware-processed"
+	TotalPackagesProcessed        Key = "total-packages-processed"
 	URLCacheMiss                  Key = "url-cache-miss"
 	URLCacheRefresh               Key = "url-cache-refresh"
 

--- a/src/pkg/count/keys.go
+++ b/src/pkg/count/keys.go
@@ -9,10 +9,8 @@ const (
 	ThrottledAPICalls Key = "throttled-api-calls"
 )
 
-// Tracked during backup
+// backup amounts reported by kopia
 const (
-	// amounts reported by kopia
-
 	PersistedCachedFiles          Key = "persisted-cached-files"
 	PersistedDirectories          Key = "persisted-directories"
 	PersistedFiles                Key = "persisted-files"
@@ -24,9 +22,10 @@ const (
 	PersistenceErrors             Key = "persistence-errors"
 	PersistenceExpectedErrors     Key = "persistence-expected-errors"
 	PersistenceIgnoredErrors      Key = "persistence-ignored-errors"
+)
 
-	// amounts reported by data providers
-
+// backup amounts reported by data providers
+const (
 	Channels                      Key = "channels"
 	CollectionMoved               Key = "collection-moved"
 	CollectionNew                 Key = "collection-state-new"
@@ -67,14 +66,26 @@ const (
 	StreamItemsFound              Key = "stream-items-found"
 	StreamItemsRemoved            Key = "stream-items-removed"
 	TotalContainersSkipped        Key = "total-containers-skipped"
-	TotalDeleteFoldersProcessed   Key = "total-delete-folders-processed"
-	TotalFoldersProcessed         Key = "total-folders-processed"
-	TotalMalwareProcessed         Key = "total-malware-processed"
-	TotalPackagesProcessed        Key = "total-packages-processed"
 	URLCacheMiss                  Key = "url-cache-miss"
 	URLCacheRefresh               Key = "url-cache-refresh"
+)
 
-	// miscellaneous
+// Total___Processed counts are used to track raw processing numbers
+// for values that may have a similar, but different, end result count.
+// For example: a delta query may add the same folder to many different pages.
+// instead of adding logic to catch folder duplications and only count new
+// entries, we can increment TotalFoldersProcessed for every duplication,
+// and use a separate Key (Folders) for the end count of folders produced
+// at the end of the delta enumeration.
+const (
+	TotalDeleteFoldersProcessed Key = "total-delete-folders-processed"
+	TotalFoldersProcessed       Key = "total-folders-processed"
+	TotalMalwareProcessed       Key = "total-malware-processed"
+	TotalPackagesProcessed      Key = "total-packages-processed"
+)
+
+// miscellaneous
+const (
 	RequiresUserPnToIDMigration Key = "requires-user-pn-to-id-migration"
 )
 

--- a/src/pkg/count/keys.go
+++ b/src/pkg/count/keys.go
@@ -66,7 +66,6 @@ const (
 	StreamItemsErrored            Key = "stream-items-errored"
 	StreamItemsFound              Key = "stream-items-found"
 	StreamItemsRemoved            Key = "stream-items-removed"
-	Tombstones                    Key = "tombstones"
 	TotalContainersSkipped        Key = "total-containers-skipped"
 	TotalDeleteFoldersProcessed   Key = "total-delete-folders-processed"
 	TotalFoldersProcessed         Key = "total-folders-processed"


### PR DESCRIPTION
adds basic parity for folder enumeration using the new delta tree struct.  Focuses only on handling new folder additions from delta enumeration.  PrevPath handling and item additions will come in later PRs.

PR bookend for:
* https://github.com/alcionai/corso/pull/4719

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #4689

#### Test Plan

- [x] :zap: Unit test
