### PR TITLE
Switch to custom drive items for backup operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
+- Memory optimizations for large scale OneDrive and Sharepoint backups.
 ### Fixed
 
 ## [v0.16.0] (beta) - 2023-11-28

--- a/src/internal/m365/collection/drive/collection.go
+++ b/src/internal/m365/collection/drive/collection.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/alcionai/clues"
-	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/spatialcurrent/go-lazy/pkg/lazy"
 
 	"github.com/alcionai/corso/src/internal/common/idname"
@@ -191,11 +190,9 @@ func newColl(
 // Adds an itemID to the collection.  This will make it eligible to be
 // populated. The return values denotes if the item was previously
 // present or is new one.
-func (oc *Collection) Add(item models.DriveItemable) bool {
-	liteItem := custom.ToLiteDriveItemable(item)
-
-	_, found := oc.driveItems[ptr.Val(liteItem.GetId())]
-	oc.driveItems[ptr.Val(liteItem.GetId())] = liteItem
+func (oc *Collection) Add(item custom.LiteDriveItemable) bool {
+	_, found := oc.driveItems[ptr.Val(item.GetId())]
+	oc.driveItems[ptr.Val(item.GetId())] = item
 
 	// if !found, it's a new addition
 	return !found
@@ -220,7 +217,7 @@ func (oc *Collection) IsEmpty() bool {
 
 // ContainsItem returns true if the collection has the given item as one of its
 // children.
-func (oc Collection) ContainsItem(item models.DriveItemable) bool {
+func (oc Collection) ContainsItem(item custom.LiteDriveItemable) bool {
 	_, ok := oc.driveItems[ptr.Val(item.GetId())]
 	return ok
 }

--- a/src/internal/m365/collection/drive/collection.go
+++ b/src/internal/m365/collection/drive/collection.go
@@ -28,6 +28,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
 const (
@@ -52,7 +53,7 @@ type Collection struct {
 	// represents
 	folderPath path.Path
 	// M365 IDs of file items within this collection
-	driveItems map[string]models.DriveItemable
+	driveItems map[string]custom.LiteDriveItemable
 
 	// Primary M365 ID of the drive this collection was created from
 	driveID   string
@@ -172,7 +173,7 @@ func newColl(
 		protectedResource:         resource,
 		folderPath:                currPath,
 		prevPath:                  prevPath,
-		driveItems:                map[string]models.DriveItemable{},
+		driveItems:                map[string]custom.LiteDriveItemable{},
 		driveID:                   driveID,
 		data:                      dataCh,
 		statusUpdater:             statusUpdater,
@@ -191,8 +192,10 @@ func newColl(
 // populated. The return values denotes if the item was previously
 // present or is new one.
 func (oc *Collection) Add(item models.DriveItemable) bool {
-	_, found := oc.driveItems[ptr.Val(item.GetId())]
-	oc.driveItems[ptr.Val(item.GetId())] = item
+	liteItem := custom.ToLiteDriveItemable(item)
+
+	_, found := oc.driveItems[ptr.Val(liteItem.GetId())]
+	oc.driveItems[ptr.Val(liteItem.GetId())] = liteItem
 
 	// if !found, it's a new addition
 	return !found
@@ -277,7 +280,7 @@ func (oc Collection) DoNotMergeItems() bool {
 func (oc *Collection) getDriveItemContent(
 	ctx context.Context,
 	driveID string,
-	item models.DriveItemable,
+	item custom.LiteDriveItemable,
 	errs *fault.Bus,
 ) (io.ReadCloser, error) {
 	var (
@@ -355,7 +358,7 @@ func downloadContent(
 	ctx context.Context,
 	iaag itemAndAPIGetter,
 	uc getItemPropertyer,
-	item models.DriveItemable,
+	item custom.LiteDriveItemable,
 	driveID string,
 	counter *count.Bus,
 ) (io.ReadCloser, error) {
@@ -389,7 +392,9 @@ func downloadContent(
 		return nil, clues.Wrap(err, "retrieving expired item")
 	}
 
-	content, err = downloadItem(ctx, iaag, di)
+	ldi := custom.ToLiteDriveItemable(di)
+
+	content, err = downloadItem(ctx, iaag, ldi)
 	if err != nil {
 		return nil, clues.Wrap(err, "content download retry")
 	}
@@ -483,7 +488,7 @@ func (oc *Collection) streamItems(ctx context.Context, errs *fault.Bus) {
 
 		wg.Add(1)
 
-		go func(item models.DriveItemable) {
+		go func(item custom.LiteDriveItemable) {
 			defer wg.Done()
 			defer func() { <-semaphoreCh }()
 
@@ -507,14 +512,14 @@ func (oc *Collection) streamItems(ctx context.Context, errs *fault.Bus) {
 
 type lazyItemGetter struct {
 	info                 *details.ItemInfo
-	item                 models.DriveItemable
+	item                 custom.LiteDriveItemable
 	driveID              string
 	suffix               string
 	itemExtensionFactory []extensions.CreateItemExtensioner
 	contentGetter        func(
 		ctx context.Context,
 		driveID string,
-		item models.DriveItemable,
+		item custom.LiteDriveItemable,
 		errs *fault.Bus) (io.ReadCloser, error)
 }
 
@@ -555,7 +560,7 @@ func (lig *lazyItemGetter) GetData(
 func (oc *Collection) streamDriveItem(
 	ctx context.Context,
 	parentPath *path.Builder,
-	item models.DriveItemable,
+	item custom.LiteDriveItemable,
 	stats *driveStats,
 	itemExtensionFactory []extensions.CreateItemExtensioner,
 	errs *fault.Bus,
@@ -578,7 +583,7 @@ func (oc *Collection) streamDriveItem(
 		"item_name", clues.Hide(itemName),
 		"item_size", itemSize)
 
-	item.SetParentReference(setName(item.GetParentReference(), oc.driveName))
+	item.SetParentReference(custom.SetParentName(item.GetParentReference(), oc.driveName))
 
 	isFile := item.GetFile() != nil
 

--- a/src/internal/m365/collection/drive/collection.go
+++ b/src/internal/m365/collection/drive/collection.go
@@ -389,9 +389,9 @@ func downloadContent(
 		return nil, clues.Wrap(err, "retrieving expired item")
 	}
 
-	ldi := custom.ToCustomDriveItem(di)
+	cdi := custom.ToCustomDriveItem(di)
 
-	content, err = downloadItem(ctx, iaag, ldi)
+	content, err = downloadItem(ctx, iaag, cdi)
 	if err != nil {
 		return nil, clues.Wrap(err, "content download retry")
 	}

--- a/src/internal/m365/collection/drive/collection_test.go
+++ b/src/internal/m365/collection/drive/collection_test.go
@@ -233,7 +233,7 @@ func (suite *CollectionUnitSuite) TestCollection() {
 				true)
 
 			for i := 0; i < test.numInstances; i++ {
-				coll.Add(stubItem)
+				coll.Add(custom.ToLiteDriveItemable(stubItem))
 			}
 
 			// Read items from the collection
@@ -353,7 +353,7 @@ func (suite *CollectionUnitSuite) TestCollectionReadError() {
 		true,
 		false)
 
-	coll.Add(stubItem)
+	coll.Add(custom.ToLiteDriveItemable(stubItem))
 
 	collItem, ok := <-coll.Items(ctx, fault.New(true))
 	assert.True(t, ok)
@@ -423,7 +423,7 @@ func (suite *CollectionUnitSuite) TestCollectionReadUnauthorizedErrorRetry() {
 		count.New())
 	require.NoError(t, err, clues.ToCore(err))
 
-	coll.Add(stubItem)
+	coll.Add(custom.ToLiteDriveItemable(stubItem))
 
 	collItem, ok := <-coll.Items(ctx, fault.New(true))
 	assert.True(t, ok)
@@ -491,7 +491,7 @@ func (suite *CollectionUnitSuite) TestCollectionPermissionBackupLatestModTime() 
 		true,
 		false)
 
-	coll.Add(stubItem)
+	coll.Add(custom.ToLiteDriveItemable(stubItem))
 
 	coll.handler = mbh
 
@@ -1021,7 +1021,7 @@ func (suite *CollectionUnitSuite) TestItemExtensions() {
 				true,
 				false)
 
-			coll.Add(stubItem)
+			coll.Add(custom.ToLiteDriveItemable(stubItem))
 
 			collItem, ok := <-coll.Items(ctx, fault.New(true))
 			assert.True(t, ok)

--- a/src/internal/m365/collection/drive/collection_test.go
+++ b/src/internal/m365/collection/drive/collection_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
 // ---------------------------------------------------------------------------
@@ -641,7 +642,7 @@ func (suite *GetDriveItemUnitTestSuite) TestGetDriveItem_error() {
 
 			col.handler = mbh
 
-			_, err := col.getDriveItemContent(ctx, "driveID", stubItem, errs)
+			_, err := col.getDriveItemContent(ctx, "driveID", custom.ToLiteDriveItemable(stubItem), errs)
 			if test.err == nil {
 				assert.NoError(t, err, clues.ToCore(err))
 				return
@@ -819,7 +820,7 @@ func (suite *GetDriveItemUnitTestSuite) TestDownloadContent() {
 			mbh.GetResps = resps
 			mbh.GetErrs = test.getErr
 
-			r, err := downloadContent(ctx, mbh, test.muc, item, driveID, count.New())
+			r, err := downloadContent(ctx, mbh, test.muc, custom.ToLiteDriveItemable(item), driveID, count.New())
 			test.expect(t, r)
 			test.expectErr(t, err, clues.ToCore(err))
 		})

--- a/src/internal/m365/collection/drive/collection_test.go
+++ b/src/internal/m365/collection/drive/collection_test.go
@@ -233,7 +233,7 @@ func (suite *CollectionUnitSuite) TestCollection() {
 				true)
 
 			for i := 0; i < test.numInstances; i++ {
-				coll.Add(custom.ToLiteDriveItemable(stubItem))
+				coll.Add(custom.ToCustomDriveItem(stubItem))
 			}
 
 			// Read items from the collection
@@ -353,7 +353,7 @@ func (suite *CollectionUnitSuite) TestCollectionReadError() {
 		true,
 		false)
 
-	coll.Add(custom.ToLiteDriveItemable(stubItem))
+	coll.Add(custom.ToCustomDriveItem(stubItem))
 
 	collItem, ok := <-coll.Items(ctx, fault.New(true))
 	assert.True(t, ok)
@@ -423,7 +423,7 @@ func (suite *CollectionUnitSuite) TestCollectionReadUnauthorizedErrorRetry() {
 		count.New())
 	require.NoError(t, err, clues.ToCore(err))
 
-	coll.Add(custom.ToLiteDriveItemable(stubItem))
+	coll.Add(custom.ToCustomDriveItem(stubItem))
 
 	collItem, ok := <-coll.Items(ctx, fault.New(true))
 	assert.True(t, ok)
@@ -491,7 +491,7 @@ func (suite *CollectionUnitSuite) TestCollectionPermissionBackupLatestModTime() 
 		true,
 		false)
 
-	coll.Add(custom.ToLiteDriveItemable(stubItem))
+	coll.Add(custom.ToCustomDriveItem(stubItem))
 
 	coll.handler = mbh
 
@@ -642,7 +642,7 @@ func (suite *GetDriveItemUnitTestSuite) TestGetDriveItem_error() {
 
 			col.handler = mbh
 
-			_, err := col.getDriveItemContent(ctx, "driveID", custom.ToLiteDriveItemable(stubItem), errs)
+			_, err := col.getDriveItemContent(ctx, "driveID", custom.ToCustomDriveItem(stubItem), errs)
 			if test.err == nil {
 				assert.NoError(t, err, clues.ToCore(err))
 				return
@@ -820,7 +820,7 @@ func (suite *GetDriveItemUnitTestSuite) TestDownloadContent() {
 			mbh.GetResps = resps
 			mbh.GetErrs = test.getErr
 
-			r, err := downloadContent(ctx, mbh, test.muc, custom.ToLiteDriveItemable(item), driveID, count.New())
+			r, err := downloadContent(ctx, mbh, test.muc, custom.ToCustomDriveItem(item), driveID, count.New())
 			test.expect(t, r)
 			test.expectErr(t, err, clues.ToCore(err))
 		})
@@ -1021,7 +1021,7 @@ func (suite *CollectionUnitSuite) TestItemExtensions() {
 				true,
 				false)
 
-			coll.Add(custom.ToLiteDriveItemable(stubItem))
+			coll.Add(custom.ToCustomDriveItem(stubItem))
 
 			collItem, ok := <-coll.Items(ctx, fault.New(true))
 			assert.True(t, ok)

--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -944,6 +944,9 @@ func (c *Collections) processItem(
 	skipper fault.AddSkipper,
 ) error {
 	var (
+		// Convert the DriveItemable retrieved from graph SDK to custom DriveItem
+		// which only stores the properties corso cares about during the backup
+		// operation. This is a memory optimization.
 		item     = custom.ToCustomDriveItem(di)
 		itemID   = ptr.Val(item.GetId())
 		itemName = ptr.Val(item.GetName())

--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -956,8 +956,8 @@ func (c *Collections) processItem(
 		"item_is_folder", isFolder)
 
 	if item.GetMalware() != nil {
-		// TODO(pandeyabs): Fix this after we move conversion logic to the top of this
-		// func.
+		// TODO(pandeyabs): Fix this after we move the ToLiteDriveItemable call
+		// to the beginning of this func.
 		addtl := graph.ItemInfo(custom.ToLiteDriveItemable(item))
 		skip := fault.FileSkip(fault.SkipMalware, driveID, itemID, itemName, addtl)
 

--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -716,7 +716,7 @@ func (c *Collections) handleDelete(
 
 func (c *Collections) getCollectionPath(
 	driveID string,
-	item custom.LiteDriveItemable,
+	item *custom.DriveItem,
 ) (path.Path, error) {
 	var (
 		pb     = odConsts.DriveFolderPrefixBuilder(driveID)
@@ -944,7 +944,7 @@ func (c *Collections) processItem(
 	skipper fault.AddSkipper,
 ) error {
 	var (
-		item     = custom.ToLiteDriveItemable(di)
+		item     = custom.ToCustomDriveItem(di)
 		itemID   = ptr.Val(item.GetId())
 		itemName = ptr.Val(item.GetName())
 		isFolder = item.GetFolder() != nil || item.GetPackageEscaped() != nil

--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -27,6 +27,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/pagers"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
 const (
@@ -955,7 +956,9 @@ func (c *Collections) processItem(
 		"item_is_folder", isFolder)
 
 	if item.GetMalware() != nil {
-		addtl := graph.ItemInfo(item)
+		// TODO(pandeyabs): Fix this after we move conversion logic to the top of this
+		// func.
+		addtl := graph.ItemInfo(custom.ToLiteDriveItemable(item))
 		skip := fault.FileSkip(fault.SkipMalware, driveID, itemID, itemName, addtl)
 
 		if isFolder {

--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -716,7 +716,7 @@ func (c *Collections) handleDelete(
 
 func (c *Collections) getCollectionPath(
 	driveID string,
-	item models.DriveItemable,
+	item custom.LiteDriveItemable,
 ) (path.Path, error) {
 	var (
 		pb     = odConsts.DriveFolderPrefixBuilder(driveID)
@@ -931,7 +931,7 @@ func (c *Collections) PopulateDriveCollections(
 
 func (c *Collections) processItem(
 	ctx context.Context,
-	item models.DriveItemable,
+	di models.DriveItemable,
 	driveID, driveName string,
 	oldPrevPaths, currPrevPaths, newPrevPaths map[string]string,
 	seenFolders map[string]string,
@@ -944,6 +944,7 @@ func (c *Collections) processItem(
 	skipper fault.AddSkipper,
 ) error {
 	var (
+		item     = custom.ToLiteDriveItemable(di)
 		itemID   = ptr.Val(item.GetId())
 		itemName = ptr.Val(item.GetName())
 		isFolder = item.GetFolder() != nil || item.GetPackageEscaped() != nil
@@ -956,9 +957,7 @@ func (c *Collections) processItem(
 		"item_is_folder", isFolder)
 
 	if item.GetMalware() != nil {
-		// TODO(pandeyabs): Fix this after we move the ToLiteDriveItemable call
-		// to the beginning of this func.
-		addtl := graph.ItemInfo(custom.ToLiteDriveItemable(item))
+		addtl := graph.ItemInfo(item)
 		skip := fault.FileSkip(fault.SkipMalware, driveID, itemID, itemName, addtl)
 
 		if isFolder {

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -577,7 +577,7 @@ func (c *Collections) addFileToTree(
 			driveID,
 			fileID,
 			fileName,
-			graph.ItemInfo(file))
+			graph.ItemInfo(custom.ToCustomDriveItem(file)))
 
 		logger.Ctx(ctx).Infow("malware file detected")
 

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -19,6 +19,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/pagers"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
 // ---------------------------------------------------------------------------
@@ -475,7 +476,7 @@ func (c *Collections) addFolderToTree(
 			driveID,
 			folderID,
 			folderName,
-			graph.ItemInfo(folder))
+			graph.ItemInfo(custom.ToLiteDriveItemable(folder)))
 
 		logger.Ctx(ctx).Infow("malware folder detected")
 

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -476,7 +476,7 @@ func (c *Collections) addFolderToTree(
 			driveID,
 			folderID,
 			folderName,
-			graph.ItemInfo(custom.ToLiteDriveItemable(folder)))
+			graph.ItemInfo(custom.ToCustomDriveItem(folder)))
 
 		logger.Ctx(ctx).Infow("malware folder detected")
 

--- a/src/internal/m365/collection/drive/group_handler.go
+++ b/src/internal/m365/collection/drive/group_handler.go
@@ -105,7 +105,7 @@ func (h groupBackupHandler) SitePathPrefix(tenantID string) (path.Path, error) {
 func (h groupBackupHandler) AugmentItemInfo(
 	dii details.ItemInfo,
 	resource idname.Provider,
-	item custom.LiteDriveItemable,
+	item *custom.DriveItem,
 	size int64,
 	parentPath *path.Builder,
 ) details.ItemInfo {

--- a/src/internal/m365/collection/drive/group_handler.go
+++ b/src/internal/m365/collection/drive/group_handler.go
@@ -2,7 +2,6 @@ package drive
 
 import (
 	"github.com/alcionai/clues"
-	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
 	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/common/ptr"
@@ -11,6 +10,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
 var _ BackupHandler = &groupBackupHandler{}
@@ -105,7 +105,7 @@ func (h groupBackupHandler) SitePathPrefix(tenantID string) (path.Path, error) {
 func (h groupBackupHandler) AugmentItemInfo(
 	dii details.ItemInfo,
 	resource idname.Provider,
-	item models.DriveItemable,
+	item custom.LiteDriveItemable,
 	size int64,
 	parentPath *path.Builder,
 ) details.ItemInfo {

--- a/src/internal/m365/collection/drive/handler_utils.go
+++ b/src/internal/m365/collection/drive/handler_utils.go
@@ -7,7 +7,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
-func getItemCreator(item custom.LiteDriveItemable) string {
+func getItemCreator(item *custom.DriveItem) string {
 	if item.GetCreatedBy() == nil || item.GetCreatedBy().GetUser() == nil {
 		return ""
 	}
@@ -29,7 +29,7 @@ func getItemCreator(item custom.LiteDriveItemable) string {
 	return *ed.(*string)
 }
 
-func getItemDriveInfo(item custom.LiteDriveItemable) (string, string) {
+func getItemDriveInfo(item *custom.DriveItem) (string, string) {
 	if item.GetParentReference() == nil {
 		return "", ""
 	}

--- a/src/internal/m365/collection/drive/handler_utils.go
+++ b/src/internal/m365/collection/drive/handler_utils.go
@@ -3,12 +3,11 @@ package drive
 import (
 	"strings"
 
-	"github.com/microsoftgraph/msgraph-sdk-go/models"
-
 	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
-func getItemCreator(item models.DriveItemable) string {
+func getItemCreator(item custom.LiteDriveItemable) string {
 	if item.GetCreatedBy() == nil || item.GetCreatedBy().GetUser() == nil {
 		return ""
 	}
@@ -30,7 +29,7 @@ func getItemCreator(item models.DriveItemable) string {
 	return *ed.(*string)
 }
 
-func getItemDriveInfo(item models.DriveItemable) (string, string) {
+func getItemDriveInfo(item custom.LiteDriveItemable) (string, string) {
 	if item.GetParentReference() == nil {
 		return "", ""
 	}

--- a/src/internal/m365/collection/drive/handlers.go
+++ b/src/internal/m365/collection/drive/handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/pagers"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
 type ItemInfoAugmenter interface {
@@ -23,7 +24,7 @@ type ItemInfoAugmenter interface {
 	AugmentItemInfo(
 		dii details.ItemInfo,
 		resource idname.Provider,
-		item models.DriveItemable,
+		item custom.LiteDriveItemable,
 		size int64,
 		parentPath *path.Builder,
 	) details.ItemInfo

--- a/src/internal/m365/collection/drive/handlers.go
+++ b/src/internal/m365/collection/drive/handlers.go
@@ -24,7 +24,7 @@ type ItemInfoAugmenter interface {
 	AugmentItemInfo(
 		dii details.ItemInfo,
 		resource idname.Provider,
-		item custom.LiteDriveItemable,
+		item *custom.DriveItem,
 		size int64,
 		parentPath *path.Builder,
 	) details.ItemInfo

--- a/src/internal/m365/collection/drive/item.go
+++ b/src/internal/m365/collection/drive/item.go
@@ -7,7 +7,6 @@ import (
 	"io"
 
 	"github.com/alcionai/clues"
-	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"golang.org/x/exp/maps"
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
@@ -18,6 +17,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
 const (
@@ -34,7 +34,7 @@ var downloadURLKeys = []string{
 func downloadItem(
 	ctx context.Context,
 	ag api.Getter,
-	item models.DriveItemable,
+	item custom.LiteDriveItemable,
 ) (io.ReadCloser, error) {
 	if item == nil {
 		return nil, clues.New("nil item")
@@ -152,7 +152,7 @@ func downloadItemMeta(
 	ctx context.Context,
 	getter GetItemPermissioner,
 	driveID string,
-	item models.DriveItemable,
+	item custom.LiteDriveItemable,
 ) (io.ReadCloser, int, error) {
 	meta := metadata.Metadata{
 		FileName:    ptr.Val(item.GetName()),
@@ -203,14 +203,4 @@ func driveItemWriter(
 		counter)
 
 	return iw, ptr.Val(icu.GetUploadUrl()), nil
-}
-
-func setName(orig models.ItemReferenceable, driveName string) models.ItemReferenceable {
-	if orig == nil {
-		return nil
-	}
-
-	orig.SetName(&driveName)
-
-	return orig
 }

--- a/src/internal/m365/collection/drive/item.go
+++ b/src/internal/m365/collection/drive/item.go
@@ -34,7 +34,7 @@ var downloadURLKeys = []string{
 func downloadItem(
 	ctx context.Context,
 	ag api.Getter,
-	item custom.LiteDriveItemable,
+	item *custom.DriveItem,
 ) (io.ReadCloser, error) {
 	if item == nil {
 		return nil, clues.New("nil item")
@@ -152,7 +152,7 @@ func downloadItemMeta(
 	ctx context.Context,
 	getter GetItemPermissioner,
 	driveID string,
-	item custom.LiteDriveItemable,
+	item *custom.DriveItem,
 ) (io.ReadCloser, int, error) {
 	meta := metadata.Metadata{
 		FileName:    ptr.Val(item.GetName()),

--- a/src/internal/m365/collection/drive/item_test.go
+++ b/src/internal/m365/collection/drive/item_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
 type ItemIntegrationSuite struct {
@@ -123,7 +124,7 @@ func (suite *ItemIntegrationSuite) TestItemReader_oneDrive() {
 	}
 
 	// Read data for the file
-	itemData, err := downloadItem(ctx, bh, driveItem)
+	itemData, err := downloadItem(ctx, bh, custom.ToLiteDriveItemable(driveItem))
 	require.NoError(t, err, clues.ToCore(err))
 
 	size, err := io.Copy(io.Discard, itemData)
@@ -462,7 +463,7 @@ func (suite *ItemUnitTestSuite) TestDownloadItem() {
 			mg := mockGetter{
 				GetFunc: test.GetFunc,
 			}
-			rc, err := downloadItem(ctx, mg, test.itemFunc())
+			rc, err := downloadItem(ctx, mg, custom.ToLiteDriveItemable(test.itemFunc()))
 			test.errorExpected(t, err, clues.ToCore(err))
 			test.rcExpected(t, rc)
 		})
@@ -521,7 +522,7 @@ func (suite *ItemUnitTestSuite) TestDownloadItem_ConnectionResetErrorOnFirstRead
 	mg := mockGetter{
 		GetFunc: GetFunc,
 	}
-	rc, err := downloadItem(ctx, mg, itemFunc())
+	rc, err := downloadItem(ctx, mg, custom.ToLiteDriveItemable(itemFunc()))
 	errorExpected(t, err, clues.ToCore(err))
 	rcExpected(t, rc)
 

--- a/src/internal/m365/collection/drive/item_test.go
+++ b/src/internal/m365/collection/drive/item_test.go
@@ -124,7 +124,7 @@ func (suite *ItemIntegrationSuite) TestItemReader_oneDrive() {
 	}
 
 	// Read data for the file
-	itemData, err := downloadItem(ctx, bh, custom.ToLiteDriveItemable(driveItem))
+	itemData, err := downloadItem(ctx, bh, custom.ToCustomDriveItem(driveItem))
 	require.NoError(t, err, clues.ToCore(err))
 
 	size, err := io.Copy(io.Discard, itemData)
@@ -463,7 +463,7 @@ func (suite *ItemUnitTestSuite) TestDownloadItem() {
 			mg := mockGetter{
 				GetFunc: test.GetFunc,
 			}
-			rc, err := downloadItem(ctx, mg, custom.ToLiteDriveItemable(test.itemFunc()))
+			rc, err := downloadItem(ctx, mg, custom.ToCustomDriveItem(test.itemFunc()))
 			test.errorExpected(t, err, clues.ToCore(err))
 			test.rcExpected(t, rc)
 		})
@@ -522,7 +522,7 @@ func (suite *ItemUnitTestSuite) TestDownloadItem_ConnectionResetErrorOnFirstRead
 	mg := mockGetter{
 		GetFunc: GetFunc,
 	}
-	rc, err := downloadItem(ctx, mg, custom.ToLiteDriveItemable(itemFunc()))
+	rc, err := downloadItem(ctx, mg, custom.ToCustomDriveItem(itemFunc()))
 	errorExpected(t, err, clues.ToCore(err))
 	rcExpected(t, rc)
 

--- a/src/internal/m365/collection/drive/restore.go
+++ b/src/internal/m365/collection/drive/restore.go
@@ -864,7 +864,7 @@ func restoreFile(
 	dii := ir.AugmentItemInfo(
 		details.ItemInfo{},
 		rcc.ProtectedResource,
-		custom.ToLiteDriveItemable(newItem),
+		custom.ToCustomDriveItem(newItem),
 		written,
 		nil)
 

--- a/src/internal/m365/collection/drive/restore.go
+++ b/src/internal/m365/collection/drive/restore.go
@@ -30,6 +30,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
 const (
@@ -863,7 +864,7 @@ func restoreFile(
 	dii := ir.AugmentItemInfo(
 		details.ItemInfo{},
 		rcc.ProtectedResource,
-		newItem,
+		custom.ToLiteDriveItemable(newItem),
 		written,
 		nil)
 

--- a/src/internal/m365/collection/drive/site_handler.go
+++ b/src/internal/m365/collection/drive/site_handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/pagers"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
 type baseSiteHandler struct {
@@ -33,7 +34,7 @@ func (h baseSiteHandler) NewDrivePager(
 func (h baseSiteHandler) AugmentItemInfo(
 	dii details.ItemInfo,
 	resource idname.Provider,
-	item models.DriveItemable,
+	item custom.LiteDriveItemable,
 	size int64,
 	parentPath *path.Builder,
 ) details.ItemInfo {

--- a/src/internal/m365/collection/drive/site_handler.go
+++ b/src/internal/m365/collection/drive/site_handler.go
@@ -34,7 +34,7 @@ func (h baseSiteHandler) NewDrivePager(
 func (h baseSiteHandler) AugmentItemInfo(
 	dii details.ItemInfo,
 	resource idname.Provider,
-	item custom.LiteDriveItemable,
+	item *custom.DriveItem,
 	size int64,
 	parentPath *path.Builder,
 ) details.ItemInfo {

--- a/src/internal/m365/collection/drive/user_drive_handler.go
+++ b/src/internal/m365/collection/drive/user_drive_handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/pagers"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
 // ---------------------------------------------------------------------------
@@ -42,7 +43,7 @@ func (h baseUserDriveHandler) NewDrivePager(
 func (h baseUserDriveHandler) AugmentItemInfo(
 	dii details.ItemInfo,
 	resource idname.Provider,
-	item models.DriveItemable,
+	item custom.LiteDriveItemable,
 	size int64,
 	parentPath *path.Builder,
 ) details.ItemInfo {

--- a/src/internal/m365/collection/drive/user_drive_handler.go
+++ b/src/internal/m365/collection/drive/user_drive_handler.go
@@ -43,7 +43,7 @@ func (h baseUserDriveHandler) NewDrivePager(
 func (h baseUserDriveHandler) AugmentItemInfo(
 	dii details.ItemInfo,
 	resource idname.Provider,
-	item custom.LiteDriveItemable,
+	item *custom.DriveItem,
 	size int64,
 	parentPath *path.Builder,
 ) details.ItemInfo {

--- a/src/internal/m365/service/onedrive/mock/handlers.go
+++ b/src/internal/m365/service/onedrive/mock/handlers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	apiMock "github.com/alcionai/corso/src/pkg/services/m365/api/mock"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/pagers"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
 // ---------------------------------------------------------------------------
@@ -165,7 +166,7 @@ func (h BackupHandler[T]) NewLocationIDer(driveID string, elems ...string) detai
 func (h BackupHandler[T]) AugmentItemInfo(
 	details.ItemInfo,
 	idname.Provider,
-	models.DriveItemable,
+	custom.LiteDriveItemable,
 	int64,
 	*path.Builder,
 ) details.ItemInfo {
@@ -405,7 +406,7 @@ func (h RestoreHandler) NewDrivePager(string, []string) pagers.NonDeltaHandler[m
 func (h *RestoreHandler) AugmentItemInfo(
 	details.ItemInfo,
 	idname.Provider,
-	models.DriveItemable,
+	custom.LiteDriveItemable,
 	int64,
 	*path.Builder,
 ) details.ItemInfo {

--- a/src/internal/m365/service/onedrive/mock/handlers.go
+++ b/src/internal/m365/service/onedrive/mock/handlers.go
@@ -166,7 +166,7 @@ func (h BackupHandler[T]) NewLocationIDer(driveID string, elems ...string) detai
 func (h BackupHandler[T]) AugmentItemInfo(
 	details.ItemInfo,
 	idname.Provider,
-	custom.LiteDriveItemable,
+	*custom.DriveItem,
 	int64,
 	*path.Builder,
 ) details.ItemInfo {
@@ -406,7 +406,7 @@ func (h RestoreHandler) NewDrivePager(string, []string) pagers.NonDeltaHandler[m
 func (h *RestoreHandler) AugmentItemInfo(
 	details.ItemInfo,
 	idname.Provider,
-	custom.LiteDriveItemable,
+	*custom.DriveItem,
 	int64,
 	*path.Builder,
 ) details.ItemInfo {

--- a/src/pkg/services/m365/api/graph/errors.go
+++ b/src/pkg/services/m365/api/graph/errors.go
@@ -10,7 +10,6 @@ import (
 	"syscall"
 
 	"github.com/alcionai/clues"
-	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 	"github.com/pkg/errors"
 
@@ -20,6 +19,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/str"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/filters"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
 // ---------------------------------------------------------------------------
@@ -517,18 +517,20 @@ func appendIf(a []any, k string, v *string) []any {
 
 // ItemInfo gathers potentially useful information about a drive item,
 // and aggregates that data into a map.
-func ItemInfo(item models.DriveItemable) map[string]any {
+func ItemInfo(item custom.LiteDriveItemable) map[string]any {
 	m := map[string]any{}
 
-	creator := item.GetCreatedByUser()
-	if creator != nil {
-		m[fault.AddtlCreatedBy] = ptr.Val(creator.GetId())
-	}
+	// TODO(pandeyabs): These fields are not available in the LiteDriveItemable
+	// yet. We need to add them.
+	// creator := item.GetCreatedByUser()
+	// if creator != nil {
+	// 	m[fault.AddtlCreatedBy] = ptr.Val(creator.GetId())
+	// }
 
-	lastmodder := item.GetLastModifiedByUser()
-	if lastmodder != nil {
-		m[fault.AddtlLastModBy] = ptr.Val(lastmodder.GetId())
-	}
+	// lastmodder := item.GetLastModifiedByUser()
+	// if lastmodder != nil {
+	// 	m[fault.AddtlLastModBy] = ptr.Val(lastmodder.GetId())
+	// }
 
 	parent := item.GetParentReference()
 	if parent != nil {
@@ -545,10 +547,10 @@ func ItemInfo(item models.DriveItemable) map[string]any {
 		m[fault.AddtlContainerPath] = containerPath
 	}
 
-	malware := item.GetMalware()
-	if malware != nil {
-		m[fault.AddtlMalwareDesc] = ptr.Val(malware.GetDescription())
-	}
+	// malware := item.GetMalware()
+	// if malware != nil {
+	// 	m[fault.AddtlMalwareDesc] = ptr.Val(malware.GetDescription())
+	// }
 
 	return m
 }

--- a/src/pkg/services/m365/api/graph/errors.go
+++ b/src/pkg/services/m365/api/graph/errors.go
@@ -517,7 +517,7 @@ func appendIf(a []any, k string, v *string) []any {
 
 // ItemInfo gathers potentially useful information about a drive item,
 // and aggregates that data into a map.
-func ItemInfo(item custom.LiteDriveItemable) map[string]any {
+func ItemInfo(item *custom.DriveItem) map[string]any {
 	m := map[string]any{}
 
 	creator := item.GetCreatedByUser()

--- a/src/pkg/services/m365/api/graph/errors.go
+++ b/src/pkg/services/m365/api/graph/errors.go
@@ -520,17 +520,15 @@ func appendIf(a []any, k string, v *string) []any {
 func ItemInfo(item custom.LiteDriveItemable) map[string]any {
 	m := map[string]any{}
 
-	// TODO(pandeyabs): These fields are not available in the LiteDriveItemable
-	// yet. We need to add them.
-	// creator := item.GetCreatedByUser()
-	// if creator != nil {
-	// 	m[fault.AddtlCreatedBy] = ptr.Val(creator.GetId())
-	// }
+	creator := item.GetCreatedByUser()
+	if creator != nil {
+		m[fault.AddtlCreatedBy] = ptr.Val(creator.GetId())
+	}
 
-	// lastmodder := item.GetLastModifiedByUser()
-	// if lastmodder != nil {
-	// 	m[fault.AddtlLastModBy] = ptr.Val(lastmodder.GetId())
-	// }
+	lastmodder := item.GetLastModifiedByUser()
+	if lastmodder != nil {
+		m[fault.AddtlLastModBy] = ptr.Val(lastmodder.GetId())
+	}
 
 	parent := item.GetParentReference()
 	if parent != nil {
@@ -547,10 +545,10 @@ func ItemInfo(item custom.LiteDriveItemable) map[string]any {
 		m[fault.AddtlContainerPath] = containerPath
 	}
 
-	// malware := item.GetMalware()
-	// if malware != nil {
-	// 	m[fault.AddtlMalwareDesc] = ptr.Val(malware.GetDescription())
-	// }
+	malware := item.GetMalware()
+	if malware != nil {
+		m[fault.AddtlMalwareDesc] = ptr.Val(malware.GetDescription())
+	}
 
 	return m
 }

--- a/src/pkg/services/m365/api/graph/errors_test.go
+++ b/src/pkg/services/m365/api/graph/errors_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/fault"
 	graphTD "github.com/alcionai/corso/src/pkg/services/m365/api/graph/testdata"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
 type GraphErrorsUnitSuite struct {
@@ -566,7 +567,7 @@ func (suite *GraphErrorsUnitSuite) TestMalwareInfo() {
 		fault.AddtlMalwareDesc:   malDesc,
 	}
 
-	assert.Equal(suite.T(), expect, ItemInfo(i))
+	assert.Equal(suite.T(), expect, ItemInfo(custom.ToLiteDriveItemable(i)))
 }
 
 func (suite *GraphErrorsUnitSuite) TestIsErrFolderExists() {

--- a/src/pkg/services/m365/api/graph/errors_test.go
+++ b/src/pkg/services/m365/api/graph/errors_test.go
@@ -567,7 +567,7 @@ func (suite *GraphErrorsUnitSuite) TestMalwareInfo() {
 		fault.AddtlMalwareDesc:   malDesc,
 	}
 
-	assert.Equal(suite.T(), expect, ItemInfo(custom.ToLiteDriveItemable(i)))
+	assert.Equal(suite.T(), expect, ItemInfo(custom.ToCustomDriveItem(i)))
 }
 
 func (suite *GraphErrorsUnitSuite) TestIsErrFolderExists() {

--- a/src/pkg/services/m365/custom/drive_item.go
+++ b/src/pkg/services/m365/custom/drive_item.go
@@ -362,7 +362,6 @@ func ToCustomDriveItem(item models.DriveItemable) *DriveItem {
 	return di
 }
 
-// TODO(pandeyabs): This could replace `SetParentReference` method.
 func SetParentName(orig *itemReference, driveName string) *itemReference {
 	if orig == nil {
 		return nil

--- a/src/pkg/services/m365/custom/drive_item.go
+++ b/src/pkg/services/m365/custom/drive_item.go
@@ -361,3 +361,14 @@ func ToCustomDriveItem(item models.DriveItemable) *DriveItem {
 
 	return di
 }
+
+func SetParentName(orig parentReferenceable, driveName string) parentReferenceable {
+	if orig == nil {
+		return nil
+	}
+
+	pr := orig.(*parentRef)
+	pr.name = driveName
+
+	return pr
+}

--- a/src/pkg/services/m365/custom/drive_item.go
+++ b/src/pkg/services/m365/custom/drive_item.go
@@ -362,13 +362,13 @@ func ToCustomDriveItem(item models.DriveItemable) *DriveItem {
 	return di
 }
 
-func SetParentName(orig itemReferenceable, driveName string) itemReferenceable {
+// TODO(pandeyabs): This could replace `SetParentReference` method.
+func SetParentName(orig *itemReference, driveName string) *itemReference {
 	if orig == nil {
 		return nil
 	}
 
-	pr := orig.(*parentRef)
-	pr.name = driveName
+	orig.name = &driveName
 
-	return pr
+	return orig
 }

--- a/src/pkg/services/m365/custom/drive_item.go
+++ b/src/pkg/services/m365/custom/drive_item.go
@@ -362,7 +362,7 @@ func ToCustomDriveItem(item models.DriveItemable) *DriveItem {
 	return di
 }
 
-func SetParentName(orig parentReferenceable, driveName string) parentReferenceable {
+func SetParentName(orig itemReferenceable, driveName string) itemReferenceable {
 	if orig == nil {
 		return nil
 	}

--- a/src/pkg/services/m365/custom/drive_item_test.go
+++ b/src/pkg/services/m365/custom/drive_item_test.go
@@ -527,3 +527,65 @@ func (suite *driveItemUnitSuite) TestToLiteDriveItemable() {
 		})
 	}
 }
+
+func (suite *driveItemUnitSuite) TestSetParentName() {
+	parentID := "parentID"
+	parentPath := "/parentPath"
+	parentName := "parentName"
+	parentDriveID := "parentDriveID"
+
+	table := []struct {
+		name         string
+		driveName    string
+		itemFunc     func() *itemReference
+		validateFunc func(
+			t *testing.T,
+			expected *itemReference,
+			got *itemReference)
+	}{
+		{
+			name: "nil item",
+			itemFunc: func() *itemReference {
+				return nil
+			},
+			validateFunc: func(
+				t *testing.T,
+				expected *itemReference,
+				got *itemReference,
+			) {
+				require.Nil(t, got)
+			},
+		},
+		{
+			name:      "set name",
+			driveName: "testDrive",
+			itemFunc: func() *itemReference {
+				return &itemReference{
+					id:      &parentID,
+					path:    &parentPath,
+					name:    &parentName,
+					driveID: &parentDriveID,
+				}
+			},
+			validateFunc: func(
+				t *testing.T,
+				expected *itemReference,
+				got *itemReference,
+			) {
+				assert.Equal(t, ptr.Val(got.name), "testDrive")
+				assert.Equal(t, ptr.Val(got.id), ptr.Val(expected.id))
+				assert.Equal(t, ptr.Val(got.path), ptr.Val(expected.path))
+				assert.Equal(t, ptr.Val(got.driveID), ptr.Val(expected.driveID))
+			},
+		},
+	}
+
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			orig := test.itemFunc()
+
+			got := SetParentName(orig, test.driveName)
+			test.validateFunc(suite.T(), orig, got)
+		})
+	}
+}


### PR DESCRIPTION
<!-- PR description-->

Switch to using `custom.DriveItem` instead of `models.DriveItemable` during backups. There is a slight impact to restore as well, since backup and restore both use a few common interfaces e.g. `AugmentItemInfo`. 

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
