### PR TITLE
use a drive to identify all file paths

### DIFF
--- a/src/internal/m365/collection/drive/collections_test.go
+++ b/src/internal/m365/collection/drive/collections_test.go
@@ -40,6 +40,7 @@ func TestCollectionsUnitSuite(t *testing.T) {
 
 func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 	t := suite.T()
+	d := drive()
 
 	tests := []struct {
 		name                     string
@@ -62,18 +63,18 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "Invalid item",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveItem(id(item), name(item), driveParentDir(drivePfx), rootID, -1),
+				driveItem(id(item), name(item), d.dir(), rootID, -1),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.Error,
 			expectedCollectionIDs: map[string]statePath{
-				rootID: asNotMoved(t, driveFullPath(drivePfx)),
+				rootID: asNotMoved(t, d.strPath()),
 			},
 			expectedContainerCount: 1,
 			expectedPrevPaths: map[string]string{
-				rootID: driveFullPath(drivePfx),
+				rootID: d.strPath(),
 			},
 			expectedExcludes:         map[string]struct{}{},
 			expectedTopLevelPackages: map[string]struct{}{},
@@ -82,21 +83,21 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "Single File",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFile(driveParentDir(drivePfx), rootID),
+				driveFile(d.dir(), rootID),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID: asNotMoved(t, driveFullPath(drivePfx)),
+				rootID: asNotMoved(t, d.strPath()),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      1,
 			expectedContainerCount: 1,
 			// Root folder is skipped since it's always present.
 			expectedPrevPaths: map[string]string{
-				rootID: driveFullPath(drivePfx),
+				rootID: d.strPath(),
 			},
 			expectedExcludes:         makeExcludeMap(fileID()),
 			expectedTopLevelPackages: map[string]struct{}{},
@@ -105,19 +106,19 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "Single Folder",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFolder(driveParentDir(drivePfx), rootID),
+				driveFolder(d.dir(), rootID),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, driveFullPath(drivePfx)),
-				folderID(): asNew(t, driveFullPath(drivePfx, folderName())),
+				rootID:     asNotMoved(t, d.strPath()),
+				folderID(): asNew(t, d.strPath(folderName())),
 			},
 			expectedPrevPaths: map[string]string{
-				rootID:     driveFullPath(drivePfx),
-				folderID(): driveFullPath(drivePfx, folderName()),
+				rootID:     d.strPath(),
+				folderID(): d.strPath(folderName()),
 			},
 			expectedItemCount:        1,
 			expectedContainerCount:   2,
@@ -128,20 +129,20 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "Single Folder created twice", // deleted a created with same name in between a backup
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFolder(driveParentDir(drivePfx), rootID),
-				driveItem(folderID(2), folderName(), driveParentDir(drivePfx), rootID, isFolder),
+				driveFolder(d.dir(), rootID),
+				driveItem(folderID(2), folderName(), d.dir(), rootID, isFolder),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:      asNotMoved(t, driveFullPath(drivePfx)),
-				folderID(2): asNew(t, driveFullPath(drivePfx, folderName())),
+				rootID:      asNotMoved(t, d.strPath()),
+				folderID(2): asNew(t, d.strPath(folderName())),
 			},
 			expectedPrevPaths: map[string]string{
-				rootID:      driveFullPath(drivePfx),
-				folderID(2): driveFullPath(drivePfx, folderName()),
+				rootID:      d.strPath(),
+				folderID(2): d.strPath(folderName()),
 			},
 			expectedItemCount:        1,
 			expectedContainerCount:   2,
@@ -152,25 +153,25 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "Single Package",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveItem(id(pkg), name(pkg), driveParentDir(drivePfx), rootID, isPackage),
+				driveItem(id(pkg), name(pkg), d.dir(), rootID, isPackage),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:  asNotMoved(t, driveFullPath(drivePfx)),
-				id(pkg): asNew(t, driveFullPath(drivePfx, name(pkg))),
+				rootID:  asNotMoved(t, d.strPath()),
+				id(pkg): asNew(t, d.strPath(name(pkg))),
 			},
 			expectedPrevPaths: map[string]string{
-				rootID:  driveFullPath(drivePfx),
-				id(pkg): driveFullPath(drivePfx, name(pkg)),
+				rootID:  d.strPath(),
+				id(pkg): d.strPath(name(pkg)),
 			},
 			expectedItemCount:      1,
 			expectedContainerCount: 2,
 			expectedExcludes:       map[string]struct{}{},
 			expectedTopLevelPackages: map[string]struct{}{
-				driveFullPath(drivePfx, name(pkg)): {},
+				d.strPath(name(pkg)): {},
 			},
 			expectedCountPackages: 1,
 		},
@@ -178,31 +179,31 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "Single Package with subfolder",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveItem(id(pkg), name(pkg), driveParentDir(drivePfx), rootID, isPackage),
-				driveItem(folderID(), folderName(), driveParentDir(drivePfx, name(pkg)), id(pkg), isFolder),
-				driveItem(id(subfolder), name(subfolder), driveParentDir(drivePfx, name(pkg)), id(pkg), isFolder),
+				driveItem(id(pkg), name(pkg), d.dir(), rootID, isPackage),
+				driveItem(folderID(), folderName(), d.dir(name(pkg)), id(pkg), isFolder),
+				driveItem(id(subfolder), name(subfolder), d.dir(name(pkg)), id(pkg), isFolder),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:        asNotMoved(t, driveFullPath(drivePfx)),
-				id(pkg):       asNew(t, driveFullPath(drivePfx, name(pkg))),
-				folderID():    asNew(t, driveFullPath(drivePfx, name(pkg), folderName())),
-				id(subfolder): asNew(t, driveFullPath(drivePfx, name(pkg), name(subfolder))),
+				rootID:        asNotMoved(t, d.strPath()),
+				id(pkg):       asNew(t, d.strPath(name(pkg))),
+				folderID():    asNew(t, d.strPath(name(pkg), folderName())),
+				id(subfolder): asNew(t, d.strPath(name(pkg), name(subfolder))),
 			},
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drivePfx),
-				id(pkg):       driveFullPath(drivePfx, name(pkg)),
-				folderID():    driveFullPath(drivePfx, name(pkg), folderName()),
-				id(subfolder): driveFullPath(drivePfx, name(pkg), name(subfolder)),
+				rootID:        d.strPath(),
+				id(pkg):       d.strPath(name(pkg)),
+				folderID():    d.strPath(name(pkg), folderName()),
+				id(subfolder): d.strPath(name(pkg), name(subfolder)),
 			},
 			expectedItemCount:      3,
 			expectedContainerCount: 4,
 			expectedExcludes:       map[string]struct{}{},
 			expectedTopLevelPackages: map[string]struct{}{
-				driveFullPath(drivePfx, name(pkg)): {},
+				d.strPath(name(pkg)): {},
 			},
 			expectedCountPackages: 3,
 		},
@@ -210,31 +211,31 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "1 root file, 1 folder, 1 package, 2 files, 3 collections",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFile(driveParentDir(drivePfx), rootID, "inRoot"),
-				driveFolder(driveParentDir(drivePfx), rootID),
-				driveItem(id(pkg), name(pkg), driveParentDir(drivePfx), rootID, isPackage),
-				driveFile(driveParentDir(drivePfx, folderName()), folderID(), "inFolder"),
-				driveFile(driveParentDir(drivePfx, name(pkg)), id(pkg), "inPackage"),
+				driveFile(d.dir(), rootID, "inRoot"),
+				driveFolder(d.dir(), rootID),
+				driveItem(id(pkg), name(pkg), d.dir(), rootID, isPackage),
+				driveFile(d.dir(folderName()), folderID(), "inFolder"),
+				driveFile(d.dir(name(pkg)), id(pkg), "inPackage"),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, driveFullPath(drivePfx)),
-				folderID(): asNew(t, driveFullPath(drivePfx, folderName())),
-				id(pkg):    asNew(t, driveFullPath(drivePfx, name(pkg))),
+				rootID:     asNotMoved(t, d.strPath()),
+				folderID(): asNew(t, d.strPath(folderName())),
+				id(pkg):    asNew(t, d.strPath(name(pkg))),
 			},
 			expectedItemCount:      5,
 			expectedFileCount:      3,
 			expectedContainerCount: 3,
 			expectedPrevPaths: map[string]string{
-				rootID:     driveFullPath(drivePfx),
-				folderID(): driveFullPath(drivePfx, folderName()),
-				id(pkg):    driveFullPath(drivePfx, name(pkg)),
+				rootID:     d.strPath(),
+				folderID(): d.strPath(folderName()),
+				id(pkg):    d.strPath(name(pkg)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{
-				driveFullPath(drivePfx, name(pkg)): {},
+				d.strPath(name(pkg)): {},
 			},
 			expectedCountPackages: 1,
 			expectedExcludes:      makeExcludeMap(fileID("inRoot"), fileID("inFolder"), fileID("inPackage")),
@@ -243,23 +244,23 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "contains folder selector",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFile(driveParentDir(drivePfx), rootID, "inRoot"),
-				driveFolder(driveParentDir(drivePfx), rootID),
-				driveItem(id(subfolder), name(subfolder), driveParentDir(drivePfx, folderName()), folderID(), isFolder),
-				driveItem(folderID(2), folderName(), driveParentDir(drivePfx, folderName(), name(subfolder)), id(subfolder), isFolder),
-				driveItem(id(pkg), name(pkg), driveParentDir(drivePfx), rootID, isPackage),
-				driveItem(fileID("inFolder"), fileID("inFolder"), driveParentDir(drivePfx, folderName()), folderID(), isFile),
-				driveItem(fileID("inFolder2"), fileName("inFolder2"), driveParentDir(drivePfx, folderName(), name(subfolder), folderName()), folderID(2), isFile),
-				driveItem(fileID("inFolderPackage"), fileName("inPackage"), driveParentDir(drivePfx, name(pkg)), id(pkg), isFile),
+				driveFile(d.dir(), rootID, "inRoot"),
+				driveFolder(d.dir(), rootID),
+				driveItem(id(subfolder), name(subfolder), d.dir(folderName()), folderID(), isFolder),
+				driveItem(folderID(2), folderName(), d.dir(folderName(), name(subfolder)), id(subfolder), isFolder),
+				driveItem(id(pkg), name(pkg), d.dir(), rootID, isPackage),
+				driveItem(fileID("inFolder"), fileID("inFolder"), d.dir(folderName()), folderID(), isFile),
+				driveItem(fileID("inFolder2"), fileName("inFolder2"), d.dir(folderName(), name(subfolder), folderName()), folderID(2), isFile),
+				driveItem(fileID("inFolderPackage"), fileName("inPackage"), d.dir(name(pkg)), id(pkg), isFile),
 			},
 			previousPaths:    map[string]string{},
 			scope:            (&selectors.OneDriveBackup{}).Folders([]string{folderName()})[0],
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				folderID():    asNew(t, driveFullPath(drivePfx, folderName())),
-				id(subfolder): asNew(t, driveFullPath(drivePfx, folderName(), name(subfolder))),
-				folderID(2):   asNew(t, driveFullPath(drivePfx, folderName(), name(subfolder), folderName())),
+				folderID():    asNew(t, d.strPath(folderName())),
+				id(subfolder): asNew(t, d.strPath(folderName(), name(subfolder))),
+				folderID(2):   asNew(t, d.strPath(folderName(), name(subfolder), folderName())),
 			},
 			expectedItemCount:      5,
 			expectedFileCount:      2,
@@ -267,9 +268,9 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			// just "folder" isn't added here because the include check is done on the
 			// parent path since we only check later if something is a folder or not.
 			expectedPrevPaths: map[string]string{
-				folderID():    driveFullPath(drivePfx, folderName()),
-				id(subfolder): driveFullPath(drivePfx, folderName(), name(subfolder)),
-				folderID(2):   driveFullPath(drivePfx, folderName(), name(subfolder), folderName()),
+				folderID():    d.strPath(folderName()),
+				id(subfolder): d.strPath(folderName(), name(subfolder)),
+				folderID(2):   d.strPath(folderName(), name(subfolder), folderName()),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(fileID("inFolder"), fileID("inFolder2")),
@@ -278,14 +279,14 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "prefix subfolder selector",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFile(driveParentDir(drivePfx), rootID, "inRoot"),
-				driveFolder(driveParentDir(drivePfx), rootID),
-				driveItem(id(subfolder), name(subfolder), driveParentDir(drivePfx, folderName()), folderID(), isFolder),
-				driveItem(folderID(2), folderName(), driveParentDir(drivePfx, folderName(), name(subfolder)), id(subfolder), isFolder),
-				driveItem(id(pkg), name(pkg), driveParentDir(drivePfx), rootID, isPackage),
-				driveItem(fileID("inFolder"), fileID("inFolder"), driveParentDir(drivePfx, folderName()), folderID(), isFile),
-				driveItem(fileID("inFolder2"), fileName("inFolder2"), driveParentDir(drivePfx, folderName(), name(subfolder), folderName()), folderID(2), isFile),
-				driveItem(fileID("inFolderPackage"), fileName("inPackage"), driveParentDir(drivePfx, name(pkg)), id(pkg), isFile),
+				driveFile(d.dir(), rootID, "inRoot"),
+				driveFolder(d.dir(), rootID),
+				driveItem(id(subfolder), name(subfolder), d.dir(folderName()), folderID(), isFolder),
+				driveItem(folderID(2), folderName(), d.dir(folderName(), name(subfolder)), id(subfolder), isFolder),
+				driveItem(id(pkg), name(pkg), d.dir(), rootID, isPackage),
+				driveItem(fileID("inFolder"), fileID("inFolder"), d.dir(folderName()), folderID(), isFile),
+				driveItem(fileID("inFolder2"), fileName("inFolder2"), d.dir(folderName(), name(subfolder), folderName()), folderID(2), isFile),
+				driveItem(fileID("inFolderPackage"), fileName("inPackage"), d.dir(name(pkg)), id(pkg), isFile),
 			},
 			previousPaths: map[string]string{},
 			scope: (&selectors.OneDriveBackup{}).Folders(
@@ -294,15 +295,15 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				id(subfolder): asNew(t, driveFullPath(drivePfx, folderName(), name(subfolder))),
-				folderID(2):   asNew(t, driveFullPath(drivePfx, folderName(), name(subfolder), folderName())),
+				id(subfolder): asNew(t, d.strPath(folderName(), name(subfolder))),
+				folderID(2):   asNew(t, d.strPath(folderName(), name(subfolder), folderName())),
 			},
 			expectedItemCount:      3,
 			expectedFileCount:      1,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				id(subfolder): driveFullPath(drivePfx, folderName(), name(subfolder)),
