### PR TITLE
generate collectables from tree

### DIFF
--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -292,11 +292,11 @@ func DeserializeMap[T any](reader io.ReadCloser, alreadyFound map[string]T) erro
 func (c *Collections) Get(
 	ctx context.Context,
 	prevMetadata []data.RestoreCollection,
-	ssmb *prefixmatcher.StringSetMatchBuilder,
+	globalExcludeItemIDs *prefixmatcher.StringSetMatchBuilder,
 	errs *fault.Bus,
 ) ([]data.BackupCollection, bool, error) {
 	if c.ctrl.ToggleFeatures.UseDeltaTree {
-		colls, canUsePrevBackup, err := c.getTree(ctx, prevMetadata, ssmb, errs)
+		colls, canUsePrevBackup, err := c.getTree(ctx, prevMetadata, globalExcludeItemIDs, errs)
 		if err != nil && !errors.Is(err, errGetTreeNotImplemented) {
 			return nil, false, clues.Wrap(err, "processing backup using tree")
 		}
@@ -457,7 +457,7 @@ func (c *Collections) Get(
 				return nil, false, clues.WrapWC(ictx, err, "making exclude prefix")
 			}
 
-			ssmb.Add(p.String(), excludedItemIDs)
+			globalExcludeItemIDs.Add(p.String(), excludedItemIDs)
 
 			continue
 		}

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -2,6 +2,7 @@ package drive
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -33,7 +34,7 @@ import (
 func (c *Collections) getTree(
 	ctx context.Context,
 	prevMetadata []data.RestoreCollection,
-	ssmb *prefixmatcher.StringSetMatchBuilder,
+	globalExcludeItemIDsByDrivePrefix *prefixmatcher.StringSetMatchBuilder,
 	errs *fault.Bus,
 ) ([]data.BackupCollection, bool, error) {
 	ctx = clues.AddTraceName(ctx, "GetTree")
@@ -114,6 +115,7 @@ func (c *Collections) getTree(
 			prevPathsByDriveID[driveID],
 			deltasByDriveID[driveID],
 			limiter,
+			globalExcludeItemIDsByDrivePrefix,
 			cl,
 			el)
 		if err != nil {
@@ -168,6 +170,7 @@ func (c *Collections) makeDriveCollections(
 	prevPaths map[string]string,
 	prevDeltaLink string,
 	limiter *pagerLimiter,
+	globalExcludeItemIDsByDrivePrefix *prefixmatcher.StringSetMatchBuilder,
 	counter *count.Bus,
 	errs *fault.Bus,
 ) ([]data.BackupCollection, map[string]string, pagers.DeltaUpdate, error) {
@@ -189,7 +192,7 @@ func (c *Collections) makeDriveCollections(
 
 	// --- delta item aggregation
 
-	du, err := c.populateTree(
+	du, countPagesInDelta, err := c.populateTree(
 		ctx,
 		tree,
 		drv,
@@ -214,39 +217,31 @@ func (c *Collections) makeDriveCollections(
 
 	// --- post-processing
 
-	// Attach an url cache to the drive if the number of discovered items is
-	// below the threshold. Attaching cache to larger drives can cause
-	// performance issues since cache delta queries start taking up majority of
-	// the hour the refreshed URLs are valid for.
-
-	// if numDriveItems < urlCacheDriveItemThreshold {
-	// 	logger.Ctx(ictx).Infow(
-	// 		"adding url cache for drive",
-	// 		"num_drive_items", numDriveItems)
-
-	// 	uc, err := newURLCache(
-	// 		driveID,
-	// 		prevDeltaLink,
-	// 		urlCacheRefreshInterval,
-	// 		c.handler,
-	// 		cl,
-	// 		errs)
-	// 	if err != nil {
-	// 		return nil, false, clues.Stack(err)
-	// 	}
-
-	// 	// Set the URL cache instance for all collections in this drive.
-	// 	for id := range c.CollectionMap[driveID] {
-	// 		c.CollectionMap[driveID][id].urlCache = uc
-	// 	}
-	// }
-
-	// this is a dumb hack to satisfy the linter.
-	if ctx == nil {
-		return nil, nil, du, nil
+	collections, newPrevs, excludedItemIDs, err := c.turnTreeIntoCollections(
+		ctx,
+		tree,
+		driveID,
+		prevDeltaLink,
+		countPagesInDelta,
+		errs)
+	if err != nil {
+		return nil, nil, pagers.DeltaUpdate{}, clues.Stack(err).Label(fault.LabelForceNoBackupCreation)
 	}
 
-	return nil, nil, du, errGetTreeNotImplemented
+	// only populate the global excluded items if no delta reset occurred.
+	// if a reset did occur, the collections should already be marked as
+	// "do not merge", therefore everything will get processed as a new addition.
+	if !tree.hadReset {
+		p, err := c.handler.CanonicalPath(odConsts.DriveFolderPrefixBuilder(driveID), c.tenantID)
+		if err != nil {
+			err = clues.WrapWC(ctx, err, "making canonical path for item exclusions")
+			return nil, nil, pagers.DeltaUpdate{}, err
+		}
+
+		globalExcludeItemIDsByDrivePrefix.Add(p.String(), excludedItemIDs)
+	}
+
+	return collections, newPrevs, du, nil
 }
 
 // populateTree constructs a new tree and populates it with items
@@ -259,8 +254,8 @@ func (c *Collections) populateTree(
 	limiter *pagerLimiter,
 	counter *count.Bus,
 	errs *fault.Bus,
-) (pagers.DeltaUpdate, error) {
-	ctx = clues.Add(ctx, "invalid_prev_delta", len(prevDeltaLink) == 0)
+) (pagers.DeltaUpdate, int, error) {
+	ctx = clues.Add(ctx, "has_prev_delta", len(prevDeltaLink) > 0)
 
 	var (
 		currDeltaLink = prevDeltaLink
@@ -270,23 +265,48 @@ func (c *Collections) populateTree(
 		finished      bool
 		hitLimit      bool
 		// TODO: plug this into the limiter
-		maxDeltas   = 100
-		countDeltas = 0
+		maximumTotalDeltasAllowed int64 = 100
+		// pageCounter is intended as a separate local instance
+		// compared to the counter we use for other item tracking.
+		// IE: don't pass it around into other funcs.
+		//
+		// This allows us to reset pageCounter on a reset without
+		// cross-contaminating other counts.
+		//
+		// We use this to track three keys: 1. the total number of
+		// deltas enumerated (so that we don't hit an infinite
+		// loop); 2. the number of pages in each delta (for the
+		// limiter, but also for the URL cache so that it knows
+		// if we have too many pages for it to efficiently operate);
+		// and 3. the number of items in each delta (to know if we're
+		// done enumerating delta queries).
+		pageCounter = counter.Local()
+	)
+
+	const (
+		// track the exact number of pages across all deltas (correct across resets)
+		// so that the url cache knows if it can operate within performance bounds.
+		truePageCount count.Key = "pages-with-items-across-all-deltas"
 	)
 
 	// enumerate through multiple deltas until we either:
 	// 1. hit a consistent state (ie: no changes since last delta enum)
-	// 2. hit the limit
+	// 2. hit the limit based on the limiter
+	// 3. run 100 total delta enumerations without hitting 1. (no infinite loops)
 	for !hitLimit && !finished && el.Failure() == nil {
 		counter.Inc(count.TotalDeltasProcessed)
 
 		var (
-			pageCount     int
-			pageItemCount int
-			err           error
+			// this is used to track stats the total number of items
+			// processed in each delta.  Since delta queries don't give
+			// us a plain flag for "no changes occurred", we check for
+			// 0 items in the delta as the "no changes occurred" state.
+			// The final page of any delta query may also return 0 items,
+			// so we need to combine both the item count and the deltaPageCount
+			// to get a correct flag.
+			iPageCounter = pageCounter.Local()
+			err          error
 		)
-
-		countDeltas++
 
 		pager := c.handler.EnumerateDriveItemsDelta(
 			ctx,
@@ -298,19 +318,22 @@ func (c *Collections) populateTree(
 
 		for page, reset, done := pager.NextPage(); !done; page, reset, done = pager.NextPage() {
 			if el.Failure() != nil {
-				return du, el.Failure()
+				return du, 0, el.Failure()
 			}
+
+			// track the exact number of pages within a single delta (correct across resets)
+			// so that we can check for "no changes occurred" results.
+			// Note: don't inc `count.TotalPagesEnumerated` outside of this (ie, for the
+			// truePageCount), or else we'll double up on the inc.
+			iPageCounter.Inc(count.TotalPagesEnumerated)
 
 			if reset {
 				counter.Inc(count.PagerResets)
 				tree.reset()
 				c.resetStats()
 
-				pageCount = 0
-				pageItemCount = 0
-				countDeltas = 0
-			} else {
-				counter.Inc(count.TotalPagesEnumerated)
+				pageCounter = counter.Local()
+				iPageCounter = pageCounter.Local()
 			}
 
 			err = c.enumeratePageOfItems(
@@ -330,14 +353,17 @@ func (c *Collections) populateTree(
 				el.AddRecoverable(ctx, clues.Stack(err))
 			}
 
-			pageCount++
+			itemCount := int64(len(page))
+			iPageCounter.Add(count.TotalItemsProcessed, itemCount)
 
-			pageItemCount += len(page)
+			if itemCount > 0 {
+				pageCounter.Inc(truePageCount)
+			}
 
-			// Stop enumeration early if we've reached the page limit. Keep this
+			// Stop enumeration early if we've reached the total page limit. Keep this
 			// at the end of the loop so we don't request another page (pager.NextPage)
 			// before seeing we've passed the limit.
-			if limiter.hitPageLimit(pageCount) {
+			if limiter.hitPageLimit(int(pageCounter.Get(truePageCount))) {
 				hitLimit = true
 				break
 			}
@@ -350,23 +376,32 @@ func (c *Collections) populateTree(
 
 		du, err = pager.Results()
 		if err != nil {
-			return du, clues.Stack(err)
+			return du, 0, clues.Stack(err)
 		}
 
 		currDeltaLink = du.URL
 
 		// 0 pages is never expected.  We should at least have one (empty) page to
 		// consume.  But checking pageCount == 1 is brittle in a non-helpful way.
-		finished = pageCount < 2 && pageItemCount == 0
+		finished = iPageCounter.Get(count.TotalPagesEnumerated) < 2 &&
+			iPageCounter.Get(count.TotalItemsProcessed) == 0
 
-		if countDeltas >= maxDeltas {
-			return pagers.DeltaUpdate{}, clues.New("unable to produce consistent delta after 100 queries")
+		// ensure we don't enumerate more than the maximum allotted count of deltas.
+		if counter.Get(count.TotalDeltasProcessed) >= maximumTotalDeltasAllowed {
+			err := clues.NewWC(
+				ctx,
+				fmt.Sprintf("unable to produce consistent delta after %d queries", maximumTotalDeltasAllowed))
+
+			return pagers.DeltaUpdate{}, 0, err
 		}
 	}
 
-	logger.Ctx(ctx).Infow("enumerated collection delta", "stats", counter.Values())
+	logger.Ctx(ctx).Infow(
+		"enumerated collection delta",
+		"stats", counter.Values(),
+		"delta_stats", pageCounter.Values())
 
-	return du, el.Failure()
+	return du, int(pageCounter.Get(truePageCount)), el.Failure()
 }
 
 func (c *Collections) enumeratePageOfItems(
@@ -381,12 +416,13 @@ func (c *Collections) enumeratePageOfItems(
 	ctx = clues.Add(ctx, "page_lenth", len(page))
 	el := errs.Local()
 
-	for i, item := range page {
+	for i, driveItem := range page {
 		if el.Failure() != nil {
 			break
 		}
 
 		var (
+			item     = custom.ToCustomDriveItem(driveItem)
 			isFolder = item.GetFolder() != nil || item.GetPackageEscaped() != nil
 			isFile   = item.GetFile() != nil
 			itemID   = ptr.Val(item.GetId())
@@ -432,7 +468,7 @@ func (c *Collections) addFolderToTree(
 	ctx context.Context,
 	tree *folderyMcFolderFace,
 	drv models.Driveable,
-	folder models.DriveItemable,
+	folder *custom.DriveItem,
 	limiter *pagerLimiter,
 	counter *count.Bus,
 ) (*fault.Skipped, error) {
@@ -481,7 +517,7 @@ func (c *Collections) addFolderToTree(
 			driveID,
 			folderID,
 			folderName,
-			graph.ItemInfo(custom.ToCustomDriveItem(folder)))
+			graph.ItemInfo(folder))
 
 		logger.Ctx(ctx).Infow("malware folder detected")
 
@@ -513,7 +549,7 @@ func (c *Collections) addFolderToTree(
 func (c *Collections) makeFolderCollectionPath(
 	ctx context.Context,
 	driveID string,
-	folder models.DriveItemable,
+	folder *custom.DriveItem,
 ) (path.Path, error) {
 	if folder.GetRoot() != nil {
 		pb := odConsts.DriveFolderPrefixBuilder(driveID)
@@ -545,20 +581,19 @@ func (c *Collections) addFileToTree(
 	ctx context.Context,
 	tree *folderyMcFolderFace,
 	drv models.Driveable,
-	file models.DriveItemable,
+	file *custom.DriveItem,
 	limiter *pagerLimiter,
 	counter *count.Bus,
 ) (*fault.Skipped, error) {
 	var (
-		driveID      = ptr.Val(drv.GetId())
-		fileID       = ptr.Val(file.GetId())
-		fileName     = ptr.Val(file.GetName())
-		fileSize     = ptr.Val(file.GetSize())
-		lastModified = ptr.Val(file.GetLastModifiedDateTime())
-		isDeleted    = file.GetDeleted() != nil
-		isMalware    = file.GetMalware() != nil
-		parent       = file.GetParentReference()
-		parentID     string
+		driveID   = ptr.Val(drv.GetId())
+		fileID    = ptr.Val(file.GetId())
+		fileName  = ptr.Val(file.GetName())
+		fileSize  = ptr.Val(file.GetSize())
+		isDeleted = file.GetDeleted() != nil
+		isMalware = file.GetMalware() != nil
+		parent    = file.GetParentReference()
+		parentID  string
 	)
 
 	if parent != nil {
@@ -582,7 +617,7 @@ func (c *Collections) addFileToTree(
 			driveID,
 			fileID,
 			fileName,
-			graph.ItemInfo(custom.ToCustomDriveItem(file)))
+			graph.ItemInfo(file))
 
 		logger.Ctx(ctx).Infow("malware file detected")
 
@@ -615,7 +650,7 @@ func (c *Collections) addFileToTree(
 		}
 	}
 
-	err := tree.addFile(parentID, fileID, lastModified, fileSize)
+	err := tree.addFile(parentID, fileID, file)
 	if err != nil {
 		return nil, clues.StackWC(ctx, err)
 	}
@@ -750,4 +785,88 @@ func addPrevPathsToTree(
 	}
 
 	return el.Failure()
+}
+
+func (c *Collections) turnTreeIntoCollections(
+	ctx context.Context,
+	tree *folderyMcFolderFace,
+	driveID string,
+	prevDeltaLink string,
+	countPagesInDelta int,
+	errs *fault.Bus,
+) (
+	[]data.BackupCollection,
+	map[string]string,
+	map[string]struct{},
+	error,
+) {
+	collectables, err := tree.generateCollectables()
+	if err != nil {
+		err = clues.WrapWC(ctx, err, "generating backup collection data")
+		return nil, nil, nil, err
+	}
+
+	var (
+		collections  = []data.BackupCollection{}
+		newPrevPaths = map[string]string{}
+		uc           *urlCache
+		el           = errs.Local()
+	)
+
+	// Attach an url cache to the drive if the number of discovered items is
+	// below the threshold. Attaching cache to larger drives can cause
+	// performance issues since cache delta queries start taking up majority of
+	// the hour the refreshed URLs are valid for.
+	if countPagesInDelta < urlCacheDriveItemThreshold {
+		logger.Ctx(ctx).Info("adding url cache for drive collections")
+
+		uc, err = newURLCache(
+			driveID,
+			// we need the original prevDeltaLink here; a cache update will need
+			// to process all changes since the start of the backup.  On the bright
+			// side, instead of running multiple delta enumerations, all changes
+			// in the backup should get compressed into the single delta query, which
+			// ensures the two states are sufficiently consistent with just the
+			// original delta token.
+			prevDeltaLink,
+			urlCacheRefreshInterval,
+			c.handler,
+			c.counter.Local(),
+			errs)
+		if err != nil {
+			return nil, nil, nil, clues.StackWC(ctx, err)
+		}
+	}
+
+	for id, cbl := range collectables {
+		if el.Failure() != nil {
+			break
+		}
+
+		if cbl.currPath != nil {
+			newPrevPaths[id] = cbl.currPath.String()
+		}
+
+		coll, err := NewCollection(
+			c.handler,
+			c.protectedResource,
+			cbl.currPath,
+			cbl.prevPath,
+			driveID,
+			c.statusUpdater,
+			c.ctrl,
+			cbl.isPackageOrChildOfPackage,
+			tree.hadReset,
+			uc,
+			c.counter.Local())
+		if err != nil {
+			return nil, nil, nil, clues.StackWC(ctx, err)
+		}
+
+		coll.driveItems = cbl.files
+
+		collections = append(collections, coll)
+	}
+
+	return collections, newPrevPaths, tree.generateExcludeItemIDs(), el.Failure()
 }

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -214,7 +214,7 @@ func (c *Collections) makeDriveCollections(
 		if err != nil {
 			errs.AddRecoverable(ctx, clues.WrapWC(ctx, err, "invalid previous path").
 				With("folderID", folderID, "prev_path", p).
-				Label(fault.LabelForceNoBackupCreation))
+				Label(fault.LabelForceNoBackupCreation, count.BadPrevPath))
 
 			continue
 		}

--- a/src/internal/m365/collection/drive/collections_tree_test.go
+++ b/src/internal/m365/collection/drive/collections_tree_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/fault"
 	apiMock "github.com/alcionai/corso/src/pkg/services/m365/api/mock"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/pagers"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
 type CollectionsTreeUnitSuite struct {
@@ -151,7 +152,6 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_GetTree() {
 
 	type expected struct {
 		canUsePrevBackup assert.BoolAssertionFunc
-		collAssertions   collectionAssertions
 		counts           countTD.Expected
 		deltas           map[string]string
 		prevPaths        map[string]map[string]string
@@ -176,12 +176,6 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_GetTree() {
 						aPage()))),
 			expect: expected{
 				canUsePrevBackup: assert.False,
-				collAssertions: collectionAssertions{
-					driveFullPath(1): newCollAssertion(
-						doNotMergeItems,
-						statesToItemIDs{data.NotMovedState: {}},
-						id(file)),
-				},
 				counts: countTD.Expected{
 					count.PrevPaths: 0,
 				},
@@ -281,10 +275,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 			enumerator: mock.DriveEnumerator(
 				mock.Drive(id(drive)).With(
 					mock.Delta(id(delta), nil).With(
-						aPage(),
-					))),
+						aPage()))),
 			prevPaths: map[string]string{
-				id(folder): fullPath(id(folder)),
+				id(folder): fullPath(name(folder)),
 			},
 			expectErr: require.NoError,
 			expectCounts: countTD.Expected{
@@ -297,8 +290,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 			enumerator: mock.DriveEnumerator(
 				mock.Drive(id(drive)).With(
 					mock.Delta(id(delta), nil).With(
-						aPage(folderAtRoot(), fileAt(folder)),
-					))),
+						aPage(folderAtRoot(), fileAt(folder))))),
 			prevPaths: map[string]string{},
 			expectErr: require.NoError,
 			expectCounts: countTD.Expected{
@@ -311,10 +303,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 			enumerator: mock.DriveEnumerator(
 				mock.Drive(id(drive)).With(
 					mock.Delta(id(delta), nil).With(
-						aPage(folderAtRoot(), fileAt(folder)),
-					))),
+						aPage(folderAtRoot(), fileAt(folder))))),
 			prevPaths: map[string]string{
-				id(folder): fullPath(id(folder)),
+				id(folder): fullPath(name(folder)),
 			},
 			expectErr: require.NoError,
 			expectCounts: countTD.Expected{
@@ -328,8 +319,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 				mock.Drive(id(drive)).With(
 					mock.DeltaWReset(id(delta), nil).With(
 						aReset(),
-						aPage(),
-					))),
+						aPage()))),
 			prevPaths: map[string]string{},
 			expectErr: require.NoError,
 			expectCounts: countTD.Expected{
@@ -343,10 +333,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 				mock.Drive(id(drive)).With(
 					mock.DeltaWReset(id(delta), nil).With(
 						aReset(),
-						aPage(),
-					))),
+						aPage()))),
 			prevPaths: map[string]string{
-				id(folder): fullPath(id(folder)),
+				id(folder): fullPath(name(folder)),
 			},
 			expectErr: require.NoError,
 			expectCounts: countTD.Expected{
@@ -360,8 +349,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 				mock.Drive(id(drive)).With(
 					mock.DeltaWReset(id(delta), nil).With(
 						aReset(),
-						aPage(folderAtRoot(), fileAt(folder)),
-					))),
+						aPage(folderAtRoot(), fileAt(folder))))),
 			prevPaths: map[string]string{},
 			expectErr: require.NoError,
 			expectCounts: countTD.Expected{
@@ -375,10 +363,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 				mock.Drive(id(drive)).With(
 					mock.DeltaWReset(id(delta), nil).With(
 						aReset(),
-						aPage(folderAtRoot(), fileAt(folder)),
-					))),
+						aPage(folderAtRoot(), fileAt(folder))))),
 			prevPaths: map[string]string{
-				id(folder): fullPath(id(folder)),
+				id(folder): fullPath(name(folder)),
 			},
 			expectErr: require.NoError,
 			expectCounts: countTD.Expected{
@@ -405,6 +392,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 				test.prevPaths,
 				idx(delta, "prev"),
 				newPagerLimiter(control.DefaultOptions()),
+				prefixmatcher.NewStringSetBuilder(),
 				c.counter,
 				fault.New(true))
 
@@ -413,6 +401,286 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 			test.expectErr(t, err, clues.ToCore(err))
 
 			test.expectCounts.Compare(t, c.counter)
+		})
+	}
+}
+
+func (suite *CollectionsTreeUnitSuite) TestCollections_AddPrevPathsToTree_errors() {
+	table := []struct {
+		name      string
+		tree      func(t *testing.T) *folderyMcFolderFace
+		prevPaths map[string]string
+		expectErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "no error - normal usage",
+			tree: treeWithFolders,
+			prevPaths: map[string]string{
+				idx(folder, "parent"): fullPath(namex(folder, "parent")),
+				id(folder):            fullPath(namex(folder, "parent"), name(folder)),
+			},
+			expectErr: require.NoError,
+		},
+		{
+			name:      "no error - prev paths are empty",
+			tree:      treeWithFolders,
+			prevPaths: map[string]string{},
+			expectErr: require.NoError,
+		},
+		{
+			name: "no error - folder not visited in this delta",
+			tree: treeWithFolders,
+			prevPaths: map[string]string{
+				id("santa"): fullPath(name("santa")),
+			},
+			expectErr: require.NoError,
+		},
+		{
+			name: "empty key in previous paths",
+			tree: treeWithFolders,
+			prevPaths: map[string]string{
+				"": fullPath(namex(folder, "parent")),
+			},
+			expectErr: require.Error,
+		},
+		{
+			name: "empty value in previous paths",
+			tree: treeWithFolders,
+			prevPaths: map[string]string{
+				id(folder): "",
+			},
+			expectErr: require.Error,
+		},
+		{
+			name: "malformed value in previous paths",
+			tree: treeWithFolders,
+			prevPaths: map[string]string{
+				id(folder): "not a path",
+			},
+			expectErr: require.Error,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			tree := test.tree(t)
+
+			err := addPrevPathsToTree(
+				ctx,
+				tree,
+				test.prevPaths,
+				fault.New(true))
+			test.expectErr(t, err, clues.ToCore(err))
+		})
+	}
+}
+
+func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections() {
+	type expected struct {
+		prevPaths             map[string]string
+		collections           func(t *testing.T) expectedCollections
+		globalExcludedFileIDs map[string]struct{}
+	}
+
+	table := []struct {
+		name           string
+		tree           func(t *testing.T) *folderyMcFolderFace
+		prevPaths      map[string]string
+		enableURLCache bool
+		expect         expected
+	}{
+		{
+			name:           "all new collections",
+			tree:           fullTree,
+			prevPaths:      map[string]string{},
+			enableURLCache: true,
+			expect: expected{
+				prevPaths: map[string]string{
+					rootID:                fullPath(),
+					idx(folder, "parent"): fullPath(namex(folder, "parent")),
+					id(folder):            fullPath(namex(folder, "parent"), name(folder)),
+				},
+				collections: func(t *testing.T) expectedCollections {
+					return expectCollections(
+						false,
+						true,
+						aColl(
+							fullPathPath(t),
+							nil,
+							idx(file, "r")),
+						aColl(
+							fullPathPath(t, namex(folder, "parent")),
+							nil,
+							idx(file, "p")),
+						aColl(
+							fullPathPath(t, namex(folder, "parent"), name(folder)),
+							nil,
+							id(file)))
+				},
+				globalExcludedFileIDs: makeExcludeMap(
+					idx(file, "r"),
+					idx(file, "p"),
+					idx(file, "d"),
+					id(file)),
+			},
+		},
+		{
+			name:           "all folders moved",
+			tree:           fullTree,
+			enableURLCache: true,
+			prevPaths: map[string]string{
+				rootID:                   fullPath(),
+				idx(folder, "parent"):    fullPath(namex(folder, "parent-prev")),
+				id(folder):               fullPath(namex(folder, "parent-prev"), name(folder)),
+				idx(folder, "tombstone"): fullPath(namex(folder, "tombstone-prev")),
+			},
+			expect: expected{
+				prevPaths: map[string]string{
+					rootID:                fullPath(),
+					idx(folder, "parent"): fullPath(namex(folder, "parent")),
+					id(folder):            fullPath(namex(folder, "parent"), name(folder)),
+				},
+				collections: func(t *testing.T) expectedCollections {
+					return expectCollections(
+						false,
+						true,
+						aColl(
+							fullPathPath(t),
+							fullPathPath(t),
+							idx(file, "r")),
+						aColl(
+							fullPathPath(t, namex(folder, "parent")),
+							fullPathPath(t, namex(folder, "parent-prev")),
+							idx(file, "p")),
+						aColl(
+							fullPathPath(t, namex(folder, "parent"), name(folder)),
+							fullPathPath(t, namex(folder, "parent-prev"), name(folder)),
+							id(file)),
+						aColl(nil, fullPathPath(t, namex(folder, "tombstone-prev"))))
+				},
+				globalExcludedFileIDs: makeExcludeMap(
+					idx(file, "r"),
+					idx(file, "p"),
+					idx(file, "d"),
+					id(file)),
+			},
+		},
+		{
+			name:           "all folders moved - todo: path separator string check",
+			tree:           fullTreeWithNames("parent", "tombstone"),
+			enableURLCache: true,
+			prevPaths: map[string]string{
+				rootID:                    fullPath(),
+				idx(folder, "pa/rent"):    fullPath(namex(folder, "parent-prev")),
+				id(folder):                fullPath(namex(folder, "parent-prev"), name(folder)),
+				idx(folder, "to/mbstone"): fullPath(namex(folder, "tombstone-prev")),
+			},
+			expect: expected{
+				prevPaths: map[string]string{
+					rootID:                 fullPath(),
+					idx(folder, "pa/rent"): fullPath(namex(folder, "parent")),
+					id(folder):             fullPath(namex(folder, "parent"), name(folder)),
+				},
+				collections: func(t *testing.T) expectedCollections {
+					return expectCollections(
+						false,
+						true,
+						aColl(
+							fullPathPath(t),
+							fullPathPath(t),
+							idx(file, "r")),
+						aColl(
+							fullPathPath(t, namex(folder, "parent")),
+							fullPathPath(t, namex(folder, "parent-prev")),
+							idx(file, "p")),
+						aColl(
+							fullPathPath(t, namex(folder, "parent"), name(folder)),
+							fullPathPath(t, namex(folder, "parent-prev"), name(folder)),
+							id(file)),
+						aColl(nil, fullPathPath(t, namex(folder, "tombstone-prev"))))
+				},
+			},
+		},
+		{
+			name:           "no folders moved",
+			tree:           fullTree,
+			enableURLCache: true,
+			prevPaths: map[string]string{
+				rootID:                   fullPath(),
+				idx(folder, "parent"):    fullPath(namex(folder, "parent")),
+				id(folder):               fullPath(namex(folder, "parent"), name(folder)),
+				idx(folder, "tombstone"): fullPath(namex(folder, "tombstone")),
+			},
+			expect: expected{
+				prevPaths: map[string]string{
+					rootID:                fullPath(),
+					idx(folder, "parent"): fullPath(namex(folder, "parent")),
+					id(folder):            fullPath(namex(folder, "parent"), name(folder)),
+				},
+				collections: func(t *testing.T) expectedCollections {
+					return expectCollections(
+						false,
+						true,
+						aColl(
+							fullPathPath(t),
+							fullPathPath(t),
+							idx(file, "r")),
+						aColl(
+							fullPathPath(t, namex(folder, "parent")),
+							fullPathPath(t, namex(folder, "parent")),
+							idx(file, "p")),
+						aColl(
+							fullPathPath(t, namex(folder, "parent"), name(folder)),
+							fullPathPath(t, namex(folder, "parent"), name(folder)),
+							id(file)),
+						aColl(nil, fullPathPath(t, namex(folder, "tombstone"))))
+				},
+				globalExcludedFileIDs: makeExcludeMap(
+					idx(file, "r"),
+					idx(file, "p"),
+					idx(file, "d"),
+					id(file)),
+			},
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			tree := test.tree(t)
+
+			err := addPrevPathsToTree(ctx, tree, test.prevPaths, fault.New(true))
+			require.NoError(t, err, clues.ToCore(err))
+
+			c := collWithMBH(mock.DefaultOneDriveBH(user))
+
+			countPages := 9001
+			if test.enableURLCache {
+				countPages = 1
+			}
+
+			colls, newPrevPaths, excluded, err := c.turnTreeIntoCollections(
+				ctx,
+				tree,
+				id(drive),
+				delta,
+				countPages,
+				fault.New(true))
+			require.NoError(t, err, clues.ToCore(err))
+			assert.Equal(t, test.expect.prevPaths, newPrevPaths, "new previous paths")
+
+			expectColls := test.expect.collections(t)
+			expectColls.compare(t, colls)
+			expectColls.requireNoUnseenCollections(t)
+
+			assert.Equal(t, test.expect.globalExcludedFileIDs, excluded)
 		})
 	}
 }
