### PR TITLE
Add a GetTeamByID API to lookup a team by ID

### DIFF
--- a/src/pkg/services/m365/api/groups.go
+++ b/src/pkg/services/m365/api/groups.go
@@ -101,6 +101,25 @@ const (
 	filterGroupByMailQueryTmpl        = "proxyAddresses/any(a:a eq 'smtp:%s')"
 )
 
+// GetTeamByID can lookup a team by its group id. It will fail if the group
+// is not a Team.
+func (c Groups) GetTeamByID(
+	ctx context.Context,
+	identifier string,
+	_ CallConfig, // matching standards
+) (models.Teamable, error) {
+	ctx = clues.Add(ctx, "resource_identifier", identifier)
+
+	t, err := c.Stable.Client().Teams().ByTeamId(identifier).Get(ctx, nil)
+	if err != nil {
+		if graph.IsErrResourceLocked(err) {
+			return nil, graph.Stack(ctx, clues.Stack(graph.ErrResourceLocked, err))
+		}
+		return nil, graph.Wrap(ctx, err, "finding team by ID")
+	}
+	return t, err
+}
+
 // GetID can look up a group by either its canonical id (a uuid)
 // or by the group's display name.  If looking up the display name
 // an error will be returned if more than one group gets returned

--- a/src/pkg/services/m365/api/groups.go
+++ b/src/pkg/services/m365/api/groups.go
@@ -115,8 +115,10 @@ func (c Groups) GetTeamByID(
 		if graph.IsErrResourceLocked(err) {
 			return nil, graph.Stack(ctx, clues.Stack(graph.ErrResourceLocked, err))
 		}
+
 		return nil, graph.Wrap(ctx, err, "finding team by ID")
 	}
+
 	return t, err
 }
 


### PR DESCRIPTION
Allows the caller to get Team information if they know a group is a team.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
