### PR TITLE
swap tree file types for models.DriveItemable

### DIFF
--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -292,11 +292,11 @@ func DeserializeMap[T any](reader io.ReadCloser, alreadyFound map[string]T) erro
 func (c *Collections) Get(
 	ctx context.Context,
 	prevMetadata []data.RestoreCollection,
-	ssmb *prefixmatcher.StringSetMatchBuilder,
+	globalExcludeItemIDs *prefixmatcher.StringSetMatchBuilder,
 	errs *fault.Bus,
 ) ([]data.BackupCollection, bool, error) {
 	if c.ctrl.ToggleFeatures.UseDeltaTree {
-		colls, canUsePrevBackup, err := c.getTree(ctx, prevMetadata, ssmb, errs)
+		colls, canUsePrevBackup, err := c.getTree(ctx, prevMetadata, globalExcludeItemIDs, errs)
 		if err != nil && !errors.Is(err, errGetTreeNotImplemented) {
 			return nil, false, clues.Wrap(err, "processing backup using tree")
 		}
@@ -457,7 +457,7 @@ func (c *Collections) Get(
 				return nil, false, clues.WrapWC(ictx, err, "making exclude prefix")
 			}
 
-			ssmb.Add(p.String(), excludedItemIDs)
+			globalExcludeItemIDs.Add(p.String(), excludedItemIDs)
 
 			continue
 		}

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -575,15 +575,14 @@ func (c *Collections) addFileToTree(
 	counter *count.Bus,
 ) (*fault.Skipped, error) {
 	var (
-		driveID      = ptr.Val(drv.GetId())
-		fileID       = ptr.Val(file.GetId())
-		fileName     = ptr.Val(file.GetName())
-		fileSize     = ptr.Val(file.GetSize())
-		lastModified = ptr.Val(file.GetLastModifiedDateTime())
-		isDeleted    = file.GetDeleted() != nil
-		isMalware    = file.GetMalware() != nil
-		parent       = file.GetParentReference()
-		parentID     string
+		driveID   = ptr.Val(drv.GetId())
+		fileID    = ptr.Val(file.GetId())
+		fileName  = ptr.Val(file.GetName())
+		fileSize  = ptr.Val(file.GetSize())
+		isDeleted = file.GetDeleted() != nil
+		isMalware = file.GetMalware() != nil
+		parent    = file.GetParentReference()
+		parentID  string
 	)
 
 	if parent != nil {
@@ -640,7 +639,7 @@ func (c *Collections) addFileToTree(
 		}
 	}
 
-	err := tree.addFile(parentID, fileID, lastModified, fileSize)
+	err := tree.addFile(parentID, fileID, file)
 	if err != nil {
 		return nil, clues.StackWC(ctx, err)
 	}
@@ -846,6 +845,8 @@ func (c *Collections) turnTreeIntoCollections(
 		if err != nil {
 			return nil, nil, clues.StackWC(ctx, err)
 		}
+
+		coll.driveItems = cbl.files
 
 		collections = append(collections, coll)
 	}

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -34,7 +34,7 @@ import (
 func (c *Collections) getTree(
 	ctx context.Context,
 	prevMetadata []data.RestoreCollection,
-	ssmb *prefixmatcher.StringSetMatchBuilder,
+	globalExcludeItemIDsByDrivePrefix *prefixmatcher.StringSetMatchBuilder,
 	errs *fault.Bus,
 ) ([]data.BackupCollection, bool, error) {
 	ctx = clues.AddTraceName(ctx, "GetTree")
@@ -115,6 +115,7 @@ func (c *Collections) getTree(
 			prevPathsByDriveID[driveID],
 			deltasByDriveID[driveID],
 			limiter,
+			globalExcludeItemIDsByDrivePrefix,
 			cl,
 			el)
 		if err != nil {
@@ -169,6 +170,7 @@ func (c *Collections) makeDriveCollections(
 	prevPaths map[string]string,
 	prevDeltaLink string,
 	limiter *pagerLimiter,
+	globalExcludeItemIDsByDrivePrefix *prefixmatcher.StringSetMatchBuilder,
 	counter *count.Bus,
 	errs *fault.Bus,
 ) ([]data.BackupCollection, map[string]string, pagers.DeltaUpdate, error) {
@@ -215,7 +217,7 @@ func (c *Collections) makeDriveCollections(
 
 	// --- post-processing
 
-	collections, _, err := c.turnTreeIntoCollections(
+	collections, newPrevs, excludedItemIDs, err := c.turnTreeIntoCollections(
 		ctx,
 		tree,
 		driveID,
@@ -226,12 +228,20 @@ func (c *Collections) makeDriveCollections(
 		return nil, nil, pagers.DeltaUpdate{}, clues.Stack(err).Label(fault.LabelForceNoBackupCreation)
 	}
 
-	// this is a dumb hack to satisfy the linter.
-	if ctx == nil {
-		return nil, nil, du, nil
+	// only populate the global excluded items if no delta reset occurred.
+	// if a reset did occur, the collections should already be marked as
+	// "do not merge", therefore everything will get processed as a new addition.
+	if !tree.hadReset {
+		p, err := c.handler.CanonicalPath(odConsts.DriveFolderPrefixBuilder(driveID), c.tenantID)
+		if err != nil {
+			err = clues.WrapWC(ctx, err, "making canonical path for item exclusions")
+			return nil, nil, pagers.DeltaUpdate{}, err
+		}
+
+		globalExcludeItemIDsByDrivePrefix.Add(p.String(), excludedItemIDs)
 	}
 
-	return collections, nil, du, errGetTreeNotImplemented
+	return collections, newPrevs, du, nil
 }
 
 // populateTree constructs a new tree and populates it with items
@@ -406,12 +416,13 @@ func (c *Collections) enumeratePageOfItems(
 	ctx = clues.Add(ctx, "page_lenth", len(page))
 	el := errs.Local()
 
-	for i, item := range page {
+	for i, driveItem := range page {
 		if el.Failure() != nil {
 			break
 		}
 
 		var (
+			item     = custom.ToCustomDriveItem(driveItem)
 			isFolder = item.GetFolder() != nil || item.GetPackageEscaped() != nil
 			isFile   = item.GetFile() != nil
 			itemID   = ptr.Val(item.GetId())
@@ -457,7 +468,7 @@ func (c *Collections) addFolderToTree(
 	ctx context.Context,
 	tree *folderyMcFolderFace,
 	drv models.Driveable,
-	folder models.DriveItemable,
+	folder *custom.DriveItem,
 	limiter *pagerLimiter,
 	counter *count.Bus,
 ) (*fault.Skipped, error) {
@@ -506,7 +517,7 @@ func (c *Collections) addFolderToTree(
 			driveID,
 			folderID,
 			folderName,
-			graph.ItemInfo(custom.ToCustomDriveItem(folder)))
+			graph.ItemInfo(folder))
 
 		logger.Ctx(ctx).Infow("malware folder detected")
 
@@ -538,7 +549,7 @@ func (c *Collections) addFolderToTree(
 func (c *Collections) makeFolderCollectionPath(
 	ctx context.Context,
 	driveID string,
-	folder models.DriveItemable,
+	folder *custom.DriveItem,
 ) (path.Path, error) {
 	if folder.GetRoot() != nil {
 		pb := odConsts.DriveFolderPrefixBuilder(driveID)
@@ -570,7 +581,7 @@ func (c *Collections) addFileToTree(
 	ctx context.Context,
 	tree *folderyMcFolderFace,
 	drv models.Driveable,
-	file models.DriveItemable,
+	file *custom.DriveItem,
 	limiter *pagerLimiter,
 	counter *count.Bus,
 ) (*fault.Skipped, error) {
@@ -606,7 +617,7 @@ func (c *Collections) addFileToTree(
 			driveID,
 			fileID,
 			fileName,
-			graph.ItemInfo(custom.ToCustomDriveItem(file)))
+			graph.ItemInfo(file))
 
 		logger.Ctx(ctx).Infow("malware file detected")
 
@@ -783,10 +794,16 @@ func (c *Collections) turnTreeIntoCollections(
 	prevDeltaLink string,
 	countPagesInDelta int,
 	errs *fault.Bus,
-) ([]data.BackupCollection, map[string]string, error) {
+) (
+	[]data.BackupCollection,
+	map[string]string,
+	map[string]struct{},
+	error,
+) {
 	collectables, err := tree.generateCollectables()
 	if err != nil {
-		return nil, nil, clues.WrapWC(ctx, err, "generating backup collection data")
+		err = clues.WrapWC(ctx, err, "generating backup collection data")
+		return nil, nil, nil, err
 	}
 
 	var (
@@ -817,7 +834,7 @@ func (c *Collections) turnTreeIntoCollections(
 			c.counter.Local(),
 			errs)
 		if err != nil {
-			return nil, nil, clues.StackWC(ctx, err)
+			return nil, nil, nil, clues.StackWC(ctx, err)
 		}
 	}
 
@@ -843,7 +860,7 @@ func (c *Collections) turnTreeIntoCollections(
 			uc,
 			c.counter.Local())
 		if err != nil {
-			return nil, nil, clues.StackWC(ctx, err)
+			return nil, nil, nil, clues.StackWC(ctx, err)
 		}
 
 		coll.driveItems = cbl.files
@@ -851,5 +868,5 @@ func (c *Collections) turnTreeIntoCollections(
 		collections = append(collections, coll)
 	}
 
-	return collections, newPrevPaths, el.Failure()
+	return collections, newPrevPaths, tree.generateExcludeItemIDs(), el.Failure()
 }

--- a/src/internal/m365/collection/drive/collections_tree_test.go
+++ b/src/internal/m365/collection/drive/collections_tree_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/fault"
 	apiMock "github.com/alcionai/corso/src/pkg/services/m365/api/mock"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/pagers"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
 type CollectionsTreeUnitSuite struct {
@@ -274,8 +275,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 			enumerator: mock.DriveEnumerator(
 				mock.Drive(id(drive)).With(
 					mock.Delta(id(delta), nil).With(
-						aPage(),
-					))),
+						aPage()))),
 			prevPaths: map[string]string{
 				id(folder): fullPath(name(folder)),
 			},
@@ -290,8 +290,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 			enumerator: mock.DriveEnumerator(
 				mock.Drive(id(drive)).With(
 					mock.Delta(id(delta), nil).With(
-						aPage(folderAtRoot(), fileAt(folder)),
-					))),
+						aPage(folderAtRoot(), fileAt(folder))))),
 			prevPaths: map[string]string{},
 			expectErr: require.NoError,
 			expectCounts: countTD.Expected{
@@ -304,8 +303,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 			enumerator: mock.DriveEnumerator(
 				mock.Drive(id(drive)).With(
 					mock.Delta(id(delta), nil).With(
-						aPage(folderAtRoot(), fileAt(folder)),
-					))),
+						aPage(folderAtRoot(), fileAt(folder))))),
 			prevPaths: map[string]string{
 				id(folder): fullPath(name(folder)),
 			},
@@ -321,8 +319,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 				mock.Drive(id(drive)).With(
 					mock.DeltaWReset(id(delta), nil).With(
 						aReset(),
-						aPage(),
-					))),
+						aPage()))),
 			prevPaths: map[string]string{},
 			expectErr: require.NoError,
 			expectCounts: countTD.Expected{
@@ -336,8 +333,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 				mock.Drive(id(drive)).With(
 					mock.DeltaWReset(id(delta), nil).With(
 						aReset(),
-						aPage(),
-					))),
+						aPage()))),
 			prevPaths: map[string]string{
 				id(folder): fullPath(name(folder)),
 			},
@@ -353,8 +349,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 				mock.Drive(id(drive)).With(
 					mock.DeltaWReset(id(delta), nil).With(
 						aReset(),
-						aPage(folderAtRoot(), fileAt(folder)),
-					))),
+						aPage(folderAtRoot(), fileAt(folder))))),
 			prevPaths: map[string]string{},
 			expectErr: require.NoError,
 			expectCounts: countTD.Expected{
@@ -368,8 +363,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 				mock.Drive(id(drive)).With(
 					mock.DeltaWReset(id(delta), nil).With(
 						aReset(),
-						aPage(folderAtRoot(), fileAt(folder)),
-					))),
+						aPage(folderAtRoot(), fileAt(folder))))),
 			prevPaths: map[string]string{
 				id(folder): fullPath(name(folder)),
 			},
