### PR TITLE
swap stats for in-tree item counts for limits

### DIFF
--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -29,6 +29,8 @@ import (
 	"github.com/alcionai/corso/src/pkg/services/m365/api/pagers"
 )
 
+var errGetTreeNotImplemented = clues.New("forced error: cannot run tree-based backup: incomplete implementation")
+
 const (
 	restrictedDirectory = "Site Pages"
 
@@ -292,14 +294,14 @@ func (c *Collections) Get(
 	errs *fault.Bus,
 ) ([]data.BackupCollection, bool, error) {
 	if c.ctrl.ToggleFeatures.UseDeltaTree {
-		_, _, err := c.getTree(ctx, prevMetadata, ssmb, errs)
+		colls, canUsePrevBackup, err := c.getTree(ctx, prevMetadata, ssmb, errs)
 		if err != nil {
 			return nil, false, clues.Wrap(err, "processing backup using tree")
 		}
 
-		return nil,
-			false,
-			clues.New("forced error: cannot run tree-based backup: incomplete implementation")
+		return colls,
+			canUsePrevBackup,
+			errGetTreeNotImplemented
 	}
 
 	deltasByDriveID, prevPathsByDriveID, canUsePrevBackup, err := deserializeAndValidateMetadata(

--- a/src/internal/m365/collection/drive/collections_test.go
+++ b/src/internal/m365/collection/drive/collections_test.go
@@ -172,11 +172,11 @@ func malwareItem(
 	return c
 }
 
-func driveRootItem(id string) models.DriveItemable {
+func driveRootItem() models.DriveItemable {
 	name := rootName
 	item := models.NewDriveItem()
 	item.SetName(&name)
-	item.SetId(&id)
+	item.SetId(ptr.To(rootID))
 	item.SetRoot(models.NewRoot())
 	item.SetFolder(models.NewFolder())
 
@@ -243,7 +243,19 @@ func toPath(elems ...string) string {
 	}
 }
 
-func fullPath(driveID any, elems ...string) string {
+func fullPath(elems ...string) string {
+	return toPath(append(
+		[]string{
+			tenant,
+			path.OneDriveService.String(),
+			user,
+			path.FilesCategory.String(),
+			odConsts.DriveFolderPrefixBuilder(id(drive)).String(),
+		},
+		elems...)...)
+}
+
+func driveFullPath(driveID any, elems ...string) string {
 	return toPath(append(
 		[]string{
 			tenant,
@@ -255,7 +267,13 @@ func fullPath(driveID any, elems ...string) string {
 		elems...)...)
 }
 
-func parent(driveID any, elems ...string) string {
+func parentDir(elems ...string) string {
+	return toPath(append(
+		[]string{odConsts.DriveFolderPrefixBuilder(id(drive)).String()},
+		elems...)...)
+}
+
+func driveParentDir(driveID any, elems ...string) string {
 	return toPath(append(
 		[]string{odConsts.DriveFolderPrefixBuilder(idx(drive, driveID)).String()},
 		elems...)...)
@@ -347,19 +365,19 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "Invalid item",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				driveItem(id(item), name(item), parent(drive), rootID, -1),
+				driveRootItem(),
+				driveItem(id(item), name(item), driveParentDir(drive), rootID, -1),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.Error,
 			expectedCollectionIDs: map[string]statePath{
-				rootID: asNotMoved(t, fullPath(drive)),
+				rootID: asNotMoved(t, driveFullPath(drive)),
 			},
 			expectedContainerCount: 1,
 			expectedPrevPaths: map[string]string{
-				rootID: fullPath(drive),
+				rootID: driveFullPath(drive),
 			},
 			expectedExcludes:         map[string]struct{}{},
 			expectedTopLevelPackages: map[string]struct{}{},
@@ -367,22 +385,22 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "Single File",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				driveItem(id(file), name(file), parent(drive), rootID, isFile),
+				driveRootItem(),
+				driveItem(id(file), name(file), driveParentDir(drive), rootID, isFile),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID: asNotMoved(t, fullPath(drive)),
+				rootID: asNotMoved(t, driveFullPath(drive)),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      1,
 			expectedContainerCount: 1,
 			// Root folder is skipped since it's always present.
 			expectedPrevPaths: map[string]string{
-				rootID: fullPath(drive),
+				rootID: driveFullPath(drive),
 			},
 			expectedExcludes:         makeExcludeMap(id(file)),
 			expectedTopLevelPackages: map[string]struct{}{},
@@ -390,20 +408,20 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "Single Folder",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				driveItem(id(folder), name(folder), parent(drive), rootID, isFolder),
+				driveRootItem(),
+				driveItem(id(folder), name(folder), driveParentDir(drive), rootID, isFolder),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, fullPath(drive)),
-				id(folder): asNew(t, fullPath(drive, name(folder))),
+				rootID:     asNotMoved(t, driveFullPath(drive)),
+				id(folder): asNew(t, driveFullPath(drive, name(folder))),
 			},
 			expectedPrevPaths: map[string]string{
-				rootID:     fullPath(drive),
-				id(folder): fullPath(drive, name(folder)),
+				rootID:     driveFullPath(drive),
+				id(folder): driveFullPath(drive, name(folder)),
 			},
 			expectedItemCount:        1,
 			expectedContainerCount:   2,
@@ -413,21 +431,21 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "Single Folder created twice", // deleted a created with same name in between a backup
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				driveItem(id(folder), name(folder), parent(drive), rootID, isFolder),
-				driveItem(idx(folder, 2), name(folder), parent(drive), rootID, isFolder),
+				driveRootItem(),
+				driveItem(id(folder), name(folder), driveParentDir(drive), rootID, isFolder),
+				driveItem(idx(folder, 2), name(folder), driveParentDir(drive), rootID, isFolder),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:         asNotMoved(t, fullPath(drive)),
-				idx(folder, 2): asNew(t, fullPath(drive, name(folder))),
+				rootID:         asNotMoved(t, driveFullPath(drive)),
+				idx(folder, 2): asNew(t, driveFullPath(drive, name(folder))),
 			},
 			expectedPrevPaths: map[string]string{
-				rootID:         fullPath(drive),
-				idx(folder, 2): fullPath(drive, name(folder)),
+				rootID:         driveFullPath(drive),
+				idx(folder, 2): driveFullPath(drive, name(folder)),
 			},
 			expectedItemCount:        1,
 			expectedContainerCount:   2,
@@ -437,90 +455,90 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "Single Package",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				driveItem(id(pkg), name(pkg), parent(drive), rootID, isPackage),
+				driveRootItem(),
+				driveItem(id(pkg), name(pkg), driveParentDir(drive), rootID, isPackage),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:  asNotMoved(t, fullPath(drive)),
-				id(pkg): asNew(t, fullPath(drive, name(pkg))),
+				rootID:  asNotMoved(t, driveFullPath(drive)),
+				id(pkg): asNew(t, driveFullPath(drive, name(pkg))),
 			},
 			expectedPrevPaths: map[string]string{
-				rootID:  fullPath(drive),
-				id(pkg): fullPath(drive, name(pkg)),
+				rootID:  driveFullPath(drive),
+				id(pkg): driveFullPath(drive, name(pkg)),
 			},
 			expectedItemCount:      1,
 			expectedContainerCount: 2,
 			expectedExcludes:       map[string]struct{}{},
 			expectedTopLevelPackages: map[string]struct{}{
-				fullPath(drive, name(pkg)): {},
+				driveFullPath(drive, name(pkg)): {},
 			},
 			expectedCountPackages: 1,
 		},
 		{
 			name: "Single Package with subfolder",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				driveItem(id(pkg), name(pkg), parent(drive), rootID, isPackage),
-				driveItem(id(folder), name(folder), parent(drive, name(pkg)), id(pkg), isFolder),
-				driveItem(id(subfolder), name(subfolder), parent(drive, name(pkg)), id(pkg), isFolder),
+				driveRootItem(),
+				driveItem(id(pkg), name(pkg), driveParentDir(drive), rootID, isPackage),
+				driveItem(id(folder), name(folder), driveParentDir(drive, name(pkg)), id(pkg), isFolder),
+				driveItem(id(subfolder), name(subfolder), driveParentDir(drive, name(pkg)), id(pkg), isFolder),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:        asNotMoved(t, fullPath(drive)),
-				id(pkg):       asNew(t, fullPath(drive, name(pkg))),
-				id(folder):    asNew(t, fullPath(drive, name(pkg), name(folder))),
-				id(subfolder): asNew(t, fullPath(drive, name(pkg), name(subfolder))),
+				rootID:        asNotMoved(t, driveFullPath(drive)),
+				id(pkg):       asNew(t, driveFullPath(drive, name(pkg))),
+				id(folder):    asNew(t, driveFullPath(drive, name(pkg), name(folder))),
+				id(subfolder): asNew(t, driveFullPath(drive, name(pkg), name(subfolder))),
 			},
 			expectedPrevPaths: map[string]string{
-				rootID:        fullPath(drive),
-				id(pkg):       fullPath(drive, name(pkg)),
-				id(folder):    fullPath(drive, name(pkg), name(folder)),
-				id(subfolder): fullPath(drive, name(pkg), name(subfolder)),
+				rootID:        driveFullPath(drive),
+				id(pkg):       driveFullPath(drive, name(pkg)),
+				id(folder):    driveFullPath(drive, name(pkg), name(folder)),
+				id(subfolder): driveFullPath(drive, name(pkg), name(subfolder)),
 			},
 			expectedItemCount:      3,
 			expectedContainerCount: 4,
 			expectedExcludes:       map[string]struct{}{},
 			expectedTopLevelPackages: map[string]struct{}{
-				fullPath(drive, name(pkg)): {},
+				driveFullPath(drive, name(pkg)): {},
 			},
 			expectedCountPackages: 3,
 		},
 		{
 			name: "1 root file, 1 folder, 1 package, 2 files, 3 collections",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				driveItem(idx(file, "inRoot"), namex(file, "inRoot"), parent(drive), rootID, isFile),
-				driveItem(id(folder), name(folder), parent(drive), rootID, isFolder),
-				driveItem(id(pkg), name(pkg), parent(drive), rootID, isPackage),
-				driveItem(idx(file, "inFolder"), namex(file, "inFolder"), parent(drive, name(folder)), id(folder), isFile),
-				driveItem(idx(file, "inPackage"), namex(file, "inPackage"), parent(drive, name(pkg)), id(pkg), isFile),
+				driveRootItem(),
+				driveItem(idx(file, "inRoot"), namex(file, "inRoot"), driveParentDir(drive), rootID, isFile),
+				driveItem(id(folder), name(folder), driveParentDir(drive), rootID, isFolder),
+				driveItem(id(pkg), name(pkg), driveParentDir(drive), rootID, isPackage),
+				driveItem(idx(file, "inFolder"), namex(file, "inFolder"), driveParentDir(drive, name(folder)), id(folder), isFile),
+				driveItem(idx(file, "inPackage"), namex(file, "inPackage"), driveParentDir(drive, name(pkg)), id(pkg), isFile),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, fullPath(drive)),
-				id(folder): asNew(t, fullPath(drive, name(folder))),
-				id(pkg):    asNew(t, fullPath(drive, name(pkg))),
+				rootID:     asNotMoved(t, driveFullPath(drive)),
+				id(folder): asNew(t, driveFullPath(drive, name(folder))),
+				id(pkg):    asNew(t, driveFullPath(drive, name(pkg))),
 			},
 			expectedItemCount:      5,
 			expectedFileCount:      3,
 			expectedContainerCount: 3,
 			expectedPrevPaths: map[string]string{
-				rootID:     fullPath(drive),
-				id(folder): fullPath(drive, name(folder)),
-				id(pkg):    fullPath(drive, name(pkg)),
+				rootID:     driveFullPath(drive),
+				id(folder): driveFullPath(drive, name(folder)),
+				id(pkg):    driveFullPath(drive, name(pkg)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{
-				fullPath(drive, name(pkg)): {},
+				driveFullPath(drive, name(pkg)): {},
 			},
 			expectedCountPackages: 1,
 			expectedExcludes:      makeExcludeMap(idx(file, "inRoot"), idx(file, "inFolder"), idx(file, "inPackage")),
@@ -528,24 +546,24 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "contains folder selector",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				driveItem(idx(file, "inRoot"), namex(file, "inRoot"), parent(drive), rootID, isFile),
-				driveItem(id(folder), name(folder), parent(drive), rootID, isFolder),
-				driveItem(id(subfolder), name(subfolder), parent(drive, name(folder)), id(folder), isFolder),
-				driveItem(idx(folder, 2), name(folder), parent(drive, name(folder), name(subfolder)), id(subfolder), isFolder),
-				driveItem(id(pkg), name(pkg), parent(drive), rootID, isPackage),
-				driveItem(idx(file, "inFolder"), idx(file, "inFolder"), parent(drive, name(folder)), id(folder), isFile),
-				driveItem(idx(file, "inFolder2"), namex(file, "inFolder2"), parent(drive, name(folder), name(subfolder), name(folder)), idx(folder, 2), isFile),
-				driveItem(idx(file, "inFolderPackage"), namex(file, "inPackage"), parent(drive, name(pkg)), id(pkg), isFile),
+				driveRootItem(),
+				driveItem(idx(file, "inRoot"), namex(file, "inRoot"), driveParentDir(drive), rootID, isFile),
+				driveItem(id(folder), name(folder), driveParentDir(drive), rootID, isFolder),
+				driveItem(id(subfolder), name(subfolder), driveParentDir(drive, name(folder)), id(folder), isFolder),
+				driveItem(idx(folder, 2), name(folder), driveParentDir(drive, name(folder), name(subfolder)), id(subfolder), isFolder),
+				driveItem(id(pkg), name(pkg), driveParentDir(drive), rootID, isPackage),
+				driveItem(idx(file, "inFolder"), idx(file, "inFolder"), driveParentDir(drive, name(folder)), id(folder), isFile),
+				driveItem(idx(file, "inFolder2"), namex(file, "inFolder2"), driveParentDir(drive, name(folder), name(subfolder), name(folder)), idx(folder, 2), isFile),
+				driveItem(idx(file, "inFolderPackage"), namex(file, "inPackage"), driveParentDir(drive, name(pkg)), id(pkg), isFile),
 			},
 			previousPaths:    map[string]string{},
 			scope:            (&selectors.OneDriveBackup{}).Folders([]string{name(folder)})[0],
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				id(folder):     asNew(t, fullPath(drive, name(folder))),
-				id(subfolder):  asNew(t, fullPath(drive, name(folder), name(subfolder))),
-				idx(folder, 2): asNew(t, fullPath(drive, name(folder), name(subfolder), name(folder))),
+				id(folder):     asNew(t, driveFullPath(drive, name(folder))),
+				id(subfolder):  asNew(t, driveFullPath(drive, name(folder), name(subfolder))),
+				idx(folder, 2): asNew(t, driveFullPath(drive, name(folder), name(subfolder), name(folder))),
 			},
 			expectedItemCount:      5,
 			expectedFileCount:      2,
@@ -553,9 +571,9 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			// just "folder" isn't added here because the include check is done on the
 			// parent path since we only check later if something is a folder or not.
 			expectedPrevPaths: map[string]string{
-				id(folder):     fullPath(drive, name(folder)),
-				id(subfolder):  fullPath(drive, name(folder), name(subfolder)),
-				idx(folder, 2): fullPath(drive, name(folder), name(subfolder), name(folder)),
+				id(folder):     driveFullPath(drive, name(folder)),
+				id(subfolder):  driveFullPath(drive, name(folder), name(subfolder)),
+				idx(folder, 2): driveFullPath(drive, name(folder), name(subfolder), name(folder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(idx(file, "inFolder"), idx(file, "inFolder2")),
@@ -563,15 +581,15 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "prefix subfolder selector",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				driveItem(idx(file, "inRoot"), namex(file, "inRoot"), parent(drive), rootID, isFile),
-				driveItem(id(folder), name(folder), parent(drive), rootID, isFolder),
-				driveItem(id(subfolder), name(subfolder), parent(drive, name(folder)), id(folder), isFolder),
-				driveItem(idx(folder, 2), name(folder), parent(drive, name(folder), name(subfolder)), id(subfolder), isFolder),
-				driveItem(id(pkg), name(pkg), parent(drive), rootID, isPackage),
-				driveItem(idx(file, "inFolder"), idx(file, "inFolder"), parent(drive, name(folder)), id(folder), isFile),
-				driveItem(idx(file, "inFolder2"), namex(file, "inFolder2"), parent(drive, name(folder), name(subfolder), name(folder)), idx(folder, 2), isFile),
-				driveItem(idx(file, "inFolderPackage"), namex(file, "inPackage"), parent(drive, name(pkg)), id(pkg), isFile),
+				driveRootItem(),
+				driveItem(idx(file, "inRoot"), namex(file, "inRoot"), driveParentDir(drive), rootID, isFile),
+				driveItem(id(folder), name(folder), driveParentDir(drive), rootID, isFolder),
+				driveItem(id(subfolder), name(subfolder), driveParentDir(drive, name(folder)), id(folder), isFolder),
+				driveItem(idx(folder, 2), name(folder), driveParentDir(drive, name(folder), name(subfolder)), id(subfolder), isFolder),
+				driveItem(id(pkg), name(pkg), driveParentDir(drive), rootID, isPackage),
+				driveItem(idx(file, "inFolder"), idx(file, "inFolder"), driveParentDir(drive, name(folder)), id(folder), isFile),
+				driveItem(idx(file, "inFolder2"), namex(file, "inFolder2"), driveParentDir(drive, name(folder), name(subfolder), name(folder)), idx(folder, 2), isFile),
+				driveItem(idx(file, "inFolderPackage"), namex(file, "inPackage"), driveParentDir(drive, name(pkg)), id(pkg), isFile),
 			},
 			previousPaths: map[string]string{},
 			scope: (&selectors.OneDriveBackup{}).Folders(
@@ -580,15 +598,15 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				id(subfolder):  asNew(t, fullPath(drive, name(folder), name(subfolder))),
-				idx(folder, 2): asNew(t, fullPath(drive, name(folder), name(subfolder), name(folder))),
+				id(subfolder):  asNew(t, driveFullPath(drive, name(folder), name(subfolder))),
+				idx(folder, 2): asNew(t, driveFullPath(drive, name(folder), name(subfolder), name(folder))),
 			},
 			expectedItemCount:      3,
 			expectedFileCount:      1,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				id(subfolder):  fullPath(drive, name(folder), name(subfolder)),
-				idx(folder, 2): fullPath(drive, name(folder), name(subfolder), name(folder)),
+				id(subfolder):  driveFullPath(drive, name(folder), name(subfolder)),
+				idx(folder, 2): driveFullPath(drive, name(folder), name(subfolder), name(folder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(idx(file, "inFolder2")),
@@ -596,28 +614,28 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "match subfolder selector",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				driveItem(id(file), name(file), parent(drive), rootID, isFile),
-				driveItem(id(folder), name(folder), parent(drive), rootID, isFolder),
-				driveItem(id(subfolder), name(subfolder), parent(drive, name(folder)), id(folder), isFolder),
-				driveItem(id(pkg), name(pkg), parent(drive), rootID, isPackage),
-				driveItem(idx(file, 1), namex(file, 1), parent(drive, name(folder)), id(folder), isFile),
-				driveItem(idx(file, "inSubfolder"), namex(file, "inSubfolder"), parent(drive, name(folder), name(subfolder)), id(subfolder), isFile),
-				driveItem(idx(file, 9), namex(file, 9), parent(drive, name(pkg)), id(pkg), isFile),
+				driveRootItem(),
+				driveItem(id(file), name(file), driveParentDir(drive), rootID, isFile),
+				driveItem(id(folder), name(folder), driveParentDir(drive), rootID, isFolder),
+				driveItem(id(subfolder), name(subfolder), driveParentDir(drive, name(folder)), id(folder), isFolder),
+				driveItem(id(pkg), name(pkg), driveParentDir(drive), rootID, isPackage),
+				driveItem(idx(file, 1), namex(file, 1), driveParentDir(drive, name(folder)), id(folder), isFile),
+				driveItem(idx(file, "inSubfolder"), namex(file, "inSubfolder"), driveParentDir(drive, name(folder), name(subfolder)), id(subfolder), isFile),
+				driveItem(idx(file, 9), namex(file, 9), driveParentDir(drive, name(pkg)), id(pkg), isFile),
 			},
 			previousPaths:    map[string]string{},
 			scope:            (&selectors.OneDriveBackup{}).Folders([]string{toPath(name(folder), name(subfolder))})[0],
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				id(subfolder): asNew(t, fullPath(drive, name(folder), name(subfolder))),
+				id(subfolder): asNew(t, driveFullPath(drive, name(folder), name(subfolder))),
 			},
 			expectedItemCount:      2,
 			expectedFileCount:      1,
 			expectedContainerCount: 1,
 			// No child folders for subfolder so nothing here.
 			expectedPrevPaths: map[string]string{
-				id(subfolder): fullPath(drive, name(folder), name(subfolder)),
+				id(subfolder): driveFullPath(drive, name(folder), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(idx(file, "inSubfolder")),
@@ -625,27 +643,27 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "not moved folder tree",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				driveItem(id(folder), name(folder), parent(drive), rootID, isFolder),
+				driveRootItem(),
+				driveItem(id(folder), name(folder), driveParentDir(drive), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				id(folder):    fullPath(drive, name(folder)),
-				id(subfolder): fullPath(drive, name(folder), name(subfolder)),
+				id(folder):    driveFullPath(drive, name(folder)),
+				id(subfolder): driveFullPath(drive, name(folder), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, fullPath(drive)),
-				id(folder): asNotMoved(t, fullPath(drive, name(folder))),
+				rootID:     asNotMoved(t, driveFullPath(drive)),
+				id(folder): asNotMoved(t, driveFullPath(drive, name(folder))),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      0,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:        fullPath(drive),
-				id(folder):    fullPath(drive, name(folder)),
-				id(subfolder): fullPath(drive, name(folder), name(subfolder)),
+				rootID:        driveFullPath(drive),
+				id(folder):    driveFullPath(drive, name(folder)),
+				id(subfolder): driveFullPath(drive, name(folder), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -653,27 +671,27 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "moved folder tree",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				driveItem(id(folder), name(folder), parent(drive), rootID, isFolder),
+				driveRootItem(),
+				driveItem(id(folder), name(folder), driveParentDir(drive), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				id(folder):    fullPath(drive, namex(folder, "a")),
-				id(subfolder): fullPath(drive, namex(folder, "a"), name(subfolder)),
+				id(folder):    driveFullPath(drive, namex(folder, "a")),
+				id(subfolder): driveFullPath(drive, namex(folder, "a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, fullPath(drive)),
-				id(folder): asMoved(t, fullPath(drive, namex(folder, "a")), fullPath(drive, name(folder))),
+				rootID:     asNotMoved(t, driveFullPath(drive)),
+				id(folder): asMoved(t, driveFullPath(drive, namex(folder, "a")), driveFullPath(drive, name(folder))),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      0,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:        fullPath(drive),
-				id(folder):    fullPath(drive, name(folder)),
-				id(subfolder): fullPath(drive, name(folder), name(subfolder)),
+				rootID:        driveFullPath(drive),
+				id(folder):    driveFullPath(drive, name(folder)),
+				id(subfolder): driveFullPath(drive, name(folder), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -681,28 +699,28 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "moved folder tree twice within backup",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				driveItem(idx(folder, 1), name(folder), parent(drive), rootID, isFolder),
-				driveItem(idx(folder, 2), name(folder), parent(drive), rootID, isFolder),
+				driveRootItem(),
+				driveItem(idx(folder, 1), name(folder), driveParentDir(drive), rootID, isFolder),
+				driveItem(idx(folder, 2), name(folder), driveParentDir(drive), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				idx(folder, 1): fullPath(drive, namex(folder, "a")),
-				id(subfolder):  fullPath(drive, namex(folder, "a"), name(subfolder)),
+				idx(folder, 1): driveFullPath(drive, namex(folder, "a")),
+				id(subfolder):  driveFullPath(drive, namex(folder, "a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:         asNotMoved(t, fullPath(drive)),
-				idx(folder, 2): asNew(t, fullPath(drive, name(folder))),
+				rootID:         asNotMoved(t, driveFullPath(drive)),
+				idx(folder, 2): asNew(t, driveFullPath(drive, name(folder))),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      0,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:         fullPath(drive),
-				idx(folder, 2): fullPath(drive, name(folder)),
-				id(subfolder):  fullPath(drive, name(folder), name(subfolder)),
+				rootID:         driveFullPath(drive),
+				idx(folder, 2): driveFullPath(drive, name(folder)),
+				id(subfolder):  driveFullPath(drive, name(folder), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -710,28 +728,28 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "deleted folder tree twice within backup",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				delItem(id(folder), parent(drive), rootID, isFolder),
-				driveItem(id(folder), name(drive), parent(drive), rootID, isFolder),
-				delItem(id(folder), parent(drive), rootID, isFolder),
+				driveRootItem(),
+				delItem(id(folder), driveParentDir(drive), rootID, isFolder),
+				driveItem(id(folder), name(drive), driveParentDir(drive), rootID, isFolder),
+				delItem(id(folder), driveParentDir(drive), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				id(folder):    fullPath(drive),
-				id(subfolder): fullPath(drive, namex(folder, "a"), name(subfolder)),
+				id(folder):    driveFullPath(drive),
+				id(subfolder): driveFullPath(drive, namex(folder, "a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, fullPath(drive)),
-				id(folder): asDeleted(t, fullPath(drive, "")),
+				rootID:     asNotMoved(t, driveFullPath(drive)),
+				id(folder): asDeleted(t, driveFullPath(drive, "")),
 			},
 			expectedItemCount:      0,
 			expectedFileCount:      0,
 			expectedContainerCount: 1,
 			expectedPrevPaths: map[string]string{
-				rootID:        fullPath(drive),
-				id(subfolder): fullPath(drive, namex(folder, "a"), name(subfolder)),
+				rootID:        driveFullPath(drive),
+				id(subfolder): driveFullPath(drive, namex(folder, "a"), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -739,29 +757,29 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "moved folder tree twice within backup including delete",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				driveItem(id(folder), name(folder), parent(drive), rootID, isFolder),
-				delItem(id(folder), parent(drive), rootID, isFolder),
-				driveItem(idx(folder, 2), name(folder), parent(drive), rootID, isFolder),
+				driveRootItem(),
+				driveItem(id(folder), name(folder), driveParentDir(drive), rootID, isFolder),
+				delItem(id(folder), driveParentDir(drive), rootID, isFolder),
+				driveItem(idx(folder, 2), name(folder), driveParentDir(drive), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				id(folder):    fullPath(drive, namex(folder, "a")),
-				id(subfolder): fullPath(drive, namex(folder, "a"), name(subfolder)),
+				id(folder):    driveFullPath(drive, namex(folder, "a")),
+				id(subfolder): driveFullPath(drive, namex(folder, "a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:         asNotMoved(t, fullPath(drive)),
-				idx(folder, 2): asNew(t, fullPath(drive, name(folder))),
+				rootID:         asNotMoved(t, driveFullPath(drive)),
+				idx(folder, 2): asNew(t, driveFullPath(drive, name(folder))),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      0,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:         fullPath(drive),
-				idx(folder, 2): fullPath(drive, name(folder)),
-				id(subfolder):  fullPath(drive, name(folder), name(subfolder)),
+				rootID:         driveFullPath(drive),
+				idx(folder, 2): driveFullPath(drive, name(folder)),
+				id(subfolder):  driveFullPath(drive, name(folder), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -769,28 +787,28 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "deleted folder tree twice within backup with addition",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				driveItem(idx(folder, 1), name(folder), parent(drive), rootID, isFolder),
-				delItem(idx(folder, 1), parent(drive), rootID, isFolder),
-				driveItem(idx(folder, 2), name(folder), parent(drive), rootID, isFolder),
-				delItem(idx(folder, 2), parent(drive), rootID, isFolder),
+				driveRootItem(),
+				driveItem(idx(folder, 1), name(folder), driveParentDir(drive), rootID, isFolder),
+				delItem(idx(folder, 1), driveParentDir(drive), rootID, isFolder),
+				driveItem(idx(folder, 2), name(folder), driveParentDir(drive), rootID, isFolder),
+				delItem(idx(folder, 2), driveParentDir(drive), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				idx(folder, 1): fullPath(drive, namex(folder, "a")),
-				id(subfolder):  fullPath(drive, namex(folder, "a"), name(subfolder)),
+				idx(folder, 1): driveFullPath(drive, namex(folder, "a")),
+				id(subfolder):  driveFullPath(drive, namex(folder, "a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID: asNotMoved(t, fullPath(drive)),
+				rootID: asNotMoved(t, driveFullPath(drive)),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      0,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:        fullPath(drive),
-				id(subfolder): fullPath(drive, name(folder), name(subfolder)),
+				rootID:        driveFullPath(drive),
+				id(subfolder): driveFullPath(drive, name(folder), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -798,25 +816,25 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "moved folder tree with file no previous",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				driveItem(id(folder), name(folder), parent(drive), rootID, isFolder),
-				driveItem(id(file), name(file), parent(drive, name(folder)), id(folder), isFile),
-				driveItem(id(folder), namex(folder, 2), parent(drive), rootID, isFolder),
+				driveRootItem(),
+				driveItem(id(folder), name(folder), driveParentDir(drive), rootID, isFolder),
+				driveItem(id(file), name(file), driveParentDir(drive, name(folder)), id(folder), isFile),
+				driveItem(id(folder), namex(folder, 2), driveParentDir(drive), rootID, isFolder),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, fullPath(drive)),
-				id(folder): asNew(t, fullPath(drive, namex(folder, 2))),
+				rootID:     asNotMoved(t, driveFullPath(drive)),
+				id(folder): asNew(t, driveFullPath(drive, namex(folder, 2))),
 			},
 			expectedItemCount:      2,
 			expectedFileCount:      1,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:     fullPath(drive),
-				id(folder): fullPath(drive, namex(folder, 2)),
+				rootID:     driveFullPath(drive),
+				id(folder): driveFullPath(drive, namex(folder, 2)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(id(file)),
@@ -824,24 +842,24 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "moved folder tree with file no previous 1",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				driveItem(id(folder), name(folder), parent(drive), rootID, isFolder),
-				driveItem(id(file), name(file), parent(drive, name(folder)), id(folder), isFile),
+				driveRootItem(),
+				driveItem(id(folder), name(folder), driveParentDir(drive), rootID, isFolder),
+				driveItem(id(file), name(file), driveParentDir(drive, name(folder)), id(folder), isFile),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, fullPath(drive)),
-				id(folder): asNew(t, fullPath(drive, name(folder))),
+				rootID:     asNotMoved(t, driveFullPath(drive)),
+				id(folder): asNew(t, driveFullPath(drive, name(folder))),
 			},
 			expectedItemCount:      2,
 			expectedFileCount:      1,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:     fullPath(drive),
-				id(folder): fullPath(drive, name(folder)),
+				rootID:     driveFullPath(drive),
+				id(folder): driveFullPath(drive, name(folder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(id(file)),
@@ -849,29 +867,29 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "moved folder tree and subfolder 1",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				driveItem(id(folder), name(folder), parent(drive), rootID, isFolder),
-				driveItem(id(subfolder), name(subfolder), parent(drive), rootID, isFolder),
+				driveRootItem(),
+				driveItem(id(folder), name(folder), driveParentDir(drive), rootID, isFolder),
+				driveItem(id(subfolder), name(subfolder), driveParentDir(drive), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				id(folder):    fullPath(drive, namex(folder, "a")),
-				id(subfolder): fullPath(drive, namex(folder, "a"), name(subfolder)),
+				id(folder):    driveFullPath(drive, namex(folder, "a")),
+				id(subfolder): driveFullPath(drive, namex(folder, "a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:        asNotMoved(t, fullPath(drive)),
-				id(folder):    asMoved(t, fullPath(drive, namex(folder, "a")), fullPath(drive, name(folder))),
-				id(subfolder): asMoved(t, fullPath(drive, namex(folder, "a"), name(subfolder)), fullPath(drive, name(subfolder))),
+				rootID:        asNotMoved(t, driveFullPath(drive)),
+				id(folder):    asMoved(t, driveFullPath(drive, namex(folder, "a")), driveFullPath(drive, name(folder))),
+				id(subfolder): asMoved(t, driveFullPath(drive, namex(folder, "a"), name(subfolder)), driveFullPath(drive, name(subfolder))),
 			},
 			expectedItemCount:      2,
 			expectedFileCount:      0,
 			expectedContainerCount: 3,
 			expectedPrevPaths: map[string]string{
-				rootID:        fullPath(drive),
-				id(folder):    fullPath(drive, name(folder)),
-				id(subfolder): fullPath(drive, name(subfolder)),
+				rootID:        driveFullPath(drive),
+				id(folder):    driveFullPath(drive, name(folder)),
+				id(subfolder): driveFullPath(drive, name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -879,29 +897,29 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "moved folder tree and subfolder 2",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				driveItem(id(subfolder), name(subfolder), parent(drive), rootID, isFolder),
-				driveItem(id(folder), name(folder), parent(drive), rootID, isFolder),
+				driveRootItem(),
+				driveItem(id(subfolder), name(subfolder), driveParentDir(drive), rootID, isFolder),
+				driveItem(id(folder), name(folder), driveParentDir(drive), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				id(folder):    fullPath(drive, namex(folder, "a")),
-				id(subfolder): fullPath(drive, namex(folder, "a"), name(subfolder)),
+				id(folder):    driveFullPath(drive, namex(folder, "a")),
+				id(subfolder): driveFullPath(drive, namex(folder, "a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:        asNotMoved(t, fullPath(drive)),
-				id(folder):    asMoved(t, fullPath(drive, namex(folder, "a")), fullPath(drive, name(folder))),
-				id(subfolder): asMoved(t, fullPath(drive, namex(folder, "a"), name(subfolder)), fullPath(drive, name(subfolder))),
+				rootID:        asNotMoved(t, driveFullPath(drive)),
+				id(folder):    asMoved(t, driveFullPath(drive, namex(folder, "a")), driveFullPath(drive, name(folder))),
+				id(subfolder): asMoved(t, driveFullPath(drive, namex(folder, "a"), name(subfolder)), driveFullPath(drive, name(subfolder))),
 			},
 			expectedItemCount:      2,
 			expectedFileCount:      0,
 			expectedContainerCount: 3,
 			expectedPrevPaths: map[string]string{
-				rootID:        fullPath(drive),
-				id(folder):    fullPath(drive, name(folder)),
-				id(subfolder): fullPath(drive, name(subfolder)),
+				rootID:        driveFullPath(drive),
+				id(folder):    driveFullPath(drive, name(folder)),
+				id(subfolder): driveFullPath(drive, name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -909,37 +927,37 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "move subfolder when moving parent",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				driveItem(idx(folder, 2), namex(folder, 2), parent(drive), rootID, isFolder),
-				driveItem(id(item), name(item), parent(drive, namex(folder, 2)), idx(folder, 2), isFile),
+				driveRootItem(),
+				driveItem(idx(folder, 2), namex(folder, 2), driveParentDir(drive), rootID, isFolder),
+				driveItem(id(item), name(item), driveParentDir(drive, namex(folder, 2)), idx(folder, 2), isFile),
 				// Need to see the parent folder first (expected since that's what Graph
 				// consistently returns).
-				driveItem(id(folder), namex(folder, "a"), parent(drive), rootID, isFolder),
-				driveItem(id(subfolder), name(subfolder), parent(drive, namex(folder, "a")), id(folder), isFolder),
-				driveItem(idx(item, 2), namex(item, 2), parent(drive, namex(folder, "a"), name(subfolder)), id(subfolder), isFile),
-				driveItem(id(folder), name(folder), parent(drive), rootID, isFolder),
+				driveItem(id(folder), namex(folder, "a"), driveParentDir(drive), rootID, isFolder),
+				driveItem(id(subfolder), name(subfolder), driveParentDir(drive, namex(folder, "a")), id(folder), isFolder),
+				driveItem(idx(item, 2), namex(item, 2), driveParentDir(drive, namex(folder, "a"), name(subfolder)), id(subfolder), isFile),
+				driveItem(id(folder), name(folder), driveParentDir(drive), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				id(folder):    fullPath(drive, namex(folder, "a")),
-				id(subfolder): fullPath(drive, namex(folder, "a"), name(subfolder)),
+				id(folder):    driveFullPath(drive, namex(folder, "a")),
+				id(subfolder): driveFullPath(drive, namex(folder, "a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:         asNotMoved(t, fullPath(drive)),
-				idx(folder, 2): asNew(t, fullPath(drive, namex(folder, 2))),
-				id(folder):     asMoved(t, fullPath(drive, namex(folder, "a")), fullPath(drive, name(folder))),
-				id(subfolder):  asMoved(t, fullPath(drive, namex(folder, "a"), name(subfolder)), fullPath(drive, name(folder), name(subfolder))),
+				rootID:         asNotMoved(t, driveFullPath(drive)),
+				idx(folder, 2): asNew(t, driveFullPath(drive, namex(folder, 2))),
+				id(folder):     asMoved(t, driveFullPath(drive, namex(folder, "a")), driveFullPath(drive, name(folder))),
+				id(subfolder):  asMoved(t, driveFullPath(drive, namex(folder, "a"), name(subfolder)), driveFullPath(drive, name(folder), name(subfolder))),
 			},
 			expectedItemCount:      5,
 			expectedFileCount:      2,
 			expectedContainerCount: 4,
 			expectedPrevPaths: map[string]string{
-				rootID:         fullPath(drive),
-				id(folder):     fullPath(drive, name(folder)),
-				idx(folder, 2): fullPath(drive, namex(folder, 2)),
-				id(subfolder):  fullPath(drive, name(folder), name(subfolder)),
+				rootID:         driveFullPath(drive),
+				id(folder):     driveFullPath(drive, name(folder)),
+				idx(folder, 2): driveFullPath(drive, namex(folder, 2)),
+				id(subfolder):  driveFullPath(drive, name(folder), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(id(item), idx(item, 2)),
@@ -947,29 +965,29 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "moved folder tree multiple times",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				driveItem(id(folder), name(folder), parent(drive), rootID, isFolder),
-				driveItem(id(file), name(file), parent(drive, name(folder)), id(folder), isFile),
-				driveItem(id(folder), namex(folder, 2), parent(drive), rootID, isFolder),
+				driveRootItem(),
+				driveItem(id(folder), name(folder), driveParentDir(drive), rootID, isFolder),
+				driveItem(id(file), name(file), driveParentDir(drive, name(folder)), id(folder), isFile),
+				driveItem(id(folder), namex(folder, 2), driveParentDir(drive), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				id(folder):    fullPath(drive, namex(folder, "a")),
-				id(subfolder): fullPath(drive, namex(folder, "a"), name(subfolder)),
+				id(folder):    driveFullPath(drive, namex(folder, "a")),
+				id(subfolder): driveFullPath(drive, namex(folder, "a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, fullPath(drive)),
-				id(folder): asMoved(t, fullPath(drive, namex(folder, "a")), fullPath(drive, namex(folder, 2))),
+				rootID:     asNotMoved(t, driveFullPath(drive)),
+				id(folder): asMoved(t, driveFullPath(drive, namex(folder, "a")), driveFullPath(drive, namex(folder, 2))),
 			},
 			expectedItemCount:      2,
 			expectedFileCount:      1,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:        fullPath(drive),
-				id(folder):    fullPath(drive, namex(folder, 2)),
-				id(subfolder): fullPath(drive, namex(folder, 2), name(subfolder)),
+				rootID:        driveFullPath(drive),
+				id(folder):    driveFullPath(drive, namex(folder, 2)),
+				id(subfolder): driveFullPath(drive, namex(folder, 2), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(id(file)),
@@ -977,28 +995,28 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "deleted folder and package",
 			items: []models.DriveItemable{
-				driveRootItem(rootID), // root is always present, but not necessary here
-				delItem(id(folder), parent(drive), rootID, isFolder),
-				delItem(id(pkg), parent(drive), rootID, isPackage),
+				driveRootItem(), // root is always present, but not necessary here
+				delItem(id(folder), driveParentDir(drive), rootID, isFolder),
+				delItem(id(pkg), driveParentDir(drive), rootID, isPackage),
 			},
 			previousPaths: map[string]string{
-				rootID:     fullPath(drive),
-				id(folder): fullPath(drive, name(folder)),
-				id(pkg):    fullPath(drive, name(pkg)),
+				rootID:     driveFullPath(drive),
+				id(folder): driveFullPath(drive, name(folder)),
+				id(pkg):    driveFullPath(drive, name(pkg)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, fullPath(drive)),
-				id(folder): asDeleted(t, fullPath(drive, name(folder))),
-				id(pkg):    asDeleted(t, fullPath(drive, name(pkg))),
+				rootID:     asNotMoved(t, driveFullPath(drive)),
+				id(folder): asDeleted(t, driveFullPath(drive, name(folder))),
+				id(pkg):    asDeleted(t, driveFullPath(drive, name(pkg))),
 			},
 			expectedItemCount:      0,
 			expectedFileCount:      0,
 			expectedContainerCount: 1,
 			expectedPrevPaths: map[string]string{
-				rootID: fullPath(drive),
+				rootID: driveFullPath(drive),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -1006,23 +1024,23 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "delete folder without previous",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				delItem(id(folder), parent(drive), rootID, isFolder),
+				driveRootItem(),
+				delItem(id(folder), driveParentDir(drive), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				rootID: fullPath(drive),
+				rootID: driveFullPath(drive),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID: asNotMoved(t, fullPath(drive)),
+				rootID: asNotMoved(t, driveFullPath(drive)),
 			},
 			expectedItemCount:      0,
 			expectedFileCount:      0,
 			expectedContainerCount: 1,
 			expectedPrevPaths: map[string]string{
-				rootID: fullPath(drive),
+				rootID: driveFullPath(drive),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -1030,29 +1048,29 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "delete folder tree move subfolder",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				delItem(id(folder), parent(drive), rootID, isFolder),
-				driveItem(id(subfolder), name(subfolder), parent(drive), rootID, isFolder),
+				driveRootItem(),
+				delItem(id(folder), driveParentDir(drive), rootID, isFolder),
+				driveItem(id(subfolder), name(subfolder), driveParentDir(drive), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				rootID:        fullPath(drive),
-				id(folder):    fullPath(drive, name(folder)),
-				id(subfolder): fullPath(drive, name(folder), name(subfolder)),
+				rootID:        driveFullPath(drive),
+				id(folder):    driveFullPath(drive, name(folder)),
+				id(subfolder): driveFullPath(drive, name(folder), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:        asNotMoved(t, fullPath(drive)),
-				id(folder):    asDeleted(t, fullPath(drive, name(folder))),
-				id(subfolder): asMoved(t, fullPath(drive, name(folder), name(subfolder)), fullPath(drive, name(subfolder))),
+				rootID:        asNotMoved(t, driveFullPath(drive)),
+				id(folder):    asDeleted(t, driveFullPath(drive, name(folder))),
+				id(subfolder): asMoved(t, driveFullPath(drive, name(folder), name(subfolder)), driveFullPath(drive, name(subfolder))),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      0,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:        fullPath(drive),
-				id(subfolder): fullPath(drive, name(subfolder)),
+				rootID:        driveFullPath(drive),
+				id(subfolder): driveFullPath(drive, name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -1060,23 +1078,23 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "delete file",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				delItem(id(item), parent(drive), rootID, isFile),
+				driveRootItem(),
+				delItem(id(item), driveParentDir(drive), rootID, isFile),
 			},
 			previousPaths: map[string]string{
-				rootID: fullPath(drive),
+				rootID: driveFullPath(drive),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID: asNotMoved(t, fullPath(drive)),
+				rootID: asNotMoved(t, driveFullPath(drive)),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      1,
 			expectedContainerCount: 1,
 			expectedPrevPaths: map[string]string{
-				rootID: fullPath(drive),
+				rootID: driveFullPath(drive),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(id(item)),
@@ -1084,22 +1102,22 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "item before parent errors",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				driveItem(id(file), name(file), parent(drive, name(folder)), id(folder), isFile),
-				driveItem(id(folder), name(folder), parent(drive), rootID, isFolder),
+				driveRootItem(),
+				driveItem(id(file), name(file), driveParentDir(drive, name(folder)), id(folder), isFile),
+				driveItem(id(folder), name(folder), driveParentDir(drive), rootID, isFolder),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.Error,
 			expectedCollectionIDs: map[string]statePath{
-				rootID: asNotMoved(t, fullPath(drive)),
+				rootID: asNotMoved(t, driveFullPath(drive)),
 			},
 			expectedItemCount:      0,
 			expectedFileCount:      0,
 			expectedContainerCount: 1,
 			expectedPrevPaths: map[string]string{
-				rootID: fullPath(drive),
+				rootID: driveFullPath(drive),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -1107,33 +1125,33 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "1 root file, 1 folder, 1 package, 1 good file, 1 malware",
 			items: []models.DriveItemable{
-				driveRootItem(rootID),
-				driveItem(id(file), id(file), parent(drive), rootID, isFile),
-				driveItem(id(folder), name(folder), parent(drive), rootID, isFolder),
-				driveItem(id(pkg), name(pkg), parent(drive), rootID, isPackage),
-				driveItem(idx(file, "good"), namex(file, "good"), parent(drive, name(folder)), id(folder), isFile),
-				malwareItem(id(malware), name(malware), parent(drive, name(folder)), id(folder), isFile),
+				driveRootItem(),
+				driveItem(id(file), id(file), driveParentDir(drive), rootID, isFile),
+				driveItem(id(folder), name(folder), driveParentDir(drive), rootID, isFolder),
+				driveItem(id(pkg), name(pkg), driveParentDir(drive), rootID, isPackage),
+				driveItem(idx(file, "good"), namex(file, "good"), driveParentDir(drive, name(folder)), id(folder), isFile),
+				malwareItem(id(malware), name(malware), driveParentDir(drive, name(folder)), id(folder), isFile),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, fullPath(drive)),
-				id(folder): asNew(t, fullPath(drive, name(folder))),
-				id(pkg):    asNew(t, fullPath(drive, name(pkg))),
+				rootID:     asNotMoved(t, driveFullPath(drive)),
+				id(folder): asNew(t, driveFullPath(drive, name(folder))),
+				id(pkg):    asNew(t, driveFullPath(drive, name(pkg))),
 			},
 			expectedItemCount:      4,
 			expectedFileCount:      2,
 			expectedContainerCount: 3,
 			expectedSkippedCount:   1,
 			expectedPrevPaths: map[string]string{
-				rootID:     fullPath(drive),
-				id(folder): fullPath(drive, name(folder)),
-				id(pkg):    fullPath(drive, name(pkg)),
+				rootID:     driveFullPath(drive),
+				id(folder): driveFullPath(drive, name(folder)),
+				id(pkg):    driveFullPath(drive, name(pkg)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{
-				fullPath(drive, name(pkg)): {},
+				driveFullPath(drive, name(pkg)): {},
 			},
 			expectedCountPackages: 1,
 			expectedExcludes:      makeExcludeMap(id(file), idx(file, "good")),
@@ -1256,7 +1274,7 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
 								id(drive): {
-									idx(folder, 1): fullPath(1),
+									idx(folder, 1): driveFullPath(1),
 								},
 							}),
 					}
@@ -1267,7 +1285,7 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 			},
 			expectedPaths: map[string]map[string]string{
 				id(drive): {
-					idx(folder, 1): fullPath(1),
+					idx(folder, 1): driveFullPath(1),
 				},
 			},
 			canUsePreviousBackup: true,
@@ -1298,7 +1316,7 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
 								id(drive): {
-									idx(folder, 1): fullPath(1),
+									idx(folder, 1): driveFullPath(1),
 								},
 							}),
 					}
@@ -1307,7 +1325,7 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 			expectedDeltas: map[string]string{},
 			expectedPaths: map[string]map[string]string{
 				id(drive): {
-					idx(folder, 1): fullPath(1),
+					idx(folder, 1): driveFullPath(1),
 				},
 			},
 			canUsePreviousBackup: true,
@@ -1354,7 +1372,7 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
 								id(drive): {
-									idx(folder, 1): fullPath(1),
+									idx(folder, 1): driveFullPath(1),
 								},
 							}),
 					}
@@ -1363,7 +1381,7 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 			expectedDeltas: map[string]string{id(drive): ""},
 			expectedPaths: map[string]map[string]string{
 				id(drive): {
-					idx(folder, 1): fullPath(1),
+					idx(folder, 1): driveFullPath(1),
 				},
 			},
 			canUsePreviousBackup: true,
@@ -1381,7 +1399,7 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
 								id(drive): {
-									idx(folder, 1): fullPath(1),
+									idx(folder, 1): driveFullPath(1),
 								},
 							}),
 					}
@@ -1395,7 +1413,7 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
 								idx(drive, 2): {
-									idx(folder, 2): fullPath(2),
+									idx(folder, 2): driveFullPath(2),
 								},
 							}),
 					}
@@ -1407,10 +1425,10 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 			},
 			expectedPaths: map[string]map[string]string{
 				id(drive): {
-					idx(folder, 1): fullPath(1),
+					idx(folder, 1): driveFullPath(1),
 				},
 				idx(drive, 2): {
-					idx(folder, 2): fullPath(2),
+					idx(folder, 2): driveFullPath(2),
 				},
 			},
 			canUsePreviousBackup: true,
@@ -1448,7 +1466,7 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
 								id(drive): {
-									idx(folder, 1): fullPath(1),
+									idx(folder, 1): driveFullPath(1),
 								},
 							}),
 						graph.NewMetadataEntry(
@@ -1462,7 +1480,7 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 			},
 			expectedPaths: map[string]map[string]string{
 				id(drive): {
-					idx(folder, 1): fullPath(1),
+					idx(folder, 1): driveFullPath(1),
 				},
 			},
 			canUsePreviousBackup: true,
@@ -1480,7 +1498,7 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
 								id(drive): {
-									idx(folder, 1): fullPath(1),
+									idx(folder, 1): driveFullPath(1),
 								},
 							}),
 					}
@@ -1491,7 +1509,7 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
 								id(drive): {
-									idx(folder, 2): fullPath(2),
+									idx(folder, 2): driveFullPath(2),
 								},
 							}),
 					}
@@ -1514,7 +1532,7 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
 								id(drive): {
-									idx(folder, 1): fullPath(1),
+									idx(folder, 1): driveFullPath(1),
 								},
 							}),
 					}
@@ -1544,8 +1562,8 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
 								id(drive): {
-									idx(folder, 1): fullPath(1),
-									idx(folder, 2): fullPath(1),
+									idx(folder, 1): driveFullPath(1),
+									idx(folder, 2): driveFullPath(1),
 								},
 							}),
 					}
@@ -1556,8 +1574,8 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 			},
 			expectedPaths: map[string]map[string]string{
 				id(drive): {
-					idx(folder, 1): fullPath(1),
-					idx(folder, 2): fullPath(1),
+					idx(folder, 1): driveFullPath(1),
+					idx(folder, 2): driveFullPath(1),
 				},
 			},
 			expectedAlerts:       []string{fault.AlertPreviousPathCollision},
@@ -1578,8 +1596,8 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
 								id(drive): {
-									idx(folder, 1): fullPath(1),
-									idx(folder, 2): fullPath(1),
+									idx(folder, 1): driveFullPath(1),
+									idx(folder, 2): driveFullPath(1),
 								},
 							}),
 					}
@@ -1593,7 +1611,7 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
 								idx(drive, 2): {
-									idx(folder, 1): fullPath(1),
+									idx(folder, 1): driveFullPath(1),
 								},
 							}),
 					}
@@ -1605,11 +1623,11 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 			},
 			expectedPaths: map[string]map[string]string{
 				id(drive): {
-					idx(folder, 1): fullPath(1),
-					idx(folder, 2): fullPath(1),
+					idx(folder, 1): driveFullPath(1),
+					idx(folder, 2): driveFullPath(1),
 				},
 				idx(drive, 2): {
-					idx(folder, 1): fullPath(1),
+					idx(folder, 1): driveFullPath(1),
 				},
 			},
 			expectedAlerts:       []string{fault.AlertPreviousPathCollision},
@@ -1694,8 +1712,8 @@ func (suite *CollectionsUnitSuite) TestGet_treeCannotBeUsedWhileIncomplete() {
 	defer flush()
 
 	drv := models.NewDrive()
-	drv.SetId(ptr.To("id"))
-	drv.SetName(ptr.To("name"))
+	drv.SetId(ptr.To(id(drive)))
+	drv.SetName(ptr.To(name(drive)))
 
 	mbh := mock.DefaultOneDriveBH(user)
 	opts := control.DefaultOptions()
@@ -1704,11 +1722,11 @@ func (suite *CollectionsUnitSuite) TestGet_treeCannotBeUsedWhileIncomplete() {
 	mbh.DrivePagerV = pagerForDrives(drv)
 	mbh.DriveItemEnumeration = mock.EnumerateItemsDeltaByDrive{
 		DrivePagers: map[string]*mock.DriveItemsDeltaPager{
-			"id": {
+			id(drive): {
 				Pages: []mock.NextPage{{
 					Items: []models.DriveItemable{
-						driveRootItem(rootID), // will be present, not needed
-						delItem(id(file), parent(1), rootID, isFile),
+						driveRootItem(), // will be present, not needed
+						delItem(id(file), parentDir(), rootID, isFile),
 					},
 				}},
 				DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
@@ -1720,7 +1738,7 @@ func (suite *CollectionsUnitSuite) TestGet_treeCannotBeUsedWhileIncomplete() {
 	c.ctrl = opts
 
 	_, _, err := c.Get(ctx, nil, nil, fault.New(true))
-	require.ErrorContains(t, err, "not implemented", clues.ToCore(err))
+	require.ErrorIs(t, err, errGetTreeNotImplemented, clues.ToCore(err))
 }
 
 func (suite *CollectionsUnitSuite) TestGet() {
@@ -1767,8 +1785,8 @@ func (suite *CollectionsUnitSuite) TestGet() {
 					idx(drive, 1): {
 						Pages: []mock.NextPage{{
 							Items: []models.DriveItemable{
-								driveRootItem(rootID), // will be present, not needed
-								delItem(id(file), parent(1), rootID, isFile),
+								driveRootItem(), // will be present, not needed
+								delItem(id(file), driveParentDir(1), rootID, isFile),
 							},
 						}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
@@ -1778,19 +1796,19 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				idx(drive, 1): {rootID: fullPath(1)},
+				idx(drive, 1): {rootID: driveFullPath(1)},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1): {data.NotMovedState: {}},
+				driveFullPath(1): {data.NotMovedState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
 				idx(drive, 1): id(delta),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				idx(drive, 1): {rootID: fullPath(1)},
+				idx(drive, 1): {rootID: driveFullPath(1)},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{
-				fullPath(1): makeExcludeMap(id(file)),
+				driveFullPath(1): makeExcludeMap(id(file)),
 			}),
 		},
 		{
@@ -1801,8 +1819,8 @@ func (suite *CollectionsUnitSuite) TestGet() {
 					idx(drive, 1): {
 						Pages: []mock.NextPage{{
 							Items: []models.DriveItemable{
-								driveRootItem(rootID),
-								driveItem(id(file), name(file), parent(1), rootID, isFile),
+								driveRootItem(),
+								driveItem(id(file), name(file), driveParentDir(1), rootID, isFile),
 							},
 						}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
@@ -1812,19 +1830,19 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				idx(drive, 1): {rootID: fullPath(1)},
+				idx(drive, 1): {rootID: driveFullPath(1)},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1): {data.NotMovedState: {id(file)}},
+				driveFullPath(1): {data.NotMovedState: {id(file)}},
 			},
 			expectedDeltaURLs: map[string]string{
 				idx(drive, 1): id(delta),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				idx(drive, 1): {rootID: fullPath(1)},
+				idx(drive, 1): {rootID: driveFullPath(1)},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{
-				fullPath(1): makeExcludeMap(id(file)),
+				driveFullPath(1): makeExcludeMap(id(file)),
 			}),
 		},
 		{
@@ -1835,9 +1853,9 @@ func (suite *CollectionsUnitSuite) TestGet() {
 					idx(drive, 1): {
 						Pages: []mock.NextPage{{
 							Items: []models.DriveItemable{
-								driveRootItem(rootID),
-								driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-								driveItem(id(file), name(file), parent(1, name(folder)), id(folder), isFile),
+								driveRootItem(),
+								driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+								driveItem(id(file), name(file), driveParentDir(1, name(folder)), id(folder), isFile),
 							},
 						}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta), Reset: true},
@@ -1848,22 +1866,22 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			errCheck:             assert.NoError,
 			previousPaths:        map[string]map[string]string{},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1):               {data.NewState: {}},
-				fullPath(1, name(folder)): {data.NewState: {id(folder), id(file)}},
+				driveFullPath(1):               {data.NewState: {}},
+				driveFullPath(1, name(folder)): {data.NewState: {id(folder), id(file)}},
 			},
 			expectedDeltaURLs: map[string]string{
 				idx(drive, 1): id(delta),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:     fullPath(1),
-					id(folder): fullPath(1, name(folder)),
+					rootID:     driveFullPath(1),
+					id(folder): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1):               true,
-				fullPath(1, name(folder)): true,
+				driveFullPath(1):               true,
+				driveFullPath(1, name(folder)): true,
 			},
 		},
 		{
@@ -1874,10 +1892,10 @@ func (suite *CollectionsUnitSuite) TestGet() {
 					idx(drive, 1): {
 						Pages: []mock.NextPage{{
 							Items: []models.DriveItemable{
-								driveRootItem(rootID),
-								driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-								driveItem(id(file), name(file), parent(1, name(folder)), id(folder), isFile),
-								driveItem(id(file), namex(file, 2), parent(1, name(folder)), id(folder), isFile),
+								driveRootItem(),
+								driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+								driveItem(id(file), name(file), driveParentDir(1, name(folder)), id(folder), isFile),
+								driveItem(id(file), namex(file, 2), driveParentDir(1, name(folder)), id(folder), isFile),
 							},
 						}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta), Reset: true},
@@ -1888,22 +1906,22 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			errCheck:             assert.NoError,
 			previousPaths:        map[string]map[string]string{},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1):               {data.NewState: {}},
-				fullPath(1, name(folder)): {data.NewState: {id(folder), id(file)}},
+				driveFullPath(1):               {data.NewState: {}},
+				driveFullPath(1, name(folder)): {data.NewState: {id(folder), id(file)}},
 			},
 			expectedDeltaURLs: map[string]string{
 				idx(drive, 1): id(delta),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:     fullPath(1),
-					id(folder): fullPath(1, name(folder)),
+					rootID:     driveFullPath(1),
+					id(folder): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1):               true,
-				fullPath(1, name(folder)): true,
+				driveFullPath(1):               true,
+				driveFullPath(1, name(folder)): true,
 			},
 		},
 		{
@@ -1913,10 +1931,10 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
 					idx(drive, 1): {
 						Pages: []mock.NextPage{{Items: []models.DriveItemable{
-							driveRootItem(rootID),
-							driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-							driveItem(id(file), name(file), parent(1, name(folder)), id(folder), isFile),
-							driveItem(id(file), namex(file, 2), parent(1), rootID, isFile),
+							driveRootItem(),
+							driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+							driveItem(id(file), name(file), driveParentDir(1, name(folder)), id(folder), isFile),
+							driveItem(id(file), namex(file, 2), driveParentDir(1), rootID, isFile),
 						}}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
@@ -1926,24 +1944,24 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID: fullPath(1),
+					rootID: driveFullPath(1),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1):               {data.NotMovedState: {id(file)}},
-				fullPath(1, name(folder)): {data.NewState: {id(folder)}},
+				driveFullPath(1):               {data.NotMovedState: {id(file)}},
+				driveFullPath(1, name(folder)): {data.NewState: {id(folder)}},
 			},
 			expectedDeltaURLs: map[string]string{
 				idx(drive, 1): id(delta),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:     fullPath(1),
-					id(folder): fullPath(1, name(folder)),
+					rootID:     driveFullPath(1),
+					id(folder): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{
-				fullPath(1): makeExcludeMap(id(file)),
+				driveFullPath(1): makeExcludeMap(id(file)),
 			}),
 		},
 		{
@@ -1953,9 +1971,9 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
 					idx(drive, 1): {
 						Pages: []mock.NextPage{{Items: []models.DriveItemable{
-							driveRootItem(rootID),
-							driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-							driveItem(id(file), name(file), parent(1, name(folder)), id(folder), isFile),
+							driveRootItem(),
+							driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+							driveItem(id(file), name(file), driveParentDir(1, name(folder)), id(folder), isFile),
 						}}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: "", Reset: true},
 					},
@@ -1967,20 +1985,20 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				idx(drive, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1):               {data.NewState: {}},
-				fullPath(1, name(folder)): {data.NewState: {id(folder), id(file)}},
+				driveFullPath(1):               {data.NewState: {}},
+				driveFullPath(1, name(folder)): {data.NewState: {id(folder), id(file)}},
 			},
 			expectedDeltaURLs: map[string]string{},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:     fullPath(1),
-					id(folder): fullPath(1, name(folder)),
+					rootID:     driveFullPath(1),
+					id(folder): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1):               true,
-				fullPath(1, name(folder)): true,
+				driveFullPath(1):               true,
+				driveFullPath(1, name(folder)): true,
 			},
 		},
 		{
@@ -1992,16 +2010,16 @@ func (suite *CollectionsUnitSuite) TestGet() {
 						Pages: []mock.NextPage{
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-									driveItem(id(file), name(file), parent(1, name(folder)), id(folder), isFile),
+									driveRootItem(),
+									driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(id(file), name(file), driveParentDir(1, name(folder)), id(folder), isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-									driveItem(idx(file, 2), namex(file, 2), parent(1, name(folder)), id(folder), isFile),
+									driveRootItem(),
+									driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(idx(file, 2), namex(file, 2), driveParentDir(1, name(folder)), id(folder), isFile),
 								},
 							},
 						},
@@ -2015,22 +2033,22 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				idx(drive, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1):               {data.NewState: {}},
-				fullPath(1, name(folder)): {data.NewState: {id(folder), id(file), idx(file, 2)}},
+				driveFullPath(1):               {data.NewState: {}},
+				driveFullPath(1, name(folder)): {data.NewState: {id(folder), id(file), idx(file, 2)}},
 			},
 			expectedDeltaURLs: map[string]string{
 				idx(drive, 1): id(delta),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:     fullPath(1),
-					id(folder): fullPath(1, name(folder)),
+					rootID:     driveFullPath(1),
+					id(folder): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1):               true,
-				fullPath(1, name(folder)): true,
+				driveFullPath(1):               true,
+				driveFullPath(1, name(folder)): true,
 			},
 		},
 		{
@@ -2042,10 +2060,10 @@ func (suite *CollectionsUnitSuite) TestGet() {
 						Pages: []mock.NextPage{
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-									driveItem(id(file), name(file), parent(1, name(folder)), id(folder), isFile),
-									driveItem(idx(file, 3), namex(file, 3), parent(1, name(folder)), id(folder), isFile),
+									driveRootItem(),
+									driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(id(file), name(file), driveParentDir(1, name(folder)), id(folder), isFile),
+									driveItem(idx(file, 3), namex(file, 3), driveParentDir(1, name(folder)), id(folder), isFile),
 								},
 							},
 							{
@@ -2054,16 +2072,16 @@ func (suite *CollectionsUnitSuite) TestGet() {
 							},
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-									driveItem(id(file), name(file), parent(1, name(folder)), id(folder), isFile),
+									driveRootItem(),
+									driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(id(file), name(file), driveParentDir(1, name(folder)), id(folder), isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-									driveItem(idx(file, 2), namex(file, 2), parent(1, name(folder)), id(folder), isFile),
+									driveRootItem(),
+									driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(idx(file, 2), namex(file, 2), driveParentDir(1, name(folder)), id(folder), isFile),
 								},
 							},
 						},
@@ -2077,22 +2095,22 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				idx(drive, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1):               {data.NewState: {}},
-				fullPath(1, name(folder)): {data.NewState: {id(folder), id(file), idx(file, 2)}},
+				driveFullPath(1):               {data.NewState: {}},
+				driveFullPath(1, name(folder)): {data.NewState: {id(folder), id(file), idx(file, 2)}},
 			},
 			expectedDeltaURLs: map[string]string{
 				idx(drive, 1): id(delta),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:     fullPath(1),
-					id(folder): fullPath(1, name(folder)),
+					rootID:     driveFullPath(1),
+					id(folder): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1):               true,
-				fullPath(1, name(folder)): true,
+				driveFullPath(1):               true,
+				driveFullPath(1, name(folder)): true,
 			},
 		},
 		{
@@ -2104,24 +2122,24 @@ func (suite *CollectionsUnitSuite) TestGet() {
 						Pages: []mock.NextPage{
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-									driveItem(id(file), name(file), parent(1, name(folder)), id(folder), isFile),
+									driveRootItem(),
+									driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(id(file), name(file), driveParentDir(1, name(folder)), id(folder), isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-									driveItem(id(file), name(file), parent(1, name(folder)), id(folder), isFile),
+									driveRootItem(),
+									driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(id(file), name(file), driveParentDir(1, name(folder)), id(folder), isFile),
 								},
 								Reset: true,
 							},
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-									driveItem(idx(file, 2), namex(file, 2), parent(1, name(folder)), id(folder), isFile),
+									driveRootItem(),
+									driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(idx(file, 2), namex(file, 2), driveParentDir(1, name(folder)), id(folder), isFile),
 								},
 							},
 						},
@@ -2135,22 +2153,22 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				idx(drive, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1):               {data.NewState: {}},
-				fullPath(1, name(folder)): {data.NewState: {id(folder), id(file), idx(file, 2)}},
+				driveFullPath(1):               {data.NewState: {}},
+				driveFullPath(1, name(folder)): {data.NewState: {id(folder), id(file), idx(file, 2)}},
 			},
 			expectedDeltaURLs: map[string]string{
 				idx(drive, 1): id(delta),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:     fullPath(1),
-					id(folder): fullPath(1, name(folder)),
+					rootID:     driveFullPath(1),
+					id(folder): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1):               true,
-				fullPath(1, name(folder)): true,
+				driveFullPath(1):               true,
+				driveFullPath(1, name(folder)): true,
 			},
 		},
 		{
@@ -2163,17 +2181,17 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
 					idx(drive, 1): {
 						Pages: []mock.NextPage{{Items: []models.DriveItemable{
-							driveRootItem(rootID),
-							driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-							driveItem(id(file), name(file), parent(1, name(folder)), id(folder), isFile),
+							driveRootItem(),
+							driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+							driveItem(id(file), name(file), driveParentDir(1, name(folder)), id(folder), isFile),
 						}}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta), Reset: true},
 					},
 					idx(drive, 2): {
 						Pages: []mock.NextPage{{Items: []models.DriveItemable{
-							driveRootItem(idx("root", 2)),
-							driveItem(idx(folder, 2), name(folder), parent(2), idx("root", 2), isFolder),
-							driveItem(idx(file, 2), name(file), parent(2, name(folder)), idx(folder, 2), isFile),
+							driveRootItem(),
+							driveItem(idx(folder, 2), name(folder), driveParentDir(2), rootID, isFolder),
+							driveItem(idx(file, 2), name(file), driveParentDir(2, name(folder)), idx(folder, 2), isFile),
 						}}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: idx(delta, 2), Reset: true},
 					},
@@ -2186,10 +2204,10 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				idx(drive, 2): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1):               {data.NewState: {}},
-				fullPath(1, name(folder)): {data.NewState: {id(folder), id(file)}},
-				fullPath(2):               {data.NewState: {}},
-				fullPath(2, name(folder)): {data.NewState: {idx(folder, 2), idx(file, 2)}},
+				driveFullPath(1):               {data.NewState: {}},
+				driveFullPath(1, name(folder)): {data.NewState: {id(folder), id(file)}},
+				driveFullPath(2):               {data.NewState: {}},
+				driveFullPath(2, name(folder)): {data.NewState: {idx(folder, 2), idx(file, 2)}},
 			},
 			expectedDeltaURLs: map[string]string{
 				idx(drive, 1): id(delta),
@@ -2197,20 +2215,20 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:     fullPath(1),
-					id(folder): fullPath(1, name(folder)),
+					rootID:     driveFullPath(1),
+					id(folder): driveFullPath(1, name(folder)),
 				},
 				idx(drive, 2): {
-					idx("root", 2): fullPath(2),
-					idx(folder, 2): fullPath(2, name(folder)),
+					rootID:         driveFullPath(2),
+					idx(folder, 2): driveFullPath(2, name(folder)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1):               true,
-				fullPath(1, name(folder)): true,
-				fullPath(2):               true,
-				fullPath(2, name(folder)): true,
+				driveFullPath(1):               true,
+				driveFullPath(1, name(folder)): true,
+				driveFullPath(2):               true,
+				driveFullPath(2, name(folder)): true,
 			},
 		},
 		{
@@ -2223,17 +2241,17 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
 					idx(drive, 1): {
 						Pages: []mock.NextPage{{Items: []models.DriveItemable{
-							driveRootItem(rootID),
-							driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-							driveItem(id(file), name(file), parent(1, name(folder)), id(folder), isFile),
+							driveRootItem(),
+							driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+							driveItem(id(file), name(file), driveParentDir(1, name(folder)), id(folder), isFile),
 						}}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta), Reset: true},
 					},
 					idx(drive, 2): {
 						Pages: []mock.NextPage{{Items: []models.DriveItemable{
-							driveRootItem(rootID),
-							driveItem(id(folder), name(folder), parent(2), rootID, isFolder),
-							driveItem(idx(file, 2), name(file), parent(2, name(folder)), id(folder), isFile),
+							driveRootItem(),
+							driveItem(id(folder), name(folder), driveParentDir(2), rootID, isFolder),
+							driveItem(idx(file, 2), name(file), driveParentDir(2, name(folder)), id(folder), isFile),
 						}}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: idx(delta, 2), Reset: true},
 					},
@@ -2246,10 +2264,10 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				idx(drive, 2): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1):               {data.NewState: {}},
-				fullPath(1, name(folder)): {data.NewState: {id(folder), id(file)}},
-				fullPath(2):               {data.NewState: {}},
-				fullPath(2, name(folder)): {data.NewState: {id(folder), idx(file, 2)}},
+				driveFullPath(1):               {data.NewState: {}},
+				driveFullPath(1, name(folder)): {data.NewState: {id(folder), id(file)}},
+				driveFullPath(2):               {data.NewState: {}},
+				driveFullPath(2, name(folder)): {data.NewState: {id(folder), idx(file, 2)}},
 			},
 			expectedDeltaURLs: map[string]string{
 				idx(drive, 1): id(delta),
@@ -2257,20 +2275,20 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:     fullPath(1),
-					id(folder): fullPath(1, name(folder)),
+					rootID:     driveFullPath(1),
+					id(folder): driveFullPath(1, name(folder)),
 				},
 				idx(drive, 2): {
-					rootID:     fullPath(2),
-					id(folder): fullPath(2, name(folder)),
+					rootID:     driveFullPath(2),
+					id(folder): driveFullPath(2, name(folder)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1):               true,
-				fullPath(1, name(folder)): true,
-				fullPath(2):               true,
-				fullPath(2, name(folder)): true,
+				driveFullPath(1):               true,
+				driveFullPath(1, name(folder)): true,
+				driveFullPath(2):               true,
+				driveFullPath(2, name(folder)): true,
 			},
 		},
 		{
@@ -2308,9 +2326,9 @@ func (suite *CollectionsUnitSuite) TestGet() {
 							},
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(idx(folder, 2), namex(folder, 2), parent(1), rootID, isFolder),
-									driveItem(id(file), name(file), parent(1, namex(folder, 2)), idx(folder, 2), isFile),
+									driveRootItem(),
+									driveItem(idx(folder, 2), namex(folder, 2), driveParentDir(1), rootID, isFolder),
+									driveItem(id(file), name(file), driveParentDir(1, namex(folder, 2)), idx(folder, 2), isFile),
 								},
 							},
 						},