-				folderID(2):   driveFullPath(drivePfx, folderName(), name(subfolder), folderName()),
+				id(subfolder): d.strPath(folderName(), name(subfolder)),
+				folderID(2):   d.strPath(folderName(), name(subfolder), folderName()),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(fileID("inFolder2")),
@@ -311,27 +312,27 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "match subfolder selector",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFile(driveParentDir(drivePfx), rootID),
-				driveFolder(driveParentDir(drivePfx), rootID),
-				driveItem(id(subfolder), name(subfolder), driveParentDir(drivePfx, folderName()), folderID(), isFolder),
-				driveItem(id(pkg), name(pkg), driveParentDir(drivePfx), rootID, isPackage),
-				driveItem(fileID(1), fileName(1), driveParentDir(drivePfx, folderName()), folderID(), isFile),
-				driveItem(fileID("inSubfolder"), fileName("inSubfolder"), driveParentDir(drivePfx, folderName(), name(subfolder)), id(subfolder), isFile),
-				driveItem(fileID(9), fileName(9), driveParentDir(drivePfx, name(pkg)), id(pkg), isFile),
+				driveFile(d.dir(), rootID),
+				driveFolder(d.dir(), rootID),
+				driveItem(id(subfolder), name(subfolder), d.dir(folderName()), folderID(), isFolder),
+				driveItem(id(pkg), name(pkg), d.dir(), rootID, isPackage),
+				driveItem(fileID(1), fileName(1), d.dir(folderName()), folderID(), isFile),
+				driveItem(fileID("inSubfolder"), fileName("inSubfolder"), d.dir(folderName(), name(subfolder)), id(subfolder), isFile),
+				driveItem(fileID(9), fileName(9), d.dir(name(pkg)), id(pkg), isFile),
 			},
 			previousPaths:    map[string]string{},
 			scope:            (&selectors.OneDriveBackup{}).Folders([]string{toPath(folderName(), name(subfolder))})[0],
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				id(subfolder): asNew(t, driveFullPath(drivePfx, folderName(), name(subfolder))),
+				id(subfolder): asNew(t, d.strPath(folderName(), name(subfolder))),
 			},
 			expectedItemCount:      2,
 			expectedFileCount:      1,
 			expectedContainerCount: 1,
 			// No child folders for subfolder so nothing here.
 			expectedPrevPaths: map[string]string{
-				id(subfolder): driveFullPath(drivePfx, folderName(), name(subfolder)),
+				id(subfolder): d.strPath(folderName(), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(fileID("inSubfolder")),
@@ -340,26 +341,26 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "not moved folder tree",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFolder(driveParentDir(drivePfx), rootID),
+				driveFolder(d.dir(), rootID),
 			},
 			previousPaths: map[string]string{
-				folderID():    driveFullPath(drivePfx, folderName()),
-				id(subfolder): driveFullPath(drivePfx, folderName(), name(subfolder)),
+				folderID():    d.strPath(folderName()),
+				id(subfolder): d.strPath(folderName(), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, driveFullPath(drivePfx)),
-				folderID(): asNotMoved(t, driveFullPath(drivePfx, folderName())),
+				rootID:     asNotMoved(t, d.strPath()),
+				folderID(): asNotMoved(t, d.strPath(folderName())),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      0,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drivePfx),
-				folderID():    driveFullPath(drivePfx, folderName()),
-				id(subfolder): driveFullPath(drivePfx, folderName(), name(subfolder)),
+				rootID:        d.strPath(),
+				folderID():    d.strPath(folderName()),
+				id(subfolder): d.strPath(folderName(), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -368,26 +369,26 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "moved folder tree",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFolder(driveParentDir(drivePfx), rootID),
+				driveFolder(d.dir(), rootID),
 			},
 			previousPaths: map[string]string{
-				folderID():    driveFullPath(drivePfx, folderName("a")),
-				id(subfolder): driveFullPath(drivePfx, folderName("a"), name(subfolder)),
+				folderID():    d.strPath(folderName("a")),
+				id(subfolder): d.strPath(folderName("a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, driveFullPath(drivePfx)),
-				folderID(): asMoved(t, driveFullPath(drivePfx, folderName("a")), driveFullPath(drivePfx, folderName())),
+				rootID:     asNotMoved(t, d.strPath()),
+				folderID(): asMoved(t, d.strPath(folderName("a")), d.strPath(folderName())),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      0,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drivePfx),
-				folderID():    driveFullPath(drivePfx, folderName()),
-				id(subfolder): driveFullPath(drivePfx, folderName(), name(subfolder)),
+				rootID:        d.strPath(),
+				folderID():    d.strPath(folderName()),
+				id(subfolder): d.strPath(folderName(), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -396,27 +397,27 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "moved folder tree twice within backup",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveItem(folderID(1), folderName(), driveParentDir(drivePfx), rootID, isFolder),
-				driveItem(folderID(2), folderName(), driveParentDir(drivePfx), rootID, isFolder),
+				driveItem(folderID(1), folderName(), d.dir(), rootID, isFolder),
+				driveItem(folderID(2), folderName(), d.dir(), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				folderID(1):   driveFullPath(drivePfx, folderName("a")),
-				id(subfolder): driveFullPath(drivePfx, folderName("a"), name(subfolder)),
+				folderID(1):   d.strPath(folderName("a")),
+				id(subfolder): d.strPath(folderName("a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:      asNotMoved(t, driveFullPath(drivePfx)),
-				folderID(2): asNew(t, driveFullPath(drivePfx, folderName())),
+				rootID:      asNotMoved(t, d.strPath()),
+				folderID(2): asNew(t, d.strPath(folderName())),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      0,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drivePfx),
-				folderID(2):   driveFullPath(drivePfx, folderName()),
-				id(subfolder): driveFullPath(drivePfx, folderName(), name(subfolder)),
+				rootID:        d.strPath(),
+				folderID(2):   d.strPath(folderName()),
+				id(subfolder): d.strPath(folderName(), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -426,26 +427,26 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			items: []models.DriveItemable{
 				driveRootFolder(),
 				delItem(folderID(), rootID, isFolder),
-				driveItem(folderID(), name(drivePfx), driveParentDir(drivePfx), rootID, isFolder),
+				driveItem(folderID(), name(drivePfx), d.dir(), rootID, isFolder),
 				delItem(folderID(), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				folderID():    driveFullPath(drivePfx),
-				id(subfolder): driveFullPath(drivePfx, folderName("a"), name(subfolder)),
+				folderID():    d.strPath(),
+				id(subfolder): d.strPath(folderName("a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, driveFullPath(drivePfx)),
-				folderID(): asDeleted(t, driveFullPath(drivePfx, "")),
+				rootID:     asNotMoved(t, d.strPath()),
+				folderID(): asDeleted(t, d.strPath("")),
 			},
 			expectedItemCount:      0,
 			expectedFileCount:      0,
 			expectedContainerCount: 1,
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drivePfx),
-				id(subfolder): driveFullPath(drivePfx, folderName("a"), name(subfolder)),
+				rootID:        d.strPath(),
+				id(subfolder): d.strPath(folderName("a"), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -454,28 +455,28 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "moved folder tree twice within backup including delete",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFolder(driveParentDir(drivePfx), rootID),
+				driveFolder(d.dir(), rootID),
 				delItem(folderID(), rootID, isFolder),
-				driveItem(folderID(2), folderName(), driveParentDir(drivePfx), rootID, isFolder),
+				driveItem(folderID(2), folderName(), d.dir(), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				folderID():    driveFullPath(drivePfx, folderName("a")),
-				id(subfolder): driveFullPath(drivePfx, folderName("a"), name(subfolder)),
+				folderID():    d.strPath(folderName("a")),
+				id(subfolder): d.strPath(folderName("a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:      asNotMoved(t, driveFullPath(drivePfx)),
-				folderID(2): asNew(t, driveFullPath(drivePfx, folderName())),
+				rootID:      asNotMoved(t, d.strPath()),
+				folderID(2): asNew(t, d.strPath(folderName())),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      0,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drivePfx),
-				folderID(2):   driveFullPath(drivePfx, folderName()),
-				id(subfolder): driveFullPath(drivePfx, folderName(), name(subfolder)),
+				rootID:        d.strPath(),
+				folderID(2):   d.strPath(folderName()),
+				id(subfolder): d.strPath(folderName(), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -484,27 +485,27 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "deleted folder tree twice within backup with addition",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveItem(folderID(1), folderName(), driveParentDir(drivePfx), rootID, isFolder),
+				driveItem(folderID(1), folderName(), d.dir(), rootID, isFolder),
 				delItem(folderID(1), rootID, isFolder),
-				driveItem(folderID(2), folderName(), driveParentDir(drivePfx), rootID, isFolder),
+				driveItem(folderID(2), folderName(), d.dir(), rootID, isFolder),
 				delItem(folderID(2), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				folderID(1):   driveFullPath(drivePfx, folderName("a")),
-				id(subfolder): driveFullPath(drivePfx, folderName("a"), name(subfolder)),
+				folderID(1):   d.strPath(folderName("a")),
+				id(subfolder): d.strPath(folderName("a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID: asNotMoved(t, driveFullPath(drivePfx)),
+				rootID: asNotMoved(t, d.strPath()),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      0,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drivePfx),
-				id(subfolder): driveFullPath(drivePfx, folderName(), name(subfolder)),
+				rootID:        d.strPath(),
+				id(subfolder): d.strPath(folderName(), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -513,24 +514,24 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "moved folder tree with file no previous",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFolder(driveParentDir(drivePfx), rootID),
-				driveItem(fileID(), fileName(), driveParentDir(drivePfx, folderName()), folderID(), isFile),
-				driveItem(folderID(), folderName(2), driveParentDir(drivePfx), rootID, isFolder),
+				driveFolder(d.dir(), rootID),
+				driveItem(fileID(), fileName(), d.dir(folderName()), folderID(), isFile),
+				driveItem(folderID(), folderName(2), d.dir(), rootID, isFolder),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, driveFullPath(drivePfx)),
-				folderID(): asNew(t, driveFullPath(drivePfx, folderName(2))),
+				rootID:     asNotMoved(t, d.strPath()),
+				folderID(): asNew(t, d.strPath(folderName(2))),
 			},
 			expectedItemCount:      2,
 			expectedFileCount:      1,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:     driveFullPath(drivePfx),
-				folderID(): driveFullPath(drivePfx, folderName(2)),
+				rootID:     d.strPath(),
+				folderID(): d.strPath(folderName(2)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(fileID()),
@@ -539,23 +540,23 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "moved folder tree with file no previous 1",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFolder(driveParentDir(drivePfx), rootID),
-				driveItem(fileID(), fileName(), driveParentDir(drivePfx, folderName()), folderID(), isFile),
+				driveFolder(d.dir(), rootID),
+				driveItem(fileID(), fileName(), d.dir(folderName()), folderID(), isFile),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, driveFullPath(drivePfx)),
-				folderID(): asNew(t, driveFullPath(drivePfx, folderName())),
+				rootID:     asNotMoved(t, d.strPath()),
+				folderID(): asNew(t, d.strPath(folderName())),
 			},
 			expectedItemCount:      2,
 			expectedFileCount:      1,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:     driveFullPath(drivePfx),
-				folderID(): driveFullPath(drivePfx, folderName()),
+				rootID:     d.strPath(),
+				folderID(): d.strPath(folderName()),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(fileID()),
@@ -564,28 +565,28 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "moved folder tree and subfolder 1",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFolder(driveParentDir(drivePfx), rootID),
-				driveItem(id(subfolder), name(subfolder), driveParentDir(drivePfx), rootID, isFolder),
+				driveFolder(d.dir(), rootID),
+				driveItem(id(subfolder), name(subfolder), d.dir(), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				folderID():    driveFullPath(drivePfx, folderName("a")),
-				id(subfolder): driveFullPath(drivePfx, folderName("a"), name(subfolder)),
+				folderID():    d.strPath(folderName("a")),
+				id(subfolder): d.strPath(folderName("a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:        asNotMoved(t, driveFullPath(drivePfx)),
-				folderID():    asMoved(t, driveFullPath(drivePfx, folderName("a")), driveFullPath(drivePfx, folderName())),
-				id(subfolder): asMoved(t, driveFullPath(drivePfx, folderName("a"), name(subfolder)), driveFullPath(drivePfx, name(subfolder))),
+				rootID:        asNotMoved(t, d.strPath()),
+				folderID():    asMoved(t, d.strPath(folderName("a")), d.strPath(folderName())),
+				id(subfolder): asMoved(t, d.strPath(folderName("a"), name(subfolder)), d.strPath(name(subfolder))),
 			},
 			expectedItemCount:      2,
 			expectedFileCount:      0,
 			expectedContainerCount: 3,
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drivePfx),
-				folderID():    driveFullPath(drivePfx, folderName()),
-				id(subfolder): driveFullPath(drivePfx, name(subfolder)),
+				rootID:        d.strPath(),
+				folderID():    d.strPath(folderName()),
+				id(subfolder): d.strPath(name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -594,28 +595,28 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "moved folder tree and subfolder 2",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveItem(id(subfolder), name(subfolder), driveParentDir(drivePfx), rootID, isFolder),
-				driveFolder(driveParentDir(drivePfx), rootID),
+				driveItem(id(subfolder), name(subfolder), d.dir(), rootID, isFolder),
+				driveFolder(d.dir(), rootID),
 			},
 			previousPaths: map[string]string{
-				folderID():    driveFullPath(drivePfx, folderName("a")),
-				id(subfolder): driveFullPath(drivePfx, folderName("a"), name(subfolder)),
+				folderID():    d.strPath(folderName("a")),
+				id(subfolder): d.strPath(folderName("a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:        asNotMoved(t, driveFullPath(drivePfx)),
-				folderID():    asMoved(t, driveFullPath(drivePfx, folderName("a")), driveFullPath(drivePfx, folderName())),
-				id(subfolder): asMoved(t, driveFullPath(drivePfx, folderName("a"), name(subfolder)), driveFullPath(drivePfx, name(subfolder))),
+				rootID:        asNotMoved(t, d.strPath()),
+				folderID():    asMoved(t, d.strPath(folderName("a")), d.strPath(folderName())),
+				id(subfolder): asMoved(t, d.strPath(folderName("a"), name(subfolder)), d.strPath(name(subfolder))),
 			},
 			expectedItemCount:      2,
 			expectedFileCount:      0,
 			expectedContainerCount: 3,
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drivePfx),
-				folderID():    driveFullPath(drivePfx, folderName()),
-				id(subfolder): driveFullPath(drivePfx, name(subfolder)),
+				rootID:        d.strPath(),
+				folderID():    d.strPath(folderName()),
+				id(subfolder): d.strPath(name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -624,36 +625,36 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "move subfolder when moving parent",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveItem(folderID(2), folderName(2), driveParentDir(drivePfx), rootID, isFolder),
-				driveItem(id(item), name(item), driveParentDir(drivePfx, folderName(2)), folderID(2), isFile),
+				driveItem(folderID(2), folderName(2), d.dir(), rootID, isFolder),
+				driveItem(id(item), name(item), d.dir(folderName(2)), folderID(2), isFile),
 				// Need to see the parent folder first (expected since that's what Graph
 				// consistently returns).
-				driveItem(folderID(), folderName("a"), driveParentDir(drivePfx), rootID, isFolder),
-				driveItem(id(subfolder), name(subfolder), driveParentDir(drivePfx, folderName("a")), folderID(), isFolder),
-				driveItem(id(item, 2), name(item, 2), driveParentDir(drivePfx, folderName("a"), name(subfolder)), id(subfolder), isFile),
-				driveFolder(driveParentDir(drivePfx), rootID),
+				driveItem(folderID(), folderName("a"), d.dir(), rootID, isFolder),
+				driveItem(id(subfolder), name(subfolder), d.dir(folderName("a")), folderID(), isFolder),
+				driveItem(id(item, 2), name(item, 2), d.dir(folderName("a"), name(subfolder)), id(subfolder), isFile),
+				driveFolder(d.dir(), rootID),
 			},
 			previousPaths: map[string]string{
-				folderID():    driveFullPath(drivePfx, folderName("a")),
-				id(subfolder): driveFullPath(drivePfx, folderName("a"), name(subfolder)),
+				folderID():    d.strPath(folderName("a")),
+				id(subfolder): d.strPath(folderName("a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:        asNotMoved(t, driveFullPath(drivePfx)),
-				folderID(2):   asNew(t, driveFullPath(drivePfx, folderName(2))),
-				folderID():    asMoved(t, driveFullPath(drivePfx, folderName("a")), driveFullPath(drivePfx, folderName())),
-				id(subfolder): asMoved(t, driveFullPath(drivePfx, folderName("a"), name(subfolder)), driveFullPath(drivePfx, folderName(), name(subfolder))),
+				rootID:        asNotMoved(t, d.strPath()),
+				folderID(2):   asNew(t, d.strPath(folderName(2))),
+				folderID():    asMoved(t, d.strPath(folderName("a")), d.strPath(folderName())),
+				id(subfolder): asMoved(t, d.strPath(folderName("a"), name(subfolder)), d.strPath(folderName(), name(subfolder))),
 			},
 			expectedItemCount:      5,
 			expectedFileCount:      2,
 			expectedContainerCount: 4,
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drivePfx),
-				folderID():    driveFullPath(drivePfx, folderName()),
-				folderID(2):   driveFullPath(drivePfx, folderName(2)),
-				id(subfolder): driveFullPath(drivePfx, folderName(), name(subfolder)),
+				rootID:        d.strPath(),
+				folderID():    d.strPath(folderName()),
+				folderID(2):   d.strPath(folderName(2)),
+				id(subfolder): d.strPath(folderName(), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(id(item), id(item, 2)),
@@ -662,28 +663,28 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "moved folder tree multiple times",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveFolder(driveParentDir(drivePfx), rootID),
-				driveItem(fileID(), fileName(), driveParentDir(drivePfx, folderName()), folderID(), isFile),
-				driveItem(folderID(), folderName(2), driveParentDir(drivePfx), rootID, isFolder),
+				driveFolder(d.dir(), rootID),
+				driveItem(fileID(), fileName(), d.dir(folderName()), folderID(), isFile),
+				driveItem(folderID(), folderName(2), d.dir(), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				folderID():    driveFullPath(drivePfx, folderName("a")),
-				id(subfolder): driveFullPath(drivePfx, folderName("a"), name(subfolder)),
+				folderID():    d.strPath(folderName("a")),
+				id(subfolder): d.strPath(folderName("a"), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, driveFullPath(drivePfx)),
-				folderID(): asMoved(t, driveFullPath(drivePfx, folderName("a")), driveFullPath(drivePfx, folderName(2))),
+				rootID:     asNotMoved(t, d.strPath()),
+				folderID(): asMoved(t, d.strPath(folderName("a")), d.strPath(folderName(2))),
 			},
 			expectedItemCount:      2,
 			expectedFileCount:      1,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drivePfx),
-				folderID():    driveFullPath(drivePfx, folderName(2)),
-				id(subfolder): driveFullPath(drivePfx, folderName(2), name(subfolder)),
+				rootID:        d.strPath(),
+				folderID():    d.strPath(folderName(2)),
+				id(subfolder): d.strPath(folderName(2), name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(fileID()),
@@ -696,23 +697,23 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 				delItem(id(pkg), rootID, isPackage),
 			},
 			previousPaths: map[string]string{
-				rootID:     driveFullPath(drivePfx),
-				folderID(): driveFullPath(drivePfx, folderName()),
-				id(pkg):    driveFullPath(drivePfx, name(pkg)),
+				rootID:     d.strPath(),
+				folderID(): d.strPath(folderName()),
+				id(pkg):    d.strPath(name(pkg)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, driveFullPath(drivePfx)),
-				folderID(): asDeleted(t, driveFullPath(drivePfx, folderName())),
-				id(pkg):    asDeleted(t, driveFullPath(drivePfx, name(pkg))),
+				rootID:     asNotMoved(t, d.strPath()),
+				folderID(): asDeleted(t, d.strPath(folderName())),
+				id(pkg):    asDeleted(t, d.strPath(name(pkg))),
 			},
 			expectedItemCount:      0,
 			expectedFileCount:      0,
 			expectedContainerCount: 1,
 			expectedPrevPaths: map[string]string{
-				rootID: driveFullPath(drivePfx),
+				rootID: d.strPath(),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -724,19 +725,19 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 				delItem(folderID(), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				rootID: driveFullPath(drivePfx),
+				rootID: d.strPath(),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID: asNotMoved(t, driveFullPath(drivePfx)),
+				rootID: asNotMoved(t, d.strPath()),
 			},
 			expectedItemCount:      0,
 			expectedFileCount:      0,
 			expectedContainerCount: 1,
 			expectedPrevPaths: map[string]string{
-				rootID: driveFullPath(drivePfx),
+				rootID: d.strPath(),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -746,27 +747,27 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			items: []models.DriveItemable{
 				driveRootFolder(),
 				delItem(folderID(), rootID, isFolder),
-				driveItem(id(subfolder), name(subfolder), driveParentDir(drivePfx), rootID, isFolder),
+				driveItem(id(subfolder), name(subfolder), d.dir(), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
-				rootID:        driveFullPath(drivePfx),
-				folderID():    driveFullPath(drivePfx, folderName()),
-				id(subfolder): driveFullPath(drivePfx, folderName(), name(subfolder)),
+				rootID:        d.strPath(),
+				folderID():    d.strPath(folderName()),
+				id(subfolder): d.strPath(folderName(), name(subfolder)),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:        asNotMoved(t, driveFullPath(drivePfx)),
-				folderID():    asDeleted(t, driveFullPath(drivePfx, folderName())),
-				id(subfolder): asMoved(t, driveFullPath(drivePfx, folderName(), name(subfolder)), driveFullPath(drivePfx, name(subfolder))),
+				rootID:        asNotMoved(t, d.strPath()),
+				folderID():    asDeleted(t, d.strPath(folderName())),
+				id(subfolder): asMoved(t, d.strPath(folderName(), name(subfolder)), d.strPath(name(subfolder))),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      0,
 			expectedContainerCount: 2,
 			expectedPrevPaths: map[string]string{
-				rootID:        driveFullPath(drivePfx),
-				id(subfolder): driveFullPath(drivePfx, name(subfolder)),
+				rootID:        d.strPath(),
+				id(subfolder): d.strPath(name(subfolder)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -778,19 +779,19 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 				delItem(id(item), rootID, isFile),
 			},
 			previousPaths: map[string]string{
-				rootID: driveFullPath(drivePfx),
+				rootID: d.strPath(),
 			},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID: asNotMoved(t, driveFullPath(drivePfx)),
+				rootID: asNotMoved(t, d.strPath()),
 			},
 			expectedItemCount:      1,
 			expectedFileCount:      1,
 			expectedContainerCount: 1,
 			expectedPrevPaths: map[string]string{
-				rootID: driveFullPath(drivePfx),
+				rootID: d.strPath(),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         makeExcludeMap(id(item)),
@@ -799,21 +800,21 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "item before parent errors",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveItem(fileID(), fileName(), driveParentDir(drivePfx, folderName()), folderID(), isFile),
-				driveFolder(driveParentDir(drivePfx), rootID),
+				driveItem(fileID(), fileName(), d.dir(folderName()), folderID(), isFile),
+				driveFolder(d.dir(), rootID),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.Error,
 			expectedCollectionIDs: map[string]statePath{
-				rootID: asNotMoved(t, driveFullPath(drivePfx)),
+				rootID: asNotMoved(t, d.strPath()),
 			},
 			expectedItemCount:      0,
 			expectedFileCount:      0,
 			expectedContainerCount: 1,
 			expectedPrevPaths: map[string]string{
-				rootID: driveFullPath(drivePfx),
+				rootID: d.strPath(),
 			},
 			expectedTopLevelPackages: map[string]struct{}{},
 			expectedExcludes:         map[string]struct{}{},
@@ -822,32 +823,32 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			name: "1 root file, 1 folder, 1 package, 1 good file, 1 malware",
 			items: []models.DriveItemable{
 				driveRootFolder(),
-				driveItem(fileID(), fileID(), driveParentDir(drivePfx), rootID, isFile),
-				driveFolder(driveParentDir(drivePfx), rootID),
-				driveItem(id(pkg), name(pkg), driveParentDir(drivePfx), rootID, isPackage),
-				driveItem(fileID("good"), fileName("good"), driveParentDir(drivePfx, folderName()), folderID(), isFile),
-				malwareItem(id(malware), name(malware), driveParentDir(drivePfx, folderName()), folderID(), isFile),
+				driveItem(fileID(), fileID(), d.dir(), rootID, isFile),
+				driveFolder(d.dir(), rootID),
+				driveItem(id(pkg), name(pkg), d.dir(), rootID, isPackage),
+				driveItem(fileID("good"), fileName("good"), d.dir(folderName()), folderID(), isFile),
+				malwareItem(id(malware), name(malware), d.dir(folderName()), folderID(), isFile),
 			},
 			previousPaths:    map[string]string{},
 			scope:            anyFolderScope,
 			topLevelPackages: map[string]struct{}{},
 			expect:           assert.NoError,
 			expectedCollectionIDs: map[string]statePath{
-				rootID:     asNotMoved(t, driveFullPath(drivePfx)),
-				folderID(): asNew(t, driveFullPath(drivePfx, folderName())),
-				id(pkg):    asNew(t, driveFullPath(drivePfx, name(pkg))),
+				rootID:     asNotMoved(t, d.strPath()),
+				folderID(): asNew(t, d.strPath(folderName())),
+				id(pkg):    asNew(t, d.strPath(name(pkg))),
 			},
 			expectedItemCount:      4,
 			expectedFileCount:      2,
 			expectedContainerCount: 3,
 			expectedSkippedCount:   1,
 			expectedPrevPaths: map[string]string{
-				rootID:     driveFullPath(drivePfx),
-				folderID(): driveFullPath(drivePfx, folderName()),
-				id(pkg):    driveFullPath(drivePfx, name(pkg)),
+				rootID:     d.strPath(),
+				folderID(): d.strPath(folderName()),
+				id(pkg):    d.strPath(name(pkg)),
 			},
 			expectedTopLevelPackages: map[string]struct{}{
-				driveFullPath(drivePfx, name(pkg)): {},
+				d.strPath(name(pkg)): {},
 			},
 			expectedCountPackages: 1,
 			expectedExcludes:      makeExcludeMap(fileID(), fileID("good")),
@@ -886,11 +887,11 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 				control.Options{ToggleFeatures: control.Toggles{}},
 				count.New())
 
-			c.CollectionMap[drive.ID] = map[string]*Collection{}
+			c.CollectionMap[drive.id] = map[string]*Collection{}
 
 			_, newPrevPaths, err := c.PopulateDriveCollections(
 				ctx,
-				drive.ID,
+				drive.id,
 				"General",
 				test.previousPaths,
 				excludes,
@@ -902,7 +903,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			assert.ElementsMatch(
 				t,
 				maps.Keys(test.expectedCollectionIDs),
-				maps.Keys(c.CollectionMap[drive.ID]),
+				maps.Keys(c.CollectionMap[drive.id]),
 				"expected collection IDs")
 			assert.Equal(t, test.expectedItemCount, c.NumItems, "item count")
 			assert.Equal(t, test.expectedFileCount, c.NumFiles, "file count")
@@ -910,14 +911,14 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 			assert.Equal(t, test.expectedSkippedCount, len(errs.Skipped()), "skipped item count")
 
 			for id, sp := range test.expectedCollectionIDs {
-				if !assert.Containsf(t, c.CollectionMap[drive.ID], id, "missing collection with id %s", id) {
+				if !assert.Containsf(t, c.CollectionMap[drive.id], id, "missing collection with id %s", id) {
 					// Skip collections we don't find so we don't get an NPE.
 					continue
 				}
 
-				assert.Equalf(t, sp.state, c.CollectionMap[drive.ID][id].State(), "state for collection %s", id)
-				assert.Equalf(t, sp.currPath, c.CollectionMap[drive.ID][id].FullPath(), "current path for collection %s", id)
-				assert.Equalf(t, sp.prevPath, c.CollectionMap[drive.ID][id].PreviousPath(), "prev path for collection %s", id)
+				assert.Equalf(t, sp.state, c.CollectionMap[drive.id][id].State(), "state for collection %s", id)
+				assert.Equalf(t, sp.currPath, c.CollectionMap[drive.id][id].FullPath(), "current path for collection %s", id)
+				assert.Equalf(t, sp.prevPath, c.CollectionMap[drive.id][id].PreviousPath(), "prev path for collection %s", id)
 			}
 
 			assert.Equal(t, test.expectedPrevPaths, newPrevPaths, "previous paths")
@@ -940,6 +941,9 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 }
 
 func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
+	d := drive()
+	d2 := drive(2)
+
 	table := []struct {
 		name string
 		// Each function returns the set of files for a single data.Collection.
@@ -957,23 +961,23 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
-							map[string]string{id(drivePfx): id(deltaURL)}),
+							map[string]string{d.id: id(deltaURL)}),
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drivePfx): {
-									folderID(1): driveFullPath(1),
+								d.id: {
+									folderID(1): d.strPath(),
 								},
 							}),
 					}
 				},
 			},
 			expectedDeltas: map[string]string{
-				id(drivePfx): id(deltaURL),
+				d.id: id(deltaURL),
 			},
 			expectedPaths: map[string]map[string]string{
-				id(drivePfx): {
-					folderID(1): driveFullPath(1),
+				d.id: {
+					folderID(1): d.strPath(),
 				},
 			},
 			canUsePreviousBackup: true,
@@ -986,7 +990,7 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
-							map[string]string{id(drivePfx): id(deltaURL)}),
+							map[string]string{d.id: id(deltaURL)}),
 					}
 				},
 			},
@@ -1003,8 +1007,8 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drivePfx): {
-									folderID(1): driveFullPath(1),
+								d.id: {
+									folderID(1): d.strPath(),
 								},
 							}),
 					}
@@ -1012,8 +1016,8 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 			},
 			expectedDeltas: map[string]string{},
 			expectedPaths: map[string]map[string]string{
-				id(drivePfx): {
-					folderID(1): driveFullPath(1),
+				d.id: {
+					folderID(1): d.strPath(),
 				},
 			},
 			canUsePreviousBackup: true,
@@ -1029,17 +1033,17 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
-							map[string]string{id(drivePfx): id(deltaURL)}),
+							map[string]string{d.id: id(deltaURL)}),
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drivePfx): {},
+								d.id: {},
 							}),
 					}
 				},
 			},
 			expectedDeltas:       map[string]string{},