@@ -398,6 +392,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 				test.prevPaths,
 				idx(delta, "prev"),
 				newPagerLimiter(control.DefaultOptions()),
+				prefixmatcher.NewStringSetBuilder(),
 				c.counter,
 				fault.New(true))
 
@@ -486,8 +481,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddPrevPathsToTree_errors
 
 func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections() {
 	type expected struct {
-		prevPaths   map[string]string
-		collections func(t *testing.T) expectedCollections
+		prevPaths             map[string]string
+		collections           func(t *testing.T) expectedCollections
+		globalExcludedFileIDs map[string]struct{}
 	}
 
 	table := []struct {
@@ -525,6 +521,11 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 							nil,
 							id(file)))
 				},
+				globalExcludedFileIDs: makeExcludeMap(
+					idx(file, "r"),
+					idx(file, "p"),
+					idx(file, "d"),
+					id(file)),
 			},
 		},
 		{
@@ -561,6 +562,11 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 							id(file)),
 						aColl(nil, fullPathPath(t, namex(folder, "tombstone-prev"))))
 				},
+				globalExcludedFileIDs: makeExcludeMap(
+					idx(file, "r"),
+					idx(file, "p"),
+					idx(file, "d"),
+					id(file)),
 			},
 		},
 		{
@@ -633,6 +639,11 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 							id(file)),
 						aColl(nil, fullPathPath(t, namex(folder, "tombstone"))))
 				},