@@ -2322,29 +2340,29 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:     fullPath(1),
-					id(folder): fullPath(1, name(folder)),
+					rootID:     driveFullPath(1),
+					id(folder): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1):                   {data.NewState: {}},
-				fullPath(1, name(folder)):     {data.DeletedState: {}},
-				fullPath(1, namex(folder, 2)): {data.NewState: {idx(folder, 2), id(file)}},
+				driveFullPath(1):                   {data.NewState: {}},
+				driveFullPath(1, name(folder)):     {data.DeletedState: {}},
+				driveFullPath(1, namex(folder, 2)): {data.NewState: {idx(folder, 2), id(file)}},
 			},
 			expectedDeltaURLs: map[string]string{
 				idx(drive, 1): id(delta),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:         fullPath(1),
-					idx(folder, 2): fullPath(1, namex(folder, 2)),
+					rootID:         driveFullPath(1),
+					idx(folder, 2): driveFullPath(1, namex(folder, 2)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1):                   true,
-				fullPath(1, name(folder)):     true,
-				fullPath(1, namex(folder, 2)): true,
+				driveFullPath(1):                   true,
+				driveFullPath(1, name(folder)):     true,
+				driveFullPath(1, namex(folder, 2)): true,
 			},
 		},
 		{
@@ -2360,9 +2378,9 @@ func (suite *CollectionsUnitSuite) TestGet() {
 							},
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(idx(folder, 2), namex(folder, 2), parent(1), rootID, isFolder),
-									driveItem(id(file), name(file), parent(1, namex(folder, 2)), idx(folder, 2), isFile),
+									driveRootItem(),
+									driveItem(idx(folder, 2), namex(folder, 2), driveParentDir(1), rootID, isFolder),
+									driveItem(id(file), name(file), driveParentDir(1, namex(folder, 2)), idx(folder, 2), isFile),
 								},
 							},
 						},