-			expectedPaths:        map[string]map[string]string{id(drivePfx): {}},
+			expectedPaths:        map[string]map[string]string{d.id: {}},
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 		},
@@ -1054,22 +1058,22 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
 							map[string]string{
-								id(drivePfx): "",
+								d.id: "",
 							}),
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drivePfx): {
-									folderID(1): driveFullPath(1),
+								d.id: {
+									folderID(1): d.strPath(),
 								},
 							}),
 					}
 				},
 			},
-			expectedDeltas: map[string]string{id(drivePfx): ""},
+			expectedDeltas: map[string]string{d.id: ""},
 			expectedPaths: map[string]map[string]string{
-				id(drivePfx): {
-					folderID(1): driveFullPath(1),
+				d.id: {
+					folderID(1): d.strPath(),
 				},
 			},
 			canUsePreviousBackup: true,
@@ -1082,12 +1086,12 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
-							map[string]string{id(drivePfx): id(deltaURL)}),
+							map[string]string{d.id: id(deltaURL)}),
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drivePfx): {
-									folderID(1): driveFullPath(1),
+								d.id: {
+									folderID(1): d.strPath(),
 								},
 							}),
 					}
@@ -1096,27 +1100,27 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
-							map[string]string{id(drivePfx, 2): id(deltaURL, 2)}),
+							map[string]string{d2.id: id(deltaURL, 2)}),
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drivePfx, 2): {
-									folderID(2): driveFullPath(2),
+								d2.id: {
+									folderID(2): d2.strPath(),
 								},
 							}),
 					}
 				},
 			},
 			expectedDeltas: map[string]string{
-				id(drivePfx):    id(deltaURL),
-				id(drivePfx, 2): id(deltaURL, 2),
+				d.id:  id(deltaURL),
+				d2.id: id(deltaURL, 2),
 			},
 			expectedPaths: map[string]map[string]string{
-				id(drivePfx): {
-					folderID(1): driveFullPath(1),
+				d.id: {
+					folderID(1): d.strPath(),
 				},
-				id(drivePfx, 2): {
-					folderID(2): driveFullPath(2),
+				d2.id: {
+					folderID(2): d2.strPath(),
 				},
 			},
 			canUsePreviousBackup: true,
@@ -1133,7 +1137,7 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
-							map[string]string{id(drivePfx): id(deltaURL)}),
+							map[string]string{d.id: id(deltaURL)}),
 					}
 				},
 			},
@@ -1149,26 +1153,26 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
-							map[string]string{id(drivePfx): id(deltaURL)}),
+							map[string]string{d.id: id(deltaURL)}),
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drivePfx): {
-									folderID(1): driveFullPath(1),
+								d.id: {
+									folderID(1): d.strPath(),
 								},
 							}),
 						graph.NewMetadataEntry(
 							"foo",
-							map[string]string{id(drivePfx): id(deltaURL)}),
+							map[string]string{d.id: id(deltaURL)}),
 					}
 				},
 			},
 			expectedDeltas: map[string]string{
-				id(drivePfx): id(deltaURL),
+				d.id: id(deltaURL),
 			},
 			expectedPaths: map[string]map[string]string{
-				id(drivePfx): {
-					folderID(1): driveFullPath(1),
+				d.id: {
+					folderID(1): d.strPath(),
 				},
 			},
 			canUsePreviousBackup: true,
@@ -1181,12 +1185,12 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
-							map[string]string{id(drivePfx): id(deltaURL)}),
+							map[string]string{d.id: id(deltaURL)}),
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drivePfx): {
-									folderID(1): driveFullPath(1),
+								d.id: {
+									folderID(1): d.strPath(),
 								},
 							}),
 					}
@@ -1196,8 +1200,8 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drivePfx): {
-									folderID(2): driveFullPath(2),
+								d.id: {
+									folderID(2): d2.strPath(),
 								},
 							}),
 					}
@@ -1215,12 +1219,12 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
-							map[string]string{id(drivePfx): id(deltaURL)}),
+							map[string]string{d.id: id(deltaURL)}),
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drivePfx): {
-									folderID(1): driveFullPath(1),
+								d.id: {
+									folderID(1): d.strPath(),
 								},
 							}),
 					}
@@ -1229,7 +1233,7 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
-							map[string]string{id(drivePfx): id(deltaURL, 2)}),
+							map[string]string{d.id: id(deltaURL, 2)}),
 					}
 				},
 			},
@@ -1245,25 +1249,25 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
-							map[string]string{id(drivePfx): id(deltaURL)}),
+							map[string]string{d.id: id(deltaURL)}),
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drivePfx): {
-									folderID(1): driveFullPath(1),
-									folderID(2): driveFullPath(1),
+								d.id: {
+									folderID(1): d.strPath(),
+									folderID(2): d.strPath(),
 								},
 							}),
 					}
 				},
 			},
 			expectedDeltas: map[string]string{
-				id(drivePfx): id(deltaURL),
+				d.id: id(deltaURL),
 			},
 			expectedPaths: map[string]map[string]string{
-				id(drivePfx): {
-					folderID(1): driveFullPath(1),
-					folderID(2): driveFullPath(1),
+				d.id: {
+					folderID(1): d.strPath(),
+					folderID(2): d.strPath(),
 				},
 			},
 			expectedAlerts:       []string{fault.AlertPreviousPathCollision},
@@ -1278,14 +1282,14 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
 							map[string]string{
-								id(drivePfx): id(deltaURL),
+								d.id: id(deltaURL),
 							}),
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drivePfx): {
-									folderID(1): driveFullPath(1),
-									folderID(2): driveFullPath(1),
+								d.id: {
+									folderID(1): d.strPath(),
+									folderID(2): d.strPath(),
 								},
 							}),
 					}
@@ -1294,28 +1298,28 @@ func (suite *CollectionsUnitSuite) TestDeserializeMetadata() {
 					return []graph.MetadataCollectionEntry{
 						graph.NewMetadataEntry(
 							bupMD.DeltaURLsFileName,
-							map[string]string{id(drivePfx, 2): id(deltaURL, 2)}),
+							map[string]string{d2.id: id(deltaURL, 2)}),
 						graph.NewMetadataEntry(
 							bupMD.PreviousPathFileName,
 							map[string]map[string]string{
-								id(drivePfx, 2): {
-									folderID(1): driveFullPath(1),
+								d2.id: {
+									folderID(1): d.strPath(),
 								},
 							}),
 					}
 				},
 			},
 			expectedDeltas: map[string]string{
-				id(drivePfx):    id(deltaURL),
-				id(drivePfx, 2): id(deltaURL, 2),
+				d.id:  id(deltaURL),
+				d2.id: id(deltaURL, 2),
 			},
 			expectedPaths: map[string]map[string]string{
-				id(drivePfx): {
-					folderID(1): driveFullPath(1),
-					folderID(2): driveFullPath(1),
+				d.id: {
+					folderID(1): d.strPath(),
+					folderID(2): d.strPath(),
 				},
-				id(drivePfx, 2): {
-					folderID(1): driveFullPath(1),
+				d2.id: {
+					folderID(1): d.strPath(),
 				},
 			},
 			expectedAlerts:       []string{fault.AlertPreviousPathCollision},
@@ -1425,8 +1429,8 @@ func (suite *CollectionsUnitSuite) TestGet() {
 		false)
 	require.NoError(suite.T(), err, "making metadata path", clues.ToCore(err))
 
-	drive1 := drive(1)
-	drive2 := drive(2)
+	d := drive(1)
+	d2 := drive(2)
 
 	table := []struct {
 		name                 string
@@ -1449,357 +1453,357 @@ func (suite *CollectionsUnitSuite) TestGet() {
 		{
 			name: "OneDrive_OneItemPage_DelFileOnly_NoFolders_NoErrors",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
 							delItem(fileID(), rootID, isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drivePfx, 1): {rootID: driveFullPath(1)},
+				id(drivePfx, 1): {rootID: d.strPath()},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {data.NotMovedState: {}},
+				d.strPath(): {data.NotMovedState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drivePfx, 1): {rootID: driveFullPath(1)},
+				id(drivePfx, 1): {rootID: d.strPath()},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{
-				driveFullPath(1): makeExcludeMap(fileID()),
+				d.strPath(): makeExcludeMap(fileID()),
 			}),
 		},
 		{
 			name: "OneDrive_OneItemPage_NoFolderDeltas_NoErrors",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							driveFile(driveParentDir(1), rootID))))),
+							driveFile(d.dir(), rootID))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drivePfx, 1): {rootID: driveFullPath(1)},
+				id(drivePfx, 1): {rootID: d.strPath()},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {data.NotMovedState: {fileID()}},
+				d.strPath(): {data.NotMovedState: {fileID()}},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drivePfx, 1): {rootID: driveFullPath(1)},
+				id(drivePfx, 1): {rootID: d.strPath()},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{
-				driveFullPath(1): makeExcludeMap(fileID()),
+				d.strPath(): makeExcludeMap(fileID()),
 			}),
 		},
 		{
 			name: "OneDrive_OneItemPage_NoErrors",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID()))))),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID()))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths:        map[string]map[string]string{},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.NewState: {folderID(), fileID()}},
+				d.strPath():             {data.NewState: {}},
+				d.strPath(folderName()): {data.NewState: {folderID(), fileID()}},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "OneDrive_OneItemPage_NoErrors_FileRenamedMultiple",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID()),
-							driveItem(fileID(), fileName(2), driveParentDir(1, folderName()), folderID(), isFile))))),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID()),
+							driveItem(fileID(), fileName(2), d.dir(folderName()), folderID(), isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths:        map[string]map[string]string{},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.NewState: {folderID(), fileID()}},
+				d.strPath():             {data.NewState: {}},
+				d.strPath(folderName()): {data.NewState: {folderID(), fileID()}},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "OneDrive_OneItemPage_NoErrors_FileMovedMultiple",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID()),
-							driveItem(fileID(), fileName(2), driveParentDir(1), rootID, isFile))))),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID()),
+							driveItem(fileID(), fileName(2), d.dir(), rootID, isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID: driveFullPath(1),
+					rootID: d.strPath(),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NotMovedState: {fileID()}},
-				driveFullPath(1, folderName()): {data.NewState: {folderID()}},
+				d.strPath():             {data.NotMovedState: {fileID()}},
+				d.strPath(folderName()): {data.NewState: {folderID()}},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{
-				driveFullPath(1): makeExcludeMap(fileID()),
+				d.strPath(): makeExcludeMap(fileID()),
 			}),
 		},
 		{
 			name: "OneDrive_TwoItemPages_NoErrors",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID())),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())),
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID(), 2))))),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID(), 2))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.NewState: {folderID(), fileID(), fileID(2)}},
+				d.strPath():             {data.NewState: {}},
+				d.strPath(folderName()): {data.NewState: {folderID(), fileID(), fileID(2)}},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "OneDrive_TwoItemPages_WithReset",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID()),
-							driveItem(fileID(3), fileName(3), driveParentDir(1, folderName()), folderID(), isFile)),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID()),
+							driveItem(fileID(3), fileName(3), d.dir(folderName()), folderID(), isFile)),
 						aReset(),
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID())),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())),
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID(), 2))))),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID(), 2))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.NewState: {folderID(), fileID(), fileID(2)}},
+				d.strPath():             {data.NewState: {}},
+				d.strPath(folderName()): {data.NewState: {folderID(), fileID(), fileID(2)}},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "OneDrive_TwoItemPages_WithResetCombinedWithItems",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID())),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())),
 						aPageWReset(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID())),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())),
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID(), 2))))),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID(), 2))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.NewState: {folderID(), fileID(), fileID(2)}},
+				d.strPath():             {data.NewState: {}},
+				d.strPath(folderName()): {data.NewState: {folderID(), fileID(), fileID(2)}},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "TwoDrives_OneItemPageEach_NoErrors",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID())))),
-				drive2.newEnumer().with(
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())))),
+				d2.newEnumer().with(
 					deltaWReset(id(deltaURL, 2), nil).with(aPage(
-						driveItem(folderID(2), folderName(), driveParentDir(2), rootID, isFolder),
-						driveItem(fileID(2), fileName(), driveParentDir(2, folderName()), folderID(2), isFile))))),
+						driveItem(folderID(2), folderName(), d2.dir(), rootID, isFolder),
+						driveItem(fileID(2), fileName(), d2.dir(folderName()), folderID(2), isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {},
-				id(drivePfx, 2): {},
+				d2.id:           {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.NewState: {folderID(), fileID()}},
-				driveFullPath(2):               {data.NewState: {}},
-				driveFullPath(2, folderName()): {data.NewState: {folderID(2), fileID(2)}},
+				d.strPath():              {data.NewState: {}},
+				d.strPath(folderName()):  {data.NewState: {folderID(), fileID()}},
+				d2.strPath():             {data.NewState: {}},
+				d2.strPath(folderName()): {data.NewState: {folderID(2), fileID(2)}},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL),
-				id(drivePfx, 2): id(deltaURL, 2),
+				d2.id:           id(deltaURL, 2),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
-				id(drivePfx, 2): {
-					rootID:      driveFullPath(2),
-					folderID(2): driveFullPath(2, folderName()),
+				d2.id: {
+					rootID:      d2.strPath(),
+					folderID(2): d2.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
-				driveFullPath(2):               true,
-				driveFullPath(2, folderName()): true,
+				d.strPath():              true,
+				d.strPath(folderName()):  true,
+				d2.strPath():             true,
+				d2.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "TwoDrives_DuplicateIDs_OneItemPageEach_NoErrors",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID())))),
-				drive2.newEnumer().with(
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())))),
+				d2.newEnumer().with(
 					deltaWReset(id(deltaURL, 2), nil).with(
 						aPage(
-							driveFolder(driveParentDir(2), rootID),
-							driveItem(fileID(2), fileName(), driveParentDir(2, folderName()), folderID(), isFile))))),
+							driveFolder(d2.dir(), rootID),
+							driveItem(fileID(2), fileName(), d2.dir(folderName()), folderID(), isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {},
-				id(drivePfx, 2): {},
+				d2.id:           {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.NewState: {folderID(), fileID()}},
-				driveFullPath(2):               {data.NewState: {}},
-				driveFullPath(2, folderName()): {data.NewState: {folderID(), fileID(2)}},
+				d.strPath():              {data.NewState: {}},
+				d.strPath(folderName()):  {data.NewState: {folderID(), fileID()}},
+				d2.strPath():             {data.NewState: {}},
+				d2.strPath(folderName()): {data.NewState: {folderID(), fileID(2)}},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL),
-				id(drivePfx, 2): id(deltaURL, 2),
+				d2.id:           id(deltaURL, 2),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
-				id(drivePfx, 2): {
-					rootID:     driveFullPath(2),
-					folderID(): driveFullPath(2, folderName()),
+				d2.id: {
+					rootID:     d2.strPath(),
+					folderID(): d2.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
-				driveFullPath(2):               true,
-				driveFullPath(2, folderName()): true,
+				d.strPath():              true,
+				d.strPath(folderName()):  true,
+				d2.strPath():             true,
+				d2.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "OneDrive_OneItemPage_Errors",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					delta("", assert.AnError))),
 			canUsePreviousBackup: false,
 			errCheck:             assert.Error,
@@ -1814,102 +1818,102 @@ func (suite *CollectionsUnitSuite) TestGet() {
 		{
 			name: "OneDrive_OneItemPage_InvalidPrevDelta_DeleteNonExistentFolder",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aReset(),
 						aPage(
-							driveFolder(driveParentDir(1), rootID, 2),
-							driveFile(driveParentDir(1, folderName(2)), folderID(2)))))),
+							driveFolder(d.dir(), rootID, 2),
+							driveFile(d.dir(folderName(2)), folderID(2)))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):                {data.NewState: {}},
-				driveFullPath(1, folderName()):  {data.DeletedState: {}},
-				driveFullPath(1, folderName(2)): {data.NewState: {folderID(2), fileID()}},
+				d.strPath():              {data.NewState: {}},
+				d.strPath(folderName()):  {data.DeletedState: {}},
+				d.strPath(folderName(2)): {data.NewState: {folderID(2), fileID()}},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:      driveFullPath(1),
-					folderID(2): driveFullPath(1, folderName(2)),
+					rootID:      d.strPath(),
+					folderID(2): d.strPath(folderName(2)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):                true,
-				driveFullPath(1, folderName()):  true,
-				driveFullPath(1, folderName(2)): true,
+				d.strPath():              true,
+				d.strPath(folderName()):  true,
+				d.strPath(folderName(2)): true,
 			},
 		},
 		{
 			name: "OneDrive_OneItemPage_InvalidPrevDeltaCombinedWithItems_DeleteNonExistentFolder",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aReset(),
 						aPage(
-							driveFolder(driveParentDir(1), rootID, 2),
-							driveFile(driveParentDir(1, folderName(2)), folderID(2)))))),
+							driveFolder(d.dir(), rootID, 2),
+							driveFile(d.dir(folderName(2)), folderID(2)))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):                {data.NewState: {}},
-				driveFullPath(1, folderName()):  {data.DeletedState: {}},
-				driveFullPath(1, folderName(2)): {data.NewState: {folderID(2), fileID()}},
+				d.strPath():              {data.NewState: {}},
+				d.strPath(folderName()):  {data.DeletedState: {}},
+				d.strPath(folderName(2)): {data.NewState: {folderID(2), fileID()}},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:      driveFullPath(1),
-					folderID(2): driveFullPath(1, folderName(2)),
+					rootID:      d.strPath(),
+					folderID(2): d.strPath(folderName(2)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):                true,
-				driveFullPath(1, folderName()):  true,
-				driveFullPath(1, folderName(2)): true,
+				d.strPath():              true,
+				d.strPath(folderName()):  true,
+				d.strPath(folderName(2)): true,
 			},
 		},
 		{
 			name: "OneDrive_OneItemPage_InvalidPrevDelta_AnotherFolderAtDeletedLocation",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aPage(
-							driveItem(folderID(2), folderName(), driveParentDir(1), rootID, isFolder),
-							driveFile(driveParentDir(1, folderName()), folderID(2))),
+							driveItem(folderID(2), folderName(), d.dir(), rootID, isFolder),
+							driveFile(d.dir(folderName()), folderID(2))),
 						aReset(),
 						aPage(
-							driveItem(folderID(2), folderName(), driveParentDir(1), rootID, isFolder),
-							driveFile(driveParentDir(1, folderName()), folderID(2)))))),
+							driveItem(folderID(2), folderName(), d.dir(), rootID, isFolder),
+							driveFile(d.dir(folderName()), folderID(2)))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {data.NewState: {}},
-				driveFullPath(1, folderName()): {
+				d.strPath(): {data.NewState: {}},
+				d.strPath(folderName()): {
 					// Old folder path should be marked as deleted since it should compare
 					// by ID.
 					data.DeletedState: {},
@@ -1921,39 +1925,39 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:      driveFullPath(1),
-					folderID(2): driveFullPath(1, folderName()),
+					rootID:      d.strPath(),
+					folderID(2): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "OneDrive_OneItemPage_InvalidPrevDelta_AnotherFolderAtExistingLocation",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID())),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())),
 						aReset(),
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID()))))),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID()))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {data.NewState: {}},
-				driveFullPath(1, folderName()): {
+				d.strPath(): {data.NewState: {}},
+				d.strPath(folderName()): {
 					data.NewState: {folderID(), fileID()},
 				},
 			},
