### PR TITLE
Rework binary publish failure notification

### DIFF
--- a/.github/actions/publish-binary/action.yml
+++ b/.github/actions/publish-binary/action.yml
@@ -13,9 +13,6 @@ inputs:
   rudderstack_data_plane_url:
     description: Data plane URL for RudderStack
     required: true
-  slack_webhook_url:
-    description: Slack webhook url
-    required: true
 
 runs:
   using: composite
@@ -76,35 +73,3 @@ runs:
       with:
         name: corso_Windows_amd64
         path: src/dist/corso_windows_amd64_v1/corso.exe
-
-    - name: SHA info
-      shell: bash
-      id: sha-info
-      if: failure()
-      run: |
-        echo ${GITHUB_REF#refs/heads/}-${GITHUB_SHA}
-        echo SHA=${GITHUB_REF#refs/heads/}-${GITHUB_SHA} >> $GITHUB_OUTPUT
-        echo RUN_URL=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}  >> $GITHUB_OUTPUT
-        echo COMMIT_URL=${{ github.server_url }}/${{ github.repository }}/commit/${GITHUB_SHA} >> $GITHUB_OUTPUT
-
-    - name: Send Github Action failure to Slack
-      id: slack-notification
-      if: failure()
-      uses: slackapi/slack-github-action@v1.24.0
-      with:
-        payload: |
-          {
-            "text": "Publish failure - build: ${{ job.status }} - SHA: ${{  steps.sha-info.outputs.SHA }}",
-            "blocks": [
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "[FAILED] Publishing Binary :: <${{  steps.sha-info.outputs.RUN_URL }}|[Logs]> <${{ steps.sha-info.outputs.COMMIT_URL }}|[Base]>\nCommit: <${{  steps.sha-info.outputs.COMMIT_URL }}|${{  steps.sha-info.outputs.SHA }}>"
-                }
-              }
-            ]
-          }
-      env:
-        SLACK_WEBHOOK_URL: ${{ inputs.slack_webhook_url }}
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/binary-publish.yml
+++ b/.github/workflows/binary-publish.yml
@@ -35,4 +35,10 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           rudderstack_write_key: ${{ secrets.RUDDERSTACK_CORSO_WRITE_KEY }}
           rudderstack_data_plane_url: ${{ secrets.RUDDERSTACK_CORSO_DATA_PLANE_URL }}
-          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Notify failure in teams
+        if: failure()
+        uses: ./.github/actions/teams-message
+        with:
+          msg: "[FAILED] Publishing Binary"
+          teams_url: ${{ secrets.TEAMS_CORSO_CI_WEBHOOK_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,7 +556,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           rudderstack_write_key: ${{ secrets.RUDDERSTACK_CORSO_WRITE_KEY }}
           rudderstack_data_plane_url: ${{ secrets.RUDDERSTACK_CORSO_DATA_PLANE_URL }}
-          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   Publish-Image:
     needs: [Test-Suite-Trusted, Source-Code-Linting, Website-Linting, SetEnv]


### PR DESCRIPTION
Switch notification to be per workflow instead of per action. This means that CI jobs that want to check the result of the binary publish step will need to do so manually after the step runs.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [x] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

* closes #4758

#### Test Plan

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