@@ -2374,29 +2392,29 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:     fullPath(1),
-					id(folder): fullPath(1, name(folder)),
+					rootID:     driveFullPath(1),
+					id(folder): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1):                   {data.NewState: {}},
-				fullPath(1, name(folder)):     {data.DeletedState: {}},
-				fullPath(1, namex(folder, 2)): {data.NewState: {idx(folder, 2), id(file)}},
+				driveFullPath(1):                   {data.NewState: {}},
+				driveFullPath(1, name(folder)):     {data.DeletedState: {}},
+				driveFullPath(1, namex(folder, 2)): {data.NewState: {idx(folder, 2), id(file)}},
 			},
 			expectedDeltaURLs: map[string]string{
 				idx(drive, 1): id(delta),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:         fullPath(1),
-					idx(folder, 2): fullPath(1, namex(folder, 2)),
+					rootID:         driveFullPath(1),
+					idx(folder, 2): driveFullPath(1, namex(folder, 2)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1):                   true,
-				fullPath(1, name(folder)):     true,
-				fullPath(1, namex(folder, 2)): true,
+				driveFullPath(1):                   true,
+				driveFullPath(1, name(folder)):     true,
+				driveFullPath(1, namex(folder, 2)): true,
 			},
 		},
 		{
@@ -2410,9 +2428,9 @@ func (suite *CollectionsUnitSuite) TestGet() {
 								// on the first page, if this is the total data, we'd expect both folder and folder2
 								// since new previousPaths merge with the old previousPaths.
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(idx(folder, 2), name(folder), parent(1), rootID, isFolder),
-									driveItem(id(file), name(file), parent(1, name(folder)), idx(folder, 2), isFile),
+									driveRootItem(),
+									driveItem(idx(folder, 2), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(id(file), name(file), driveParentDir(1, name(folder)), idx(folder, 2), isFile),
 								},
 							},
 							{
@@ -2423,9 +2441,9 @@ func (suite *CollectionsUnitSuite) TestGet() {
 								// but after a delta reset, we treat this as the total end set of folders, which means
 								// we don't expect folder to exist any longer.
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(idx(folder, 2), name(folder), parent(1), rootID, isFolder),
-									driveItem(id(file), name(file), parent(1, name(folder)), idx(folder, 2), isFile),
+									driveRootItem(),
+									driveItem(idx(folder, 2), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(id(file), name(file), driveParentDir(1, name(folder)), idx(folder, 2), isFile),
 								},
 							},
 						},
@@ -2437,13 +2455,13 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:     fullPath(1),
-					id(folder): fullPath(1, name(folder)),
+					rootID:     driveFullPath(1),
+					id(folder): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1): {data.NewState: {}},
-				fullPath(1, name(folder)): {
+				driveFullPath(1): {data.NewState: {}},
+				driveFullPath(1, name(folder)): {
 					// Old folder path should be marked as deleted since it should compare
 					// by ID.
 					data.DeletedState: {},
@@ -2455,14 +2473,14 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:         fullPath(1),
-					idx(folder, 2): fullPath(1, name(folder)),
+					rootID:         driveFullPath(1),
+					idx(folder, 2): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1):               true,
-				fullPath(1, name(folder)): true,
+				driveFullPath(1):               true,
+				driveFullPath(1, name(folder)): true,
 			},
 		},
 		{
@@ -2474,9 +2492,9 @@ func (suite *CollectionsUnitSuite) TestGet() {
 						Pages: []mock.NextPage{
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-									driveItem(id(file), name(file), parent(1, name(folder)), id(folder), isFile),
+									driveRootItem(),
+									driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(id(file), name(file), driveParentDir(1, name(folder)), id(folder), isFile),
 								},
 							},
 							{
@@ -2485,9 +2503,9 @@ func (suite *CollectionsUnitSuite) TestGet() {
 							},
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-									driveItem(id(file), name(file), parent(1, name(folder)), id(folder), isFile),
+									driveRootItem(),
+									driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(id(file), name(file), driveParentDir(1, name(folder)), id(folder), isFile),
 								},
 							},
 						},