@@ -1962,36 +1966,36 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "OneDrive_OneItemPage_ImmediateInvalidPrevDelta_MoveFolderToPreviouslyExistingPath",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aReset(),
 						aPage(
-							driveItem(folderID(2), folderName(), driveParentDir(1), rootID, isFolder),
-							driveItem(fileID(2), fileName(), driveParentDir(1, folderName()), folderID(2), isFile))))),
+							driveItem(folderID(2), folderName(), d.dir(), rootID, isFolder),
+							driveItem(fileID(2), fileName(), d.dir(folderName()), folderID(2), isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {data.NewState: {}},
-				driveFullPath(1, folderName()): {
+				d.strPath(): {data.NewState: {}},
+				d.strPath(folderName()): {
 					data.DeletedState: {},
 					data.NewState:     {folderID(2), fileID(2)},
 				},
@@ -2001,36 +2005,36 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:      driveFullPath(1),
-					folderID(2): driveFullPath(1, folderName()),
+					rootID:      d.strPath(),
+					folderID(2): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "OneDrive_OneItemPage_InvalidPrevDelta_AnotherFolderAtDeletedLocation",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aReset(),
 						aPage(
-							driveItem(folderID(2), folderName(), driveParentDir(1), rootID, isFolder),
-							driveFile(driveParentDir(1, folderName()), folderID(2)))))),
+							driveItem(folderID(2), folderName(), d.dir(), rootID, isFolder),
+							driveFile(d.dir(folderName()), folderID(2)))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {data.NewState: {}},
-				driveFullPath(1, folderName()): {
+				d.strPath(): {data.NewState: {}},
+				d.strPath(folderName()): {
 					// Old folder path should be marked as deleted since it should compare
 					// by ID.
 					data.DeletedState: {},
@@ -2042,104 +2046,104 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:      driveFullPath(1),
-					folderID(2): driveFullPath(1, folderName()),
+					rootID:      d.strPath(),
+					folderID(2): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "OneDrive Two Item Pages with Malware",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID()),
-							malwareItem(id(malware), name(malware), driveParentDir(1, folderName()), folderID(), isFile)),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID()),
+							malwareItem(id(malware), name(malware), d.dir(folderName()), folderID(), isFile)),
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID(), 2),
-							malwareItem(id(malware, 2), name(malware, 2), driveParentDir(1, folderName()), folderID(), isFile))))),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID(), 2),
+							malwareItem(id(malware, 2), name(malware, 2), d.dir(folderName()), folderID(), isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.NewState: {folderID(), fileID(), fileID(2)}},
+				d.strPath():             {data.NewState: {}},
+				d.strPath(folderName()): {data.NewState: {folderID(), fileID(), fileID(2)}},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 			expectedSkippedCount: 2,
 		},
 		{
 			name: "One Drive Deleted Folder In New Results With Invalid Delta",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL, 2), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID()),
-							driveFolder(driveParentDir(1), rootID, 2),
-							driveFile(driveParentDir(1, folderName(2)), folderID(2), 2)),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID()),
+							driveFolder(d.dir(), rootID, 2),
+							driveFile(d.dir(folderName(2)), folderID(2), 2)),
 						aReset(),
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID()),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID()),
 							delItem(folderID(2), rootID, isFolder),
 							delItem(fileName(2), rootID, isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:      driveFullPath(1),
-					folderID():  driveFullPath(1, folderName()),
-					folderID(2): driveFullPath(1, folderName(2)),
+					rootID:      d.strPath(),
+					folderID():  d.strPath(folderName()),
+					folderID(2): d.strPath(folderName(2)),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):                {data.NewState: {}},
-				driveFullPath(1, folderName()):  {data.NewState: {folderID(), fileID()}},
-				driveFullPath(1, folderName(2)): {data.DeletedState: {}},
+				d.strPath():              {data.NewState: {}},
+				d.strPath(folderName()):  {data.NewState: {folderID(), fileID()}},
+				d.strPath(folderName(2)): {data.DeletedState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL, 2),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):                true,
-				driveFullPath(1, folderName()):  true,
-				driveFullPath(1, folderName(2)): true,
+				d.strPath():              true,
+				d.strPath(folderName()):  true,
+				d.strPath(folderName(2)): true,
 			},
 		},
 		{
 			name: "One Drive Folder Delete After Invalid Delta",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aPageWReset(
 							delItem(folderID(), rootID, isFolder))))),
@@ -2147,32 +2151,32 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.DeletedState: {}},
+				d.strPath():             {data.NewState: {}},
+				d.strPath(folderName()): {data.DeletedState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID: driveFullPath(1),
+					rootID: d.strPath(),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "One Drive Item Delete After Invalid Delta",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aPageWReset(
 							delItem(fileID(), rootID, isFile))))),
@@ -2180,33 +2184,33 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID: driveFullPath(1),
+					rootID: d.strPath(),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {data.NewState: {}},
+				d.strPath(): {data.NewState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID: driveFullPath(1),
+					rootID: d.strPath(),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1): true,
+				d.strPath(): true,
 			},
 		},
 		{
 			name: "One Drive Folder Made And Deleted",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL, 2), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID())),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())),
 						aPage(
 							delItem(folderID(), rootID, isFolder),
 							delItem(fileID(), rootID, isFile))))),
@@ -2216,70 +2220,70 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				id(drivePfx, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {data.NewState: {}},
+				d.strPath(): {data.NewState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL, 2),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID: driveFullPath(1),
+					rootID: d.strPath(),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1): true,
+				d.strPath(): true,
 			},
 		},
 		{
 			name: "One Drive Folder Created -> Deleted -> Created",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL, 2), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID())),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())),
 						aPage(
 							delItem(folderID(), rootID, isFolder),
 							delItem(fileID(), rootID, isFile)),
 						aPage(
-							driveItem(folderID(1), folderName(), driveParentDir(1), rootID, isFolder),
-							driveItem(fileID(1), fileName(), driveParentDir(1, folderName()), folderID(1), isFile))))),
+							driveItem(folderID(1), folderName(), d.dir(), rootID, isFolder),
+							driveItem(fileID(1), fileName(), d.dir(folderName()), folderID(1), isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.NewState: {folderID(1), fileID(1)}},
+				d.strPath():             {data.NewState: {}},
+				d.strPath(folderName()): {data.NewState: {folderID(1), fileID(1)}},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL, 2),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:      driveFullPath(1),
-					folderID(1): driveFullPath(1, folderName()),
+					rootID:      d.strPath(),
+					folderID(1): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "One Drive Folder Deleted -> Created -> Deleted",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL, 2), nil).with(
 						aPage(
 							delItem(folderID(), rootID, isFolder),
 							delItem(fileID(), rootID, isFile)),
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID())),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())),
 						aPage(
 							delItem(folderID(), rootID, isFolder),
 							delItem(fileID(), rootID, isFile))))),
@@ -2287,20 +2291,20 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NotMovedState: {}},
-				driveFullPath(1, folderName()): {data.DeletedState: {}},
+				d.strPath():             {data.NotMovedState: {}},
+				d.strPath(folderName()): {data.DeletedState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL, 2),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID: driveFullPath(1),
+					rootID: d.strPath(),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
@@ -2309,52 +2313,52 @@ func (suite *CollectionsUnitSuite) TestGet() {
 		{
 			name: "One Drive Folder Created -> Deleted -> Created with prev",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL, 2), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID())),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())),
 						aPage(
 							delItem(folderID(), rootID, isFolder),
 							delItem(fileID(), rootID, isFile)),
 						aPage(
-							driveItem(folderID(1), folderName(), driveParentDir(1), rootID, isFolder),
-							driveItem(fileID(1), fileName(), driveParentDir(1, folderName()), folderID(1), isFile))))),
+							driveItem(folderID(1), folderName(), d.dir(), rootID, isFolder),
+							driveItem(fileID(1), fileName(), d.dir(folderName()), folderID(1), isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.DeletedState: {}, data.NewState: {folderID(1), fileID(1)}},
+				d.strPath():             {data.NewState: {}},
+				d.strPath(folderName()): {data.DeletedState: {}, data.NewState: {folderID(1), fileID(1)}},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL, 2),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:      driveFullPath(1),
-					folderID(1): driveFullPath(1, folderName()),
+					rootID:      d.strPath(),
+					folderID(1): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               false,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             false,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "One Drive Item Made And Deleted",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID())),
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())),
 						aPage(delItem(fileID(), rootID, isFile))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
@@ -2362,28 +2366,28 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				id(drivePfx, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1):               {data.NewState: {}},
-				driveFullPath(1, folderName()): {data.NewState: {folderID()}},
+				d.strPath():             {data.NewState: {}},
+				d.strPath(folderName()): {data.NewState: {folderID()}},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:     driveFullPath(1),
-					folderID(): driveFullPath(1, folderName()),
+					rootID:     d.strPath(),
+					folderID(): d.strPath(folderName()),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1):               true,
-				driveFullPath(1, folderName()): true,
+				d.strPath():             true,
+				d.strPath(folderName()): true,
 			},
 		},
 		{
 			name: "One Drive Random Folder Delete",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aPage(
 							delItem(folderID(), rootID, isFolder))))),
@@ -2393,25 +2397,25 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				id(drivePfx, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {data.NewState: {}},
+				d.strPath(): {data.NewState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID: driveFullPath(1),
+					rootID: d.strPath(),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1): true,
+				d.strPath(): true,
 			},
 		},
 		{
 			name: "One Drive Random Item Delete",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
 							delItem(fileID(), rootID, isFile))))),
@@ -2421,146 +2425,146 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				id(drivePfx, 1): {},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {data.NewState: {}},
+				d.strPath(): {data.NewState: {}},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID: driveFullPath(1),
+					rootID: d.strPath(),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(1): true,
+				d.strPath(): true,
 			},
 		},
 		{
 			name: "TwoPriorDrives_OneTombstoned",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(aPage()))), // root only
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
-				id(drivePfx, 1): {rootID: driveFullPath(1)},
-				id(drivePfx, 2): {rootID: driveFullPath(2)},
+				id(drivePfx, 1): {rootID: d.strPath()},
+				d2.id:           {rootID: d2.strPath()},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {data.NotMovedState: {}},
-				driveFullPath(2): {data.DeletedState: {}},
+				d.strPath():  {data.NotMovedState: {}},
+				d2.strPath(): {data.DeletedState: {}},
 			},
 			expectedDeltaURLs: map[string]string{id(drivePfx, 1): id(deltaURL)},
 			expectedPreviousPaths: map[string]map[string]string{
-				id(drivePfx, 1): {rootID: driveFullPath(1)},
+				id(drivePfx, 1): {rootID: d.strPath()},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{}),
 			doNotMergeItems: map[string]bool{
-				driveFullPath(2): true,
+				d2.strPath(): true,
 			},
 		},
 		{
 			name: "duplicate previous paths in metadata",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID()),
-							driveFolder(driveParentDir(1), rootID, 2),
-							driveFile(driveParentDir(1, folderName(2)), folderID(2), 2)))),
-				drive2.newEnumer().with(
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID()),
+							driveFolder(d.dir(), rootID, 2),
+							driveFile(d.dir(folderName(2)), folderID(2), 2)))),
+				d2.newEnumer().with(
 					delta(id(deltaURL, 2), nil).with(
 						aPage(
-							driveFolder(driveParentDir(2), rootID),
-							driveFile(driveParentDir(2, folderName()), folderID()),
-							driveFolder(driveParentDir(2), rootID, 2),
-							driveFile(driveParentDir(2, folderName(2)), folderID(2), 2))))),
+							driveFolder(d2.dir(), rootID),
+							driveFile(d2.dir(folderName()), folderID()),
+							driveFolder(d2.dir(), rootID, 2),
+							driveFile(d2.dir(folderName(2)), folderID(2), 2))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:      driveFullPath(1),
-					folderID():  driveFullPath(1, folderName()),
-					folderID(2): driveFullPath(1, folderName()),
-					folderID(3): driveFullPath(1, folderName()),
+					rootID:      d.strPath(),
+					folderID():  d.strPath(folderName()),
+					folderID(2): d.strPath(folderName()),
+					folderID(3): d.strPath(folderName()),
 				},
-				id(drivePfx, 2): {
-					rootID:      driveFullPath(2),
-					folderID():  driveFullPath(2, folderName()),
-					folderID(2): driveFullPath(2, folderName(2)),
+				d2.id: {
+					rootID:      d2.strPath(),
+					folderID():  d2.strPath(folderName()),
+					folderID(2): d2.strPath(folderName(2)),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {
+				d.strPath(): {
 					data.NewState: {folderID(), folderID(2)},
 				},
-				driveFullPath(1, folderName()): {
+				d.strPath(folderName()): {
 					data.NotMovedState: {folderID(), fileID()},
 				},
-				driveFullPath(1, folderName(2)): {
+				d.strPath(folderName(2)): {
 					data.MovedState: {folderID(2), fileID(2)},
 				},
-				driveFullPath(2): {
+				d2.strPath(): {
 					data.NewState: {folderID(), folderID(2)},
 				},
-				driveFullPath(2, folderName()): {
+				d2.strPath(folderName()): {
 					data.NotMovedState: {folderID(), fileID()},
 				},
-				driveFullPath(2, folderName(2)): {
+				d2.strPath(folderName(2)): {
 					data.NotMovedState: {folderID(2), fileID(2)},
 				},
 			},
 			expectedDeltaURLs: map[string]string{
 				id(drivePfx, 1): id(deltaURL),
-				id(drivePfx, 2): id(deltaURL, 2),
+				d2.id:           id(deltaURL, 2),
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:      driveFullPath(1),
-					folderID():  driveFullPath(1, folderName(2)), // note: this is a bug, but is currently expected
-					folderID(2): driveFullPath(1, folderName(2)),
-					folderID(3): driveFullPath(1, folderName(2)),
+					rootID:      d.strPath(),
+					folderID():  d.strPath(folderName(2)), // note: this is a bug, but is currently expected
+					folderID(2): d.strPath(folderName(2)),
+					folderID(3): d.strPath(folderName(2)),
 				},
-				id(drivePfx, 2): {
-					rootID:      driveFullPath(2),
-					folderID():  driveFullPath(2, folderName()),
-					folderID(2): driveFullPath(2, folderName(2)),
+				d2.id: {
+					rootID:      d2.strPath(),
+					folderID():  d2.strPath(folderName()),
+					folderID(2): d2.strPath(folderName(2)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{
-				driveFullPath(1): makeExcludeMap(fileID(), fileID(2)),
-				driveFullPath(2): makeExcludeMap(fileID(), fileID(2)),
+				d.strPath():  makeExcludeMap(fileID(), fileID(2)),
+				d2.strPath(): makeExcludeMap(fileID(), fileID(2)),
 			}),
 			doNotMergeItems: map[string]bool{},
 		},
 		{
 			name: "out of order item enumeration causes prev path collisions",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							driveItem(folderID(fanny, 2), folderName(fanny), driveParentDir(1), rootID, isFolder),
-							driveFile(driveParentDir(1, folderName(fanny)), folderID(fanny, 2), 2),
-							driveFolder(driveParentDir(1), rootID, nav),
-							driveFile(driveParentDir(1, folderName(nav)), folderID(nav)))))),
+							driveItem(folderID(fanny, 2), folderName(fanny), d.dir(), rootID, isFolder),
+							driveFile(d.dir(folderName(fanny)), folderID(fanny, 2), 2),
+							driveFolder(d.dir(), rootID, nav),
+							driveFile(d.dir(folderName(nav)), folderID(nav)))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:        driveFullPath(1),
-					folderID(nav): driveFullPath(1, folderName(fanny)),
+					rootID:        d.strPath(),
+					folderID(nav): d.strPath(folderName(fanny)),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {
+				d.strPath(): {
 					data.NewState: {folderID(fanny, 2)},
 				},
-				driveFullPath(1, folderName(nav)): {
+				d.strPath(folderName(nav)): {
 					data.MovedState: {folderID(nav), fileID()},
 				},
-				driveFullPath(1, folderName(fanny)): {
+				d.strPath(folderName(fanny)): {
 					data.NewState: {folderID(fanny, 2), fileID(2)},
 				},
 			},
@@ -2569,52 +2573,52 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:             driveFullPath(1),
-					folderID(nav):      driveFullPath(1, folderName(nav)),
-					folderID(fanny, 2): driveFullPath(1, folderName(nav)), // note: this is a bug, but currently expected
+					rootID:             d.strPath(),
+					folderID(nav):      d.strPath(folderName(nav)),
+					folderID(fanny, 2): d.strPath(folderName(nav)), // note: this is a bug, but currently expected
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{
-				driveFullPath(1): makeExcludeMap(fileID(), fileID(2)),
+				d.strPath(): makeExcludeMap(fileID(), fileID(2)),
 			}),
 			doNotMergeItems: map[string]bool{},
 		},
 		{
 			name: "out of order item enumeration causes opposite prev path collisions",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							driveFile(driveParentDir(1), rootID, 1),
-							driveFolder(driveParentDir(1), rootID, fanny),
-							driveFolder(driveParentDir(1), rootID, nav),
-							driveFolder(driveParentDir(1, folderName(fanny)), folderID(fanny), foo),
-							driveItem(folderID(bar), folderName(foo), driveParentDir(1, folderName(nav)), folderID(nav), isFolder))))),
+							driveFile(d.dir(), rootID, 1),
+							driveFolder(d.dir(), rootID, fanny),
+							driveFolder(d.dir(), rootID, nav),
+							driveFolder(d.dir(folderName(fanny)), folderID(fanny), foo),
+							driveItem(folderID(bar), folderName(foo), d.dir(folderName(nav)), folderID(nav), isFolder))))),
 			canUsePreviousBackup: true,
 			errCheck:             assert.NoError,
 			previousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:          driveFullPath(1),
