### PR TITLE
Remove duplicate recoverable err during item download

### DIFF
--- a/src/internal/m365/collection/drive/collection.go
+++ b/src/internal/m365/collection/drive/collection.go
@@ -335,14 +335,9 @@ func (oc *Collection) getDriveItemContent(
 			return nil, clues.Wrap(err, "inaccesible oneNote item").Label(graph.LabelsSkippable)
 		}
 
-		errs.AddRecoverable(
-			ctx,
-			clues.WrapWC(ctx, err, "downloading item content").
-				Label(fault.LabelForceNoBackupCreation))
-
 		// return err, not el.Err(), because the lazy reader needs to communicate to
 		// the data consumer that this item is unreadable, regardless of the fault state.
-		return nil, clues.Wrap(err, "fetching item content")
+		return nil, clues.Wrap(err, "downloading item content")
 	}
 
 	return itemData, nil


### PR DESCRIPTION
<!-- PR description-->

We are logging a recoverable error in 2 places for the same failure during lazy item download. See the [code](https://github.com/alcionai/corso/blob/6307d8cbf6ece36e4afc7e04bb2664f1f95ae865/src/internal/kopia/upload.go#L228) for the other location.  For e.g. below 2 recoverable errors are referring to the same graph 400 failure. 

`running backup: recoverable error 1 of 6: downloading item content: retrieving expired item: getting item: Invalid request: Invalid request`
`
running backup: recoverable error 2 of 6: kopia reported error: fetching item content: retrieving expired item: getting item: Invalid request: Invalid request`

Removing the duplicate since it can be confusing to the end user & devs.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [x] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
