### PR TITLE
add test.t and pfx to test tree generators

### DIFF
--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -292,11 +292,11 @@ func DeserializeMap[T any](reader io.ReadCloser, alreadyFound map[string]T) erro
 func (c *Collections) Get(
 	ctx context.Context,
 	prevMetadata []data.RestoreCollection,
-	ssmb *prefixmatcher.StringSetMatchBuilder,
+	globalExcludeItemIDs *prefixmatcher.StringSetMatchBuilder,
 	errs *fault.Bus,
 ) ([]data.BackupCollection, bool, error) {
 	if c.ctrl.ToggleFeatures.UseDeltaTree {
-		colls, canUsePrevBackup, err := c.getTree(ctx, prevMetadata, ssmb, errs)
+		colls, canUsePrevBackup, err := c.getTree(ctx, prevMetadata, globalExcludeItemIDs, errs)
 		if err != nil && !errors.Is(err, errGetTreeNotImplemented) {
 			return nil, false, clues.Wrap(err, "processing backup using tree")
 		}
@@ -457,7 +457,7 @@ func (c *Collections) Get(
 				return nil, false, clues.WrapWC(ictx, err, "making exclude prefix")
 			}
 
-			ssmb.Add(p.String(), excludedItemIDs)
+			globalExcludeItemIDs.Add(p.String(), excludedItemIDs)
 
 			continue
 		}

--- a/src/internal/m365/collection/drive/collections_tree_test.go
+++ b/src/internal/m365/collection/drive/collections_tree_test.go
@@ -562,16 +562,16 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 			tree:           fullTreeWithNames("parent", "tombstone"),
 			enableURLCache: true,
 			prevPaths: map[string]string{
-				rootID:                    fullPath(),
-				idx(folder, "pa/rent"):    fullPath(namex(folder, "parent-prev")),
-				id(folder):                fullPath(namex(folder, "parent-prev"), name(folder)),
-				idx(folder, "to/mbstone"): fullPath(namex(folder, "tombstone-prev")),
+				rootID:                   fullPath(),
+				idx(folder, "parent"):    fullPath(namex(folder, "parent-prev")),
+				id(folder):               fullPath(namex(folder, "parent-prev"), name(folder)),
+				idx(folder, "tombstone"): fullPath(namex(folder, "tombstone-prev")),
 			},
 			expect: expected{
 				prevPaths: map[string]string{
-					rootID:                 fullPath(),
-					idx(folder, "pa/rent"): fullPath(namex(folder, "parent")),
-					id(folder):             fullPath(namex(folder, "parent"), name(folder)),
+					rootID:                fullPath(),
+					idx(folder, "parent"): fullPath(namex(folder, "parent")),
+					id(folder):            fullPath(namex(folder, "parent"), name(folder)),
 				},
 				collections: func(t *testing.T) expectedCollections {
 					return expectCollections(
@@ -591,6 +591,11 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 							id(file)),
 						aColl(nil, fullPathPath(t, namex(folder, "tombstone-prev"))))
 				},
+				globalExcludedFileIDs: makeExcludeMap(
+					idx(file, "r"),
+					idx(file, "p"),
+					idx(file, "d"),
+					id(file)),
 			},
 		},
 		{

--- a/src/internal/m365/collection/drive/collections_tree_test.go
+++ b/src/internal/m365/collection/drive/collections_tree_test.go
@@ -386,10 +386,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 				prefixmatcher.NewStringSetBuilder(),
 				c.counter,
 				fault.New(true))
-
-			// TODO(keepers): implementation is incomplete
-			// an error check is the best we can get at the moment.
-			require.ErrorIs(t, err, errGetTreeNotImplemented, clues.ToCore(err))
+			require.NoError(t, err, clues.ToCore(err))
 
 			test.expectCounts.Compare(t, c.counter)
 		})