@@ -2499,13 +2517,13 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:     fullPath(1),
-					id(folder): fullPath(1, name(folder)),
+					rootID:     driveFullPath(1),
+					id(folder): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1): {data.NewState: {}},
-				fullPath(1, name(folder)): {
+				driveFullPath(1): {data.NewState: {}},
+				driveFullPath(1, name(folder)): {
 					data.NewState: {id(folder), id(file)},
 				},
 			},
@@ -2514,14 +2532,14 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:     fullPath(1),
-					id(folder): fullPath(1, name(folder)),
+					rootID:     driveFullPath(1),
+					id(folder): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1):               true,
-				fullPath(1, name(folder)): true,
+				driveFullPath(1):               true,
+				driveFullPath(1, name(folder)): true,
 			},
 		},
 		{
@@ -2537,9 +2555,9 @@ func (suite *CollectionsUnitSuite) TestGet() {
 							},
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(idx(folder, 2), name(folder), parent(1), rootID, isFolder),
-									driveItem(idx(file, 2), name(file), parent(1, name(folder)), idx(folder, 2), isFile),
+									driveRootItem(),
+									driveItem(idx(folder, 2), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(idx(file, 2), name(file), driveParentDir(1, name(folder)), idx(folder, 2), isFile),
 								},
 							},
 						},
@@ -2551,13 +2569,13 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:     fullPath(1),
-					id(folder): fullPath(1, name(folder)),
+					rootID:     driveFullPath(1),
+					id(folder): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1): {data.NewState: {}},
-				fullPath(1, name(folder)): {
+				driveFullPath(1): {data.NewState: {}},
+				driveFullPath(1, name(folder)): {
 					data.DeletedState: {},
 					data.NewState:     {idx(folder, 2), idx(file, 2)},
 				},
@@ -2567,14 +2585,14 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:         fullPath(1),
-					idx(folder, 2): fullPath(1, name(folder)),
+					rootID:         driveFullPath(1),
+					idx(folder, 2): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1):               true,
-				fullPath(1, name(folder)): true,
+				driveFullPath(1):               true,
+				driveFullPath(1, name(folder)): true,
 			},
 		},
 		{
@@ -2590,9 +2608,9 @@ func (suite *CollectionsUnitSuite) TestGet() {
 							},
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(idx(folder, 2), name(folder), parent(1), rootID, isFolder),
-									driveItem(id(file), name(file), parent(1, name(folder)), idx(folder, 2), isFile),
+									driveRootItem(),
+									driveItem(idx(folder, 2), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(id(file), name(file), driveParentDir(1, name(folder)), idx(folder, 2), isFile),
 								},
 							},
 						},
@@ -2604,13 +2622,13 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:     fullPath(1),
-					id(folder): fullPath(1, name(folder)),
+					rootID:     driveFullPath(1),
+					id(folder): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1): {data.NewState: {}},
-				fullPath(1, name(folder)): {
+				driveFullPath(1): {data.NewState: {}},
+				driveFullPath(1, name(folder)): {
 					// Old folder path should be marked as deleted since it should compare
 					// by ID.
 					data.DeletedState: {},
@@ -2622,14 +2640,14 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:         fullPath(1),
-					idx(folder, 2): fullPath(1, name(folder)),
+					rootID:         driveFullPath(1),
+					idx(folder, 2): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1):               true,
-				fullPath(1, name(folder)): true,
+				driveFullPath(1):               true,
+				driveFullPath(1, name(folder)): true,
 			},
 		},
 		{
@@ -2641,18 +2659,18 @@ func (suite *CollectionsUnitSuite) TestGet() {
 						Pages: []mock.NextPage{
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-									driveItem(id(file), name(file), parent(1, name(folder)), id(folder), isFile),
-									malwareItem(id(malware), name(malware), parent(1, name(folder)), id(folder), isFile),
+									driveRootItem(),
+									driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(id(file), name(file), driveParentDir(1, name(folder)), id(folder), isFile),
+									malwareItem(id(malware), name(malware), driveParentDir(1, name(folder)), id(folder), isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-									driveItem(idx(file, 2), namex(file, 2), parent(1, name(folder)), id(folder), isFile),
-									malwareItem(idx(malware, 2), namex(malware, 2), parent(1, name(folder)), id(folder), isFile),
+									driveRootItem(),
+									driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(idx(file, 2), namex(file, 2), driveParentDir(1, name(folder)), id(folder), isFile),
+									malwareItem(idx(malware, 2), namex(malware, 2), driveParentDir(1, name(folder)), id(folder), isFile),
 								},
 							},
 						},
@@ -2666,22 +2684,22 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				idx(drive, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1):               {data.NewState: {}},
-				fullPath(1, name(folder)): {data.NewState: {id(folder), id(file), idx(file, 2)}},
+				driveFullPath(1):               {data.NewState: {}},
+				driveFullPath(1, name(folder)): {data.NewState: {id(folder), id(file), idx(file, 2)}},
 			},
 			expectedDeltaURLs: map[string]string{
 				idx(drive, 1): id(delta),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:     fullPath(1),
-					id(folder): fullPath(1, name(folder)),
+					rootID:     driveFullPath(1),
+					id(folder): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1):               true,
-				fullPath(1, name(folder)): true,
+				driveFullPath(1):               true,
+				driveFullPath(1, name(folder)): true,
 			},
 			expectedSkippedCount: 2,
 		},
@@ -2694,11 +2712,11 @@ func (suite *CollectionsUnitSuite) TestGet() {
 						Pages: []mock.NextPage{
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-									driveItem(id(file), name(file), parent(1, name(folder)), id(folder), isFile),
-									driveItem(idx(folder, 2), namex(folder, 2), parent(1), rootID, isFolder),
-									driveItem(idx(file, 2), namex(file, 2), parent(1, namex(folder, 2)), idx(folder, 2), isFile),
+									driveRootItem(),
+									driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(id(file), name(file), driveParentDir(1, name(folder)), id(folder), isFile),
+									driveItem(idx(folder, 2), namex(folder, 2), driveParentDir(1), rootID, isFolder),
+									driveItem(idx(file, 2), namex(file, 2), driveParentDir(1, namex(folder, 2)), idx(folder, 2), isFile),
 								},
 							},
 							{
@@ -2706,11 +2724,11 @@ func (suite *CollectionsUnitSuite) TestGet() {
 							},
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-									driveItem(id(file), name(file), parent(1, name(folder)), id(folder), isFile),
-									delItem(idx(folder, 2), parent(1), rootID, isFolder),
-									delItem(namex(file, 2), parent(1), rootID, isFile),
+									driveRootItem(),
+									driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(id(file), name(file), driveParentDir(1, name(folder)), id(folder), isFile),
+									delItem(idx(folder, 2), driveParentDir(1), rootID, isFolder),
+									delItem(namex(file, 2), driveParentDir(1), rootID, isFile),
 								},
 							},
 						},
@@ -2722,30 +2740,30 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:         fullPath(1),
-					id(folder):     fullPath(1, name(folder)),
-					idx(folder, 2): fullPath(1, namex(folder, 2)),
+					rootID:         driveFullPath(1),
+					id(folder):     driveFullPath(1, name(folder)),
+					idx(folder, 2): driveFullPath(1, namex(folder, 2)),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1):                   {data.NewState: {}},
-				fullPath(1, name(folder)):     {data.NewState: {id(folder), id(file)}},
-				fullPath(1, namex(folder, 2)): {data.DeletedState: {}},
+				driveFullPath(1):                   {data.NewState: {}},
+				driveFullPath(1, name(folder)):     {data.NewState: {id(folder), id(file)}},
+				driveFullPath(1, namex(folder, 2)): {data.DeletedState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
 				idx(drive, 1): idx(delta, 2),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:     fullPath(1),
-					id(folder): fullPath(1, name(folder)),
+					rootID:     driveFullPath(1),
+					id(folder): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1):                   true,
-				fullPath(1, name(folder)):     true,
-				fullPath(1, namex(folder, 2)): true,
+				driveFullPath(1):                   true,
+				driveFullPath(1, name(folder)):     true,
+				driveFullPath(1, namex(folder, 2)): true,
 			},
 		},
 		{
@@ -2756,8 +2774,8 @@ func (suite *CollectionsUnitSuite) TestGet() {
 					idx(drive, 1): {
 						Pages: []mock.NextPage{{
 							Items: []models.DriveItemable{
-								driveRootItem(rootID),
-								delItem(id(folder), parent(1), rootID, isFolder),
+								driveRootItem(),
+								delItem(id(folder), driveParentDir(1), rootID, isFolder),
 							},
 							Reset: true,
 						}},
@@ -2769,26 +2787,26 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:     fullPath(1),
-					id(folder): fullPath(1, name(folder)),
+					rootID:     driveFullPath(1),
+					id(folder): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1):               {data.NewState: {}},
-				fullPath(1, name(folder)): {data.DeletedState: {}},
+				driveFullPath(1):               {data.NewState: {}},
+				driveFullPath(1, name(folder)): {data.DeletedState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
 				idx(drive, 1): id(delta),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID: fullPath(1),
+					rootID: driveFullPath(1),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1):               true,
-				fullPath(1, name(folder)): true,
+				driveFullPath(1):               true,
+				driveFullPath(1, name(folder)): true,
 			},
 		},
 		{
@@ -2800,8 +2818,8 @@ func (suite *CollectionsUnitSuite) TestGet() {
 						Pages: []mock.NextPage{
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									delItem(id(file), parent(1), rootID, isFile),
+									driveRootItem(),
+									delItem(id(file), driveParentDir(1), rootID, isFile),
 								},
 								Reset: true,
 							},
@@ -2814,23 +2832,23 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID: fullPath(1),
+					rootID: driveFullPath(1),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1): {data.NewState: {}},
+				driveFullPath(1): {data.NewState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
 				idx(drive, 1): id(delta),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID: fullPath(1),
+					rootID: driveFullPath(1),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1): true,
+				driveFullPath(1): true,
 			},
 		},
 		{
@@ -2842,16 +2860,16 @@ func (suite *CollectionsUnitSuite) TestGet() {
 						Pages: []mock.NextPage{
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-									driveItem(id(file), name(file), parent(1, name(folder)), id(folder), isFile),
+									driveRootItem(),
+									driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(id(file), name(file), driveParentDir(1, name(folder)), id(folder), isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									delItem(id(folder), parent(1), rootID, isFolder),
-									delItem(id(file), parent(1), rootID, isFile),
+									driveRootItem(),
+									delItem(id(folder), driveParentDir(1), rootID, isFolder),
+									delItem(id(file), driveParentDir(1), rootID, isFile),
 								},
 							},
 						},
@@ -2865,19 +2883,19 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				idx(drive, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1): {data.NewState: {}},
+				driveFullPath(1): {data.NewState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
 				idx(drive, 1): idx(delta, 2),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID: fullPath(1),
+					rootID: driveFullPath(1),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1): true,
+				driveFullPath(1): true,
 			},
 		},
 		{
@@ -2889,23 +2907,23 @@ func (suite *CollectionsUnitSuite) TestGet() {
 						Pages: []mock.NextPage{
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-									driveItem(id(file), name(file), parent(1, name(folder)), id(folder), isFile),
+									driveRootItem(),
+									driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(id(file), name(file), driveParentDir(1, name(folder)), id(folder), isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									delItem(id(folder), parent(1), rootID, isFolder),
-									delItem(id(file), parent(1), rootID, isFile),
+									driveRootItem(),
+									delItem(id(folder), driveParentDir(1), rootID, isFolder),
+									delItem(id(file), driveParentDir(1), rootID, isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(idx(folder, 1), name(folder), parent(1), rootID, isFolder),
-									driveItem(idx(file, 1), name(file), parent(1, name(folder)), idx(folder, 1), isFile),
+									driveRootItem(),
+									driveItem(idx(folder, 1), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(idx(file, 1), name(file), driveParentDir(1, name(folder)), idx(folder, 1), isFile),
 								},
 							},
 						},
@@ -2919,22 +2937,22 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				idx(drive, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1):               {data.NewState: {}},
-				fullPath(1, name(folder)): {data.NewState: {idx(folder, 1), idx(file, 1)}},
+				driveFullPath(1):               {data.NewState: {}},
+				driveFullPath(1, name(folder)): {data.NewState: {idx(folder, 1), idx(file, 1)}},
 			},
 			expectedDeltaURLs: map[string]string{
 				idx(drive, 1): idx(delta, 2),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:         fullPath(1),
-					idx(folder, 1): fullPath(1, name(folder)),
+					rootID:         driveFullPath(1),
+					idx(folder, 1): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1):               true,
-				fullPath(1, name(folder)): true,
+				driveFullPath(1):               true,
+				driveFullPath(1, name(folder)): true,
 			},
 		},
 		{
@@ -2946,23 +2964,23 @@ func (suite *CollectionsUnitSuite) TestGet() {
 						Pages: []mock.NextPage{
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									delItem(id(folder), parent(1), rootID, isFolder),
-									delItem(id(file), parent(1, name(folder)), rootID, isFile),
+									driveRootItem(),
+									delItem(id(folder), driveParentDir(1), rootID, isFolder),
+									delItem(id(file), driveParentDir(1, name(folder)), rootID, isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-									driveItem(id(file), name(file), parent(1, name(folder)), id(folder), isFile),
+									driveRootItem(),
+									driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(id(file), name(file), driveParentDir(1, name(folder)), id(folder), isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									delItem(id(folder), parent(1), rootID, isFolder),
-									delItem(id(file), parent(1, name(folder)), rootID, isFile),
+									driveRootItem(),
+									delItem(id(folder), driveParentDir(1), rootID, isFolder),
+									delItem(id(file), driveParentDir(1, name(folder)), rootID, isFile),
 								},
 							},
 						},
@@ -2974,20 +2992,20 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:     fullPath(1),
-					id(folder): fullPath(1, name(folder)),
+					rootID:     driveFullPath(1),
+					id(folder): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1):               {data.NotMovedState: {}},
-				fullPath(1, name(folder)): {data.DeletedState: {}},
+				driveFullPath(1):               {data.NotMovedState: {}},
+				driveFullPath(1, name(folder)): {data.DeletedState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
 				idx(drive, 1): idx(delta, 2),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID: fullPath(1),
+					rootID: driveFullPath(1),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
@@ -3002,23 +3020,23 @@ func (suite *CollectionsUnitSuite) TestGet() {
 						Pages: []mock.NextPage{
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-									driveItem(id(file), name(file), parent(1, name(folder)), id(folder), isFile),
+									driveRootItem(),
+									driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(id(file), name(file), driveParentDir(1, name(folder)), id(folder), isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									delItem(id(folder), parent(1), rootID, isFolder),
-									delItem(id(file), parent(1), rootID, isFile),
+									driveRootItem(),
+									delItem(id(folder), driveParentDir(1), rootID, isFolder),
+									delItem(id(file), driveParentDir(1), rootID, isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(idx(folder, 1), name(folder), parent(1), rootID, isFolder),
-									driveItem(idx(file, 1), name(file), parent(1, name(folder)), idx(folder, 1), isFile),
+									driveRootItem(),
+									driveItem(idx(folder, 1), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(idx(file, 1), name(file), driveParentDir(1, name(folder)), idx(folder, 1), isFile),
 								},
 							},
 						},
@@ -3030,27 +3048,27 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:     fullPath(1),
-					id(folder): fullPath(1, name(folder)),
+					rootID:     driveFullPath(1),
+					id(folder): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1):               {data.NewState: {}},
-				fullPath(1, name(folder)): {data.DeletedState: {}, data.NewState: {idx(folder, 1), idx(file, 1)}},
+				driveFullPath(1):               {data.NewState: {}},
+				driveFullPath(1, name(folder)): {data.DeletedState: {}, data.NewState: {idx(folder, 1), idx(file, 1)}},
 			},
 			expectedDeltaURLs: map[string]string{
 				idx(drive, 1): idx(delta, 2),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:         fullPath(1),
-					idx(folder, 1): fullPath(1, name(folder)),
+					rootID:         driveFullPath(1),
+					idx(folder, 1): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1):               false,
-				fullPath(1, name(folder)): true,
+				driveFullPath(1):               false,
+				driveFullPath(1, name(folder)): true,
 			},
 		},
 		{
@@ -3062,15 +3080,15 @@ func (suite *CollectionsUnitSuite) TestGet() {
 						Pages: []mock.NextPage{
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-									driveItem(id(file), name(file), parent(1, name(folder)), id(folder), isFile),
+									driveRootItem(),
+									driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+									driveItem(id(file), name(file), driveParentDir(1, name(folder)), id(folder), isFile),
 								},
 							},
 							{
 								Items: []models.DriveItemable{
-									driveRootItem(rootID),
-									delItem(id(file), parent(1), rootID, isFile),
+									driveRootItem(),
+									delItem(id(file), driveParentDir(1), rootID, isFile),
 								},
 							},
 						},
@@ -3084,22 +3102,22 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				idx(drive, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1):               {data.NewState: {}},
-				fullPath(1, name(folder)): {data.NewState: {id(folder)}},
+				driveFullPath(1):               {data.NewState: {}},
+				driveFullPath(1, name(folder)): {data.NewState: {id(folder)}},
 			},
 			expectedDeltaURLs: map[string]string{
 				idx(drive, 1): id(delta),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:     fullPath(1),
-					id(folder): fullPath(1, name(folder)),
+					rootID:     driveFullPath(1),
+					id(folder): driveFullPath(1, name(folder)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1):               true,
-				fullPath(1, name(folder)): true,
+				driveFullPath(1):               true,
+				driveFullPath(1, name(folder)): true,
 			},
 		},
 		{
@@ -3109,8 +3127,8 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
 					idx(drive, 1): {
 						Pages: []mock.NextPage{{Items: []models.DriveItemable{
-							driveRootItem(rootID),
-							delItem(id(folder), parent(1), rootID, isFolder),
+							driveRootItem(),
+							delItem(id(folder), driveParentDir(1), rootID, isFolder),
 						}}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta), Reset: true},
 					},
@@ -3122,19 +3140,19 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				idx(drive, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1): {data.NewState: {}},
+				driveFullPath(1): {data.NewState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
 				idx(drive, 1): id(delta),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID: fullPath(1),
+					rootID: driveFullPath(1),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1): true,
+				driveFullPath(1): true,
 			},
 		},
 		{
@@ -3144,8 +3162,8 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
 					idx(drive, 1): {
 						Pages: []mock.NextPage{{Items: []models.DriveItemable{
-							driveRootItem(rootID),
-							delItem(id(file), parent(1), rootID, isFile),
+							driveRootItem(),
+							delItem(id(file), driveParentDir(1), rootID, isFile),
 						}}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta), Reset: true},
 					},
