### PR TITLE
Fix panic in GroupByID call

### DIFF
--- a/src/pkg/services/m365/api/groups.go
+++ b/src/pkg/services/m365/api/groups.go
@@ -150,15 +150,15 @@ func (c Groups) GetByID(
 		}
 
 		resp, err := service.Client().Groups().Get(ctx, opts)
-		if err != nil {
-			if graph.IsErrResourceLocked(err) {
-				err = clues.Stack(graph.ErrResourceLocked, err)
-			}
-
-			logger.CtxErr(ctx, err).Info("finding group by email, falling back to display name")
+		if err == nil {
+			return getGroupFromResponse(ctx, resp)
 		}
 
-		return getGroupFromResponse(ctx, resp)
+		if graph.IsErrResourceLocked(err) {
+			err = clues.Stack(graph.ErrResourceLocked, err)
+		}
+
+		logger.CtxErr(ctx, err).Info("finding group by email, falling back to display name")
 	}
 
 	// fall back to display name


### PR DESCRIPTION
`resp` is nil if there's an error and `getGroupFromResponse` will panic.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
