### PR TITLE
4689 cleanup 2

### DIFF
--- a/src/internal/m365/collection/drive/collection_test.go
+++ b/src/internal/m365/collection/drive/collection_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive/metadata"
 	metaTD "github.com/alcionai/corso/src/internal/m365/collection/drive/metadata/testdata"
-	"github.com/alcionai/corso/src/internal/m365/service/onedrive/mock"
 	odTD "github.com/alcionai/corso/src/internal/m365/service/onedrive/testdata"
 	"github.com/alcionai/corso/src/internal/m365/support"
 	"github.com/alcionai/corso/src/internal/tester"
@@ -185,9 +184,9 @@ func (suite *CollectionUnitSuite) TestCollection() {
 			folderPath, err := pb.ToDataLayerOneDrivePath("tenant", "owner", false)
 			require.NoError(t, err, clues.ToCore(err))
 
-			mbh := mock.DefaultOneDriveBH("a-user")
+			mbh := defaultOneDriveBH("a-user")
 			if test.service == path.SharePointService {
-				mbh = mock.DefaultSharePointBH("a-site")
+				mbh = defaultSharePointBH("a-site")
 				mbh.ItemInfo.SharePoint.Modified = now
 				mbh.ItemInfo.SharePoint.ItemName = stubItemName
 			} else {
@@ -202,10 +201,10 @@ func (suite *CollectionUnitSuite) TestCollection() {
 				},
 			}
 			mbh.GetErrs = []error{test.getErr}
-			mbh.GI = mock.GetsItem{Err: assert.AnError}
+			mbh.GI = getsItem{Err: assert.AnError}
 
 			pcr := metaTD.NewStubPermissionResponse(metadata.GV2User, stubMetaID, stubMetaEntityID, stubMetaRoles)
-			mbh.GIP = mock.GetsItemPermission{Perm: pcr}
+			mbh.GIP = getsItemPermission{Perm: pcr}
 
 			coll, err := NewCollection(
 				mbh,
@@ -318,9 +317,9 @@ func (suite *CollectionUnitSuite) TestCollectionReadError() {
 	folderPath, err := pb.ToDataLayerOneDrivePath("a-tenant", "a-user", false)
 	require.NoError(t, err, clues.ToCore(err))
 
-	mbh := mock.DefaultOneDriveBH("a-user")
-	mbh.GI = mock.GetsItem{Err: assert.AnError}
-	mbh.GIP = mock.GetsItemPermission{Perm: models.NewPermissionCollectionResponse()}
+	mbh := defaultOneDriveBH("a-user")
+	mbh.GI = getsItem{Err: assert.AnError}
+	mbh.GIP = getsItemPermission{Perm: models.NewPermissionCollectionResponse()}
 	mbh.GetResps = []*http.Response{
 		nil,
 		{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("test"))},
@@ -397,9 +396,9 @@ func (suite *CollectionUnitSuite) TestCollectionReadUnauthorizedErrorRetry() {
 	folderPath, err := pb.ToDataLayerOneDrivePath("a-tenant", "a-user", false)
 	require.NoError(t, err)
 
-	mbh := mock.DefaultOneDriveBH("a-user")
-	mbh.GI = mock.GetsItem{Item: stubItem}
-	mbh.GIP = mock.GetsItemPermission{Perm: models.NewPermissionCollectionResponse()}
+	mbh := defaultOneDriveBH("a-user")
+	mbh.GI = getsItem{Item: stubItem}
+	mbh.GIP = getsItemPermission{Perm: models.NewPermissionCollectionResponse()}
 	mbh.GetResps = []*http.Response{
 		nil,
 		{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("test"))},
@@ -457,9 +456,9 @@ func (suite *CollectionUnitSuite) TestCollectionPermissionBackupLatestModTime() 
 	folderPath, err := pb.ToDataLayerOneDrivePath("a-tenant", "a-user", false)
 	require.NoError(t, err, clues.ToCore(err))
 
-	mbh := mock.DefaultOneDriveBH("a-user")
+	mbh := defaultOneDriveBH("a-user")
 	mbh.ItemInfo = details.ItemInfo{OneDrive: &details.OneDriveInfo{ItemName: "fakeName", Modified: time.Now()}}
-	mbh.GIP = mock.GetsItemPermission{Perm: models.NewPermissionCollectionResponse()}
+	mbh.GIP = getsItemPermission{Perm: models.NewPermissionCollectionResponse()}
 	mbh.GetResps = []*http.Response{{
 		StatusCode: http.StatusOK,
 		Body:       io.NopCloser(strings.NewReader("Fake Data!")),
@@ -635,8 +634,8 @@ func (suite *GetDriveItemUnitTestSuite) TestGetDriveItem_error() {
 
 			stubItem.GetFile().SetMimeType(&test.itemMimeType)
 
-			mbh := mock.DefaultOneDriveBH("a-user")
-			mbh.GI = mock.GetsItem{Item: stubItem}
+			mbh := defaultOneDriveBH("a-user")
+			mbh.GI = getsItem{Item: stubItem}
 			mbh.GetResps = []*http.Response{{StatusCode: http.StatusOK}}
 			mbh.GetErrs = []error{test.err}
 
@@ -692,7 +691,7 @@ func (suite *GetDriveItemUnitTestSuite) TestDownloadContent() {
 
 	table := []struct {
 		name      string
-		mgi       mock.GetsItem
+		mgi       getsItem
 		itemInfo  details.ItemInfo
 		respBody  []io.ReadCloser
 		getErr    []error
@@ -711,7 +710,7 @@ func (suite *GetDriveItemUnitTestSuite) TestDownloadContent() {
 		},
 		{
 			name:      "expired url redownloads",
-			mgi:       mock.GetsItem{Item: itemWID, Err: nil},
+			mgi:       getsItem{Item: itemWID, Err: nil},
 			itemInfo:  details.ItemInfo{},
 			respBody:  []io.ReadCloser{nil, iorc},
 			getErr:    []error{errUnauth, nil},
@@ -731,14 +730,14 @@ func (suite *GetDriveItemUnitTestSuite) TestDownloadContent() {
 			name:      "re-fetching the item fails",
 			itemInfo:  details.ItemInfo{},
 			getErr:    []error{errUnauth},
-			mgi:       mock.GetsItem{Item: nil, Err: assert.AnError},
+			mgi:       getsItem{Item: nil, Err: assert.AnError},
 			expectErr: require.Error,
 			expect:    require.Nil,
 			muc:       m,
 		},
 		{
 			name:      "expired url fails redownload",
-			mgi:       mock.GetsItem{Item: itemWID, Err: nil},
+			mgi:       getsItem{Item: itemWID, Err: nil},
 			itemInfo:  details.ItemInfo{},
 			respBody:  []io.ReadCloser{nil, nil},
 			getErr:    []error{errUnauth, assert.AnError},
@@ -748,7 +747,7 @@ func (suite *GetDriveItemUnitTestSuite) TestDownloadContent() {
 		},
 		{
 			name:      "url refreshed from cache",
-			mgi:       mock.GetsItem{Item: itemWID, Err: nil},
+			mgi:       getsItem{Item: itemWID, Err: nil},
 			itemInfo:  details.ItemInfo{},
 			respBody:  []io.ReadCloser{nil, iorc},
 			getErr:    []error{errUnauth, nil},
@@ -766,7 +765,7 @@ func (suite *GetDriveItemUnitTestSuite) TestDownloadContent() {
 		},
 		{
 			name:      "url refreshed from cache but item deleted",
-			mgi:       mock.GetsItem{Item: itemWID, Err: graph.ErrDeletedInFlight},
+			mgi:       getsItem{Item: itemWID, Err: graph.ErrDeletedInFlight},
 			itemInfo:  details.ItemInfo{},
 			respBody:  []io.ReadCloser{nil, nil, nil},
 			getErr:    []error{errUnauth, graph.ErrDeletedInFlight, graph.ErrDeletedInFlight},
@@ -784,7 +783,7 @@ func (suite *GetDriveItemUnitTestSuite) TestDownloadContent() {
 		},
 		{
 			name:      "fallback to item fetch on any cache error",
-			mgi:       mock.GetsItem{Item: itemWID, Err: nil},
+			mgi:       getsItem{Item: itemWID, Err: nil},
 			itemInfo:  details.ItemInfo{},
 			respBody:  []io.ReadCloser{nil, iorc},
 			getErr:    []error{errUnauth, nil},
@@ -814,7 +813,7 @@ func (suite *GetDriveItemUnitTestSuite) TestDownloadContent() {
 				}
 			}
 
-			mbh := mock.DefaultOneDriveBH("a-user")
+			mbh := defaultOneDriveBH("a-user")
 			mbh.GI = test.mgi
 			mbh.ItemInfo = test.itemInfo
 			mbh.GetResps = resps
@@ -980,9 +979,9 @@ func (suite *CollectionUnitSuite) TestItemExtensions() {
 
 			wg.Add(1)
 
-			mbh := mock.DefaultOneDriveBH("a-user")
-			mbh.GI = mock.GetsItem{Err: assert.AnError}
-			mbh.GIP = mock.GetsItemPermission{Perm: models.NewPermissionCollectionResponse()}
+			mbh := defaultOneDriveBH("a-user")
+			mbh.GI = getsItem{Err: assert.AnError}
+			mbh.GIP = getsItemPermission{Perm: models.NewPermissionCollectionResponse()}
 			mbh.GetResps = []*http.Response{
 				{
 					StatusCode: http.StatusOK,

--- a/src/internal/m365/collection/drive/collections_test.go
+++ b/src/internal/m365/collection/drive/collections_test.go
@@ -15,7 +15,6 @@ import (
 	pmMock "github.com/alcionai/corso/src/internal/common/prefixmatcher/mock"
 	"github.com/alcionai/corso/src/internal/data"
 	dataMock "github.com/alcionai/corso/src/internal/data/mock"
-	"github.com/alcionai/corso/src/internal/m365/service/onedrive/mock"
 	"github.com/alcionai/corso/src/internal/m365/support"
 	"github.com/alcionai/corso/src/internal/tester"
 	bupMD "github.com/alcionai/corso/src/pkg/backup/metadata"
@@ -41,6 +40,7 @@ func TestCollectionsUnitSuite(t *testing.T) {
 
 func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 	t := suite.T()
+	d := drive()
 
 	tests := []struct {
 		name                     string
@@ -63,18 +63,18 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "Invalid item",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveItem(id(item), name(item), driveParentDir(drive), rootID, -1),
+				driveItem(id(item), name(item), d.dir(), rootID, -1),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.Error,
 			expectedCollectionIDs: map[string]statePath{
-				rootID: asNotMoved(t, driveFullPath(drive)),
+				rootID: asNotMoved(t, d.strPath()),
 			},
 			expectedContainerCount: 1,
 			expectedPrevPaths: map[string]string{
-				rootID: driveFullPath(drive),
+				rootID: d.strPath(),
 			},
 			expectedExcludes:         map[string]struct{}{},
 			expectedTopLevelPackages: map[string]struct{}{},
@@ -83,21 +83,21 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "Single File",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFile(driveParentDir(drive), rootID),
+				driveFile(d.dir(), rootID),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID: asNotMoved(t, driveFullPath(drive)),
+				rootID: asNotMoved(t, d.strPath()),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      1,
 			expectedContainerCount: 1,
 			// Root folder is skipped since it's always present.
 			expectedPrevPaths: map[string]string{
-				rootID: driveFullPath(drive),
+				rootID: d.strPath(),
 			},
 			expectedExcludes:         makeExcludeMap(fileID()),
 			expectedTopLevelPackages: map[string]struct{}{},
@@ -106,19 +106,19 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "Single Folder",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFolder(driveParentDir(drive), rootID),
+				driveFolder(d.dir(), rootID),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, driveFullPath(drive)),
-				folderID(): asNew(t, driveFullPath(drive, folderName())),
+				rootID:     asNotMoved(t, d.strPath()),
+				folderID(): asNew(t, d.strPath(folderName())),
 			},
 			expectedPrevPaths: map[string]string{
-				rootID:     driveFullPath(drive),
-				folderID(): driveFullPath(drive, folderName()),
+				rootID:     d.strPath(),
+				folderID(): d.strPath(folderName()),
 			},
 			expectedItemCount:        1,
 			expectedContainerCount:   2,
@@ -129,20 +129,20 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "Single Folder created twice", // deleted a created with same name in between a backup
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFolder(driveParentDir(drive), rootID),
-				driveItem(folderID(2), folderName(), driveParentDir(drive), rootID, isFolder),
+				driveFolder(d.dir(), rootID),
+				driveItem(folderID(2), folderName(), d.dir(), rootID, isFolder),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:      asNotMoved(t, driveFullPath(drive)),
-				folderID(2): asNew(t, driveFullPath(drive, folderName())),
+				rootID:      asNotMoved(t, d.strPath()),
+				folderID(2): asNew(t, d.strPath(folderName())),
 			},
 			expectedPrevPaths: map[string]string{
-				rootID:      driveFullPath(drive),
-				folderID(2): driveFullPath(drive, folderName()),
+				rootID:      d.strPath(),
+				folderID(2): d.strPath(folderName()),
 			},
 			expectedItemCount:        1,
 			expectedContainerCount:   2,
@@ -153,25 +153,25 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "Single Package",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveItem(id(pkg), name(pkg), driveParentDir(drive), rootID, isPackage),
+				driveItem(id(pkg), name(pkg), d.dir(), rootID, isPackage),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:  asNotMoved(t, driveFullPath(drive)),
-				id(pkg): asNew(t, driveFullPath(drive, name(pkg))),
+				rootID:  asNotMoved(t, d.strPath()),
+				id(pkg): asNew(t, d.strPath(name(pkg))),
 			},
 			expectedPrevPaths: map[string]string{
-				rootID:  driveFullPath(drive),
-				id(pkg): driveFullPath(drive, name(pkg)),
+				rootID:  d.strPath(),
+				id(pkg): d.strPath(name(pkg)),
 			},
 			expectedItemCount:      1,
 			expectedContainerCount: 2,
 			expectedExcludes:       map[string]struct{}{},
 			expectedTopLevelPackages: map[string]struct{}{
-				driveFullPath(drive, name(pkg)): {},
+				d.strPath(name(pkg)): {},
 			},
 			expectedCountPackages: 1,
 		},
@@ -179,31 +179,31 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "Single Package with subfolder",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveItem(id(pkg), name(pkg), driveParentDir(drive), rootID, isPackage),
-				driveItem(folderID(), folderName(), driveParentDir(drive, name(pkg)), id(pkg), isFolder),
-				driveItem(id(subfolder), name(subfolder), driveParentDir(drive, name(pkg)), id(pkg), isFolder),
+				driveItem(id(pkg), name(pkg), d.dir(), rootID, isPackage),
+				driveItem(folderID(), folderName(), d.dir(name(pkg)), id(pkg), isFolder),
+				driveItem(id(subfolder), name(subfolder), d.dir(name(pkg)), id(pkg), isFolder),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:        asNotMoved(t, driveFullPath(drive)),
-				id(pkg):       asNew(t, driveFullPath(drive, name(pkg))),
-				folderID():    asNew(t, driveFullPath(drive, name(pkg), folderName())),
-				id(subfolder): asNew(t, driveFullPath(drive, name(pkg), name(subfolder))),
+				rootID:        asNotMoved(t, d.strPath()),
+				id(pkg):       asNew(t, d.strPath(name(pkg))),
+				folderID():    asNew(t, d.strPath(name(pkg), folderName())),
+				id(subfolder): asNew(t, d.strPath(name(pkg), name(subfolder))),
 			},
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drive),
-				id(pkg):       driveFullPath(drive, name(pkg)),
-				folderID():    driveFullPath(drive, name(pkg), folderName()),
-				id(subfolder): driveFullPath(drive, name(pkg), name(subfolder)),
+				rootID:        d.strPath(),
+				id(pkg):       d.strPath(name(pkg)),
+				folderID():    d.strPath(name(pkg), folderName()),
+				id(subfolder): d.strPath(name(pkg), name(subfolder)),
 			},
 			expectedItemCount:      3,
 			expectedContainerCount: 4,
 			expectedExcludes:       map[string]struct{}{},
 			expectedTopLevelPackages: map[string]struct{}{
-				driveFullPath(drive, name(pkg)): {},
+				d.strPath(name(pkg)): {},
 			},
 			expectedCountPackages: 3,
 		},
@@ -211,31 +211,31 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "1 root file, 1 folder, 1 package, 2 files, 3 collections",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFile(driveParentDir(drive), rootID, "inRoot"),
-				driveFolder(driveParentDir(drive), rootID),
-				driveItem(id(pkg), name(pkg), driveParentDir(drive), rootID, isPackage),
-				driveFile(driveParentDir(drive, folderName()), folderID(), "inFolder"),
-				driveFile(driveParentDir(drive, name(pkg)), id(pkg), "inPackage"),
+				driveFile(d.dir(), rootID, "inRoot"),
+				driveFolder(d.dir(), rootID),
+				driveItem(id(pkg), name(pkg), d.dir(), rootID, isPackage),
+				driveFile(d.dir(folderName()), folderID(), "inFolder"),
+				driveFile(d.dir(name(pkg)), id(pkg), "inPackage"),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, driveFullPath(drive)),
-				folderID(): asNew(t, driveFullPath(drive, folderName())),
-				id(pkg):    asNew(t, driveFullPath(drive, name(pkg))),
+				rootID:     asNotMoved(t, d.strPath()),
+				folderID(): asNew(t, d.strPath(folderName())),
+				id(pkg):    asNew(t, d.strPath(name(pkg))),
 			},
 			expectedItemCount:      5,
 			expectedFileCount:      3,
 			expectedContainerCount: 3,
 			expectedPrevPaths: map[string]string{
-				rootID:     driveFullPath(drive),
-				folderID(): driveFullPath(drive, folderName()),
-				id(pkg):    driveFullPath(drive, name(pkg)),
+				rootID:     d.strPath(),
+				folderID(): d.strPath(folderName()),
+				id(pkg):    d.strPath(name(pkg)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{
-				driveFullPath(drive, name(pkg)): {},
+				d.strPath(name(pkg)): {},
 			},
 			expectedCountPackages: 1,
 			expectedExcludes:      makeExcludeMap(fileID("inRoot"), fileID("inFolder"), fileID("inPackage")),
@@ -244,23 +244,23 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "contains folder selector",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFile(driveParentDir(drive), rootID, "inRoot"),
-				driveFolder(driveParentDir(drive), rootID),
-				driveItem(id(subfolder), name(subfolder), driveParentDir(drive, folderName()), folderID(), isFolder),
-				driveItem(folderID(2), folderName(), driveParentDir(drive, folderName(), name(subfolder)), id(subfolder), isFolder),
-				driveItem(id(pkg), name(pkg), driveParentDir(drive), rootID, isPackage),
-				driveItem(fileID("inFolder"), fileID("inFolder"), driveParentDir(drive, folderName()), folderID(), isFile),
-				driveItem(fileID("inFolder2"), fileName("inFolder2"), driveParentDir(drive, folderName(), name(subfolder), folderName()), folderID(2), isFile),
-				driveItem(fileID("inFolderPackage"), fileName("inPackage"), driveParentDir(drive, name(pkg)), id(pkg), isFile),
+				driveFile(d.dir(), rootID, "inRoot"),
+				driveFolder(d.dir(), rootID),
+				driveItem(id(subfolder), name(subfolder), d.dir(folderName()), folderID(), isFolder),
+				driveItem(folderID(2), folderName(), d.dir(folderName(), name(subfolder)), id(subfolder), isFolder),
+				driveItem(id(pkg), name(pkg), d.dir(), rootID, isPackage),
+				driveItem(fileID("inFolder"), fileID("inFolder"), d.dir(folderName()), folderID(), isFile),
+				driveItem(fileID("inFolder2"), fileName("inFolder2"), d.dir(folderName(), name(subfolder), folderName()), folderID(2), isFile),
+				driveItem(fileID("inFolderPackage"), fileName("inPackage"), d.dir(name(pkg)), id(pkg), isFile),
 			},
 			previousPaths:    map[string]string{},
 			scope:            (&selectors.OneDriveBackup{}).Folders([]string{folderName()})[0],
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				folderID():    asNew(t, driveFullPath(drive, folderName())),
-				id(subfolder): asNew(t, driveFullPath(drive, folderName(), name(subfolder))),
-				folderID(2):   asNew(t, driveFullPath(drive, folderName(), name(subfolder), folderName())),
+				folderID():    asNew(t, d.strPath(folderName())),
+				id(subfolder): asNew(t, d.strPath(folderName(), name(subfolder))),
+				folderID(2):   asNew(t, d.strPath(folderName(), name(subfolder), folderName())),
 			},
 			expectedItemCount:      5,
 			expectedFileCount:      2,
@@ -268,9 +268,9 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			// just "folder" isn't added here because the include check is done on the
 			// parent path since we only check later if something is a folder or not.
 			expectedPrevPaths: map[string]string{
-				folderID():    driveFullPath(drive, folderName()),
-				id(subfolder): driveFullPath(drive, folderName(), name(subfolder)),
-				folderID(2):   driveFullPath(drive, folderName(), name(subfolder), folderName()),
+				folderID():    d.strPath(folderName()),
+				id(subfolder): d.strPath(folderName(), name(subfolder)),
+				folderID(2):   d.strPath(folderName(), name(subfolder), folderName()),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(fileID("inFolder"), fileID("inFolder2")),
@@ -279,14 +279,14 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "prefix subfolder selector",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFile(driveParentDir(drive), rootID, "inRoot"),
-				driveFolder(driveParentDir(drive), rootID),
-				driveItem(id(subfolder), name(subfolder), driveParentDir(drive, folderName()), folderID(), isFolder),
-				driveItem(folderID(2), folderName(), driveParentDir(drive, folderName(), name(subfolder)), id(subfolder), isFolder),
-				driveItem(id(pkg), name(pkg), driveParentDir(drive), rootID, isPackage),
-				driveItem(fileID("inFolder"), fileID("inFolder"), driveParentDir(drive, folderName()), folderID(), isFile),
-				driveItem(fileID("inFolder2"), fileName("inFolder2"), driveParentDir(drive, folderName(), name(subfolder), folderName()), folderID(2), isFile),
-				driveItem(fileID("inFolderPackage"), fileName("inPackage"), driveParentDir(drive, name(pkg)), id(pkg), isFile),
+				driveFile(d.dir(), rootID, "inRoot"),
+				driveFolder(d.dir(), rootID),
+				driveItem(id(subfolder), name(subfolder), d.dir(folderName()), folderID(), isFolder),
+				driveItem(folderID(2), folderName(), d.dir(folderName(), name(subfolder)), id(subfolder), isFolder),
+				driveItem(id(pkg), name(pkg), d.dir(), rootID, isPackage),
+				driveItem(fileID("inFolder"), fileID("inFolder"), d.dir(folderName()), folderID(), isFile),
+				driveItem(fileID("inFolder2"), fileName("inFolder2"), d.dir(folderName(), name(subfolder), folderName()), folderID(2), isFile),
+				driveItem(fileID("inFolderPackage"), fileName("inPackage"), d.dir(name(pkg)), id(pkg), isFile),
 			},
 			previousPaths: map[string]string{},
 			scope: (&selectors.OneDriveBackup{}).Folders(
@@ -295,15 +295,15 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				id(subfolder): asNew(t, driveFullPath(drive, folderName(), name(subfolder))),
-				folderID(2):   asNew(t, driveFullPath(drive, folderName(), name(subfolder), folderName())),
+				id(subfolder): asNew(t, d.strPath(folderName(), name(subfolder))),
+				folderID(2):   asNew(t, d.strPath(folderName(), name(subfolder), folderName())),
 			},
 			expectedItemCount:      3,
 			expectedFileCount:      1,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				id(subfolder): driveFullPath(drive, folderName(), name(subfolder)),
-				folderID(2):   driveFullPath(drive, folderName(), name(subfolder), folderName()),
+				id(subfolder): d.strPath(folderName(), name(subfolder)),
+				folderID(2):   d.strPath(folderName(), name(subfolder), folderName()),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(fileID("inFolder2")),
@@ -312,27 +312,27 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "match subfolder selector",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFile(driveParentDir(drive), rootID),
-				driveFolder(driveParentDir(drive), rootID),
-				driveItem(id(subfolder), name(subfolder), driveParentDir(drive, folderName()), folderID(), isFolder),
-				driveItem(id(pkg), name(pkg), driveParentDir(drive), rootID, isPackage),
-				driveItem(fileID(1), fileName(1), driveParentDir(drive, folderName()), folderID(), isFile),
-				driveItem(fileID("inSubfolder"), fileName("inSubfolder"), driveParentDir(drive, folderName(), name(subfolder)), id(subfolder), isFile),
-				driveItem(fileID(9), fileName(9), driveParentDir(drive, name(pkg)), id(pkg), isFile),
+				driveFile(d.dir(), rootID),
+				driveFolder(d.dir(), rootID),
+				driveItem(id(subfolder), name(subfolder), d.dir(folderName()), folderID(), isFolder),
+				driveItem(id(pkg), name(pkg), d.dir(), rootID, isPackage),
+				driveItem(fileID(1), fileName(1), d.dir(folderName()), folderID(), isFile),
+				driveItem(fileID("inSubfolder"), fileName("inSubfolder"), d.dir(folderName(), name(subfolder)), id(subfolder), isFile),
+				driveItem(fileID(9), fileName(9), d.dir(name(pkg)), id(pkg), isFile),
 			},
 			previousPaths:    map[string]string{},
 			scope:            (&selectors.OneDriveBackup{}).Folders([]string{toPath(folderName(), name(subfolder))})[0],
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				id(subfolder): asNew(t, driveFullPath(drive, folderName(), name(subfolder))),
+				id(subfolder): asNew(t, d.strPath(folderName(), name(subfolder))),
 			},
 			expectedItemCount:      2,
 			expectedFileCount:      1,
 			expectedContainerCount: 1,
 			// No child folders for subfolder so nothing here.
 			expectedPrevPaths: map[string]string{
-				id(subfolder): driveFullPath(drive, folderName(), name(subfolder)),
+				id(subfolder): d.strPath(folderName(), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(fileID("inSubfolder")),
@@ -341,26 +341,26 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "not moved folder tree",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFolder(driveParentDir(drive), rootID),
+				driveFolder(d.dir(), rootID),
 			},
 			previousPaths: map[string]string{
-				folderID():    driveFullPath(drive, folderName()),
-				id(subfolder): driveFullPath(drive, folderName(), name(subfolder)),
+				folderID():    d.strPath(folderName()),
+				id(subfolder): d.strPath(folderName(), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, driveFullPath(drive)),
-				folderID(): asNotMoved(t, driveFullPath(drive, folderName())),
+				rootID:     asNotMoved(t, d.strPath()),
+				folderID(): asNotMoved(t, d.strPath(folderName())),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      0,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drive),
-				folderID():    driveFullPath(drive, folderName()),
-				id(subfolder): driveFullPath(drive, folderName(), name(subfolder)),
+				rootID:        d.strPath(),
+				folderID():    d.strPath(folderName()),
+				id(subfolder): d.strPath(folderName(), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -369,26 +369,26 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "moved folder tree",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFolder(driveParentDir(drive), rootID),
+				driveFolder(d.dir(), rootID),
 			},
 			previousPaths: map[string]string{
-				folderID():    driveFullPath(drive, folderName("a")),
-				id(subfolder): driveFullPath(drive, folderName("a"), name(subfolder)),
+				folderID():    d.strPath(folderName("a")),
+				id(subfolder): d.strPath(folderName("a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, driveFullPath(drive)),
-				folderID(): asMoved(t, driveFullPath(drive, folderName("a")), driveFullPath(drive, folderName())),
+				rootID:     asNotMoved(t, d.strPath()),
+				folderID(): asMoved(t, d.strPath(folderName("a")), d.strPath(folderName())),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      0,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drive),
-				folderID():    driveFullPath(drive, folderName()),
-				id(subfolder): driveFullPath(drive, folderName(), name(subfolder)),
+				rootID:        d.strPath(),
+				folderID():    d.strPath(folderName()),
+				id(subfolder): d.strPath(folderName(), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -397,27 +397,27 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "moved folder tree twice within backup",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveItem(folderID(1), folderName(), driveParentDir(drive), rootID, isFolder),
-				driveItem(folderID(2), folderName(), driveParentDir(drive), rootID, isFolder),
+				driveItem(folderID(1), folderName(), d.dir(), rootID, isFolder),
+				driveItem(folderID(2), folderName(), d.dir(), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				folderID(1):   driveFullPath(drive, folderName("a")),
-				id(subfolder): driveFullPath(drive, folderName("a"), name(subfolder)),
+				folderID(1):   d.strPath(folderName("a")),
+				id(subfolder): d.strPath(folderName("a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:      asNotMoved(t, driveFullPath(drive)),
-				folderID(2): asNew(t, driveFullPath(drive, folderName())),
+				rootID:      asNotMoved(t, d.strPath()),
+				folderID(2): asNew(t, d.strPath(folderName())),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      0,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drive),
-				folderID(2):   driveFullPath(drive, folderName()),
-				id(subfolder): driveFullPath(drive, folderName(), name(subfolder)),
+				rootID:        d.strPath(),
+				folderID(2):   d.strPath(folderName()),
+				id(subfolder): d.strPath(folderName(), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -427,26 +427,26 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			items: []models.DriveItemable{
 				driveRootFolder(),
 				delItem(folderID(), rootID, isFolder),
-				driveItem(folderID(), name(drive), driveParentDir(drive), rootID, isFolder),
+				driveItem(folderID(), name(drivePfx), d.dir(), rootID, isFolder),
 				delItem(folderID(), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				folderID():    driveFullPath(drive),
-				id(subfolder): driveFullPath(drive, folderName("a"), name(subfolder)),
+				folderID():    d.strPath(),
+				id(subfolder): d.strPath(folderName("a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, driveFullPath(drive)),
-				folderID(): asDeleted(t, driveFullPath(drive, "")),
+				rootID:     asNotMoved(t, d.strPath()),
+				folderID(): asDeleted(t, d.strPath("")),
 			},
 			expectedItemCount:      0,
 			expectedFileCount:      0,
 			expectedContainerCount: 1,
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drive),
-				id(subfolder): driveFullPath(drive, folderName("a"), name(subfolder)),
+				rootID:        d.strPath(),
+				id(subfolder): d.strPath(folderName("a"), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -455,28 +455,28 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "moved folder tree twice within backup including delete",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFolder(driveParentDir(drive), rootID),
+				driveFolder(d.dir(), rootID),
 				delItem(folderID(), rootID, isFolder),
-				driveItem(folderID(2), folderName(), driveParentDir(drive), rootID, isFolder),
+				driveItem(folderID(2), folderName(), d.dir(), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				folderID():    driveFullPath(drive, folderName("a")),
-				id(subfolder): driveFullPath(drive, folderName("a"), name(subfolder)),
+				folderID():    d.strPath(folderName("a")),
+				id(subfolder): d.strPath(folderName("a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:      asNotMoved(t, driveFullPath(drive)),
-				folderID(2): asNew(t, driveFullPath(drive, folderName())),
+				rootID:      asNotMoved(t, d.strPath()),
+				folderID(2): asNew(t, d.strPath(folderName())),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      0,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drive),
-				folderID(2):   driveFullPath(drive, folderName()),
-				id(subfolder): driveFullPath(drive, folderName(), name(subfolder)),
+				rootID:        d.strPath(),
+				folderID(2):   d.strPath(folderName()),
+				id(subfolder): d.strPath(folderName(), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -485,27 +485,27 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "deleted folder tree twice within backup with addition",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveItem(folderID(1), folderName(), driveParentDir(drive), rootID, isFolder),
+				driveItem(folderID(1), folderName(), d.dir(), rootID, isFolder),
 				delItem(folderID(1), rootID, isFolder),
-				driveItem(folderID(2), folderName(), driveParentDir(drive), rootID, isFolder),
+				driveItem(folderID(2), folderName(), d.dir(), rootID, isFolder),
 				delItem(folderID(2), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				folderID(1):   driveFullPath(drive, folderName("a")),
-				id(subfolder): driveFullPath(drive, folderName("a"), name(subfolder)),
+				folderID(1):   d.strPath(folderName("a")),
+				id(subfolder): d.strPath(folderName("a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID: asNotMoved(t, driveFullPath(drive)),
+				rootID: asNotMoved(t, d.strPath()),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      0,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drive),
-				id(subfolder): driveFullPath(drive, folderName(), name(subfolder)),
+				rootID:        d.strPath(),
+				id(subfolder): d.strPath(folderName(), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -514,24 +514,24 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "moved folder tree with file no previous",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFolder(driveParentDir(drive), rootID),
-				driveItem(fileID(), fileName(), driveParentDir(drive, folderName()), folderID(), isFile),
-				driveItem(folderID(), folderName(2), driveParentDir(drive), rootID, isFolder),
+				driveFolder(d.dir(), rootID),
+				driveItem(fileID(), fileName(), d.dir(folderName()), folderID(), isFile),
+				driveItem(folderID(), folderName(2), d.dir(), rootID, isFolder),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, driveFullPath(drive)),
-				folderID(): asNew(t, driveFullPath(drive, folderName(2))),
+				rootID:     asNotMoved(t, d.strPath()),
+				folderID(): asNew(t, d.strPath(folderName(2))),
 			},
 			expectedItemCount:      2,
 			expectedFileCount:      1,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:     driveFullPath(drive),
-				folderID(): driveFullPath(drive, folderName(2)),
+				rootID:     d.strPath(),
+				folderID(): d.strPath(folderName(2)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(fileID()),
@@ -540,23 +540,23 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "moved folder tree with file no previous 1",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFolder(driveParentDir(drive), rootID),
-				driveItem(fileID(), fileName(), driveParentDir(drive, folderName()), folderID(), isFile),
+				driveFolder(d.dir(), rootID),
+				driveItem(fileID(), fileName(), d.dir(folderName()), folderID(), isFile),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, driveFullPath(drive)),
-				folderID(): asNew(t, driveFullPath(drive, folderName())),
+				rootID:     asNotMoved(t, d.strPath()),
+				folderID(): asNew(t, d.strPath(folderName())),
 			},
 			expectedItemCount:      2,
 			expectedFileCount:      1,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:     driveFullPath(drive),
-				folderID(): driveFullPath(drive, folderName()),
+				rootID:     d.strPath(),
+				folderID(): d.strPath(folderName()),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(fileID()),
@@ -565,28 +565,28 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "moved folder tree and subfolder 1",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFolder(driveParentDir(drive), rootID),
-				driveItem(id(subfolder), name(subfolder), driveParentDir(drive), rootID, isFolder),
+				driveFolder(d.dir(), rootID),
+				driveItem(id(subfolder), name(subfolder), d.dir(), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				folderID():    driveFullPath(drive, folderName("a")),
-				id(subfolder): driveFullPath(drive, folderName("a"), name(subfolder)),
+				folderID():    d.strPath(folderName("a")),
+				id(subfolder): d.strPath(folderName("a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:        asNotMoved(t, driveFullPath(drive)),
-				folderID():    asMoved(t, driveFullPath(drive, folderName("a")), driveFullPath(drive, folderName())),
-				id(subfolder): asMoved(t, driveFullPath(drive, folderName("a"), name(subfolder)), driveFullPath(drive, name(subfolder))),
+				rootID:        asNotMoved(t, d.strPath()),
+				folderID():    asMoved(t, d.strPath(folderName("a")), d.strPath(folderName())),
+				id(subfolder): asMoved(t, d.strPath(folderName("a"), name(subfolder)), d.strPath(name(subfolder))),
 			},
 			expectedItemCount:      2,
 			expectedFileCount:      0,
 			expectedContainerCount: 3,
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drive),
-				folderID():    driveFullPath(drive, folderName()),
-				id(subfolder): driveFullPath(drive, name(subfolder)),
+				rootID:        d.strPath(),
+				folderID():    d.strPath(folderName()),
+				id(subfolder): d.strPath(name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -595,28 +595,28 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "moved folder tree and subfolder 2",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveItem(id(subfolder), name(subfolder), driveParentDir(drive), rootID, isFolder),
-				driveFolder(driveParentDir(drive), rootID),
+				driveItem(id(subfolder), name(subfolder), d.dir(), rootID, isFolder),
+				driveFolder(d.dir(), rootID),
 			},
 			previousPaths: map[string]string{
-				folderID():    driveFullPath(drive, folderName("a")),
-				id(subfolder): driveFullPath(drive, folderName("a"), name(subfolder)),
+				folderID():    d.strPath(folderName("a")),
+				id(subfolder): d.strPath(folderName("a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:        asNotMoved(t, driveFullPath(drive)),
-				folderID():    asMoved(t, driveFullPath(drive, folderName("a")), driveFullPath(drive, folderName())),
-				id(subfolder): asMoved(t, driveFullPath(drive, folderName("a"), name(subfolder)), driveFullPath(drive, name(subfolder))),
+				rootID:        asNotMoved(t, d.strPath()),
+				folderID():    asMoved(t, d.strPath(folderName("a")), d.strPath(folderName())),
+				id(subfolder): asMoved(t, d.strPath(folderName("a"), name(subfolder)), d.strPath(name(subfolder))),
 			},
 			expectedItemCount:      2,
 			expectedFileCount:      0,
 			expectedContainerCount: 3,
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drive),
-				folderID():    driveFullPath(drive, folderName()),
-				id(subfolder): driveFullPath(drive, name(subfolder)),
+				rootID:        d.strPath(),
+				folderID():    d.strPath(folderName()),
+				id(subfolder): d.strPath(name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -625,36 +625,36 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "move subfolder when moving parent",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveItem(folderID(2), folderName(2), driveParentDir(drive), rootID, isFolder),
-				driveItem(id(item), name(item), driveParentDir(drive, folderName(2)), folderID(2), isFile),
+				driveItem(folderID(2), folderName(2), d.dir(), rootID, isFolder),
+				driveItem(id(item), name(item), d.dir(folderName(2)), folderID(2), isFile),
 				// Need to see the parent folder first (expected since that's what Graph
 				// consistently returns).
-				driveItem(folderID(), folderName("a"), driveParentDir(drive), rootID, isFolder),
-				driveItem(id(subfolder), name(subfolder), driveParentDir(drive, folderName("a")), folderID(), isFolder),
-				driveItem(id(item, 2), name(item, 2), driveParentDir(drive, folderName("a"), name(subfolder)), id(subfolder), isFile),
-				driveFolder(driveParentDir(drive), rootID),
+				driveItem(folderID(), folderName("a"), d.dir(), rootID, isFolder),
+				driveItem(id(subfolder), name(subfolder), d.dir(folderName("a")), folderID(), isFolder),
+				driveItem(id(item, 2), name(item, 2), d.dir(folderName("a"), name(subfolder)), id(subfolder), isFile),
+				driveFolder(d.dir(), rootID),
 			},
 			previousPaths: map[string]string{
-				folderID():    driveFullPath(drive, folderName("a")),
-				id(subfolder): driveFullPath(drive, folderName("a"), name(subfolder)),
+				folderID():    d.strPath(folderName("a")),
+				id(subfolder): d.strPath(folderName("a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:        asNotMoved(t, driveFullPath(drive)),
-				folderID(2):   asNew(t, driveFullPath(drive, folderName(2))),
-				folderID():    asMoved(t, driveFullPath(drive, folderName("a")), driveFullPath(drive, folderName())),
-				id(subfolder): asMoved(t, driveFullPath(drive, folderName("a"), name(subfolder)), driveFullPath(drive, folderName(), name(subfolder))),
+				rootID:        asNotMoved(t, d.strPath()),
+				folderID(2):   asNew(t, d.strPath(folderName(2))),
+				folderID():    asMoved(t, d.strPath(folderName("a")), d.strPath(folderName())),
+				id(subfolder): asMoved(t, d.strPath(folderName("a"), name(subfolder)), d.strPath(folderName(), name(subfolder))),
 			},
 			expectedItemCount:      5,
 			expectedFileCount:      2,
 			expectedContainerCount: 4,
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drive),
-				folderID():    driveFullPath(drive, folderName()),
-				folderID(2):   driveFullPath(drive, folderName(2)),
-				id(subfolder): driveFullPath(drive, folderName(), name(subfolder)),
+				rootID:        d.strPath(),
+				folderID():    d.strPath(folderName()),
+				folderID(2):   d.strPath(folderName(2)),
+				id(subfolder): d.strPath(folderName(), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(id(item), id(item, 2)),
@@ -663,28 +663,28 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "moved folder tree multiple times",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFolder(driveParentDir(drive), rootID),
-				driveItem(fileID(), fileName(), driveParentDir(drive, folderName()), folderID(), isFile),
-				driveItem(folderID(), folderName(2), driveParentDir(drive), rootID, isFolder),
+				driveFolder(d.dir(), rootID),
+				driveItem(fileID(), fileName(), d.dir(folderName()), folderID(), isFile),
+				driveItem(folderID(), folderName(2), d.dir(), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				folderID():    driveFullPath(drive, folderName("a")),
-				id(subfolder): driveFullPath(drive, folderName("a"), name(subfolder)),
+				folderID():    d.strPath(folderName("a")),
+				id(subfolder): d.strPath(folderName("a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, driveFullPath(drive)),
-				folderID(): asMoved(t, driveFullPath(drive, folderName("a")), driveFullPath(drive, folderName(2))),
+				rootID:     asNotMoved(t, d.strPath()),
+				folderID(): asMoved(t, d.strPath(folderName("a")), d.strPath(folderName(2))),
 			},
 			expectedItemCount:      2,
 			expectedFileCount:      1,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drive),
-				folderID():    driveFullPath(drive, folderName(2)),
-				id(subfolder): driveFullPath(drive, folderName(2), name(subfolder)),
+				rootID:        d.strPath(),
+				folderID():    d.strPath(folderName(2)),
+				id(subfolder): d.strPath(folderName(2), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(fileID()),
@@ -697,23 +697,23 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 				delItem(id(pkg), rootID, isPackage),
 			},
 			previousPaths: map[string]string{
-				rootID:     driveFullPath(drive),
-				folderID(): driveFullPath(drive, folderName()),
-				id(pkg):    driveFullPath(drive, name(pkg)),
+				rootID:     d.strPath(),
+				folderID(): d.strPath(folderName()),
+				id(pkg):    d.strPath(name(pkg)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, driveFullPath(drive)),
-				folderID(): asDeleted(t, driveFullPath(drive, folderName())),
-				id(pkg):    asDeleted(t, driveFullPath(drive, name(pkg))),
+				rootID:     asNotMoved(t, d.strPath()),
+				folderID(): asDeleted(t, d.strPath(folderName())),
+				id(pkg):    asDeleted(t, d.strPath(name(pkg))),
 			},
 			expectedItemCount:      0,
 			expectedFileCount:      0,
 			expectedContainerCount: 1,
 			expectedPrevPaths: map[string]string{
-				rootID: driveFullPath(drive),
+				rootID: d.strPath(),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -725,19 +725,19 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 				delItem(folderID(), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				rootID: driveFullPath(drive),
+				rootID: d.strPath(),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID: asNotMoved(t, driveFullPath(drive)),
+				rootID: asNotMoved(t, d.strPath()),
 			},
 			expectedItemCount:      0,
 			expectedFileCount:      0,
 			expectedContainerCount: 1,
 			expectedPrevPaths: map[string]string{
-				rootID: driveFullPath(drive),
+				rootID: d.strPath(),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -747,27 +747,27 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			items: []models.DriveItemable{
 				driveRootFolder(),
 				delItem(folderID(), rootID, isFolder),
-				driveItem(id(subfolder), name(subfolder), driveParentDir(drive), rootID, isFolder),
+				driveItem(id(subfolder), name(subfolder), d.dir(), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				rootID:        driveFullPath(drive),
-				folderID():    driveFullPath(drive, folderName()),
-				id(subfolder): driveFullPath(drive, folderName(), name(subfolder)),
+				rootID:        d.strPath(),
+				folderID():    d.strPath(folderName()),
+				id(subfolder): d.strPath(folderName(), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:        asNotMoved(t, driveFullPath(drive)),
-				folderID():    asDeleted(t, driveFullPath(drive, folderName())),
-				id(subfolder): asMoved(t, driveFullPath(drive, folderName(), name(subfolder)), driveFullPath(drive, name(subfolder))),
+				rootID:        asNotMoved(t, d.strPath()),
+				folderID():    asDeleted(t, d.strPath(folderName())),
+				id(subfolder): asMoved(t, d.strPath(folderName(), name(subfolder)), d.strPath(name(subfolder))),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      0,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drive),
-				id(subfolder): driveFullPath(drive, name(subfolder)),
+				rootID:        d.strPath(),
+				id(subfolder): d.strPath(name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -779,19 +779,19 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 				delItem(id(item), rootID, isFile),
 			},
 			previousPaths: map[string]string{
-				rootID: driveFullPath(drive),
+				rootID: d.strPath(),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID: asNotMoved(t, driveFullPath(drive)),
+				rootID: asNotMoved(t, d.strPath()),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      1,
 			expectedContainerCount: 1,
 			expectedPrevPaths: map[string]string{
-				rootID: driveFullPath(drive),
+				rootID: d.strPath(),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(id(item)),
@@ -800,21 +800,21 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "item before parent errors",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveItem(fileID(), fileName(), driveParentDir(drive, folderName()), folderID(), isFile),
-				driveFolder(driveParentDir(drive), rootID),
+				driveItem(fileID(), fileName(), d.dir(folderName()), folderID(), isFile),
+				driveFolder(d.dir(), rootID),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.Error,
 			expectedCollectionIDs: map[string]statePath{
-				rootID: asNotMoved(t, driveFullPath(drive)),
+				rootID: asNotMoved(t, d.strPath()),
 			},
 			expectedItemCount:      0,
 			expectedFileCount:      0,
 			expectedContainerCount: 1,
 			expectedPrevPaths: map[string]string{
-				rootID: driveFullPath(drive),
+				rootID: d.strPath(),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -823,32 +823,32 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "1 root file, 1 folder, 1 package, 1 good file, 1 malware",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveItem(fileID(), fileID(), driveParentDir(drive), rootID, isFile),
-				driveFolder(driveParentDir(drive), rootID),
-				driveItem(id(pkg), name(pkg), driveParentDir(drive), rootID, isPackage),
-				driveItem(fileID("good"), fileName("good"), driveParentDir(drive, folderName()), folderID(), isFile),
-				malwareItem(id(malware), name(malware), driveParentDir(drive, folderName()), folderID(), isFile),
+				driveItem(fileID(), fileID(), d.dir(), rootID, isFile),
+				driveFolder(d.dir(), rootID),
+				driveItem(id(pkg), name(pkg), d.dir(), rootID, isPackage),
+				driveItem(fileID("good"), fileName("good"), d.dir(folderName()), folderID(), isFile),
+				malwareItem(id(malware), name(malware), d.dir(folderName()), folderID(), isFile),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, driveFullPath(drive)),
-				folderID(): asNew(t, driveFullPath(drive, folderName())),
-				id(pkg):    asNew(t, driveFullPath(drive, name(pkg))),
+				rootID:     asNotMoved(t, d.strPath()),
+				folderID(): asNew(t, d.strPath(folderName())),
+				id(pkg):    asNew(t, d.strPath(name(pkg))),
 			},
 			expectedItemCount:      4,
 			expectedFileCount:      2,
 			expectedContainerCount: 3,
 			expectedSkippedCount:   1,
 			expectedPrevPaths: map[string]string{
-				rootID:     driveFullPath(drive),
-				folderID(): driveFullPath(drive, folderName()),
-				id(pkg):    driveFullPath(drive, name(pkg)),
+				rootID:     d.strPath(),
+				folderID(): d.strPath(folderName()),
+				id(pkg):    d.strPath(name(pkg)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{
-				driveFullPath(drive, name(pkg)): {},
+				d.strPath(name(pkg)): {},
 			},
 			expectedCountPackages: 1,
 			expectedExcludes:      makeExcludeMap(fileID(), fileID("good")),
@@ -863,15 +863,15 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			defer flush()
 
 			var (
-				drive    = mock.Drive()
-				mbh      = mock.DefaultOneDriveBH(user)
+				drive    = drive()
+				mbh      = defaultOneDriveBH(user)
 				excludes = map[string]struct{}{}
 				errs     = fault.New(true)
 			)
 
-			mbh.DriveItemEnumeration = mock.DriveEnumerator(
-				drive.NewEnumer().With(
-					mock.Delta("notempty", nil).With(
+			mbh.DriveItemEnumeration = driveEnumerator(
+				drive.newEnumer().with(
+					delta("notempty", nil).with(
 						aPage(test.items...))))
 
 			sel := selectors.NewOneDriveBackup([]string{user})
@@ -887,11 +887,11 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 				control.Options{ToggleFeatures: control.Toggles{}},
 				count.New())
 
-			c.CollectionMap[drive.ID] = map[string]*Collection{}
+			c.CollectionMap[drive.id] = map[string]*Collection{}
 
 			_, newPrevPaths, err := c.PopulateDriveCollections(
 				ctx,
-				drive.ID,
+				drive.id,
 				"General",
 				test.previousPaths,
 				excludes,
@@ -903,7 +903,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			assert.ElementsMatch(
 				t,
 				maps.Keys(test.expectedCollectionIDs),
-				maps.Keys(c.CollectionMap[drive.ID]),
+				maps.Keys(c.CollectionMap[drive.id]),
 				"expected collection IDs")
 			assert.Equal(t, test.expectedItemCount, c.NumItems, "item count")
 			assert.Equal(t, test.expectedFileCount, c.NumFiles, "file count")
@@ -911,14 +911,14 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			assert.Equal(t, test.expectedSkippedCount, len(errs.Skipped()), "skipped item count")
 
 			for id, sp := range test.expectedCollectionIDs {
-				if !assert.Containsf(t, c.CollectionMap[drive.ID], id, "missing collection with id %s", id) {
+				if !assert.Containsf(t, c.CollectionMap[drive.id], id, "missing collection with id %s", id) {
 					// Skip collections we don't find so we don't get an NPE.
 					continue
 				}
 
-				assert.Equalf(t, sp.state, c.CollectionMap[drive.ID][id].State(), "state for collection %s", id)
-				assert.Equalf(t, sp.currPath, c.CollectionMap[drive.ID][id].FullPath(), "current path for collection %s", id)
-				assert.Equalf(t, sp.prevPath, c.CollectionMap[drive.ID][id].PreviousPath(), "prev path for collection %s", id)
+				assert.Equalf(t, sp.state, c.CollectionMap[drive.id][id].State(), "state for collection %s", id)
+				assert.Equalf(t, sp.currPath, c.CollectionMap[drive.id][id].FullPath(), "current path for collection %s", id)
+				assert.Equalf(t, sp.prevPath, c.CollectionMap[drive.id][id].PreviousPath(), "prev path for collection %s", id)
 			}
 
 			assert.Equal(t, test.expectedPrevPaths, newPrevPaths, "previous paths")
@@ -941,6 +941,9 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 }
 
 func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
+	d := drive()
+	d2 := drive(2)
+
 	table := []struct {
 		name string
 		// Each function returns the set of files for a single data.Collection.
@@ -958,23 +961,23 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
-							map[string]string{id(drive): id(delta)}),
+							map[string]string{d.id: id(deltaURL)}),
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drive): {
-									folderID(1): driveFullPath(1),
+								d.id: {
+									folderID(1): d.strPath(),
 								},
 							}),
 					}
 				},
 			},
 			expectedDeltas: map[string]string{
-				id(drive): id(delta),
+				d.id: id(deltaURL),
 			},
 			expectedPaths: map[string]map[string]string{
-				id(drive): {
-					folderID(1): driveFullPath(1),
+				d.id: {
+					folderID(1): d.strPath(),
 				},
 			},
 			canUsePreviousBackup: true,
@@ -987,7 +990,7 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
-							map[string]string{id(drive): id(delta)}),
+							map[string]string{d.id: id(deltaURL)}),
 					}
 				},
 			},
@@ -1004,8 +1007,8 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drive): {
-									folderID(1): driveFullPath(1),
+								d.id: {
+									folderID(1): d.strPath(),
 								},
 							}),
 					}
@@ -1013,8 +1016,8 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 			},
 			expectedDeltas: map[string]string{},
 			expectedPaths: map[string]map[string]string{
-				id(drive): {
-					folderID(1): driveFullPath(1),
+				d.id: {
+					folderID(1): d.strPath(),
 				},
 			},
 			canUsePreviousBackup: true,
@@ -1030,17 +1033,17 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
-							map[string]string{id(drive): id(delta)}),
+							map[string]string{d.id: id(deltaURL)}),
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drive): {},
+								d.id: {},
 							}),
 					}
 				},
 			},
 			expectedDeltas:       map[string]string{},
-			expectedPaths:        map[string]map[string]string{id(drive): {}},
+			expectedPaths:        map[string]map[string]string{d.id: {}},
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 		},
@@ -1055,22 +1058,22 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
 							map[string]string{
-								id(drive): "",
+								d.id: "",
 							}),
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drive): {
-									folderID(1): driveFullPath(1),
+								d.id: {
+									folderID(1): d.strPath(),
 								},
 							}),
 					}
 				},
 			},
-			expectedDeltas: map[string]string{id(drive): ""},
+			expectedDeltas: map[string]string{d.id: ""},
 			expectedPaths: map[string]map[string]string{
-				id(drive): {
-					folderID(1): driveFullPath(1),
+				d.id: {
+					folderID(1): d.strPath(),
 				},
 			},
 			canUsePreviousBackup: true,
@@ -1083,12 +1086,12 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
-							map[string]string{id(drive): id(delta)}),
+							map[string]string{d.id: id(deltaURL)}),
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drive): {
-									folderID(1): driveFullPath(1),
+								d.id: {
+									folderID(1): d.strPath(),
 								},
 							}),
 					}
@@ -1097,27 +1100,27 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
-							map[string]string{id(drive, 2): id(delta, 2)}),
+							map[string]string{d2.id: id(deltaURL, 2)}),
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drive, 2): {
-									folderID(2): driveFullPath(2),
+								d2.id: {
+									folderID(2): d2.strPath(),
 								},
 							}),
 					}
 				},
 			},
 			expectedDeltas: map[string]string{
-				id(drive):    id(delta),
-				id(drive, 2): id(delta, 2),
+				d.id:  id(deltaURL),
+				d2.id: id(deltaURL, 2),
 			},
 			expectedPaths: map[string]map[string]string{
-				id(drive): {
-					folderID(1): driveFullPath(1),
+				d.id: {
+					folderID(1): d.strPath(),
 				},
-				id(drive, 2): {
-					folderID(2): driveFullPath(2),
+				d2.id: {
+					folderID(2): d2.strPath(),
 				},
 			},
 			canUsePreviousBackup: true,
@@ -1134,7 +1137,7 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
-							map[string]string{id(drive): id(delta)}),
+							map[string]string{d.id: id(deltaURL)}),
 					}
 				},
 			},