+				globalExcludedFileIDs: makeExcludeMap(
+					idx(file, "r"),
+					idx(file, "p"),
+					idx(file, "d"),
+					id(file)),
 			},
 		},
 	}
@@ -655,7 +666,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 				countPages = 1
 			}
 
-			colls, newPrevPaths, err := c.turnTreeIntoCollections(
+			colls, newPrevPaths, excluded, err := c.turnTreeIntoCollections(
 				ctx,
 				tree,
 				id(drive),
@@ -668,6 +679,8 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 			expectColls := test.expect.collections(t)
 			expectColls.compare(t, colls)
 			expectColls.requireNoUnseenCollections(t)
+
+			assert.Equal(t, test.expect.globalExcludedFileIDs, excluded)
 		})
 	}
 }
@@ -1522,11 +1535,14 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 	drv.SetId(ptr.To(id(drive)))
 	drv.SetName(ptr.To(name(drive)))
 
-	fld := folderAtRoot()
-	subFld := folderAtDeep(driveParentDir(drv, namex(folder, "parent")), idx(folder, "parent"))
-	pack := driveItem(id(pkg), name(pkg), parentDir(), rootID, isPackage)
-	del := delItem(id(folder), rootID, isFolder)
-	mal := malwareItem(idx(folder, "mal"), namex(folder, "mal"), parentDir(), rootID, isFolder)
+	var (
+		fld    = custom.ToCustomDriveItem(folderAtRoot())
+		subFld = custom.ToCustomDriveItem(folderAtDeep(driveParentDir(drv, namex(folder, "parent")), idx(folder, "parent")))
+		pack   = custom.ToCustomDriveItem(driveItem(id(pkg), name(pkg), parentDir(), rootID, isPackage))
+		del    = custom.ToCustomDriveItem(delItem(id(folder), rootID, isFolder))
+		mal    = custom.ToCustomDriveItem(
+			malwareItem(idx(folder, "mal"), namex(folder, "mal"), parentDir(), rootID, isFolder))
+	)
 
 	type expected struct {
 		countLiveFolders   int
@@ -1541,7 +1557,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 	table := []struct {
 		name    string
 		tree    func(t *testing.T) *folderyMcFolderFace
-		folder  models.DriveItemable
+		folder  *custom.DriveItem
 		limiter *pagerLimiter
 		expect  expected
 	}{
@@ -1819,7 +1835,10 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeFolderCollectionPath(
 
 			c := collWithMBH(mock.DefaultOneDriveBH(user))
 
-			p, err := c.makeFolderCollectionPath(ctx, id(drive), test.folder)
+			p, err := c.makeFolderCollectionPath(
+				ctx,
+				id(drive),
+				custom.ToCustomDriveItem(test.folder))
 			test.expectErr(t, err, clues.ToCore(err))
 
 			if err == nil {
@@ -2255,7 +2274,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 				ctx,
 				tree,
 				drv,
-				test.file,
+				custom.ToCustomDriveItem(test.file),
 				test.limiter,
 				counter)
 

--- a/src/internal/m365/collection/drive/collections_tree_test.go
+++ b/src/internal/m365/collection/drive/collections_tree_test.go
@@ -498,12 +498,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 		expect         expected
 	}{
 		{
-			name: "all new collections",
-			tree: fullTree,
-			prevPaths: map[string]string{
-				// required for NPE avoidance
-				idx(folder, "tombstone"): fullPath(namex(folder, "tombstone-prev")),
-			},
+			name:           "all new collections",
+			tree:           fullTree,
+			prevPaths:      map[string]string{},
 			enableURLCache: true,
 			expect: expected{
 				prevPaths: map[string]string{
@@ -526,8 +523,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 						aColl(
 							fullPathPath(t, namex(folder, "parent"), name(folder)),
 							nil,
-							id(file)),
-						aColl(nil, fullPathPath(t, namex(folder, "tombstone-prev"))))
+							id(file)))
 				},
 			},
 		},

