### PR TITLE
update previous paths after tree delta

### DIFF
--- a/src/internal/m365/collection/drive/delta_tree.go
+++ b/src/internal/m365/collection/drive/delta_tree.go
@@ -81,8 +81,8 @@ type nodeyMcNodeFace struct {
 	id string
 	// single directory name, not a path
 	name string
-	// only contains the folders starting at and including '/root:'
-	prev path.Elements
+	// contains the complete previous path
+	prev path.Path
 	// folderID -> node
 	children map[string]*nodeyMcNodeFace
 	// file item ID -> file metadata
@@ -272,24 +272,23 @@ func (face *folderyMcFolderFace) setTombstone(
 // deltas, and gets turned into a tombstone.
 func (face *folderyMcFolderFace) setPreviousPath(
 	folderID string,
-	prevDir path.Elements,
+	prev path.Path,
 ) error {
 	if len(folderID) == 0 {
 		return clues.New("missing folder id")
 	}
 
-	// the previous dir should contain the root folder reference, at least.
-	if len(prevDir) == 0 {
+	if prev == nil {
 		return clues.New("missing previous path")
 	}
 
 	if zombey, isDie := face.tombstones[folderID]; isDie {
-		zombey.prev = prevDir
+		zombey.prev = prev
 		return nil
 	}
 
 	if nodey, exists := face.folderIDToNode[folderID]; exists {
-		nodey.prev = prevDir
+		nodey.prev = prev
 		return nil
 	}
 
@@ -303,7 +302,7 @@ func (face *folderyMcFolderFace) setPreviousPath(
 	}
 
 	zombey := newNodeyMcNodeFace(nil, folderID, "", false)
-	zombey.prev = prevDir
+	zombey.prev = prev
 	face.tombstones[folderID] = zombey
 
 	return nil


### PR DESCRIPTION
following the delta enumeration in the tree process, feed the old previous paths back into the tree.  This should do one of four things:
1. update a tombstone
2. update a live node
3. (if not 1 or 2)  ignore the previous path
4. (if a reset occurred, and not 1 or 2) create a new tombstone.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #4689

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