@@ -1150,26 +1153,26 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
-							map[string]string{id(drive): id(delta)}),
+							map[string]string{d.id: id(deltaURL)}),
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drive): {
-									folderID(1): driveFullPath(1),
+								d.id: {
+									folderID(1): d.strPath(),
 								},
 							}),
 						graph.NewMetadataEntry(
 							"foo",
-							map[string]string{id(drive): id(delta)}),
+							map[string]string{d.id: id(deltaURL)}),
 					}
 				},
 			},
 			expectedDeltas: map[string]string{
-				id(drive): id(delta),
+				d.id: id(deltaURL),
 			},
 			expectedPaths: map[string]map[string]string{
-				id(drive): {
-					folderID(1): driveFullPath(1),
+				d.id: {
+					folderID(1): d.strPath(),
 				},
 			},
 			canUsePreviousBackup: true,
@@ -1182,12 +1185,12 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
-							map[string]string{id(drive): id(delta)}),
+							map[string]string{d.id: id(deltaURL)}),
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drive): {
-									folderID(1): driveFullPath(1),
+								d.id: {
+									folderID(1): d.strPath(),
 								},
 							}),
 					}
@@ -1197,8 +1200,8 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drive): {
-									folderID(2): driveFullPath(2),
+								d.id: {
+									folderID(2): d2.strPath(),
 								},
 							}),
 					}