-					folderID(nav):   driveFullPath(1, folderName(nav)),
-					folderID(fanny): driveFullPath(1, folderName(fanny)),
-					folderID(foo):   driveFullPath(1, folderName(nav), folderName(foo)),
-					folderID(bar):   driveFullPath(1, folderName(fanny), folderName(foo)),
+					rootID:          d.strPath(),
+					folderID(nav):   d.strPath(folderName(nav)),
+					folderID(fanny): d.strPath(folderName(fanny)),
+					folderID(foo):   d.strPath(folderName(nav), folderName(foo)),
+					folderID(bar):   d.strPath(folderName(fanny), folderName(foo)),
 				},
 			},
 			expectedCollections: map[string]map[data.CollectionState][]string{
-				driveFullPath(1): {
+				d.strPath(): {
 					data.NotMovedState: {fileID(1)},
 				},
-				driveFullPath(1, folderName(nav)): {
+				d.strPath(folderName(nav)): {
 					data.NotMovedState: {folderID(nav)},
 				},
-				driveFullPath(1, folderName(nav), folderName(foo)): {
+				d.strPath(folderName(nav), folderName(foo)): {
 					data.MovedState: {folderID(bar)},
 				},
-				driveFullPath(1, folderName(fanny)): {
+				d.strPath(folderName(fanny)): {
 					data.NotMovedState: {folderID(fanny)},
 				},
-				driveFullPath(1, folderName(fanny), folderName(foo)): {
+				d.strPath(folderName(fanny), folderName(foo)): {
 					data.MovedState: {folderID(foo)},
 				},
 			},
@@ -2623,15 +2627,15 @@ func (suite *CollectionsUnitSuite) TestGet() {
 			},
 			expectedPreviousPaths: map[string]map[string]string{
 				id(drivePfx, 1): {
-					rootID:          driveFullPath(1),
-					folderID(nav):   driveFullPath(1, folderName(nav)),
-					folderID(fanny): driveFullPath(1, folderName(fanny)),
-					folderID(foo):   driveFullPath(1, folderName(nav), folderName(foo)), // note: this is a bug, but currently expected
-					folderID(bar):   driveFullPath(1, folderName(nav), folderName(foo)),
+					rootID:          d.strPath(),
+					folderID(nav):   d.strPath(folderName(nav)),
+					folderID(fanny): d.strPath(folderName(fanny)),
+					folderID(foo):   d.strPath(folderName(nav), folderName(foo)), // note: this is a bug, but currently expected
+					folderID(bar):   d.strPath(folderName(nav), folderName(foo)),
 				},
 			},
 			expectedDelList: pmMock.NewPrefixMap(map[string]map[string]struct{}{
-				driveFullPath(1): makeExcludeMap(fileID(1)),
+				d.strPath(): makeExcludeMap(fileID(1)),
 			}),
 			doNotMergeItems: map[string]bool{},
 		},
@@ -2666,7 +2670,7 @@ func (suite *CollectionsUnitSuite) TestGet() {
 						bupMD.DeltaURLsFileName,
 						map[string]string{
 							id(drivePfx, 1): prevDelta,
-							id(drivePfx, 2): prevDelta,
+							d2.id:           prevDelta,
 						}),
 					graph.NewMetadataEntry(
 						bupMD.PreviousPathFileName,
@@ -2774,8 +2778,8 @@ func (suite *CollectionsUnitSuite) TestGet() {
 }
 
 func (suite *CollectionsUnitSuite) TestAddURLCacheToDriveCollections() {
-	drive1 := drive(1)
-	drive2 := drive(2)
+	d := drive(1)
+	d2 := drive(2)
 
 	table := []struct {
 		name       string
@@ -2785,16 +2789,16 @@ func (suite *CollectionsUnitSuite) TestAddURLCacheToDriveCollections() {
 		{
 			name: "Two drives with unique url cache instances",
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							driveFolder(driveParentDir(1), rootID),
-							driveFile(driveParentDir(1, folderName()), folderID())))),
-				drive2.newEnumer().with(
+							driveFolder(d.dir(), rootID),
+							driveFile(d.dir(folderName()), folderID())))),
+				d2.newEnumer().with(
 					delta(id(deltaURL, 2), nil).with(
 						aPage(
-							driveItem(folderID(2), folderName(), driveParentDir(2), rootID, isFolder),
-							driveItem(fileID(2), fileName(), driveParentDir(2, folderName()), folderID(2), isFile))))),
+							driveItem(folderID(2), folderName(), d2.dir(), rootID, isFolder),
+							driveItem(fileID(2), fileName(), d2.dir(folderName()), folderID(2), isFile))))),
 			errCheck: assert.NoError,
 		},
 		// TODO(pandeyabs): Add a test case to check that the cache is not attached

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -629,7 +629,7 @@ func (c *Collections) addFileToTree(
 		return nil, nil
 	}
 
-	_, alreadySeen := tree.fileIDToParentID[fileID]
+	alreadySeen := tree.hasFile(fileID)
 	parentNode, parentNotNil := tree.folderIDToNode[parentID]
 
 	if parentNotNil && !alreadySeen {
@@ -686,25 +686,10 @@ func (c *Collections) makeDriveTombstones(
 			continue
 		}
 
-		// TODO: call NewTombstoneCollection
-		coll, err := NewCollection(
-			c.handler,
-			c.protectedResource,
-			nil, // delete the drive
+		coll := data.NewTombstoneCollection(
 			prevDrivePath,
-			driveID,
-			c.statusUpdater,
 			c.ctrl,
-			false,
-			true,
-			nil,
 			c.counter.Local())
-		if err != nil {
-			err = clues.WrapWC(ctx, err, "making drive tombstone")
-			el.AddRecoverable(ctx, err)
-
-			continue
-		}
 
 		colls = append(colls, coll)
 	}

--- a/src/internal/m365/collection/drive/collections_tree_test.go
+++ b/src/internal/m365/collection/drive/collections_tree_test.go
@@ -236,7 +236,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_GetTree() {
 // at lower levels are better for verifing fine-grained concerns.  This test only needs
 // to ensure we stitch the parts together correctly.
 func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
-	drv := drive()
+	d := drive()
 
 	table := []struct {
 		name         string
@@ -247,9 +247,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 	}{
 		{
 			name:  "only root in delta, no prev paths",
-			drive: drv,
+			drive: d,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage()))),
 			prevPaths: map[string]string{},
@@ -259,13 +259,13 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 		},
 		{
 			name:  "only root in delta, with prev paths",
-			drive: drv,
+			drive: d,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage()))),
 			prevPaths: map[string]string{
-				folderID(): fullPath(folderName()),
+				folderID(): d.strPath(folderName()),
 			},
 			expectCounts: countTD.Expected{
 				count.PrevPaths: 1,
@@ -273,11 +273,11 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 		},
 		{
 			name:  "some items, no prev paths",
-			drive: drv,
+			drive: d,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
-						aPage(folderAtRoot(), fileAt(folder))))),
+						aPage(d.folderAtRoot(), d.fileAt(folder))))),
 			prevPaths: map[string]string{},
 			expectCounts: countTD.Expected{
 				count.PrevPaths: 0,
@@ -285,13 +285,13 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 		},
 		{
 			name:  "some items, with prev paths",
-			drive: drv,
+			drive: d,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
-						aPage(folderAtRoot(), fileAt(folder))))),
+						aPage(d.folderAtRoot(), d.fileAt(folder))))),
 			prevPaths: map[string]string{
-				folderID(): fullPath(folderName()),
+				folderID(): d.strPath(folderName()),
 			},
 			expectCounts: countTD.Expected{
 				count.PrevPaths: 1,
@@ -299,9 +299,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 		},
 		{
 			name:  "tree had delta reset, only root after, no prev paths",
-			drive: drv,
+			drive: d,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aReset(),
 						aPage()))),
@@ -312,14 +312,14 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 		},
 		{
 			name:  "tree had delta reset, only root after, with prev paths",
-			drive: drv,
+			drive: d,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aReset(),
 						aPage()))),
 			prevPaths: map[string]string{
-				folderID(): fullPath(folderName()),
+				folderID(): d.strPath(folderName()),
 			},
 			expectCounts: countTD.Expected{
 				count.PrevPaths: 1,
@@ -327,12 +327,12 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 		},
 		{
 			name:  "tree had delta reset, enumerate items after, no prev paths",
-			drive: drv,
+			drive: d,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aReset(),
-						aPage(folderAtRoot(), fileAt(folder))))),
+						aPage(d.folderAtRoot(), d.fileAt(folder))))),
 			prevPaths: map[string]string{},
 			expectCounts: countTD.Expected{
 				count.PrevPaths: 0,
@@ -340,14 +340,14 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 		},
 		{
 			name:  "tree had delta reset, enumerate items after, with prev paths",
-			drive: drv,
+			drive: d,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aReset(),
-						aPage(folderAtRoot(), fileAt(folder))))),
+						aPage(d.folderAtRoot(), d.fileAt(folder))))),
 			prevPaths: map[string]string{
-				folderID(): fullPath(folderName()),
+				folderID(): d.strPath(folderName()),
 			},
 			expectCounts: countTD.Expected{
 				count.PrevPaths: 1,
@@ -368,7 +368,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 
 			_, _, _, err := c.makeDriveCollections(
 				ctx,
-				test.drive.Able,
+				test.drive.able,
 				test.prevPaths,
 				id(deltaURL, "prev"),
 				newPagerLimiter(control.DefaultOptions()),
@@ -383,9 +383,11 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 }
 
 func (suite *CollectionsTreeUnitSuite) TestCollections_AddPrevPathsToTree_errors() {
+	d := drive()
+
 	table := []struct {
 		name      string
-		tree      func(t *testing.T) *folderyMcFolderFace
+		tree      func(t *testing.T, d *deltaDrive) *folderyMcFolderFace
 		prevPaths map[string]string
 		expectErr require.ErrorAssertionFunc
 	}{
@@ -393,8 +395,8 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddPrevPathsToTree_errors
 			name: "no error - normal usage",
 			tree: treeWithFolders,
 			prevPaths: map[string]string{
-				folderID("parent"): fullPath(folderName("parent")),
-				folderID():         fullPath(folderName("parent"), folderName()),
+				folderID("parent"): d.strPath(folderName("parent")),
+				folderID():         d.strPath(folderName("parent"), folderName()),
 			},
 			expectErr: require.NoError,
 		},
@@ -408,7 +410,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddPrevPathsToTree_errors
 			name: "no error - folder not visited in this delta",
 			tree: treeWithFolders,
 			prevPaths: map[string]string{
-				id("santa"): fullPath(name("santa")),
+				id("santa"): d.strPath(name("santa")),
 			},
 			expectErr: require.NoError,
 		},
@@ -416,7 +418,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddPrevPathsToTree_errors
 			name: "empty key in previous paths",
 			tree: treeWithFolders,
 			prevPaths: map[string]string{
-				"": fullPath(folderName("parent")),
+				"": d.strPath(folderName("parent")),
 			},
 			expectErr: require.Error,
 		},
@@ -444,7 +446,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddPrevPathsToTree_errors
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			tree := test.tree(t)
+			tree := test.tree(t, d)
 
 			err := addPrevPathsToTree(
 				ctx,
@@ -457,15 +459,17 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddPrevPathsToTree_errors
 }
 
 func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections() {
+	d := drive()
+
 	type expected struct {
 		prevPaths             map[string]string
-		collections           func(t *testing.T) expectedCollections
+		collections           func(t *testing.T, d *deltaDrive) expectedCollections
 		globalExcludedFileIDs map[string]struct{}
 	}
 
 	table := []struct {
 		name           string
-		tree           func(t *testing.T) *folderyMcFolderFace
+		tree           func(t *testing.T, d *deltaDrive) *folderyMcFolderFace
 		prevPaths      map[string]string
 		enableURLCache bool
 		expect         expected
@@ -477,24 +481,24 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 			enableURLCache: true,
 			expect: expected{
 				prevPaths: map[string]string{
-					rootID:             fullPath(),
-					folderID("parent"): fullPath(folderName("parent")),
-					folderID():         fullPath(folderName("parent"), folderName()),
+					rootID:             d.strPath(),
+					folderID("parent"): d.strPath(folderName("parent")),
+					folderID():         d.strPath(folderName("parent"), folderName()),
 				},
-				collections: func(t *testing.T) expectedCollections {
+				collections: func(t *testing.T, d *deltaDrive) expectedCollections {
 					return expectCollections(
 						false,
 						true,
 						aColl(
-							fullPathPath(t),
+							d.fullPath(t),
 							nil,
 							fileID("r")),
 						aColl(
-							fullPathPath(t, folderName("parent")),
+							d.fullPath(t, folderName("parent")),
 							nil,
 							fileID("p")),
 						aColl(
-							fullPathPath(t, folderName("parent"), folderName()),
+							d.fullPath(t, folderName("parent"), folderName()),
 							nil,
 							fileID()))
 				},
@@ -510,34 +514,34 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 			tree:           fullTree,
 			enableURLCache: true,
 			prevPaths: map[string]string{
-				rootID:                fullPath(),
-				folderID("parent"):    fullPath(folderName("parent-prev")),
-				folderID():            fullPath(folderName("parent-prev"), folderName()),
-				folderID("tombstone"): fullPath(folderName("tombstone-prev")),
+				rootID:                d.strPath(),
+				folderID("parent"):    d.strPath(folderName("parent-prev")),
+				folderID():            d.strPath(folderName("parent-prev"), folderName()),
+				folderID("tombstone"): d.strPath(folderName("tombstone-prev")),
 			},
 			expect: expected{
 				prevPaths: map[string]string{
-					rootID:             fullPath(),
-					folderID("parent"): fullPath(folderName("parent")),
-					folderID():         fullPath(folderName("parent"), folderName()),
+					rootID:             d.strPath(),
+					folderID("parent"): d.strPath(folderName("parent")),
+					folderID():         d.strPath(folderName("parent"), folderName()),
 				},
-				collections: func(t *testing.T) expectedCollections {
+				collections: func(t *testing.T, d *deltaDrive) expectedCollections {
 					return expectCollections(
 						false,
 						true,
 						aColl(
-							fullPathPath(t),
-							fullPathPath(t),
+							d.fullPath(t),
+							d.fullPath(t),
 							fileID("r")),
 						aColl(
-							fullPathPath(t, folderName("parent")),
-							fullPathPath(t, folderName("parent-prev")),
+							d.fullPath(t, folderName("parent")),
+							d.fullPath(t, folderName("parent-prev")),
 							fileID("p")),
 						aColl(
-							fullPathPath(t, folderName("parent"), folderName()),
-							fullPathPath(t, folderName("parent-prev"), folderName()),
+							d.fullPath(t, folderName("parent"), folderName()),
+							d.fullPath(t, folderName("parent-prev"), folderName()),
 							fileID()),
-						aColl(nil, fullPathPath(t, folderName("tombstone-prev"))))
+						aColl(nil, d.fullPath(t, folderName("tombstone-prev"))))
 				},
 				globalExcludedFileIDs: makeExcludeMap(
 					fileID("r"),
@@ -551,34 +555,34 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 			tree:           fullTreeWithNames("parent", "tombstone"),
 			enableURLCache: true,
 			prevPaths: map[string]string{
-				rootID:                fullPath(),
-				folderID("parent"):    fullPath(folderName("parent-prev")),
-				folderID():            fullPath(folderName("parent-prev"), folderName()),
-				folderID("tombstone"): fullPath(folderName("tombstone-prev")),
+				rootID:                d.strPath(),
+				folderID("parent"):    d.strPath(folderName("parent-prev")),
+				folderID():            d.strPath(folderName("parent-prev"), folderName()),
+				folderID("tombstone"): d.strPath(folderName("tombstone-prev")),
 			},
 			expect: expected{
 				prevPaths: map[string]string{
-					rootID:             fullPath(),
-					folderID("parent"): fullPath(folderName("parent")),
-					folderID():         fullPath(folderName("parent"), folderName()),
+					rootID:             d.strPath(),
+					folderID("parent"): d.strPath(folderName("parent")),
+					folderID():         d.strPath(folderName("parent"), folderName()),
 				},
-				collections: func(t *testing.T) expectedCollections {
+				collections: func(t *testing.T, d *deltaDrive) expectedCollections {
 					return expectCollections(
 						false,
 						true,
 						aColl(
-							fullPathPath(t),
-							fullPathPath(t),
+							d.fullPath(t),
+							d.fullPath(t),
 							fileID("r")),
 						aColl(
-							fullPathPath(t, folderName("parent")),
-							fullPathPath(t, folderName("parent-prev")),
+							d.fullPath(t, folderName("parent")),
+							d.fullPath(t, folderName("parent-prev")),
 							fileID("p")),
 						aColl(
-							fullPathPath(t, folderName("parent"), folderName()),
-							fullPathPath(t, folderName("parent-prev"), folderName()),
+							d.fullPath(t, folderName("parent"), folderName()),
+							d.fullPath(t, folderName("parent-prev"), folderName()),
 							fileID()),
-						aColl(nil, fullPathPath(t, folderName("tombstone-prev"))))
+						aColl(nil, d.fullPath(t, folderName("tombstone-prev"))))
 				},
 				globalExcludedFileIDs: makeExcludeMap(
 					fileID("r"),
@@ -592,34 +596,34 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 			tree:           fullTree,
 			enableURLCache: true,
 			prevPaths: map[string]string{
-				rootID:                fullPath(),
-				folderID("parent"):    fullPath(folderName("parent")),
-				folderID():            fullPath(folderName("parent"), folderName()),
-				folderID("tombstone"): fullPath(folderName("tombstone")),
+				rootID:                d.strPath(),
+				folderID("parent"):    d.strPath(folderName("parent")),
+				folderID():            d.strPath(folderName("parent"), folderName()),
+				folderID("tombstone"): d.strPath(folderName("tombstone")),
 			},
 			expect: expected{
 				prevPaths: map[string]string{
-					rootID:             fullPath(),
-					folderID("parent"): fullPath(folderName("parent")),
-					folderID():         fullPath(folderName("parent"), folderName()),
+					rootID:             d.strPath(),
+					folderID("parent"): d.strPath(folderName("parent")),
+					folderID():         d.strPath(folderName("parent"), folderName()),
 				},
-				collections: func(t *testing.T) expectedCollections {
+				collections: func(t *testing.T, d *deltaDrive) expectedCollections {
 					return expectCollections(
 						false,
 						true,
 						aColl(
-							fullPathPath(t),
-							fullPathPath(t),
+							d.fullPath(t),
+							d.fullPath(t),
 							fileID("r")),
 						aColl(
-							fullPathPath(t, folderName("parent")),
-							fullPathPath(t, folderName("parent")),
+							d.fullPath(t, folderName("parent")),
+							d.fullPath(t, folderName("parent")),
 							fileID("p")),
 						aColl(
-							fullPathPath(t, folderName("parent"), folderName()),
-							fullPathPath(t, folderName("parent"), folderName()),
+							d.fullPath(t, folderName("parent"), folderName()),
+							d.fullPath(t, folderName("parent"), folderName()),
 							fileID()),
-						aColl(nil, fullPathPath(t, folderName("tombstone"))))
+						aColl(nil, d.fullPath(t, folderName("tombstone"))))
 				},
 				globalExcludedFileIDs: makeExcludeMap(
 					fileID("r"),
@@ -636,7 +640,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			tree := test.tree(t)
+			tree := test.tree(t, d)
 
 			err := addPrevPathsToTree(ctx, tree, test.prevPaths, fault.New(true))
 			require.NoError(t, err, clues.ToCore(err))
@@ -651,14 +655,14 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 			colls, newPrevPaths, excluded, err := c.turnTreeIntoCollections(
 				ctx,
 				tree,
-				id(drivePfx),
+				d.id,
 				deltaURL,
 				countPages,
 				fault.New(true))
 			require.NoError(t, err, clues.ToCore(err))
 			assert.Equal(t, test.expect.prevPaths, newPrevPaths, "new previous paths")
 
-			expectColls := test.expect.collections(t)
+			expectColls := test.expect.collections(t, d)
 			expectColls.compare(t, colls)
 			expectColls.requireNoUnseenCollections(t)
 
@@ -682,7 +686,7 @@ type populateTreeExpected struct {
 type populateTreeTest struct {
 	name       string
 	enumerator enumerateDriveItemsDelta
-	tree       func(t *testing.T) *folderyMcFolderFace
+	tree       func(t *testing.T, d *deltaDrive) *folderyMcFolderFace
 	limiter    *pagerLimiter
 	expect     populateTreeExpected
 }
@@ -690,7 +694,7 @@ type populateTreeTest struct {
 // this test focuses on the population of a tree using a single delta's enumeration data.
 // It is not concerned with unifying previous paths or post-processing collections.
 func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta() {
-	drv := drive()
+	d := drive()
 
 	table := []populateTreeTest{
 		{
@@ -700,8 +704,8 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 			// otherwise all enumerators should be DriveEnumerator()s.
 			enumerator: enumerateDriveItemsDelta{
 				DrivePagers: map[string]*DeltaDriveEnumerator{
-					drv.ID: {
-						Drive: drv,
+					d.id: {
+						Drive: d,
 						DeltaQueries: []*deltaQuery{{
 							Pages:       nil,
 							DeltaUpdate: pagers.DeltaUpdate{URL: id(deltaURL)},
@@ -725,7 +729,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 			name: "root only",
 			tree: newTree,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage()))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
@@ -750,7 +754,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 			name: "root only on two pages",
 			tree: newTree,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(),
 						aPage()))),
@@ -776,13 +780,13 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 			name: "many folders in a hierarchy across multiple pages",
 			tree: newTree,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
-						aPage(folderAtRoot()),
-						aPage(folderAtRoot("sib")),
+						aPage(d.folderAtRoot()),
+						aPage(d.folderAtRoot("sib")),
 						aPage(
-							folderAtRoot(),
-							folderAt(folder, "chld"))))),
+							d.folderAtRoot(),
+							d.folderAt(folder, "chld"))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
@@ -808,18 +812,18 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 			name: "many folders with files",
 			tree: newTree,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							folderAtRoot(),
-							fileAt(folder)),
+							d.folderAtRoot(),
+							d.fileAt(folder)),
 						aPage(
-							folderAtRoot("sib"),
-							fileAt("sib", "fsib")),
+							d.folderAtRoot("sib"),
+							d.fileAt("sib", "fsib")),
 						aPage(
-							folderAtRoot(),
-							folderAt(folder, "chld"),
-							fileAt("chld", "fchld")),
+							d.folderAtRoot(),
+							d.folderAt(folder, "chld"),
+							d.fileAt("chld", "fchld")),
 					))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: populateTreeExpected{
@@ -850,7 +854,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 			name: "tombstone with unpopulated tree",
 			tree: newTree,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(delItem(folderID(), folderID("parent"), isFolder)),
 					))),
@@ -879,7 +883,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 			name: "tombstone with populated tree",
 			tree: treeWithFileInFolder,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(aPage(
 						delItem(folderID(), folderID("parent"), isFolder),
 					)))),
@@ -913,11 +917,11 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 			name: "create->delete folder",
 			tree: newTree,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							folderAtRoot(),
-							fileAt(folder)),
+							d.folderAtRoot(),
+							d.fileAt(folder)),
 						aPage(delItem(folderID(), rootID, isFolder))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: populateTreeExpected{
@@ -946,12 +950,12 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 			name: "move->delete folder with populated tree",
 			tree: treeWithFolders,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							folderAtRoot("parent"),
-							driveItem(folderID(), folderName("moved"), parentDir(), folderID("parent"), isFolder),
-							driveFile(parentDir(folderName("parent"), folderName()), folderID())),
+							d.folderAtRoot("parent"),
+							driveItem(folderID(), folderName("moved"), d.dir(), folderID("parent"), isFolder),
+							driveFile(d.dir(folderName("parent"), folderName()), folderID())),
 						aPage(delItem(folderID(), folderID("parent"), isFolder))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: populateTreeExpected{
@@ -981,12 +985,12 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 			name: "delete->create folder with previous path",
 			tree: newTree,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(delItem(folderID(), rootID, isFolder)),
 						aPage(
-							folderAtRoot(),
-							fileAt(folder)),
+							d.folderAtRoot(),
+							d.fileAt(folder)),
 					))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: populateTreeExpected{
@@ -1014,12 +1018,12 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 			name: "delete->create folder without previous path",
 			tree: treeWithRoot,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(delItem(folderID(), rootID, isFolder)),
 						aPage(
-							folderAtRoot(),
-							fileAt(folder)),
+							d.folderAtRoot(),
+							d.fileAt(folder)),
 					))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: populateTreeExpected{
@@ -1047,18 +1051,18 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 			name: "at folder limit before enumeration",
 			tree: treeWithFileAtRoot,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							folderAtRoot(),
-							fileAt(folder)),
+							d.folderAtRoot(),
+							d.fileAt(folder)),
 						aPage(
-							folderAtRoot("sib"),
-							fileAt("sib", "fsib")),
+							d.folderAtRoot("sib"),
+							d.fileAt("sib", "fsib")),
 						aPage(
-							folderAtRoot(),
-							folderAt(folder, "chld"),
-							fileAt("chld", "fchld"))))),
+							d.folderAtRoot(),
+							d.folderAt(folder, "chld"),
+							d.fileAt("chld", "fchld"))))),
 			limiter: newPagerLimiter(minimumLimitOpts()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
@@ -1083,18 +1087,18 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 			name: "hit folder limit during enumeration",
 			tree: newTree,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							folderAtRoot(),
-							fileAt(folder)),
+							d.folderAtRoot(),
+							d.fileAt(folder)),
 						aPage(
-							folderAtRoot("sib"),
-							fileAt("sib", "fsib")),
+							d.folderAtRoot("sib"),
+							d.fileAt("sib", "fsib")),
 						aPage(
-							folderAtRoot(),
-							folderAt(folder, "chld"),
-							fileAt("chld", "fchld"))))),
+							d.folderAtRoot(),
+							d.folderAt(folder, "chld"),
+							d.fileAt("chld", "fchld"))))),
 			limiter: newPagerLimiter(minimumLimitOpts()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
@@ -1118,7 +1122,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			runPopulateTreeTest(suite.T(), drv.Able, test)
+			runPopulateTreeTest(suite.T(), d.able, test)
 		})
 	}
 }
