### PR TITLE
produce global excludes using tree

### DIFF
--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -292,11 +292,11 @@ func DeserializeMap[T any](reader io.ReadCloser, alreadyFound map[string]T) erro
 func (c *Collections) Get(
 	ctx context.Context,
 	prevMetadata []data.RestoreCollection,
-	ssmb *prefixmatcher.StringSetMatchBuilder,
+	globalExcludeItemIDs *prefixmatcher.StringSetMatchBuilder,
 	errs *fault.Bus,
 ) ([]data.BackupCollection, bool, error) {
 	if c.ctrl.ToggleFeatures.UseDeltaTree {
-		colls, canUsePrevBackup, err := c.getTree(ctx, prevMetadata, ssmb, errs)
+		colls, canUsePrevBackup, err := c.getTree(ctx, prevMetadata, globalExcludeItemIDs, errs)
 		if err != nil && !errors.Is(err, errGetTreeNotImplemented) {
 			return nil, false, clues.Wrap(err, "processing backup using tree")
 		}
@@ -457,7 +457,7 @@ func (c *Collections) Get(
 				return nil, false, clues.WrapWC(ictx, err, "making exclude prefix")
 			}
 
-			ssmb.Add(p.String(), excludedItemIDs)
+			globalExcludeItemIDs.Add(p.String(), excludedItemIDs)
 
 			continue
 		}

--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -457,7 +457,7 @@ func (c *Collections) Get(
 				return nil, false, clues.WrapWC(ictx, err, "making exclude prefix")
 			}
 
-			ssmb.Add(p.String(), excludedItemIDs)
+			globalExcludeItemIDs.Add(p.String(), excludedItemIDs)
 
 			continue
 		}

--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -457,7 +457,7 @@ func (c *Collections) Get(
 				return nil, false, clues.WrapWC(ictx, err, "making exclude prefix")
 			}
 
-			globalExcludeItemIDs.Add(p.String(), excludedItemIDs)
+			ssmb.Add(p.String(), excludedItemIDs)
 
 			continue
 		}

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -33,7 +33,7 @@ import (
 func (c *Collections) getTree(
 	ctx context.Context,
 	prevMetadata []data.RestoreCollection,
-	ssmb *prefixmatcher.StringSetMatchBuilder,
+	globalExcludeItemIDs *prefixmatcher.StringSetMatchBuilder,
 	errs *fault.Bus,
 ) ([]data.BackupCollection, bool, error) {
 	ctx = clues.AddTraceName(ctx, "GetTree")

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -33,7 +33,7 @@ import (
 func (c *Collections) getTree(
 	ctx context.Context,
 	prevMetadata []data.RestoreCollection,
-	globalExcludeItemIDs *prefixmatcher.StringSetMatchBuilder,
+	ssmb *prefixmatcher.StringSetMatchBuilder,
 	errs *fault.Bus,
 ) ([]data.BackupCollection, bool, error) {
 	ctx = clues.AddTraceName(ctx, "GetTree")

--- a/src/internal/m365/collection/drive/collections_tree_test.go
+++ b/src/internal/m365/collection/drive/collections_tree_test.go
@@ -274,8 +274,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 			enumerator: mock.DriveEnumerator(
 				mock.Drive(id(drive)).With(
 					mock.Delta(id(delta), nil).With(
-						aPage(),
-					))),
+						aPage()))),
 			prevPaths: map[string]string{
 				id(folder): fullPath(name(folder)),
 			},
@@ -290,8 +289,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 			enumerator: mock.DriveEnumerator(
 				mock.Drive(id(drive)).With(
 					mock.Delta(id(delta), nil).With(
-						aPage(folderAtRoot(), fileAt(folder)),
-					))),
+						aPage(folderAtRoot(), fileAt(folder))))),
 			prevPaths: map[string]string{},
 			expectErr: require.NoError,
 			expectCounts: countTD.Expected{
@@ -304,8 +302,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 			enumerator: mock.DriveEnumerator(
 				mock.Drive(id(drive)).With(
 					mock.Delta(id(delta), nil).With(
-						aPage(folderAtRoot(), fileAt(folder)),
-					))),
+						aPage(folderAtRoot(), fileAt(folder))))),
 			prevPaths: map[string]string{
 				id(folder): fullPath(name(folder)),
 			},