@@ -1216,12 +1219,12 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
-							map[string]string{id(drive): id(delta)}),
+							map[string]string{d.id: id(deltaURL)}),
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drive): {
-									folderID(1): driveFullPath(1),
+								d.id: {
+									folderID(1): d.strPath(),
 								},
 							}),
 					}
@@ -1230,7 +1233,7 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
-							map[string]string{id(drive): id(delta, 2)}),
+							map[string]string{d.id: id(deltaURL, 2)}),
 					}
 				},
 			},
@@ -1246,25 +1249,25 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
-							map[string]string{id(drive): id(delta)}),
+							map[string]string{d.id: id(deltaURL)}),
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drive): {
-									folderID(1): driveFullPath(1),
-									folderID(2): driveFullPath(1),
+								d.id: {
+									folderID(1): d.strPath(),
+									folderID(2): d.strPath(),
 								},
 							}),
 					}
 				},
 			},
 			expectedDeltas: map[string]string{
-				id(drive): id(delta),
+				d.id: id(deltaURL),
 			},
 			expectedPaths: map[string]map[string]string{
-				id(drive): {
-					folderID(1): driveFullPath(1),
-					folderID(2): driveFullPath(1),
+				d.id: {
+					folderID(1): d.strPath(),
+					folderID(2): d.strPath(),
 				},
 			},
 			expectedAlerts:       []string{fault.AlertPreviousPathCollision},
@@ -1279,14 +1282,14 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
 							map[string]string{
-								id(drive): id(delta),
+								d.id: id(deltaURL),
 							}),
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drive): {
-									folderID(1): driveFullPath(1),
-									folderID(2): driveFullPath(1),
+								d.id: {
+									folderID(1): d.strPath(),
+									folderID(2): d.strPath(),
 								},
 							}),
 					}