@@ -1127,27 +1131,27 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 // multiple delta enumerations.
 // It is not concerned with unifying previous paths or post-processing collections.
 func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta() {
-	drv := drive()
+	d := drive()
 
 	table := []populateTreeTest{
 		{
 			name: "sanity case: normal enumeration split across multiple deltas",
 			tree: newTree,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).
 						with(aPage(
-							folderAtRoot(),
-							fileAt(folder))),
+							d.folderAtRoot(),
+							d.fileAt(folder))),
 					delta(id(deltaURL), nil).
 						with(aPage(
-							folderAtRoot("sib"),
-							fileAt("sib", "fsib"))),
+							d.folderAtRoot("sib"),
+							d.fileAt("sib", "fsib"))),
 					delta(id(deltaURL), nil).
 						with(aPage(
-							folderAtRoot(),
-							folderAt(folder, "chld"),
-							fileAt("chld", "fchld"))))),
+							d.folderAtRoot(),
+							d.folderAt(folder, "chld"),
+							d.fileAt("chld", "fchld"))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
@@ -1180,11 +1184,11 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 			name: "create->delete,create",
 			tree: newTree,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							folderAtRoot(),
-							fileAt(folder))),
+							d.folderAtRoot(),
+							d.fileAt(folder))),
 					// a (delete,create) pair in the same delta can occur when
 					// a user deletes and restores an item in-between deltas.
 					delta(id(deltaURL), nil).with(
@@ -1192,8 +1196,8 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 							delItem(folderID(), rootID, isFolder),
 							delItem(fileID(), folderID(), isFile)),
 						aPage(
-							folderAtRoot(),
-							fileAt(folder))))),
+							d.folderAtRoot(),
+							d.fileAt(folder))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
@@ -1220,15 +1224,15 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 			name: "visit->rename",
 			tree: newTree,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							folderAtRoot(),
