### PR TITLE
Switch to new secret name for teams webhook

### DIFF
--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -440,4 +440,4 @@ jobs:
         uses: ./.github/actions/teams-message
         with:
           msg: "[FAILED] Sanity Tests"
-          teams_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          teams_url: ${{ secrets.TEAMS_WEBHOOK_URL }}


### PR DESCRIPTION
Fix notification delivery for sanity test failures

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [x] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