@@ -599,7 +867,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 		},
 		{
 			name: "many folders with files across multiple deltas",
-			tree: newFolderyMcFolderFace(nil, rootID),
+			tree: newTree,
 			enumerator: mock.DriveEnumerator(
 				mock.Drive(id(drive)).With(
 					mock.Delta(id(delta), nil).With(aPage(
@@ -989,7 +1257,7 @@ func runPopulateTreeTest(
 		tree    = test.tree(t)
 	)
 
-	_, err := c.populateTree(
+	_, _, err := c.populateTree(
 		ctx,
 		tree,
 		drv,
@@ -1267,11 +1535,14 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 	drv.SetId(ptr.To(id(drive)))
 	drv.SetName(ptr.To(name(drive)))
 
-	fld := folderAtRoot()
-	subFld := folderAtDeep(driveParentDir(drv, namex(folder, "parent")), idx(folder, "parent"))
-	pack := driveItem(id(pkg), name(pkg), parentDir(), rootID, isPackage)
-	del := delItem(id(folder), rootID, isFolder)
-	mal := malwareItem(idx(folder, "mal"), namex(folder, "mal"), parentDir(), rootID, isFolder)
+	var (
+		fld    = custom.ToCustomDriveItem(folderAtRoot())
+		subFld = custom.ToCustomDriveItem(folderAtDeep(driveParentDir(drv, namex(folder, "parent")), idx(folder, "parent")))
+		pack   = custom.ToCustomDriveItem(driveItem(id(pkg), name(pkg), parentDir(), rootID, isPackage))
+		del    = custom.ToCustomDriveItem(delItem(id(folder), rootID, isFolder))
+		mal    = custom.ToCustomDriveItem(
+			malwareItem(idx(folder, "mal"), namex(folder, "mal"), parentDir(), rootID, isFolder))
+	)
 
 	type expected struct {
 		countLiveFolders   int
@@ -1286,7 +1557,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 	table := []struct {
 		name    string
 		tree    func(t *testing.T) *folderyMcFolderFace
-		folder  models.DriveItemable
+		folder  *custom.DriveItem
 		limiter *pagerLimiter
 		expect  expected
 	}{
@@ -1368,7 +1639,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 		},
 		{
 			name:    "tombstone new folder in unpopulated tree",
-			tree:    newFolderyMcFolderFace(nil, rootID),
+			tree:    newTree,
 			folder:  del,
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
@@ -1424,7 +1695,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 		},
 		{
 			name:    "already over container limit, folder seen twice",
-			tree:    treeWithFolders(),
+			tree:    treeWithFolders,
 			folder:  fld,
 			limiter: newPagerLimiter(minimumLimitOpts()),
 			expect: expected{
@@ -1444,7 +1715,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 		},
 		{
 			name:    "already at container limit",
-			tree:    treeWithRoot(),
+			tree:    treeWithRoot,
 			folder:  fld,
 			limiter: newPagerLimiter(minimumLimitOpts()),
 			expect: expected{
@@ -1564,7 +1835,10 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeFolderCollectionPath(
 
 			c := collWithMBH(mock.DefaultOneDriveBH(user))
 
-			p, err := c.makeFolderCollectionPath(ctx, id(drive), test.folder)
+			p, err := c.makeFolderCollectionPath(
+				ctx,
+				id(drive),
+				custom.ToCustomDriveItem(test.folder))
 			test.expectErr(t, err, clues.ToCore(err))
 
 			if err == nil {
@@ -1639,7 +1913,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 		},
 		{
 			name: "many files in a hierarchy",
-			tree: treeWithRoot(),
+			tree: treeWithRoot,
 			page: aPage(
 				fileAtRoot(),
 				folderAtRoot(),
@@ -1815,7 +2089,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 				fault.New(true))
 			test.expect.err(t, err, clues.ToCore(err))
 
-			countSize := test.tree.countLiveFilesAndSizes()
+			countSize := tree.countLiveFilesAndSizes()
 			assert.Equal(t, test.expect.countLiveFiles, countSize.numFiles, "count of files")
 			assert.Equal(t, test.expect.countTotalBytes, countSize.totalBytes, "total size in bytes")
 			assert.Equal(t, test.expect.treeContainsFileIDsWithParent, tree.fileIDToParentID)
@@ -2000,7 +2274,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 				ctx,
 				tree,
 				drv,
-				test.file,
+				custom.ToCustomDriveItem(test.file),
 				test.limiter,
 				counter)
 

--- a/src/internal/m365/collection/drive/delta_tree.go
+++ b/src/internal/m365/collection/drive/delta_tree.go
@@ -379,11 +379,12 @@ func (face *folderyMcFolderFace) deleteFile(id string) {
 // ---------------------------------------------------------------------------
 
 type collectable struct {
-	currPath path.Path
-	files    map[string]fileyMcFileFace
-	folderID string
-	loc      path.Elements
-	prevPath path.Path
+	currPath                  path.Path
+	files                     map[string]fileyMcFileFace
+	folderID                  string
+	isPackageOrChildOfPackage bool
+	loc                       path.Elements
+	prevPath                  path.Path
 }
 
 // produces a map of folderID -> collectable
@@ -393,6 +394,7 @@ func (face *folderyMcFolderFace) generateCollectables() (map[string]collectable,
 		face.root,
 		face.prefix,
 		&path.Builder{},
+		false,
 		result)
 
 	for id, tombstone := range face.tombstones {
@@ -409,6 +411,7 @@ func walkTreeAndBuildCollections(
 	node *nodeyMcNodeFace,
 	pathPfx path.Path,
 	parentPath *path.Builder,
+	isChildOfPackage bool,
 	result map[string]collectable,
 ) error {
 	if node == nil {
@@ -423,6 +426,7 @@ func walkTreeAndBuildCollections(
 			child,
 			pathPfx,
 			parentPath,
+			node.isPackage || isChildOfPackage,
 			result)
 		if err != nil {
 			return err
@@ -436,11 +440,12 @@ func walkTreeAndBuildCollections(
 	}
 
 	cbl := collectable{
-		currPath: currPath,
-		files:    node.files,
-		folderID: node.id,
-		loc:      loc,
-		prevPath: node.prev,
+		currPath:                  currPath,
+		files:                     node.files,
+		folderID:                  node.id,
+		isPackageOrChildOfPackage: node.isPackage || isChildOfPackage,
+		loc:                       loc,
+		prevPath:                  node.prev,
 	}
 
 	result[node.id] = cbl

--- a/src/internal/m365/collection/drive/delta_tree.go
+++ b/src/internal/m365/collection/drive/delta_tree.go
@@ -418,14 +418,14 @@ func walkTreeAndBuildCollections(
 		return nil
 	}
 
-	loc := parentPath.Elements()
-	parentPath = parentPath.Append(node.name)
+	parentLocation := parentPath.Elements()
+	currentLocation := parentPath.Append(node.name)
 
 	for _, child := range node.children {
 		err := walkTreeAndBuildCollections(
 			child,
 			pathPfx,
-			parentPath,
+			currentLocation,
 			node.isPackage || isChildOfPackage,
 			result)
 		if err != nil {
@@ -433,18 +433,20 @@ func walkTreeAndBuildCollections(
 		}
 	}
 
-	currPath, err := pathPfx.Append(false, parentPath.Elements()...)
+	collectionPath, err := pathPfx.Append(false, currentLocation.Elements()...)
 	if err != nil {
 		return clues.Wrap(err, "building collection path").
-			With("path_prefix", pathPfx, "path_suffix", parentPath.Elements())
+			With(
+				"path_prefix", pathPfx,
+				"path_suffix", currentLocation.Elements())
 	}
 
 	cbl := collectable{
-		currPath:                  currPath,
+		currPath:                  collectionPath,
 		files:                     node.files,
 		folderID:                  node.id,
 		isPackageOrChildOfPackage: node.isPackage || isChildOfPackage,
-		loc:                       loc,
+		loc:                       parentLocation,
 		prevPath:                  node.prev,
 	}
 

--- a/src/internal/m365/collection/drive/delta_tree_test.go
+++ b/src/internal/m365/collection/drive/delta_tree_test.go
@@ -955,10 +955,11 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expectErr: require.NoError,
 			expect: map[string]collectable{
 				rootID: {
-					currPath: fullPathPath(t),
-					files:    map[string]fileyMcFileFace{},
-					folderID: rootID,
-					loc:      path.Elements{},
+					currPath:                  fullPathPath(t),
+					files:                     map[string]fileyMcFileFace{},
+					folderID:                  rootID,
+					isPackageOrChildOfPackage: false,
+					loc:                       path.Elements{},
 				},
 			},
 		},
@@ -972,8 +973,9 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 					files: map[string]fileyMcFileFace{
 						id(file): {},
 					},
-					folderID: rootID,
-					loc:      path.Elements{},
+					folderID:                  rootID,
+					isPackageOrChildOfPackage: false,
+					loc:                       path.Elements{},
 				},
 			},
 		},
@@ -983,24 +985,64 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expectErr: require.NoError,
 			expect: map[string]collectable{
 				rootID: {
-					currPath: fullPathPath(t),
-					files:    map[string]fileyMcFileFace{},
-					folderID: rootID,
-					loc:      path.Elements{},
+					currPath:                  fullPathPath(t),
+					files:                     map[string]fileyMcFileFace{},
+					folderID:                  rootID,
+					isPackageOrChildOfPackage: false,
+					loc:                       path.Elements{},
 				},
 				idx(folder, "parent"): {
-					currPath: fullPathPath(t, namex(folder, "parent")),
-					files:    map[string]fileyMcFileFace{},
-					folderID: idx(folder, "parent"),
-					loc:      path.Elements{rootName},
+					currPath:                  fullPathPath(t, namex(folder, "parent")),
+					files:                     map[string]fileyMcFileFace{},
+					folderID:                  idx(folder, "parent"),
+					isPackageOrChildOfPackage: false,
+					loc:                       path.Elements{rootName},
 				},
 				id(folder): {
 					currPath: fullPathPath(t, namex(folder, "parent"), name(folder)),
 					files: map[string]fileyMcFileFace{
 						id(file): {},
 					},
-					folderID: id(folder),
-					loc:      path.Elements{rootName, namex(folder, "parent")},
+					folderID:                  id(folder),
+					isPackageOrChildOfPackage: false,
+					loc:                       path.Elements{rootName, namex(folder, "parent")},
+				},
+			},
+		},
+		{
+			name: "package in hierarchy",
+			tree: func(t *testing.T) *folderyMcFolderFace {
+				ctx, flush := tester.NewContext(t)
+				defer flush()
+
+				tree := treeWithRoot(t)
+				tree.setFolder(ctx, rootID, id(pkg), name(pkg), true)
+				tree.setFolder(ctx, id(pkg), id(folder), name(folder), false)
+
+				return tree
+			},
+			expectErr: require.NoError,
+			expect: map[string]collectable{
+				rootID: {
+					currPath:                  fullPathPath(t),
+					files:                     map[string]fileyMcFileFace{},
+					folderID:                  rootID,
+					isPackageOrChildOfPackage: false,
+					loc:                       path.Elements{},
+				},
+				id(pkg): {
+					currPath:                  fullPathPath(t, name(pkg)),
+					files:                     map[string]fileyMcFileFace{},
+					folderID:                  id(pkg),
+					isPackageOrChildOfPackage: true,
+					loc:                       path.Elements{rootName},
+				},
+				id(folder): {
+					currPath:                  fullPathPath(t, name(pkg), name(folder)),
+					files:                     map[string]fileyMcFileFace{},
+					folderID:                  id(folder),
+					isPackageOrChildOfPackage: true,
+					loc:                       path.Elements{rootName, name(pkg)},
 				},
 			},
 		},
@@ -1015,22 +1057,25 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			},
 			expect: map[string]collectable{
 				rootID: {
-					currPath: fullPathPath(t),
-					files:    map[string]fileyMcFileFace{},
-					folderID: rootID,
-					loc:      path.Elements{},
-					prevPath: fullPathPath(t),
+					currPath:                  fullPathPath(t),
+					files:                     map[string]fileyMcFileFace{},
+					folderID:                  rootID,
+					isPackageOrChildOfPackage: false,
+					loc:                       path.Elements{},
+					prevPath:                  fullPathPath(t),
 				},
 				idx(folder, "parent"): {
-					currPath: fullPathPath(t, namex(folder, "parent")),
-					files:    map[string]fileyMcFileFace{},
-					folderID: idx(folder, "parent"),
-					loc:      path.Elements{rootName},
-					prevPath: fullPathPath(t, namex(folder, "parent-prev")),
+					currPath:                  fullPathPath(t, namex(folder, "parent")),
+					files:                     map[string]fileyMcFileFace{},
+					folderID:                  idx(folder, "parent"),
+					isPackageOrChildOfPackage: false,
+					loc:                       path.Elements{rootName},
+					prevPath:                  fullPathPath(t, namex(folder, "parent-prev")),
 				},
 				id(folder): {
-					currPath: fullPathPath(t, namex(folder, "parent"), name(folder)),
-					folderID: id(folder),
+					currPath:                  fullPathPath(t, namex(folder, "parent"), name(folder)),
+					folderID:                  id(folder),
+					isPackageOrChildOfPackage: false,
 					files: map[string]fileyMcFileFace{
 						id(file): {},
 					},
@@ -1049,16 +1094,18 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expectErr: require.NoError,
 			expect: map[string]collectable{
 				rootID: {
-					currPath: fullPathPath(t),
-					files:    map[string]fileyMcFileFace{},
-					folderID: rootID,
-					loc:      path.Elements{},
-					prevPath: fullPathPath(t),
+					currPath:                  fullPathPath(t),
+					files:                     map[string]fileyMcFileFace{},
+					folderID:                  rootID,
+					isPackageOrChildOfPackage: false,
+					loc:                       path.Elements{},
+					prevPath:                  fullPathPath(t),
 				},
 				id(folder): {
-					files:    map[string]fileyMcFileFace{},
-					folderID: id(folder),
-					prevPath: fullPathPath(t, name(folder)),
+					files:                     map[string]fileyMcFileFace{},
+					folderID:                  id(folder),
+					isPackageOrChildOfPackage: false,
+					prevPath:                  fullPathPath(t, name(folder)),
 				},
 			},
 		},

--- a/src/internal/m365/collection/drive/delta_tree_test.go
+++ b/src/internal/m365/collection/drive/delta_tree_test.go
@@ -2,7 +2,6 @@ package drive
 
 import (
 	"testing"
-	"time"
 
 	"github.com/alcionai/clues"
 	"github.com/stretchr/testify/assert"
@@ -10,8 +9,10 @@ import (
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/exp/maps"
 
+	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
 // ---------------------------------------------------------------------------
@@ -52,7 +53,7 @@ func (suite *DeltaTreeUnitSuite) TestNewNodeyMcNodeFace() {
 	assert.Equal(t, parent, nodeFace.parent)
 	assert.Equal(t, "id", nodeFace.id)
 	assert.Equal(t, "name", nodeFace.name)
-	assert.NotEqual(t, defaultLoc, nodeFace.prev)
+	assert.Nil(t, nodeFace.prev)
 	assert.True(t, nodeFace.isPackage)
 	assert.NotNil(t, nodeFace.children)
 	assert.NotNil(t, nodeFace.files)
@@ -67,7 +68,7 @@ func (suite *DeltaTreeUnitSuite) TestNewNodeyMcNodeFace() {
 func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 	table := []struct {
 		tname     string
-		tree      *folderyMcFolderFace
+		tree      func(t *testing.T) *folderyMcFolderFace
 		parentID  string
 		id        string
 		name      string
@@ -286,8 +287,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetPreviousPath() {
 		{
 			name:            "added folders after reset",
 			id:              id(folder),
-			loc:             loc,
-			tree:            treeWithFoldersAfterReset(),
+			prev:            pathWith(defaultLoc()),
+			tree:            treeWithFoldersAfterReset,
 			expectErr:       assert.NoError,
 			expectLive:      true,
 			expectTombstone: false,
@@ -823,11 +824,13 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			t := suite.T()
 			tree := test.tree(t)
 
+			df := driveFile(file, parentDir(), test.parentID)
+			df.SetSize(ptr.To(test.contentSize))
+
 			err := tree.addFile(
 				test.parentID,
 				id(file),
-				time.Now(),
-				test.contentSize)
+				custom.ToCustomDriveItem(df))
 			test.expectErr(t, err, clues.ToCore(err))
 			assert.Equal(t, test.expectFiles, tree.fileIDToParentID)
 
@@ -845,7 +848,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			assert.Equal(t, test.contentSize, countSize.totalBytes, "tree should be sized to test file contents")
 
 			if len(test.oldParentID) > 0 && test.oldParentID != test.parentID {
-				old, := tree.GetNode(test.oldParentID)
+				old := tree.getNode(test.oldParentID)
 
 				require.NotNil(t, old)
 				assert.NotContains(t, old.files, id(file))
@@ -900,7 +903,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_DeleteFile() {
 
 func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_addAndDeleteFile() {
 	t := suite.T()
-	tree := treeWithRoot()
+	tree := treeWithRoot(t)
 	fID := id(file)
 
 	require.Len(t, tree.fileIDToParentID, 0)
@@ -913,7 +916,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_addAndDeleteFile() {
 	assert.Len(t, tree.deletedFileIDs, 1)
 	assert.Contains(t, tree.deletedFileIDs, fID)
 
-	err := tree.addFile(rootID, fID, time.Now(), defaultItemSize)
+	err := tree.addFile(rootID, fID, custom.ToCustomDriveItem(fileAtRoot()))
 	require.NoError(t, err, clues.ToCore(err))
 
 	assert.Len(t, tree.fileIDToParentID, 1)
@@ -927,6 +930,53 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_addAndDeleteFile() {
 	assert.NotContains(t, tree.fileIDToParentID, fID)
 	assert.Len(t, tree.deletedFileIDs, 1)
 	assert.Contains(t, tree.deletedFileIDs, fID)
+}
+
+func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateExcludeItemIDs() {
+	table := []struct {
+		name   string
+		tree   func(t *testing.T) *folderyMcFolderFace
+		expect map[string]struct{}
+	}{
+		{
+			name:   "no files",
+			tree:   treeWithRoot,
+			expect: map[string]struct{}{},
+		},
+		{
+			name:   "one file in a folder",
+			tree:   treeWithFileInFolder,
+			expect: makeExcludeMap(id(file)),
+		},
+		{
+			name:   "one file in a tombstone",
+			tree:   treeWithFileInTombstone,
+			expect: map[string]struct{}{},
+		},
+		{
+			name:   "one deleted file",
+			tree:   treeWithDeletedFile,
+			expect: makeExcludeMap(idx(file, "d")),
+		},
+		{
+			name: "files in folders and tombstones",
+			tree: fullTree,
+			expect: makeExcludeMap(
+				id(file),
+				idx(file, "r"),
+				idx(file, "p"),
+				idx(file, "d")),
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+			tree := test.tree(t)
+
+			result := tree.generateExcludeItemIDs()
+			assert.Equal(t, test.expect, result)
+		})
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -956,7 +1006,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expect: map[string]collectable{
 				rootID: {
 					currPath:                  fullPathPath(t),
-					files:                     map[string]fileyMcFileFace{},
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{},
@@ -970,8 +1020,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expect: map[string]collectable{
 				rootID: {
 					currPath: fullPathPath(t),
-					files: map[string]fileyMcFileFace{
-						id(file): {},
+					files: map[string]*custom.DriveItem{
+						id(file): custom.ToCustomDriveItem(fileAtRoot()),
 					},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
@@ -986,22 +1036,22 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expect: map[string]collectable{
 				rootID: {
 					currPath:                  fullPathPath(t),
-					files:                     map[string]fileyMcFileFace{},
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{},
 				},
 				idx(folder, "parent"): {
 					currPath:                  fullPathPath(t, namex(folder, "parent")),
-					files:                     map[string]fileyMcFileFace{},
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  idx(folder, "parent"),
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{rootName},
 				},
 				id(folder): {
 					currPath: fullPathPath(t, namex(folder, "parent"), name(folder)),
-					files: map[string]fileyMcFileFace{
-						id(file): {},
+					files: map[string]*custom.DriveItem{
+						id(file): custom.ToCustomDriveItem(fileAt("parent")),
 					},
 					folderID:                  id(folder),
 					isPackageOrChildOfPackage: false,
@@ -1028,21 +1078,21 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expect: map[string]collectable{
 				rootID: {
 					currPath:                  fullPathPath(t),
-					files:                     map[string]fileyMcFileFace{},
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{},
 				},
 				id(pkg): {
 					currPath:                  fullPathPath(t, name(pkg)),
-					files:                     map[string]fileyMcFileFace{},
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  id(pkg),
 					isPackageOrChildOfPackage: true,
 					loc:                       path.Elements{rootName},
 				},
 				id(folder): {
 					currPath:                  fullPathPath(t, name(pkg), name(folder)),
-					files:                     map[string]fileyMcFileFace{},
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  id(folder),
 					isPackageOrChildOfPackage: true,
 					loc:                       path.Elements{rootName, name(pkg)},
@@ -1061,7 +1111,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expect: map[string]collectable{
 				rootID: {
 					currPath:                  fullPathPath(t),
-					files:                     map[string]fileyMcFileFace{},
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{},
@@ -1069,7 +1119,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 				},
 				idx(folder, "parent"): {
 					currPath:                  fullPathPath(t, namex(folder, "parent")),
-					files:                     map[string]fileyMcFileFace{},
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  idx(folder, "parent"),
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{rootName},
@@ -1079,8 +1129,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 					currPath:                  fullPathPath(t, namex(folder, "parent"), name(folder)),
 					folderID:                  id(folder),
 					isPackageOrChildOfPackage: false,
-					files: map[string]fileyMcFileFace{
-						id(file): {},
+					files: map[string]*custom.DriveItem{
+						id(file): custom.ToCustomDriveItem(fileAt("parent")),
 					},
 					loc:      path.Elements{rootName, namex(folder, "parent")},
 					prevPath: fullPathPath(t, namex(folder, "parent-prev"), name(folder)),
@@ -1098,14 +1148,14 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expect: map[string]collectable{
 				rootID: {
 					currPath:                  fullPathPath(t),
-					files:                     map[string]fileyMcFileFace{},
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{},
 					prevPath:                  fullPathPath(t),
 				},
 				id(folder): {
-					files:                     map[string]fileyMcFileFace{},
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  id(folder),
 					isPackageOrChildOfPackage: false,
 					prevPath:                  fullPathPath(t, name(folder)),

--- a/src/internal/m365/collection/drive/delta_tree_test.go
+++ b/src/internal/m365/collection/drive/delta_tree_test.go
@@ -1016,8 +1016,11 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 				defer flush()
 
 				tree := treeWithRoot(t)
-				tree.setFolder(ctx, rootID, id(pkg), name(pkg), true)
-				tree.setFolder(ctx, id(pkg), id(folder), name(folder), false)
+				err := tree.setFolder(ctx, rootID, id(pkg), name(pkg), true)
+				require.NoError(t, err, clues.ToCore(err))
+
+				err = tree.setFolder(ctx, id(pkg), id(folder), name(folder), false)
+				require.NoError(t, err, clues.ToCore(err))
 
 				return tree
 			},

--- a/src/internal/m365/collection/drive/helper_test.go
+++ b/src/internal/m365/collection/drive/helper_test.go
@@ -785,16 +785,28 @@ func aReset(items ...models.DriveItemable) mock.NextPage {
 // delta trees
 // ---------------------------------------------------------------------------
 
+func defaultTreePfx(t *testing.T) path.Path {
+	fpb := fullPathPath(t).ToBuilder()
+	fpe := fpb.Elements()
+	fpe = fpe[:len(fpe)-1]
+	fpb = path.Builder{}.Append(fpe...)
+
+	p, err := path.FromDataLayerPath(fpb.String(), false)
+	require.NoError(t, err, clues.ToCore(err))
+
+	return p
+}
+
 func defaultLoc() path.Elements {
 	return path.NewElements("root:/foo/bar/baz/qux/fnords/smarf/voi/zumba/bangles/howdyhowdyhowdy")
 }
 
 func newTree(t *testing.T) *folderyMcFolderFace {
-	return newFolderyMcFolderFace(fullPathPath(t), rootID)
+	return newFolderyMcFolderFace(defaultTreePfx(t), rootID)
 }
 
 func treeWithRoot(t *testing.T) *folderyMcFolderFace {
-	tree := newFolderyMcFolderFace(fullPathPath(t), rootID)
+	tree := newFolderyMcFolderFace(defaultTreePfx(t), rootID)
 	rootey := newNodeyMcNodeFace(nil, rootID, rootName, false)
 	tree.root = rootey
 	tree.folderIDToNode[rootID] = rootey
@@ -803,7 +815,7 @@ func treeWithRoot(t *testing.T) *folderyMcFolderFace {
 }
 
 func treeAfterReset(t *testing.T) *folderyMcFolderFace {
-	tree := newFolderyMcFolderFace(fullPathPath(t), rootID)
+	tree := newFolderyMcFolderFace(defaultTreePfx(t), rootID)
 	tree.reset()
 
 	return tree

--- a/src/internal/m365/collection/drive/helper_test.go
+++ b/src/internal/m365/collection/drive/helper_test.go
@@ -19,6 +19,7 @@ import (
 	odConsts "github.com/alcionai/corso/src/internal/m365/service/onedrive/consts"
 	"github.com/alcionai/corso/src/internal/m365/service/onedrive/mock"
 	"github.com/alcionai/corso/src/internal/m365/support"
+	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
 	bupMD "github.com/alcionai/corso/src/pkg/backup/metadata"
@@ -30,6 +31,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 	apiMock "github.com/alcionai/corso/src/pkg/services/m365/api/mock"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
 const defaultItemSize int64 = 42
@@ -152,6 +154,7 @@ func coreItem(
 	item := models.NewDriveItem()
 	item.SetName(&name)
 	item.SetId(&id)
+	item.SetLastModifiedDateTime(ptr.To(time.Now()))
 
 	parentReference := models.NewItemReference()
 	parentReference.SetPath(&parentPath)
@@ -176,6 +179,21 @@ func driveItem(
 	it itemType,
 ) models.DriveItemable {
 	return coreItem(id, name, parentPath, parentID, it)
+}
+
+func driveFile(
+	idX any,
+	parentPath, parentID string,
+) models.DriveItemable {
+	i := id(file)
+	n := name(file)
+
+	if idX != file {
+		i = idx(file, idX)
+		n = namex(file, idX)
+	}
+
+	return driveItem(i, n, parentPath, parentID, isFile)
 }
 
 func fileAtRoot() models.DriveItemable {
@@ -475,12 +493,6 @@ func driveParentDir(driveID any, elems ...string) string {
 		elems...)...)
 }
 
-// just for readability
-const (
-	doMergeItems    = true
-	doNotMergeItems = false
-)
-
 // common item names
 const (
 	bar       = "bar"
@@ -571,26 +583,6 @@ func collWithMBHAndOpts(
 		count.New())
 }
 
-// func fullOrPrevPath(
-// 	t *testing.T,
-// 	coll data.BackupCollection,
-// ) path.Path {
-// 	var collPath path.Path
-
-// 	if coll.State() != data.DeletedState {
-// 		collPath = coll.FullPath()
-// 	} else {
-// 		collPath = coll.PreviousPath()
-// 	}
-
-// 	require.False(
-// 		t,
-// 		len(collPath.Elements()) < 4,
-// 		"malformed or missing collection path")
-
-// 	return collPath
-// }
-
 func pagerForDrives(drives ...models.Driveable) *apiMock.Pager[models.Driveable] {
 	return &apiMock.Pager[models.Driveable]{
 		ToReturn: []apiMock.PagerResult[models.Driveable]{
@@ -598,6 +590,30 @@ func pagerForDrives(drives ...models.Driveable) *apiMock.Pager[models.Driveable]
 		},
 	}
 }
+
+func aPage(items ...models.DriveItemable) mock.NextPage {
+	return mock.NextPage{
+		Items: append([]models.DriveItemable{driveRootItem()}, items...),
+	}
+}
+
+func aPageWReset(items ...models.DriveItemable) mock.NextPage {
+	return mock.NextPage{
+		Items: append([]models.DriveItemable{driveRootItem()}, items...),
+		Reset: true,
+	}
+}
+
+func aReset(items ...models.DriveItemable) mock.NextPage {
+	return mock.NextPage{
+		Items: []models.DriveItemable{},
+		Reset: true,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// metadata
+// ---------------------------------------------------------------------------
 
 func makePrevMetadataColls(
 	t *testing.T,
@@ -651,133 +667,150 @@ func makePrevMetadataColls(
 // 	assert.Equal(t, expectPrevPaths, prevs, "previous paths")
 // }
 
-// for comparisons done by collection state
-type stateAssertion struct {
-	itemIDs []string
-	// should never get set by the user.
-	// this flag gets flipped when calling assertions.compare.
-	// any unseen collection will error on requireNoUnseenCollections
-	// sawCollection bool
-}
+// ---------------------------------------------------------------------------
+// collections
+// ---------------------------------------------------------------------------
 
 // for comparisons done by a given collection path
 type collectionAssertion struct {
-	doNotMerge    assert.BoolAssertionFunc
-	states        map[data.CollectionState]*stateAssertion
-	excludedItems map[string]struct{}
+	curr    path.Path
+	prev    path.Path
+	state   data.CollectionState
+	fileIDs []string
+	// should never get set by the user.
+	// this flag gets flipped when calling assertions.compare.
+	// any unseen collection will error on requireNoUnseenCollections
+	sawCollection bool
 }
 
-type statesToItemIDs map[data.CollectionState][]string
+func aColl(
+	curr, prev path.Path,
+	fileIDs ...string,
+) *collectionAssertion {
+	ids := make([]string, 0, 2*len(fileIDs))
 
-// TODO(keepers): move excludeItems to a more global position.
-func newCollAssertion(
-	doNotMerge bool,
-	itemsByState statesToItemIDs,
-	excludeItems ...string,
-) collectionAssertion {
-	states := map[data.CollectionState]*stateAssertion{}
-
-	for state, itemIDs := range itemsByState {
-		states[state] = &stateAssertion{
-			itemIDs: itemIDs,
-		}
+	for _, fUD := range fileIDs {
+		ids = append(ids, fUD+metadata.DataFileSuffix)
+		ids = append(ids, fUD+metadata.MetaFileSuffix)
 	}
 
-	dnm := assert.False
-	if doNotMerge {
-		dnm = assert.True
-	}
-
-	return collectionAssertion{
-		doNotMerge:    dnm,
-		states:        states,
-		excludedItems: makeExcludeMap(excludeItems...),
+	return &collectionAssertion{
+		curr:    curr,
+		prev:    prev,
+		state:   data.StateOf(prev, curr, count.New()),
+		fileIDs: ids,
 	}
 }
 
 // to aggregate all collection-related expectations in the backup
 // map collection path -> collection state -> assertion
-type collectionAssertions map[string]collectionAssertion
+type expectedCollections struct {
+	assertions  map[string]*collectionAssertion
+	doNotMerge  assert.BoolAssertionFunc
+	hasURLCache assert.ValueAssertionFunc
+}
 
-// ensure the provided collection matches expectations as set by the test.
-// func (cas collectionAssertions) compare(
-// 	t *testing.T,
-// 	coll data.BackupCollection,
-// 	excludes *prefixmatcher.StringSetMatchBuilder,
-// ) {
-// 	ctx, flush := tester.NewContext(t)
-// 	defer flush()
+func expectCollections(
+	doNotMerge bool,
+	hasURLCache bool,
+	colls ...*collectionAssertion,
+) expectedCollections {
+	as := map[string]*collectionAssertion{}
 
-// 	var (
-// 		itemCh  = coll.Items(ctx, fault.New(true))
-// 		itemIDs = []string{}
-// 	)
+	for _, coll := range colls {
+		as[expectFullOrPrev(coll).String()] = coll
+	}
 
-// 	p := fullOrPrevPath(t, coll)
+	dontMerge := assert.False
+	if doNotMerge {
+		dontMerge = assert.True
+	}
 
-// 	for itm := range itemCh {
-// 		itemIDs = append(itemIDs, itm.ID())
-// 	}
+	hasCache := assert.Nil
+	if hasURLCache {
+		hasCache = assert.NotNil
+	}
 
-// 	expect := cas[p.String()]
-// 	expectState := expect.states[coll.State()]
-// 	expectState.sawCollection = true
+	return expectedCollections{
+		assertions:  as,
+		doNotMerge:  dontMerge,
+		hasURLCache: hasCache,
+	}
+}
 
-// 	assert.ElementsMatchf(
-// 		t,
-// 		expectState.itemIDs,
-// 		itemIDs,
-// 		"expected all items to match in collection with:\nstate %q\npath %q",
-// 		coll.State(),
-// 		p)
+func (ecs expectedCollections) compare(
+	t *testing.T,
+	colls []data.BackupCollection,
+) {
+	for _, coll := range colls {
+		ecs.compareColl(t, coll)
+	}
+}
 
-// 	expect.doNotMerge(
-// 		t,
-// 		coll.DoNotMergeItems(),
-// 		"expected collection to have the appropariate doNotMerge flag")
+func (ecs expectedCollections) compareColl(t *testing.T, coll data.BackupCollection) {
+	ctx, flush := tester.NewContext(t)
+	defer flush()
 
-// 	if result, ok := excludes.Get(p.String()); ok {
-// 		assert.Equal(
-// 			t,
-// 			expect.excludedItems,
-// 			result,
-// 			"excluded items")
-// 	}
-// }
+	var (
+		itemIDs = []string{}
+		p       = fullOrPrevPath(t, coll)
+	)
+
+	if coll.State() != data.DeletedState {
+		for itm := range coll.Items(ctx, fault.New(true)) {
+			itemIDs = append(itemIDs, itm.ID())
+		}
+	}
+
+	expect := ecs.assertions[p.String()]
+	require.NotNil(
+		t,
+		expect,
+		"test should have an expected entry for collection with:\n\tstate %q\n\tpath %q",
+		coll.State(),
+		p)
+
+	expect.sawCollection = true
+
+	assert.ElementsMatchf(
+		t,
+		expect.fileIDs,
+		itemIDs,
+		"expected all items to match in collection with:\n\tstate %q\n\tpath %q",
+		coll.State(),
+		p)
+
+	if expect.prev == nil {
+		assert.Nil(t, coll.PreviousPath(), "previous path")
+	} else {
+		assert.Equal(t, expect.prev, coll.PreviousPath())
+	}
+
+	if expect.curr == nil {
+		assert.Nil(t, coll.FullPath(), "collection path")
+	} else {
+		assert.Equal(t, expect.curr, coll.FullPath())
+	}
+
+	ecs.doNotMerge(
+		t,
+		coll.DoNotMergeItems(),
+		"expected collection to have the appropariate doNotMerge flag")
+
+	driveColl := coll.(*Collection)
+
+	ecs.hasURLCache(t, driveColl.urlCache, "has a populated url cache handler")
+}
 
 // ensure that no collections in the expected set are still flagged
 // as sawCollection == false.
-// func (cas collectionAssertions) requireNoUnseenCollections(
-// 	t *testing.T,
-// ) {
-// 	for p, withPath := range cas {
-// 		for _, state := range withPath.states {
-// 			require.True(
-// 				t,
-// 				state.sawCollection,
-// 				"results should have contained collection:\n\t%q\t\n%q",
-// 				state, p)
-// 		}
-// 	}
-// }
-
-func aPage(items ...models.DriveItemable) mock.NextPage {
-	return mock.NextPage{
-		Items: append([]models.DriveItemable{driveRootItem()}, items...),
-	}
-}
-
-func aPageWReset(items ...models.DriveItemable) mock.NextPage {
-	return mock.NextPage{
-		Items: append([]models.DriveItemable{driveRootItem()}, items...),
-		Reset: true,
-	}
-}
-
-func aReset(items ...models.DriveItemable) mock.NextPage {
-	return mock.NextPage{
-		Items: []models.DriveItemable{},
-		Reset: true,
+func (ecs expectedCollections) requireNoUnseenCollections(t *testing.T) {
+	for _, ca := range ecs.assertions {
+		require.True(
+			t,
+			ca.sawCollection,
+			"results did not include collection at:\n\tstate %q\t\npath %q",
+			ca.state, expectFullOrPrev(ca))
 	}
 }
 
@@ -792,7 +825,12 @@ func defaultTreePfx(t *testing.T) path.Path {
 	fpb = path.Builder{}.Append(fpe...)
 
 	p, err := path.FromDataLayerPath(fpb.String(), false)
-	require.NoError(t, err, clues.ToCore(err))
+	require.NoErrorf(
+		t,
+		err,
+		"err processing path:\n\terr %+v\n\tpath %q",
+		clues.ToCore(err),
+		fpb)
 
 	return p
 }
@@ -851,21 +889,22 @@ func treeWithFolders(t *testing.T) *folderyMcFolderFace {
 
 func treeWithFileAtRoot(t *testing.T) *folderyMcFolderFace {
 	tree := treeWithRoot(t)
-	tree.root.files[id(file)] = fileyMcFileFace{
-		lastModified: time.Now(),
-		contentSize:  42,
-	}
+	tree.root.files[id(file)] = custom.ToCustomDriveItem(fileAtRoot())
 	tree.fileIDToParentID[id(file)] = rootID
+
+	return tree
+}
+
+func treeWithDeletedFile(t *testing.T) *folderyMcFolderFace {
+	tree := treeWithRoot(t)
+	tree.deleteFile(idx(file, "d"))
 
 	return tree
 }
 
 func treeWithFileInFolder(t *testing.T) *folderyMcFolderFace {
 	tree := treeWithFolders(t)
-	tree.folderIDToNode[id(folder)].files[id(file)] = fileyMcFileFace{
-		lastModified: time.Now(),
-		contentSize:  42,
-	}
+	tree.folderIDToNode[id(folder)].files[id(file)] = custom.ToCustomDriveItem(fileAt(folder))
 	tree.fileIDToParentID[id(file)] = id(folder)
 
 	return tree
@@ -873,11 +912,121 @@ func treeWithFileInFolder(t *testing.T) *folderyMcFolderFace {
 
 func treeWithFileInTombstone(t *testing.T) *folderyMcFolderFace {
 	tree := treeWithTombstone(t)
-	tree.tombstones[id(folder)].files[id(file)] = fileyMcFileFace{
-		lastModified: time.Now(),
-		contentSize:  42,
-	}
+	tree.tombstones[id(folder)].files[id(file)] = custom.ToCustomDriveItem(fileAt("tombstone"))
 	tree.fileIDToParentID[id(file)] = id(folder)
 
 	return tree
+}
+
+// root -> idx(folder, parent) -> id(folder)
+// one item at each dir
+// one tombstone: idx(folder, tombstone)
+// one item in the tombstone
+// one deleted item
+func fullTree(t *testing.T) *folderyMcFolderFace {
+	return fullTreeWithNames("parent", "tombstone")(t)
+}
+
+func fullTreeWithNames(
+	parentFolderX, tombstoneX any,
+) func(t *testing.T) *folderyMcFolderFace {
+	return func(t *testing.T) *folderyMcFolderFace {
+		ctx, flush := tester.NewContext(t)
+		defer flush()
+
+		tree := treeWithRoot(t)
+
+		// file in root
+		df := driveFile("r", parentDir(), rootID)
+		err := tree.addFile(
+			rootID,
+			idx(file, "r"),
+			custom.ToCustomDriveItem(df))
+		require.NoError(t, err, clues.ToCore(err))
+
+		// root -> idx(folder, parent)
+		err = tree.setFolder(ctx, rootID, idx(folder, parentFolderX), namex(folder, parentFolderX), false)
+		require.NoError(t, err, clues.ToCore(err))
+
+		// file in idx(folder, parent)
+		df = driveFile("p", parentDir(namex(folder, parentFolderX)), idx(folder, parentFolderX))
+		err = tree.addFile(
+			idx(folder, parentFolderX),
+			idx(file, "p"),
+			custom.ToCustomDriveItem(df))
+		require.NoError(t, err, clues.ToCore(err))
+
+		// idx(folder, parent) -> id(folder)
+		err = tree.setFolder(ctx, idx(folder, parentFolderX), id(folder), name(folder), false)
+		require.NoError(t, err, clues.ToCore(err))
+
+		// file in id(folder)
+		df = driveFile(file, parentDir(name(folder)), id(folder))
+		err = tree.addFile(
+			id(folder),
+			id(file),
+			custom.ToCustomDriveItem(df))
+		require.NoError(t, err, clues.ToCore(err))
+
+		// tombstone - have to set a non-tombstone folder first, then add the item, then tombstone the folder
+		err = tree.setFolder(ctx, rootID, idx(folder, tombstoneX), namex(folder, tombstoneX), false)
+		require.NoError(t, err, clues.ToCore(err))
+
+		// file in tombstone
+		df = driveFile("t", parentDir(namex(folder, tombstoneX)), idx(folder, tombstoneX))
+		err = tree.addFile(
+			idx(folder, tombstoneX),
+			idx(file, "t"),
+			custom.ToCustomDriveItem(df))
+		require.NoError(t, err, clues.ToCore(err))
+
+		err = tree.setTombstone(ctx, idx(folder, tombstoneX))
+		require.NoError(t, err, clues.ToCore(err))
+
+		// deleted file
+		tree.deleteFile(idx(file, "d"))
+
+		return tree
+	}
+}
+
+// ---------------------------------------------------------------------------
+// misc
+// ---------------------------------------------------------------------------
+func expectFullOrPrev(ca *collectionAssertion) path.Path {
+	var p path.Path
+
+	if ca.state != data.DeletedState {
+		p = ca.curr
+	} else {
+		p = ca.prev
+	}
+
+	return p
+}
+
+func fullOrPrevPath(
+	t *testing.T,
+	coll data.BackupCollection,
+) path.Path {
+	var collPath path.Path
+
+	if coll.State() == data.DeletedState {
+		collPath = coll.PreviousPath()
+	} else {
+		collPath = coll.FullPath()
+	}
+
+	require.NotNil(
+		t,
+		collPath,
+		"full or prev path are nil for collection with state:\n\t%s",
+		coll.State())
+
+	require.False(
+		t,
+		len(collPath.Elements()) < 4,
+		"malformed or missing collection path")
+
+	return collPath
 }

--- a/src/internal/m365/collection/drive/url_cache.go
+++ b/src/internal/m365/collection/drive/url_cache.go
@@ -19,7 +19,10 @@ import (
 
 const (
 	urlCacheDriveItemThreshold = 300 * 1000
-	urlCacheRefreshInterval    = 1 * time.Hour
+	// 600 pages = 300k items, since delta enumeration produces 500 items per page
+	// TODO: export standard page size and swap to 300k/defaultDeltaPageSize
+	urlCacheDrivePagesThreshold = 600
+	urlCacheRefreshInterval     = 1 * time.Hour
 )
 
 type getItemPropertyer interface {

--- a/src/pkg/count/keys.go
+++ b/src/pkg/count/keys.go
@@ -82,6 +82,7 @@ const (
 	TotalDeltasProcessed        Key = "total-deltas-processed"
 	TotalFilesProcessed         Key = "total-files-processed"
 	TotalFoldersProcessed       Key = "total-folders-processed"
+	TotalItemsProcessed         Key = "total-items-processed"
 	TotalMalwareProcessed       Key = "total-malware-processed"
 	TotalPackagesProcessed      Key = "total-packages-processed"
 	TotalPagesEnumerated        Key = "total-pages-enumerated"


### PR DESCRIPTION
post-process handling to produce a set of collectable data from the current state of the tree. Collectable data is a minimization of collection data, where the collection will require additional properties that aren't owned by the tree.  The caller is expected to be able to produce a complete data.BackupCollection and newPrevPaths from the produced collectables.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #4689

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