-							fileAt(folder))),
+							d.folderAtRoot(),
+							d.fileAt(folder))),
 					delta(id(deltaURL), nil).with(
 						aPage(
-							driveItem(folderID(), folderName("rename"), parentDir(), rootID, isFolder),
-							driveItem(fileID(), fileName("rename"), parentDir(folderName("rename")), folderID(), isFile))))),
+							driveItem(folderID(), folderName("rename"), d.dir(), rootID, isFolder),
+							driveItem(fileID(), fileName("rename"), d.dir(folderName("rename")), folderID(), isFile))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
@@ -1257,12 +1261,12 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 			name: "duplicate folder name from deferred delete marker",
 			tree: newTree,
 			enumerator: driveEnumerator(
-				drv.newEnumer().with(
+				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						// first page: create /root/folder and /root/folder/file
 						aPage(
-							folderAtRoot(),
-							fileAt(folder)),
+							d.folderAtRoot(),
+							d.fileAt(folder)),
 						// assume the user makes changes at this point:
 						// * create a new /root/folder
 						// * move /root/folder/file from old to new folder (same file ID)
@@ -1270,8 +1274,8 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 						// in drive deltas, this will show up as another folder creation sharing
 						// the same dirname, but we won't see the delete until...
 						aPage(
-							driveItem(folderID(2), folderName(), parentDir(), rootID, isFolder),
-							driveItem(fileID(), fileName(), parentDir(folderName()), folderID(2), isFile))),
+							driveItem(folderID(2), folderName(), d.dir(), rootID, isFolder),
+							driveItem(fileID(), fileName(), d.dir(folderName()), folderID(2), isFile))),
 					// the next delta, containing the delete marker for the original /root/folder
 					delta(id(deltaURL), nil).with(
 						aPage(
@@ -1303,14 +1307,14 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			runPopulateTreeTest(suite.T(), drv.Able, test)
+			runPopulateTreeTest(suite.T(), d.able, test)
 		})
 	}
 }
 
 func runPopulateTreeTest(
 	t *testing.T,
-	drv models.Driveable,
+	d models.Driveable,
 	test populateTreeTest,
 ) {
 	ctx, flush := tester.NewContext(t)
@@ -1320,13 +1324,13 @@ func runPopulateTreeTest(
 		mbh     = defaultDriveBHWith(user, test.enumerator)
 		c       = collWithMBH(mbh)
 		counter = count.New()
-		tree    = test.tree(t)
+		tree    = test.tree(t, drive())
 	)
 
 	_, _, err := c.populateTree(
 		ctx,
 		tree,
-		drv,
+		d,
 		id(deltaURL),
 		test.limiter,
 		counter,
@@ -1374,7 +1378,7 @@ func runPopulateTreeTest(
 // This test focuses on folder assertions when enumerating a page of items.
 // File-specific assertions are focused in the _folders test variant.
 func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_folders() {
-	drv := drive()
+	d := drive()
 
 	type expected struct {
 		counts                   countTD.Expected
@@ -1387,7 +1391,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 
 	table := []struct {
 		name    string
-		tree    func(t *testing.T) *folderyMcFolderFace
+		tree    func(t *testing.T, d *deltaDrive) *folderyMcFolderFace
 		page    nextPage
 		limiter *pagerLimiter
 		expect  expected
@@ -1443,9 +1447,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			name: "many folders in a hierarchy",
 			tree: treeWithRoot,
 			page: aPage(
-				folderAtRoot(),
-				folderAtRoot("sib"),
-				folderAt(folder, "chld")),
+				d.folderAtRoot(),
+				d.folderAtRoot("sib"),
+				d.folderAt(folder, "chld")),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1466,7 +1470,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			name: "create->delete",
 			tree: treeWithRoot,
 			page: aPage(
-				folderAtRoot(),
+				d.folderAtRoot(),
 				delItem(folderID(), rootID, isFolder)),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
@@ -1486,8 +1490,8 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			name: "move->delete",
 			tree: treeWithFolders,
 			page: aPage(
-				folderAtRoot("parent"),
-				driveItem(folderID(), folderName("moved"), parentDir(folderName("parent")), folderID("parent"), isFolder),
+				d.folderAtRoot("parent"),
+				driveItem(folderID(), folderName("moved"), d.dir(folderName("parent")), folderID("parent"), isFolder),
 				delItem(folderID(), folderID("parent"), isFolder)),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
@@ -1511,7 +1515,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			tree: treeWithRoot,
 			page: aPage(
 				delItem(folderID(), rootID, isFolder),
-				folderAtRoot()),
+				d.folderAtRoot()),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1532,7 +1536,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			tree: treeWithRoot,
 			page: aPage(
 				delItem(folderID(), rootID, isFolder),
-				folderAtRoot()),
+				d.folderAtRoot()),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1559,13 +1563,13 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			var (
 				c       = collWithMBH(defaultOneDriveBH(user))
 				counter = count.New()
-				tree    = test.tree(t)
+				tree    = test.tree(t, d)
 			)
 
 			err := c.enumeratePageOfItems(
 				ctx,
 				tree,
-				drv.Able,
+				d.able,
 				test.page.Items,
 				test.limiter,
 				counter,
@@ -1596,12 +1600,12 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 
 func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 	var (
-		drv    = drive()
-		fld    = custom.ToCustomDriveItem(folderAtRoot())
-		subFld = custom.ToCustomDriveItem(driveFolder(driveParentDir(drv, folderName("parent")), folderID("parent")))
-		pack   = custom.ToCustomDriveItem(driveItem(id(pkg), name(pkg), parentDir(), rootID, isPackage))
+		d      = drive()
+		fld    = custom.ToCustomDriveItem(d.folderAtRoot())
+		subFld = custom.ToCustomDriveItem(driveFolder(d.dir(folderName("parent")), folderID("parent")))
+		pack   = custom.ToCustomDriveItem(driveItem(id(pkg), name(pkg), d.dir(), rootID, isPackage))
 		del    = custom.ToCustomDriveItem(delItem(folderID(), rootID, isFolder))
-		mal    = custom.ToCustomDriveItem(malwareItem(folderID("mal"), folderName("mal"), parentDir(), rootID, isFolder))
+		mal    = custom.ToCustomDriveItem(malwareItem(folderID("mal"), folderName("mal"), d.dir(), rootID, isFolder))
 	)
 
 	type expected struct {
@@ -1616,7 +1620,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 
 	table := []struct {
 		name    string
-		tree    func(t *testing.T) *folderyMcFolderFace
+		tree    func(t *testing.T, d *deltaDrive) *folderyMcFolderFace
 		folder  *custom.DriveItem
 		limiter *pagerLimiter
 		expect  expected
@@ -1824,13 +1828,13 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 			var (
 				c       = collWithMBH(defaultOneDriveBH(user))
 				counter = count.New()
-				tree    = test.tree(t)
+				tree    = test.tree(t, d)
 			)
 
 			skipped, err := c.addFolderToTree(
 				ctx,
 				tree,
-				drv.Able,
+				d.able,
 				test.folder,
 				test.limiter,
 				counter)
@@ -1855,9 +1859,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 }
 
 func (suite *CollectionsTreeUnitSuite) TestCollections_MakeFolderCollectionPath() {
-	drv := drive()
+	d := drive()
 
-	basePath, err := odConsts.DriveFolderPrefixBuilder(drv.ID).
+	basePath, err := odConsts.DriveFolderPrefixBuilder(d.id).
 		ToDataLayerOneDrivePath(tenant, user, false)
 	require.NoError(suite.T(), err, clues.ToCore(err))
 
@@ -1878,7 +1882,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeFolderCollectionPath(
 		},
 		{
 			name:      "folder",
-			folder:    folderAtRoot(),
+			folder:    d.folderAtRoot(),
 			expect:    folderPath.String(),
 			expectErr: require.NoError,
 		},
@@ -1899,7 +1903,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeFolderCollectionPath(
 
 			p, err := c.makeFolderCollectionPath(
 				ctx,
-				drv.ID,
+				d.id,
 				custom.ToCustomDriveItem(test.folder))
 			test.expectErr(t, err, clues.ToCore(err))
 
@@ -1917,7 +1921,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeFolderCollectionPath(
 // this test focuses on folder assertions when enumerating a page of items
 // file-specific assertions are in the next test
 func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_files() {
-	drv := drive()
+	d := drive()
 
 	type expected struct {
 		counts                        countTD.Expected
@@ -1929,14 +1933,14 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 
 	table := []struct {
 		name   string
-		tree   func(t *testing.T) *folderyMcFolderFace
+		tree   func(t *testing.T, d *deltaDrive) *folderyMcFolderFace
 		page   nextPage
 		expect expected
 	}{
 		{
 			name: "one file at root",
 			tree: treeWithRoot,
-			page: aPage(fileAtRoot()),
+			page: aPage(d.fileAtRoot()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 0,
@@ -1955,9 +1959,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 			name: "many files in a hierarchy",
 			tree: treeWithRoot,
 			page: aPage(
-				fileAtRoot(),
-				folderAtRoot(),
-				fileAt(folder, "fchld")),
+				d.fileAtRoot(),
+				d.folderAtRoot(),
+				d.fileAt(folder, "fchld")),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 0,
@@ -1977,9 +1981,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 			name: "many updates to the same file",
 			tree: treeWithRoot,
 			page: aPage(
-				fileAtRoot(),
-				driveItem(fileID(), fileName(1), parentDir(), rootID, isFile),
-				driveItem(fileID(), fileName(2), parentDir(), rootID, isFile)),
+				d.fileAtRoot(),
+				driveItem(fileID(), fileName(1), d.dir(), rootID, isFile),
+				driveItem(fileID(), fileName(2), d.dir(), rootID, isFile)),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 0,
@@ -2032,7 +2036,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 			name: "create->delete",
 			tree: treeWithRoot,
 			page: aPage(
-				fileAtRoot(),
+				d.fileAtRoot(),
 				delItem(fileID(), rootID, isFile)),
 			expect: expected{
 				counts: countTD.Expected{
@@ -2050,8 +2054,8 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 			name: "move->delete",
 			tree: treeWithFileAtRoot,
 			page: aPage(
-				folderAtRoot(),
-				fileAt(folder),
+				d.folderAtRoot(),
+				d.fileAt(folder),
 				delItem(fileID(), folderID(), isFile)),
 			expect: expected{
 				counts: countTD.Expected{
@@ -2070,7 +2074,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 			tree: treeWithFileAtRoot,
 			page: aPage(
 				delItem(fileID(), rootID, isFile),
-				fileAtRoot()),
+				d.fileAtRoot()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 1,
@@ -2090,7 +2094,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 			tree: treeWithRoot,
 			page: aPage(
 				delItem(fileID(), rootID, isFile),
-				fileAtRoot()),
+				d.fileAtRoot()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 1,
@@ -2116,13 +2120,13 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 			var (
 				c       = collWithMBH(defaultOneDriveBH(user))
 				counter = count.New()
-				tree    = test.tree(t)
+				tree    = test.tree(t, d)
 			)
 
 			err := c.enumeratePageOfItems(
 				ctx,
 				tree,
-				drv.Able,
+				d.able,
 				test.page.Items,
 				newPagerLimiter(control.DefaultOptions()),
 				counter,
@@ -2139,7 +2143,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 }
 
 func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
-	drv := drive()
+	d := drive()
 
 	type expected struct {
 		counts                        countTD.Expected
@@ -2153,7 +2157,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 
 	table := []struct {
 		name    string
-		tree    func(t *testing.T) *folderyMcFolderFace
+		tree    func(t *testing.T, d *deltaDrive) *folderyMcFolderFace
 		file    models.DriveItemable
 		limiter *pagerLimiter
 		expect  expected
@@ -2161,7 +2165,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 		{
 			name:    "add new file",
 			tree:    treeWithRoot,
-			file:    fileAtRoot(),
+			file:    d.fileAtRoot(),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -2179,7 +2183,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 		{
 			name:    "duplicate file",
 			tree:    treeWithFileAtRoot,
-			file:    fileAtRoot(),
+			file:    d.fileAtRoot(),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -2197,7 +2201,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 		{
 			name:    "error file seen before parent",
 			tree:    treeWithRoot,
-			file:    fileAt(folder),
+			file:    d.fileAt(folder),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -2213,7 +2217,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 		{
 			name:    "malware file",
 			tree:    treeWithRoot,
-			file:    malwareItem(fileID(), fileName(), parentDir(folderName()), rootID, isFile),
+			file:    malwareItem(fileID(), fileName(), d.dir(folderName()), rootID, isFile),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -2261,7 +2265,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 		{
 			name:    "already at container file limit",
 			tree:    treeWithFileAtRoot,
-			file:    fileAtRoot(2),
+			file:    d.fileAtRoot(2),
 			limiter: newPagerLimiter(minimumLimitOpts()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -2280,7 +2284,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 		{
 			name:    "goes over total byte limit",
 			tree:    treeWithRoot,
-			file:    fileAtRoot(),
+			file:    d.fileAtRoot(),
 			limiter: newPagerLimiter(minimumLimitOpts()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -2305,13 +2309,13 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 			var (
 				c       = collWithMBH(defaultOneDriveBH(user))
 				counter = count.New()
-				tree    = test.tree(t)
+				tree    = test.tree(t, d)
 			)
 
 			skipped, err := c.addFileToTree(
 				ctx,
 				tree,
-				drv.Able,
+				d.able,
 				custom.ToCustomDriveItem(test.file),
 				test.limiter,
 				counter)

--- a/src/internal/m365/collection/drive/delta_tree.go
+++ b/src/internal/m365/collection/drive/delta_tree.go
@@ -309,6 +309,11 @@ func (face *folderyMcFolderFace) setPreviousPath(
 // file handling
 // ---------------------------------------------------------------------------
 
+func (face *folderyMcFolderFace) hasFile(id string) bool {
+	_, exists := face.fileIDToParentID[id]
+	return exists
+}
+
 // addFile places the file in the correct parent node.  If the
 // file was already added to the tree and is getting relocated,
 // this func will update and/or clean up all the old references.

--- a/src/internal/m365/collection/drive/delta_tree_test.go
+++ b/src/internal/m365/collection/drive/delta_tree_test.go
@@ -733,6 +733,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 	table := []struct {
 		tname       string
 		tree        func(t *testing.T, d *deltaDrive) *folderyMcFolderFace
+		id          string
 		oldParentID string
 		parentID    string
 		contentSize int64
@@ -742,6 +743,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 		{
 			tname:       "add file to root",
 			tree:        treeWithRoot,
+			id:          fileID(),
 			oldParentID: "",
 			parentID:    rootID,
 			contentSize: 42,
@@ -751,6 +753,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 		{
 			tname:       "add file to folder",
 			tree:        treeWithFolders,
+			id:          fileID(),
 			oldParentID: "",
 			parentID:    folderID(),
 			contentSize: 24,
@@ -760,6 +763,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 		{
 			tname:       "re-add file at the same location",
 			tree:        treeWithFileAtRoot,
+			id:          fileID(),
 			oldParentID: rootID,
 			parentID:    rootID,
 			contentSize: 84,
@@ -769,6 +773,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 		{
 			tname:       "move file from folder to root",
 			tree:        treeWithFileInFolder,
+			id:          fileID(),
 			oldParentID: folderID(),
 			parentID:    rootID,
 			contentSize: 48,
@@ -778,6 +783,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 		{
 			tname:       "move file from tombstone to root",
 			tree:        treeWithFileInTombstone,
+			id:          fileID(),
 			oldParentID: folderID(),
 			parentID:    rootID,
 			contentSize: 2,
@@ -785,8 +791,9 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			expectFiles: map[string]string{fileID(): rootID},
 		},
 		{
-			tname:       "error adding file to tombstone",
+			tname:       "adding file with no ID",
 			tree:        treeWithTombstone,
+			id:          "",
 			oldParentID: "",
 			parentID:    folderID(),
 			contentSize: 4,
@@ -794,17 +801,29 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			expectFiles: map[string]string{},
 		},
 		{
+			tname:       "error adding file to tombstone",
+			tree:        treeWithTombstone,
+			id:          fileID(),
+			oldParentID: "",
+			parentID:    folderID(),
+			contentSize: 8,
+			expectErr:   assert.Error,
+			expectFiles: map[string]string{},
+		},
+		{
 			tname:       "error adding file before parent",
 			tree:        treeWithTombstone,
+			id:          fileID(),
 			oldParentID: "",
 			parentID:    folderID("not-in-tree"),
-			contentSize: 8,
+			contentSize: 16,
 			expectErr:   assert.Error,
 			expectFiles: map[string]string{},
 		},
 		{
 			tname:       "error adding file without parent id",
 			tree:        treeWithTombstone,
+			id:          fileID(),
 			oldParentID: "",
 			parentID:    "",
 			contentSize: 16,
@@ -820,7 +839,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 
 			err := tree.addFile(
 				test.parentID,
-				fileID(),
+				test.id,
 				custom.ToCustomDriveItem(d.fileWSizeAt(test.contentSize, test.parentID)))
 			test.expectErr(t, err, clues.ToCore(err))
 			assert.Equal(t, test.expectFiles, tree.fileIDToParentID)

--- a/src/internal/m365/collection/drive/delta_tree_test.go
+++ b/src/internal/m365/collection/drive/delta_tree_test.go
@@ -67,7 +67,7 @@ func (suite *DeltaTreeUnitSuite) TestNewNodeyMcNodeFace() {
 func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 	table := []struct {
 		tname     string
-		tree      func(t *testing.T) *folderyMcFolderFace
+		tree      func(t *testing.T, d *deltaDrive) *folderyMcFolderFace
 		parentID  string
 		id        string
 		name      string
@@ -140,7 +140,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 		},
 		{
 			tname: "add folder before parent",
-			tree: func(t *testing.T) *folderyMcFolderFace {
+			tree: func(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
 				return &folderyMcFolderFace{
 					folderIDToNode: map[string]*nodeyMcNodeFace{},
 				}
@@ -167,7 +167,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			tree := test.tree(t)
+			tree := test.tree(t, drive())
 
 			err := tree.setFolder(
 				ctx,
@@ -202,7 +202,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddTombstone() {
 	table := []struct {
 		name      string
 		id        string
-		tree      func(t *testing.T) *folderyMcFolderFace
+		tree      func(t *testing.T, d *deltaDrive) *folderyMcFolderFace
 		expectErr assert.ErrorAssertionFunc
 	}{
 		{
@@ -236,7 +236,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddTombstone() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			tree := test.tree(t)
+			tree := test.tree(t, drive())
 
 			err := tree.setTombstone(ctx, test.id)
 			test.expectErr(t, err, clues.ToCore(err))
@@ -263,7 +263,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetPreviousPath() {
 		name            string
 		id              string
 		prev            path.Path
-		tree            func(t *testing.T) *folderyMcFolderFace
+		tree            func(t *testing.T, d *deltaDrive) *folderyMcFolderFace
 		expectErr       assert.ErrorAssertionFunc
 		expectLive      bool
 		expectTombstone bool
@@ -333,7 +333,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetPreviousPath() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
-			tree := test.tree(t)
+			tree := test.tree(t, drive())
 
 			err := tree.setPreviousPath(test.id, test.prev)
 			test.expectErr(t, err, clues.ToCore(err))
@@ -471,7 +471,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder_correctTree()
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	tree := treeWithRoot(t)
+	tree := treeWithRoot(t, drive())
 
 	set := func(
 		parentID, fid, fname string,
@@ -557,7 +557,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder_correctTombst
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	tree := treeWithRoot(t)
+	tree := treeWithRoot(t, drive())
 
 	set := func(
 		parentID, fid, fname string,
@@ -732,7 +732,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder_correctTombst
 func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 	table := []struct {
 		tname       string
-		tree        func(t *testing.T) *folderyMcFolderFace
+		tree        func(t *testing.T, d *deltaDrive) *folderyMcFolderFace
 		oldParentID string
 		parentID    string
 		contentSize int64
@@ -815,12 +815,13 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 	for _, test := range table {
 		suite.Run(test.tname, func() {
 			t := suite.T()
-			tree := test.tree(t)
+			d := drive()
+			tree := test.tree(t, d)
 
 			err := tree.addFile(
 				test.parentID,
 				fileID(),
-				custom.ToCustomDriveItem(fileWSizeAt(test.contentSize, test.parentID)))
+				custom.ToCustomDriveItem(d.fileWSizeAt(test.contentSize, test.parentID)))
 			test.expectErr(t, err, clues.ToCore(err))
 			assert.Equal(t, test.expectFiles, tree.fileIDToParentID)
 
@@ -850,7 +851,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_DeleteFile() {
 	table := []struct {
 		tname    string
-		tree     func(t *testing.T) *folderyMcFolderFace
+		tree     func(t *testing.T, d *deltaDrive) *folderyMcFolderFace
 		parentID string
 	}{
 		{
@@ -877,7 +878,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_DeleteFile() {
 	for _, test := range table {
 		suite.Run(test.tname, func() {
 			t := suite.T()
-			tree := test.tree(t)
+			tree := test.tree(t, drive())
 
 			tree.deleteFile(fileID())
 
@@ -893,7 +894,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_DeleteFile() {
 
 func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_addAndDeleteFile() {
 	t := suite.T()
-	tree := treeWithRoot(t)
+	d := drive()
+	tree := treeWithRoot(t, d)
 	fID := id(file)
 
 	require.Len(t, tree.fileIDToParentID, 0)
@@ -906,7 +908,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_addAndDeleteFile() {
 	assert.Len(t, tree.deletedFileIDs, 1)
 	assert.Contains(t, tree.deletedFileIDs, fID)
 
-	err := tree.addFile(rootID, fID, custom.ToCustomDriveItem(fileAtRoot()))
+	err := tree.addFile(rootID, fID, custom.ToCustomDriveItem(d.fileAtRoot()))
 	require.NoError(t, err, clues.ToCore(err))
 
 	assert.Len(t, tree.fileIDToParentID, 1)
@@ -925,7 +927,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_addAndDeleteFile() {
 func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateExcludeItemIDs() {
 	table := []struct {
 		name   string
-		tree   func(t *testing.T) *folderyMcFolderFace
+		tree   func(t *testing.T, d *deltaDrive) *folderyMcFolderFace
 		expect map[string]struct{}
 	}{
 		{
@@ -961,7 +963,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateExcludeItemIDs(
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
-			tree := test.tree(t)
+			tree := test.tree(t, drive())
 
 			result := tree.generateExcludeItemIDs()
 			assert.Equal(t, test.expect, result)
@@ -975,10 +977,11 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateExcludeItemIDs(
 
 func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() {
 	t := suite.T()
+	d := drive()
 
 	table := []struct {
 		name      string
-		tree      func(t *testing.T) *folderyMcFolderFace
+		tree      func(t *testing.T, d *deltaDrive) *folderyMcFolderFace
 		prevPaths map[string]string
 		expectErr require.ErrorAssertionFunc
 		expect    map[string]collectable
@@ -995,7 +998,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expectErr: require.NoError,
 			expect: map[string]collectable{
 				rootID: {
-					currPath:                  fullPathPath(t),
+					currPath:                  d.fullPath(t),
 					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
@@ -1009,9 +1012,9 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expectErr: require.NoError,
 			expect: map[string]collectable{
 				rootID: {
-					currPath: fullPathPath(t),
+					currPath: d.fullPath(t),
 					files: map[string]*custom.DriveItem{
-						fileID(): custom.ToCustomDriveItem(fileAtRoot()),
+						fileID(): custom.ToCustomDriveItem(d.fileAtRoot()),
 					},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
@@ -1025,23 +1028,23 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expectErr: require.NoError,
 			expect: map[string]collectable{
 				rootID: {
-					currPath:                  fullPathPath(t),
+					currPath:                  d.fullPath(t),
 					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{},
 				},
 				folderID("parent"): {
-					currPath:                  fullPathPath(t, folderName("parent")),
+					currPath:                  d.fullPath(t, folderName("parent")),
 					files:                     map[string]*custom.DriveItem{},
 					folderID:                  folderID("parent"),
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{rootName},
 				},
 				folderID(): {
-					currPath: fullPathPath(t, folderName("parent"), folderName()),
+					currPath: d.fullPath(t, folderName("parent"), folderName()),
 					files: map[string]*custom.DriveItem{
-						fileID(): custom.ToCustomDriveItem(fileAt("parent")),
+						fileID(): custom.ToCustomDriveItem(d.fileAt("parent")),
 					},
 					folderID:                  folderID(),
 					isPackageOrChildOfPackage: false,
@@ -1051,11 +1054,11 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 		},
 		{
 			name: "package in hierarchy",
-			tree: func(t *testing.T) *folderyMcFolderFace {
+			tree: func(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
 				ctx, flush := tester.NewContext(t)
 				defer flush()
 
-				tree := treeWithRoot(t)
+				tree := treeWithRoot(t, d)
 				err := tree.setFolder(ctx, rootID, id(pkg), name(pkg), true)
 				require.NoError(t, err, clues.ToCore(err))
 
@@ -1067,21 +1070,21 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expectErr: require.NoError,
 			expect: map[string]collectable{
 				rootID: {
-					currPath:                  fullPathPath(t),
+					currPath:                  d.fullPath(t),
 					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{},
 				},
 				id(pkg): {
-					currPath:                  fullPathPath(t, name(pkg)),
+					currPath:                  d.fullPath(t, name(pkg)),
 					files:                     map[string]*custom.DriveItem{},
 					folderID:                  id(pkg),
 					isPackageOrChildOfPackage: true,
 					loc:                       path.Elements{rootName},
 				},
 				folderID(): {
-					currPath:                  fullPathPath(t, name(pkg), folderName()),
+					currPath:                  d.fullPath(t, name(pkg), folderName()),
 					files:                     map[string]*custom.DriveItem{},
 					folderID:                  folderID(),
 					isPackageOrChildOfPackage: true,
@@ -1094,36 +1097,36 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			tree:      treeWithFileInFolder,
 			expectErr: require.NoError,
 			prevPaths: map[string]string{
-				rootID:             fullPath(),
-				folderID("parent"): fullPath(folderName("parent-prev")),
-				folderID():         fullPath(folderName("parent-prev"), folderName()),
+				rootID:             d.strPath(),
+				folderID("parent"): d.strPath(folderName("parent-prev")),
+				folderID():         d.strPath(folderName("parent-prev"), folderName()),
 			},
 			expect: map[string]collectable{
 				rootID: {
-					currPath:                  fullPathPath(t),
+					currPath:                  d.fullPath(t),
 					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{},
-					prevPath:                  fullPathPath(t),
+					prevPath:                  d.fullPath(t),
 				},
 				folderID("parent"): {
-					currPath:                  fullPathPath(t, folderName("parent")),
+					currPath:                  d.fullPath(t, folderName("parent")),
 					files:                     map[string]*custom.DriveItem{},
 					folderID:                  folderID("parent"),
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{rootName},
-					prevPath:                  fullPathPath(t, folderName("parent-prev")),
+					prevPath:                  d.fullPath(t, folderName("parent-prev")),
 				},
 				folderID(): {
-					currPath:                  fullPathPath(t, folderName("parent"), folderName()),
+					currPath:                  d.fullPath(t, folderName("parent"), folderName()),
 					folderID:                  folderID(),
 					isPackageOrChildOfPackage: false,
 					files: map[string]*custom.DriveItem{
-						fileID(): custom.ToCustomDriveItem(fileAt("parent")),
+						fileID(): custom.ToCustomDriveItem(d.fileAt("parent")),
 					},
 					loc:      path.Elements{rootName, folderName("parent")},
-					prevPath: fullPathPath(t, folderName("parent-prev"), folderName()),
+					prevPath: d.fullPath(t, folderName("parent-prev"), folderName()),
 				},
 			},
 		},
@@ -1131,24 +1134,24 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			name: "root and tombstones",
 			tree: treeWithFileInTombstone,
 			prevPaths: map[string]string{
-				rootID:     fullPath(),
-				folderID(): fullPath(folderName()),
+				rootID:     d.strPath(),
+				folderID(): d.strPath(folderName()),
 			},
 			expectErr: require.NoError,
 			expect: map[string]collectable{
 				rootID: {
-					currPath:                  fullPathPath(t),
+					currPath:                  d.fullPath(t),
 					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					loc:                       path.Elements{},
-					prevPath:                  fullPathPath(t),
+					prevPath:                  d.fullPath(t),
 				},
 				folderID(): {
 					files:                     map[string]*custom.DriveItem{},
 					folderID:                  folderID(),
 					isPackageOrChildOfPackage: false,
-					prevPath:                  fullPathPath(t, folderName()),
+					prevPath:                  d.fullPath(t, folderName()),
 				},
 			},
 		},
@@ -1156,7 +1159,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
-			tree := test.tree(t)
+			tree := test.tree(t, d)
 
 			if len(test.prevPaths) > 0 {
 				for id, ps := range test.prevPaths {

--- a/src/internal/m365/collection/drive/helper_test.go
+++ b/src/internal/m365/collection/drive/helper_test.go
@@ -1567,8 +1567,8 @@ func (dd *deltaDrive) fullPath(t *testing.T, elems ...string) path.Path {
 	return p
 }
 
-// produces a complete path prefix up to the drive root folder, and including any
-// elements passed in.
+// produces a complete path prefix up to the drive root folder with any
+// elements passed in appended to the generated prefix.
 func (dd *deltaDrive) dir(elems ...string) string {
 	return toPath(append(
 		[]string{odConsts.DriveFolderPrefixBuilder(dd.id).String()},

--- a/src/internal/m365/collection/drive/limiter_test.go
+++ b/src/internal/m365/collection/drive/limiter_test.go
@@ -36,7 +36,7 @@ type backupLimitTest struct {
 	expectedItemIDsInCollection map[string][]string
 }
 
-func backupLimitTable(drive1, drive2 *deltaDrive) []backupLimitTest {
+func backupLimitTable(d1, d2 *deltaDrive) []backupLimitTest {
 	return []backupLimitTest{
 		{
 			name: "OneDrive SinglePage ExcludeItemsOverMaxSize",
@@ -49,13 +49,13 @@ func backupLimitTable(drive1, drive2 *deltaDrive) []backupLimitTest {
 				MaxPages:             999,
 			},
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(aPage(
-						fileWSizeAtRoot(7, "f1"),
-						fileWSizeAtRoot(1, "f2"),
-						fileWSizeAtRoot(1, "f3"))))),
+						d1.fileWSizeAtRoot(7, "f1"),
+						d1.fileWSizeAtRoot(1, "f2"),
+						d1.fileWSizeAtRoot(1, "f3"))))),
 			expectedItemIDsInCollection: map[string][]string{
-				fullPath(): {fileID("f2"), fileID("f3")},
+				d1.strPath(): {fileID("f2"), fileID("f3")},
 			},
 		},
 		{
@@ -69,13 +69,13 @@ func backupLimitTable(drive1, drive2 *deltaDrive) []backupLimitTest {
 				MaxPages:             999,
 			},
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(aPage(
-						fileWSizeAtRoot(1, "f1"),
-						fileWSizeAtRoot(2, "f2"),
-						fileWSizeAtRoot(1, "f3"))))),
+						d1.fileWSizeAtRoot(1, "f1"),
+						d1.fileWSizeAtRoot(2, "f2"),
+						d1.fileWSizeAtRoot(1, "f3"))))),
 			expectedItemIDsInCollection: map[string][]string{
-				fullPath(): {fileID("f1"), fileID("f2")},
+				d1.strPath(): {fileID("f1"), fileID("f2")},
 			},
 		},
 		{
@@ -89,15 +89,15 @@ func backupLimitTable(drive1, drive2 *deltaDrive) []backupLimitTest {
 				MaxPages:             999,
 			},
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(aPage(
-						fileWSizeAtRoot(1, "f1"),
-						folderAtRoot(),
-						fileWSizeAt(2, folder, "f2"),
-						fileWSizeAt(1, folder, "f3"))))),
+						d1.fileWSizeAtRoot(1, "f1"),
+						d1.folderAtRoot(),
+						d1.fileWSizeAt(2, folder, "f2"),
+						d1.fileWSizeAt(1, folder, "f3"))))),
 			expectedItemIDsInCollection: map[string][]string{
-				fullPath():             {fileID("f1")},
-				fullPath(folderName()): {folderID(), fileID("f2")},
+				d1.strPath():             {fileID("f1")},
+				d1.strPath(folderName()): {folderID(), fileID("f2")},
 			},
 		},
 		{
@@ -111,16 +111,16 @@ func backupLimitTable(drive1, drive2 *deltaDrive) []backupLimitTest {
 				MaxPages:             999,
 			},
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(aPage(
-						fileAtRoot("f1"),
-						fileAtRoot("f2"),
-						fileAtRoot("f3"),
-						fileAtRoot("f4"),
-						fileAtRoot("f5"),
-						fileAtRoot("f6"))))),
+						d1.fileAtRoot("f1"),
+						d1.fileAtRoot("f2"),
+						d1.fileAtRoot("f3"),
+						d1.fileAtRoot("f4"),
+						d1.fileAtRoot("f5"),
+						d1.fileAtRoot("f6"))))),
 			expectedItemIDsInCollection: map[string][]string{
-				fullPath(): {fileID("f1"), fileID("f2"), fileID("f3")},
+				d1.strPath(): {fileID("f1"), fileID("f2"), fileID("f3")},
 			},
 		},
 		{
@@ -134,22 +134,22 @@ func backupLimitTable(drive1, drive2 *deltaDrive) []backupLimitTest {
 				MaxPages:             999,
 			},
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							fileAtRoot("f1"),
-							fileAtRoot("f2")),
+							d1.fileAtRoot("f1"),
+							d1.fileAtRoot("f2")),
 						aPage(
 							// Repeated items shouldn't count against the limit.
-							fileAtRoot("f1"),
-							folderAtRoot(),
-							fileAt(folder, "f3"),
-							fileAt(folder, "f4"),
-							fileAt(folder, "f5"),
-							fileAt(folder, "f6"))))),
+							d1.fileAtRoot("f1"),
+							d1.folderAtRoot(),
+							d1.fileAt(folder, "f3"),
+							d1.fileAt(folder, "f4"),
+							d1.fileAt(folder, "f5"),
+							d1.fileAt(folder, "f6"))))),
 			expectedItemIDsInCollection: map[string][]string{
-				fullPath():             {fileID("f1"), fileID("f2")},
-				fullPath(folderName()): {folderID(), fileID("f3")},
+				d1.strPath():             {fileID("f1"), fileID("f2")},
+				d1.strPath(folderName()): {folderID(), fileID("f3")},
 			},
 		},
 		{
@@ -163,19 +163,19 @@ func backupLimitTable(drive1, drive2 *deltaDrive) []backupLimitTest {
 				MaxPages:             1,
 			},
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							fileAtRoot("f1"),
-							fileAtRoot("f2")),
+							d1.fileAtRoot("f1"),
+							d1.fileAtRoot("f2")),
 						aPage(
-							folderAtRoot(),
-							fileAt(folder, "f3"),
-							fileAt(folder, "f4"),
-							fileAt(folder, "f5"),
-							fileAt(folder, "f6"))))),
+							d1.folderAtRoot(),
+							d1.fileAt(folder, "f3"),
+							d1.fileAt(folder, "f4"),
+							d1.fileAt(folder, "f5"),
+							d1.fileAt(folder, "f6"))))),
 			expectedItemIDsInCollection: map[string][]string{
-				fullPath(): {fileID("f1"), fileID("f2")},
+				d1.strPath(): {fileID("f1"), fileID("f2")},
 			},
 		},
 		{
@@ -189,21 +189,21 @@ func backupLimitTable(drive1, drive2 *deltaDrive) []backupLimitTest {
 				MaxPages:             999,
 			},
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							fileAtRoot("f1"),
-							fileAtRoot("f2"),
-							fileAtRoot("f3")),
+							d1.fileAtRoot("f1"),
+							d1.fileAtRoot("f2"),
+							d1.fileAtRoot("f3")),
 						aPage(
-							folderAtRoot(),
-							fileAt(folder, "f4"),
-							fileAt(folder, "f5"))))),
+							d1.folderAtRoot(),
+							d1.fileAt(folder, "f4"),
+							d1.fileAt(folder, "f5"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				// Root has an additional item. It's hard to fix that in the code
 				// though.
-				fullPath():             {fileID("f1"), fileID("f2")},
-				fullPath(folderName()): {folderID(), fileID("f4")},
+				d1.strPath():             {fileID("f1"), fileID("f2")},
+				d1.strPath(folderName()): {folderID(), fileID("f4")},
 			},
 		},
 		{
@@ -217,21 +217,21 @@ func backupLimitTable(drive1, drive2 *deltaDrive) []backupLimitTest {
 				MaxPages:             999,
 			},
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							folderAtRoot(),
-							fileAt(folder, "f1"),
-							fileAt(folder, "f2")),
+							d1.folderAtRoot(),
+							d1.fileAt(folder, "f1"),
+							d1.fileAt(folder, "f2")),
 						aPage(
-							folderAtRoot(),
+							d1.folderAtRoot(),
 							// Updated item that shouldn't count against the limit a second time.
-							fileAt(folder, "f2"),
-							fileAt(folder, "f3"),
-							fileAt(folder, "f4"))))),
+							d1.fileAt(folder, "f2"),
+							d1.fileAt(folder, "f3"),
+							d1.fileAt(folder, "f4"))))),
 			expectedItemIDsInCollection: map[string][]string{
-				fullPath():             {},
-				fullPath(folderName()): {folderID(), fileID("f1"), fileID("f2"), fileID("f3")},
+				d1.strPath():             {},
+				d1.strPath(folderName()): {folderID(), fileID("f1"), fileID("f2"), fileID("f3")},
 			},
 		},
 		{
@@ -245,22 +245,22 @@ func backupLimitTable(drive1, drive2 *deltaDrive) []backupLimitTest {
 				MaxPages:             999,
 			},
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							fileAtRoot("f1"),
-							fileAtRoot("f2"),
+							d1.fileAtRoot("f1"),
+							d1.fileAtRoot("f2"),
 							// Put folder 0 at limit.
-							folderAtRoot(),
-							fileAt(folder, "f3"),
-							fileAt(folder, "f4")),
+							d1.folderAtRoot(),
+							d1.fileAt(folder, "f3"),
+							d1.fileAt(folder, "f4")),
 						aPage(
-							folderAtRoot(),
+							d1.folderAtRoot(),
 							// Try to move item from root to folder 0 which is already at the limit.
-							fileAt(folder, "f1"))))),
+							d1.fileAt(folder, "f1"))))),
 			expectedItemIDsInCollection: map[string][]string{
-				fullPath():             {fileID("f1"), fileID("f2")},
-				fullPath(folderName()): {folderID(), fileID("f3"), fileID("f4")},
+				d1.strPath():             {fileID("f1"), fileID("f2")},
+				d1.strPath(folderName()): {folderID(), fileID("f3"), fileID("f4")},
 			},
 		},
 		{
@@ -274,21 +274,21 @@ func backupLimitTable(drive1, drive2 *deltaDrive) []backupLimitTest {
 				MaxPages:             999,
 			},
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							fileAtRoot("f1"),
-							fileAtRoot("f2"),
-							fileAtRoot("f3")),
+							d1.fileAtRoot("f1"),
+							d1.fileAtRoot("f2"),
+							d1.fileAtRoot("f3")),
 						aPage(
-							folderAtRoot(),
-							fileAt(folder, "f4")),
+							d1.folderAtRoot(),
+							d1.fileAt(folder, "f4")),
 						aPage(
-							folderAtRoot(),
-							fileAt(folder, "f5"))))),
+							d1.folderAtRoot(),
+							d1.fileAt(folder, "f5"))))),
 			expectedItemIDsInCollection: map[string][]string{
-				fullPath():             {fileID("f1"), fileID("f2"), fileID("f3")},
-				fullPath(folderName()): {folderID(), fileID("f4"), fileID("f5")},
+				d1.strPath():             {fileID("f1"), fileID("f2"), fileID("f3")},
+				d1.strPath(folderName()): {folderID(), fileID("f4"), fileID("f5")},
 			},
 		},
 		{
@@ -302,24 +302,24 @@ func backupLimitTable(drive1, drive2 *deltaDrive) []backupLimitTest {
 				MaxPages:             999,
 			},
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							fileAtRoot("f1"),
-							fileAtRoot("f2"),
-							fileAtRoot("f3")),
+							d1.fileAtRoot("f1"),
+							d1.fileAtRoot("f2"),
+							d1.fileAtRoot("f3")),
 						aPage(
-							folderAtRoot(),
-							fileAt(folder, "f4"),
-							fileAt(folder, "f5"),
+							d1.folderAtRoot(),
+							d1.fileAt(folder, "f4"),
+							d1.fileAt(folder, "f5"),
 							// This container shouldn't be returned.
-							folderAtRoot(2),
-							fileAt(2, "f7"),
-							fileAt(2, "f8"),
-							fileAt(2, "f9"))))),
+							d1.folderAtRoot(2),
+							d1.fileAt(2, "f7"),
+							d1.fileAt(2, "f8"),
+							d1.fileAt(2, "f9"))))),
 			expectedItemIDsInCollection: map[string][]string{
-				fullPath():             {fileID("f1"), fileID("f2"), fileID("f3")},
-				fullPath(folderName()): {folderID(), fileID("f4"), fileID("f5")},
+				d1.strPath():             {fileID("f1"), fileID("f2"), fileID("f3")},
+				d1.strPath(folderName()): {folderID(), fileID("f4"), fileID("f5")},
 			},
 		},
 		{
@@ -333,25 +333,25 @@ func backupLimitTable(drive1, drive2 *deltaDrive) []backupLimitTest {
 				MaxPages:             999,
 			},
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							fileAtRoot("f1"),
-							fileAtRoot("f2"),
-							fileAtRoot("f3")),
+							d1.fileAtRoot("f1"),
+							d1.fileAtRoot("f2"),
+							d1.fileAtRoot("f3")),
 						aPage(
-							folderAtRoot(),
-							fileAt(folder, "f4"),
-							fileAt(folder, "f5")),
+							d1.folderAtRoot(),
+							d1.fileAt(folder, "f4"),
+							d1.fileAt(folder, "f5")),
 						aPage(
 							// This container shouldn't be returned.
-							folderAtRoot(2),
-							fileAt(2, "f7"),
-							fileAt(2, "f8"),
-							fileAt(2, "f9"))))),
+							d1.folderAtRoot(2),
+							d1.fileAt(2, "f7"),
+							d1.fileAt(2, "f8"),
+							d1.fileAt(2, "f9"))))),
 			expectedItemIDsInCollection: map[string][]string{
-				fullPath():             {fileID("f1"), fileID("f2"), fileID("f3")},
-				fullPath(folderName()): {folderID(), fileID("f4"), fileID("f5")},
+				d1.strPath():             {fileID("f1"), fileID("f2"), fileID("f3")},
+				d1.strPath(folderName()): {folderID(), fileID("f4"), fileID("f5")},
 			},
 		},
 		{
@@ -365,23 +365,23 @@ func backupLimitTable(drive1, drive2 *deltaDrive) []backupLimitTest {
 				MaxPages:             999,
 			},
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(aPage(
-						fileAtRoot("f1"),
-						fileAtRoot("f2"),
-						fileAtRoot("f3"),
-						fileAtRoot("f4"),
-						fileAtRoot("f5")))),
-				drive2.newEnumer().with(
+						d1.fileAtRoot("f1"),
+						d1.fileAtRoot("f2"),
+						d1.fileAtRoot("f3"),
+						d1.fileAtRoot("f4"),
+						d1.fileAtRoot("f5")))),
+				d2.newEnumer().with(
 					delta(id(deltaURL), nil).with(aPage(
-						fileAtRoot("f1"),
-						fileAtRoot("f2"),
-						fileAtRoot("f3"),
-						fileAtRoot("f4"),
-						fileAtRoot("f5"))))),
+						d2.fileAtRoot("f1"),
+						d2.fileAtRoot("f2"),
+						d2.fileAtRoot("f3"),
+						d2.fileAtRoot("f4"),
+						d2.fileAtRoot("f5"))))),
 			expectedItemIDsInCollection: map[string][]string{
-				fullPath():       {fileID("f1"), fileID("f2"), fileID("f3")},
-				driveFullPath(2): {fileID("f1"), fileID("f2"), fileID("f3")},
+				d1.strPath(): {fileID("f1"), fileID("f2"), fileID("f3")},
+				d2.strPath(): {fileID("f1"), fileID("f2"), fileID("f3")},
 			},
 		},
 		{
@@ -394,21 +394,21 @@ func backupLimitTable(drive1, drive2 *deltaDrive) []backupLimitTest {
 				MaxPages:             1,
 			},
 			enumerator: driveEnumerator(
-				drive1.newEnumer().with(
+				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							fileAtRoot("f1"),
-							fileAtRoot("f2"),
-							fileAtRoot("f3")),
+							d1.fileAtRoot("f1"),
+							d1.fileAtRoot("f2"),
+							d1.fileAtRoot("f3")),
 						aPage(
-							folderAtRoot(),
-							fileAt(folder, "f4")),
+							d1.folderAtRoot(),
+							d1.fileAt(folder, "f4")),
 						aPage(
-							folderAtRoot(),
-							fileAt(folder, "f5"))))),
+							d1.folderAtRoot(),
+							d1.fileAt(folder, "f5"))))),
 			expectedItemIDsInCollection: map[string][]string{
-				fullPath():             {fileID("f1"), fileID("f2"), fileID("f3")},
-				fullPath(folderName()): {folderID(), fileID("f4"), fileID("f5")},
+				d1.strPath():             {fileID("f1"), fileID("f2"), fileID("f3")},
+				d1.strPath(folderName()): {folderID(), fileID("f4"), fileID("f5")},
 			},
 		},
 	}