@@ -1295,28 +1298,28 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
-							map[string]string{id(drive, 2): id(delta, 2)}),
+							map[string]string{d2.id: id(deltaURL, 2)}),
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drive, 2): {
-									folderID(1): driveFullPath(1),
+								d2.id: {
+									folderID(1): d.strPath(),
 								},
 							}),
 					}
 				},
 			},
 			expectedDeltas: map[string]string{
-				id(drive):    id(delta),
-				id(drive, 2): id(delta, 2),
+				d.id:  id(deltaURL),
+				d2.id: id(deltaURL, 2),
 			},
 			expectedPaths: map[string]map[string]string{
-				id(drive): {
-					folderID(1): driveFullPath(1),
-					folderID(2): driveFullPath(1),
+				d.id: {
+					folderID(1): d.strPath(),
+					folderID(2): d.strPath(),
 				},
-				id(drive, 2): {
-					folderID(1): driveFullPath(1),
+				d2.id: {
+					folderID(1): d.strPath(),
 				},
 			},
 			expectedAlerts:       []string{fault.AlertPreviousPathCollision},
@@ -1400,14 +1403,15 @@ func (suite *CollectionsUnitSuite) TestGet_treeCannotBeUsedWhileIncomplete() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	mbh := mock.DefaultOneDriveBH(user)
+	mbh := defaultOneDriveBH(user)
 	opts := control.DefaultOptions()
 	opts.ToggleFeatures.UseDeltaTree = true
 
-	mbh.DriveItemEnumeration = mock.DriveEnumerator(
-		mock.Drive().NewEnumer().With(
-			mock.Delta(id(delta), nil).With(
-				aPage(delItem(fileID(), rootID, isFile)))))
+	mbh.DriveItemEnumeration = driveEnumerator(
+		drive().newEnumer().with(
+			delta(id(deltaURL), nil).with(
+				aPage(
+					delItem(fileID(), rootID, isFile)))))
 
 	c := collWithMBH(mbh)
 	c.ctrl = opts
@@ -1425,12 +1429,12 @@ func (suite *CollectionsUnitSuite) TestGet() {
 		false)
 	require.NoError(suite.T(), err, "making metadata path", clues.ToCore(err))
 
-	drive1 := mock.Drive(1)
-	drive2 := mock.Drive(2)
+	d := drive(1)
+	d2 := drive(2)
 
 	table := []struct {
 		name                 string
-		enumerator           mock.EnumerateDriveItemsDelta
+		enumerator           enumerateDriveItemsDelta
 		canUsePreviousBackup bool
 		errCheck             assert.ErrorAssertionFunc
 		previousPaths        map[string]map[string]string
@@ -1448,355 +1452,363 @@ func (suite *CollectionsUnitSuite) TestGet() {
 	}{
 		{
 			name: "OneDrive_OneItemPage_DelFileOnly_NoFolders_NoErrors",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.Delta(id(delta), nil).With(aPage(
-						delItem(fileID(), rootID, isFile))))),
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					delta(id(deltaURL), nil).with(
+						aPage(
+							delItem(fileID(), rootID, isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {rootID: driveFullPath(1)},
+				id(drivePfx, 1): {rootID: d.strPath()},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {data.NotMovedState: {}},
+				d.strPath(): {data.NotMovedState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
+				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {rootID: driveFullPath(1)},
+				id(drivePfx, 1): {rootID: d.strPath()},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{
-				driveFullPath(1): makeExcludeMap(fileID()),
+				d.strPath(): makeExcludeMap(fileID()),
 			}),
 		},
 		{
 			name: "OneDrive_OneItemPage_NoFolderDeltas_NoErrors",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.Delta(id(delta), nil).With(aPage(
-						driveFile(driveParentDir(1), rootID))))),
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					delta(id(deltaURL), nil).with(
+						aPage(
+							driveFile(d.dir(), rootID))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {rootID: driveFullPath(1)},
+				id(drivePfx, 1): {rootID: d.strPath()},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {data.NotMovedState: {fileID()}},
+				d.strPath(): {data.NotMovedState: {fileID()}},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
+				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {rootID: driveFullPath(1)},
+				id(drivePfx, 1): {rootID: d.strPath()},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{
-				driveFullPath(1): makeExcludeMap(fileID()),
+				d.strPath(): makeExcludeMap(fileID()),
 			}),
 		},
 		{
 			name: "OneDrive_OneItemPage_NoErrors",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.DeltaWReset(id(delta), nil).With(aPage(
-						driveFolder(driveParentDir(1), rootID),
-						driveFile(driveParentDir(1, folderName()), folderID()))))),
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					deltaWReset(id(deltaURL), nil).with(
+						aPage(
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID()))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths:        map[string]map[string]string{},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.NewState: {folderID(), fileID()}},
+				d.strPath():             {data.NewState: {}},
+				d.strPath(folderName()): {data.NewState: {folderID(), fileID()}},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
+				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "OneDrive_OneItemPage_NoErrors_FileRenamedMultiple",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.DeltaWReset(id(delta), nil).With(aPage(
-						driveFolder(driveParentDir(1), rootID),
-						driveFile(driveParentDir(1, folderName()), folderID()),
-						driveItem(fileID(), fileName(2), driveParentDir(1, folderName()), folderID(), isFile))))),
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					deltaWReset(id(deltaURL), nil).with(
+						aPage(
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID()),
+							driveItem(fileID(), fileName(2), d.dir(folderName()), folderID(), isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths:        map[string]map[string]string{},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.NewState: {folderID(), fileID()}},
+				d.strPath():             {data.NewState: {}},
+				d.strPath(folderName()): {data.NewState: {folderID(), fileID()}},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
+				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "OneDrive_OneItemPage_NoErrors_FileMovedMultiple",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.Delta(id(delta), nil).With(aPage(
-						driveFolder(driveParentDir(1), rootID),
-						driveFile(driveParentDir(1, folderName()), folderID()),
-						driveItem(fileID(), fileName(2), driveParentDir(1), rootID, isFile))))),
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					delta(id(deltaURL), nil).with(
+						aPage(
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID()),
+							driveItem(fileID(), fileName(2), d.dir(), rootID, isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID: driveFullPath(1),
+				id(drivePfx, 1): {
+					rootID: d.strPath(),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NotMovedState: {fileID()}},
-				driveFullPath(1, folderName()): {data.NewState: {folderID()}},
+				d.strPath():             {data.NotMovedState: {fileID()}},
+				d.strPath(folderName()): {data.NewState: {folderID()}},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
+				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{
-				driveFullPath(1): makeExcludeMap(fileID()),
+				d.strPath(): makeExcludeMap(fileID()),
 			}),
 		},
 		{
 			name: "OneDrive_TwoItemPages_NoErrors",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.DeltaWReset(id(delta), nil).With(
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					deltaWReset(id(deltaURL), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID())),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())),
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID(), 2))))),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID(), 2))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {},
+				id(drivePfx, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.NewState: {folderID(), fileID(), fileID(2)}},
+				d.strPath():             {data.NewState: {}},
+				d.strPath(folderName()): {data.NewState: {folderID(), fileID(), fileID(2)}},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
+				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "OneDrive_TwoItemPages_WithReset",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.DeltaWReset(id(delta), nil).With(
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					deltaWReset(id(deltaURL), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID()),
-							driveItem(fileID(3), fileName(3), driveParentDir(1, folderName()), folderID(), isFile)),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID()),
+							driveItem(fileID(3), fileName(3), d.dir(folderName()), folderID(), isFile)),
 						aReset(),
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID())),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())),
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID(), 2))))),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID(), 2))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {},
+				id(drivePfx, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.NewState: {folderID(), fileID(), fileID(2)}},
+				d.strPath():             {data.NewState: {}},
+				d.strPath(folderName()): {data.NewState: {folderID(), fileID(), fileID(2)}},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
+				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "OneDrive_TwoItemPages_WithResetCombinedWithItems",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.DeltaWReset(id(delta), nil).With(
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					deltaWReset(id(deltaURL), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID())),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())),
 						aPageWReset(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID())),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())),
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID(), 2))))),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID(), 2))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {},
+				id(drivePfx, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.NewState: {folderID(), fileID(), fileID(2)}},
+				d.strPath():             {data.NewState: {}},
+				d.strPath(folderName()): {data.NewState: {folderID(), fileID(), fileID(2)}},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
+				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "TwoDrives_OneItemPageEach_NoErrors",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.DeltaWReset(id(delta), nil).With(aPage(
-						driveFolder(driveParentDir(1), rootID),
-						driveFile(driveParentDir(1, folderName()), folderID())))),
-				drive2.NewEnumer().With(
-					mock.DeltaWReset(id(delta, 2), nil).With(aPage(
-						driveItem(folderID(2), folderName(), driveParentDir(2), rootID, isFolder),
-						driveItem(fileID(2), fileName(), driveParentDir(2, folderName()), folderID(2), isFile))))),
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					deltaWReset(id(deltaURL), nil).with(
+						aPage(
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())))),
+				d2.newEnumer().with(
+					deltaWReset(id(deltaURL, 2), nil).with(aPage(
+						driveItem(folderID(2), folderName(), d2.dir(), rootID, isFolder),
+						driveItem(fileID(2), fileName(), d2.dir(folderName()), folderID(2), isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {},
-				id(drive, 2): {},
+				id(drivePfx, 1): {},
+				d2.id:           {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.NewState: {folderID(), fileID()}},
-				driveFullPath(2):               {data.NewState: {}},
-				driveFullPath(2, folderName()): {data.NewState: {folderID(2), fileID(2)}},
+				d.strPath():              {data.NewState: {}},
+				d.strPath(folderName()):  {data.NewState: {folderID(), fileID()}},
+				d2.strPath():             {data.NewState: {}},
+				d2.strPath(folderName()): {data.NewState: {folderID(2), fileID(2)}},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
-				id(drive, 2): id(delta, 2),
+				id(drivePfx, 1): id(deltaURL),
+				d2.id:           id(deltaURL, 2),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
-				id(drive, 2): {
-					rootID:      driveFullPath(2),
-					folderID(2): driveFullPath(2, folderName()),
+				d2.id: {
+					rootID:      d2.strPath(),
+					folderID(2): d2.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
-				driveFullPath(2):               true,
-				driveFullPath(2, folderName()): true,
+				d.strPath():              true,
+				d.strPath(folderName()):  true,
+				d2.strPath():             true,
+				d2.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "TwoDrives_DuplicateIDs_OneItemPageEach_NoErrors",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.DeltaWReset(id(delta), nil).With(aPage(
-						driveFolder(driveParentDir(1), rootID),
-						driveFile(driveParentDir(1, folderName()), folderID())))),
-				drive2.NewEnumer().With(
-					mock.DeltaWReset(id(delta, 2), nil).With(aPage(
-						driveFolder(driveParentDir(2), rootID),
-						driveItem(fileID(2), fileName(), driveParentDir(2, folderName()), folderID(), isFile))))),
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					deltaWReset(id(deltaURL), nil).with(
+						aPage(
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())))),
+				d2.newEnumer().with(
+					deltaWReset(id(deltaURL, 2), nil).with(
+						aPage(
+							driveFolder(d2.dir(), rootID),
+							driveItem(fileID(2), fileName(), d2.dir(folderName()), folderID(), isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {},
-				id(drive, 2): {},
+				id(drivePfx, 1): {},
+				d2.id:           {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.NewState: {folderID(), fileID()}},
-				driveFullPath(2):               {data.NewState: {}},
-				driveFullPath(2, folderName()): {data.NewState: {folderID(), fileID(2)}},
+				d.strPath():              {data.NewState: {}},
+				d.strPath(folderName()):  {data.NewState: {folderID(), fileID()}},
+				d2.strPath():             {data.NewState: {}},
+				d2.strPath(folderName()): {data.NewState: {folderID(), fileID(2)}},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
-				id(drive, 2): id(delta, 2),
+				id(drivePfx, 1): id(deltaURL),
+				d2.id:           id(deltaURL, 2),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
-				id(drive, 2): {
-					rootID:     driveFullPath(2),
-					folderID(): driveFullPath(2, folderName()),
+				d2.id: {
+					rootID:     d2.strPath(),
+					folderID(): d2.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
-				driveFullPath(2):               true,
-				driveFullPath(2, folderName()): true,
+				d.strPath():              true,
+				d.strPath(folderName()):  true,
+				d2.strPath():             true,
+				d2.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "OneDrive_OneItemPage_Errors",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.Delta("", assert.AnError))),
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					delta("", assert.AnError))),
 			canUsePreviousBackup: false,
 			errCheck:             assert.Error,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {},
+				id(drivePfx, 1): {},
 			},
 			expectedCollections:   nil,
 			expectedDeltaURLs:     nil,
@@ -1805,103 +1817,103 @@ func (suite *CollectionsUnitSuite) TestGet() {
 		},
 		{
 			name: "OneDrive_OneItemPage_InvalidPrevDelta_DeleteNonExistentFolder",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.DeltaWReset(id(delta), nil).With(
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					deltaWReset(id(deltaURL), nil).with(
 						aReset(),
 						aPage(
-							driveFolder(driveParentDir(1), rootID, 2),
-							driveFile(driveParentDir(1, folderName(2)), folderID(2)))))),
+							driveFolder(d.dir(), rootID, 2),
+							driveFile(d.dir(folderName(2)), folderID(2)))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):                {data.NewState: {}},
-				driveFullPath(1, folderName()):  {data.DeletedState: {}},
-				driveFullPath(1, folderName(2)): {data.NewState: {folderID(2), fileID()}},
+				d.strPath():              {data.NewState: {}},
+				d.strPath(folderName()):  {data.DeletedState: {}},
+				d.strPath(folderName(2)): {data.NewState: {folderID(2), fileID()}},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
+				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:      driveFullPath(1),
-					folderID(2): driveFullPath(1, folderName(2)),
+				id(drivePfx, 1): {
+					rootID:      d.strPath(),
+					folderID(2): d.strPath(folderName(2)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):                true,
-				driveFullPath(1, folderName()):  true,
-				driveFullPath(1, folderName(2)): true,
+				d.strPath():              true,
+				d.strPath(folderName()):  true,
+				d.strPath(folderName(2)): true,
 			},
 		},
 		{
 			name: "OneDrive_OneItemPage_InvalidPrevDeltaCombinedWithItems_DeleteNonExistentFolder",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.DeltaWReset(id(delta), nil).With(
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					deltaWReset(id(deltaURL), nil).with(
 						aReset(),
 						aPage(
-							driveFolder(driveParentDir(1), rootID, 2),
-							driveFile(driveParentDir(1, folderName(2)), folderID(2)))))),
+							driveFolder(d.dir(), rootID, 2),
+							driveFile(d.dir(folderName(2)), folderID(2)))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):                {data.NewState: {}},
-				driveFullPath(1, folderName()):  {data.DeletedState: {}},
-				driveFullPath(1, folderName(2)): {data.NewState: {folderID(2), fileID()}},
+				d.strPath():              {data.NewState: {}},
+				d.strPath(folderName()):  {data.DeletedState: {}},
+				d.strPath(folderName(2)): {data.NewState: {folderID(2), fileID()}},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
+				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:      driveFullPath(1),
-					folderID(2): driveFullPath(1, folderName(2)),
+				id(drivePfx, 1): {
+					rootID:      d.strPath(),
+					folderID(2): d.strPath(folderName(2)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):                true,
-				driveFullPath(1, folderName()):  true,
-				driveFullPath(1, folderName(2)): true,
+				d.strPath():              true,
+				d.strPath(folderName()):  true,
+				d.strPath(folderName(2)): true,
 			},
 		},
 		{
 			name: "OneDrive_OneItemPage_InvalidPrevDelta_AnotherFolderAtDeletedLocation",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.DeltaWReset(id(delta), nil).With(
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					deltaWReset(id(deltaURL), nil).with(
 						aPage(
-							driveItem(folderID(2), folderName(), driveParentDir(1), rootID, isFolder),
-							driveFile(driveParentDir(1, folderName()), folderID(2))),
+							driveItem(folderID(2), folderName(), d.dir(), rootID, isFolder),
+							driveFile(d.dir(folderName()), folderID(2))),
 						aReset(),
 						aPage(
-							driveItem(folderID(2), folderName(), driveParentDir(1), rootID, isFolder),
-							driveFile(driveParentDir(1, folderName()), folderID(2)))))),
+							driveItem(folderID(2), folderName(), d.dir(), rootID, isFolder),
+							driveFile(d.dir(folderName()), folderID(2)))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {data.NewState: {}},
-				driveFullPath(1, folderName()): {
+				d.strPath(): {data.NewState: {}},
+				d.strPath(folderName()): {
 					// Old folder path should be marked as deleted since it should compare
 					// by ID.
 					data.DeletedState: {},
@@ -1909,120 +1921,120 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
+				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:      driveFullPath(1),
-					folderID(2): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:      d.strPath(),
+					folderID(2): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "OneDrive_OneItemPage_InvalidPrevDelta_AnotherFolderAtExistingLocation",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.DeltaWReset(id(delta), nil).With(
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					deltaWReset(id(deltaURL), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID())),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())),
 						aReset(),
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID()))))),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID()))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {data.NewState: {}},
-				driveFullPath(1, folderName()): {
+				d.strPath(): {data.NewState: {}},
+				d.strPath(folderName()): {
 					data.NewState: {folderID(), fileID()},
 				},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
+				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "OneDrive_OneItemPage_ImmediateInvalidPrevDelta_MoveFolderToPreviouslyExistingPath",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.DeltaWReset(id(delta), nil).With(
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					deltaWReset(id(deltaURL), nil).with(
 						aReset(),
 						aPage(
-							driveItem(folderID(2), folderName(), driveParentDir(1), rootID, isFolder),
-							driveItem(fileID(2), fileName(), driveParentDir(1, folderName()), folderID(2), isFile))))),
+							driveItem(folderID(2), folderName(), d.dir(), rootID, isFolder),
+							driveItem(fileID(2), fileName(), d.dir(folderName()), folderID(2), isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {data.NewState: {}},
-				driveFullPath(1, folderName()): {
+				d.strPath(): {data.NewState: {}},
+				d.strPath(folderName()): {
 					data.DeletedState: {},
 					data.NewState:     {folderID(2), fileID(2)},
 				},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
+				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:      driveFullPath(1),
-					folderID(2): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:      d.strPath(),
+					folderID(2): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "OneDrive_OneItemPage_InvalidPrevDelta_AnotherFolderAtDeletedLocation",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.DeltaWReset(id(delta), nil).With(
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					deltaWReset(id(deltaURL), nil).with(
 						aReset(),
 						aPage(
-							driveItem(folderID(2), folderName(), driveParentDir(1), rootID, isFolder),
-							driveFile(driveParentDir(1, folderName()), folderID(2)))))),
+							driveItem(folderID(2), folderName(), d.dir(), rootID, isFolder),
+							driveFile(d.dir(folderName()), folderID(2)))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {data.NewState: {}},
-				driveFullPath(1, folderName()): {
+				d.strPath(): {data.NewState: {}},
+				d.strPath(folderName()): {
 					// Old folder path should be marked as deleted since it should compare
 					// by ID.
 					data.DeletedState: {},
@@ -2030,267 +2042,269 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
+				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:      driveFullPath(1),
-					folderID(2): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:      d.strPath(),
+					folderID(2): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "OneDrive Two Item Pages with Malware",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.DeltaWReset(id(delta), nil).With(
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					deltaWReset(id(deltaURL), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID()),
-							malwareItem(id(malware), name(malware), driveParentDir(1, folderName()), folderID(), isFile)),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID()),
+							malwareItem(id(malware), name(malware), d.dir(folderName()), folderID(), isFile)),
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID(), 2),
-							malwareItem(id(malware, 2), name(malware, 2), driveParentDir(1, folderName()), folderID(), isFile))))),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID(), 2),
+							malwareItem(id(malware, 2), name(malware, 2), d.dir(folderName()), folderID(), isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {},
+				id(drivePfx, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.NewState: {folderID(), fileID(), fileID(2)}},
+				d.strPath():             {data.NewState: {}},
+				d.strPath(folderName()): {data.NewState: {folderID(), fileID(), fileID(2)}},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
+				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 			expectedSkippedCount: 2,
 		},
 		{
 			name: "One Drive Deleted Folder In New Results With Invalid Delta",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.DeltaWReset(id(delta, 2), nil).With(
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					deltaWReset(id(deltaURL, 2), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID()),
-							driveFolder(driveParentDir(1), rootID, 2),
-							driveFile(driveParentDir(1, folderName(2)), folderID(2), 2)),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID()),
+							driveFolder(d.dir(), rootID, 2),
+							driveFile(d.dir(folderName(2)), folderID(2), 2)),
 						aReset(),
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID()),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID()),
 							delItem(folderID(2), rootID, isFolder),
 							delItem(fileName(2), rootID, isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:      driveFullPath(1),
-					folderID():  driveFullPath(1, folderName()),
-					folderID(2): driveFullPath(1, folderName(2)),
+				id(drivePfx, 1): {
+					rootID:      d.strPath(),
+					folderID():  d.strPath(folderName()),
+					folderID(2): d.strPath(folderName(2)),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):                {data.NewState: {}},
-				driveFullPath(1, folderName()):  {data.NewState: {folderID(), fileID()}},
-				driveFullPath(1, folderName(2)): {data.DeletedState: {}},
+				d.strPath():              {data.NewState: {}},
+				d.strPath(folderName()):  {data.NewState: {folderID(), fileID()}},
+				d.strPath(folderName(2)): {data.DeletedState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta, 2),
+				id(drivePfx, 1): id(deltaURL, 2),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):                true,
-				driveFullPath(1, folderName()):  true,
-				driveFullPath(1, folderName(2)): true,
+				d.strPath():              true,
+				d.strPath(folderName()):  true,
+				d.strPath(folderName(2)): true,
 			},
 		},
 		{
 			name: "One Drive Folder Delete After Invalid Delta",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.DeltaWReset(id(delta), nil).With(aPageWReset(
-						delItem(folderID(), rootID, isFolder))))),
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					deltaWReset(id(deltaURL), nil).with(
+						aPageWReset(
+							delItem(folderID(), rootID, isFolder))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.DeletedState: {}},
+				d.strPath():             {data.NewState: {}},
+				d.strPath(folderName()): {data.DeletedState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
+				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID: driveFullPath(1),
+				id(drivePfx, 1): {
+					rootID: d.strPath(),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "One Drive Item Delete After Invalid Delta",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.DeltaWReset(id(delta), nil).With(aPageWReset(
-						delItem(fileID(), rootID, isFile))))),
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					deltaWReset(id(deltaURL), nil).with(
+						aPageWReset(
+							delItem(fileID(), rootID, isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID: driveFullPath(1),
+				id(drivePfx, 1): {
+					rootID: d.strPath(),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {data.NewState: {}},
+				d.strPath(): {data.NewState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
+				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID: driveFullPath(1),
+				id(drivePfx, 1): {
+					rootID: d.strPath(),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1): true,
+				d.strPath(): true,
 			},
 		},
 		{
 			name: "One Drive Folder Made And Deleted",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.DeltaWReset(id(delta, 2), nil).With(
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					deltaWReset(id(deltaURL, 2), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID())),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())),
 						aPage(
 							delItem(folderID(), rootID, isFolder),
 							delItem(fileID(), rootID, isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {},
+				id(drivePfx, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {data.NewState: {}},
+				d.strPath(): {data.NewState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta, 2),
+				id(drivePfx, 1): id(deltaURL, 2),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID: driveFullPath(1),
+				id(drivePfx, 1): {
+					rootID: d.strPath(),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1): true,
+				d.strPath(): true,
 			},
 		},
 		{
 			name: "One Drive Folder Created -> Deleted -> Created",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.DeltaWReset(id(delta, 2), nil).With(
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					deltaWReset(id(deltaURL, 2), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID())),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())),
 						aPage(
 							delItem(folderID(), rootID, isFolder),
 							delItem(fileID(), rootID, isFile)),
 						aPage(
-							driveItem(folderID(1), folderName(), driveParentDir(1), rootID, isFolder),
-							driveItem(fileID(1), fileName(), driveParentDir(1, folderName()), folderID(1), isFile))))),
+							driveItem(folderID(1), folderName(), d.dir(), rootID, isFolder),
+							driveItem(fileID(1), fileName(), d.dir(folderName()), folderID(1), isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {},
+				id(drivePfx, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.NewState: {folderID(1), fileID(1)}},
+				d.strPath():             {data.NewState: {}},
+				d.strPath(folderName()): {data.NewState: {folderID(1), fileID(1)}},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta, 2),
+				id(drivePfx, 1): id(deltaURL, 2),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:      driveFullPath(1),
-					folderID(1): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:      d.strPath(),
+					folderID(1): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "One Drive Folder Deleted -> Created -> Deleted",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.DeltaWReset(id(delta, 2), nil).With(
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					deltaWReset(id(deltaURL, 2), nil).with(
 						aPage(
 							delItem(folderID(), rootID, isFolder),
 							delItem(fileID(), rootID, isFile)),
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID())),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())),
 						aPage(
 							delItem(folderID(), rootID, isFolder),
 							delItem(fileID(), rootID, isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NotMovedState: {}},
-				driveFullPath(1, folderName()): {data.DeletedState: {}},
+				d.strPath():             {data.NotMovedState: {}},
+				d.strPath(folderName()): {data.DeletedState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta, 2),
+				id(drivePfx, 1): id(deltaURL, 2),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID: driveFullPath(1),
+				id(drivePfx, 1): {
+					rootID: d.strPath(),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
@@ -2298,324 +2312,330 @@ func (suite *CollectionsUnitSuite) TestGet() {
 		},
 		{
 			name: "One Drive Folder Created -> Deleted -> Created with prev",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.DeltaWReset(id(delta, 2), nil).With(
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					deltaWReset(id(deltaURL, 2), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID())),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())),
 						aPage(
 							delItem(folderID(), rootID, isFolder),
 							delItem(fileID(), rootID, isFile)),
 						aPage(
-							driveItem(folderID(1), folderName(), driveParentDir(1), rootID, isFolder),
-							driveItem(fileID(1), fileName(), driveParentDir(1, folderName()), folderID(1), isFile))))),
+							driveItem(folderID(1), folderName(), d.dir(), rootID, isFolder),
+							driveItem(fileID(1), fileName(), d.dir(folderName()), folderID(1), isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.DeletedState: {}, data.NewState: {folderID(1), fileID(1)}},
+				d.strPath():             {data.NewState: {}},
+				d.strPath(folderName()): {data.DeletedState: {}, data.NewState: {folderID(1), fileID(1)}},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta, 2),
+				id(drivePfx, 1): id(deltaURL, 2),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:      driveFullPath(1),
-					folderID(1): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:      d.strPath(),
+					folderID(1): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               false,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             false,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "One Drive Item Made And Deleted",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.DeltaWReset(id(delta), nil).With(
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					deltaWReset(id(deltaURL), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID())),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())),
 						aPage(delItem(fileID(), rootID, isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {},
+				id(drivePfx, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.NewState: {folderID()}},
+				d.strPath():             {data.NewState: {}},
+				d.strPath(folderName()): {data.NewState: {folderID()}},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
+				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "One Drive Random Folder Delete",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.DeltaWReset(id(delta), nil).With(aPage(
-						delItem(folderID(), rootID, isFolder))))),
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					deltaWReset(id(deltaURL), nil).with(
+						aPage(
+							delItem(folderID(), rootID, isFolder))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {},
+				id(drivePfx, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {data.NewState: {}},
+				d.strPath(): {data.NewState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
+				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID: driveFullPath(1),
+				id(drivePfx, 1): {
+					rootID: d.strPath(),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1): true,
+				d.strPath(): true,
 			},
 		},
 		{
 			name: "One Drive Random Item Delete",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.Delta(id(delta), nil).With(aPage(
-						delItem(fileID(), rootID, isFile))))),
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					delta(id(deltaURL), nil).with(
+						aPage(
+							delItem(fileID(), rootID, isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {},
+				id(drivePfx, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {data.NewState: {}},
+				d.strPath(): {data.NewState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
+				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID: driveFullPath(1),
+				id(drivePfx, 1): {
+					rootID: d.strPath(),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1): true,
+				d.strPath(): true,
 			},
 		},
 		{
 			name: "TwoPriorDrives_OneTombstoned",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.Delta(id(delta), nil).With(aPage()))), // root only
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					delta(id(deltaURL), nil).with(aPage()))), // root only
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {rootID: driveFullPath(1)},
-				id(drive, 2): {rootID: driveFullPath(2)},
+				id(drivePfx, 1): {rootID: d.strPath()},
+				d2.id:           {rootID: d2.strPath()},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {data.NotMovedState: {}},
-				driveFullPath(2): {data.DeletedState: {}},
+				d.strPath():  {data.NotMovedState: {}},
+				d2.strPath(): {data.DeletedState: {}},
 			},
