### PR TITLE
Add retries for posting item attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Handle the case where an email cannot be retrieved from Exchange due to an `ErrorInvalidRecipients` error. In
 this case, Corso will skip over the item but report this in the backup summary.
-- Fixed restore failure for items with attachments where the error was reported as `ErrorItemNotFound`.
+- Guarantee Exchange email restoration when restoring multiple attachments. Some previous restores were failing with `ErrorItemNotFound`.
 
 ## [v0.17.0] (beta) - 2023-12-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Handle the case where an email cannot be retrieved from Exchange due to an `ErrorInvalidRecipients` error. In
 this case, Corso will skip over the item but report this in the backup summary.
+- Fixed restore failure for items with attachments where the error was reported as `ErrorItemNotFound`.
 
 ## [v0.17.0] (beta) - 2023-12-11
 

--- a/src/pkg/services/m365/api/graph/errors.go
+++ b/src/pkg/services/m365/api/graph/errors.go
@@ -166,7 +166,7 @@ func IsErrDeletedInFlight(err error) bool {
 }
 
 func IsErrItemNotFound(err error) bool {
-	return hasErrorCode(err, itemNotFound)
+	return hasErrorCode(err, itemNotFound, errorItemNotFound)
 }
 
 func IsErrInvalidDelta(err error) bool {

--- a/src/pkg/services/m365/api/graph/errors_test.go
+++ b/src/pkg/services/m365/api/graph/errors_test.go
@@ -858,8 +858,13 @@ func (suite *GraphErrorsUnitSuite) TestIsErrItemNotFound() {
 			expect: assert.False,
 		},
 		{
-			name:   "item nott found oDataErr",
+			name:   "item not found oDataErr",
 			err:    graphTD.ODataErr(string(itemNotFound)),
+			expect: assert.True,
+		},
+		{
+			name:   "error item not found oDataErr",
+			err:    graphTD.ODataErr(string(errorItemNotFound)),
 			expect: assert.True,
 		},
 	}


### PR DESCRIPTION
Add exponential backoff and some retries when posting item attachments.

Manual testing was showing upwards of 50 retries in some cases when
~250-300 attachments total were being added. Of the retries, none
were at the max amount. However, all tests were for relatively small
datasets

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