@@ -3157,19 +3175,19 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				idx(drive, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1): {data.NewState: {}},
+				driveFullPath(1): {data.NewState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
 				idx(drive, 1): id(delta),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID: fullPath(1),
+					rootID: driveFullPath(1),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(1): true,
+				driveFullPath(1): true,
 			},
 		},
 		{
@@ -3179,7 +3197,7 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
 					idx(drive, 1): {
 						Pages: []mock.NextPage{{Items: []models.DriveItemable{
-							driveRootItem(rootID), // will be present
+							driveRootItem(), // will be present
 						}}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
@@ -3188,20 +3206,20 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				idx(drive, 1): {rootID: fullPath(1)},
-				idx(drive, 2): {rootID: fullPath(2)},
+				idx(drive, 1): {rootID: driveFullPath(1)},
+				idx(drive, 2): {rootID: driveFullPath(2)},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1): {data.NotMovedState: {}},
-				fullPath(2): {data.DeletedState: {}},
+				driveFullPath(1): {data.NotMovedState: {}},
+				driveFullPath(2): {data.DeletedState: {}},
 			},
 			expectedDeltaURLs: map[string]string{idx(drive, 1): id(delta)},
 			expectedPreviousPaths: map[string]map[string]string{
-				idx(drive, 1): {rootID: fullPath(1)},
+				idx(drive, 1): {rootID: driveFullPath(1)},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				fullPath(2): true,
+				driveFullPath(2): true,
 			},
 		},
 		{
@@ -3213,11 +3231,11 @@ func (suite *CollectionsUnitSuite) TestGet() {
 					idx(drive, 1): {
 						Pages: []mock.NextPage{{
 							Items: []models.DriveItemable{
-								driveRootItem(rootID),
-								driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-								driveItem(id(file), name(file), parent(1, name(folder)), id(folder), isFile),
-								driveItem(idx(folder, 2), namex(folder, 2), parent(1), rootID, isFolder),
-								driveItem(idx(file, 2), namex(file, 2), parent(1, namex(folder, 2)), idx(folder, 2), isFile),
+								driveRootItem(),
+								driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+								driveItem(id(file), name(file), driveParentDir(1, name(folder)), id(folder), isFile),
+								driveItem(idx(folder, 2), namex(folder, 2), driveParentDir(1), rootID, isFolder),
+								driveItem(idx(file, 2), namex(file, 2), driveParentDir(1, namex(folder, 2)), idx(folder, 2), isFile),
 							},
 						}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
@@ -3226,11 +3244,11 @@ func (suite *CollectionsUnitSuite) TestGet() {
 					idx(drive, 2): {
 						Pages: []mock.NextPage{{
 							Items: []models.DriveItemable{
-								driveRootItem(rootID),
-								driveItem(id(folder), name(folder), parent(2), rootID, isFolder),
-								driveItem(id(file), name(file), parent(2, name(folder)), id(folder), isFile),
-								driveItem(idx(folder, 2), namex(folder, 2), parent(2), rootID, isFolder),
-								driveItem(idx(file, 2), namex(file, 2), parent(2, namex(folder, 2)), idx(folder, 2), isFile),
+								driveRootItem(),
+								driveItem(id(folder), name(folder), driveParentDir(2), rootID, isFolder),
+								driveItem(id(file), name(file), driveParentDir(2, name(folder)), id(folder), isFile),
+								driveItem(idx(folder, 2), namex(folder, 2), driveParentDir(2), rootID, isFolder),
+								driveItem(idx(file, 2), namex(file, 2), driveParentDir(2, namex(folder, 2)), idx(folder, 2), isFile),
 							},
 						}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: idx(delta, 2)},
@@ -3241,34 +3259,34 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:         fullPath(1),
-					id(folder):     fullPath(1, name(folder)),
-					idx(folder, 2): fullPath(1, name(folder)),
-					idx(folder, 3): fullPath(1, name(folder)),
+					rootID:         driveFullPath(1),
+					id(folder):     driveFullPath(1, name(folder)),
+					idx(folder, 2): driveFullPath(1, name(folder)),
+					idx(folder, 3): driveFullPath(1, name(folder)),
 				},
 				idx(drive, 2): {
-					rootID:         fullPath(2),
-					id(folder):     fullPath(2, name(folder)),
-					idx(folder, 2): fullPath(2, namex(folder, 2)),
+					rootID:         driveFullPath(2),
+					id(folder):     driveFullPath(2, name(folder)),
+					idx(folder, 2): driveFullPath(2, namex(folder, 2)),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1): {
+				driveFullPath(1): {
 					data.NewState: {id(folder), idx(folder, 2)},
 				},
-				fullPath(1, name(folder)): {
+				driveFullPath(1, name(folder)): {
 					data.NotMovedState: {id(folder), id(file)},
 				},
-				fullPath(1, namex(folder, 2)): {
+				driveFullPath(1, namex(folder, 2)): {
 					data.MovedState: {idx(folder, 2), idx(file, 2)},
 				},
-				fullPath(2): {
+				driveFullPath(2): {
 					data.NewState: {id(folder), idx(folder, 2)},
 				},
-				fullPath(2, name(folder)): {
+				driveFullPath(2, name(folder)): {
 					data.NotMovedState: {id(folder), id(file)},
 				},
-				fullPath(2, namex(folder, 2)): {
+				driveFullPath(2, namex(folder, 2)): {
 					data.NotMovedState: {idx(folder, 2), idx(file, 2)},
 				},
 			},
@@ -3278,20 +3296,20 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:         fullPath(1),
-					id(folder):     fullPath(1, namex(folder, 2)), // note: this is a bug, but is currently expected
-					idx(folder, 2): fullPath(1, namex(folder, 2)),
-					idx(folder, 3): fullPath(1, namex(folder, 2)),
+					rootID:         driveFullPath(1),
+					id(folder):     driveFullPath(1, namex(folder, 2)), // note: this is a bug, but is currently expected
+					idx(folder, 2): driveFullPath(1, namex(folder, 2)),
+					idx(folder, 3): driveFullPath(1, namex(folder, 2)),
 				},
 				idx(drive, 2): {
-					rootID:         fullPath(2),
-					id(folder):     fullPath(2, name(folder)),
-					idx(folder, 2): fullPath(2, namex(folder, 2)),
+					rootID:         driveFullPath(2),
+					id(folder):     driveFullPath(2, name(folder)),
+					idx(folder, 2): driveFullPath(2, namex(folder, 2)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{
-				fullPath(1): makeExcludeMap(id(file), idx(file, 2)),
-				fullPath(2): makeExcludeMap(id(file), idx(file, 2)),
+				driveFullPath(1): makeExcludeMap(id(file), idx(file, 2)),
+				driveFullPath(2): makeExcludeMap(id(file), idx(file, 2)),
 			}),
 			doNotMergeItems: map[string]bool{},
 		},
@@ -3303,11 +3321,11 @@ func (suite *CollectionsUnitSuite) TestGet() {
 					idx(drive, 1): {
 						Pages: []mock.NextPage{{
 							Items: []models.DriveItemable{
-								driveRootItem(rootID),
-								driveItem(idx(fanny, 2), name(fanny), parent(1), rootID, isFolder),
-								driveItem(idx(file, 2), namex(file, 2), parent(1, name(fanny)), idx(fanny, 2), isFile),
-								driveItem(id(nav), name(nav), parent(1), rootID, isFolder),
-								driveItem(id(file), name(file), parent(1, name(nav)), id(nav), isFile),
+								driveRootItem(),
+								driveItem(idx(fanny, 2), name(fanny), driveParentDir(1), rootID, isFolder),
+								driveItem(idx(file, 2), namex(file, 2), driveParentDir(1, name(fanny)), idx(fanny, 2), isFile),
+								driveItem(id(nav), name(nav), driveParentDir(1), rootID, isFolder),
+								driveItem(id(file), name(file), driveParentDir(1, name(nav)), id(nav), isFile),
 							},
 						}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
@@ -3318,18 +3336,18 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:  fullPath(1),
-					id(nav): fullPath(1, name(fanny)),
+					rootID:  driveFullPath(1),
+					id(nav): driveFullPath(1, name(fanny)),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1): {
+				driveFullPath(1): {
 					data.NewState: {idx(fanny, 2)},
 				},
-				fullPath(1, name(nav)): {
+				driveFullPath(1, name(nav)): {
 					data.MovedState: {id(nav), id(file)},
 				},
-				fullPath(1, name(fanny)): {
+				driveFullPath(1, name(fanny)): {
 					data.NewState: {idx(fanny, 2), idx(file, 2)},
 				},
 			},
@@ -3338,13 +3356,13 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:        fullPath(1),
-					id(nav):       fullPath(1, name(nav)),
-					idx(fanny, 2): fullPath(1, name(nav)), // note: this is a bug, but currently expected
+					rootID:        driveFullPath(1),
+					id(nav):       driveFullPath(1, name(nav)),
+					idx(fanny, 2): driveFullPath(1, name(nav)), // note: this is a bug, but currently expected
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{
-				fullPath(1): makeExcludeMap(id(file), idx(file, 2)),
+				driveFullPath(1): makeExcludeMap(id(file), idx(file, 2)),
 			}),
 			doNotMergeItems: map[string]bool{},
 		},
@@ -3356,11 +3374,11 @@ func (suite *CollectionsUnitSuite) TestGet() {
 					idx(drive, 1): {
 						Pages: []mock.NextPage{{
 							Items: []models.DriveItemable{
-								driveRootItem(rootID),
-								driveItem(idx(fanny, 2), name(fanny), parent(1), rootID, isFolder),
-								driveItem(idx(file, 2), namex(file, 2), parent(1, name(fanny)), idx(fanny, 2), isFile),
-								driveItem(id(nav), name(nav), parent(1), rootID, isFolder),
-								driveItem(id(file), name(file), parent(1, name(nav)), id(nav), isFile),
+								driveRootItem(),
+								driveItem(idx(fanny, 2), name(fanny), driveParentDir(1), rootID, isFolder),
+								driveItem(idx(file, 2), namex(file, 2), driveParentDir(1, name(fanny)), idx(fanny, 2), isFile),
+								driveItem(id(nav), name(nav), driveParentDir(1), rootID, isFolder),
+								driveItem(id(file), name(file), driveParentDir(1, name(nav)), id(nav), isFile),
 							},
 						}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
@@ -3371,18 +3389,18 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:  fullPath(1),
-					id(nav): fullPath(1, name(fanny)),
+					rootID:  driveFullPath(1),
+					id(nav): driveFullPath(1, name(fanny)),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1): {
+				driveFullPath(1): {
 					data.NewState: {idx(fanny, 2)},
 				},
-				fullPath(1, name(nav)): {
+				driveFullPath(1, name(nav)): {
 					data.MovedState: {id(nav), id(file)},
 				},
-				fullPath(1, name(fanny)): {
+				driveFullPath(1, name(fanny)): {
 					data.NewState: {idx(fanny, 2), idx(file, 2)},
 				},
 			},
@@ -3391,13 +3409,13 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:        fullPath(1),
-					id(nav):       fullPath(1, name(nav)),
-					idx(fanny, 2): fullPath(1, name(nav)), // note: this is a bug, but currently expected
+					rootID:        driveFullPath(1),
+					id(nav):       driveFullPath(1, name(nav)),
+					idx(fanny, 2): driveFullPath(1, name(nav)), // note: this is a bug, but currently expected
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{
-				fullPath(1): makeExcludeMap(id(file), idx(file, 2)),
+				driveFullPath(1): makeExcludeMap(id(file), idx(file, 2)),
 			}),
 			doNotMergeItems: map[string]bool{},
 		},
@@ -3409,12 +3427,12 @@ func (suite *CollectionsUnitSuite) TestGet() {
 					idx(drive, 1): {
 						Pages: []mock.NextPage{{
 							Items: []models.DriveItemable{
-								driveRootItem(rootID),
-								driveItem(idx(file, 1), namex(file, 1), parent(1), rootID, isFile),
-								driveItem(id(fanny), name(fanny), parent(1), rootID, isFolder),
-								driveItem(id(nav), name(nav), parent(1), rootID, isFolder),
-								driveItem(id(foo), name(foo), parent(1, name(fanny)), id(fanny), isFolder),
-								driveItem(id(bar), name(foo), parent(1, name(nav)), id(nav), isFolder),
+								driveRootItem(),
+								driveItem(idx(file, 1), namex(file, 1), driveParentDir(1), rootID, isFile),
+								driveItem(id(fanny), name(fanny), driveParentDir(1), rootID, isFolder),
+								driveItem(id(nav), name(nav), driveParentDir(1), rootID, isFolder),
+								driveItem(id(foo), name(foo), driveParentDir(1, name(fanny)), id(fanny), isFolder),
+								driveItem(id(bar), name(foo), driveParentDir(1, name(nav)), id(nav), isFolder),
 							},
 						}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
@@ -3425,27 +3443,27 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:    fullPath(1),
-					id(nav):   fullPath(1, name(nav)),
-					id(fanny): fullPath(1, name(fanny)),
-					id(foo):   fullPath(1, name(nav), name(foo)),
-					id(bar):   fullPath(1, name(fanny), name(foo)),
+					rootID:    driveFullPath(1),
+					id(nav):   driveFullPath(1, name(nav)),
+					id(fanny): driveFullPath(1, name(fanny)),
+					id(foo):   driveFullPath(1, name(nav), name(foo)),
+					id(bar):   driveFullPath(1, name(fanny), name(foo)),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				fullPath(1): {
+				driveFullPath(1): {
 					data.NotMovedState: {idx(file, 1)},
 				},
-				fullPath(1, name(nav)): {
+				driveFullPath(1, name(nav)): {
 					data.NotMovedState: {id(nav)},
 				},
-				fullPath(1, name(nav), name(foo)): {
+				driveFullPath(1, name(nav), name(foo)): {
 					data.MovedState: {id(bar)},
 				},
-				fullPath(1, name(fanny)): {
+				driveFullPath(1, name(fanny)): {
 					data.NotMovedState: {id(fanny)},
 				},
-				fullPath(1, name(fanny), name(foo)): {
+				driveFullPath(1, name(fanny), name(foo)): {
 					data.MovedState: {id(foo)},
 				},
 			},
@@ -3454,15 +3472,15 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				idx(drive, 1): {
-					rootID:    fullPath(1),
-					id(nav):   fullPath(1, name(nav)),
-					id(fanny): fullPath(1, name(fanny)),
-					id(foo):   fullPath(1, name(nav), name(foo)), // note: this is a bug, but currently expected
-					id(bar):   fullPath(1, name(nav), name(foo)),
+					rootID:    driveFullPath(1),
+					id(nav):   driveFullPath(1, name(nav)),
+					id(fanny): driveFullPath(1, name(fanny)),
+					id(foo):   driveFullPath(1, name(nav), name(foo)), // note: this is a bug, but currently expected
+					id(bar):   driveFullPath(1, name(nav), name(foo)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{
-				fullPath(1): makeExcludeMap(idx(file, 1)),
+				driveFullPath(1): makeExcludeMap(idx(file, 1)),
 			}),
 			doNotMergeItems: map[string]bool{},
 		},
@@ -3636,17 +3654,17 @@ func (suite *CollectionsUnitSuite) TestAddURLCacheToDriveCollections() {
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
 					idx(drive, 1): {
 						Pages: []mock.NextPage{{Items: []models.DriveItemable{
-							driveRootItem(rootID),
-							driveItem(id(folder), name(folder), parent(1), rootID, isFolder),
-							driveItem(id(file), name(file), parent(1, name(folder)), id(folder), isFile),
+							driveRootItem(),
+							driveItem(id(folder), name(folder), driveParentDir(1), rootID, isFolder),
+							driveItem(id(file), name(file), driveParentDir(1, name(folder)), id(folder), isFile),
 						}}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta), Reset: true},
 					},
 					idx(drive, 2): {
 						Pages: []mock.NextPage{{Items: []models.DriveItemable{
-							driveRootItem(rootID),
-							driveItem(idx(folder, 2), name(folder), parent(2), rootID, isFolder),
-							driveItem(idx(file, 2), name(file), parent(2, name(folder)), idx(folder, 2), isFile),
+							driveRootItem(),
+							driveItem(idx(folder, 2), name(folder), driveParentDir(2), rootID, isFolder),
+							driveItem(idx(file, 2), name(file), driveParentDir(2, name(folder)), idx(folder, 2), isFile),
 						}}},
 						DeltaUpdate: pagers.DeltaUpdate{URL: idx(delta, 2), Reset: true},
 					},

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -156,8 +156,6 @@ func (c *Collections) getTree(
 	return collections, canUsePrevBackup, nil
 }
 
-var errTreeNotImplemented = clues.New("backup tree not implemented")
-
 func (c *Collections) makeDriveCollections(
 	ctx context.Context,
 	drv models.Driveable,
@@ -173,8 +171,8 @@ func (c *Collections) makeDriveCollections(
 	}
 
 	var (
-		tree  = newFolderyMcFolderFace(ppfx)
-		stats = &driveEnumerationStats{}
+		tree    = newFolderyMcFolderFace(ppfx)
+		limiter = newPagerLimiter(c.ctrl)
 	)
 
 	counter.Add(count.PrevPaths, int64(len(prevPaths)))
@@ -184,10 +182,9 @@ func (c *Collections) makeDriveCollections(
 	du, err := c.populateTree(
 		ctx,
 		tree,
-		limiter,
-		stats,
 		drv,
 		prevDeltaLink,
+		limiter,
 		counter,
 		errs)
 	if err != nil {
@@ -268,10 +265,9 @@ func (c *Collections) makeDriveCollections(
 func (c *Collections) populateTree(
 	ctx context.Context,
 	tree *folderyMcFolderFace,
-	limiter *pagerLimiter,
-	stats *driveEnumerationStats,
 	drv models.Driveable,
 	prevDeltaLink string,
+	limiter *pagerLimiter,
 	counter *count.Bus,
 	errs *fault.Bus,
 ) (pagers.DeltaUpdate, error) {
@@ -297,23 +293,18 @@ func (c *Collections) populateTree(
 			break
 		}
 
-		counter.Inc(count.PagesEnumerated)
-
 		if reset {
 			counter.Inc(count.PagerResets)
 			tree.reset()
 			c.resetStats()
-
-			*stats = driveEnumerationStats{}
 		}
 
 		err := c.enumeratePageOfItems(
 			ctx,
 			tree,
-			limiter,
-			stats,
 			drv,
 			page,
+			limiter,
 			counter,
 			errs)
 		if err != nil {
@@ -324,17 +315,12 @@ func (c *Collections) populateTree(
 			el.AddRecoverable(ctx, clues.Stack(err))
 		}
 
-		// Stop enumeration early if we've reached the item or page limit. Do this
-		// at the end of the loop so we don't request another page in the
-		// background.
-		//
-		// We don't want to break on just the container limit here because it's
-		// possible that there's more items in the current (final) container that
-		// we're processing. We need to see the next page to determine if we've
-		// reached the end of the container. Note that this doesn't take into
-		// account the number of items in the current container, so it's possible it
-		// will fetch more data when it doesn't really need to.
-		if limiter.atPageLimit(stats) || limiter.atItemLimit(stats) {
+		counter.Inc(count.PagesEnumerated)
+
+		// Stop enumeration early if we've reached the page limit. Keep this
+		// at the end of the loop so we don't request another page (pager.NextPage)
+		// before seeing we've passed the limit.
+		if limiter.hitPageLimit(int(counter.Get(count.PagesEnumerated))) {
 			break
 		}
 	}
@@ -357,15 +343,18 @@ func (c *Collections) populateTree(
 func (c *Collections) enumeratePageOfItems(
 	ctx context.Context,
 	tree *folderyMcFolderFace,
-	limiter *pagerLimiter,
-	stats *driveEnumerationStats,
 	drv models.Driveable,
 	page []models.DriveItemable,
+	limiter *pagerLimiter,
 	counter *count.Bus,
 	errs *fault.Bus,
 ) error {
 	ctx = clues.Add(ctx, "page_lenth", len(page))
-	el := errs.Local()
+
+	var (
+		el  = errs.Local()
+		err error
+	)
 
 	for i, item := range page {
 		if el.Failure() != nil {
@@ -390,14 +379,9 @@ func (c *Collections) enumeratePageOfItems(
 
 		switch {
 		case isFolder:
-			// check limits before adding the next new folder
-			if !tree.containsFolder(itemID) && limiter.atLimit(stats) {
-				return errHitLimit
-			}
-
-			skipped, err = c.addFolderToTree(ictx, tree, drv, item, stats, counter)
+			err = c.addFolderToTree(ictx, tree, drv, item, limiter, counter, el)
 		case isFile:
-			skipped, err = c.addFileToTree(ictx, tree, drv, item, limiter, stats, counter)
+			err = c.addFileToTree(ictx, tree, drv, item, limiter, counter, el)
 		default:
 			err = clues.NewWC(ictx, "item is neither folder nor file").
 				Label(fault.LabelForceNoBackupCreation, count.UnknownItemType)
@@ -409,20 +393,18 @@ func (c *Collections) enumeratePageOfItems(
 
 		if err != nil {
 			el.AddRecoverable(ictx, clues.Wrap(err, "adding item"))
+
+			return nil
 		}
 
-		// Check if we reached the item or size limit while processing this page.
-		// The check after this loop will get us out of the pager.
-		// We don't want to check all limits because it's possible we've reached
-		// the container limit but haven't reached the item limit or really added
-		// items to the last container we found.
-		// FIXME(keepers): this isn't getting handled properly at the moment
-		if limiter.atItemLimit(stats) {
-			return errHitLimit
+		if err != nil {
+			if errors.Is(err, errHitLimit) {
+				return err
+			}
+
+			el.AddRecoverable(ictx, clues.Wrap(err, "adding folder"))
 		}
 	}
-
-	stats.numPages++
 
 	return clues.Stack(el.Failure()).OrNil()
 }
@@ -432,7 +414,7 @@ func (c *Collections) addFolderToTree(
 	tree *folderyMcFolderFace,
 	drv models.Driveable,
 	folder models.DriveItemable,
-	stats *driveEnumerationStats,
+	limiter *pagerLimiter,
 	counter *count.Bus,
 ) (*fault.Skipped, error) {
 	var (
@@ -446,6 +428,11 @@ func (c *Collections) addFolderToTree(
 		parentID    string
 		notSelected bool
 	)
+
+	// check container limits before adding the next new folder
+	if !tree.containsFolder(folderID) && limiter.hitContainerLimit(tree.countLiveFolders()) {
+		return errHitLimit
+	}
 
 	if parent != nil {
 		parentID = ptr.Val(parent.GetId())
@@ -541,18 +528,18 @@ func (c *Collections) addFileToTree(
 	drv models.Driveable,
 	file models.DriveItemable,
 	limiter *pagerLimiter,
-	stats *driveEnumerationStats,
 	counter *count.Bus,
 ) (*fault.Skipped, error) {
 	var (
-		driveID   = ptr.Val(drv.GetId())
-		fileID    = ptr.Val(file.GetId())
-		fileName  = ptr.Val(file.GetName())
-		fileSize  = ptr.Val(file.GetSize())
-		isDeleted = file.GetDeleted() != nil
-		isMalware = file.GetMalware() != nil
-		parent    = file.GetParentReference()
-		parentID  string
+		driveID      = ptr.Val(drv.GetId())
+		fileID       = ptr.Val(file.GetId())
+		fileName     = ptr.Val(file.GetName())
+		fileSize     = ptr.Val(file.GetSize())
+		lastModified = ptr.Val(file.GetLastModifiedDateTime())
+		isDeleted    = file.GetDeleted() != nil
+		isMalware    = file.GetMalware() != nil
+		parent       = file.GetParentReference()
+		parentID     string
 	)
 
 	if parent != nil {
@@ -583,51 +570,35 @@ func (c *Collections) addFileToTree(
 		return skip, nil
 	}
 
-	_, alreadySeen := tree.fileIDToParentID[fileID]
-
 	if isDeleted {
 		tree.deleteFile(fileID)
+		return nil, nil
+	}
 
-		if alreadySeen {
-			stats.numAddedFiles--
-			// FIXME(keepers): this might be faulty,
-			// since deletes may not include the file size.
-			// it will likely need to be tracked in
-			// the tree alongside the file modtime.
-			stats.numBytes -= fileSize
-		} else {
-			c.NumItems++
-			c.NumFiles++
+	_, alreadySeen := tree.fileIDToParentID[fileID]
+	parentNode, parentNotNil := tree.folderIDToNode[parentID]
+
+	if parentNotNil && !alreadySeen {
+		fileCount, totalBytes := tree.countLiveFilesAndSizes()
+
+		// Don't add new items if the new collection has already reached it's limit.
+		// item moves and updates are generally allowed through.
+		if limiter.atContainerItemsLimit(len(parentNode.files)) || limiter.hitItemLimit(fileCount) {
+			return nil, errHitLimit
 		}
 
-		return nil, nil
+		// Skip large files that don't fit within the size limit.
+		// unlike the other checks, which see if we're already at the limit, this check
+		// needs to be forward-facing to ensure we don't go far over the limit.
+		// Example case: a 1gb limit and a 25gb file.
+		if limiter.hitTotalBytesLimit(fileSize + totalBytes) {
+			return nil, errHitLimit
+		}
 	}
 
-	parentNode, ok := tree.folderIDToNode[parentID]
-
-	// Don't add new items if the new collection is already reached it's limit.
-	// item moves and updates are generally allowed through.
-	if ok && !alreadySeen && limiter.atContainerItemsLimit(len(parentNode.files)) {
-		return nil, nil
-	}
-
-	// Skip large files that don't fit within the size limit.
-	if limiter.hitTotalBytesLimit(fileSize + stats.numBytes) {
-		return nil, nil
-	}
-
-	err := tree.addFile(parentID, fileID, ptr.Val(file.GetLastModifiedDateTime()))
+	err := tree.addFile(parentID, fileID, lastModified, fileSize)
 	if err != nil {
 		return nil, clues.StackWC(ctx, err)
-	}
-
-	// Only increment counters for new files
-	if !alreadySeen {
-		// todo: remmove c.NumItems/Files in favor of counter and tree counting.
-		c.NumItems++
-		c.NumFiles++
-		stats.numAddedFiles++
-		stats.numBytes += fileSize
 	}
 
 	return nil, nil

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -385,12 +385,6 @@ func (c *Collections) enumeratePageOfItems(
 		}
 
 		if err != nil {
-			el.AddRecoverable(ictx, clues.Wrap(err, "adding item"))
-
-			return nil
-		}
-
-		if err != nil {
 			if errors.Is(err, errHitLimit) {
 				return err
 			}
@@ -572,11 +566,11 @@ func (c *Collections) addFileToTree(
 	parentNode, parentNotNil := tree.folderIDToNode[parentID]
 
 	if parentNotNil && !alreadySeen {
-		fileCount, totalBytes := tree.countLiveFilesAndSizes()
+		countSize := tree.countLiveFilesAndSizes()
 
 		// Don't add new items if the new collection has already reached it's limit.
 		// item moves and updates are generally allowed through.
-		if limiter.atContainerItemsLimit(len(parentNode.files)) || limiter.hitItemLimit(fileCount) {
+		if limiter.atContainerItemsLimit(len(parentNode.files)) || limiter.hitItemLimit(countSize.numFiles) {
 			return nil, errHitLimit
 		}
 
@@ -584,7 +578,7 @@ func (c *Collections) addFileToTree(
 		// unlike the other checks, which see if we're already at the limit, this check
 		// needs to be forward-facing to ensure we don't go far over the limit.
 		// Example case: a 1gb limit and a 25gb file.
-		if limiter.hitTotalBytesLimit(fileSize + totalBytes) {
+		if limiter.hitTotalBytesLimit(fileSize + countSize.totalBytes) {
 			return nil, errHitLimit
 		}
 	}

--- a/src/internal/m365/collection/drive/collections_tree_test.go
+++ b/src/internal/m365/collection/drive/collections_tree_test.go
@@ -247,8 +247,8 @@ type collectionAssertions map[string]collectionAssertion
 // 	}
 // }
 
-func rootAnd(items ...models.DriveItemable) []models.DriveItemable {
-	return append([]models.DriveItemable{driveItem(rootID, rootName, parent(0), "", isFolder)}, items...)
+func pageItems(items ...models.DriveItemable) []models.DriveItemable {
+	return append([]models.DriveItemable{driveRootItem()}, items...)
 }
 
 func pagesOf(pages ...[]models.DriveItemable) []mock.NextPage {
@@ -416,7 +416,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_GetTree() {
 			enumerator: mock.EnumerateItemsDeltaByDrive{
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
 					id(drive): {
-						Pages:       pagesOf(rootAnd()),
+						Pages:       pagesOf(pageItems()),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
@@ -424,7 +424,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_GetTree() {
 			expect: expected{
 				canUsePrevBackup: assert.False,
 				collAssertions: collectionAssertions{
-					fullPath(1): newCollAssertion(
+					driveFullPath(1): newCollAssertion(
 						doNotMergeItems,
 						statesToItemIDs{data.NotMovedState: {}},
 						id(file)),
@@ -516,7 +516,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 			enumerator: mock.EnumerateItemsDeltaByDrive{
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
 					id(drive): {
-						Pages:       pagesOf(rootAnd()),
+						Pages:       pagesOf(pageItems()),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
@@ -612,7 +612,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 			enumerator: mock.EnumerateItemsDeltaByDrive{
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
 					id(drive): {
-						Pages:       pagesOf(rootAnd()),
+						Pages:       pagesOf(pageItems()),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
@@ -641,7 +641,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 			enumerator: mock.EnumerateItemsDeltaByDrive{
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
 					id(drive): {
-						Pages:       pagesOf(rootAnd(), rootAnd()),
+						Pages:       pagesOf(pageItems(), pageItems()),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
@@ -671,11 +671,11 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
 					id(drive): {
 						Pages: pagesOf(
-							rootAnd(driveItem(id(folder), name(folder), parent(0), rootID, isFolder)),
-							rootAnd(driveItem(idx(folder, "sib"), namex(folder, "sib"), parent(0), rootID, isFolder)),
-							rootAnd(
-								driveItem(id(folder), name(folder), parent(0), rootID, isFolder),
-								driveItem(idx(folder, "chld"), namex(folder, "chld"), parent(0), id(folder), isFolder))),
+							pageItems(driveItem(id(folder), name(folder), parentDir(), rootID, isFolder)),
+							pageItems(driveItem(idx(folder, "sib"), namex(folder, "sib"), parentDir(), rootID, isFolder)),
+							pageItems(
+								driveItem(id(folder), name(folder), parentDir(), rootID, isFolder),
+								driveItem(idx(folder, "chld"), namex(folder, "chld"), parentDir(), id(folder), isFolder))),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
@@ -708,16 +708,16 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
 					id(drive): {
 						Pages: pagesOf(
-							rootAnd(
-								driveItem(id(folder), name(folder), parent(0), rootID, isFolder),
-								driveItem(id(file), name(file), parent(0, name(folder)), id(folder), isFile)),
-							rootAnd(
-								driveItem(idx(folder, "sib"), namex(folder, "sib"), parent(0), rootID, isFolder),
-								driveItem(idx(file, "sib"), namex(file, "sib"), parent(0, namex(folder, "sib")), idx(folder, "sib"), isFile)),
-							rootAnd(
-								driveItem(id(folder), name(folder), parent(0), rootID, isFolder),
-								driveItem(idx(folder, "chld"), namex(folder, "chld"), parent(0), id(folder), isFolder),
-								driveItem(idx(file, "chld"), namex(file, "chld"), parent(0, namex(folder, "chld")), idx(folder, "chld"), isFile))),
+							pageItems(
+								driveItem(id(folder), name(folder), parentDir(), rootID, isFolder),
+								driveItem(id(file), name(file), parentDir(name(folder)), id(folder), isFile)),
+							pageItems(
+								driveItem(idx(folder, "sib"), namex(folder, "sib"), parentDir(), rootID, isFolder),
+								driveItem(idx(file, "sib"), namex(file, "sib"), parentDir(namex(folder, "sib")), idx(folder, "sib"), isFile)),
+							pageItems(
+								driveItem(id(folder), name(folder), parentDir(), rootID, isFolder),
+								driveItem(idx(folder, "chld"), namex(folder, "chld"), parentDir(), id(folder), isFolder),
+								driveItem(idx(file, "chld"), namex(file, "chld"), parentDir(namex(folder, "chld")), idx(folder, "chld"), isFile))),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
@@ -756,10 +756,10 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
 					id(drive): {
 						Pages: pagesOf(
-							rootAnd(
-								driveItem(id(folder), name(folder), parent(0), rootID, isFolder),
-								driveItem(id(file), name(file), parent(0, name(folder)), id(folder), isFile)),
-							rootAnd(delItem(id(folder), parent(0), rootID, isFolder))),
+							pageItems(
+								driveItem(id(folder), name(folder), parentDir(), rootID, isFolder),
+								driveItem(id(file), name(file), parentDir(name(folder)), id(folder), isFile)),
+							pageItems(delItem(id(folder), parentDir(), rootID, isFolder))),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
@@ -774,7 +774,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 				},
 				err:            require.NoError,
 				numLiveFiles:   0,
-				numLiveFolders: 2,
+				numLiveFolders: 1,
 				sizeBytes:      0,
 				treeContainsFolderIDs: []string{
 					rootID,
@@ -794,11 +794,11 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
 					id(drive): {
 						Pages: pagesOf(
-							rootAnd(
-								driveItem(idx(folder, "parent"), namex(folder, "parent"), parent(0), rootID, isFolder),
-								driveItem(id(folder), namex(folder, "moved"), parent(0), idx(folder, "parent"), isFolder),
-								driveItem(id(file), name(file), parent(0, namex(folder, "parent"), name(folder)), id(folder), isFile)),
-							rootAnd(delItem(id(folder), parent(0), idx(folder, "parent"), isFolder))),
+							pageItems(
+								driveItem(idx(folder, "parent"), namex(folder, "parent"), parentDir(), rootID, isFolder),
+								driveItem(id(folder), namex(folder, "moved"), parentDir(), idx(folder, "parent"), isFolder),
+								driveItem(id(file), name(file), parentDir(namex(folder, "parent"), name(folder)), id(folder), isFile)),
+							pageItems(delItem(id(folder), parentDir(), idx(folder, "parent"), isFolder))),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
@@ -834,16 +834,16 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
 					id(drive): {
 						Pages: pagesOf(
-							rootAnd(
-								driveItem(id(folder), name(folder), parent(0), rootID, isFolder),
-								driveItem(id(file), name(file), parent(0, name(folder)), id(folder), isFile)),
-							rootAnd(
-								driveItem(idx(folder, "sib"), namex(folder, "sib"), parent(0), rootID, isFolder),
-								driveItem(idx(file, "sib"), namex(file, "sib"), parent(0, namex(folder, "sib")), idx(folder, "sib"), isFile)),
-							rootAnd(
-								driveItem(id(folder), name(folder), parent(0), rootID, isFolder),
-								driveItem(idx(folder, "chld"), namex(folder, "chld"), parent(0), id(folder), isFolder),
-								driveItem(idx(file, "chld"), namex(file, "chld"), parent(0, namex(folder, "chld")), idx(folder, "chld"), isFile))),
+							pageItems(
+								driveItem(id(folder), name(folder), parentDir(), rootID, isFolder),
+								driveItem(id(file), name(file), parentDir(name(folder)), id(folder), isFile)),
+							pageItems(
+								driveItem(idx(folder, "sib"), namex(folder, "sib"), parentDir(), rootID, isFolder),
+								driveItem(idx(file, "sib"), namex(file, "sib"), parentDir(namex(folder, "sib")), idx(folder, "sib"), isFile)),
+							pageItems(
+								driveItem(id(folder), name(folder), parentDir(), rootID, isFolder),
+								driveItem(idx(folder, "chld"), namex(folder, "chld"), parentDir(), id(folder), isFolder),
+								driveItem(idx(file, "chld"), namex(file, "chld"), parentDir(namex(folder, "chld")), idx(folder, "chld"), isFile))),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
@@ -875,16 +875,16 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
 					id(drive): {
 						Pages: pagesOf(
-							rootAnd(
-								driveItem(id(folder), name(folder), parent(0), rootID, isFolder),
-								driveItem(id(file), name(file), parent(0, name(folder)), id(folder), isFile)),
-							rootAnd(
-								driveItem(idx(folder, "sib"), namex(folder, "sib"), parent(0), rootID, isFolder),
-								driveItem(idx(file, "sib"), namex(file, "sib"), parent(0, namex(folder, "sib")), idx(folder, "sib"), isFile)),
-							rootAnd(
-								driveItem(id(folder), name(folder), parent(0), rootID, isFolder),
-								driveItem(idx(folder, "chld"), namex(folder, "chld"), parent(0), id(folder), isFolder),
-								driveItem(idx(file, "chld"), namex(file, "chld"), parent(0, namex(folder, "chld")), idx(folder, "chld"), isFile))),
+							pageItems(
+								driveItem(id(folder), name(folder), parentDir(), rootID, isFolder),
+								driveItem(id(file), name(file), parentDir(name(folder)), id(folder), isFile)),
+							pageItems(
+								driveItem(idx(folder, "sib"), namex(folder, "sib"), parentDir(), rootID, isFolder),
+								driveItem(idx(file, "sib"), namex(file, "sib"), parentDir(namex(folder, "sib")), idx(folder, "sib"), isFile)),
+							pageItems(
+								driveItem(id(folder), name(folder), parentDir(), rootID, isFolder),
+								driveItem(idx(folder, "chld"), namex(folder, "chld"), parentDir(), id(folder), isFolder),
+								driveItem(idx(file, "chld"), namex(file, "chld"), parentDir(namex(folder, "chld")), idx(folder, "chld"), isFile))),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
@@ -1032,8 +1032,8 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 		},
 		{
 			name:    "root only",
-			tree:    newFolderyMcFolderFace(nil),
-			page:    rootAnd(),
+			tree:    treeWithRoot(),
+			page:    pageItems(),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1050,10 +1050,10 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 		{
 			name: "many folders in a hierarchy",
 			tree: treeWithRoot(),
-			page: rootAnd(
-				driveItem(id(folder), name(folder), parent(0), rootID, isFolder),
-				driveItem(idx(folder, "sib"), namex(folder, "sib"), parent(0), rootID, isFolder),
-				driveItem(idx(folder, "chld"), namex(folder, "chld"), parent(0, name(folder)), id(folder), isFolder)),
+			page: pageItems(
+				driveItem(id(folder), name(folder), parentDir(), rootID, isFolder),
+				driveItem(idx(folder, "sib"), namex(folder, "sib"), parentDir(), rootID, isFolder),
+				driveItem(idx(folder, "chld"), namex(folder, "chld"), parentDir(name(folder)), id(folder), isFolder)),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1071,32 +1071,11 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			},
 		},
 		{
-			name: "already hit folder limit",
-			tree: treeWithRoot(),
-			page: rootAnd(
-				driveItem(id(folder), name(folder), parent(0), rootID, isFolder),
-				driveItem(idx(folder, "sib"), namex(folder, "sib"), parent(0), rootID, isFolder),
-				driveItem(idx(folder, "chld"), namex(folder, "chld"), parent(0, name(folder)), id(folder), isFolder)),
-			limiter: newPagerLimiter(minimumLimitOpts()),
-			expect: expected{
-				counts: countTD.Expected{
-					count.TotalFoldersProcessed: 1,
-				},
-				err:            require.Error,
-				shouldHitLimit: true,
-				treeSize:       1,
-				treeContainsFolderIDs: []string{
-					rootID,
-				},
-				treeContainsTombstoneIDs: []string{},
-			},
-		},
-		{
 			name: "create->delete",
 			tree: treeWithRoot(),
-			page: rootAnd(
-				driveItem(id(folder), name(folder), parent(0), rootID, isFolder),
-				delItem(id(folder), parent(0), rootID, isFolder)),
+			page: pageItems(
+				driveItem(id(folder), name(folder), parentDir(), rootID, isFolder),
+				delItem(id(folder), parentDir(), rootID, isFolder)),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1114,10 +1093,10 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 		{
 			name: "move->delete",
 			tree: treeWithFolders(),
-			page: rootAnd(
-				driveItem(idx(folder, "parent"), namex(folder, "parent"), parent(0), rootID, isFolder),
-				driveItem(id(folder), namex(folder, "moved"), parent(0, namex(folder, "parent")), idx(folder, "parent"), isFolder),
-				delItem(id(folder), parent(0), idx(folder, "parent"), isFolder)),
+			page: pageItems(
+				driveItem(idx(folder, "parent"), namex(folder, "parent"), parentDir(), rootID, isFolder),
+				driveItem(id(folder), namex(folder, "moved"), parentDir(namex(folder, "parent")), idx(folder, "parent"), isFolder),
+				delItem(id(folder), parentDir(), idx(folder, "parent"), isFolder)),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1136,11 +1115,32 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			},
 		},
 		{
-			name: "delete->create",
+			name: "delete->create with previous path",
 			tree: treeWithRoot(),
-			page: rootAnd(
-				delItem(id(folder), parent(0), rootID, isFolder),
-				driveItem(id(folder), name(folder), parent(0), rootID, isFolder)),
+			page: pageItems(
+				delItem(id(folder), parentDir(), rootID, isFolder),
+				driveItem(id(folder), name(folder), parentDir(), rootID, isFolder)),
+			limiter: newPagerLimiter(control.DefaultOptions()),
+			expect: expected{
+				counts: countTD.Expected{
+					count.TotalFoldersProcessed:       2,
+					count.TotalDeleteFoldersProcessed: 1,
+				},
+				err:      require.NoError,
+				treeSize: 2,
+				treeContainsFolderIDs: []string{
+					rootID,
+					id(folder),
+				},
+				treeContainsTombstoneIDs: []string{},
+			},
+		},
+		{
+			name: "delete->create without previous path",
+			tree: treeWithRoot(),
+			page: pageItems(
+				delItem(id(folder), parentDir(), rootID, isFolder),
+				driveItem(id(folder), name(folder), parentDir(), rootID, isFolder)),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1204,11 +1204,11 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 	drv.SetId(ptr.To(id(drive)))
 	drv.SetName(ptr.To(name(drive)))
 
-	fld := driveItem(id(folder), name(folder), parent(0), rootID, isFolder)
-	subFld := driveItem(id(folder), name(folder), parent(drv, namex(folder, "parent")), idx(folder, "parent"), isFolder)
-	pack := driveItem(id(pkg), name(pkg), parent(0), rootID, isPackage)
-	del := delItem(id(folder), parent(0), rootID, isFolder)
-	mal := malwareItem(idx(folder, "mal"), namex(folder, "mal"), parent(0), rootID, isFolder)
+	fld := driveItem(id(folder), name(folder), parentDir(), rootID, isFolder)
+	subFld := driveItem(id(folder), name(folder), driveParentDir(drv, namex(folder, "parent")), idx(folder, "parent"), isFolder)
+	pack := driveItem(id(pkg), name(pkg), parentDir(), rootID, isPackage)
+	del := delItem(id(folder), parentDir(), rootID, isFolder)
+	mal := malwareItem(idx(folder, "mal"), namex(folder, "mal"), parentDir(), rootID, isFolder)
 
 	type expected struct {
 		countLiveFolders   int
@@ -1233,9 +1233,14 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 			folder:  fld,
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
-				countLiveFolders:   2,
-				err:                require.NoError,
-				counts:             countTD.Expected{count.TotalFoldersProcessed: 1},
+				countLiveFolders: 2,
+				err:              require.NoError,
+				counts: countTD.Expected{
+					count.TotalMalwareProcessed:       0,
+					count.TotalPackagesProcessed:      0,
+					count.TotalFoldersProcessed:       1,
+					count.TotalDeleteFoldersProcessed: 0,
+				},
 				treeSize:           2,
 				treeContainsFolder: assert.True,
 				skipped:            assert.Nil,
@@ -1247,9 +1252,14 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 			folder:  subFld,
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
-				countLiveFolders:   3,
-				err:                require.NoError,
-				counts:             countTD.Expected{count.TotalFoldersProcessed: 1},
+				countLiveFolders: 3,
+				err:              require.NoError,
+				counts: countTD.Expected{
+					count.TotalMalwareProcessed:       0,
+					count.TotalPackagesProcessed:      0,
+					count.TotalFoldersProcessed:       1,
+					count.TotalDeleteFoldersProcessed: 0,
+				},
 				treeSize:           3,
 				treeContainsFolder: assert.True,
 				skipped:            assert.Nil,
@@ -1261,9 +1271,14 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 			folder:  pack,
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
-				countLiveFolders:   2,
-				err:                require.NoError,
-				counts:             countTD.Expected{count.TotalPackagesProcessed: 1},
+				countLiveFolders: 2,
+				err:              require.NoError,
+				counts: countTD.Expected{
+					count.TotalMalwareProcessed:       0,
+					count.TotalPackagesProcessed:      1,
+					count.TotalFoldersProcessed:       0,
+					count.TotalDeleteFoldersProcessed: 0,
+				},
 				treeSize:           2,
 				treeContainsFolder: assert.True,
 				skipped:            assert.Nil,
@@ -1275,21 +1290,32 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 			folder:  del,
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
-				countLiveFolders:   2,
-				err:                require.NoError,
-				counts:             countTD.Expected{count.TotalDeleteFoldersProcessed: 1},
+				countLiveFolders: 2,
+				err:              require.NoError,
+				counts: countTD.Expected{
+					count.TotalMalwareProcessed:       0,
+					count.TotalPackagesProcessed:      0,
+					count.TotalFoldersProcessed:       0,
+					count.TotalDeleteFoldersProcessed: 1,
+				},
 				treeSize:           3,
 				treeContainsFolder: assert.True,
 				skipped:            assert.Nil,
 			},
 		},
 		{
-			name:   "tombstone new folder in unpopulated tree",
-			tree:   newFolderyMcFolderFace(nil),
-			folder: del,
+			name:    "tombstone new folder in unpopulated tree",
+			tree:    newFolderyMcFolderFace(nil),
+			folder:  del,
+			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
-				err:                require.NoError,
-				counts:             countTD.Expected{count.TotalDeleteFoldersProcessed: 1},
+				err: require.NoError,
+				counts: countTD.Expected{
+					count.TotalMalwareProcessed:       0,
+					count.TotalPackagesProcessed:      0,
+					count.TotalFoldersProcessed:       0,
+					count.TotalDeleteFoldersProcessed: 1,
+				},
 				treeSize:           1,
 				treeContainsFolder: assert.True,
 				skipped:            assert.Nil,
@@ -1301,9 +1327,14 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 			folder:  del,
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
-				countLiveFolders:   1,
-				err:                require.NoError,
-				counts:             countTD.Expected{count.TotalDeleteFoldersProcessed: 1},
+				countLiveFolders: 1,
+				err:              require.NoError,
+				counts: countTD.Expected{
+					count.TotalMalwareProcessed:       0,
+					count.TotalPackagesProcessed:      0,
+					count.TotalFoldersProcessed:       0,
+					count.TotalDeleteFoldersProcessed: 1,
+				},
 				treeSize:           2,
 				treeContainsFolder: assert.True,
 				skipped:            assert.Nil,
@@ -1315,29 +1346,77 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 			folder:  mal,
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
-				countLiveFolders:   1,
-				err:                require.NoError,
-				counts:             countTD.Expected{count.TotalMalwareProcessed: 1},
+				countLiveFolders: 1,
+				err:              require.NoError,
+				counts: countTD.Expected{
+					count.TotalMalwareProcessed:       1,
+					count.TotalPackagesProcessed:      0,
+					count.TotalFoldersProcessed:       0,
+					count.TotalDeleteFoldersProcessed: 0,
+				},
 				treeSize:           1,
 				treeContainsFolder: assert.False,
 				skipped:            assert.NotNil,
 			},
 		},
 		{
-			name:    "over container limit",
+			name:    "already over container limit, folder seen twice",
 			tree:    treeWithFolders(),
-			folder:  pack,
+			folder:  fld,
 			limiter: newPagerLimiter(minimumLimitOpts()),
 			expect: expected{
 				countLiveFolders: 3,
+				err:              require.NoError,
+				counts: countTD.Expected{
+					count.TotalMalwareProcessed:       0,
+					count.TotalPackagesProcessed:      0,
+					count.TotalFoldersProcessed:       1,
+					count.TotalDeleteFoldersProcessed: 0,
+				},
+				shouldHitLimit:     false,
+				skipped:            assert.Nil,
+				treeSize:           3,
+				treeContainsFolder: assert.True,
+			},
+		},
+		{
+			name:    "already at container limit",
+			tree:    treeWithRoot(),
+			folder:  fld,
+			limiter: newPagerLimiter(minimumLimitOpts()),
+			expect: expected{
+				countLiveFolders: 1,
 				err:              require.Error,
 				counts: countTD.Expected{
-					count.TotalPackagesProcessed: 0,
-					count.TotalFoldersProcessed:  0,
+					count.TotalMalwareProcessed:       0,
+					count.TotalPackagesProcessed:      0,
+					count.TotalFoldersProcessed:       0,
+					count.TotalDeleteFoldersProcessed: 0,
 				},
 				shouldHitLimit:     true,
-				treeSize:           3,
+				skipped:            assert.Nil,
+				treeSize:           1,
 				treeContainsFolder: assert.False,
+			},
+		},
+		{
+			name:    "process tombstone when over folder limits",
+			tree:    treeWithFolders(),
+			folder:  del,
+			limiter: newPagerLimiter(minimumLimitOpts()),
+			expect: expected{
+				countLiveFolders: 2,
+				err:              require.NoError,
+				counts: countTD.Expected{
+					count.TotalMalwareProcessed:       0,
+					count.TotalPackagesProcessed:      0,
+					count.TotalFoldersProcessed:       0,
+					count.TotalDeleteFoldersProcessed: 1,
+				},
+				shouldHitLimit:     false,
+				skipped:            assert.Nil,
+				treeSize:           3,
+				treeContainsFolder: assert.True,
 			},
 		},
 	}
@@ -1393,13 +1472,13 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeFolderCollectionPath(
 	}{
 		{
 			name:      "root",
-			folder:    driveRootItem(rootID),
+			folder:    driveRootItem(),
 			expect:    basePath.String(),
 			expectErr: require.NoError,
 		},
 		{
 			name:      "folder",
-			folder:    driveItem(id(folder), name(folder), parent(0), rootID, isFolder),
+			folder:    driveItem(id(folder), name(folder), parentDir(), rootID, isFolder),
 			expect:    folderPath.String(),
 			expectErr: require.NoError,
 		},
@@ -1457,7 +1536,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 		{
 			name: "one file at root",
 			tree: treeWithRoot(),
-			page: rootAnd(driveItem(id(file), name(file), parent(0, name(folder)), rootID, isFile)),
+			page: pageItems(driveItem(id(file), name(file), parentDir(name(folder)), rootID, isFile)),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 0,
@@ -1475,9 +1554,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 		{
 			name: "one file in a folder",
 			tree: newFolderyMcFolderFace(nil),
-			page: rootAnd(
-				driveItem(id(folder), name(folder), parent(0), rootID, isFolder),
-				driveItem(id(file), name(file), parent(0, name(folder)), id(folder), isFile)),
+			page: pageItems(
+				driveItem(id(folder), name(folder), parentDir(), rootID, isFolder),
+				driveItem(id(file), name(file), parentDir(name(folder)), id(folder), isFile)),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 0,
@@ -1495,10 +1574,10 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 		{
 			name: "many files in a hierarchy",
 			tree: treeWithRoot(),
-			page: rootAnd(
-				driveItem(id(file), name(file), parent(0), rootID, isFile),
-				driveItem(id(folder), name(folder), parent(0), rootID, isFolder),
-				driveItem(idx(file, "chld"), namex(file, "chld"), parent(0, name(folder)), id(folder), isFile)),
+			page: pageItems(
+				driveItem(id(file), name(file), parentDir(), rootID, isFile),
+				driveItem(id(folder), name(folder), parentDir(), rootID, isFolder),
+				driveItem(idx(file, "chld"), namex(file, "chld"), parentDir(name(folder)), id(folder), isFile)),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 0,
@@ -1517,10 +1596,10 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 		{
 			name: "many updates to the same file",
 			tree: treeWithRoot(),
-			page: rootAnd(
-				driveItem(id(file), name(file), parent(0), rootID, isFile),
-				driveItem(id(file), namex(file, 1), parent(0), rootID, isFile),
-				driveItem(id(file), namex(file, 2), parent(0), rootID, isFile)),
+			page: pageItems(
+				driveItem(id(file), name(file), parentDir(), rootID, isFile),
+				driveItem(id(file), namex(file, 1), parentDir(), rootID, isFile),
+				driveItem(id(file), namex(file, 2), parentDir(), rootID, isFile)),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 0,
@@ -1538,7 +1617,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 		{
 			name: "delete an existing file",
 			tree: treeWithFileAtRoot(),
-			page: rootAnd(delItem(id(file), parent(0), rootID, isFile)),
+			page: pageItems(delItem(id(file), parentDir(), rootID, isFile)),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 1,
@@ -1554,9 +1633,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 		{
 			name: "delete the same file twice",
 			tree: treeWithFileAtRoot(),
-			page: rootAnd(
-				delItem(id(file), parent(0), rootID, isFile),
-				delItem(id(file), parent(0), rootID, isFile)),
+			page: pageItems(
+				delItem(id(file), parentDir(), rootID, isFile),
+				delItem(id(file), parentDir(), rootID, isFile)),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 2,
@@ -1572,9 +1651,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 		{
 			name: "create->delete",
 			tree: treeWithRoot(),
-			page: rootAnd(
-				driveItem(id(file), name(file), parent(0), rootID, isFile),
-				delItem(id(file), parent(0), rootID, isFile)),
+			page: pageItems(
+				driveItem(id(file), name(file), parentDir(), rootID, isFile),
+				delItem(id(file), parentDir(), rootID, isFile)),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 1,
@@ -1590,10 +1669,10 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 		{
 			name: "move->delete",
 			tree: treeWithFileAtRoot(),
-			page: rootAnd(
-				driveItem(id(folder), name(folder), parent(0), rootID, isFolder),
-				driveItem(id(file), name(file), parent(0, name(folder)), id(folder), isFile),
-				delItem(id(file), parent(0, name(folder)), id(folder), isFile)),
+			page: pageItems(
+				driveItem(id(folder), name(folder), parentDir(), rootID, isFolder),
+				driveItem(id(file), name(file), parentDir(name(folder)), id(folder), isFile),
+				delItem(id(file), parentDir(name(folder)), id(folder), isFile)),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 1,
@@ -1609,9 +1688,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 		{
 			name: "delete->create an existing file",
 			tree: treeWithFileAtRoot(),
-			page: rootAnd(
-				delItem(id(file), parent(0), rootID, isFile),
-				driveItem(id(file), name(file), parent(0), rootID, isFile)),
+			page: pageItems(
+				delItem(id(file), parentDir(), rootID, isFile),
+				driveItem(id(file), name(file), parentDir(), rootID, isFile)),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 1,
@@ -1629,9 +1708,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 		{
 			name: "delete->create a non-existing file",
 			tree: treeWithRoot(),
-			page: rootAnd(
-				delItem(id(file), parent(0), rootID, isFile),
-				driveItem(id(file), name(file), parent(0), rootID, isFile)),
+			page: pageItems(
+				delItem(id(file), parentDir(), rootID, isFile),
+				driveItem(id(file), name(file), parentDir(), rootID, isFile)),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 1,
@@ -1701,7 +1780,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 		{
 			name:    "add new file",
 			tree:    treeWithRoot(),
-			file:    driveItem(id(file), name(file), parent(0), rootID, isFile),
+			file:    driveItem(id(file), name(file), parentDir(), rootID, isFile),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1719,7 +1798,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 		{
 			name:    "duplicate file",
 			tree:    treeWithFileAtRoot(),
-			file:    driveItem(id(file), name(file), parent(0), rootID, isFile),
+			file:    driveItem(id(file), name(file), parentDir(), rootID, isFile),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1737,7 +1816,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 		{
 			name:    "error file seen before parent",
 			tree:    treeWithRoot(),
-			file:    driveItem(id(file), name(file), parent(0, name(folder)), id(folder), isFile),
+			file:    driveItem(id(file), name(file), parentDir(name(folder)), id(folder), isFile),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1753,7 +1832,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 		{
 			name:    "malware file",
 			tree:    treeWithRoot(),
-			file:    malwareItem(id(file), name(file), parent(0, name(folder)), rootID, isFile),
+			file:    malwareItem(id(file), name(file), parentDir(name(folder)), rootID, isFile),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1769,7 +1848,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 		{
 			name:    "delete non-existing file",
 			tree:    treeWithRoot(),
-			file:    delItem(id(file), parent(0, name(folder)), id(folder), isFile),
+			file:    delItem(id(file), parentDir(name(folder)), id(folder), isFile),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1785,7 +1864,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 		{
 			name:    "delete existing file",
 			tree:    treeWithFileAtRoot(),
-			file:    delItem(id(file), parent(0), rootID, isFile),
+			file:    delItem(id(file), parentDir(), rootID, isFile),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1801,7 +1880,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 		{
 			name:    "already at container file limit",
 			tree:    treeWithFileAtRoot(),
-			file:    driveItem(idx(file, 2), namex(file, 2), parent(0), rootID, isFile),
+			file:    driveItem(idx(file, 2), namex(file, 2), parentDir(), rootID, isFile),
 			limiter: newPagerLimiter(minimumLimitOpts()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1820,7 +1899,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 		{
 			name:    "goes over total byte limit",
 			tree:    treeWithRoot(),
-			file:    driveItem(id(file), name(file), parent(0), rootID, isFile),
+			file:    driveItem(id(file), name(file), parentDir(), rootID, isFile),
 			limiter: newPagerLimiter(minimumLimitOpts()),
 			expect: expected{
 				counts: countTD.Expected{

--- a/src/internal/m365/collection/drive/collections_tree_test.go
+++ b/src/internal/m365/collection/drive/collections_tree_test.go
@@ -944,16 +944,16 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree() {
 				test.tree.countLiveFolders(),
 				"count folders in tree")
 
-			countFiles, totalBytes := test.tree.countLiveFilesAndSizes()
+			countSize := test.tree.countLiveFilesAndSizes()
 			assert.Equal(
 				t,
 				test.expect.numLiveFiles,
-				countFiles,
+				countSize.numFiles,
 				"count files in tree")
 			assert.Equal(
 				t,
 				test.expect.sizeBytes,
-				totalBytes,
+				countSize.totalBytes,
 				"count total bytes in tree")
 			test.expect.counts.Compare(t, counter)
 
@@ -1184,7 +1184,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			assert.Equal(
 				t,
 				test.expect.treeSize,
-				len(test.tree.tombstones)+len(test.tree.folderIDToNode),
+				len(test.tree.tombstones)+test.tree.countLiveFolders(),
 				"count folders in tree")
 			test.expect.counts.Compare(t, counter)
 
@@ -1371,7 +1371,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 			assert.Equal(
 				t,
 				test.expect.treeSize,
-				len(test.tree.tombstones)+len(test.tree.folderIDToNode),
+				len(test.tree.tombstones)+test.tree.countLiveFolders(),
 				"folders in tree")
 			test.expect.treeContainsFolder(t, test.tree.containsFolder(ptr.Val(test.folder.GetId())))
 		})
@@ -1667,9 +1667,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 				fault.New(true))
 			test.expect.err(t, err, clues.ToCore(err))
 
-			countFiles, sizeBytes := test.tree.countLiveFilesAndSizes()
-			assert.Equal(t, test.expect.countLiveFiles, countFiles, "count of files")
-			assert.Equal(t, test.expect.countTotalBytes, sizeBytes, "total size in bytes")
+			countSize := test.tree.countLiveFilesAndSizes()
+			assert.Equal(t, test.expect.countLiveFiles, countSize.numFiles, "count of files")
+			assert.Equal(t, test.expect.countTotalBytes, countSize.totalBytes, "total size in bytes")
 			assert.Equal(t, test.expect.treeContainsFileIDsWithParent, test.tree.fileIDToParentID)
 			test.expect.counts.Compare(t, counter)
 		})
@@ -1863,9 +1863,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 			assert.Equal(t, test.expect.treeContainsFileIDsWithParent, test.tree.fileIDToParentID)
 			test.expect.counts.Compare(t, counter)
 
-			countFiles, sizeBytes := test.tree.countLiveFilesAndSizes()
-			assert.Equal(t, test.expect.countLiveFiles, countFiles, "count of files")
-			assert.Equal(t, test.expect.countTotalBytes, sizeBytes, "total size in bytes")
+			countSize := test.tree.countLiveFilesAndSizes()
+			assert.Equal(t, test.expect.countLiveFiles, countSize.numFiles, "count of files")
+			assert.Equal(t, test.expect.countTotalBytes, countSize.totalBytes, "total size in bytes")
 		})
 	}
 }

--- a/src/internal/m365/collection/drive/collections_tree_test.go
+++ b/src/internal/m365/collection/drive/collections_tree_test.go
@@ -1488,8 +1488,8 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 				treeContainsFileIDsWithParent: map[string]string{
 					id(file): id(folder),
 				},
-				statsNumAddedFiles: 1,
-				statsNumBytes:      defaultItemSize,
+				countLiveFiles:  1,
+				countTotalBytes: defaultItemSize,
 			},
 		},
 		{
@@ -1851,8 +1851,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 				drv,
 				test.file,
 				test.limiter,
-				counter,
-				fault.New(true))
+				counter)
 
 			test.expect.err(t, err, clues.ToCore(err))
 			test.expect.skipped(t, skipped)

--- a/src/internal/m365/collection/drive/delta_tree_test.go
+++ b/src/internal/m365/collection/drive/delta_tree_test.go
@@ -40,6 +40,7 @@ func treeWithFolders() *folderyMcFolderFace {
 
 	o := newNodeyMcNodeFace(tree.root, idx(folder, "parent"), namex(folder, "parent"), true)
 	tree.folderIDToNode[o.id] = o
+	tree.root.children[o.id] = o
 
 	f := newNodeyMcNodeFace(o, id(folder), name(folder), false)
 	tree.folderIDToNode[f.id] = f
@@ -730,10 +731,10 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			expectFiles: map[string]string{id(file): rootID},
 		},
 		{
-			tname:       "move file from root to folder",
-			tree:        treeWithFileAtRoot(),
-			oldParentID: rootID,
-			parentID:    id(folder),
+			tname:       "move file from folder to root",
+			tree:        treeWithFileInFolder(),
+			oldParentID: id(folder),
+			parentID:    rootID,
 			contentSize: 48,
 			expectErr:   assert.NoError,
 			expectFiles: map[string]string{id(file): rootID},
@@ -798,9 +799,9 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 
 			countSize := test.tree.countLiveFilesAndSizes()
 			assert.Equal(t, 1, countSize.numFiles, "should have one file in the tree")
-			assert.Equal(t, test.contentSize, countSize.totalBytes, "should have one file in the tree")
+			assert.Equal(t, test.contentSize, countSize.totalBytes, "tree should be sized to test file contents")
 
-			if len(test.oldParentID) > 0 {
+			if len(test.oldParentID) > 0 && test.oldParentID != test.parentID {
 				old, ok := test.tree.folderIDToNode[test.oldParentID]
 				if !ok {
 					old = test.tree.tombstones[test.oldParentID]

--- a/src/internal/m365/collection/drive/delta_tree_test.go
+++ b/src/internal/m365/collection/drive/delta_tree_test.go
@@ -796,9 +796,9 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			require.NotNil(t, parent)
 			assert.Contains(t, parent.files, id(file))
 
-			count, size := test.tree.countLiveFilesAndSizes()
-			assert.Equal(t, 1, count, "should have one file in the tree")
-			assert.Equal(t, test.contentSize, size, "should have one file in the tree")
+			countSize := test.tree.countLiveFilesAndSizes()
+			assert.Equal(t, 1, countSize.numFiles, "should have one file in the tree")
+			assert.Equal(t, test.contentSize, countSize.totalBytes, "should have one file in the tree")
 
 			if len(test.oldParentID) > 0 {
 				old, ok := test.tree.folderIDToNode[test.oldParentID]

--- a/src/internal/m365/collection/drive/delta_tree_test.go
+++ b/src/internal/m365/collection/drive/delta_tree_test.go
@@ -871,7 +871,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_addAndDeleteFile() {
 	assert.Len(t, tree.deletedFileIDs, 1)
 	assert.Contains(t, tree.deletedFileIDs, fID)
 
-	err := tree.addFile(rootID, fID, time.Now())
+	err := tree.addFile(rootID, fID, time.Now(), defaultItemSize)
 	require.NoError(t, err, clues.ToCore(err))
 
 	assert.Len(t, tree.fileIDToParentID, 1)

--- a/src/internal/m365/collection/drive/limiter.go
+++ b/src/internal/m365/collection/drive/limiter.go
@@ -93,18 +93,6 @@ func (l pagerLimiter) atLimit(stats *driveEnumerationStats) bool {
 // Used by the tree version limit handling
 // ---------------------------------------------------------------------------
 
-// hitLimit returns true if the limiter is enabled and meets any of the
-// conditions for max items, containers, etc for this backup.
-func (l pagerLimiter) hitLimit(
-	pageCount, containerCount, itemCount int,
-	totalBytesCount int64,
-) bool {
-	return l.hitItemLimit(itemCount) ||
-		l.hitTotalBytesLimit(totalBytesCount) ||
-		l.hitContainerLimit(containerCount) ||
-		l.hitPageLimit(pageCount)
-}
-
 // hitPageLimit returns true if the limiter is enabled and the number of
 // pages processed so far is beyond the limit for this backup.
 func (l pagerLimiter) hitPageLimit(pageCount int) bool {

--- a/src/internal/m365/collection/drive/limiter_test.go
+++ b/src/internal/m365/collection/drive/limiter_test.go
@@ -58,7 +58,7 @@ type backupLimitTest struct {
 	enumerator mock.EnumerateItemsDeltaByDrive
 	// Collection name -> set of item IDs. We can't check item data because
 	// that's not mocked out. Metadata is checked separately.
-	expectedCollections map[string][]string
+	expectedItemIDsInCollection map[string][]string
 }
 
 func backupLimitTable() (models.Driveable, models.Driveable, []backupLimitTest) {
@@ -84,17 +84,17 @@ func backupLimitTable() (models.Driveable, models.Driveable, []backupLimitTest) 
 			drives: []models.Driveable{drive1},
 			enumerator: mock.EnumerateItemsDeltaByDrive{
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
-					idx(drive, 1): {
-						Pages: pagesOf(rootAnd(
-							driveItemWithSize(idx(file, 1), namex(file, 1), parent(1), rootID, 7, isFile),
-							driveItemWithSize(idx(file, 2), namex(file, 2), parent(1), rootID, 1, isFile),
-							driveItemWithSize(idx(file, 3), namex(file, 3), parent(1), rootID, 1, isFile))),
+					id(drive): {
+						Pages: pagesOf(pageItems(
+							driveItemWithSize(idx(file, 1), namex(file, 1), parentDir(), rootID, 7, isFile),
+							driveItemWithSize(idx(file, 2), namex(file, 2), parentDir(), rootID, 1, isFile),
+							driveItemWithSize(idx(file, 3), namex(file, 3), parentDir(), rootID, 1, isFile))),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
 			},
-			expectedCollections: map[string][]string{
-				fullPath(1): {idx(file, 2), idx(file, 3)},
+			expectedItemIDsInCollection: map[string][]string{
+				fullPath(): {idx(file, 2), idx(file, 3)},
 			},
 		},
 		{
@@ -110,17 +110,17 @@ func backupLimitTable() (models.Driveable, models.Driveable, []backupLimitTest) 
 			drives: []models.Driveable{drive1},
 			enumerator: mock.EnumerateItemsDeltaByDrive{
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
-					idx(drive, 1): {
-						Pages: pagesOf(rootAnd(
-							driveItemWithSize(idx(file, 1), namex(file, 1), parent(1), rootID, 1, isFile),
-							driveItemWithSize(idx(file, 2), namex(file, 2), parent(1), rootID, 2, isFile),
-							driveItemWithSize(idx(file, 3), namex(file, 3), parent(1), rootID, 1, isFile))),
+					id(drive): {
+						Pages: pagesOf(pageItems(
+							driveItemWithSize(idx(file, 1), namex(file, 1), parentDir(), rootID, 1, isFile),
+							driveItemWithSize(idx(file, 2), namex(file, 2), parentDir(), rootID, 2, isFile),
+							driveItemWithSize(idx(file, 3), namex(file, 3), parentDir(), rootID, 1, isFile))),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
 			},
-			expectedCollections: map[string][]string{
-				fullPath(1): {idx(file, 1), idx(file, 2)},
+			expectedItemIDsInCollection: map[string][]string{
+				fullPath(): {idx(file, 1), idx(file, 2)},
 			},
 		},
 		{
@@ -136,19 +136,19 @@ func backupLimitTable() (models.Driveable, models.Driveable, []backupLimitTest) 
 			drives: []models.Driveable{drive1},
 			enumerator: mock.EnumerateItemsDeltaByDrive{
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
-					idx(drive, 1): {
-						Pages: pagesOf(rootAnd(
-							driveItemWithSize(idx(file, 1), namex(file, 1), parent(1), rootID, 1, isFile),
-							driveItemWithSize(idx(folder, 1), namex(folder, 1), parent(1), rootID, 1, isFolder),
-							driveItemWithSize(idx(file, 2), namex(file, 2), parent(1, namex(folder, 1)), idx(folder, 1), 2, isFile),
-							driveItemWithSize(idx(file, 3), namex(file, 3), parent(1, namex(folder, 1)), idx(folder, 1), 1, isFile))),
+					id(drive): {
+						Pages: pagesOf(pageItems(
+							driveItemWithSize(idx(file, 1), namex(file, 1), parentDir(), rootID, 1, isFile),
+							driveItemWithSize(idx(folder, 1), namex(folder, 1), parentDir(), rootID, 1, isFolder),
+							driveItemWithSize(idx(file, 2), namex(file, 2), parentDir(namex(folder, 1)), idx(folder, 1), 2, isFile),
+							driveItemWithSize(idx(file, 3), namex(file, 3), parentDir(namex(folder, 1)), idx(folder, 1), 1, isFile))),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
 			},
-			expectedCollections: map[string][]string{
-				fullPath(1):                   {idx(file, 1)},
-				fullPath(1, namex(folder, 1)): {idx(folder, 1), idx(file, 2)},
+			expectedItemIDsInCollection: map[string][]string{
+				fullPath():                 {idx(file, 1)},
+				fullPath(namex(folder, 1)): {idx(folder, 1), idx(file, 2)},
 			},
 		},
 		{
@@ -164,20 +164,20 @@ func backupLimitTable() (models.Driveable, models.Driveable, []backupLimitTest) 
 			drives: []models.Driveable{drive1},
 			enumerator: mock.EnumerateItemsDeltaByDrive{
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
-					idx(drive, 1): {
-						Pages: pagesOf(rootAnd(
-							driveItem(idx(file, 1), namex(file, 1), parent(1), rootID, isFile),
-							driveItem(idx(file, 2), namex(file, 2), parent(1), rootID, isFile),
-							driveItem(idx(file, 3), namex(file, 3), parent(1), rootID, isFile),
-							driveItem(idx(file, 4), namex(file, 4), parent(1), rootID, isFile),
-							driveItem(idx(file, 5), namex(file, 5), parent(1), rootID, isFile),
-							driveItem(idx(file, 6), namex(file, 6), parent(1), rootID, isFile))),
+					id(drive): {
+						Pages: pagesOf(pageItems(
+							driveItem(idx(file, 1), namex(file, 1), parentDir(), rootID, isFile),
+							driveItem(idx(file, 2), namex(file, 2), parentDir(), rootID, isFile),
+							driveItem(idx(file, 3), namex(file, 3), parentDir(), rootID, isFile),
+							driveItem(idx(file, 4), namex(file, 4), parentDir(), rootID, isFile),
+							driveItem(idx(file, 5), namex(file, 5), parentDir(), rootID, isFile),
+							driveItem(idx(file, 6), namex(file, 6), parentDir(), rootID, isFile))),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
 			},
-			expectedCollections: map[string][]string{
-				fullPath(1): {idx(file, 1), idx(file, 2), idx(file, 3)},
+			expectedItemIDsInCollection: map[string][]string{
+				fullPath(): {idx(file, 1), idx(file, 2), idx(file, 3)},
 			},
 		},
 		{
@@ -193,26 +193,26 @@ func backupLimitTable() (models.Driveable, models.Driveable, []backupLimitTest) 
 			drives: []models.Driveable{drive1},
 			enumerator: mock.EnumerateItemsDeltaByDrive{
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
-					idx(drive, 1): {
+					id(drive): {
 						Pages: pagesOf(
-							rootAnd(
-								driveItem(idx(file, 1), namex(file, 1), parent(1), rootID, isFile),
-								driveItem(idx(file, 2), namex(file, 2), parent(1), rootID, isFile)),
-							rootAnd(
+							pageItems(
+								driveItem(idx(file, 1), namex(file, 1), parentDir(), rootID, isFile),
+								driveItem(idx(file, 2), namex(file, 2), parentDir(), rootID, isFile)),
+							pageItems(
 								// Repeated items shouldn't count against the limit.
-								driveItem(idx(file, 1), namex(file, 1), parent(1), rootID, isFile),
-								driveItem(idx(folder, 1), namex(folder, 1), parent(1), rootID, isFolder),
-								driveItem(idx(file, 3), namex(file, 3), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
-								driveItem(idx(file, 4), namex(file, 4), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
-								driveItem(idx(file, 5), namex(file, 5), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
-								driveItem(idx(file, 6), namex(file, 6), parent(1, namex(folder, 1)), idx(folder, 1), isFile))),
+								driveItem(idx(file, 1), namex(file, 1), parentDir(), rootID, isFile),
+								driveItem(idx(folder, 1), namex(folder, 1), parentDir(), rootID, isFolder),
+								driveItem(idx(file, 3), namex(file, 3), parentDir(namex(folder, 1)), idx(folder, 1), isFile),
+								driveItem(idx(file, 4), namex(file, 4), parentDir(namex(folder, 1)), idx(folder, 1), isFile),
+								driveItem(idx(file, 5), namex(file, 5), parentDir(namex(folder, 1)), idx(folder, 1), isFile),
+								driveItem(idx(file, 6), namex(file, 6), parentDir(namex(folder, 1)), idx(folder, 1), isFile))),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
 			},
-			expectedCollections: map[string][]string{
-				fullPath(1):                   {idx(file, 1), idx(file, 2)},
-				fullPath(1, namex(folder, 1)): {idx(folder, 1), idx(file, 3)},
+			expectedItemIDsInCollection: map[string][]string{
+				fullPath():                 {idx(file, 1), idx(file, 2)},
+				fullPath(namex(folder, 1)): {idx(folder, 1), idx(file, 3)},
 			},
 		},
 		{
@@ -228,23 +228,23 @@ func backupLimitTable() (models.Driveable, models.Driveable, []backupLimitTest) 
 			drives: []models.Driveable{drive1},
 			enumerator: mock.EnumerateItemsDeltaByDrive{
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
-					idx(drive, 1): {
+					id(drive): {
 						Pages: pagesOf(
-							rootAnd(
-								driveItem(idx(file, 1), namex(file, 1), parent(1), rootID, isFile),
-								driveItem(idx(file, 2), namex(file, 2), parent(1), rootID, isFile)),
-							rootAnd(
-								driveItem(idx(folder, 1), namex(folder, 1), parent(1), rootID, isFolder),
-								driveItem(idx(file, 3), namex(file, 3), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
-								driveItem(idx(file, 4), namex(file, 4), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
-								driveItem(idx(file, 5), namex(file, 5), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
-								driveItem(idx(file, 6), namex(file, 6), parent(1, namex(folder, 1)), idx(folder, 1), isFile))),
+							pageItems(
+								driveItem(idx(file, 1), namex(file, 1), parentDir(), rootID, isFile),
+								driveItem(idx(file, 2), namex(file, 2), parentDir(), rootID, isFile)),
+							pageItems(
+								driveItem(idx(folder, 1), namex(folder, 1), parentDir(), rootID, isFolder),
+								driveItem(idx(file, 3), namex(file, 3), parentDir(namex(folder, 1)), idx(folder, 1), isFile),
+								driveItem(idx(file, 4), namex(file, 4), parentDir(namex(folder, 1)), idx(folder, 1), isFile),
+								driveItem(idx(file, 5), namex(file, 5), parentDir(namex(folder, 1)), idx(folder, 1), isFile),
+								driveItem(idx(file, 6), namex(file, 6), parentDir(namex(folder, 1)), idx(folder, 1), isFile))),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
 			},
-			expectedCollections: map[string][]string{
-				fullPath(1): {idx(file, 1), idx(file, 2)},
+			expectedItemIDsInCollection: map[string][]string{
+				fullPath(): {idx(file, 1), idx(file, 2)},
 			},
 		},
 		{
@@ -260,25 +260,25 @@ func backupLimitTable() (models.Driveable, models.Driveable, []backupLimitTest) 
 			drives: []models.Driveable{drive1},
 			enumerator: mock.EnumerateItemsDeltaByDrive{
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
-					idx(drive, 1): {
+					id(drive): {
 						Pages: pagesOf(
-							rootAnd(
-								driveItem(idx(file, 1), namex(file, 1), parent(1), rootID, isFile),
-								driveItem(idx(file, 2), namex(file, 2), parent(1), rootID, isFile),
-								driveItem(idx(file, 3), namex(file, 3), parent(1), rootID, isFile)),
-							rootAnd(
-								driveItem(idx(folder, 1), namex(folder, 1), parent(1), rootID, isFolder),
-								driveItem(idx(file, 4), namex(file, 4), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
-								driveItem(idx(file, 5), namex(file, 5), parent(1, namex(folder, 1)), idx(folder, 1), isFile))),
+							pageItems(
+								driveItem(idx(file, 1), namex(file, 1), parentDir(), rootID, isFile),
+								driveItem(idx(file, 2), namex(file, 2), parentDir(), rootID, isFile),
+								driveItem(idx(file, 3), namex(file, 3), parentDir(), rootID, isFile)),
+							pageItems(
+								driveItem(idx(folder, 1), namex(folder, 1), parentDir(), rootID, isFolder),
+								driveItem(idx(file, 4), namex(file, 4), parentDir(namex(folder, 1)), idx(folder, 1), isFile),
+								driveItem(idx(file, 5), namex(file, 5), parentDir(namex(folder, 1)), idx(folder, 1), isFile))),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
 			},
-			expectedCollections: map[string][]string{
+			expectedItemIDsInCollection: map[string][]string{
 				// Root has an additional item. It's hard to fix that in the code
 				// though.
-				fullPath(1):                   {idx(file, 1), idx(file, 2)},
-				fullPath(1, namex(folder, 1)): {idx(folder, 1), idx(file, 4)},
+				fullPath():                 {idx(file, 1), idx(file, 2)},
+				fullPath(namex(folder, 1)): {idx(folder, 1), idx(file, 4)},
 			},
 		},
 		{
@@ -294,25 +294,25 @@ func backupLimitTable() (models.Driveable, models.Driveable, []backupLimitTest) 
 			drives: []models.Driveable{drive1},
 			enumerator: mock.EnumerateItemsDeltaByDrive{
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
-					idx(drive, 1): {
+					id(drive): {
 						Pages: pagesOf(
-							rootAnd(
-								driveItem(idx(folder, 0), namex(folder, 0), parent(1), rootID, isFolder),
-								driveItem(idx(file, 1), namex(file, 1), parent(1, namex(folder, 0)), idx(folder, 0), isFile),
-								driveItem(idx(file, 2), namex(file, 2), parent(1, namex(folder, 0)), idx(folder, 0), isFile)),
-							rootAnd(
-								driveItem(idx(folder, 0), namex(folder, 0), parent(1), rootID, isFolder),
+							pageItems(
+								driveItem(id(folder), name(folder), parentDir(), rootID, isFolder),
+								driveItem(idx(file, 1), namex(file, 1), parentDir(name(folder)), id(folder), isFile),
+								driveItem(idx(file, 2), namex(file, 2), parentDir(name(folder)), id(folder), isFile)),
+							pageItems(
+								driveItem(id(folder), name(folder), parentDir(), rootID, isFolder),
 								// Updated item that shouldn't count against the limit a second time.
-								driveItem(idx(file, 2), namex(file, 2), parent(1, namex(folder, 0)), idx(folder, 0), isFile),
-								driveItem(idx(file, 3), namex(file, 3), parent(1, namex(folder, 0)), idx(folder, 0), isFile),
-								driveItem(idx(file, 4), namex(file, 4), parent(1, namex(folder, 0)), idx(folder, 0), isFile))),
+								driveItem(idx(file, 2), namex(file, 2), parentDir(name(folder)), id(folder), isFile),
+								driveItem(idx(file, 3), namex(file, 3), parentDir(name(folder)), id(folder), isFile),
+								driveItem(idx(file, 4), namex(file, 4), parentDir(name(folder)), id(folder), isFile))),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
 			},
-			expectedCollections: map[string][]string{
-				fullPath(1):                   {},
-				fullPath(1, namex(folder, 0)): {idx(folder, 0), idx(file, 1), idx(file, 2), idx(file, 3)},
+			expectedItemIDsInCollection: map[string][]string{
+				fullPath():             {},
+				fullPath(name(folder)): {id(folder), idx(file, 1), idx(file, 2), idx(file, 3)},
 			},
 		},
 		{
@@ -328,26 +328,26 @@ func backupLimitTable() (models.Driveable, models.Driveable, []backupLimitTest) 
 			drives: []models.Driveable{drive1},
 			enumerator: mock.EnumerateItemsDeltaByDrive{
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
-					idx(drive, 1): {
+					id(drive): {
 						Pages: pagesOf(
-							rootAnd(
-								driveItem(idx(file, 1), namex(file, 1), parent(1), rootID, isFile),
-								driveItem(idx(file, 2), namex(file, 2), parent(1), rootID, isFile),
+							pageItems(
+								driveItem(idx(file, 1), namex(file, 1), parentDir(), rootID, isFile),
+								driveItem(idx(file, 2), namex(file, 2), parentDir(), rootID, isFile),
 								// Put folder 0 at limit.
-								driveItem(idx(folder, 0), namex(folder, 0), parent(1), rootID, isFolder),
-								driveItem(idx(file, 3), namex(file, 3), parent(1, namex(folder, 0)), idx(folder, 0), isFile),
-								driveItem(idx(file, 4), namex(file, 4), parent(1, namex(folder, 0)), idx(folder, 0), isFile)),
-							rootAnd(
-								driveItem(idx(folder, 0), namex(folder, 0), parent(1), rootID, isFolder),
+								driveItem(id(folder), name(folder), parentDir(), rootID, isFolder),
+								driveItem(idx(file, 3), namex(file, 3), parentDir(name(folder)), id(folder), isFile),
+								driveItem(idx(file, 4), namex(file, 4), parentDir(name(folder)), id(folder), isFile)),
+							pageItems(
+								driveItem(id(folder), name(folder), parentDir(), rootID, isFolder),
 								// Try to move item from root to folder 0 which is already at the limit.
-								driveItem(idx(file, 1), namex(file, 1), parent(1, namex(folder, 0)), idx(folder, 0), isFile))),
+								driveItem(idx(file, 1), namex(file, 1), parentDir(name(folder)), id(folder), isFile))),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
 			},
-			expectedCollections: map[string][]string{
-				fullPath(1):                   {idx(file, 1), idx(file, 2)},
-				fullPath(1, namex(folder, 0)): {idx(folder, 0), idx(file, 3), idx(file, 4)},
+			expectedItemIDsInCollection: map[string][]string{
+				fullPath():             {idx(file, 1), idx(file, 2)},
+				fullPath(name(folder)): {id(folder), idx(file, 3), idx(file, 4)},
 			},
 		},
 		{
@@ -363,25 +363,25 @@ func backupLimitTable() (models.Driveable, models.Driveable, []backupLimitTest) 
 			drives: []models.Driveable{drive1},
 			enumerator: mock.EnumerateItemsDeltaByDrive{
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
-					idx(drive, 1): {
+					id(drive): {
 						Pages: pagesOf(
-							rootAnd(
-								driveItem(idx(file, 1), namex(file, 1), parent(1), rootID, isFile),
-								driveItem(idx(file, 2), namex(file, 2), parent(1), rootID, isFile),
-								driveItem(idx(file, 3), namex(file, 3), parent(1), rootID, isFile)),
-							rootAnd(
-								driveItem(idx(folder, 1), namex(folder, 1), parent(1), rootID, isFolder),
-								driveItem(idx(file, 4), namex(file, 4), parent(1, namex(folder, 1)), idx(folder, 1), isFile)),
-							rootAnd(
-								driveItem(idx(folder, 1), namex(folder, 1), parent(1), rootID, isFolder),
-								driveItem(idx(file, 5), namex(file, 5), parent(1, namex(folder, 1)), idx(folder, 1), isFile))),
+							pageItems(
+								driveItem(idx(file, 1), namex(file, 1), parentDir(), rootID, isFile),
+								driveItem(idx(file, 2), namex(file, 2), parentDir(), rootID, isFile),
+								driveItem(idx(file, 3), namex(file, 3), parentDir(), rootID, isFile)),
+							pageItems(
+								driveItem(idx(folder, 1), namex(folder, 1), parentDir(), rootID, isFolder),
+								driveItem(idx(file, 4), namex(file, 4), parentDir(namex(folder, 1)), idx(folder, 1), isFile)),
+							pageItems(
+								driveItem(idx(folder, 1), namex(folder, 1), parentDir(), rootID, isFolder),
+								driveItem(idx(file, 5), namex(file, 5), parentDir(namex(folder, 1)), idx(folder, 1), isFile))),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
 			},
-			expectedCollections: map[string][]string{
-				fullPath(1):                   {idx(file, 1), idx(file, 2), idx(file, 3)},
-				fullPath(1, namex(folder, 1)): {idx(folder, 1), idx(file, 4), idx(file, 5)},
+			expectedItemIDsInCollection: map[string][]string{
+				fullPath():                 {idx(file, 1), idx(file, 2), idx(file, 3)},
+				fullPath(namex(folder, 1)): {idx(folder, 1), idx(file, 4), idx(file, 5)},
 			},
 		},
 		{
@@ -397,28 +397,28 @@ func backupLimitTable() (models.Driveable, models.Driveable, []backupLimitTest) 
 			drives: []models.Driveable{drive1},
 			enumerator: mock.EnumerateItemsDeltaByDrive{
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
-					idx(drive, 1): {
+					id(drive): {
 						Pages: pagesOf(
-							rootAnd(
-								driveItem(idx(file, 1), namex(file, 1), parent(1), rootID, isFile),
-								driveItem(idx(file, 2), namex(file, 2), parent(1), rootID, isFile),
-								driveItem(idx(file, 3), namex(file, 3), parent(1), rootID, isFile)),
-							rootAnd(
-								driveItem(idx(folder, 1), namex(folder, 1), parent(1), rootID, isFolder),
-								driveItem(idx(file, 4), namex(file, 4), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
-								driveItem(idx(file, 5), namex(file, 5), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
+							pageItems(
+								driveItem(idx(file, 1), namex(file, 1), parentDir(), rootID, isFile),
+								driveItem(idx(file, 2), namex(file, 2), parentDir(), rootID, isFile),
+								driveItem(idx(file, 3), namex(file, 3), parentDir(), rootID, isFile)),
+							pageItems(
+								driveItem(idx(folder, 1), namex(folder, 1), parentDir(), rootID, isFolder),
+								driveItem(idx(file, 4), namex(file, 4), parentDir(namex(folder, 1)), idx(folder, 1), isFile),
+								driveItem(idx(file, 5), namex(file, 5), parentDir(namex(folder, 1)), idx(folder, 1), isFile),
 								// This container shouldn't be returned.
-								driveItem(idx(folder, 2), namex(folder, 2), parent(1), rootID, isFolder),
-								driveItem(idx(file, 7), namex(file, 7), parent(1, namex(folder, 2)), idx(folder, 2), isFile),
-								driveItem(idx(file, 8), namex(file, 8), parent(1, namex(folder, 2)), idx(folder, 2), isFile),
-								driveItem(idx(file, 9), namex(file, 9), parent(1, namex(folder, 2)), idx(folder, 2), isFile))),
+								driveItem(idx(folder, 2), namex(folder, 2), parentDir(), rootID, isFolder),
+								driveItem(idx(file, 7), namex(file, 7), parentDir(namex(folder, 2)), idx(folder, 2), isFile),
+								driveItem(idx(file, 8), namex(file, 8), parentDir(namex(folder, 2)), idx(folder, 2), isFile),
+								driveItem(idx(file, 9), namex(file, 9), parentDir(namex(folder, 2)), idx(folder, 2), isFile))),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
 			},
-			expectedCollections: map[string][]string{
-				fullPath(1):                   {idx(file, 1), idx(file, 2), idx(file, 3)},
-				fullPath(1, namex(folder, 1)): {idx(folder, 1), idx(file, 4), idx(file, 5)},
+			expectedItemIDsInCollection: map[string][]string{
+				fullPath():                 {idx(file, 1), idx(file, 2), idx(file, 3)},
+				fullPath(namex(folder, 1)): {idx(folder, 1), idx(file, 4), idx(file, 5)},
 			},
 		},
 		{
@@ -434,29 +434,29 @@ func backupLimitTable() (models.Driveable, models.Driveable, []backupLimitTest) 
 			drives: []models.Driveable{drive1},
 			enumerator: mock.EnumerateItemsDeltaByDrive{
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
-					idx(drive, 1): {
+					id(drive): {
 						Pages: pagesOf(
-							rootAnd(
-								driveItem(idx(file, 1), namex(file, 1), parent(1), rootID, isFile),
-								driveItem(idx(file, 2), namex(file, 2), parent(1), rootID, isFile),
-								driveItem(idx(file, 3), namex(file, 3), parent(1), rootID, isFile)),
-							rootAnd(
-								driveItem(idx(folder, 1), namex(folder, 1), parent(1), rootID, isFolder),
-								driveItem(idx(file, 4), namex(file, 4), parent(1, namex(folder, 1)), idx(folder, 1), isFile),
-								driveItem(idx(file, 5), namex(file, 5), parent(1, namex(folder, 1)), idx(folder, 1), isFile)),
-							rootAnd(
+							pageItems(
+								driveItem(idx(file, 1), namex(file, 1), parentDir(), rootID, isFile),
+								driveItem(idx(file, 2), namex(file, 2), parentDir(), rootID, isFile),
+								driveItem(idx(file, 3), namex(file, 3), parentDir(), rootID, isFile)),
+							pageItems(
+								driveItem(idx(folder, 1), namex(folder, 1), parentDir(), rootID, isFolder),
+								driveItem(idx(file, 4), namex(file, 4), parentDir(namex(folder, 1)), idx(folder, 1), isFile),
+								driveItem(idx(file, 5), namex(file, 5), parentDir(namex(folder, 1)), idx(folder, 1), isFile)),
+							pageItems(
 								// This container shouldn't be returned.
-								driveItem(idx(folder, 2), namex(folder, 2), parent(1), rootID, isFolder),
-								driveItem(idx(file, 7), namex(file, 7), parent(1, namex(folder, 2)), idx(folder, 2), isFile),
-								driveItem(idx(file, 8), namex(file, 8), parent(1, namex(folder, 2)), idx(folder, 2), isFile),
-								driveItem(idx(file, 9), namex(file, 9), parent(1, namex(folder, 2)), idx(folder, 2), isFile))),
+								driveItem(idx(folder, 2), namex(folder, 2), parentDir(), rootID, isFolder),
+								driveItem(idx(file, 7), namex(file, 7), parentDir(namex(folder, 2)), idx(folder, 2), isFile),
+								driveItem(idx(file, 8), namex(file, 8), parentDir(namex(folder, 2)), idx(folder, 2), isFile),
+								driveItem(idx(file, 9), namex(file, 9), parentDir(namex(folder, 2)), idx(folder, 2), isFile))),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
 			},
-			expectedCollections: map[string][]string{
-				fullPath(1):                   {idx(file, 1), idx(file, 2), idx(file, 3)},
-				fullPath(1, namex(folder, 1)): {idx(folder, 1), idx(file, 4), idx(file, 5)},
+			expectedItemIDsInCollection: map[string][]string{
+				fullPath():                 {idx(file, 1), idx(file, 2), idx(file, 3)},
+				fullPath(namex(folder, 1)): {idx(folder, 1), idx(file, 4), idx(file, 5)},
 			},
 		},
 		{
@@ -472,31 +472,29 @@ func backupLimitTable() (models.Driveable, models.Driveable, []backupLimitTest) 
 			drives: []models.Driveable{drive1, drive2},
 			enumerator: mock.EnumerateItemsDeltaByDrive{
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
-					idx(drive, 1): {
-						Pages: pagesOf(rootAnd(
-							driveItem(idx(file, 1), namex(file, 1), parent(1), rootID, isFile),
-							driveItem(idx(file, 2), namex(file, 2), parent(1), rootID, isFile),
-							driveItem(idx(file, 3), namex(file, 3), parent(1), rootID, isFile),
-							driveItem(idx(file, 4), namex(file, 4), parent(1), rootID, isFile),
-							driveItem(idx(file, 5), namex(file, 5), parent(1), rootID, isFile),
-						)),
+					id(drive): {
+						Pages: pagesOf(pageItems(
+							driveItem(idx(file, 1), namex(file, 1), parentDir(), rootID, isFile),
+							driveItem(idx(file, 2), namex(file, 2), parentDir(), rootID, isFile),
+							driveItem(idx(file, 3), namex(file, 3), parentDir(), rootID, isFile),
+							driveItem(idx(file, 4), namex(file, 4), parentDir(), rootID, isFile),
+							driveItem(idx(file, 5), namex(file, 5), parentDir(), rootID, isFile))),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 					idx(drive, 2): {
-						Pages: pagesOf(rootAnd(
-							driveItem(idx(file, 1), namex(file, 1), parent(2), rootID, isFile),
-							driveItem(idx(file, 2), namex(file, 2), parent(2), rootID, isFile),
-							driveItem(idx(file, 3), namex(file, 3), parent(2), rootID, isFile),
-							driveItem(idx(file, 4), namex(file, 4), parent(2), rootID, isFile),
-							driveItem(idx(file, 5), namex(file, 5), parent(2), rootID, isFile),
-						)),
+						Pages: pagesOf(pageItems(
+							driveItem(idx(file, 1), namex(file, 1), driveParentDir(2), rootID, isFile),
+							driveItem(idx(file, 2), namex(file, 2), driveParentDir(2), rootID, isFile),
+							driveItem(idx(file, 3), namex(file, 3), driveParentDir(2), rootID, isFile),
+							driveItem(idx(file, 4), namex(file, 4), driveParentDir(2), rootID, isFile),
+							driveItem(idx(file, 5), namex(file, 5), driveParentDir(2), rootID, isFile))),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
 			},
-			expectedCollections: map[string][]string{
-				fullPath(1): {idx(file, 1), idx(file, 2), idx(file, 3)},
-				fullPath(2): {idx(file, 1), idx(file, 2), idx(file, 3)},
+			expectedItemIDsInCollection: map[string][]string{
+				fullPath():       {idx(file, 1), idx(file, 2), idx(file, 3)},
+				driveFullPath(2): {idx(file, 1), idx(file, 2), idx(file, 3)},
 			},
 		},
 		{
@@ -511,25 +509,25 @@ func backupLimitTable() (models.Driveable, models.Driveable, []backupLimitTest) 
 			drives: []models.Driveable{drive1},
 			enumerator: mock.EnumerateItemsDeltaByDrive{
 				DrivePagers: map[string]*mock.DriveItemsDeltaPager{
-					idx(drive, 1): {
+					id(drive): {
 						Pages: pagesOf(
-							rootAnd(
-								driveItem(idx(file, 1), namex(file, 1), parent(1), rootID, isFile),
-								driveItem(idx(file, 2), namex(file, 2), parent(1), rootID, isFile),
-								driveItem(idx(file, 3), namex(file, 3), parent(1), rootID, isFile)),
-							rootAnd(
-								driveItem(idx(folder, 1), namex(folder, 1), parent(1), rootID, isFolder),
-								driveItem(idx(file, 4), namex(file, 4), parent(1, namex(folder, 1)), idx(folder, 1), isFile)),
-							rootAnd(
-								driveItem(idx(folder, 1), namex(folder, 1), parent(1), rootID, isFolder),
-								driveItem(idx(file, 5), namex(file, 5), parent(1, namex(folder, 1)), idx(folder, 1), isFile))),
+							pageItems(
+								driveItem(idx(file, 1), namex(file, 1), parentDir(), rootID, isFile),
+								driveItem(idx(file, 2), namex(file, 2), parentDir(), rootID, isFile),
+								driveItem(idx(file, 3), namex(file, 3), parentDir(), rootID, isFile)),
+							pageItems(
+								driveItem(idx(folder, 1), namex(folder, 1), parentDir(), rootID, isFolder),
+								driveItem(idx(file, 4), namex(file, 4), parentDir(namex(folder, 1)), idx(folder, 1), isFile)),
+							pageItems(
+								driveItem(idx(folder, 1), namex(folder, 1), parentDir(), rootID, isFolder),
+								driveItem(idx(file, 5), namex(file, 5), parentDir(namex(folder, 1)), idx(folder, 1), isFile))),
 						DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 					},
 				},
 			},
-			expectedCollections: map[string][]string{
-				fullPath(1):                   {idx(file, 1), idx(file, 2), idx(file, 3)},
-				fullPath(1, namex(folder, 1)): {idx(folder, 1), idx(file, 4), idx(file, 5)},
+			expectedItemIDsInCollection: map[string][]string{
+				fullPath():                 {idx(file, 1), idx(file, 2), idx(file, 3)},
+				fullPath(namex(folder, 1)): {idx(folder, 1), idx(file, 4), idx(file, 5)},
 			},
 		},
 	}
@@ -649,15 +647,15 @@ func runGetPreviewLimits(
 
 		assert.ElementsMatchf(
 			t,
-			test.expectedCollections[folderPath],
+			test.expectedItemIDsInCollection[folderPath],
 			itemIDs,
-			"expected elements to match in collection with path %q",
+			"item IDs in collection with path %q",
 			folderPath)
 	}
 
 	assert.ElementsMatch(
 		t,
-		maps.Keys(test.expectedCollections),
+		maps.Keys(test.expectedItemIDsInCollection),
 		collPaths,
 		"collection paths")
 }
@@ -776,15 +774,17 @@ func defaultLimitsTable() []defaultLimitTest {
 // making a preview backup if the user didn't provide some options.
 // These tests run a reduced set of checks that really just look for item counts
 // and such. Other tests are expected to provide more comprehensive checks.
-func (suite *LimiterUnitSuite) TestGet_PreviewLimits_Defaults_noTree() {
+func (suite *LimiterUnitSuite) TestGet_PreviewLimits_defaultsNoTree() {
+	t := suite.T()
+
 	// Add a check that will fail if we make the default smaller than expected.
 	require.LessOrEqual(
-		suite.T(),
+		t,
 		int64(1024*1024),
 		defaultPreviewMaxBytes,
 		"default number of bytes changed; DefaultNumBytes test case may need updating!")
 	require.Zero(
-		suite.T(),
+		t,
 		defaultPreviewMaxBytes%(1024*1024),
 		"default number of bytes isn't divisible by 1MB; DefaultNumBytes test case may need updating!")
 
@@ -802,15 +802,19 @@ func (suite *LimiterUnitSuite) TestGet_PreviewLimits_Defaults_noTree() {
 // making a preview backup if the user didn't provide some options.
 // These tests run a reduced set of checks that really just look for item counts
 // and such. Other tests are expected to provide more comprehensive checks.
-func (suite *LimiterUnitSuite) TestGet_PreviewLimits_Defaults_tree() {
+func (suite *LimiterUnitSuite) TestGet_PreviewLimits_defaultsWithTree() {
+	t := suite.T()
+
+	t.Skip("TODO: unskip when tree produces collections")
+
 	// Add a check that will fail if we make the default smaller than expected.
 	require.LessOrEqual(
-		suite.T(),
+		t,
 		int64(1024*1024),
 		defaultPreviewMaxBytes,
 		"default number of bytes changed; DefaultNumBytes test case may need updating!")
 	require.Zero(
-		suite.T(),
+		t,
 		defaultPreviewMaxBytes%(1024*1024),
 		"default number of bytes isn't divisible by 1MB; DefaultNumBytes test case may need updating!")
 
@@ -852,11 +856,11 @@ func runGetPreviewLimitsDefaults(
 	for containerIdx := 0; containerIdx < test.numContainers; containerIdx++ {
 		page := mock.NextPage{
 			Items: []models.DriveItemable{
-				driveRootItem(rootID),
+				driveRootItem(),
 				driveItem(
 					idx(folder, containerIdx),
 					namex(folder, containerIdx),
-					parent(1),
+					parentDir(),
 					rootID,
 					isFolder),
 			},
@@ -868,7 +872,7 @@ func runGetPreviewLimitsDefaults(
 			page.Items = append(page.Items, driveItemWithSize(
 				idx(file, itemSuffix),
 				namex(file, itemSuffix),
-				parent(1, namex(folder, containerIdx)),
+				parentDir(namex(folder, containerIdx)),
 				idx(folder, containerIdx),
 				test.itemSize,
 				isFile))
@@ -887,7 +891,7 @@ func runGetPreviewLimitsDefaults(
 		}
 		mockEnumerator = mock.EnumerateItemsDeltaByDrive{
 			DrivePagers: map[string]*mock.DriveItemsDeltaPager{
-				idx(drive, 1): {
+				id(drive): {
 					Pages:       pages,
 					DeltaUpdate: pagers.DeltaUpdate{URL: id(delta)},
 				},

--- a/src/internal/m365/collection/drive/limiter_test.go
+++ b/src/internal/m365/collection/drive/limiter_test.go
@@ -606,7 +606,12 @@ func runGetPreviewLimits(
 	)
 
 	cols, canUsePreviousBackup, err := c.Get(ctx, nil, delList, errs)
-	require.NoError(t, err, clues.ToCore(err))
+
+	if opts.ToggleFeatures.UseDeltaTree {
+		require.ErrorIs(t, err, errGetTreeNotImplemented, clues.ToCore(err))
+	} else {
+		require.NoError(t, err, clues.ToCore(err))
+	}
 
 	assert.True(t, canUsePreviousBackup, "can use previous backup")
 	assert.Empty(t, errs.Skipped())
@@ -897,7 +902,12 @@ func runGetPreviewLimitsDefaults(
 	)
 
 	cols, canUsePreviousBackup, err := c.Get(ctx, nil, delList, errs)
-	require.NoError(t, err, clues.ToCore(err))
+
+	if opts.ToggleFeatures.UseDeltaTree {
+		require.ErrorIs(t, err, errGetTreeNotImplemented, clues.ToCore(err))
+	} else {
+		require.NoError(t, err, clues.ToCore(err))
+	}
 
 	assert.True(t, canUsePreviousBackup, "can use previous backup")
 	assert.Empty(t, errs.Skipped())


### PR DESCRIPTION
In the tree-based implementation of drive collections.Get, swaps out the driveEnumerationStats and instead uses the current state of the tree to count the items within and compare those counts to the expected preview limits.

Tests are known to still be failing.  Next PR will bring things back to green.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #4689

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