@@ -321,8 +318,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 				mock.Drive(id(drive)).With(
 					mock.DeltaWReset(id(delta), nil).With(
 						aReset(),
-						aPage(),
-					))),
+						aPage()))),
 			prevPaths: map[string]string{},
 			expectErr: require.NoError,
 			expectCounts: countTD.Expected{
@@ -336,8 +332,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 				mock.Drive(id(drive)).With(
 					mock.DeltaWReset(id(delta), nil).With(
 						aReset(),
-						aPage(),
-					))),
+						aPage()))),
 			prevPaths: map[string]string{
 				id(folder): fullPath(name(folder)),
 			},
@@ -353,8 +348,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 				mock.Drive(id(drive)).With(
 					mock.DeltaWReset(id(delta), nil).With(
 						aReset(),
-						aPage(folderAtRoot(), fileAt(folder)),
-					))),
+						aPage(folderAtRoot(), fileAt(folder))))),
 			prevPaths: map[string]string{},
 			expectErr: require.NoError,
 			expectCounts: countTD.Expected{
@@ -368,8 +362,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 				mock.Drive(id(drive)).With(
 					mock.DeltaWReset(id(delta), nil).With(
 						aReset(),
-						aPage(folderAtRoot(), fileAt(folder)),
-					))),
+						aPage(folderAtRoot(), fileAt(folder))))),
 			prevPaths: map[string]string{
 				id(folder): fullPath(name(folder)),
 			},
@@ -398,6 +391,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 				test.prevPaths,
 				idx(delta, "prev"),
 				newPagerLimiter(control.DefaultOptions()),
+				prefixmatcher.NewStringSetBuilder(),
 				c.counter,
 				fault.New(true))
 
@@ -486,9 +480,10 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddPrevPathsToTree_errors
 
 func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections() {
 	type expected struct {
-		err         require.ErrorAssertionFunc
-		prevPaths   map[string]string
-		collections func(t *testing.T) expectedCollections
+		err                   require.ErrorAssertionFunc
+		prevPaths             map[string]string
+		collections           func(t *testing.T) expectedCollections
+		globalExcludedFileIDs map[string]struct{}
 	}
 
 	table := []struct {
@@ -527,6 +522,11 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 							nil,
 							id(file)))
 				},
+				globalExcludedFileIDs: makeExcludeMap(
+					idx(file, "r"),
+					idx(file, "p"),
+					idx(file, "d"),
+					id(file)),
 			},
 		},
 		{
@@ -564,6 +564,11 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 							id(file)),
 						aColl(nil, fullPathPath(t, namex(folder, "tombstone-prev"))))
 				},
+				globalExcludedFileIDs: makeExcludeMap(
+					idx(file, "r"),
+					idx(file, "p"),
+					idx(file, "d"),
+					id(file)),
 			},
 		},
 		{
@@ -601,6 +606,11 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 							id(file)),
 						aColl(nil, fullPathPath(t, namex(folder, "tombstone"))))
 				},
+				globalExcludedFileIDs: makeExcludeMap(
+					idx(file, "r"),
+					idx(file, "p"),
+					idx(file, "d"),
+					id(file)),
 			},
 		},
 	}
@@ -623,7 +633,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 				countPages = 1
 			}
 
-			colls, newPrevPaths, err := c.turnTreeIntoCollections(
+			colls, newPrevPaths, excluded, err := c.turnTreeIntoCollections(
 				ctx,
 				tree,
 				id(drive),
@@ -636,6 +646,8 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 			expectColls := test.expect.collections(t)
 			expectColls.compare(t, colls)
 			expectColls.requireNoUnseenCollections(t)
+
+			assert.Equal(t, test.expect.globalExcludedFileIDs, excluded)
 		})
 	}
 }