--- a/src/internal/m365/collection/drive/delta_tree.go
+++ b/src/internal/m365/collection/drive/delta_tree.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/alcionai/clues"
-	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/internal/m365/collection/drive/metadata"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
 // folderyMcFolderFace owns our delta processing tree.
@@ -87,7 +88,7 @@ type nodeyMcNodeFace struct {
 	// folderID -> node
 	children map[string]*nodeyMcNodeFace
 	// file item ID -> file metadata
-	files map[string]models.DriveItemable
+	files map[string]*custom.DriveItem
 	// for special handling protocols around packages
 	isPackage bool
 }
@@ -102,7 +103,7 @@ func newNodeyMcNodeFace(
 		id:        id,
 		name:      name,
 		children:  map[string]*nodeyMcNodeFace{},
-		files:     map[string]models.DriveItemable{},
+		files:     map[string]*custom.DriveItem{},
 		isPackage: isPackage,
 	}
 }
@@ -313,7 +314,7 @@ func (face *folderyMcFolderFace) setPreviousPath(
 // this func will update and/or clean up all the old references.
 func (face *folderyMcFolderFace) addFile(
 	parentID, id string,
-	file models.DriveItemable,
+	file *custom.DriveItem,
 ) error {
 	if len(parentID) == 0 {
 		return clues.New("item added without parent folder ID")
@@ -372,7 +373,7 @@ func (face *folderyMcFolderFace) deleteFile(id string) {
 
 type collectable struct {
 	currPath                  path.Path
-	files                     map[string]models.DriveItemable
+	files                     map[string]*custom.DriveItem
 	folderID                  string
 	isPackageOrChildOfPackage bool
 	loc                       path.Elements
@@ -448,6 +449,28 @@ func walkTreeAndBuildCollections(
 	result[node.id] = cbl
 
 	return nil
+}
+
+func (face *folderyMcFolderFace) generateExcludeItemIDs() map[string]struct{} {
+	result := map[string]struct{}{}
+
+	for iID, pID := range face.fileIDToParentID {
+		if _, itsAlive := face.folderIDToNode[pID]; !itsAlive {
+			// don't worry about items whose parents are tombstoned.
+			// those will get handled in the delete cascade.
+			continue
+		}
+
+		result[iID+metadata.DataFileSuffix] = struct{}{}
+		result[iID+metadata.MetaFileSuffix] = struct{}{}
+	}
+
+	for iID := range face.deletedFileIDs {
+		result[iID+metadata.DataFileSuffix] = struct{}{}
+		result[iID+metadata.MetaFileSuffix] = struct{}{}
+	}
+
+	return result
 }
 
 // ---------------------------------------------------------------------------

--- a/src/internal/m365/collection/drive/delta_tree_test.go
+++ b/src/internal/m365/collection/drive/delta_tree_test.go
@@ -4,14 +4,15 @@ import (
 	"testing"
 
 	"github.com/alcionai/clues"
-	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/exp/maps"
 
+	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
 // ---------------------------------------------------------------------------
@@ -52,7 +53,7 @@ func (suite *DeltaTreeUnitSuite) TestNewNodeyMcNodeFace() {
 	assert.Equal(t, parent, nodeFace.parent)
 	assert.Equal(t, "id", nodeFace.id)
 	assert.Equal(t, "name", nodeFace.name)
-	assert.NotEqual(t, defaultLoc, nodeFace.prev)
+	assert.Nil(t, nodeFace.prev)
 	assert.True(t, nodeFace.isPackage)
 	assert.NotNil(t, nodeFace.children)
 	assert.NotNil(t, nodeFace.files)
@@ -823,10 +824,13 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			t := suite.T()
 			tree := test.tree(t)
 
+			df := driveFile(file, parentDir(), test.parentID)
+			df.SetSize(ptr.To(test.contentSize))
+
 			err := tree.addFile(
 				test.parentID,
 				id(file),
-				driveFile(file, parentDir(), test.parentID))
+				custom.ToCustomDriveItem(df))
 			test.expectErr(t, err, clues.ToCore(err))
 			assert.Equal(t, test.expectFiles, tree.fileIDToParentID)
 
@@ -912,7 +916,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_addAndDeleteFile() {
 	assert.Len(t, tree.deletedFileIDs, 1)
 	assert.Contains(t, tree.deletedFileIDs, fID)
 
-	err := tree.addFile(rootID, fID, time.Now(), defaultItemSize)
+	err := tree.addFile(rootID, fID, custom.ToCustomDriveItem(fileAtRoot()))
 	require.NoError(t, err, clues.ToCore(err))
 
 	assert.Len(t, tree.fileIDToParentID, 1)
@@ -926,6 +930,53 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_addAndDeleteFile() {
 	assert.NotContains(t, tree.fileIDToParentID, fID)
 	assert.Len(t, tree.deletedFileIDs, 1)
 	assert.Contains(t, tree.deletedFileIDs, fID)
+}
+
+func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateExcludeItemIDs() {
+	table := []struct {
+		name   string
+		tree   func(t *testing.T) *folderyMcFolderFace
+		expect map[string]struct{}
+	}{
+		{
+			name:   "no files",
+			tree:   treeWithRoot,
+			expect: map[string]struct{}{},
+		},
+		{
+			name:   "one file in a folder",
+			tree:   treeWithFileInFolder,
+			expect: makeExcludeMap(id(file)),
+		},
+		{
+			name:   "one file in a tombstone",
+			tree:   treeWithFileInTombstone,
+			expect: map[string]struct{}{},
+		},
+		{
+			name:   "one deleted file",
+			tree:   treeWithDeletedFile,
+			expect: makeExcludeMap(idx(file, "d")),
+		},
+		{
+			name: "files in folders and tombstones",
+			tree: fullTree,
+			expect: makeExcludeMap(
+				id(file),
+				idx(file, "r"),
+				idx(file, "p"),
+				idx(file, "d")),
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+			tree := test.tree(t)
+
+			result := tree.generateExcludeItemIDs()
+			assert.Equal(t, test.expect, result)
+		})
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -955,7 +1006,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expect: map[string]collectable{
 				rootID: {
 					currPath:                  fullPathPath(t),
-					files:                     map[string]models.DriveItemable{},
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{},
@@ -969,8 +1020,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expect: map[string]collectable{
 				rootID: {
 					currPath: fullPathPath(t),
-					files: map[string]models.DriveItemable{
-						id(file): fileAtRoot(),
+					files: map[string]*custom.DriveItem{
+						id(file): custom.ToCustomDriveItem(fileAtRoot()),
 					},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
@@ -985,22 +1036,22 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expect: map[string]collectable{
 				rootID: {
 					currPath:                  fullPathPath(t),
-					files:                     map[string]models.DriveItemable{},
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{},
 				},
 				idx(folder, "parent"): {
 					currPath:                  fullPathPath(t, namex(folder, "parent")),
-					files:                     map[string]models.DriveItemable{},
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  idx(folder, "parent"),
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{rootName},
 				},
 				id(folder): {
 					currPath: fullPathPath(t, namex(folder, "parent"), name(folder)),
-					files: map[string]models.DriveItemable{
-						id(file): fileAt("parent"),
+					files: map[string]*custom.DriveItem{
+						id(file): custom.ToCustomDriveItem(fileAt("parent")),
 					},
 					folderID:                  id(folder),
 					isPackageOrChildOfPackage: false,
@@ -1027,21 +1078,21 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expect: map[string]collectable{
 				rootID: {
 					currPath:                  fullPathPath(t),
-					files:                     map[string]models.DriveItemable{},
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{},
 				},
 				id(pkg): {
 					currPath:                  fullPathPath(t, name(pkg)),
-					files:                     map[string]models.DriveItemable{},
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  id(pkg),
 					isPackageOrChildOfPackage: true,
 					loc:                       path.Elements{rootName},
 				},
 				id(folder): {
 					currPath:                  fullPathPath(t, name(pkg), name(folder)),
-					files:                     map[string]models.DriveItemable{},
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  id(folder),
 					isPackageOrChildOfPackage: true,
 					loc:                       path.Elements{rootName, name(pkg)},
@@ -1060,7 +1111,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expect: map[string]collectable{
 				rootID: {
 					currPath:                  fullPathPath(t),
-					files:                     map[string]models.DriveItemable{},
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{},
@@ -1068,7 +1119,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 				},
 				idx(folder, "parent"): {
 					currPath:                  fullPathPath(t, namex(folder, "parent")),
-					files:                     map[string]models.DriveItemable{},
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  idx(folder, "parent"),
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{rootName},
@@ -1078,8 +1129,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 					currPath:                  fullPathPath(t, namex(folder, "parent"), name(folder)),
 					folderID:                  id(folder),
 					isPackageOrChildOfPackage: false,
-					files: map[string]models.DriveItemable{
-						id(file): fileAt("parent"),
+					files: map[string]*custom.DriveItem{
+						id(file): custom.ToCustomDriveItem(fileAt("parent")),
 					},
 					loc:      path.Elements{rootName, namex(folder, "parent")},
 					prevPath: fullPathPath(t, namex(folder, "parent-prev"), name(folder)),
@@ -1097,14 +1148,14 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expect: map[string]collectable{
 				rootID: {
 					currPath:                  fullPathPath(t),
-					files:                     map[string]models.DriveItemable{},
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{},
 					prevPath:                  fullPathPath(t),
 				},
 				id(folder): {
-					files:                     map[string]models.DriveItemable{},
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  id(folder),
 					isPackageOrChildOfPackage: false,
 					prevPath:                  fullPathPath(t, name(folder)),

--- a/src/internal/m365/collection/drive/delta_tree_test.go
+++ b/src/internal/m365/collection/drive/delta_tree_test.go
@@ -2,9 +2,9 @@ package drive
 
 import (
 	"testing"
-	"time"
 
 	"github.com/alcionai/clues"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -826,8 +826,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			err := tree.addFile(
 				test.parentID,
 				id(file),
-				time.Now(),
-				test.contentSize)
+				driveFile(file, parentDir(), test.parentID))
 			test.expectErr(t, err, clues.ToCore(err))
 			assert.Equal(t, test.expectFiles, tree.fileIDToParentID)
 
@@ -956,7 +955,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expect: map[string]collectable{
 				rootID: {
 					currPath:                  fullPathPath(t),
-					files:                     map[string]fileyMcFileFace{},
+					files:                     map[string]models.DriveItemable{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{},
@@ -970,8 +969,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expect: map[string]collectable{
 				rootID: {
 					currPath: fullPathPath(t),
-					files: map[string]fileyMcFileFace{
-						id(file): {},
+					files: map[string]models.DriveItemable{
+						id(file): fileAtRoot(),
 					},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
@@ -986,22 +985,22 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expect: map[string]collectable{
 				rootID: {
 					currPath:                  fullPathPath(t),
-					files:                     map[string]fileyMcFileFace{},
+					files:                     map[string]models.DriveItemable{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{},
 				},
 				idx(folder, "parent"): {
 					currPath:                  fullPathPath(t, namex(folder, "parent")),
-					files:                     map[string]fileyMcFileFace{},
+					files:                     map[string]models.DriveItemable{},
 					folderID:                  idx(folder, "parent"),
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{rootName},
 				},
 				id(folder): {
 					currPath: fullPathPath(t, namex(folder, "parent"), name(folder)),
-					files: map[string]fileyMcFileFace{
-						id(file): {},
+					files: map[string]models.DriveItemable{
+						id(file): fileAt("parent"),
 					},
 					folderID:                  id(folder),
 					isPackageOrChildOfPackage: false,
@@ -1028,21 +1027,21 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expect: map[string]collectable{
 				rootID: {
 					currPath:                  fullPathPath(t),
-					files:                     map[string]fileyMcFileFace{},
+					files:                     map[string]models.DriveItemable{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{},
 				},
 				id(pkg): {
 					currPath:                  fullPathPath(t, name(pkg)),
-					files:                     map[string]fileyMcFileFace{},
+					files:                     map[string]models.DriveItemable{},
 					folderID:                  id(pkg),
 					isPackageOrChildOfPackage: true,
 					loc:                       path.Elements{rootName},
 				},
 				id(folder): {
 					currPath:                  fullPathPath(t, name(pkg), name(folder)),
-					files:                     map[string]fileyMcFileFace{},
+					files:                     map[string]models.DriveItemable{},
 					folderID:                  id(folder),
 					isPackageOrChildOfPackage: true,
 					loc:                       path.Elements{rootName, name(pkg)},
@@ -1061,7 +1060,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expect: map[string]collectable{
 				rootID: {
 					currPath:                  fullPathPath(t),
-					files:                     map[string]fileyMcFileFace{},
+					files:                     map[string]models.DriveItemable{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{},
@@ -1069,7 +1068,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 				},
 				idx(folder, "parent"): {
 					currPath:                  fullPathPath(t, namex(folder, "parent")),
-					files:                     map[string]fileyMcFileFace{},
+					files:                     map[string]models.DriveItemable{},
 					folderID:                  idx(folder, "parent"),
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{rootName},
@@ -1079,8 +1078,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 					currPath:                  fullPathPath(t, namex(folder, "parent"), name(folder)),
 					folderID:                  id(folder),
 					isPackageOrChildOfPackage: false,
-					files: map[string]fileyMcFileFace{
-						id(file): {},
+					files: map[string]models.DriveItemable{
+						id(file): fileAt("parent"),
 					},
 					loc:      path.Elements{rootName, namex(folder, "parent")},
 					prevPath: fullPathPath(t, namex(folder, "parent-prev"), name(folder)),
@@ -1098,14 +1097,14 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expect: map[string]collectable{
 				rootID: {
 					currPath:                  fullPathPath(t),
-					files:                     map[string]fileyMcFileFace{},
+					files:                     map[string]models.DriveItemable{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{},
 					prevPath:                  fullPathPath(t),
 				},
 				id(folder): {
-					files:                     map[string]fileyMcFileFace{},
+					files:                     map[string]models.DriveItemable{},
 					folderID:                  id(folder),
 					isPackageOrChildOfPackage: false,
 					prevPath:                  fullPathPath(t, name(folder)),

--- a/src/internal/m365/collection/drive/helper_test.go
+++ b/src/internal/m365/collection/drive/helper_test.go
@@ -153,6 +153,7 @@ func coreItem(
 	item := models.NewDriveItem()
 	item.SetName(&name)
 	item.SetId(&id)
+	item.SetLastModifiedDateTime(ptr.To(time.Now()))
 
 	parentReference := models.NewItemReference()
 	parentReference.SetPath(&parentPath)
@@ -177,6 +178,21 @@ func driveItem(
 	it itemType,
 ) models.DriveItemable {
 	return coreItem(id, name, parentPath, parentID, it)
+}
+
+func driveFile(
+	idX any,
+	parentPath, parentID string,
+) models.DriveItemable {
+	i := id(file)
+	n := name(file)
+
+	if idX != file {
+		i = idx(file, idX)
+		n = namex(file, idX)
+	}
+
+	return driveItem(i, n, parentPath, parentID, isFile)
 }
 
 func fileAtRoot() models.DriveItemable {
@@ -659,7 +675,7 @@ type collectionAssertion struct {
 	curr    path.Path
 	prev    path.Path
 	state   data.CollectionState
-	itemIDs []string
+	fileIDs []string
 	// should never get set by the user.
 	// this flag gets flipped when calling assertions.compare.
 	// any unseen collection will error on requireNoUnseenCollections
@@ -668,13 +684,20 @@ type collectionAssertion struct {
 
 func aColl(
 	curr, prev path.Path,
-	itemIDs ...string,
+	fileIDs ...string,
 ) *collectionAssertion {
+	ids := make([]string, 0, 2*len(fileIDs))
+
+	for _, fUD := range fileIDs {
+		ids = append(ids, fUD+metadata.DataFileSuffix)
+		ids = append(ids, fUD+metadata.MetaFileSuffix)
+	}
+
 	return &collectionAssertion{
 		curr:    curr,
 		prev:    prev,
 		state:   data.StateOf(prev, curr, count.New()),
-		itemIDs: itemIDs,
+		fileIDs: ids,
 	}
 }
 
@@ -750,7 +773,7 @@ func (ecs expectedCollections) compareColl(t *testing.T, coll data.BackupCollect
 
 	assert.ElementsMatchf(
 		t,
-		expect.itemIDs,
+		expect.fileIDs,
 		itemIDs,
 		"expected all items to match in collection with:\n\tstate %q\n\tpath %q",
 		coll.State(),
@@ -865,10 +888,7 @@ func treeWithFolders(t *testing.T) *folderyMcFolderFace {
 
 func treeWithFileAtRoot(t *testing.T) *folderyMcFolderFace {
 	tree := treeWithRoot(t)
-	tree.root.files[id(file)] = fileyMcFileFace{
-		lastModified: time.Now(),
-		contentSize:  42,
-	}
+	tree.root.files[id(file)] = fileAtRoot()
 	tree.fileIDToParentID[id(file)] = rootID
 
 	return tree
@@ -876,10 +896,7 @@ func treeWithFileAtRoot(t *testing.T) *folderyMcFolderFace {
 
 func treeWithFileInFolder(t *testing.T) *folderyMcFolderFace {
 	tree := treeWithFolders(t)
-	tree.folderIDToNode[id(folder)].files[id(file)] = fileyMcFileFace{
-		lastModified: time.Now(),
-		contentSize:  42,
-	}
+	tree.folderIDToNode[id(folder)].files[id(file)] = fileAt(folder)
 	tree.fileIDToParentID[id(file)] = id(folder)
 
 	return tree
@@ -887,10 +904,7 @@ func treeWithFileInFolder(t *testing.T) *folderyMcFolderFace {
 
 func treeWithFileInTombstone(t *testing.T) *folderyMcFolderFace {
 	tree := treeWithTombstone(t)
-	tree.tombstones[id(folder)].files[id(file)] = fileyMcFileFace{
-		lastModified: time.Now(),
-		contentSize:  42,
-	}
+	tree.tombstones[id(folder)].files[id(file)] = fileAt("tombstone")
 	tree.fileIDToParentID[id(file)] = id(folder)
 
 	return tree
@@ -915,7 +929,10 @@ func fullTreeWithNames(
 		tree := treeWithRoot(t)
 
 		// file in root
-		err := tree.addFile(rootID, idx(file, "r"), time.Now(), 42)
+		err := tree.addFile(
+			rootID,
+			idx(file, "r"),
+			driveFile("r", parentDir(), rootID))
 		require.NoError(t, err, clues.ToCore(err))
 
 		// root -> idx(folder, parent)
@@ -923,7 +940,10 @@ func fullTreeWithNames(
 		require.NoError(t, err, clues.ToCore(err))
 
 		// file in idx(folder, parent)
-		err = tree.addFile(idx(folder, parentFolderX), idx(file, "p"), time.Now(), 42)
+		err = tree.addFile(
+			idx(folder, parentFolderX),
+			idx(file, "p"),
+			driveFile("p", parentDir(namex(folder, parentFolderX)), idx(folder, parentFolderX)))
 		require.NoError(t, err, clues.ToCore(err))
 
 		// idx(folder, parent) -> id(folder)
@@ -931,7 +951,10 @@ func fullTreeWithNames(
 		require.NoError(t, err, clues.ToCore(err))
 
 		// file in id(folder)
-		err = tree.addFile(id(folder), id(file), time.Now(), 42)
+		err = tree.addFile(
+			id(folder),
+			id(file),
+			driveFile(file, parentDir(name(folder)), id(folder)))
 		require.NoError(t, err, clues.ToCore(err))
 
 		// tombstone - have to set a non-tombstone folder first, then add the item, then tombstone the folder
@@ -939,7 +962,10 @@ func fullTreeWithNames(
 		require.NoError(t, err, clues.ToCore(err))
 
 		// file in tombstone
-		err = tree.addFile(idx(folder, tombstoneX), idx(file, "t"), time.Now(), 42)
+		err = tree.addFile(
+			idx(folder, tombstoneX),
+			idx(file, "t"),
+			driveFile("t", parentDir(namex(folder, tombstoneX)), idx(folder, tombstoneX)))
 		require.NoError(t, err, clues.ToCore(err))
 
 		err = tree.setTombstone(ctx, idx(folder, tombstoneX))


### PR DESCRIPTION
drive collections curently pass around models.DriveItemables for their item data.  The reduction to a modtime and size in the delta tree was a design miss, and needs to be corrected.

This PR should put the tests into a green state again.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #4689

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