-			expectedDeltaURLs: map[string]string{id(drive, 1): id(delta)},
+			expectedDeltaURLs: map[string]string{id(drivePfx, 1): id(deltaURL)},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {rootID: driveFullPath(1)},
+				id(drivePfx, 1): {rootID: d.strPath()},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(2): true,
+				d2.strPath(): true,
 			},
 		},
 		{
 			name: "duplicate previous paths in metadata",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.Delta(id(delta), nil).With(aPage(
-						driveFolder(driveParentDir(1), rootID),
-						driveFile(driveParentDir(1, folderName()), folderID()),
-						driveFolder(driveParentDir(1), rootID, 2),
-						driveFile(driveParentDir(1, folderName(2)), folderID(2), 2)))),
-				drive2.NewEnumer().With(
-					mock.Delta(id(delta, 2), nil).With(aPage(
-						driveFolder(driveParentDir(2), rootID),
-						driveFile(driveParentDir(2, folderName()), folderID()),
-						driveFolder(driveParentDir(2), rootID, 2),
-						driveFile(driveParentDir(2, folderName(2)), folderID(2), 2))))),
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					delta(id(deltaURL), nil).with(
+						aPage(
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID()),
+							driveFolder(d.dir(), rootID, 2),
+							driveFile(d.dir(folderName(2)), folderID(2), 2)))),
+				d2.newEnumer().with(
+					delta(id(deltaURL, 2), nil).with(
+						aPage(
+							driveFolder(d2.dir(), rootID),
+							driveFile(d2.dir(folderName()), folderID()),
+							driveFolder(d2.dir(), rootID, 2),
+							driveFile(d2.dir(folderName(2)), folderID(2), 2))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:      driveFullPath(1),
-					folderID():  driveFullPath(1, folderName()),
-					folderID(2): driveFullPath(1, folderName()),
-					folderID(3): driveFullPath(1, folderName()),
+				id(drivePfx, 1): {
+					rootID:      d.strPath(),
+					folderID():  d.strPath(folderName()),
+					folderID(2): d.strPath(folderName()),
+					folderID(3): d.strPath(folderName()),
 				},
-				id(drive, 2): {
-					rootID:      driveFullPath(2),
-					folderID():  driveFullPath(2, folderName()),
-					folderID(2): driveFullPath(2, folderName(2)),
+				d2.id: {
+					rootID:      d2.strPath(),
+					folderID():  d2.strPath(folderName()),
+					folderID(2): d2.strPath(folderName(2)),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {
+				d.strPath(): {
 					data.NewState: {folderID(), folderID(2)},
 				},
-				driveFullPath(1, folderName()): {
+				d.strPath(folderName()): {
 					data.NotMovedState: {folderID(), fileID()},
 				},
-				driveFullPath(1, folderName(2)): {
+				d.strPath(folderName(2)): {
 					data.MovedState: {folderID(2), fileID(2)},
 				},
-				driveFullPath(2): {
+				d2.strPath(): {
 					data.NewState: {folderID(), folderID(2)},
 				},
-				driveFullPath(2, folderName()): {
+				d2.strPath(folderName()): {
 					data.NotMovedState: {folderID(), fileID()},
 				},
-				driveFullPath(2, folderName(2)): {
+				d2.strPath(folderName(2)): {
 					data.NotMovedState: {folderID(2), fileID(2)},
 				},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
-				id(drive, 2): id(delta, 2),
+				id(drivePfx, 1): id(deltaURL),
+				d2.id:           id(deltaURL, 2),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:      driveFullPath(1),
-					folderID():  driveFullPath(1, folderName(2)), // note: this is a bug, but is currently expected
-					folderID(2): driveFullPath(1, folderName(2)),
-					folderID(3): driveFullPath(1, folderName(2)),
+				id(drivePfx, 1): {
+					rootID:      d.strPath(),
+					folderID():  d.strPath(folderName(2)), // note: this is a bug, but is currently expected
+					folderID(2): d.strPath(folderName(2)),
+					folderID(3): d.strPath(folderName(2)),
 				},
-				id(drive, 2): {
-					rootID:      driveFullPath(2),
-					folderID():  driveFullPath(2, folderName()),
-					folderID(2): driveFullPath(2, folderName(2)),
+				d2.id: {
+					rootID:      d2.strPath(),
+					folderID():  d2.strPath(folderName()),
+					folderID(2): d2.strPath(folderName(2)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{
-				driveFullPath(1): makeExcludeMap(fileID(), fileID(2)),
-				driveFullPath(2): makeExcludeMap(fileID(), fileID(2)),
+				d.strPath():  makeExcludeMap(fileID(), fileID(2)),
+				d2.strPath(): makeExcludeMap(fileID(), fileID(2)),
 			}),
 			doNotMergeItems: map[string]bool{},
 		},
 		{
 			name: "out of order item enumeration causes prev path collisions",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.Delta(id(delta), nil).With(aPage(
-						driveItem(folderID(fanny, 2), folderName(fanny), driveParentDir(1), rootID, isFolder),
-						driveFile(driveParentDir(1, folderName(fanny)), folderID(fanny, 2), 2),
-						driveFolder(driveParentDir(1), rootID, nav),
-						driveFile(driveParentDir(1, folderName(nav)), folderID(nav)))))),
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					delta(id(deltaURL), nil).with(
+						aPage(
+							driveItem(folderID(fanny, 2), folderName(fanny), d.dir(), rootID, isFolder),
+							driveFile(d.dir(folderName(fanny)), folderID(fanny, 2), 2),
+							driveFolder(d.dir(), rootID, nav),
+							driveFile(d.dir(folderName(nav)), folderID(nav)))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:        driveFullPath(1),
-					folderID(nav): driveFullPath(1, folderName(fanny)),
+				id(drivePfx, 1): {
+					rootID:        d.strPath(),
+					folderID(nav): d.strPath(folderName(fanny)),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {
+				d.strPath(): {
 					data.NewState: {folderID(fanny, 2)},
 				},
-				driveFullPath(1, folderName(nav)): {
+				d.strPath(folderName(nav)): {
 					data.MovedState: {folderID(nav), fileID()},
 				},
-				driveFullPath(1, folderName(fanny)): {
+				d.strPath(folderName(fanny)): {
 					data.NewState: {folderID(fanny, 2), fileID(2)},
 				},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
+				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:             driveFullPath(1),
-					folderID(nav):      driveFullPath(1, folderName(nav)),
-					folderID(fanny, 2): driveFullPath(1, folderName(nav)), // note: this is a bug, but currently expected
+				id(drivePfx, 1): {
+					rootID:             d.strPath(),
+					folderID(nav):      d.strPath(folderName(nav)),
+					folderID(fanny, 2): d.strPath(folderName(nav)), // note: this is a bug, but currently expected
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{
-				driveFullPath(1): makeExcludeMap(fileID(), fileID(2)),
+				d.strPath(): makeExcludeMap(fileID(), fileID(2)),
 			}),
 			doNotMergeItems: map[string]bool{},
 		},
 		{
 			name: "out of order item enumeration causes opposite prev path collisions",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.Delta(id(delta), nil).With(aPage(
-						driveFile(driveParentDir(1), rootID, 1),
-						driveFolder(driveParentDir(1), rootID, fanny),
-						driveFolder(driveParentDir(1), rootID, nav),
-						driveFolder(driveParentDir(1, folderName(fanny)), folderID(fanny), foo),
-						driveItem(folderID(bar), folderName(foo), driveParentDir(1, folderName(nav)), folderID(nav), isFolder))))),
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					delta(id(deltaURL), nil).with(
+						aPage(
+							driveFile(d.dir(), rootID, 1),
+							driveFolder(d.dir(), rootID, fanny),
+							driveFolder(d.dir(), rootID, nav),
+							driveFolder(d.dir(folderName(fanny)), folderID(fanny), foo),
+							driveItem(folderID(bar), folderName(foo), d.dir(folderName(nav)), folderID(nav), isFolder))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:          driveFullPath(1),
-					folderID(nav):   driveFullPath(1, folderName(nav)),
-					folderID(fanny): driveFullPath(1, folderName(fanny)),
-					folderID(foo):   driveFullPath(1, folderName(nav), folderName(foo)),
-					folderID(bar):   driveFullPath(1, folderName(fanny), folderName(foo)),
+				id(drivePfx, 1): {
+					rootID:          d.strPath(),
+					folderID(nav):   d.strPath(folderName(nav)),
+					folderID(fanny): d.strPath(folderName(fanny)),
+					folderID(foo):   d.strPath(folderName(nav), folderName(foo)),
+					folderID(bar):   d.strPath(folderName(fanny), folderName(foo)),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {
+				d.strPath(): {
 					data.NotMovedState: {fileID(1)},
 				},
-				driveFullPath(1, folderName(nav)): {
+				d.strPath(folderName(nav)): {
 					data.NotMovedState: {folderID(nav)},
 				},
-				driveFullPath(1, folderName(nav), folderName(foo)): {
+				d.strPath(folderName(nav), folderName(foo)): {
 					data.MovedState: {folderID(bar)},
 				},
-				driveFullPath(1, folderName(fanny)): {
+				d.strPath(folderName(fanny)): {
 					data.NotMovedState: {folderID(fanny)},
 				},
-				driveFullPath(1, folderName(fanny), folderName(foo)): {
+				d.strPath(folderName(fanny), folderName(foo)): {
 					data.MovedState: {folderID(foo)},
 				},
 			},
 			expectedDeltaURLs: map[string]string{
-				id(drive, 1): id(delta),
+				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drive, 1): {
-					rootID:          driveFullPath(1),
-					folderID(nav):   driveFullPath(1, folderName(nav)),
-					folderID(fanny): driveFullPath(1, folderName(fanny)),
-					folderID(foo):   driveFullPath(1, folderName(nav), folderName(foo)), // note: this is a bug, but currently expected
-					folderID(bar):   driveFullPath(1, folderName(nav), folderName(foo)),
+				id(drivePfx, 1): {
+					rootID:          d.strPath(),
+					folderID(nav):   d.strPath(folderName(nav)),
+					folderID(fanny): d.strPath(folderName(fanny)),
+					folderID(foo):   d.strPath(folderName(nav), folderName(foo)), // note: this is a bug, but currently expected
+					folderID(bar):   d.strPath(folderName(nav), folderName(foo)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{
-				driveFullPath(1): makeExcludeMap(fileID(1)),
+				d.strPath(): makeExcludeMap(fileID(1)),
 			}),
 			doNotMergeItems: map[string]bool{},
 		},
@@ -2627,7 +2647,7 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			mbh := mock.DefaultOneDriveBH(user)
+			mbh := defaultOneDriveBH(user)
 			mbh.DriveItemEnumeration = test.enumerator
 
 			c := NewCollections(
@@ -2649,8 +2669,8 @@ func (suite *CollectionsUnitSuite) TestGet() {
 					graph.NewMetadataEntry(
 						bupMD.DeltaURLsFileName,
 						map[string]string{
-							id(drive, 1): prevDelta,
-							id(drive, 2): prevDelta,
+							id(drivePfx, 1): prevDelta,
+							d2.id:           prevDelta,
 						}),
 					graph.NewMetadataEntry(
 						bupMD.PreviousPathFileName,
@@ -2758,25 +2778,27 @@ func (suite *CollectionsUnitSuite) TestGet() {
 }
 
 func (suite *CollectionsUnitSuite) TestAddURLCacheToDriveCollections() {
-	drive1 := mock.Drive(1)
-	drive2 := mock.Drive(2)
+	d := drive(1)
+	d2 := drive(2)
 
 	table := []struct {
 		name       string
-		enumerator mock.EnumerateDriveItemsDelta
+		enumerator enumerateDriveItemsDelta
 		errCheck   assert.ErrorAssertionFunc
 	}{
 		{
 			name: "Two drives with unique url cache instances",
-			enumerator: mock.DriveEnumerator(
-				drive1.NewEnumer().With(
-					mock.Delta(id(delta), nil).With(aPage(
-						driveFolder(driveParentDir(1), rootID),
-						driveFile(driveParentDir(1, folderName()), folderID())))),
-				drive2.NewEnumer().With(
-					mock.Delta(id(delta, 2), nil).With(aPage(
-						driveItem(folderID(2), folderName(), driveParentDir(2), rootID, isFolder),
-						driveItem(fileID(2), fileName(), driveParentDir(2, folderName()), folderID(2), isFile))))),
+			enumerator: driveEnumerator(
+				d.newEnumer().with(
+					delta(id(deltaURL), nil).with(
+						aPage(
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())))),
+				d2.newEnumer().with(
+					delta(id(deltaURL, 2), nil).with(
+						aPage(
+							driveItem(folderID(2), folderName(), d2.dir(), rootID, isFolder),
+							driveItem(fileID(2), fileName(), d2.dir(folderName()), folderID(2), isFile))))),
 			errCheck: assert.NoError,
 		},
 		// TODO(pandeyabs): Add a test case to check that the cache is not attached
@@ -2791,7 +2813,7 @@ func (suite *CollectionsUnitSuite) TestAddURLCacheToDriveCollections() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			mbh := mock.DefaultOneDriveBH(user)
+			mbh := defaultOneDriveBH(user)
 			mbh.DriveItemEnumeration = test.enumerator
 
 			c := NewCollections(
@@ -2849,7 +2871,7 @@ func (suite *CollectionsUnitSuite) TestAddURLCacheToDriveCollections() {
 			// Check that we have the expected number of caches. One per drive.
 			require.Equal(
 				t,
-				len(test.enumerator.Drives()),
+				len(test.enumerator.getDrives()),
 				len(caches),
 				"expected one cache per drive")
 		})

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -629,7 +629,7 @@ func (c *Collections) addFileToTree(
 		return nil, nil
 	}
 
-	_, alreadySeen := tree.fileIDToParentID[fileID]
+	alreadySeen := tree.hasFile(fileID)
 	parentNode, parentNotNil := tree.folderIDToNode[parentID]
 
 	if parentNotNil && !alreadySeen {
@@ -686,25 +686,10 @@ func (c *Collections) makeDriveTombstones(
 			continue
 		}
 
-		// TODO: call NewTombstoneCollection
-		coll, err := NewCollection(
-			c.handler,
-			c.protectedResource,
-			nil, // delete the drive
+		coll := data.NewTombstoneCollection(
 			prevDrivePath,
-			driveID,
-			c.statusUpdater,
 			c.ctrl,
-			false,
-			true,
-			nil,
 			c.counter.Local())
-		if err != nil {
-			err = clues.WrapWC(ctx, err, "making drive tombstone")
-			el.AddRecoverable(ctx, err)
-
-			continue
-		}
 
 		colls = append(colls, coll)
 	}

--- a/src/internal/m365/collection/drive/delta_tree.go
+++ b/src/internal/m365/collection/drive/delta_tree.go
@@ -309,6 +309,11 @@ func (face *folderyMcFolderFace) setPreviousPath(
 // file handling
 // ---------------------------------------------------------------------------
 
+func (face *folderyMcFolderFace) hasFile(id string) bool {
+	_, exists := face.fileIDToParentID[id]
+	return exists
+}
+
 // addFile places the file in the correct parent node.  If the
 // file was already added to the tree and is getting relocated,
 // this func will update and/or clean up all the old references.

--- a/src/internal/m365/collection/drive/helper_test.go
+++ b/src/internal/m365/collection/drive/helper_test.go
@@ -3,10 +3,12 @@ package drive
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/alcionai/clues"
+	"github.com/microsoftgraph/msgraph-sdk-go/drives"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,11 +19,11 @@ import (
 	dataMock "github.com/alcionai/corso/src/internal/data/mock"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive/metadata"
 	odConsts "github.com/alcionai/corso/src/internal/m365/service/onedrive/consts"
-	"github.com/alcionai/corso/src/internal/m365/service/onedrive/mock"
 	"github.com/alcionai/corso/src/internal/m365/support"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
+	"github.com/alcionai/corso/src/pkg/backup/details"
 	bupMD "github.com/alcionai/corso/src/pkg/backup/metadata"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/count"
@@ -30,6 +32,8 @@ import (
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
+	apiMock "github.com/alcionai/corso/src/pkg/services/m365/api/mock"
+	"github.com/alcionai/corso/src/pkg/services/m365/api/pagers"
 	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
@@ -42,7 +46,7 @@ type oneDriveService struct {
 	ac          api.Client
 }
 
-func NewOneDriveService(credentials account.M365Config) (*oneDriveService, error) {
+func newOneDriveService(credentials account.M365Config) (*oneDriveService, error) {
 	ac, err := api.NewClient(
 		credentials,
 		control.DefaultOptions(),
@@ -73,7 +77,7 @@ func loadTestService(t *testing.T) *oneDriveService {
 	creds, err := a.M365Config()
 	require.NoError(t, err, clues.ToCore(err))
 
-	service, err := NewOneDriveService(creds)
+	service, err := newOneDriveService(creds)
 	require.NoError(t, err, clues.ToCore(err))
 
 	return service
@@ -133,381 +137,6 @@ func asNotMoved(t *testing.T, p string) statePath {
 		currPath: toODPath(t, p),
 	}
 }
-
-// ---------------------------------------------------------------------------
-// stub drive item factories
-// ---------------------------------------------------------------------------
-
-type itemType int
-
-const (
-	isFile    itemType = 1
-	isFolder  itemType = 2
-	isPackage itemType = 3
-)
-
-func coreItem(
-	id, name, parentPath, parentID string,
-	it itemType,
-) *models.DriveItem {
-	item := models.NewDriveItem()
-	item.SetName(&name)
-	item.SetId(&id)
-	item.SetLastModifiedDateTime(ptr.To(time.Now()))
-
-	parentReference := models.NewItemReference()
-	parentReference.SetPath(&parentPath)
-	parentReference.SetId(&parentID)
-	item.SetParentReference(parentReference)
-
-	switch it {
-	case isFile:
-		item.SetSize(ptr.To[int64](42))
-		item.SetFile(models.NewFile())
-	case isFolder:
-		item.SetFolder(models.NewFolder())
-	case isPackage:
-		item.SetPackageEscaped(models.NewPackageEscaped())
-	}
-
-	return item
-}
-
-func driveItem(
-	id, name, parentPath, parentID string,
-	it itemType,
-) models.DriveItemable {
-	return coreItem(id, name, parentPath, parentID, it)
-}
-
-func driveItemWSize(
-	id, name, parentPath, parentID string,
-	size int64,
-	it itemType,
-) models.DriveItemable {
-	res := coreItem(id, name, parentPath, parentID, it)
-	res.SetSize(ptr.To(size))
-
-	return res
-}
-
-func malwareItem(
-	id, name, parentPath, parentID string,
-	it itemType,
-) models.DriveItemable {
-	c := coreItem(id, name, parentPath, parentID, it)
-
-	mal := models.NewMalware()
-	malStr := "test malware"
-	mal.SetDescription(&malStr)
-
-	c.SetMalware(mal)
-
-	return c
-}
-
-// delItem creates a DriveItemable that is marked as deleted.
-func delItem(
-	id string,
-	parentID string,
-	it itemType,
-) models.DriveItemable {
-	item := models.NewDriveItem()
-	item.SetId(&id)
-	item.SetDeleted(models.NewDeleted())
-
-	parentReference := models.NewItemReference()
-	parentReference.SetId(&parentID)
-	item.SetParentReference(parentReference)
-
-	switch it {
-	case isFile:
-		item.SetFile(models.NewFile())
-	case isFolder:
-		item.SetFolder(models.NewFolder())
-	case isPackage:
-		item.SetPackageEscaped(models.NewPackageEscaped())
-	}
-
-	return item
-}
-
-// ---------------------------------------------------------------------------
-// file factories
-// ---------------------------------------------------------------------------
-
-func fileID(fileSuffixes ...any) string {
-	return id(file, fileSuffixes...)
-}
-
-func fileName(fileSuffixes ...any) string {
-	return name(file, fileSuffixes...)
-}
-
-func driveFile(
-	parentPath, parentID string,
-	fileSuffixes ...any,
-) models.DriveItemable {
-	return driveItem(
-		fileID(fileSuffixes...),
-		fileName(fileSuffixes...),
-		parentPath,
-		parentID,
-		isFile)
-}
-
-func fileAt(
-	parentSuffix any,
-	fileSuffixes ...any,
-) models.DriveItemable {
-	return driveItem(
-		fileID(fileSuffixes...),
-		fileName(fileSuffixes...),
-		parentDir(folderName(parentSuffix)),
-		folderID(parentSuffix),
-		isFile)
-}
-
-func fileAtRoot(
-	fileSuffixes ...any,
-) models.DriveItemable {
-	return driveItem(
-		fileID(fileSuffixes...),
-		fileName(fileSuffixes...),
-		parentDir(),
-		rootID,
-		isFile)
-}
-
-func fileWURLAtRoot(
-	url string,
-	isDeleted bool,
-	fileSuffixes ...any,
-) models.DriveItemable {
-	di := driveFile(parentDir(), rootID, fileSuffixes...)
-	di.SetAdditionalData(map[string]any{
-		"@microsoft.graph.downloadUrl": url,
-	})
-
-	if isDeleted {
-		di.SetDeleted(models.NewDeleted())
-	}
-
-	return di
-}
-
-func fileWSizeAtRoot(
-	size int64,
-	fileSuffixes ...any,
-) models.DriveItemable {
-	return driveItemWSize(
-		fileID(fileSuffixes...),
-		fileName(fileSuffixes...),
-		parentDir(),
-		rootID,
-		size,
-		isFile)
-}
-
-func fileWSizeAt(
-	size int64,
-	parentSuffix any,
-	fileSuffixes ...any,
-) models.DriveItemable {
-	return driveItemWSize(
-		fileID(fileSuffixes...),
-		fileName(fileSuffixes...),
-		parentDir(folderName(parentSuffix)),
-		folderID(parentSuffix),
-		size,
-		isFile)
-}
-
-// ---------------------------------------------------------------------------
-// folder factories
-// ---------------------------------------------------------------------------
-
-func folderID(folderSuffixes ...any) string {
-	return id(folder, folderSuffixes...)
-}
-
-func folderName(folderSuffixes ...any) string {
-	return name(folder, folderSuffixes...)
-}
-
-func driveFolder(
-	parentPath, parentID string,
-	folderSuffixes ...any,
-) models.DriveItemable {
-	return driveItem(
-		folderID(folderSuffixes...),
-		folderName(folderSuffixes...),
-		parentPath,
-		parentID,
-		isFolder)
-}
-
-func driveRootFolder() models.DriveItemable {
-	rootFolder := models.NewDriveItem()
-	rootFolder.SetName(ptr.To(rootName))
-	rootFolder.SetId(ptr.To(rootID))
-	rootFolder.SetRoot(models.NewRoot())
-	rootFolder.SetFolder(models.NewFolder())
-
-	return rootFolder
-}
-
-func folderAtRoot(
-	folderSuffixes ...any,
-) models.DriveItemable {
-	return driveItem(
-		folderID(folderSuffixes...),
-		folderName(folderSuffixes...),
-		parentDir(),
-		rootID,
-		isFolder)
-}
-
-func folderAt(
-	parentSuffix any,
-	folderSuffixes ...any,
-) models.DriveItemable {
-	return driveItem(
-		folderID(folderSuffixes...),
-		folderName(folderSuffixes...),
-		parentDir(folderName(parentSuffix)),
-		folderID(parentSuffix),
-		isFolder)
-}
-
-// ---------------------------------------------------------------------------
-// id, name, path factories
-// ---------------------------------------------------------------------------
-
-// assumption is only one suffix per id.  Mostly using
-// the variadic as an "optional" extension.
-func id(v string, suffixes ...any) string {
-	id := fmt.Sprintf("id_%s", v)
-
-	// a bit weird, but acts as a quality of life
-	// that allows some funcs to take in the `file`
-	// or `folder` or etc monikers as the suffix
-	// without producing weird outputs.
-	if len(suffixes) == 1 {
-		sfx0, ok := suffixes[0].(string)
-		if ok && sfx0 == v {
-			return id
-		}
-	}
-
-	for _, sfx := range suffixes {
-		id = fmt.Sprintf("%s_%v", id, sfx)
-	}
-
-	return id
-}
-
-// assumption is only one suffix per name.  Mostly using
-// the variadic as an "optional" extension.
-func name(v string, suffixes ...any) string {
-	name := fmt.Sprintf("n_%s", v)
-
-	// a bit weird, but acts as a quality of life
-	// that allows some funcs to take in the `file`
-	// or `folder` or etc monikers as the suffix
-	// without producing weird outputs.
-	if len(suffixes) == 1 {
-		sfx0, ok := suffixes[0].(string)
-		if ok && sfx0 == v {
-			return name
-		}
-	}
-
-	for _, sfx := range suffixes {
-		name = fmt.Sprintf("%s_%v", name, sfx)
-	}
-
-	return name
-}
-
-func toPath(elems ...string) string {
-	es := []string{}
-	for _, elem := range elems {
-		es = append(es, path.Split(elem)...)
-	}
-
-	switch len(es) {
-	case 0:
-		return ""
-	case 1:
-		return es[0]
-	default:
-		return path.Builder{}.Append(es...).String()
-	}
-}
-
-func fullPath(elems ...string) string {
-	return toPath(append(
-		[]string{
-			tenant,
-			path.OneDriveService.String(),
-			user,
-			path.FilesCategory.String(),
-			odConsts.DriveFolderPrefixBuilder(id(drive)).String(),
-		},
-		elems...)...)
-}
-
-func fullPathPath(t *testing.T, elems ...string) path.Path {
-	p, err := path.FromDataLayerPath(fullPath(elems...), false)
-	require.NoError(t, err, clues.ToCore(err))
-
-	return p
-}
-
-func driveFullPath(driveID any, elems ...string) string {
-	return toPath(append(
-		[]string{
-			tenant,
-			path.OneDriveService.String(),
-			user,
-			path.FilesCategory.String(),
-			odConsts.DriveFolderPrefixBuilder(id(drive, driveID)).String(),
-		},
-		elems...)...)
-}
-
-func parentDir(elems ...string) string {
-	return toPath(append(
-		[]string{odConsts.DriveFolderPrefixBuilder(id(drive)).String()},
-		elems...)...)
-}
-
-func driveParentDir(driveID any, elems ...string) string {
-	return toPath(append(
-		[]string{odConsts.DriveFolderPrefixBuilder(id(drive, driveID)).String()},
-		elems...)...)
-}
-
-// common item names
-const (
-	bar       = "bar"
-	delta     = "delta_url"
-	drive     = "drive"
-	fanny     = "fanny"
-	file      = "file"
-	folder    = "folder"
-	foo       = "foo"
-	item      = "item"
-	malware   = "malware"
-	nav       = "nav"
-	pkg       = "package"
-	rootID    = odConsts.RootID
-	rootName  = odConsts.RootPathDir
-	subfolder = "subfolder"
-	tenant    = "t"
-	user      = "u"
-)
 
 // ---------------------------------------------------------------------------
 // misc helpers
@@ -583,21 +212,21 @@ func collWithMBHAndOpts(
 		count.New())
 }
 
-func aPage(items ...models.DriveItemable) mock.NextPage {
-	return mock.NextPage{
+func aPage(items ...models.DriveItemable) nextPage {
+	return nextPage{
 		Items: append([]models.DriveItemable{driveRootFolder()}, items...),
 	}
 }
 
-func aPageWReset(items ...models.DriveItemable) mock.NextPage {
-	return mock.NextPage{
+func aPageWReset(items ...models.DriveItemable) nextPage {
+	return nextPage{
 		Items: append([]models.DriveItemable{driveRootFolder()}, items...),
 		Reset: true,
 	}
 }
 
-func aReset(items ...models.DriveItemable) mock.NextPage {
-	return mock.NextPage{
+func aReset(items ...models.DriveItemable) nextPage {
+	return nextPage{
 		Items: []models.DriveItemable{},
 		Reset: true,
 	}
@@ -618,7 +247,7 @@ func makePrevMetadataColls(
 	prevDeltas := map[string]string{}
 
 	for driveID := range previousPaths {
-		prevDeltas[driveID] = id(delta, "prev")
+		prevDeltas[driveID] = id(deltaURL, "prev")
 	}
 
 	mdColl, err := graph.MakeMetadataCollection(
@@ -810,8 +439,8 @@ func (ecs expectedCollections) requireNoUnseenCollections(t *testing.T) {
 // delta trees
 // ---------------------------------------------------------------------------
 
-func defaultTreePfx(t *testing.T) path.Path {
-	fpb := fullPathPath(t).ToBuilder()
+func defaultTreePfx(t *testing.T, d *deltaDrive) path.Path {
+	fpb := d.fullPath(t).ToBuilder()
 	fpe := fpb.Elements()
 	fpe = fpe[:len(fpe)-1]
 	fpb = path.Builder{}.Append(fpe...)
@@ -831,80 +460,89 @@ func defaultLoc() path.Elements {
 	return path.NewElements("root:/foo/bar/baz/qux/fnords/smarf/voi/zumba/bangles/howdyhowdyhowdy")
 }
 
-func newTree(t *testing.T) *folderyMcFolderFace {
-	return newFolderyMcFolderFace(defaultTreePfx(t), rootID)
+func newTree(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
+	return newFolderyMcFolderFace(defaultTreePfx(t, d), rootID)
 }
 
-func treeWithRoot(t *testing.T) *folderyMcFolderFace {
-	tree := newFolderyMcFolderFace(defaultTreePfx(t), rootID)
-	rootey := newNodeyMcNodeFace(nil, rootID, rootName, false)
-	tree.root = rootey
-	tree.folderIDToNode[rootID] = rootey
+func treeWithRoot(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
+	tree := newFolderyMcFolderFace(defaultTreePfx(t, d), rootID)
+
+	//nolint:forbidigo
+	err := tree.setFolder(context.Background(), "", rootID, rootName, false)
+	require.NoError(t, err, clues.ToCore(err))
 
 	return tree
 }
 
-func treeAfterReset(t *testing.T) *folderyMcFolderFace {
-	tree := newFolderyMcFolderFace(defaultTreePfx(t), rootID)
+func treeAfterReset(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
+	tree := newFolderyMcFolderFace(defaultTreePfx(t, d), rootID)
 	tree.reset()
 
 	return tree
 }
 
-func treeWithFoldersAfterReset(t *testing.T) *folderyMcFolderFace {
-	tree := treeWithFolders(t)
+func treeWithFoldersAfterReset(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
+	tree := treeWithFolders(t, d)
 	tree.hadReset = true
 
 	return tree
 }
 
-func treeWithTombstone(t *testing.T) *folderyMcFolderFace {
-	tree := treeWithRoot(t)
-	tree.tombstones[folderID()] = newNodeyMcNodeFace(nil, folderID(), "", false)
+func treeWithTombstone(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
+	tree := treeWithRoot(t, d)
+
+	//nolint:forbidigo
+	err := tree.setTombstone(context.Background(), folderID())
+	require.NoError(t, err, clues.ToCore(err))
 
 	return tree
 }
 
-func treeWithFolders(t *testing.T) *folderyMcFolderFace {
-	tree := treeWithRoot(t)
+func treeWithFolders(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
+	tree := treeWithRoot(t, d)
 
-	parent := newNodeyMcNodeFace(tree.root, folderID("parent"), folderName("parent"), true)
-	tree.folderIDToNode[parent.id] = parent
-	tree.root.children[parent.id] = parent
+	//nolint:forbidigo
+	err := tree.setFolder(context.Background(), rootID, folderID("parent"), folderName("parent"), true)
+	require.NoError(t, err, clues.ToCore(err))
 
-	f := newNodeyMcNodeFace(parent, folderID(), folderName(), false)
-	tree.folderIDToNode[f.id] = f
-	parent.children[f.id] = f
-
-	return tree
-}
-
-func treeWithFileAtRoot(t *testing.T) *folderyMcFolderFace {
-	tree := treeWithRoot(t)
-	tree.root.files[fileID()] = custom.ToCustomDriveItem(fileAtRoot())
-	tree.fileIDToParentID[fileID()] = rootID
+	//nolint:forbidigo
+	err = tree.setFolder(context.Background(), folderID("parent"), folderID(), folderName(), false)
+	require.NoError(t, err, clues.ToCore(err))
 
 	return tree
 }
 
-func treeWithDeletedFile(t *testing.T) *folderyMcFolderFace {
-	tree := treeWithRoot(t)
+func treeWithFileAtRoot(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
+	tree := treeWithRoot(t, d)
+
+	err := tree.addFile(rootID, fileID(), custom.ToCustomDriveItem(d.fileAtRoot()))
+	require.NoError(t, err, clues.ToCore(err))
+
+	return tree
+}
+
+func treeWithDeletedFile(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
+	tree := treeWithRoot(t, d)
 	tree.deleteFile(fileID("d"))
 
 	return tree
 }
 
-func treeWithFileInFolder(t *testing.T) *folderyMcFolderFace {
-	tree := treeWithFolders(t)
-	tree.folderIDToNode[folderID()].files[fileID()] = custom.ToCustomDriveItem(fileAt(folder))
-	tree.fileIDToParentID[fileID()] = folderID()
+func treeWithFileInFolder(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
+	tree := treeWithFolders(t, d)
+
+	err := tree.addFile(folderID(), fileID(), custom.ToCustomDriveItem(d.fileAt(folder)))
+	require.NoError(t, err, clues.ToCore(err))
 
 	return tree
 }
 
-func treeWithFileInTombstone(t *testing.T) *folderyMcFolderFace {
-	tree := treeWithTombstone(t)
-	tree.tombstones[folderID()].files[fileID()] = custom.ToCustomDriveItem(fileAt("tombstone"))
+func treeWithFileInTombstone(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
+	tree := treeWithTombstone(t, d)
+
+	// setting these directly, instead of using addFile(),
+	// because we can't add files to tombstones.
+	tree.tombstones[folderID()].files[fileID()] = custom.ToCustomDriveItem(d.fileAt("tombstone"))
 	tree.fileIDToParentID[fileID()] = folderID()
 
 	return tree
@@ -915,57 +553,59 @@ func treeWithFileInTombstone(t *testing.T) *folderyMcFolderFace {
 // one tombstone: idx(folder, tombstone)
 // one item in the tombstone
 // one deleted item
-func fullTree(t *testing.T) *folderyMcFolderFace {
-	return fullTreeWithNames("parent", "tombstone")(t)
+func fullTree(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
+	return fullTreeWithNames("parent", "tombstone")(t, d)
 }
 
 func fullTreeWithNames(
 	parentFolderX, tombstoneX any,
-) func(t *testing.T) *folderyMcFolderFace {
-	return func(t *testing.T) *folderyMcFolderFace {
+) func(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
+	return func(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
 		ctx, flush := tester.NewContext(t)
 		defer flush()
 
-		tree := treeWithRoot(t)
+		tree := treeWithRoot(t, d)
 
 		// file in root
-		df := driveFile(parentDir(), rootID, "r")
+		df := driveFile(d.dir(), rootID, "r")
 		err := tree.addFile(
 			rootID,
 			fileID("r"),
 			custom.ToCustomDriveItem(df))
 		require.NoError(t, err, clues.ToCore(err))
 
-		// root -> idx(folder, parent)
+		// root -> folderID(parentX)
 		err = tree.setFolder(ctx, rootID, folderID(parentFolderX), folderName(parentFolderX), false)
 		require.NoError(t, err, clues.ToCore(err))
 
-		// file in idx(folder, parent)
-		df = driveFile(parentDir(folderName(parentFolderX)), folderID(parentFolderX), "p")
+		// file in folderID(parentX)
+		df = driveFile(d.dir(folderName(parentFolderX)), folderID(parentFolderX), "p")
 		err = tree.addFile(
 			folderID(parentFolderX),
 			fileID("p"),
 			custom.ToCustomDriveItem(df))
 		require.NoError(t, err, clues.ToCore(err))
 
-		// idx(folder, parent) -> id(folder)
+		// folderID(parentX) -> folderID()
 		err = tree.setFolder(ctx, folderID(parentFolderX), folderID(), folderName(), false)
 		require.NoError(t, err, clues.ToCore(err))
 
-		// file in id(folder)
-		df = driveFile(parentDir(folderName()), folderID())
+		// file in folderID()
+		df = driveFile(d.dir(folderName()), folderID())
 		err = tree.addFile(
 			folderID(),
 			fileID(),
 			custom.ToCustomDriveItem(df))
 		require.NoError(t, err, clues.ToCore(err))
 
-		// tombstone - have to set a non-tombstone folder first, then add the item, then tombstone the folder
+		// tombstone - have to set a non-tombstone folder first,
+		// then add the item,
+		// then tombstone the folder
 		err = tree.setFolder(ctx, rootID, folderID(tombstoneX), folderName(tombstoneX), false)
 		require.NoError(t, err, clues.ToCore(err))
 
 		// file in tombstone
-		df = driveFile(parentDir(folderName(tombstoneX)), folderID(tombstoneX), "t")
+		df = driveFile(d.dir(folderName(tombstoneX)), folderID(tombstoneX), "t")
 		err = tree.addFile(
 			folderID(tombstoneX),
 			fileID("t"),
@@ -983,8 +623,989 @@ func fullTreeWithNames(
 }
 
 // ---------------------------------------------------------------------------
+// Backup Handler
+// ---------------------------------------------------------------------------
+
+type mockBackupHandler[T any] struct {
+	ItemInfo details.ItemInfo
+	// FIXME: this is a hacky solution.  Better to use an interface
+	// and plug in the selector scope there.
+	Sel selectors.Selector
+
+	DriveItemEnumeration enumerateDriveItemsDelta
+
+	GI  getsItem
+	GIP getsItemPermission
+
+	PathPrefixFn  pathPrefixer
+	PathPrefixErr error
+
+	MetadataPathPrefixFn  metadataPathPrefixer
+	MetadataPathPrefixErr error
+
+	CanonPathFn  canonPather
+	CanonPathErr error
+
+	ProtectedResource idname.Provider
+	Service           path.ServiceType
+	Category          path.CategoryType
+
+	// driveID -> itemPager
+	ItemPagerV map[string]pagers.DeltaHandler[models.DriveItemable]
+
+	LocationIDFn locationIDer
+
+	getCall  int
+	GetResps []*http.Response
+	GetErrs  []error
+
+	RootFolder models.DriveItemable
+}
+
+func stubRootFolder() models.DriveItemable {
+	item := models.NewDriveItem()
+	item.SetName(ptr.To(odConsts.RootPathDir))
+	item.SetId(ptr.To(odConsts.RootID))
+	item.SetRoot(models.NewRoot())
+	item.SetFolder(models.NewFolder())
+
+	return item
+}
+
+func defaultOneDriveBH(resourceOwner string) *mockBackupHandler[models.DriveItemable] {
+	sel := selectors.NewOneDriveBackup([]string{resourceOwner})
+	sel.Include(sel.AllData())
+
+	return &mockBackupHandler[models.DriveItemable]{
+		ItemInfo: details.ItemInfo{
+			OneDrive:  &details.OneDriveInfo{},
+			Extension: &details.ExtensionData{},
+		},
+		Sel:                  sel.Selector,
+		DriveItemEnumeration: enumerateDriveItemsDelta{},
+		GI:                   getsItem{Err: clues.New("not defined")},
+		GIP:                  getsItemPermission{Err: clues.New("not defined")},
+		PathPrefixFn:         defaultOneDrivePathPrefixer,
+		MetadataPathPrefixFn: defaultOneDriveMetadataPathPrefixer,
+		CanonPathFn:          defaultOneDriveCanonPather,
+		ProtectedResource:    idname.NewProvider(resourceOwner, resourceOwner),
+		Service:              path.OneDriveService,
+		Category:             path.FilesCategory,
+		LocationIDFn:         defaultOneDriveLocationIDer,
+		GetResps:             []*http.Response{nil},
+		GetErrs:              []error{clues.New("not defined")},
+		RootFolder:           stubRootFolder(),
+	}
+}
+
+func defaultSharePointBH(resourceOwner string) *mockBackupHandler[models.DriveItemable] {
+	sel := selectors.NewOneDriveBackup([]string{resourceOwner})
+	sel.Include(sel.AllData())
+
+	return &mockBackupHandler[models.DriveItemable]{
+		ItemInfo: details.ItemInfo{
+			SharePoint: &details.SharePointInfo{},
+			Extension:  &details.ExtensionData{},
+		},
+		Sel:                  sel.Selector,
+		GI:                   getsItem{Err: clues.New("not defined")},
+		GIP:                  getsItemPermission{Err: clues.New("not defined")},
+		PathPrefixFn:         defaultSharePointPathPrefixer,
+		MetadataPathPrefixFn: defaultSharePointMetadataPathPrefixer,
+		CanonPathFn:          defaultSharePointCanonPather,
+		ProtectedResource:    idname.NewProvider(resourceOwner, resourceOwner),
+		Service:              path.SharePointService,
+		Category:             path.LibrariesCategory,
+		LocationIDFn:         defaultSharePointLocationIDer,
+		GetResps:             []*http.Response{nil},
+		GetErrs:              []error{clues.New("not defined")},
+		RootFolder:           stubRootFolder(),
+	}
+}
+
+func defaultDriveBHWith(
+	resource string,
+	enumerator enumerateDriveItemsDelta,
+) *mockBackupHandler[models.DriveItemable] {
+	mbh := defaultOneDriveBH(resource)
+	mbh.DriveItemEnumeration = enumerator
+
+	return mbh
+}
+
+func (h mockBackupHandler[T]) PathPrefix(tID, driveID string) (path.Path, error) {
+	pp, err := h.PathPrefixFn(tID, h.ProtectedResource.ID(), driveID)
+	if err != nil {
+		return nil, err
+	}
+
+	return pp, h.PathPrefixErr
+}
+
+func (h mockBackupHandler[T]) MetadataPathPrefix(tID string) (path.Path, error) {
+	pp, err := h.MetadataPathPrefixFn(tID, h.ProtectedResource.ID())
+	if err != nil {
+		return nil, err
+	}
+
+	return pp, h.MetadataPathPrefixErr
+}
+
+func (h mockBackupHandler[T]) CanonicalPath(pb *path.Builder, tID string) (path.Path, error) {
+	cp, err := h.CanonPathFn(pb, tID, h.ProtectedResource.ID())
+	if err != nil {
+		return nil, err
+	}
+
+	return cp, h.CanonPathErr
+}
+
+func (h mockBackupHandler[T]) ServiceCat() (path.ServiceType, path.CategoryType) {
+	return h.Service, h.Category
+}
+
+func (h mockBackupHandler[T]) NewDrivePager(string, []string) pagers.NonDeltaHandler[models.Driveable] {
+	return h.DriveItemEnumeration.drivePager()
+}
+
+func (h mockBackupHandler[T]) FormatDisplayPath(_ string, pb *path.Builder) string {
+	return "/" + pb.String()
+}
+
+func (h mockBackupHandler[T]) NewLocationIDer(driveID string, elems ...string) details.LocationIDer {
+	return h.LocationIDFn(driveID, elems...)
+}
+
+func (h mockBackupHandler[T]) AugmentItemInfo(
+	details.ItemInfo,
+	idname.Provider,
+	*custom.DriveItem,
+	int64,
+	*path.Builder,
+) details.ItemInfo {
+	return h.ItemInfo
+}
+
+func (h *mockBackupHandler[T]) Get(context.Context, string, map[string]string) (*http.Response, error) {
+	c := h.getCall
+	h.getCall++
+
+	// allows mockers to only populate the errors slice
+	if h.GetErrs[c] != nil {
+		return nil, h.GetErrs[c]
+	}
+
+	return h.GetResps[c], h.GetErrs[c]
+}
+
+func (h mockBackupHandler[T]) EnumerateDriveItemsDelta(
+	ctx context.Context,
+	driveID, prevDeltaLink string,
+	cc api.CallConfig,
+) pagers.NextPageResulter[models.DriveItemable] {
+	return h.DriveItemEnumeration.EnumerateDriveItemsDelta(
+		ctx,
+		driveID,
+		prevDeltaLink,
+		cc)
+}
+
+func (h mockBackupHandler[T]) GetItem(ctx context.Context, _, _ string) (models.DriveItemable, error) {
+	return h.GI.GetItem(ctx, "", "")
+}
+
+func (h mockBackupHandler[T]) GetItemPermission(
+	ctx context.Context,
+	_, _ string,
+) (models.PermissionCollectionResponseable, error) {
+	return h.GIP.GetItemPermission(ctx, "", "")
+}
+
+type canonPather func(*path.Builder, string, string) (path.Path, error)
+
+var defaultOneDriveCanonPather = func(pb *path.Builder, tID, ro string) (path.Path, error) {
+	return pb.ToDataLayerOneDrivePath(tID, ro, false)
+}
+
+var defaultSharePointCanonPather = func(pb *path.Builder, tID, ro string) (path.Path, error) {
+	return pb.ToDataLayerSharePointPath(tID, ro, path.LibrariesCategory, false)
+}
+
+type (
+	pathPrefixer         func(tID, ro, driveID string) (path.Path, error)
+	metadataPathPrefixer func(tID, ro string) (path.Path, error)
+)
+
+var defaultOneDrivePathPrefixer = func(tID, ro, driveID string) (path.Path, error) {
+	return path.Build(
+		tID,
+		ro,
+		path.OneDriveService,
+		path.FilesCategory,
+		false,
+		odConsts.DrivesPathDir,
+		driveID,
+		odConsts.RootPathDir)
+}
+
+var defaultOneDriveMetadataPathPrefixer = func(tID, ro string) (path.Path, error) {
+	return path.BuildMetadata(
+		tID,
+		ro,
+		path.OneDriveService,
+		path.FilesCategory,
+		false)
+}
+
+var defaultSharePointPathPrefixer = func(tID, ro, driveID string) (path.Path, error) {
+	return path.Build(
+		tID,
+		ro,
+		path.SharePointService,
+		path.LibrariesCategory,
+		false,
+		odConsts.DrivesPathDir,
+		driveID,
+		odConsts.RootPathDir)
+}
+
+var defaultSharePointMetadataPathPrefixer = func(tID, ro string) (path.Path, error) {
+	return path.BuildMetadata(
+		tID,
+		ro,
+		path.SharePointService,
+		path.LibrariesCategory,
+		false)
+}
+
+type locationIDer func(string, ...string) details.LocationIDer
+
+var defaultOneDriveLocationIDer = func(driveID string, elems ...string) details.LocationIDer {
+	return details.NewOneDriveLocationIDer(driveID, elems...)
+}
+
+var defaultSharePointLocationIDer = func(driveID string, elems ...string) details.LocationIDer {
+	return details.NewSharePointLocationIDer(driveID, elems...)
+}
+
+func (h mockBackupHandler[T]) IsAllPass() bool {
+	scope := h.Sel.Includes[0]
+	return selectors.IsAnyTarget(selectors.SharePointScope(scope), selectors.SharePointLibraryFolder) ||
+		selectors.IsAnyTarget(selectors.OneDriveScope(scope), selectors.OneDriveFolder)
+}
+
+func (h mockBackupHandler[T]) IncludesDir(dir string) bool {
+	scope := h.Sel.Includes[0]
+	return selectors.SharePointScope(scope).Matches(selectors.SharePointLibraryFolder, dir) ||
+		selectors.OneDriveScope(scope).Matches(selectors.OneDriveFolder, dir)
+}
+
+func (h mockBackupHandler[T]) GetRootFolder(context.Context, string) (models.DriveItemable, error) {
+	return h.RootFolder, nil
+}
+
+// ---------------------------------------------------------------------------
+// Get Itemer
+// ---------------------------------------------------------------------------
+
+type getsItem struct {
+	Item models.DriveItemable
+	Err  error
+}
+
+func (m getsItem) GetItem(
+	_ context.Context,
+	_, _ string,
+) (models.DriveItemable, error) {
+	return m.Item, m.Err
+}
+
+// ---------------------------------------------------------------------------
+// Drive Item Enummerator
+// ---------------------------------------------------------------------------
+
+type nextPage struct {
+	Items []models.DriveItemable
+	Reset bool
+}
+
+type enumerateDriveItemsDelta struct {
+	DrivePagers map[string]*DeltaDriveEnumerator
+}
+
+func driveEnumerator(
+	ds ...*DeltaDriveEnumerator,
+) enumerateDriveItemsDelta {
+	enumerator := enumerateDriveItemsDelta{
+		DrivePagers: map[string]*DeltaDriveEnumerator{},
+	}
+
+	for _, drive := range ds {
+		enumerator.DrivePagers[drive.Drive.id] = drive
+	}
+
+	return enumerator
+}
+
+func (en enumerateDriveItemsDelta) EnumerateDriveItemsDelta(
+	_ context.Context,
+	driveID, _ string,
+	_ api.CallConfig,
+) pagers.NextPageResulter[models.DriveItemable] {
+	iterator := en.DrivePagers[driveID]
+	return iterator.nextDelta()
+}
+
+func (en enumerateDriveItemsDelta) drivePager() *apiMock.Pager[models.Driveable] {
+	dvs := []models.Driveable{}
+
+	for _, dp := range en.DrivePagers {
+		dvs = append(dvs, dp.Drive.able)
+	}
+
+	return &apiMock.Pager[models.Driveable]{
+		ToReturn: []apiMock.PagerResult[models.Driveable]{
+			{Values: dvs},
+		},
+	}
+}
+
+func (en enumerateDriveItemsDelta) getDrives() []*deltaDrive {
+	dvs := []*deltaDrive{}
+
+	for _, dp := range en.DrivePagers {
+		dvs = append(dvs, dp.Drive)
+	}
+
+	return dvs
+}
+
+type deltaDrive struct {
+	id   string
+	able models.Driveable
+}
+
+func drive(driveSuffix ...any) *deltaDrive {
+	driveID := id(drivePfx, driveSuffix...)
+
+	able := models.NewDrive()
+	able.SetId(ptr.To(driveID))
+	able.SetName(ptr.To(name(drivePfx, driveSuffix...)))
+
+	return &deltaDrive{
+		id:   driveID,
+		able: able,
+	}
+}
+
+func (dd *deltaDrive) newEnumer() *DeltaDriveEnumerator {
+	clone := &deltaDrive{}
+	*clone = *dd
+
+	return &DeltaDriveEnumerator{Drive: clone}
+}
+
+type DeltaDriveEnumerator struct {
+	Drive        *deltaDrive
+	idx          int
+	DeltaQueries []*deltaQuery
+	Err          error
+}
+
+func (dde *DeltaDriveEnumerator) with(ds ...*deltaQuery) *DeltaDriveEnumerator {
+	dde.DeltaQueries = ds
+	return dde
+}
+
+// withErr adds an error that is always returned in the last delta index.
+func (dde *DeltaDriveEnumerator) withErr(err error) *DeltaDriveEnumerator {
+	dde.Err = err
+	return dde
+}
+
+func (dde *DeltaDriveEnumerator) nextDelta() *deltaQuery {
+	if dde.idx == len(dde.DeltaQueries) {
+		// at the end of the enumeration, return an empty page with no items,
+		// not even the root.  This is what graph api would do to signify an absence
+		// of changes in the delta.
+		lastDU := dde.DeltaQueries[dde.idx-1].DeltaUpdate
+
+		return &deltaQuery{
+			DeltaUpdate: lastDU,
+			Pages: []nextPage{{
+				Items: []models.DriveItemable{},
+			}},
+			Err: dde.Err,
+		}
+	}
+
+	if dde.idx > len(dde.DeltaQueries) {
+		// a panic isn't optimal here, but since this mechanism is internal to testing,
+		// it's an acceptable way to have the tests ensure we don't over-enumerate deltas.
+		panic(fmt.Sprintf("delta index %d larger than count of delta iterations in mock", dde.idx))
+	}
+
+	pages := dde.DeltaQueries[dde.idx]
+
+	dde.idx++
+
+	return pages
+}
+
+var _ pagers.NextPageResulter[models.DriveItemable] = &deltaQuery{}
+
+type deltaQuery struct {
+	idx         int
+	Pages       []nextPage
+	DeltaUpdate pagers.DeltaUpdate
+	Err         error
+}
+
+func delta(
+	resultDeltaID string,
+	err error,
+) *deltaQuery {
+	return &deltaQuery{
+		DeltaUpdate: pagers.DeltaUpdate{URL: resultDeltaID},
+		Err:         err,
+	}
+}
+
+func deltaWReset(
+	resultDeltaID string,
+	err error,
+) *deltaQuery {
+	return &deltaQuery{
+		DeltaUpdate: pagers.DeltaUpdate{
+			URL:   resultDeltaID,
+			Reset: true,
+		},
+		Err: err,
+	}
+}
+
+func (dq *deltaQuery) with(
+	pages ...nextPage,
+) *deltaQuery {
+	dq.Pages = pages
+	return dq
+}
+
+func (dq *deltaQuery) NextPage() ([]models.DriveItemable, bool, bool) {
+	if dq.idx >= len(dq.Pages) {
+		return nil, false, true
+	}
+
+	np := dq.Pages[dq.idx]
+	dq.idx++
+
+	return np.Items, np.Reset, false
+}
+
+func (dq *deltaQuery) Cancel() {}
+
+func (dq *deltaQuery) Results() (pagers.DeltaUpdate, error) {
+	return dq.DeltaUpdate, dq.Err
+}
+
+// ---------------------------------------------------------------------------
+// Get Item Permissioner
+// ---------------------------------------------------------------------------
+
+type getsItemPermission struct {
+	Perm models.PermissionCollectionResponseable
+	Err  error
+}
+
+func (m getsItemPermission) GetItemPermission(
+	_ context.Context,
+	_, _ string,
+) (models.PermissionCollectionResponseable, error) {
+	return m.Perm, m.Err
+}
+
+// ---------------------------------------------------------------------------
+// Restore Handler
+// --------------------------------------------------------------------------
+
+type mockRestoreHandler struct {
+	ItemInfo details.ItemInfo
+
+	CollisionKeyMap map[string]api.DriveItemIDType
+
+	CalledDeleteItem   bool
+	CalledDeleteItemOn string
+	DeleteItemErr      error
+
+	CalledPostItem bool
+	PostItemResp   models.DriveItemable
+	PostItemErr    error
+
+	DrivePagerV pagers.NonDeltaHandler[models.Driveable]
+
+	PostDriveResp models.Driveable
+	PostDriveErr  error
+
+	UploadSessionErr error
+}
+
+func (h mockRestoreHandler) PostDrive(
+	ctx context.Context,
+	protectedResourceID, driveName string,
+) (models.Driveable, error) {
+	return h.PostDriveResp, h.PostDriveErr
+}
+
+func (h mockRestoreHandler) NewDrivePager(string, []string) pagers.NonDeltaHandler[models.Driveable] {
+	return h.DrivePagerV
+}
+
+func (h *mockRestoreHandler) AugmentItemInfo(
+	details.ItemInfo,
+	idname.Provider,
+	*custom.DriveItem,
+	int64,
+	*path.Builder,
+) details.ItemInfo {
+	return h.ItemInfo
+}
+
+func (h *mockRestoreHandler) GetItemsInContainerByCollisionKey(
+	context.Context,
+	string, string,
+) (map[string]api.DriveItemIDType, error) {
+	return h.CollisionKeyMap, nil
+}
+
+func (h *mockRestoreHandler) DeleteItem(
+	_ context.Context,
+	_, itemID string,
+) error {
+	h.CalledDeleteItem = true
+	h.CalledDeleteItemOn = itemID
+
+	return h.DeleteItemErr
+}
+
+func (h *mockRestoreHandler) DeleteItemPermission(
+	context.Context,
+	string, string, string,
+) error {
+	return nil
+}
+
+func (h *mockRestoreHandler) NewItemContentUpload(
+	context.Context,
+	string, string,
+) (models.UploadSessionable, error) {
+	return models.NewUploadSession(), h.UploadSessionErr
+}
+
+func (h *mockRestoreHandler) PostItemPermissionUpdate(
+	context.Context,
+	string, string,
+	*drives.ItemItemsItemInvitePostRequestBody,
+) (drives.ItemItemsItemInviteResponseable, error) {
+	return drives.NewItemItemsItemInviteResponse(), nil
+}
+
+func (h *mockRestoreHandler) PostItemLinkShareUpdate(
+	ctx context.Context,
+	driveID, itemID string,
+	body *drives.ItemItemsItemCreateLinkPostRequestBody,
+) (models.Permissionable, error) {
+	return nil, clues.New("not implemented")
+}
+
+func (h *mockRestoreHandler) PostItemInContainer(
+	context.Context,
+	string, string,
+	models.DriveItemable,
+	control.CollisionPolicy,
+) (models.DriveItemable, error) {
+	h.CalledPostItem = true
+	return h.PostItemResp, h.PostItemErr
+}
+
+func (h *mockRestoreHandler) GetFolderByName(
+	context.Context,
+	string, string, string,
+) (models.DriveItemable, error) {
+	return models.NewDriveItem(), nil
+}
+
+func (h *mockRestoreHandler) GetRootFolder(
+	context.Context,
+	string,
+) (models.DriveItemable, error) {
+	return models.NewDriveItem(), nil
+}
+
+// ---------------------------------------------------------------------------
+// stub drive item factories
+// ---------------------------------------------------------------------------
+
+type itemType int
+
+const (
+	isFile    itemType = 1
+	isFolder  itemType = 2
+	isPackage itemType = 3
+)
+
+func coreItem(
+	id, name, parentPath, parentID string,
+	it itemType,
+) *models.DriveItem {
+	item := models.NewDriveItem()
+	item.SetName(&name)
+	item.SetId(&id)
+	item.SetLastModifiedDateTime(ptr.To(time.Now()))
+
+	parentReference := models.NewItemReference()
+	parentReference.SetPath(&parentPath)
+	parentReference.SetId(&parentID)
+	item.SetParentReference(parentReference)
+
+	switch it {
+	case isFile:
+		item.SetSize(ptr.To[int64](42))
+		item.SetFile(models.NewFile())
+	case isFolder:
+		item.SetFolder(models.NewFolder())
+	case isPackage:
+		item.SetPackageEscaped(models.NewPackageEscaped())
+	}
+
+	return item
+}
+
+func driveItem(
+	id, name, parentPath, parentID string,
+	it itemType,
+) models.DriveItemable {
+	return coreItem(id, name, parentPath, parentID, it)
+}
+
+func driveItemWSize(
+	id, name, parentPath, parentID string,
+	size int64,
+	it itemType,
+) models.DriveItemable {
+	res := coreItem(id, name, parentPath, parentID, it)
+	res.SetSize(ptr.To(size))
+
+	return res
+}
+
+func malwareItem(
+	id, name, parentPath, parentID string,
+	it itemType,
+) models.DriveItemable {
+	c := coreItem(id, name, parentPath, parentID, it)
+
+	mal := models.NewMalware()
+	malStr := "test malware"
+	mal.SetDescription(&malStr)
+
+	c.SetMalware(mal)
+
+	return c
+}
+
+// delItem creates a DriveItemable that is marked as deleted. path must be set
+// to the base drive path.
+func delItem(
+	id string,
+	parentID string,
+	it itemType,
+) models.DriveItemable {
+	item := models.NewDriveItem()
+	item.SetId(&id)
+	item.SetDeleted(models.NewDeleted())
+
+	parentReference := models.NewItemReference()
+	parentReference.SetId(&parentID)
+	item.SetParentReference(parentReference)
+
+	switch it {
+	case isFile:
+		item.SetFile(models.NewFile())
+	case isFolder:
+		item.SetFolder(models.NewFolder())
+	case isPackage:
+		item.SetPackageEscaped(models.NewPackageEscaped())
+	}
+
+	return item
+}
+
+// ---------------------------------------------------------------------------
+// file factories
+// ---------------------------------------------------------------------------
+
+func fileID(fileSuffixes ...any) string {
+	return id(file, fileSuffixes...)
+}
+
+func fileName(fileSuffixes ...any) string {
+	return name(file, fileSuffixes...)
+}
+
+func driveFile(
+	parentPath, parentID string,
+	fileSuffixes ...any,
+) models.DriveItemable {
+	return driveItem(
+		fileID(fileSuffixes...),
+		fileName(fileSuffixes...),
+		parentPath,
+		parentID,
+		isFile)
+}
+
+func (dd *deltaDrive) fileAt(
+	parentSuffix any,
+	fileSuffixes ...any,
+) models.DriveItemable {
+	return driveItem(
+		fileID(fileSuffixes...),
+		fileName(fileSuffixes...),
+		dd.dir(folderName(parentSuffix)),
+		folderID(parentSuffix),
+		isFile)
+}
+
+func (dd *deltaDrive) fileAtRoot(
+	fileSuffixes ...any,
+) models.DriveItemable {
+	return driveItem(
+		fileID(fileSuffixes...),
+		fileName(fileSuffixes...),
+		dd.dir(),
+		rootID,
+		isFile)
+}
+
+func (dd *deltaDrive) fileWURLAtRoot(
+	url string,
+	isDeleted bool,
+	fileSuffixes ...any,
+) models.DriveItemable {
+	di := driveFile(dd.dir(), rootID, fileSuffixes...)
+	di.SetAdditionalData(map[string]any{
+		"@microsoft.graph.downloadUrl": url,
+	})
+
+	if isDeleted {
+		di.SetDeleted(models.NewDeleted())
+	}
+
+	return di
+}
+
+func (dd *deltaDrive) fileWSizeAtRoot(
+	size int64,
+	fileSuffixes ...any,
+) models.DriveItemable {
+	return driveItemWSize(
+		fileID(fileSuffixes...),
+		fileName(fileSuffixes...),
+		dd.dir(),
+		rootID,
+		size,
+		isFile)
+}
+
+func (dd *deltaDrive) fileWSizeAt(
+	size int64,
+	parentSuffix any,
+	fileSuffixes ...any,
+) models.DriveItemable {
+	return driveItemWSize(
+		fileID(fileSuffixes...),
+		fileName(fileSuffixes...),
+		dd.dir(folderName(parentSuffix)),
+		folderID(parentSuffix),
+		size,
+		isFile)
+}
+
+// ---------------------------------------------------------------------------
+// folder factories
+// ---------------------------------------------------------------------------
+
+func folderID(folderSuffixes ...any) string {
+	return id(folder, folderSuffixes...)
+}
+
+func folderName(folderSuffixes ...any) string {
+	return name(folder, folderSuffixes...)
+}
+
+func driveFolder(
+	parentPath, parentID string,
+	folderSuffixes ...any,
+) models.DriveItemable {
+	return driveItem(
+		folderID(folderSuffixes...),
+		folderName(folderSuffixes...),
+		parentPath,
+		parentID,
+		isFolder)
+}
+
+func driveRootFolder() models.DriveItemable {
+	rootFolder := models.NewDriveItem()
+	rootFolder.SetName(ptr.To(rootName))
+	rootFolder.SetId(ptr.To(rootID))
+	rootFolder.SetRoot(models.NewRoot())
+	rootFolder.SetFolder(models.NewFolder())
+
+	return rootFolder
+}
+
+func (dd *deltaDrive) folderAtRoot(
+	folderSuffixes ...any,
+) models.DriveItemable {
+	return driveItem(
+		folderID(folderSuffixes...),
+		folderName(folderSuffixes...),
+		dd.dir(),
+		rootID,
+		isFolder)
+}
+
+func (dd *deltaDrive) folderAt(
+	parentSuffix any,
+	folderSuffixes ...any,
+) models.DriveItemable {
+	return driveItem(
+		folderID(folderSuffixes...),
+		folderName(folderSuffixes...),
+		dd.dir(folderName(parentSuffix)),
+		folderID(parentSuffix),
+		isFolder)
+}
+
+// ---------------------------------------------------------------------------
+// id, name, path factories
+// ---------------------------------------------------------------------------
+
+// assumption is only one suffix per id.  Mostly using
+// the variadic as an "optional" extension.
+func id(v string, suffixes ...any) string {
+	id := fmt.Sprintf("id_%s", v)
+
+	// a bit weird, but acts as a quality of life
+	// that allows some funcs to take in the `file`
+	// or `folder` or etc monikers as the suffix
+	// without producing weird outputs.
+	if len(suffixes) == 1 {
+		sfx0, ok := suffixes[0].(string)
+		if ok && sfx0 == v {
+			return id
+		}
+	}
+
+	for _, sfx := range suffixes {
+		id = fmt.Sprintf("%s_%v", id, sfx)
+	}
+
+	return id
+}
+
+// assumption is only one suffix per name.  Mostly using
+// the variadic as an "optional" extension.
+func name(v string, suffixes ...any) string {
+	name := fmt.Sprintf("n_%s", v)
+
+	// a bit weird, but acts as a quality of life
+	// that allows some funcs to take in the `file`
+	// or `folder` or etc monikers as the suffix
+	// without producing weird outputs.
+	if len(suffixes) == 1 {
+		sfx0, ok := suffixes[0].(string)
+		if ok && sfx0 == v {
+			return name
+		}
+	}
+
+	for _, sfx := range suffixes {
+		name = fmt.Sprintf("%s_%v", name, sfx)
+	}
+
+	return name
+}
+
+func toPath(elems ...string) string {
+	es := []string{}
+	for _, elem := range elems {
+		es = append(es, path.Split(elem)...)
+	}
+
+	switch len(es) {
+	case 0:
+		return ""
+	case 1:
+		return es[0]
+	default:
+		return path.Builder{}.Append(es...).String()
+	}
+}
+
+// produces the full path for the provided drive
+func (dd *deltaDrive) strPath(elems ...string) string {
+	return toPath(append(
+		[]string{
+			tenant,
+			path.OneDriveService.String(),
+			user,
+			path.FilesCategory.String(),
+			odConsts.DriveFolderPrefixBuilder(dd.id).String(),
+		},
+		elems...)...)
+}
+
+func (dd *deltaDrive) fullPath(t *testing.T, elems ...string) path.Path {
+	p, err := path.FromDataLayerPath(dd.strPath(elems...), false)
+	require.NoError(t, err, clues.ToCore(err))
+
+	return p
+}
+
+// produces a complete path prefix up to the drive root folder with any
+// elements passed in appended to the generated prefix.
+func (dd *deltaDrive) dir(elems ...string) string {
+	return toPath(append(
+		[]string{odConsts.DriveFolderPrefixBuilder(dd.id).String()},
+		elems...)...)
+}
+
+// common item names
+const (
+	bar       = "bar"
+	deltaURL  = "delta_url"
+	drivePfx  = "drive"
+	fanny     = "fanny"
+	file      = "file"
+	folder    = "folder"
+	foo       = "foo"
+	item      = "item"
+	malware   = "malware"
+	nav       = "nav"
+	pkg       = "package"
+	rootID    = odConsts.RootID
+	rootName  = odConsts.RootPathDir
+	subfolder = "subfolder"
+	tenant    = "t"
+	user      = "u"
+)
+
+// ---------------------------------------------------------------------------
 // misc
 // ---------------------------------------------------------------------------
+
 func expectFullOrPrev(ca *collectionAssertion) path.Path {
 	var p path.Path
 

--- a/src/internal/m365/collection/drive/helper_test.go
+++ b/src/internal/m365/collection/drive/helper_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
-	apiMock "github.com/alcionai/corso/src/pkg/services/m365/api/mock"
 	"github.com/alcionai/corso/src/pkg/services/m365/custom"
 )
 
@@ -394,12 +393,15 @@ func id(v string, suffixes ...any) string {
 	// that allows some funcs to take in the `file`
 	// or `folder` or etc monikers as the suffix
 	// without producing weird outputs.
-	if len(suffixes) == 1 && suffixes[0] == v {
-		return id
+	if len(suffixes) == 1 {
+		sfx0, ok := suffixes[0].(string)
+		if ok && sfx0 == v {
+			return id
+		}
 	}
 
 	for _, sfx := range suffixes {
-		id = fmt.Sprintf("%s_%s", v, sfx)
+		id = fmt.Sprintf("%s_%v", id, sfx)
 	}
 
 	return id
@@ -414,12 +416,15 @@ func name(v string, suffixes ...any) string {
 	// that allows some funcs to take in the `file`
 	// or `folder` or etc monikers as the suffix
 	// without producing weird outputs.
-	if len(suffixes) == 1 && suffixes[0] == v {
-		return name
+	if len(suffixes) == 1 {
+		sfx0, ok := suffixes[0].(string)
+		if ok && sfx0 == v {
+			return name
+		}
 	}
 
 	for _, sfx := range suffixes {
-		name = fmt.Sprintf("%s_%s", v, sfx)
+		name = fmt.Sprintf("%s_%v", name, sfx)
 	}
 
 	return name
@@ -576,14 +581,6 @@ func collWithMBHAndOpts(
 		func(*support.ControllerOperationStatus) {},
 		opts,
 		count.New())
-}
-
-func pagerForDrives(drives ...models.Driveable) *apiMock.Pager[models.Driveable] {
-	return &apiMock.Pager[models.Driveable]{
-		ToReturn: []apiMock.PagerResult[models.Driveable]{
-			{Values: drives},
-		},
-	}
 }
 
 func aPage(items ...models.DriveItemable) mock.NextPage {

--- a/src/internal/m365/collection/drive/url_cache_test.go
+++ b/src/internal/m365/collection/drive/url_cache_test.go
@@ -532,15 +532,17 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 					ctx, flush := tester.NewContext(t)
 					defer flush()
 
+					drive := mock.Drive()
+
 					driveEnumer := mock.DriveEnumerator(
-						mock.Drive(id(drive)).
+						drive.NewEnumer().
 							WithErr(test.pagerErr).
 							With(
 								mock.Delta(delta, test.pagerErr).
 									With(test.pages...)))
 
 					cache, err := newURLCache(
-						id(drive),
+						drive.ID,
 						"",
 						1*time.Hour,
 						driveEnumer,
@@ -581,10 +583,11 @@ func (suite *URLCacheUnitSuite) TestNeedsRefresh() {
 	var (
 		t               = suite.T()
 		refreshInterval = 1 * time.Second
+		drv             = mock.Drive()
 	)
 
 	cache, err := newURLCache(
-		id(drive),
+		drv.ID,
 		"",
 		refreshInterval,
 		&mock.EnumerateDriveItemsDelta{},
@@ -610,6 +613,8 @@ func (suite *URLCacheUnitSuite) TestNeedsRefresh() {
 }
 
 func (suite *URLCacheUnitSuite) TestNewURLCache() {
+	drv := mock.Drive()
+
 	table := []struct {
 		name       string
 		driveID    string
@@ -628,7 +633,7 @@ func (suite *URLCacheUnitSuite) TestNewURLCache() {
 		},
 		{
 			name:       "invalid refresh interval",
-			driveID:    id(drive),
+			driveID:    drv.ID,
 			refreshInt: 100 * time.Millisecond,
 			itemPager:  &mock.EnumerateDriveItemsDelta{},
 			errors:     fault.New(true),
@@ -636,7 +641,7 @@ func (suite *URLCacheUnitSuite) TestNewURLCache() {
 		},
 		{
 			name:       "invalid item enumerator",
-			driveID:    id(drive),
+			driveID:    drv.ID,
 			refreshInt: 1 * time.Hour,
 			itemPager:  nil,
 			errors:     fault.New(true),
@@ -644,7 +649,7 @@ func (suite *URLCacheUnitSuite) TestNewURLCache() {
 		},
 		{
 			name:       "valid",
-			driveID:    id(drive),
+			driveID:    drv.ID,
 			refreshInt: 1 * time.Hour,
 			itemPager:  &mock.EnumerateDriveItemsDelta{},
 			errors:     fault.New(true),

--- a/src/internal/m365/collection/drive/url_cache_test.go
+++ b/src/internal/m365/collection/drive/url_cache_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common/dttm"
 	"github.com/alcionai/corso/src/internal/common/ptr"
-	"github.com/alcionai/corso/src/internal/m365/service/onedrive/mock"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/control"
@@ -214,13 +213,15 @@ func TestURLCacheUnitSuite(t *testing.T) {
 }
 
 func (suite *URLCacheUnitSuite) TestGetItemProperties() {
+	d := drive()
+
 	aURL := func(n int) string {
 		return fmt.Sprintf("https://dummy%d.com", n)
 	}
 
 	table := []struct {
 		name              string
-		pages             []mock.NextPage
+		pages             []nextPage
 		pagerErr          error
 		expectedItemProps map[string]itemProps
 		expectErr         assert.ErrorAssertionFunc
@@ -228,8 +229,8 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 	}{
 		{
 			name: "single item in cache",
-			pages: []mock.NextPage{
-				aPage(fileWURLAtRoot(aURL(1), false, 1)),
+			pages: []nextPage{
+				aPage(d.fileWURLAtRoot(aURL(1), false, 1)),
 			},
 			expectedItemProps: map[string]itemProps{
 				fileID(1): {
@@ -246,13 +247,13 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		},
 		{
 			name: "multiple items in cache",
-			pages: []mock.NextPage{
+			pages: []nextPage{
 				aPage(
-					fileWURLAtRoot(aURL(1), false, 1),
-					fileWURLAtRoot(aURL(2), false, 2),
-					fileWURLAtRoot(aURL(3), false, 3),
-					fileWURLAtRoot(aURL(4), false, 4),
-					fileWURLAtRoot(aURL(5), false, 5)),
+					d.fileWURLAtRoot(aURL(1), false, 1),
+					d.fileWURLAtRoot(aURL(2), false, 2),
+					d.fileWURLAtRoot(aURL(3), false, 3),
+					d.fileWURLAtRoot(aURL(4), false, 4),
+					d.fileWURLAtRoot(aURL(5), false, 5)),
 			},
 			expectedItemProps: map[string]itemProps{
 				fileID(1): {
@@ -285,14 +286,14 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		},
 		{
 			name: "multiple pages",
-			pages: []mock.NextPage{
+			pages: []nextPage{
 				aPage(
-					fileWURLAtRoot(aURL(1), false, 1),
-					fileWURLAtRoot(aURL(2), false, 2),
-					fileWURLAtRoot(aURL(3), false, 3)),
+					d.fileWURLAtRoot(aURL(1), false, 1),
+					d.fileWURLAtRoot(aURL(2), false, 2),
+					d.fileWURLAtRoot(aURL(3), false, 3)),
 				aPage(
-					fileWURLAtRoot(aURL(4), false, 4),
-					fileWURLAtRoot(aURL(5), false, 5)),
+					d.fileWURLAtRoot(aURL(4), false, 4),
+					d.fileWURLAtRoot(aURL(5), false, 5)),
 			},
 			expectedItemProps: map[string]itemProps{
 				fileID(1): {
@@ -325,21 +326,21 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		},
 		{
 			name: "multiple pages with resets",
-			pages: []mock.NextPage{
+			pages: []nextPage{
 				aPage(
-					fileWURLAtRoot(aURL(-1), false, -1),
-					fileWURLAtRoot(aURL(1), false, 1),
-					fileWURLAtRoot(aURL(2), false, 2),
-					fileWURLAtRoot(aURL(3), false, 3)),
+					d.fileWURLAtRoot(aURL(-1), false, -1),
+					d.fileWURLAtRoot(aURL(1), false, 1),
+					d.fileWURLAtRoot(aURL(2), false, 2),
+					d.fileWURLAtRoot(aURL(3), false, 3)),
 				aReset(),
 				aPage(
-					fileWURLAtRoot(aURL(0), false, 0),
-					fileWURLAtRoot(aURL(1), false, 1),
-					fileWURLAtRoot(aURL(2), false, 2),
-					fileWURLAtRoot(aURL(3), false, 3)),
+					d.fileWURLAtRoot(aURL(0), false, 0),
+					d.fileWURLAtRoot(aURL(1), false, 1),
+					d.fileWURLAtRoot(aURL(2), false, 2),
+					d.fileWURLAtRoot(aURL(3), false, 3)),
 				aPage(
-					fileWURLAtRoot(aURL(4), false, 4),
-					fileWURLAtRoot(aURL(5), false, 5)),
+					d.fileWURLAtRoot(aURL(4), false, 4),
+					d.fileWURLAtRoot(aURL(5), false, 5)),
 			},
 			expectedItemProps: map[string]itemProps{
 				fileID(1): {
@@ -372,19 +373,19 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		},
 		{
 			name: "multiple pages with resets and combo reset+items in page",
-			pages: []mock.NextPage{
+			pages: []nextPage{
 				aPage(
-					fileWURLAtRoot(aURL(0), false, 0),
-					fileWURLAtRoot(aURL(1), false, 1),
-					fileWURLAtRoot(aURL(2), false, 2),
-					fileWURLAtRoot(aURL(3), false, 3)),
+					d.fileWURLAtRoot(aURL(0), false, 0),
+					d.fileWURLAtRoot(aURL(1), false, 1),
+					d.fileWURLAtRoot(aURL(2), false, 2),
+					d.fileWURLAtRoot(aURL(3), false, 3)),
 				aPageWReset(
-					fileWURLAtRoot(aURL(1), false, 1),
-					fileWURLAtRoot(aURL(2), false, 2),
-					fileWURLAtRoot(aURL(3), false, 3)),
+					d.fileWURLAtRoot(aURL(1), false, 1),
+					d.fileWURLAtRoot(aURL(2), false, 2),
+					d.fileWURLAtRoot(aURL(3), false, 3)),
 				aPage(
-					fileWURLAtRoot(aURL(4), false, 4),
-					fileWURLAtRoot(aURL(5), false, 5)),
+					d.fileWURLAtRoot(aURL(4), false, 4),
+					d.fileWURLAtRoot(aURL(5), false, 5)),
 			},
 			expectedItemProps: map[string]itemProps{
 				fileID(1): {
@@ -417,13 +418,13 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		},
 		{
 			name: "duplicate items with potentially new urls",
-			pages: []mock.NextPage{
+			pages: []nextPage{
 				aPage(
-					fileWURLAtRoot(aURL(1), false, 1),
-					fileWURLAtRoot(aURL(2), false, 2),
-					fileWURLAtRoot(aURL(3), false, 3),
-					fileWURLAtRoot(aURL(100), false, 1),
-					fileWURLAtRoot(aURL(200), false, 2)),
+					d.fileWURLAtRoot(aURL(1), false, 1),
+					d.fileWURLAtRoot(aURL(2), false, 2),
+					d.fileWURLAtRoot(aURL(3), false, 3),
+					d.fileWURLAtRoot(aURL(100), false, 1),
+					d.fileWURLAtRoot(aURL(200), false, 2)),
 			},
 			expectedItemProps: map[string]itemProps{
 				fileID(1): {
@@ -448,11 +449,11 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		},
 		{
 			name: "deleted items",
-			pages: []mock.NextPage{
+			pages: []nextPage{
 				aPage(
-					fileWURLAtRoot(aURL(1), false, 1),
-					fileWURLAtRoot(aURL(2), false, 2),
-					fileWURLAtRoot(aURL(1), true, 1)),
+					d.fileWURLAtRoot(aURL(1), false, 1),
+					d.fileWURLAtRoot(aURL(2), false, 2),
+					d.fileWURLAtRoot(aURL(1), true, 1)),
 			},
 			expectedItemProps: map[string]itemProps{
 				fileID(1): {
@@ -473,8 +474,8 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		},
 		{
 			name: "item not found in cache",
-			pages: []mock.NextPage{
-				aPage(fileWURLAtRoot(aURL(1), false, 1)),
+			pages: []nextPage{
+				aPage(d.fileWURLAtRoot(aURL(1), false, 1)),
 			},
 			expectedItemProps: map[string]itemProps{
 				fileID(2): {},
@@ -488,7 +489,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		},
 		{
 			name: "delta query error",
-			pages: []mock.NextPage{
+			pages: []nextPage{
 				aPage(),
 			},
 			pagerErr: errors.New("delta query error"),
@@ -505,10 +506,10 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		},
 		{
 			name: "folder item",
-			pages: []mock.NextPage{
+			pages: []nextPage{
 				aPage(
-					fileWURLAtRoot(aURL(1), false, 1),
-					driveItem("2", "folder2", "root", "root", isFolder)),
+					d.fileWURLAtRoot(aURL(1), false, 1),
+					d.folderAtRoot(2)),
 			},
 			expectedItemProps: map[string]itemProps{
 				fileID(2): {},
@@ -532,17 +533,17 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 					ctx, flush := tester.NewContext(t)
 					defer flush()
 
-					drive := mock.Drive()
+					drive := drive()
 
-					driveEnumer := mock.DriveEnumerator(
-						drive.NewEnumer().
-							WithErr(test.pagerErr).
-							With(
-								mock.Delta(delta, test.pagerErr).
-									With(test.pages...)))
+					driveEnumer := driveEnumerator(
+						drive.newEnumer().
+							withErr(test.pagerErr).
+							with(
+								delta(deltaURL, test.pagerErr).
+									with(test.pages...)))
 
 					cache, err := newURLCache(
-						drive.ID,
+						drive.id,
 						"",
 						1*time.Hour,
 						driveEnumer,
@@ -583,14 +584,14 @@ func (suite *URLCacheUnitSuite) TestNeedsRefresh() {
 	var (
 		t               = suite.T()
 		refreshInterval = 1 * time.Second
-		drv             = mock.Drive()
+		drv             = drive()
 	)
 
 	cache, err := newURLCache(
-		drv.ID,
+		drv.id,
 		"",
 		refreshInterval,
-		&mock.EnumerateDriveItemsDelta{},
+		&enumerateDriveItemsDelta{},
 		count.New(),
 		fault.New(true))
 	require.NoError(t, err, clues.ToCore(err))
@@ -613,7 +614,7 @@ func (suite *URLCacheUnitSuite) TestNeedsRefresh() {
 }
 
 func (suite *URLCacheUnitSuite) TestNewURLCache() {
-	drv := mock.Drive()
+	drv := drive()
 
 	table := []struct {
 		name       string
@@ -627,21 +628,21 @@ func (suite *URLCacheUnitSuite) TestNewURLCache() {
 			name:       "invalid driveID",
 			driveID:    "",
 			refreshInt: 1 * time.Hour,
-			itemPager:  &mock.EnumerateDriveItemsDelta{},
+			itemPager:  &enumerateDriveItemsDelta{},
 			errors:     fault.New(true),
 			expectErr:  require.Error,
 		},
 		{
 			name:       "invalid refresh interval",
-			driveID:    drv.ID,
+			driveID:    drv.id,
 			refreshInt: 100 * time.Millisecond,
-			itemPager:  &mock.EnumerateDriveItemsDelta{},
+			itemPager:  &enumerateDriveItemsDelta{},
 			errors:     fault.New(true),
 			expectErr:  require.Error,
 		},
 		{
 			name:       "invalid item enumerator",
-			driveID:    drv.ID,
+			driveID:    drv.id,
 			refreshInt: 1 * time.Hour,
 			itemPager:  nil,
 			errors:     fault.New(true),
@@ -649,9 +650,9 @@ func (suite *URLCacheUnitSuite) TestNewURLCache() {
 		},
 		{
 			name:       "valid",
-			driveID:    drv.ID,
+			driveID:    drv.id,
 			refreshInt: 1 * time.Hour,
-			itemPager:  &mock.EnumerateDriveItemsDelta{},
+			itemPager:  &enumerateDriveItemsDelta{},
 			errors:     fault.New(true),
 			expectErr:  require.NoError,
 		},

--- a/src/internal/m365/service/onedrive/mock/handlers.go
+++ b/src/internal/m365/service/onedrive/mock/handlers.go
@@ -1,5 +1,16 @@
 package mock
 
+// ---------------------------------------------------------------------------
+// 								>>> TODO <<<
+//              https://github.com/alcionai/corso/issues/4846
+// This file's functions are duplicated into /drive/helper_test.go, which
+// should act as the clear primary owner of that functionality.  However,
+// packages outside of /drive (such as sharepoint) depend on these helpers
+// for test functionality.  We'll want to unify the two at some point.
+// In the meantime, make sure you're referencing and updating the correct
+// set of helpers (prefer the /drive version over this one).
+// ---------------------------------------------------------------------------
+
 import (
 	"context"
 	"fmt"

--- a/src/internal/m365/service/sharepoint/backup_test.go
+++ b/src/internal/m365/service/sharepoint/backup_test.go
@@ -44,12 +44,14 @@ func TestLibrariesBackupUnitSuite(t *testing.T) {
 }
 
 func (suite *LibrariesBackupUnitSuite) TestUpdateCollections() {
-	anyFolder := (&selectors.SharePointBackup{}).LibraryFolders(selectors.Any())[0]
+	var (
+		anyFolder = (&selectors.SharePointBackup{}).LibraryFolders(selectors.Any())[0]
+		drv       = mock.Drive()
+	)
 
 	const (
 		tenantID = "tenant"
 		siteID   = "site"
-		driveID  = "driveID1"
 	)
 
 	pb := path.Builder{}.Append(testBaseDrivePath.Elements()...)
@@ -96,13 +98,13 @@ func (suite *LibrariesBackupUnitSuite) TestUpdateCollections() {
 				paths    = map[string]string{}
 				excluded = map[string]struct{}{}
 				collMap  = map[string]map[string]*drive.Collection{
-					driveID: {},
+					drv.ID: {},
 				}
 				topLevelPackages = map[string]struct{}{}
 			)
 
 			mbh.DriveItemEnumeration = mock.DriveEnumerator(
-				mock.Drive(driveID).With(
+				drv.NewEnumer().With(
 					mock.Delta("notempty", nil).With(mock.NextPage{Items: test.items})))
 
 			c := drive.NewCollections(
@@ -117,7 +119,7 @@ func (suite *LibrariesBackupUnitSuite) TestUpdateCollections() {
 
 			_, _, err := c.PopulateDriveCollections(
 				ctx,
-				driveID,
+				drv.ID,
 				"General",
 				paths,
 				excluded,
@@ -134,10 +136,10 @@ func (suite *LibrariesBackupUnitSuite) TestUpdateCollections() {
 			assert.Empty(t, topLevelPackages, "should not find package type folders")
 
 			for _, collPath := range test.expectedCollectionIDs {
-				assert.Contains(t, c.CollectionMap[driveID], collPath)
+				assert.Contains(t, c.CollectionMap[drv.ID], collPath)
 			}
 
-			for _, col := range c.CollectionMap[driveID] {
+			for _, col := range c.CollectionMap[drv.ID] {
 				assert.Contains(t, test.expectedCollectionPaths, col.FullPath().String())
 			}
 		})


### PR DESCRIPTION
The next couple PRs are a distributed set of changes with the goal
of improving drive stubbing/management within testing, so that
the identification and use of a drive is more failsafe and maintainable,
and less reliant on obtuse drive id references.

-----

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Supportability/Tests
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #4689

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