@@ -822,7 +834,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 		},
 		{
 			name: "many folders with files across multiple deltas",
-			tree: newFolderyMcFolderFace(nil, rootID),
+			tree: newTree,
 			enumerator: mock.DriveEnumerator(
 				mock.Drive(id(drive)).With(
 					mock.Delta(id(delta), nil).With(aPage(
@@ -1591,7 +1603,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 		},
 		{
 			name:    "tombstone new folder in unpopulated tree",
-			tree:    newFolderyMcFolderFace(nil, rootID),
+			tree:    newTree,
 			folder:  del,
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
@@ -1647,7 +1659,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 		},
 		{
 			name:    "already over container limit, folder seen twice",
-			tree:    treeWithFolders(),
+			tree:    treeWithFolders,
 			folder:  fld,
 			limiter: newPagerLimiter(minimumLimitOpts()),
 			expect: expected{
@@ -1667,7 +1679,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 		},
 		{
 			name:    "already at container limit",
-			tree:    treeWithRoot(),
+			tree:    treeWithRoot,
 			folder:  fld,
 			limiter: newPagerLimiter(minimumLimitOpts()),
 			expect: expected{
@@ -1862,7 +1874,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 		},
 		{
 			name: "many files in a hierarchy",
-			tree: treeWithRoot(),
+			tree: treeWithRoot,
 			page: aPage(
 				fileAtRoot(),
 				folderAtRoot(),
@@ -2038,7 +2050,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 				fault.New(true))
 			test.expect.err(t, err, clues.ToCore(err))
 
-			countSize := test.tree.countLiveFilesAndSizes()
+			countSize := tree.countLiveFilesAndSizes()
 			assert.Equal(t, test.expect.countLiveFiles, countSize.numFiles, "count of files")
 			assert.Equal(t, test.expect.countTotalBytes, countSize.totalBytes, "total size in bytes")
 			assert.Equal(t, test.expect.treeContainsFileIDsWithParent, tree.fileIDToParentID)

--- a/src/internal/m365/collection/drive/delta_tree.go
+++ b/src/internal/m365/collection/drive/delta_tree.go
@@ -4,12 +4,12 @@ import (
 	"context"
 
 	"github.com/alcionai/clues"
-	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive/metadata"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
 // folderyMcFolderFace owns our delta processing tree.
@@ -88,7 +88,7 @@ type nodeyMcNodeFace struct {
 	// folderID -> node
 	children map[string]*nodeyMcNodeFace
 	// file item ID -> file metadata
-	files map[string]models.DriveItemable
+	files map[string]*custom.DriveItem
 	// for special handling protocols around packages
 	isPackage bool
 }
@@ -103,7 +103,7 @@ func newNodeyMcNodeFace(
 		id:        id,
 		name:      name,
 		children:  map[string]*nodeyMcNodeFace{},
-		files:     map[string]models.DriveItemable{},
+		files:     map[string]*custom.DriveItem{},
 		isPackage: isPackage,
 	}
 }
@@ -314,7 +314,7 @@ func (face *folderyMcFolderFace) setPreviousPath(
 // this func will update and/or clean up all the old references.
 func (face *folderyMcFolderFace) addFile(
 	parentID, id string,
-	file models.DriveItemable,
+	file *custom.DriveItem,
 ) error {
 	if len(parentID) == 0 {
 		return clues.New("item added without parent folder ID")
@@ -373,7 +373,7 @@ func (face *folderyMcFolderFace) deleteFile(id string) {
 
 type collectable struct {
 	currPath                  path.Path
-	files                     map[string]models.DriveItemable
+	files                     map[string]*custom.DriveItem
 	folderID                  string
 	isPackageOrChildOfPackage bool
 	loc                       path.Elements
@@ -466,7 +466,8 @@ func (face *folderyMcFolderFace) generateExcludeItemIDs() map[string]struct{} {
 	}
 
 	for iID := range face.deletedFileIDs {
-		result[iID] = struct{}{}
+		result[iID+metadata.DataFileSuffix] = struct{}{}
+		result[iID+metadata.MetaFileSuffix] = struct{}{}
 	}
 
 	return result

--- a/src/internal/m365/collection/drive/delta_tree.go
+++ b/src/internal/m365/collection/drive/delta_tree.go
@@ -7,6 +7,7 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/internal/m365/collection/drive/metadata"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
 )
@@ -460,7 +461,8 @@ func (face *folderyMcFolderFace) generateExcludeItemIDs() map[string]struct{} {
 			continue
 		}
 
-		result[iID] = struct{}{}
+		result[iID+metadata.DataFileSuffix] = struct{}{}
+		result[iID+metadata.MetaFileSuffix] = struct{}{}
 	}
 
 	for iID := range face.deletedFileIDs {

--- a/src/internal/m365/collection/drive/delta_tree.go
+++ b/src/internal/m365/collection/drive/delta_tree.go
@@ -450,6 +450,26 @@ func walkTreeAndBuildCollections(
 	return nil
 }
 
+func (face *folderyMcFolderFace) generateExcludeItemIDs() map[string]struct{} {
+	result := map[string]struct{}{}
+
+	for iID, pID := range face.fileIDToParentID {
+		if _, itsAlive := face.folderIDToNode[pID]; !itsAlive {
+			// don't worry about items whose parents are tombstoned.
+			// those will get handled in the delete cascade.
+			continue
+		}
+
+		result[iID] = struct{}{}
+	}
+
+	for iID := range face.deletedFileIDs {
+		result[iID] = struct{}{}
+	}
+
+	return result
+}
+
 // ---------------------------------------------------------------------------
 // quantification
 // ---------------------------------------------------------------------------

--- a/src/internal/m365/collection/drive/delta_tree_test.go
+++ b/src/internal/m365/collection/drive/delta_tree_test.go
@@ -941,11 +941,9 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateExcludeItemIDs(
 			expect: map[string]struct{}{},
 		},
 		{
-			name: "one file in a folder",
-			tree: treeWithFileInFolder,
-			expect: map[string]struct{}{
-				id(file): {},
-			},
+			name:   "one file in a folder",
+			tree:   treeWithFileInFolder,
+			expect: makeExcludeMap(id(file)),
 		},
 		{
 			name:   "one file in a tombstone",
@@ -953,21 +951,18 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateExcludeItemIDs(
 			expect: map[string]struct{}{},
 		},
 		{
-			name: "one deleted file",
-			tree: treeWithDeletedFile,
-			expect: map[string]struct{}{
-				id(file, "d"): {},
-			},
+			name:   "one deleted file",
+			tree:   treeWithDeletedFile,
+			expect: makeExcludeMap(idx(file, "d")),
 		},
 		{
 			name: "files in folders and tombstones",
 			tree: fullTree,
-			expect: map[string]struct{}{
-				id(file):       {},
-				idx(file, "r"): {},
-				idx(file, "p"): {},
-				idx(file, "d"): {},
-			},
+			expect: makeExcludeMap(
+				id(file),
+				idx(file, "r"),
+				idx(file, "p"),
+				idx(file, "d")),
 		},
 	}
 	for _, test := range table {

--- a/src/internal/m365/collection/drive/helper_test.go
+++ b/src/internal/m365/collection/drive/helper_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 	apiMock "github.com/alcionai/corso/src/pkg/services/m365/api/mock"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
 const defaultItemSize int64 = 42
@@ -883,7 +884,7 @@ func treeWithFolders(t *testing.T) *folderyMcFolderFace {
 
 func treeWithFileAtRoot(t *testing.T) *folderyMcFolderFace {
 	tree := treeWithRoot(t)
-	tree.root.files[id(file)] = fileAtRoot()
+	tree.root.files[id(file)] = custom.ToCustomDriveItem(fileAtRoot())
 	tree.fileIDToParentID[id(file)] = rootID
 
 	return tree
@@ -898,7 +899,7 @@ func treeWithDeletedFile(t *testing.T) *folderyMcFolderFace {
 
 func treeWithFileInFolder(t *testing.T) *folderyMcFolderFace {
 	tree := treeWithFolders(t)
-	tree.folderIDToNode[id(folder)].files[id(file)] = fileAt(folder)
+	tree.folderIDToNode[id(folder)].files[id(file)] = custom.ToCustomDriveItem(fileAt(folder))
 	tree.fileIDToParentID[id(file)] = id(folder)
 
 	return tree
@@ -906,7 +907,7 @@ func treeWithFileInFolder(t *testing.T) *folderyMcFolderFace {
 
 func treeWithFileInTombstone(t *testing.T) *folderyMcFolderFace {
 	tree := treeWithTombstone(t)
-	tree.tombstones[id(folder)].files[id(file)] = fileAt("tombstone")
+	tree.tombstones[id(folder)].files[id(file)] = custom.ToCustomDriveItem(fileAt("tombstone"))
 	tree.fileIDToParentID[id(file)] = id(folder)
 
 	return tree

--- a/src/internal/m365/collection/drive/helper_test.go
+++ b/src/internal/m365/collection/drive/helper_test.go
@@ -889,6 +889,13 @@ func treeWithFileAtRoot(t *testing.T) *folderyMcFolderFace {
 	return tree
 }
 
+func treeWithDeletedFile(t *testing.T) *folderyMcFolderFace {
+	tree := treeWithRoot(t)
+	tree.deleteFile(idx(file, "d"))
+
+	return tree
+}
+
 func treeWithFileInFolder(t *testing.T) *folderyMcFolderFace {
 	tree := treeWithFolders(t)
 	tree.folderIDToNode[id(folder)].files[id(file)] = fileAt(folder)


### PR DESCRIPTION
produce the global excludes list using the delta tree by aggregating all file IDs whose parents directories are not tombstoned.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #4689

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
