### PR TITLE
Skip emails that cannot be retrieved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] (beta)
 
+### Fixed
+- Handle the case where an email cannot be retrieved from Exchange due to an `ErrorInvalidRecipients` error. In
+this case, Corso will skip over the item but report this in the backup summary.
+
 ## [v0.17.0] (beta) - 2023-12-11
 
 ### Changed

--- a/src/pkg/fault/item.go
+++ b/src/pkg/fault/item.go
@@ -14,6 +14,7 @@ const (
 type ItemType string
 
 const (
+	EmailType         ItemType = "email"
 	FileType          ItemType = "file"
 	ContainerType     ItemType = "container"
 	ResourceOwnerType ItemType = "resource_owner"
@@ -21,6 +22,8 @@ const (
 
 func (it ItemType) Printable() string {
 	switch it {
+	case EmailType:
+		return "Email"
 	case FileType:
 		return "File"
 	case ContainerType:

--- a/src/pkg/fault/skipped.go
+++ b/src/pkg/fault/skipped.go
@@ -32,6 +32,10 @@ const (
 	//nolint:lll
 	// https://support.microsoft.com/en-us/office/restrictions-and-limitations-in-onedrive-and-sharepoint-64883a5d-228e-48f5-b3d2-eb39e07630fa#onenotenotebooks
 	SkipOneNote skipCause = "inaccessible_one_note_file"
+
+	// SkipInvalidRecipients identifies that an email was skipped because Exchange
+	// believes it is not valid and fails any attempt to read it.
+	SkipInvalidRecipients skipCause = "invalid_recipients_email"
 )
 
 var _ print.Printable = &Skipped{}
@@ -99,6 +103,11 @@ func (s Skipped) Values(bool) []string {
 // ContainerSkip produces a Container-kind Item for tracking skipped items.
 func ContainerSkip(cause skipCause, namespace, id, name string, addtl map[string]any) *Skipped {
 	return itemSkip(ContainerType, cause, namespace, id, name, addtl)
+}
+
+// EmailSkip produces a Email-kind Item for tracking skipped items.
+func EmailSkip(cause skipCause, user, id string, addtl map[string]any) *Skipped {
+	return itemSkip(EmailType, cause, user, id, "", addtl)
 }
 
 // FileSkip produces a File-kind Item for tracking skipped items.

--- a/src/pkg/services/m365/api/graph/errors.go
+++ b/src/pkg/services/m365/api/graph/errors.go
@@ -43,6 +43,11 @@ const (
 	emailFolderNotFound      errorCode = "ErrorSyncFolderNotFound"
 	ErrorAccessDenied        errorCode = "ErrorAccessDenied"
 	errorItemNotFound        errorCode = "ErrorItemNotFound"
+	// This error occurs when an email is enumerated but retrieving it fails
+	// - we believe - due to it pre-dating mailbox creation. Possible explanations
+	// are mailbox creation racing with email receipt or a similar issue triggered
+	// due to on-prem->M365 mailbox migration.
+	ErrorInvalidRecipients errorCode = "ErrorInvalidRecipients"
 	// This error occurs when an attempt is made to create a folder that has
 	// the same name as another folder in the same parent. Such duplicate folder
 	// names are not allowed by graph.
@@ -199,6 +204,10 @@ func IsErrUserNotFound(err error) bool {
 	}
 
 	return false
+}
+
+func IsErrInvalidRecipients(err error) bool {
+	return hasErrorCode(err, ErrorInvalidRecipients)
 }
 
 func IsErrCannotOpenFileAttachment(err error) bool {

--- a/src/pkg/services/m365/api/graph/errors_test.go
+++ b/src/pkg/services/m365/api/graph/errors_test.go
@@ -203,6 +203,40 @@ func (suite *GraphErrorsUnitSuite) TestIsErrDeletedInFlight() {
 	}
 }
 
+func (suite *GraphErrorsUnitSuite) Test() {
+	table := []struct {
+		name   string
+		err    error
+		expect assert.BoolAssertionFunc
+	}{
+		{
+			name:   "nil",
+			err:    nil,
+			expect: assert.False,
+		},
+		{
+			name:   "non-matching",
+			err:    assert.AnError,
+			expect: assert.False,
+		},
+		{
+			name:   "non-matching oDataErr",
+			err:    graphTD.ODataErr("fnords"),
+			expect: assert.False,
+		},
+		{
+			name:   "invalid receipient oDataErr",
+			err:    graphTD.ODataErr(string(ErrorInvalidRecipients)),
+			expect: assert.True,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			test.expect(suite.T(), IsErrInvalidRecipients(test.err))
+		})
+	}
+}
+
 func (suite *GraphErrorsUnitSuite) TestIsErrInvalidDelta() {
 	table := []struct {
 		name   string


### PR DESCRIPTION
Adds a skip condition for emails that can be enumerated but are not returned from the server (Exchange) because
it believes they are corrupt/invalid.

This handles the `ErrorInvalidRecipients` condition we believe is hit when exchange finds an email that pre-dates
M365 mailbox creation (either a server corruption or triggered by on-prem->M365 migration)

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