--- a/src/internal/m365/collection/drive/delta_tree.go
+++ b/src/internal/m365/collection/drive/delta_tree.go
@@ -2,12 +2,14 @@ package drive
 
 import (
 	"context"
-	"time"
 
 	"github.com/alcionai/clues"
 
+	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/internal/m365/collection/drive/metadata"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
 // folderyMcFolderFace owns our delta processing tree.
@@ -86,7 +88,7 @@ type nodeyMcNodeFace struct {
 	// folderID -> node
 	children map[string]*nodeyMcNodeFace
 	// file item ID -> file metadata
-	files map[string]fileyMcFileFace
+	files map[string]*custom.DriveItem
 	// for special handling protocols around packages
 	isPackage bool
 }
@@ -101,14 +103,9 @@ func newNodeyMcNodeFace(
 		id:        id,
 		name:      name,
 		children:  map[string]*nodeyMcNodeFace{},
-		files:     map[string]fileyMcFileFace{},
+		files:     map[string]*custom.DriveItem{},
 		isPackage: isPackage,
 	}
-}
-
-type fileyMcFileFace struct {
-	lastModified time.Time
-	contentSize  int64
 }
 
 // ---------------------------------------------------------------------------
@@ -317,8 +314,7 @@ func (face *folderyMcFolderFace) setPreviousPath(
 // this func will update and/or clean up all the old references.
 func (face *folderyMcFolderFace) addFile(
 	parentID, id string,
-	lastModified time.Time,
-	contentSize int64,
+	file *custom.DriveItem,
 ) error {
 	if len(parentID) == 0 {
 		return clues.New("item added without parent folder ID")
@@ -347,10 +343,7 @@ func (face *folderyMcFolderFace) addFile(
 	}
 
 	face.fileIDToParentID[id] = parentID
-	parent.files[id] = fileyMcFileFace{
-		lastModified: lastModified,
-		contentSize:  contentSize,
-	}
+	parent.files[id] = file
 
 	delete(face.deletedFileIDs, id)
 
@@ -372,6 +365,114 @@ func (face *folderyMcFolderFace) deleteFile(id string) {
 	delete(face.fileIDToParentID, id)
 
 	face.deletedFileIDs[id] = struct{}{}
+}
+
+// ---------------------------------------------------------------------------
+// post-processing
+// ---------------------------------------------------------------------------
+
+type collectable struct {
+	currPath                  path.Path
+	files                     map[string]*custom.DriveItem
+	folderID                  string
+	isPackageOrChildOfPackage bool
+	loc                       path.Elements
+	prevPath                  path.Path
+}
+
+// produces a map of folderID -> collectable
+func (face *folderyMcFolderFace) generateCollectables() (map[string]collectable, error) {
+	result := map[string]collectable{}
+	err := walkTreeAndBuildCollections(
+		face.root,
+		face.prefix,
+		&path.Builder{},
+		false,
+		result)
+
+	for id, tombstone := range face.tombstones {
+		// in case we got a folder deletion marker for a folder
+		// that has no previous path, drop the entry entirely.
+		// it doesn't exist in storage, so there's nothing to delete.
+		if tombstone.prev != nil {
+			result[id] = collectable{
+				folderID: id,
+				prevPath: tombstone.prev,
+			}
+		}
+	}
+
+	return result, clues.Stack(err).OrNil()
+}
+
+func walkTreeAndBuildCollections(
+	node *nodeyMcNodeFace,
+	pathPfx path.Path,
+	parentPath *path.Builder,
+	isChildOfPackage bool,
+	result map[string]collectable,
+) error {
+	if node == nil {
+		return nil
+	}
+
+	parentLocation := parentPath.Elements()
+	currentLocation := parentPath.Append(node.name)
+
+	for _, child := range node.children {
+		err := walkTreeAndBuildCollections(
+			child,
+			pathPfx,
+			currentLocation,
+			node.isPackage || isChildOfPackage,
+			result)
+		if err != nil {
+			return err
+		}
+	}
+
+	collectionPath, err := pathPfx.Append(false, currentLocation.Elements()...)
+	if err != nil {
+		return clues.Wrap(err, "building collection path").
+			With(
+				"path_prefix", pathPfx,
+				"path_suffix", currentLocation.Elements())
+	}
+
+	cbl := collectable{
+		currPath:                  collectionPath,
+		files:                     node.files,
+		folderID:                  node.id,
+		isPackageOrChildOfPackage: node.isPackage || isChildOfPackage,
+		loc:                       parentLocation,
+		prevPath:                  node.prev,
+	}
+
+	result[node.id] = cbl
+
+	return nil
+}
+
+func (face *folderyMcFolderFace) generateExcludeItemIDs() map[string]struct{} {
+	result := map[string]struct{}{}
+
+	for iID, pID := range face.fileIDToParentID {
+		if _, itsAlive := face.folderIDToNode[pID]; !itsAlive {
+			// don't worry about items whose parents are tombstoned.
+			// those will get handled in the delete cascade.
+			continue
+		}
+
+		result[iID+metadata.DataFileSuffix] = struct{}{}
+		result[iID+metadata.MetaFileSuffix] = struct{}{}
+	}
+
+	for iID := range face.deletedFileIDs {
+		result[iID+metadata.DataFileSuffix] = struct{}{}
+		result[iID+metadata.MetaFileSuffix] = struct{}{}
+	}
+
+	return result
 }
 
 // ---------------------------------------------------------------------------
@@ -414,7 +515,7 @@ func countFilesAndSizes(nodey *nodeyMcNodeFace) countAndSize {
 	}
 
 	for _, file := range nodey.files {
-		sumContentSize += file.contentSize
+		sumContentSize += ptr.Val(file.GetSize())
 	}
 
 	return countAndSize{

--- a/src/internal/m365/collection/drive/helper_test.go
+++ b/src/internal/m365/collection/drive/helper_test.go
@@ -444,6 +444,13 @@ func fullPath(elems ...string) string {
 		elems...)...)
 }
 
+func fullPathPath(t *testing.T, elems ...string) path.Path {
+	p, err := path.FromDataLayerPath(fullPath(elems...), false)
+	require.NoError(t, err, clues.ToCore(err))
+
+	return p
+}
+
 func driveFullPath(driveID any, elems ...string) string {
 	return toPath(append(
 		[]string{
@@ -778,10 +785,16 @@ func aReset(items ...models.DriveItemable) mock.NextPage {
 // delta trees
 // ---------------------------------------------------------------------------
 
-var loc = path.NewElements("root:/foo/bar/baz/qux/fnords/smarf/voi/zumba/bangles/howdyhowdyhowdy")
+func defaultLoc() path.Elements {
+	return path.NewElements("root:/foo/bar/baz/qux/fnords/smarf/voi/zumba/bangles/howdyhowdyhowdy")
+}
 
-func treeWithRoot() *folderyMcFolderFace {
-	tree := newFolderyMcFolderFace(nil, rootID)
+func newTree(t *testing.T) *folderyMcFolderFace {
+	return newFolderyMcFolderFace(fullPathPath(t), rootID)
+}
+
+func treeWithRoot(t *testing.T) *folderyMcFolderFace {
+	tree := newFolderyMcFolderFace(fullPathPath(t), rootID)
 	rootey := newNodeyMcNodeFace(nil, rootID, rootName, false)
 	tree.root = rootey
 	tree.folderIDToNode[rootID] = rootey
@@ -789,29 +802,29 @@ func treeWithRoot() *folderyMcFolderFace {
 	return tree
 }
 
-func treeAfterReset() *folderyMcFolderFace {
-	tree := newFolderyMcFolderFace(nil, rootID)
+func treeAfterReset(t *testing.T) *folderyMcFolderFace {
+	tree := newFolderyMcFolderFace(fullPathPath(t), rootID)
 	tree.reset()
 
 	return tree
 }
 
-func treeWithFoldersAfterReset() *folderyMcFolderFace {
-	tree := treeWithFolders()
+func treeWithFoldersAfterReset(t *testing.T) *folderyMcFolderFace {
+	tree := treeWithFolders(t)
 	tree.hadReset = true
 
 	return tree
 }
 
-func treeWithTombstone() *folderyMcFolderFace {
-	tree := treeWithRoot()
+func treeWithTombstone(t *testing.T) *folderyMcFolderFace {
+	tree := treeWithRoot(t)
 	tree.tombstones[id(folder)] = newNodeyMcNodeFace(nil, id(folder), "", false)
 
 	return tree
 }
 
-func treeWithFolders() *folderyMcFolderFace {
-	tree := treeWithRoot()
+func treeWithFolders(t *testing.T) *folderyMcFolderFace {
+	tree := treeWithRoot(t)
 
 	parent := newNodeyMcNodeFace(tree.root, idx(folder, "parent"), namex(folder, "parent"), true)
 	tree.folderIDToNode[parent.id] = parent
@@ -824,8 +837,8 @@ func treeWithFolders() *folderyMcFolderFace {
 	return tree
 }
 
-func treeWithFileAtRoot() *folderyMcFolderFace {
-	tree := treeWithRoot()
+func treeWithFileAtRoot(t *testing.T) *folderyMcFolderFace {
+	tree := treeWithRoot(t)
 	tree.root.files[id(file)] = fileyMcFileFace{
 		lastModified: time.Now(),
 		contentSize:  42,
@@ -835,8 +848,8 @@ func treeWithFileAtRoot() *folderyMcFolderFace {
 	return tree
 }
 
-func treeWithFileInFolder() *folderyMcFolderFace {
-	tree := treeWithFolders()
+func treeWithFileInFolder(t *testing.T) *folderyMcFolderFace {
+	tree := treeWithFolders(t)
 	tree.folderIDToNode[id(folder)].files[id(file)] = fileyMcFileFace{
 		lastModified: time.Now(),
 		contentSize:  42,
@@ -846,8 +859,8 @@ func treeWithFileInFolder() *folderyMcFolderFace {
 	return tree
 }
 
-func treeWithFileInTombstone() *folderyMcFolderFace {
-	tree := treeWithTombstone()
+func treeWithFileInTombstone(t *testing.T) *folderyMcFolderFace {
+	tree := treeWithTombstone(t)
 	tree.tombstones[id(folder)].files[id(file)] = fileyMcFileFace{
 		lastModified: time.Now(),
 		contentSize:  42,

--- a/src/internal/m365/collection/drive/url_cache.go
+++ b/src/internal/m365/collection/drive/url_cache.go
@@ -19,7 +19,10 @@ import (
 
 const (
 	urlCacheDriveItemThreshold = 300 * 1000
-	urlCacheRefreshInterval    = 1 * time.Hour
+	// 600 pages = 300k items, since delta enumeration produces 500 items per page
+	// TODO: export standard page size and swap to 300k/defaultDeltaPageSize
+	urlCacheDrivePagesThreshold = 600
+	urlCacheRefreshInterval     = 1 * time.Hour
 )
 
 type getItemPropertyer interface {

--- a/src/pkg/count/keys.go
+++ b/src/pkg/count/keys.go
@@ -92,6 +92,7 @@ const (
 	TotalDeltasProcessed        Key = "total-deltas-processed"
 	TotalFilesProcessed         Key = "total-files-processed"
 	TotalFoldersProcessed       Key = "total-folders-processed"
+	TotalItemsProcessed         Key = "total-items-processed"
 	TotalMalwareProcessed       Key = "total-malware-processed"
 	TotalPackagesProcessed      Key = "total-packages-processed"
 	TotalPagesEnumerated        Key = "total-pages-enumerated"


### PR DESCRIPTION
this is needed to standardize the presence of a path prefix in all test-helper trees, so that we can use standard test factory helpers for producing complete post-process data.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Supportability/Tests

#### Issue(s)

* #4689

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