@@ -525,7 +525,7 @@ func runGetPreviewLimits(
 			t,
 			test.expectedItemIDsInCollection[folderPath],
 			itemIDs,
-			"item IDs in collection with path %q",
+			"item IDs in collection with path:\n\t%q",
 			folderPath)
 	}
 
@@ -708,7 +708,7 @@ func runGetPreviewLimitsDefaults(
 		false)
 	require.NoError(t, err, "making metadata path", clues.ToCore(err))
 
-	drv := drive()
+	d := drive()
 	pages := make([]nextPage, 0, test.numContainers)
 
 	for containerIdx := 0; containerIdx < test.numContainers; containerIdx++ {
@@ -718,7 +718,7 @@ func runGetPreviewLimitsDefaults(
 				driveItem(
 					folderID(containerIdx),
 					folderName(containerIdx),
-					parentDir(),
+					d.dir(),
 					rootID,
 					isFolder),
 			},
@@ -730,7 +730,7 @@ func runGetPreviewLimitsDefaults(
 			page.Items = append(page.Items, driveItemWSize(
 				fileID(itemSuffix),
 				fileName(itemSuffix),
-				parentDir(folderName(containerIdx)),
+				d.dir(folderName(containerIdx)),
 				folderID(containerIdx),
 				test.itemSize,
 				isFile))
@@ -743,7 +743,7 @@ func runGetPreviewLimitsDefaults(
 
 	var (
 		mockEnumerator = driveEnumerator(
-			drv.newEnumer().with(
+			d.newEnumer().with(
 				delta(id(deltaURL), nil).with(pages...)))
 		mbh           = defaultDriveBHWith(user, mockEnumerator)
 		c             = collWithMBHAndOpts(mbh, opts)

--- a/src/internal/m365/collection/drive/url_cache_test.go
+++ b/src/internal/m365/collection/drive/url_cache_test.go
@@ -213,6 +213,8 @@ func TestURLCacheUnitSuite(t *testing.T) {
 }
 
 func (suite *URLCacheUnitSuite) TestGetItemProperties() {
+	d := drive()
+
 	aURL := func(n int) string {
 		return fmt.Sprintf("https://dummy%d.com", n)
 	}
@@ -228,7 +230,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		{
 			name: "single item in cache",
 			pages: []nextPage{
-				aPage(fileWURLAtRoot(aURL(1), false, 1)),
+				aPage(d.fileWURLAtRoot(aURL(1), false, 1)),
 			},
 			expectedItemProps: map[string]itemProps{
 				fileID(1): {
@@ -247,11 +249,11 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			name: "multiple items in cache",
 			pages: []nextPage{
 				aPage(
-					fileWURLAtRoot(aURL(1), false, 1),
-					fileWURLAtRoot(aURL(2), false, 2),
-					fileWURLAtRoot(aURL(3), false, 3),
-					fileWURLAtRoot(aURL(4), false, 4),
-					fileWURLAtRoot(aURL(5), false, 5)),
+					d.fileWURLAtRoot(aURL(1), false, 1),
+					d.fileWURLAtRoot(aURL(2), false, 2),
+					d.fileWURLAtRoot(aURL(3), false, 3),
+					d.fileWURLAtRoot(aURL(4), false, 4),
+					d.fileWURLAtRoot(aURL(5), false, 5)),
 			},
 			expectedItemProps: map[string]itemProps{
 				fileID(1): {
@@ -286,12 +288,12 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			name: "multiple pages",
 			pages: []nextPage{
 				aPage(
-					fileWURLAtRoot(aURL(1), false, 1),
-					fileWURLAtRoot(aURL(2), false, 2),
-					fileWURLAtRoot(aURL(3), false, 3)),
+					d.fileWURLAtRoot(aURL(1), false, 1),
+					d.fileWURLAtRoot(aURL(2), false, 2),
+					d.fileWURLAtRoot(aURL(3), false, 3)),
 				aPage(
-					fileWURLAtRoot(aURL(4), false, 4),
-					fileWURLAtRoot(aURL(5), false, 5)),
+					d.fileWURLAtRoot(aURL(4), false, 4),
+					d.fileWURLAtRoot(aURL(5), false, 5)),
 			},
 			expectedItemProps: map[string]itemProps{
 				fileID(1): {
@@ -326,19 +328,19 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			name: "multiple pages with resets",
 			pages: []nextPage{
 				aPage(
-					fileWURLAtRoot(aURL(-1), false, -1),
-					fileWURLAtRoot(aURL(1), false, 1),
-					fileWURLAtRoot(aURL(2), false, 2),
-					fileWURLAtRoot(aURL(3), false, 3)),
+					d.fileWURLAtRoot(aURL(-1), false, -1),
+					d.fileWURLAtRoot(aURL(1), false, 1),
+					d.fileWURLAtRoot(aURL(2), false, 2),
+					d.fileWURLAtRoot(aURL(3), false, 3)),
 				aReset(),
 				aPage(
-					fileWURLAtRoot(aURL(0), false, 0),
-					fileWURLAtRoot(aURL(1), false, 1),
-					fileWURLAtRoot(aURL(2), false, 2),
-					fileWURLAtRoot(aURL(3), false, 3)),
+					d.fileWURLAtRoot(aURL(0), false, 0),
+					d.fileWURLAtRoot(aURL(1), false, 1),
+					d.fileWURLAtRoot(aURL(2), false, 2),
+					d.fileWURLAtRoot(aURL(3), false, 3)),
 				aPage(
-					fileWURLAtRoot(aURL(4), false, 4),
-					fileWURLAtRoot(aURL(5), false, 5)),
+					d.fileWURLAtRoot(aURL(4), false, 4),
+					d.fileWURLAtRoot(aURL(5), false, 5)),
 			},
 			expectedItemProps: map[string]itemProps{
 				fileID(1): {
@@ -373,16 +375,16 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			name: "multiple pages with resets and combo reset+items in page",
 			pages: []nextPage{
 				aPage(
-					fileWURLAtRoot(aURL(1), false, 1),
-					fileWURLAtRoot(aURL(2), false, 2),
-					fileWURLAtRoot(aURL(3), false, 3)),
+					d.fileWURLAtRoot(aURL(1), false, 1),
+					d.fileWURLAtRoot(aURL(2), false, 2),
+					d.fileWURLAtRoot(aURL(3), false, 3)),
 				aPageWReset(
-					fileWURLAtRoot(aURL(1), false, 1),
-					fileWURLAtRoot(aURL(2), false, 2),
-					fileWURLAtRoot(aURL(3), false, 3)),
+					d.fileWURLAtRoot(aURL(1), false, 1),
+					d.fileWURLAtRoot(aURL(2), false, 2),
+					d.fileWURLAtRoot(aURL(3), false, 3)),
 				aPage(
-					fileWURLAtRoot(aURL(4), false, 4),
-					fileWURLAtRoot(aURL(5), false, 5)),
+					d.fileWURLAtRoot(aURL(4), false, 4),
+					d.fileWURLAtRoot(aURL(5), false, 5)),
 			},
 			expectedItemProps: map[string]itemProps{
 				fileID(1): {
@@ -417,11 +419,11 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			name: "duplicate items with potentially new urls",
 			pages: []nextPage{
 				aPage(
-					fileWURLAtRoot(aURL(1), false, 1),
-					fileWURLAtRoot(aURL(2), false, 2),
-					fileWURLAtRoot(aURL(3), false, 3),
-					fileWURLAtRoot(aURL(100), false, 1),
-					fileWURLAtRoot(aURL(200), false, 2)),
+					d.fileWURLAtRoot(aURL(1), false, 1),
+					d.fileWURLAtRoot(aURL(2), false, 2),
+					d.fileWURLAtRoot(aURL(3), false, 3),
+					d.fileWURLAtRoot(aURL(100), false, 1),
+					d.fileWURLAtRoot(aURL(200), false, 2)),
 			},
 			expectedItemProps: map[string]itemProps{
 				fileID(1): {
@@ -448,9 +450,9 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			name: "deleted items",
 			pages: []nextPage{
 				aPage(
-					fileWURLAtRoot(aURL(1), false, 1),
-					fileWURLAtRoot(aURL(2), false, 2),
-					fileWURLAtRoot(aURL(1), true, 1)),
+					d.fileWURLAtRoot(aURL(1), false, 1),
+					d.fileWURLAtRoot(aURL(2), false, 2),
+					d.fileWURLAtRoot(aURL(1), true, 1)),
 			},
 			expectedItemProps: map[string]itemProps{
 				fileID(1): {
@@ -472,7 +474,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 		{
 			name: "item not found in cache",
 			pages: []nextPage{
-				aPage(fileWURLAtRoot(aURL(1), false, 1)),
+				aPage(d.fileWURLAtRoot(aURL(1), false, 1)),
 			},
 			expectedItemProps: map[string]itemProps{
 				fileID(2): {},
@@ -505,8 +507,8 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			name: "folder item",
 			pages: []nextPage{
 				aPage(
-					fileWURLAtRoot(aURL(1), false, 1),
-					driveItem("2", "folder2", "root", "root", isFolder)),
+					d.fileWURLAtRoot(aURL(1), false, 1),
+					d.folderAtRoot(2)),
 			},
 			expectedItemProps: map[string]itemProps{
 				fileID(2): {},
@@ -540,7 +542,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 									with(test.pages...)))
 
 					cache, err := newURLCache(
-						drive.ID,
+						drive.id,
 						"",
 						1*time.Hour,
 						driveEnumer,
@@ -585,7 +587,7 @@ func (suite *URLCacheUnitSuite) TestNeedsRefresh() {
 	)
 
 	cache, err := newURLCache(
-		drv.ID,
+		drv.id,
 		"",
 		refreshInterval,
 		&enumerateDriveItemsDelta{},
@@ -631,7 +633,7 @@ func (suite *URLCacheUnitSuite) TestNewURLCache() {
 		},
 		{
 			name:       "invalid refresh interval",
-			driveID:    drv.ID,
+			driveID:    drv.id,
 			refreshInt: 100 * time.Millisecond,
 			itemPager:  &enumerateDriveItemsDelta{},
 			errors:     fault.New(true),
@@ -639,7 +641,7 @@ func (suite *URLCacheUnitSuite) TestNewURLCache() {
 		},
 		{
 			name:       "invalid item enumerator",
-			driveID:    drv.ID,
+			driveID:    drv.id,
 			refreshInt: 1 * time.Hour,
 			itemPager:  nil,
 			errors:     fault.New(true),
@@ -647,7 +649,7 @@ func (suite *URLCacheUnitSuite) TestNewURLCache() {
 		},
 		{
 			name:       "valid",
-			driveID:    drv.ID,
+			driveID:    drv.id,
 			refreshInt: 1 * time.Hour,
 			itemPager:  &enumerateDriveItemsDelta{},
 			errors:     fault.New(true),


### PR DESCRIPTION
this will ensure that the drive id is correct and consistent for each drive item, regardless of how the drive itself was composed. Minimizes the cognitive load on the test maintainer for which drive ID to use and where.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Supportability/Tests
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

* #4689

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
