### PR TITLE
ensure creation of .dirmeta files

### DIFF
--- a/src/internal/m365/collection/drive/collections_test.go
+++ b/src/internal/m365/collection/drive/collections_test.go
@@ -62,7 +62,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "Invalid item",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveItem(id(item), name(item), d.dir(), rootID, -1),
 			},
 			previousPaths:    map[string]string{},
@@ -82,7 +82,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "Single File",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveFile(d.dir(), rootID),
 			},
 			previousPaths:    map[string]string{},
@@ -105,7 +105,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "Single Folder",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveFolder(d.dir(), rootID),
 			},
 			previousPaths:    map[string]string{},
@@ -128,7 +128,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "Single Folder created twice", // deleted a created with same name in between a backup
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveFolder(d.dir(), rootID),
 				driveItem(folderID(2), folderName(), d.dir(), rootID, isFolder),
 			},
@@ -152,7 +152,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "Single Package",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveItem(id(pkg), name(pkg), d.dir(), rootID, isPackage),
 			},
 			previousPaths:    map[string]string{},
@@ -178,7 +178,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "Single Package with subfolder",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveItem(id(pkg), name(pkg), d.dir(), rootID, isPackage),
 				driveItem(folderID(), folderName(), d.dir(name(pkg)), id(pkg), isFolder),
 				driveItem(id(subfolder), name(subfolder), d.dir(name(pkg)), id(pkg), isFolder),
@@ -210,7 +210,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "1 root file, 1 folder, 1 package, 2 files, 3 collections",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveFile(d.dir(), rootID, "inRoot"),
 				driveFolder(d.dir(), rootID),
 				driveItem(id(pkg), name(pkg), d.dir(), rootID, isPackage),
@@ -243,7 +243,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "contains folder selector",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveFile(d.dir(), rootID, "inRoot"),
 				driveFolder(d.dir(), rootID),
 				driveItem(id(subfolder), name(subfolder), d.dir(folderName()), folderID(), isFolder),
@@ -278,7 +278,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "prefix subfolder selector",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveFile(d.dir(), rootID, "inRoot"),
 				driveFolder(d.dir(), rootID),
 				driveItem(id(subfolder), name(subfolder), d.dir(folderName()), folderID(), isFolder),
@@ -311,7 +311,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "match subfolder selector",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveFile(d.dir(), rootID),
 				driveFolder(d.dir(), rootID),
 				driveItem(id(subfolder), name(subfolder), d.dir(folderName()), folderID(), isFolder),
@@ -340,7 +340,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "not moved folder tree",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveFolder(d.dir(), rootID),
 			},
 			previousPaths: map[string]string{
@@ -368,7 +368,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "moved folder tree",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveFolder(d.dir(), rootID),
 			},
 			previousPaths: map[string]string{
@@ -396,7 +396,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "moved folder tree twice within backup",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveItem(folderID(1), folderName(), d.dir(), rootID, isFolder),
 				driveItem(folderID(2), folderName(), d.dir(), rootID, isFolder),
 			},
@@ -425,7 +425,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "deleted folder tree twice within backup",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				delItem(folderID(), rootID, isFolder),
 				driveItem(folderID(), name(drivePfx), d.dir(), rootID, isFolder),
 				delItem(folderID(), rootID, isFolder),
@@ -454,7 +454,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "moved folder tree twice within backup including delete",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveFolder(d.dir(), rootID),
 				delItem(folderID(), rootID, isFolder),
 				driveItem(folderID(2), folderName(), d.dir(), rootID, isFolder),
@@ -484,7 +484,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "deleted folder tree twice within backup with addition",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveItem(folderID(1), folderName(), d.dir(), rootID, isFolder),
 				delItem(folderID(1), rootID, isFolder),
 				driveItem(folderID(2), folderName(), d.dir(), rootID, isFolder),
@@ -513,7 +513,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "moved folder tree with file no previous",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveFolder(d.dir(), rootID),
 				driveItem(fileID(), fileName(), d.dir(folderName()), folderID(), isFile),
 				driveItem(folderID(), folderName(2), d.dir(), rootID, isFolder),
@@ -539,7 +539,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "moved folder tree with file no previous 1",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveFolder(d.dir(), rootID),
 				driveItem(fileID(), fileName(), d.dir(folderName()), folderID(), isFile),
 			},
@@ -564,7 +564,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "moved folder tree and subfolder 1",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveFolder(d.dir(), rootID),
 				driveItem(id(subfolder), name(subfolder), d.dir(), rootID, isFolder),
 			},
@@ -594,7 +594,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "moved folder tree and subfolder 2",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveItem(id(subfolder), name(subfolder), d.dir(), rootID, isFolder),
 				driveFolder(d.dir(), rootID),
 			},
@@ -624,7 +624,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "move subfolder when moving parent",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveItem(folderID(2), folderName(2), d.dir(), rootID, isFolder),
 				driveItem(id(item), name(item), d.dir(folderName(2)), folderID(2), isFile),
 				// Need to see the parent folder first (expected since that's what Graph
@@ -662,7 +662,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "moved folder tree multiple times",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveFolder(d.dir(), rootID),
 				driveItem(fileID(), fileName(), d.dir(folderName()), folderID(), isFile),
 				driveItem(folderID(), folderName(2), d.dir(), rootID, isFolder),
@@ -692,7 +692,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "deleted folder and package",
 			items: []models.DriveItemable{
-				driveRootFolder(), // root is always present, but not necessary here
+				rootFolder(), // root is always present, but not necessary here
 				delItem(folderID(), rootID, isFolder),
 				delItem(id(pkg), rootID, isPackage),
 			},
@@ -721,7 +721,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "delete folder without previous",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				delItem(folderID(), rootID, isFolder),
 			},
 			previousPaths: map[string]string{
@@ -745,7 +745,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "delete folder tree move subfolder",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				delItem(folderID(), rootID, isFolder),
 				driveItem(id(subfolder), name(subfolder), d.dir(), rootID, isFolder),
 			},
@@ -775,7 +775,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "delete file",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				delItem(id(item), rootID, isFile),
 			},
 			previousPaths: map[string]string{
@@ -799,7 +799,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "item before parent errors",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveItem(fileID(), fileName(), d.dir(folderName()), folderID(), isFile),
 				driveFolder(d.dir(), rootID),
 			},
@@ -822,7 +822,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 		{
 			name: "1 root file, 1 folder, 1 package, 1 good file, 1 malware",
 			items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveItem(fileID(), fileID(), d.dir(), rootID, isFile),
 				driveFolder(d.dir(), rootID),
 				driveItem(id(pkg), name(pkg), d.dir(), rootID, isPackage),

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -458,6 +458,14 @@ func (c *Collections) enumeratePageOfItems(
 				return err
 			}
 
+			// special case: we only want to add a limited number of files
+			// to each collection.  But if one collection fills up, we don't
+			// want to break out of the whole backup.  That allows us to preview
+			// many folders with a small selection of files in each.
+			if errors.Is(err, errHitCollectionLimit) {
+				continue
+			}
+
 			el.AddRecoverable(ictx, clues.Wrap(err, "adding folder"))
 		}
 	}
@@ -630,22 +638,32 @@ func (c *Collections) addFileToTree(
 	if parentNotNil && !alreadySeen {
 		countSize := tree.countLiveFilesAndSizes()
 
-		// Don't add new items if the new collection has already reached it's limit.
-		// item moves and updates are generally allowed through.
-		if limiter.atContainerItemsLimit(len(parentNode.files)) || limiter.hitItemLimit(countSize.numFiles) {
+		// Tell the enumerator to exit if we've already hit the total
+		// limit of bytes or items in this backup.
+		if limiter.alreadyHitTotalBytesLimit(countSize.totalBytes) ||
+			limiter.hitItemLimit(countSize.numFiles) {
 			return nil, errHitLimit
 		}
 
-		// Skip large files that don't fit within the size limit.
-		// unlike the other checks, which see if we're already at the limit, this check
-		// needs to be forward-facing to ensure we don't go far over the limit.
+		// Don't add new items if the new collection has already reached it's limit.
+		// item moves and updates are generally allowed through.
+		if limiter.atContainerItemsLimit(len(parentNode.files)) {
+			return nil, errHitCollectionLimit
+		}
+
+		// Don't include large files that don't fit within the size limit.
+		// Unlike the other checks, which see if we're already at the limit,
+		// this check needs to be forward-facing to ensure we don't go far
+		// over the limit
 		// Example case: a 1gb limit and a 25gb file.
-		if limiter.hitTotalBytesLimit(fileSize + countSize.totalBytes) {
-			return nil, errHitLimit
+		if limiter.willStepOverBytesLimit(countSize.totalBytes, fileSize) {
+			// don't return errHitLimit here; we only want to skip the
+			// current file.  We may not want to skip files after it.
+			return nil, nil
 		}
 	}
 
-	err := tree.addFile(parentID, fileID, file)
+	err := tree.addFile(file)
 	if err != nil {
 		return nil, clues.StackWC(ctx, err)
 	}

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -480,18 +480,12 @@ func (c *Collections) addFolderToTree(
 		isDeleted   = folder.GetDeleted() != nil
 		isMalware   = folder.GetMalware() != nil
 		isPkg       = folder.GetPackageEscaped() != nil
-		parent      = folder.GetParentReference()
-		parentID    string
 		notSelected bool
 	)
 
 	// check container limits before adding the next new folder
 	if !tree.containsFolder(folderID) && limiter.hitContainerLimit(tree.countLiveFolders()) {
 		return nil, errHitLimit
-	}
-
-	if parent != nil {
-		parentID = ptr.Val(parent.GetId())
 	}
 
 	defer func() {
@@ -526,7 +520,7 @@ func (c *Collections) addFolderToTree(
 	}
 
 	if isDeleted {
-		err := tree.setTombstone(ctx, folderID)
+		err := tree.setTombstone(ctx, folder)
 		return nil, clues.Stack(err).OrNil()
 	}
 
@@ -542,7 +536,7 @@ func (c *Collections) addFolderToTree(
 		return nil, nil
 	}
 
-	err = tree.setFolder(ctx, parentID, folderID, folderName, isPkg)
+	err = tree.setFolder(ctx, folder)
 
 	return nil, clues.Stack(err).OrNil()
 }

--- a/src/internal/m365/collection/drive/collections_tree_test.go
+++ b/src/internal/m365/collection/drive/collections_tree_test.go
@@ -1941,7 +1941,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeFolderCollectionPath(
 	}{
 		{
 			name:      "root",
-			folder:    driveRootFolder(),
+			folder:    rootFolder(),
 			expect:    basePath.String(),
 			expectErr: require.NoError,
 		},

--- a/src/internal/m365/collection/drive/collections_tree_test.go
+++ b/src/internal/m365/collection/drive/collections_tree_test.go
@@ -278,7 +278,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 			enumerator: driveEnumerator(
 				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
-						aPage(d.folderAtRoot(), d.fileAt(folder))))),
+						aPage(
+							d.folderAt(root),
+							d.fileAt(folder))))),
 			prevPaths: map[string]string{},
 			expectCounts: countTD.Expected{
 				count.PrevPaths: 0,
@@ -290,7 +292,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 			enumerator: driveEnumerator(
 				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
-						aPage(d.folderAtRoot(), d.fileAt(folder))))),
+						aPage(
+							d.folderAt(root),
+							d.fileAt(folder))))),
 			prevPaths: map[string]string{
 				folderID(): d.strPath(t, folderName()),
 			},
@@ -333,7 +337,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aReset(),
-						aPage(d.folderAtRoot(), d.fileAt(folder))))),
+						aPage(
+							d.folderAt(root),
+							d.fileAt(folder))))),
 			prevPaths: map[string]string{},
 			expectCounts: countTD.Expected{
 				count.PrevPaths: 0,
@@ -346,7 +352,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aReset(),
-						aPage(d.folderAtRoot(), d.fileAt(folder))))),
+						aPage(
+							d.folderAt(root),
+							d.fileAt(folder))))),
 			prevPaths: map[string]string{
 				folderID(): d.strPath(t, folderName()),
 			},
@@ -503,13 +511,13 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 						aColl(
 							d.fullPath(t, folderName("parent"), folderName()),
 							nil,
-							fileID()))
+							fileID("f")))
 				},
 				globalExcludedFileIDs: makeExcludeMap(
 					fileID("r"),
 					fileID("p"),
 					fileID("d"),
-					fileID()),
+					fileID("f")),
 			},
 		},
 		{
@@ -547,14 +555,14 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 						aColl(
 							d.fullPath(t, folderName("parent"), folderName()),
 							d.fullPath(t, folderName("parent-prev"), folderName()),
-							fileID()),
+							fileID("f")),
 						aColl(nil, d.fullPath(t, folderName("tombstone-prev"))))
 				},
 				globalExcludedFileIDs: makeExcludeMap(
 					fileID("r"),
 					fileID("p"),
 					fileID("d"),
-					fileID()),
+					fileID("f")),
 			},
 		},
 		{
@@ -592,14 +600,14 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 						aColl(
 							d.fullPath(t, folderName("pa/rent"), folderName()),
 							d.fullPath(t, folderName("parent/prev"), folderName()),
-							fileID()),
+							fileID("f")),
 						aColl(nil, d.fullPath(t, folderName("tombstone/prev"))))
 				},
 				globalExcludedFileIDs: makeExcludeMap(
 					fileID("r"),
 					fileID("p"),
 					fileID("d"),
-					fileID()),
+					fileID("f")),
 			},
 		},
 		{
@@ -641,14 +649,14 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 						aColl(
 							d.fullPath(t, folderName("parent"), folderName()),
 							d.fullPath(t, folderName("parent"), folderName()),
-							fileID()),
+							fileID("f")),
 						aColl(nil, d.fullPath(t, folderName("tombstone"))))
 				},
 				globalExcludedFileIDs: makeExcludeMap(
 					fileID("r"),
 					fileID("p"),
 					fileID("d"),
-					fileID()),
+					fileID("f")),
 			},
 		},
 		{
@@ -691,14 +699,14 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 						aColl(
 							d.fullPath(t, folderName("pa/rent"), folderName()),
 							d.fullPath(t, folderName("pa/rent"), folderName()),
-							fileID()),
+							fileID("f")),
 						aColl(nil, d.fullPath(t, folderName("to/mbstone"))))
 				},
 				globalExcludedFileIDs: makeExcludeMap(
 					fileID("r"),
 					fileID("p"),
 					fileID("d"),
-					fileID()),
+					fileID("f")),
 			},
 		},
 	}
@@ -852,10 +860,10 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 			enumerator: driveEnumerator(
 				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
-						aPage(d.folderAtRoot()),
-						aPage(d.folderAtRoot("sib")),
+						aPage(d.folderAt(root)),
+						aPage(d.folderAt(root, "sib")),
 						aPage(
-							d.folderAtRoot(),
+							d.folderAt(root),
 							d.folderAt(folder, "chld"))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: populateTreeExpected{
@@ -885,13 +893,13 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d.folderAtRoot(),
+							d.folderAt(root),
 							d.fileAt(folder)),
 						aPage(
-							d.folderAtRoot("sib"),
+							d.folderAt(root, "sib"),
 							d.fileAt("sib", "fsib")),
 						aPage(
-							d.folderAtRoot(),
+							d.folderAt(root),
 							d.folderAt(folder, "chld"),
 							d.fileAt("chld", "fchld"))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
@@ -987,7 +995,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d.folderAtRoot(),
+							d.folderAt(root),
 							d.fileAt(folder)),
 						aPage(delItem(folderID(), rootID, isFolder))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
@@ -1020,7 +1028,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d.folderAtRoot("parent"),
+							d.folderAt(root, "parent"),
 							driveItem(folderID(), folderName("moved"), d.dir(), folderID("parent"), isFolder),
 							driveFile(d.dir(folderName("parent"), folderName()), folderID())),
 						aPage(delItem(folderID(), folderID("parent"), isFolder))))),
@@ -1056,7 +1064,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 					delta(id(deltaURL), nil).with(
 						aPage(delItem(folderID(), rootID, isFolder)),
 						aPage(
-							d.folderAtRoot(),
+							d.folderAt(root),
 							d.fileAt(folder))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: populateTreeExpected{
@@ -1088,7 +1096,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 					delta(id(deltaURL), nil).with(
 						aPage(delItem(folderID(), rootID, isFolder)),
 						aPage(
-							d.folderAtRoot(),
+							d.folderAt(root),
 							d.fileAt(folder))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: populateTreeExpected{
@@ -1119,13 +1127,13 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d.folderAtRoot(),
+							d.folderAt(root),
 							d.fileAt(folder)),
 						aPage(
-							d.folderAtRoot("sib"),
+							d.folderAt(root, "sib"),
 							d.fileAt("sib", "fsib")),
 						aPage(
-							d.folderAtRoot(),
+							d.folderAt(root),
 							d.folderAt(folder, "chld"),
 							d.fileAt("chld", "fchld"))))),
 			limiter: newPagerLimiter(minimumLimitOpts()),
@@ -1155,13 +1163,13 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d.folderAtRoot(),
+							d.folderAt(root),
 							d.fileAt(folder)),
 						aPage(
-							d.folderAtRoot("sib"),
+							d.folderAt(root, "sib"),
 							d.fileAt("sib", "fsib")),
 						aPage(
-							d.folderAtRoot(),
+							d.folderAt(root),
 							d.folderAt(folder, "chld"),
 							d.fileAt("chld", "fchld"))))),
 			limiter: newPagerLimiter(minimumLimitOpts()),
@@ -1206,15 +1214,15 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 				d.newEnumer().with(
 					delta(id(deltaURL), nil).
 						with(aPage(
-							d.folderAtRoot(),
+							d.folderAt(root),
 							d.fileAt(folder))),
 					delta(id(deltaURL), nil).
 						with(aPage(
-							d.folderAtRoot("sib"),
+							d.folderAt(root, "sib"),
 							d.fileAt("sib", "fsib"))),
 					delta(id(deltaURL), nil).
 						with(aPage(
-							d.folderAtRoot(),
+							d.folderAt(root),
 							d.folderAt(folder, "chld"),
 							d.fileAt("chld", "fchld"))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
@@ -1252,7 +1260,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d.folderAtRoot(),
+							d.folderAt(root),
 							d.fileAt(folder))),
 					// a (delete,create) pair in the same delta can occur when
 					// a user deletes and restores an item in-between deltas.
@@ -1261,7 +1269,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 							delItem(folderID(), rootID, isFolder),
 							delItem(fileID(), folderID(), isFile)),
 						aPage(
-							d.folderAtRoot(),
+							d.folderAt(root),
 							d.fileAt(folder))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: populateTreeExpected{
@@ -1292,7 +1300,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d.folderAtRoot(),
+							d.folderAt(root),
 							d.fileAt(folder))),
 					delta(id(deltaURL), nil).with(
 						aPage(
@@ -1330,7 +1338,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 					delta(id(deltaURL), nil).with(
 						// first page: create /root/folder and /root/folder/file
 						aPage(
-							d.folderAtRoot(),
+							d.folderAt(root),
 							d.fileAt(folder)),
 						// assume the user makes changes at this point:
 						// * create a new /root/folder
@@ -1512,9 +1520,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			name: "many folders in a hierarchy",
 			tree: treeWithRoot,
 			page: aPage(
-				d.folderAtRoot(),
-				d.folderAtRoot("sib"),
-				d.folderAt(folder, "chld")),
+				d.folderAt(root),
+				d.folderAt(folder, "chld"),
+				d.folderAt(root, "sib")),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1535,7 +1543,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			name: "create->delete",
 			tree: treeWithRoot,
 			page: aPage(
-				d.folderAtRoot(),
+				d.folderAt(root),
 				delItem(folderID(), rootID, isFolder)),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
@@ -1555,7 +1563,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			name: "move->delete",
 			tree: treeWithFolders,
 			page: aPage(
-				d.folderAtRoot("parent"),
+				d.folderAt(root, "parent"),
 				driveItem(folderID(), folderName("moved"), d.dir(folderName("parent")), folderID("parent"), isFolder),
 				delItem(folderID(), folderID("parent"), isFolder)),
 			limiter: newPagerLimiter(control.DefaultOptions()),
@@ -1580,7 +1588,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			tree: treeWithRoot,
 			page: aPage(
 				delItem(folderID(), rootID, isFolder),
-				d.folderAtRoot()),
+				d.folderAt(root)),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1601,7 +1609,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			tree: treeWithRoot,
 			page: aPage(
 				delItem(folderID(), rootID, isFolder),
-				d.folderAtRoot()),
+				d.folderAt(root)),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1666,7 +1674,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 	var (
 		d      = drive()
-		fld    = custom.ToCustomDriveItem(d.folderAtRoot())
+		fld    = custom.ToCustomDriveItem(d.folderAt(root))
 		subFld = custom.ToCustomDriveItem(driveFolder(d.dir(folderName("parent")), folderID("parent")))
 		pack   = custom.ToCustomDriveItem(driveItem(id(pkg), name(pkg), d.dir(), rootID, isPackage))
 		del    = custom.ToCustomDriveItem(delItem(folderID(), rootID, isFolder))
@@ -1947,7 +1955,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeFolderCollectionPath(
 		},
 		{
 			name:      "folder",
-			folder:    d.folderAtRoot(),
+			folder:    d.folderAt(root),
 			expect:    folderPath.String(),
 			expectErr: require.NoError,
 		},
@@ -2005,7 +2013,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 		{
 			name: "one file at root",
 			tree: treeWithRoot,
-			page: aPage(d.fileAtRoot()),
+			page: aPage(d.fileAt(root)),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 0,
@@ -2024,8 +2032,8 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 			name: "many files in a hierarchy",
 			tree: treeWithRoot,
 			page: aPage(
-				d.fileAtRoot(),
-				d.folderAtRoot(),
+				d.fileAt(root),
+				d.folderAt(root),
 				d.fileAt(folder, "fchld")),
 			expect: expected{
 				counts: countTD.Expected{
@@ -2046,7 +2054,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 			name: "many updates to the same file",
 			tree: treeWithRoot,
 			page: aPage(
-				d.fileAtRoot(),
+				d.fileAt(root),
 				driveItem(fileID(), fileName(1), d.dir(), rootID, isFile),
 				driveItem(fileID(), fileName(2), d.dir(), rootID, isFile)),
 			expect: expected{
@@ -2101,7 +2109,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 			name: "create->delete",
 			tree: treeWithRoot,
 			page: aPage(
-				d.fileAtRoot(),
+				d.fileAt(root),
 				delItem(fileID(), rootID, isFile)),
 			expect: expected{
 				counts: countTD.Expected{
@@ -2119,7 +2127,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 			name: "move->delete",
 			tree: treeWithFileAtRoot,
 			page: aPage(
-				d.folderAtRoot(),
+				d.folderAt(root),
 				d.fileAt(folder),
 				delItem(fileID(), folderID(), isFile)),
 			expect: expected{
@@ -2139,7 +2147,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 			tree: treeWithFileAtRoot,
 			page: aPage(
 				delItem(fileID(), rootID, isFile),
-				d.fileAtRoot()),
+				d.fileAt(root)),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 1,
@@ -2159,7 +2167,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 			tree: treeWithRoot,
 			page: aPage(
 				delItem(fileID(), rootID, isFile),
-				d.fileAtRoot()),
+				d.fileAt(root)),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 1,
@@ -2210,10 +2218,18 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 	d := drive()
 
+	unlimitedItemsPerContainer := newPagerLimiter(minimumLimitOpts())
+	unlimitedItemsPerContainer.limits.MaxItemsPerContainer = 9001
+
+	unlimitedTotalBytesAndFiles := newPagerLimiter(minimumLimitOpts())
+	unlimitedTotalBytesAndFiles.limits.MaxBytes = 9001
+	unlimitedTotalBytesAndFiles.limits.MaxItems = 9001
+
 	type expected struct {
 		counts                        countTD.Expected
 		err                           require.ErrorAssertionFunc
 		shouldHitLimit                bool
+		shouldHitCollLimit            bool
 		skipped                       assert.ValueAssertionFunc
 		treeContainsFileIDsWithParent map[string]string
 		countLiveFiles                int
@@ -2230,7 +2246,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 		{
 			name:    "add new file",
 			tree:    treeWithRoot,
-			file:    d.fileAtRoot(),
+			file:    d.fileAt(root),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -2248,7 +2264,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 		{
 			name:    "duplicate file",
 			tree:    treeWithFileAtRoot,
-			file:    d.fileAtRoot(),
+			file:    d.fileAt(root),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -2330,8 +2346,45 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 		{
 			name:    "already at container file limit",
 			tree:    treeWithFileAtRoot,
-			file:    d.fileAtRoot(2),
-			limiter: newPagerLimiter(minimumLimitOpts()),
+			file:    d.fileAt(root, 2),
+			limiter: unlimitedTotalBytesAndFiles,
+			expect: expected{
+				counts: countTD.Expected{
+					count.TotalFilesProcessed: 1,
+				},
+				err:                require.Error,
+				shouldHitCollLimit: true,
+				skipped:            assert.Nil,
+				treeContainsFileIDsWithParent: map[string]string{
+					fileID(): rootID,
+				},
+				countLiveFiles:  1,
+				countTotalBytes: defaultFileSize,
+			},
+		},
+		{
+			name:    "goes over total byte limit",
+			tree:    treeWithRoot,
+			file:    d.fileAt(root),
+			limiter: unlimitedItemsPerContainer,
+			expect: expected{
+				counts: countTD.Expected{
+					count.TotalFilesProcessed: 1,
+				},
+				// no error here, since byte limit shouldn't
+				// make the func return an error.
+				err:                           require.NoError,
+				skipped:                       assert.Nil,
+				treeContainsFileIDsWithParent: map[string]string{},
+				countLiveFiles:                0,
+				countTotalBytes:               0,
+			},
+		},
+		{
+			name:    "already over total byte limit",
+			tree:    treeWithFileAtRoot,
+			file:    d.fileAt(root, 2),
+			limiter: unlimitedItemsPerContainer,
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalFilesProcessed: 1,
@@ -2344,23 +2397,6 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 				},
 				countLiveFiles:  1,
 				countTotalBytes: defaultFileSize,
-			},
-		},
-		{
-			name:    "goes over total byte limit",
-			tree:    treeWithRoot,
-			file:    d.fileAtRoot(),
-			limiter: newPagerLimiter(minimumLimitOpts()),
-			expect: expected{
-				counts: countTD.Expected{
-					count.TotalFilesProcessed: 1,
-				},
-				err:                           require.Error,
-				shouldHitLimit:                true,
-				skipped:                       assert.Nil,
-				treeContainsFileIDsWithParent: map[string]string{},
-				countLiveFiles:                0,
-				countTotalBytes:               0,
 			},
 		},
 	}
@@ -2387,6 +2423,10 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 
 			test.expect.err(t, err, clues.ToCore(err))
 			test.expect.skipped(t, skipped)
+
+			if test.expect.shouldHitCollLimit {
+				require.ErrorIs(t, err, errHitCollectionLimit, clues.ToCore(err))
+			}
 
 			if test.expect.shouldHitLimit {
 				require.ErrorIs(t, err, errHitLimit, clues.ToCore(err))

--- a/src/internal/m365/collection/drive/delta_tree.go
+++ b/src/internal/m365/collection/drive/delta_tree.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/alcionai/clues"
+	"golang.org/x/exp/maps"
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive/metadata"
@@ -66,7 +67,7 @@ func newFolderyMcFolderFace(
 
 // reset erases all data contained in the tree.  This is intended for
 // tracking a delta enumeration reset, not for tree re-use, and will
-// cause the tree to flag itself as dirty in order to appropriately
+// cause the tree to flag itfolder as dirty in order to appropriately
 // post-process the data.
 func (face *folderyMcFolderFace) reset() {
 	face.hadReset = true
@@ -80,33 +81,29 @@ type nodeyMcNodeFace struct {
 	// required for mid-enumeration folder moves, else we have to walk
 	// the tree completely to remove the node from its old parent.
 	parent *nodeyMcNodeFace
-	// the microsoft item ID.  Mostly because we might as well
-	// attach that to the node if we're also attaching the dir.
-	id string
-	// single directory name, not a path
-	name string
+	// folder is the actual drive item for this directory.
+	// we save this so that, during post-processing, it can
+	// get moved into the collection files, which will cause
+	// the collection processor to generate a permissions
+	// metadata file for the folder.
+	folder *custom.DriveItem
 	// contains the complete previous path
 	prev path.Path
 	// folderID -> node
 	children map[string]*nodeyMcNodeFace
 	// file item ID -> file metadata
 	files map[string]*custom.DriveItem
-	// for special handling protocols around packages
-	isPackage bool
 }
 
 func newNodeyMcNodeFace(
 	parent *nodeyMcNodeFace,
-	id, name string,
-	isPackage bool,
+	folder *custom.DriveItem,
 ) *nodeyMcNodeFace {
 	return &nodeyMcNodeFace{
-		parent:    parent,
-		id:        id,
-		name:      name,
-		children:  map[string]*nodeyMcNodeFace{},
-		files:     map[string]*custom.DriveItem{},
-		isPackage: isPackage,
+		parent:   parent,
+		folder:   folder,
+		children: map[string]*nodeyMcNodeFace{},
+		files:    map[string]*custom.DriveItem{},
 	}
 }
 
@@ -136,9 +133,14 @@ func (face *folderyMcFolderFace) getNode(id string) *nodeyMcNodeFace {
 // values are updated to match (isPackage is assumed not to change).
 func (face *folderyMcFolderFace) setFolder(
 	ctx context.Context,
-	parentID, id, name string,
-	isPackage bool,
+	folder *custom.DriveItem,
 ) error {
+	var (
+		id           = ptr.Val(folder.GetId())
+		name         = ptr.Val(folder.GetName())
+		parentFolder = folder.GetParentReference()
+	)
+
 	// need to ensure we have the minimum requirements met for adding a node.
 	if len(id) == 0 {
 		return clues.NewWC(ctx, "missing folder ID")
@@ -148,16 +150,19 @@ func (face *folderyMcFolderFace) setFolder(
 		return clues.NewWC(ctx, "missing folder name")
 	}
 
-	if len(parentID) == 0 && id != face.rootID {
+	if parentFolder == nil && id != face.rootID {
 		return clues.NewWC(ctx, "non-root folder missing parent id")
 	}
 
 	// only set the root node once.
 	if id == face.rootID {
 		if face.root == nil {
-			root := newNodeyMcNodeFace(nil, id, name, isPackage)
+			root := newNodeyMcNodeFace(nil, folder)
 			face.root = root
 			face.folderIDToNode[id] = root
+		} else {
+			// but update the folder each time, to stay in sync with changes
+			face.root.folder = folder
 		}
 
 		return nil
@@ -169,7 +174,7 @@ func (face *folderyMcFolderFace) setFolder(
 	// 3. existing folder migrated to new location.
 	// 4. tombstoned folder restored.
 
-	parent, ok := face.folderIDToNode[parentID]
+	parentNode, ok := face.folderIDToNode[ptr.Val(parentFolder.GetId())]
 	if !ok {
 		return clues.NewWC(ctx, "folder added before parent")
 	}
@@ -186,9 +191,8 @@ func (face *folderyMcFolderFace) setFolder(
 	if zombey, tombstoned := face.tombstones[id]; tombstoned {
 		delete(face.tombstones, id)
 
-		zombey.parent = parent
-		zombey.name = name
-		parent.children[id] = zombey
+		zombey.parent = parentNode
+		parentNode.children[id] = zombey
 		face.folderIDToNode[id] = zombey
 
 		return nil
@@ -206,21 +210,21 @@ func (face *folderyMcFolderFace) setFolder(
 			// technically shouldn't be possible but better to keep the problem tracked
 			// just in case.
 			logger.Ctx(ctx).Info("non-root folder already exists with no parent ref")
-		} else if nodey.parent != parent {
+		} else if nodey.parent != parentNode {
 			// change type 3.  we need to ensure the old parent stops pointing to this node.
 			delete(nodey.parent.children, id)
 		}
 
-		nodey.name = name
-		nodey.parent = parent
+		nodey.parent = parentNode
+		nodey.folder = folder
 	} else {
 		// change type 1: new addition
-		nodey = newNodeyMcNodeFace(parent, id, name, isPackage)
+		nodey = newNodeyMcNodeFace(parentNode, folder)
 	}
 
 	// ensure the parent points to this node, and that the node is registered
 	// in the map of all nodes in the tree.
-	parent.children[id] = nodey
+	parentNode.children[id] = nodey
 	face.folderIDToNode[id] = nodey
 
 	return nil
@@ -228,8 +232,10 @@ func (face *folderyMcFolderFace) setFolder(
 
 func (face *folderyMcFolderFace) setTombstone(
 	ctx context.Context,
-	id string,
+	folder *custom.DriveItem,
 ) error {
+	id := ptr.Val(folder.GetId())
+
 	if len(id) == 0 {
 		return clues.NewWC(ctx, "missing tombstone folder ID")
 	}
@@ -256,7 +262,7 @@ func (face *folderyMcFolderFace) setTombstone(
 	}
 
 	if _, alreadyBuried := face.tombstones[id]; !alreadyBuried {
-		face.tombstones[id] = newNodeyMcNodeFace(nil, id, "", false)
+		face.tombstones[id] = newNodeyMcNodeFace(nil, folder)
 	}
 
 	return nil
@@ -300,7 +306,7 @@ func (face *folderyMcFolderFace) setPreviousPath(
 		return nil
 	}
 
-	zombey := newNodeyMcNodeFace(nil, folderID, "", false)
+	zombey := newNodeyMcNodeFace(nil, custom.NewDriveItem(folderID, ""))
 	zombey.prev = prev
 	face.tombstones[folderID] = zombey
 
@@ -423,8 +429,14 @@ func walkTreeAndBuildCollections(
 		return nil
 	}
 
+	var (
+		id        = ptr.Val(node.folder.GetId())
+		name      = ptr.Val(node.folder.GetName())
+		isPackage = node.folder.GetPackageEscaped() != nil
+	)
+
 	if !isRoot {
-		parentPath = parentPath.Append(node.name)
+		parentPath = parentPath.Append(name)
 	}
 
 	for _, child := range node.children {
@@ -432,7 +444,7 @@ func walkTreeAndBuildCollections(
 			child,
 			pathPfx,
 			parentPath,
-			node.isPackage || isChildOfPackage,
+			isPackage || isChildOfPackage,
 			false,
 			result)
 		if err != nil {
@@ -448,15 +460,21 @@ func walkTreeAndBuildCollections(
 				"path_suffix", parentPath.Elements())
 	}
 
+	// add the folder itself to the list of files inside the folder.
+	// that will cause the collection processor to generate a metadata
+	// file to hold the folder's permissions.
+	files := maps.Clone(node.files)
+	files[id] = node.folder
+
 	cbl := collectable{
 		currPath:                  collectionPath,
-		files:                     node.files,
-		folderID:                  node.id,
-		isPackageOrChildOfPackage: node.isPackage || isChildOfPackage,
+		files:                     files,
+		folderID:                  id,
+		isPackageOrChildOfPackage: isPackage || isChildOfPackage,
 		prevPath:                  node.prev,
 	}
 
-	result[node.id] = cbl
+	result[id] = cbl
 
 	return nil
 }

--- a/src/internal/m365/collection/drive/delta_tree.go
+++ b/src/internal/m365/collection/drive/delta_tree.go
@@ -67,7 +67,7 @@ func newFolderyMcFolderFace(
 
 // reset erases all data contained in the tree.  This is intended for
 // tracking a delta enumeration reset, not for tree re-use, and will
-// cause the tree to flag itfolder as dirty in order to appropriately
+// cause the tree to flag itself as dirty in order to appropriately
 // post-process the data.
 func (face *folderyMcFolderFace) reset() {
 	face.hadReset = true
@@ -192,6 +192,7 @@ func (face *folderyMcFolderFace) setFolder(
 		delete(face.tombstones, id)
 
 		zombey.parent = parentNode
+		zombey.folder = folder
 		parentNode.children[id] = zombey
 		face.folderIDToNode[id] = zombey
 

--- a/src/internal/m365/collection/drive/delta_tree_test.go
+++ b/src/internal/m365/collection/drive/delta_tree_test.go
@@ -49,7 +49,7 @@ func (suite *DeltaTreeUnitSuite) TestNewNodeyMcNodeFace() {
 		t      = suite.T()
 		parent = &nodeyMcNodeFace{}
 		d      = drive()
-		fld    = custom.ToCustomDriveItem(d.folderAtRoot())
+		fld    = custom.ToCustomDriveItem(d.folderAt(root))
 	)
 
 	nodeFace := newNodeyMcNodeFace(parent, fld)
@@ -97,7 +97,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 			tname: "add folder",
 			tree:  treeWithRoot,
 			folder: func() *custom.DriveItem {
-				return custom.ToCustomDriveItem(d.folderAtRoot())
+				return custom.ToCustomDriveItem(d.folderAt(root))
 			},
 			expectErr: assert.NoError,
 		},
@@ -113,7 +113,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 			tname: "missing ID",
 			tree:  treeWithRoot,
 			folder: func() *custom.DriveItem {
-				far := d.folderAtRoot()
+				far := d.folderAt(root)
 				far.SetId(nil)
 
 				return custom.ToCustomDriveItem(far)
@@ -124,7 +124,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 			tname: "missing name",
 			tree:  treeWithRoot,
 			folder: func() *custom.DriveItem {
-				far := d.folderAtRoot()
+				far := d.folderAt(root)
 				far.SetName(nil)
 
 				return custom.ToCustomDriveItem(far)
@@ -135,7 +135,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 			tname: "missing parent",
 			tree:  treeWithRoot,
 			folder: func() *custom.DriveItem {
-				far := d.folderAtRoot()
+				far := d.folderAt(root)
 				far.SetParentReference(nil)
 
 				return custom.ToCustomDriveItem(far)
@@ -146,7 +146,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 			tname: "already tombstoned",
 			tree:  treeWithTombstone,
 			folder: func() *custom.DriveItem {
-				return custom.ToCustomDriveItem(d.folderAtRoot())
+				return custom.ToCustomDriveItem(d.folderAt(root))
 			},
 			expectErr: assert.NoError,
 		},
@@ -154,7 +154,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 			tname: "add folder before parent",
 			tree:  newTree,
 			folder: func() *custom.DriveItem {
-				return custom.ToCustomDriveItem(d.folderAtRoot())
+				return custom.ToCustomDriveItem(d.folderAt(root))
 			},
 			expectErr: assert.Error,
 		},
@@ -162,7 +162,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 			tname: "folder already exists",
 			tree:  treeWithFolders,
 			folder: func() *custom.DriveItem {
-				return custom.ToCustomDriveItem(d.folderAtRoot())
+				return custom.ToCustomDriveItem(d.folderAt(root))
 			},
 			expectErr: assert.NoError,
 		},
@@ -509,7 +509,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder_correctTree()
 		var di models.DriveItemable
 
 		if parent == rootID {
-			di = d.folderAtRoot(self)
+			di = d.folderAt(root, self)
 		} else {
 			di = driveFolder(
 				d.dir("doesn't matter for this test"),
@@ -608,7 +608,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder_correctTombst
 		var di models.DriveItemable
 
 		if parent == rootID {
-			di = d.folderAtRoot(self)
+			di = d.folderAt(root, self)
 		} else {
 			di = driveFolder(
 				d.dir("doesn't matter for this test"),
@@ -779,7 +779,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 		tree        func(t *testing.T, d *deltaDrive) *folderyMcFolderFace
 		id          string
 		oldParentID string
-		parentID    string
+		parent      any
 		contentSize int64
 		expectErr   assert.ErrorAssertionFunc
 		expectFiles map[string]string
@@ -789,7 +789,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			tree:        treeWithRoot,
 			id:          fileID(),
 			oldParentID: "",
-			parentID:    rootID,
+			parent:      root,
 			contentSize: defaultFileSize,
 			expectErr:   assert.NoError,
 			expectFiles: map[string]string{fileID(): rootID},
@@ -799,7 +799,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			tree:        treeWithFolders,
 			id:          fileID(),
 			oldParentID: "",
-			parentID:    folderID(),
+			parent:      folder,
 			contentSize: 24,
 			expectErr:   assert.NoError,
 			expectFiles: map[string]string{fileID(): folderID()},
@@ -809,7 +809,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			tree:        treeWithFileAtRoot,
 			id:          fileID(),
 			oldParentID: rootID,
-			parentID:    rootID,
+			parent:      root,
 			contentSize: 84,
 			expectErr:   assert.NoError,
 			expectFiles: map[string]string{fileID(): rootID},
@@ -819,7 +819,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			tree:        treeWithFileInFolder,
 			id:          fileID(),
 			oldParentID: folderID(),
-			parentID:    rootID,
+			parent:      root,
 			contentSize: 48,
 			expectErr:   assert.NoError,
 			expectFiles: map[string]string{fileID(): rootID},
@@ -829,7 +829,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			tree:        treeWithFileInTombstone,
 			id:          fileID(),
 			oldParentID: folderID(),
-			parentID:    rootID,
+			parent:      root,
 			contentSize: 2,
 			expectErr:   assert.NoError,
 			expectFiles: map[string]string{fileID(): rootID},
@@ -839,7 +839,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			tree:        treeWithTombstone,
 			id:          "",
 			oldParentID: "",
-			parentID:    folderID(),
+			parent:      folder,
 			contentSize: 4,
 			expectErr:   assert.Error,
 			expectFiles: map[string]string{},
@@ -849,7 +849,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			tree:        treeWithTombstone,
 			id:          fileID(),
 			oldParentID: "",
-			parentID:    folderID(),
+			parent:      folder,
 			contentSize: 8,
 			expectErr:   assert.Error,
 			expectFiles: map[string]string{},
@@ -859,7 +859,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			tree:        treeWithTombstone,
 			id:          fileID(),
 			oldParentID: "",
-			parentID:    folderID("not-in-tree"),
+			parent:      "not-in-tree",
 			contentSize: 16,
 			expectErr:   assert.Error,
 			expectFiles: map[string]string{},
@@ -869,7 +869,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			tree:        treeWithTombstone,
 			id:          fileID(),
 			oldParentID: "",
-			parentID:    "",
+			parent:      nil,
 			contentSize: 16,
 			expectErr:   assert.Error,
 			expectFiles: map[string]string{},
@@ -877,14 +877,14 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 	}
 	for _, test := range table {
 		suite.Run(test.tname, func() {
-			t := suite.T()
-			d := drive()
-			tree := test.tree(t, d)
+			var (
+				t    = suite.T()
+				d    = drive()
+				tree = test.tree(t, d)
+				df   = custom.ToCustomDriveItem(d.fileWSizeAt(test.contentSize, test.parent))
+			)
 
-			err := tree.addFile(
-				test.parentID,
-				test.id,
-				custom.ToCustomDriveItem(d.fileWSizeAt(test.contentSize, test.parentID)))
+			err := tree.addFile(df)
 			test.expectErr(t, err, clues.ToCore(err))
 			assert.Equal(t, test.expectFiles, tree.fileIDToParentID)
 
@@ -892,7 +892,12 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 				return
 			}
 
-			parent := tree.getNode(test.parentID)
+			parentID := folderID(test.parent)
+			if test.parent == root {
+				parentID = rootID
+			}
+
+			parent := tree.getNode(parentID)
 
 			require.NotNil(t, parent)
 			assert.Contains(t, parent.files, fileID())
@@ -901,7 +906,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			assert.Equal(t, 1, countSize.numFiles, "should have one file in the tree")
 			assert.Equal(t, test.contentSize, countSize.totalBytes, "tree should be sized to test file contents")
 
-			if len(test.oldParentID) > 0 && test.oldParentID != test.parentID {
+			if len(test.oldParentID) > 0 && test.oldParentID != parentID {
 				old := tree.getNode(test.oldParentID)
 
 				require.NotNil(t, old)
@@ -956,10 +961,12 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_DeleteFile() {
 }
 
 func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_addAndDeleteFile() {
-	t := suite.T()
-	d := drive()
-	tree := treeWithRoot(t, d)
-	fID := id(file)
+	var (
+		t    = suite.T()
+		d    = drive()
+		tree = treeWithRoot(t, d)
+		fID  = fileID()
+	)
 
 	require.Len(t, tree.fileIDToParentID, 0)
 	require.Len(t, tree.deletedFileIDs, 0)
@@ -971,7 +978,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_addAndDeleteFile() {
 	assert.Len(t, tree.deletedFileIDs, 1)
 	assert.Contains(t, tree.deletedFileIDs, fID)
 
-	err := tree.addFile(rootID, fID, custom.ToCustomDriveItem(d.fileAtRoot()))
+	err := tree.addFile(custom.ToCustomDriveItem(d.fileAt(root)))
 	require.NoError(t, err, clues.ToCore(err))
 
 	assert.Len(t, tree.fileIDToParentID, 1)
@@ -1017,9 +1024,9 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateExcludeItemIDs(
 			name: "files in folders and tombstones",
 			tree: fullTree,
 			expect: makeExcludeMap(
-				fileID(),
 				fileID("r"),
 				fileID("p"),
+				fileID("f"),
 				fileID("d")),
 		},
 	}
@@ -1061,10 +1068,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expectErr: require.NoError,
 			expect: map[string]collectable{
 				rootID: {
-					currPath: d.fullPath(t),
-					files: map[string]*custom.DriveItem{
-						rootID: custom.ToCustomDriveItem(rootFolder()),
-					},
+					currPath:                  d.fullPath(t),
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 				},
@@ -1078,8 +1083,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 				rootID: {
 					currPath: d.fullPath(t),
 					files: map[string]*custom.DriveItem{
-						rootID:   custom.ToCustomDriveItem(rootFolder()),
-						fileID(): custom.ToCustomDriveItem(d.fileAtRoot()),
+						fileID(): custom.ToCustomDriveItem(d.fileAt(root)),
 					},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
@@ -1092,17 +1096,15 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expectErr: require.NoError,
 			expect: map[string]collectable{
 				rootID: {
-					currPath: d.fullPath(t),
-					files: map[string]*custom.DriveItem{
-						rootID: custom.ToCustomDriveItem(rootFolder()),
-					},
+					currPath:                  d.fullPath(t),
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 				},
 				folderID("parent"): {
 					currPath: d.fullPath(t, folderName("parent")),
 					files: map[string]*custom.DriveItem{
-						folderID("parent"): custom.ToCustomDriveItem(d.folderAtRoot()),
+						folderID("parent"): custom.ToCustomDriveItem(d.folderAt(root)),
 					},
 					folderID:                  folderID("parent"),
 					isPackageOrChildOfPackage: false,
@@ -1111,7 +1113,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 					currPath: d.fullPath(t, folderName("parent"), folderName()),
 					files: map[string]*custom.DriveItem{
 						folderID(): custom.ToCustomDriveItem(d.folderAt("parent")),
-						fileID():   custom.ToCustomDriveItem(d.fileAt("parent")),
+						fileID():   custom.ToCustomDriveItem(d.fileAt(folder)),
 					},
 					folderID:                  folderID(),
 					isPackageOrChildOfPackage: false,
@@ -1136,10 +1138,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expectErr: require.NoError,
 			expect: map[string]collectable{
 				rootID: {
-					currPath: d.fullPath(t),
-					files: map[string]*custom.DriveItem{
-						rootID: custom.ToCustomDriveItem(rootFolder()),
-					},
+					currPath:                  d.fullPath(t),
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 				},
@@ -1172,10 +1172,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			},
 			expect: map[string]collectable{
 				rootID: {
-					currPath: d.fullPath(t),
-					files: map[string]*custom.DriveItem{
-						rootID: custom.ToCustomDriveItem(rootFolder()),
-					},
+					currPath:                  d.fullPath(t),
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					prevPath:                  d.fullPath(t),
@@ -1183,7 +1181,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 				folderID("parent"): {
 					currPath: d.fullPath(t, folderName("parent")),
 					files: map[string]*custom.DriveItem{
-						folderID("parent"): custom.ToCustomDriveItem(d.folderAtRoot()),
+						folderID("parent"): custom.ToCustomDriveItem(d.folderAt(root)),
 					},
 					folderID:                  folderID("parent"),
 					isPackageOrChildOfPackage: false,
@@ -1195,7 +1193,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 					isPackageOrChildOfPackage: false,
 					files: map[string]*custom.DriveItem{
 						folderID(): custom.ToCustomDriveItem(d.folderAt("parent")),
-						fileID():   custom.ToCustomDriveItem(d.fileAt("parent")),
+						fileID():   custom.ToCustomDriveItem(d.fileAt(folder)),
 					},
 					prevPath: d.fullPath(t, folderName("parent-prev"), folderName()),
 				},
@@ -1211,10 +1209,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expectErr: require.NoError,
 			expect: map[string]collectable{
 				rootID: {
-					currPath: d.fullPath(t),
-					files: map[string]*custom.DriveItem{
-						rootID: custom.ToCustomDriveItem(rootFolder()),
-					},
+					currPath:                  d.fullPath(t),
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					prevPath:                  d.fullPath(t),

--- a/src/internal/m365/collection/drive/delta_tree_test.go
+++ b/src/internal/m365/collection/drive/delta_tree_test.go
@@ -105,13 +105,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 			tname: "add package",
 			tree:  treeWithRoot,
 			folder: func() *custom.DriveItem {
-				return custom.ToCustomDriveItem(
-					driveItem(
-						folderID(pkg),
-						folderName(pkg),
-						d.dir(),
-						rootID,
-						isPackage))
+				return custom.ToCustomDriveItem(d.packageAtRoot())
 			},
 			expectErr: assert.NoError,
 		},
@@ -138,7 +132,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 			expectErr: assert.Error,
 		},
 		{
-			tname: "missing parentID",
+			tname: "missing parent",
 			tree:  treeWithRoot,
 			folder: func() *custom.DriveItem {
 				far := d.folderAtRoot()
@@ -197,9 +191,9 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 				expectID        = ptr.Val(folder.GetId())
 				expectName      = ptr.Val(folder.GetName())
 				expectIsPackage = folder.GetPackageEscaped() == nil
-				resultID        = ptr.Val(folder.GetId())
-				resultName      = ptr.Val(folder.GetName())
-				resultIsPackage = folder.GetPackageEscaped() == nil
+				resultID        = ptr.Val(result.folder.GetId())
+				resultName      = ptr.Val(result.folder.GetName())
+				resultIsPackage = result.folder.GetPackageEscaped() == nil
 			)
 
 			assert.Equal(t, expectID, resultID)
@@ -403,7 +397,7 @@ func (an assertNode) compare(
 ) {
 	var nodeCount int
 
-	t.Run("assert_tree_shape/root", func(_t *testing.T) {
+	t.Run("assert_tree_shape-root", func(_t *testing.T) {
 		nodeCount = compareNodes(_t, tree.root, an)
 	})
 
@@ -485,7 +479,7 @@ func (ts tombs) compare(
 
 		resultID := ptr.Val(zombey.folder.GetId())
 
-		t.Run("assert_tombstones/"+resultID, func(_t *testing.T) {
+		t.Run("assert_tombstones-"+resultID, func(_t *testing.T) {
 			compareNodes(_t, zombey, entombed)
 		})
 	}

--- a/src/internal/m365/collection/drive/limiter.go
+++ b/src/internal/m365/collection/drive/limiter.go
@@ -6,7 +6,10 @@ import (
 	"github.com/alcionai/corso/src/pkg/control"
 )
 
-var errHitLimit = clues.New("hit limiter limits")
+var (
+	errHitLimit           = clues.New("hit limiter limits")
+	errHitCollectionLimit = clues.New("hit item limits within the current collection")
+)
 
 type driveEnumerationStats struct {
 	numPages      int
@@ -111,9 +114,22 @@ func (l pagerLimiter) hitItemLimit(itemCount int) bool {
 	return l.enabled() && itemCount >= l.limits.MaxItems
 }
 
-// hitTotalBytesLimit returns true if the limiter is enabled and has reached the limit
+// alreadyHitTotalBytesLimit returns true if the limiter is enabled and has reached the limit
 // for the accumulated byte size of all items (the file contents, not the item metadata)
 // added to collections for this backup.
-func (l pagerLimiter) hitTotalBytesLimit(i int64) bool {
-	return l.enabled() && i >= l.limits.MaxBytes
+func (l pagerLimiter) alreadyHitTotalBytesLimit(i int64) bool {
+	return l.enabled() && i > l.limits.MaxBytes
+}
+
+// willStepOverBytesLimit returns true if the limiter is enabled and the provided addition
+// of bytes is greater than the limit plus some padding (to ensure we can always hit
+// the limit).
+func (l pagerLimiter) willStepOverBytesLimit(current, addition int64) bool {
+	if !l.enabled() {
+		return false
+	}
+
+	limitPlusPadding := int64(float64(l.limits.MaxBytes) * 1.03)
+
+	return (current + addition) > limitPlusPadding
 }

--- a/src/internal/m365/collection/drive/limiter_test.go
+++ b/src/internal/m365/collection/drive/limiter_test.go
@@ -34,6 +34,11 @@ type backupLimitTest struct {
 	// Collection name -> set of item IDs. We can't check item data because
 	// that's not mocked out. Metadata is checked separately.
 	expectedItemIDsInCollection map[string][]string
+	// Collection name -> set of item IDs. We can't check item data because
+	// that's not mocked out. Metadata is checked separately.
+	// the tree version has some different (more accurate) expectations
+	// for success
+	expectedItemIDsInCollectionTree map[string][]string
 }
 
 func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
@@ -50,10 +55,11 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 			},
 			enumerator: driveEnumerator(
 				d1.newEnumer().with(
-					delta(id(deltaURL), nil).with(aPage(
-						d1.fileWSizeAtRoot(7, "f1"),
-						d1.fileWSizeAtRoot(1, "f2"),
-						d1.fileWSizeAtRoot(1, "f3"))))),
+					delta(id(deltaURL), nil).with(
+						aPage(
+							d1.fileWSizeAt(7, root, "f1"),
+							d1.fileWSizeAt(1, root, "f2"),
+							d1.fileWSizeAt(1, root, "f3"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t): {fileID("f2"), fileID("f3")},
 			},
@@ -70,10 +76,11 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 			},
 			enumerator: driveEnumerator(
 				d1.newEnumer().with(
-					delta(id(deltaURL), nil).with(aPage(
-						d1.fileWSizeAtRoot(1, "f1"),
-						d1.fileWSizeAtRoot(2, "f2"),
-						d1.fileWSizeAtRoot(1, "f3"))))),
+					delta(id(deltaURL), nil).with(
+						aPage(
+							d1.fileWSizeAt(1, root, "f1"),
+							d1.fileWSizeAt(2, root, "f2"),
+							d1.fileWSizeAt(1, root, "f3"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t): {fileID("f1"), fileID("f2")},
 			},
@@ -90,11 +97,12 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 			},
 			enumerator: driveEnumerator(
 				d1.newEnumer().with(
-					delta(id(deltaURL), nil).with(aPage(
-						d1.fileWSizeAtRoot(1, "f1"),
-						d1.folderAtRoot(),
-						d1.fileWSizeAt(2, folder, "f2"),
-						d1.fileWSizeAt(1, folder, "f3"))))),
+					delta(id(deltaURL), nil).with(
+						aPage(
+							d1.fileWSizeAt(1, root, "f1"),
+							d1.folderAt(root),
+							d1.fileWSizeAt(2, folder, "f2"),
+							d1.fileWSizeAt(1, folder, "f3"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t):               {fileID("f1")},
 				d1.strPath(t, folderName()): {folderID(), fileID("f2")},
@@ -112,13 +120,14 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 			},
 			enumerator: driveEnumerator(
 				d1.newEnumer().with(
-					delta(id(deltaURL), nil).with(aPage(
-						d1.fileAtRoot("f1"),
-						d1.fileAtRoot("f2"),
-						d1.fileAtRoot("f3"),
-						d1.fileAtRoot("f4"),
-						d1.fileAtRoot("f5"),
-						d1.fileAtRoot("f6"))))),
+					delta(id(deltaURL), nil).with(
+						aPage(
+							d1.fileAt(root, "f1"),
+							d1.fileAt(root, "f2"),
+							d1.fileAt(root, "f3"),
+							d1.fileAt(root, "f4"),
+							d1.fileAt(root, "f5"),
+							d1.fileAt(root, "f6"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t): {fileID("f1"), fileID("f2"), fileID("f3")},
 			},
@@ -137,12 +146,12 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d1.fileAtRoot("f1"),
-							d1.fileAtRoot("f2")),
+							d1.fileAt(root, "f1"),
+							d1.fileAt(root, "f2")),
 						aPage(
 							// Repeated items shouldn't count against the limit.
-							d1.fileAtRoot("f1"),
-							d1.folderAtRoot(),
+							d1.fileAt(root, "f1"),
+							d1.folderAt(root),
 							d1.fileAt(folder, "f3"),
 							d1.fileAt(folder, "f4"),
 							d1.fileAt(folder, "f5"),
@@ -166,10 +175,10 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d1.fileAtRoot("f1"),
-							d1.fileAtRoot("f2")),
+							d1.fileAt(root, "f1"),
+							d1.fileAt(root, "f2")),
 						aPage(
-							d1.folderAtRoot(),
+							d1.folderAt(root),
 							d1.fileAt(folder, "f3"),
 							d1.fileAt(folder, "f4"),
 							d1.fileAt(folder, "f5"),
@@ -192,17 +201,21 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d1.fileAtRoot("f1"),
-							d1.fileAtRoot("f2"),
-							d1.fileAtRoot("f3")),
+							d1.fileAt(root, "f1"),
+							d1.fileAt(root, "f2"),
+							d1.fileAt(root, "f3")),
 						aPage(
-							d1.folderAtRoot(),
+							d1.folderAt(root),
 							d1.fileAt(folder, "f4"),
 							d1.fileAt(folder, "f5"))))),
 			expectedItemIDsInCollection: map[string][]string{
-				// Root has an additional item. It's hard to fix that in the code
-				// though.
+				// Root has an additional item. It's hard to fix that in the code though.
 				d1.strPath(t):               {fileID("f1"), fileID("f2")},
+				d1.strPath(t, folderName()): {folderID(), fileID("f4")},
+			},
+			expectedItemIDsInCollectionTree: map[string][]string{
+				// the tree version doesn't have this problem.
+				d1.strPath(t):               {fileID("f1")},
 				d1.strPath(t, folderName()): {folderID(), fileID("f4")},
 			},
 		},
@@ -220,11 +233,11 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d1.folderAtRoot(),
+							d1.folderAt(root),
 							d1.fileAt(folder, "f1"),
 							d1.fileAt(folder, "f2")),
 						aPage(
-							d1.folderAtRoot(),
+							d1.folderAt(root),
 							// Updated item that shouldn't count against the limit a second time.
 							d1.fileAt(folder, "f2"),
 							d1.fileAt(folder, "f3"),
@@ -248,19 +261,26 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d1.fileAtRoot("f1"),
-							d1.fileAtRoot("f2"),
-							// Put folder 0 at limit.
-							d1.folderAtRoot(),
+							d1.fileAt(root, "f1"),
+							d1.fileAt(root, "f2"),
+							// Put root/folder at limit.
+							d1.folderAt(root),
 							d1.fileAt(folder, "f3"),
 							d1.fileAt(folder, "f4")),
 						aPage(
-							d1.folderAtRoot(),
+							d1.folderAt(root),
 							// Try to move item from root to folder 0 which is already at the limit.
 							d1.fileAt(folder, "f1"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t):               {fileID("f1"), fileID("f2")},
 				d1.strPath(t, folderName()): {folderID(), fileID("f3"), fileID("f4")},
+			},
+			expectedItemIDsInCollectionTree: map[string][]string{
+				d1.strPath(t): {fileID("f2")},
+				// note that the tree version allows f1 to get moved.
+				// we've already committed to backing up the file as part of the preview,
+				// it doesn't seem rational to prevent its movement
+				d1.strPath(t, folderName()): {folderID(), fileID("f3"), fileID("f4"), fileID("f1")},
 			},
 		},
 		{
@@ -277,14 +297,14 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d1.fileAtRoot("f1"),
-							d1.fileAtRoot("f2"),
-							d1.fileAtRoot("f3")),
+							d1.fileAt(root, "f1"),
+							d1.fileAt(root, "f2"),
+							d1.fileAt(root, "f3")),
 						aPage(
-							d1.folderAtRoot(),
+							d1.folderAt(root),
 							d1.fileAt(folder, "f4")),
 						aPage(
-							d1.folderAtRoot(),
+							d1.folderAt(root),
 							d1.fileAt(folder, "f5"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t):               {fileID("f1"), fileID("f2"), fileID("f3")},
@@ -305,15 +325,15 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d1.fileAtRoot("f1"),
-							d1.fileAtRoot("f2"),
-							d1.fileAtRoot("f3")),
+							d1.fileAt(root, "f1"),
+							d1.fileAt(root, "f2"),
+							d1.fileAt(root, "f3")),
 						aPage(
-							d1.folderAtRoot(),
+							d1.folderAt(root),
 							d1.fileAt(folder, "f4"),
 							d1.fileAt(folder, "f5"),
 							// This container shouldn't be returned.
-							d1.folderAtRoot(2),
+							d1.folderAt(root, 2),
 							d1.fileAt(2, "f7"),
 							d1.fileAt(2, "f8"),
 							d1.fileAt(2, "f9"))))),
@@ -336,16 +356,16 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d1.fileAtRoot("f1"),
-							d1.fileAtRoot("f2"),
-							d1.fileAtRoot("f3")),
+							d1.fileAt(root, "f1"),
+							d1.fileAt(root, "f2"),
+							d1.fileAt(root, "f3")),
 						aPage(
-							d1.folderAtRoot(),
+							d1.folderAt(root),
 							d1.fileAt(folder, "f4"),
 							d1.fileAt(folder, "f5")),
 						aPage(
 							// This container shouldn't be returned.
-							d1.folderAtRoot(2),
+							d1.folderAt(root, 2),
 							d1.fileAt(2, "f7"),
 							d1.fileAt(2, "f8"),
 							d1.fileAt(2, "f9"))))),
@@ -366,19 +386,21 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 			},
 			enumerator: driveEnumerator(
 				d1.newEnumer().with(
-					delta(id(deltaURL), nil).with(aPage(
-						d1.fileAtRoot("f1"),
-						d1.fileAtRoot("f2"),
-						d1.fileAtRoot("f3"),
-						d1.fileAtRoot("f4"),
-						d1.fileAtRoot("f5")))),
+					delta(id(deltaURL), nil).with(
+						aPage(
+							d1.fileAt(root, "f1"),
+							d1.fileAt(root, "f2"),
+							d1.fileAt(root, "f3"),
+							d1.fileAt(root, "f4"),
+							d1.fileAt(root, "f5")))),
 				d2.newEnumer().with(
-					delta(id(deltaURL), nil).with(aPage(
-						d2.fileAtRoot("f1"),
-						d2.fileAtRoot("f2"),
-						d2.fileAtRoot("f3"),
-						d2.fileAtRoot("f4"),
-						d2.fileAtRoot("f5"))))),
+					delta(id(deltaURL), nil).with(
+						aPage(
+							d2.fileAt(root, "f1"),
+							d2.fileAt(root, "f2"),
+							d2.fileAt(root, "f3"),
+							d2.fileAt(root, "f4"),
+							d2.fileAt(root, "f5"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t): {fileID("f1"), fileID("f2"), fileID("f3")},
 				d2.strPath(t): {fileID("f1"), fileID("f2"), fileID("f3")},
@@ -397,14 +419,14 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d1.fileAtRoot("f1"),
-							d1.fileAtRoot("f2"),
-							d1.fileAtRoot("f3")),
+							d1.fileAt(root, "f1"),
+							d1.fileAt(root, "f2"),
+							d1.fileAt(root, "f3")),
 						aPage(
-							d1.folderAtRoot(),
+							d1.folderAt(root),
 							d1.fileAt(folder, "f4")),
 						aPage(
-							d1.folderAtRoot(),
+							d1.folderAt(root),
 							d1.fileAt(folder, "f5"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t):               {fileID("f1"), fileID("f2"), fileID("f3")},
@@ -427,8 +449,6 @@ func (suite *LimiterUnitSuite) TestGet_PreviewLimits_noTree() {
 // checks that don't examine metadata, collection states, etc. They really just
 // check the expected items appear.
 func (suite *LimiterUnitSuite) TestGet_PreviewLimits_tree() {
-	suite.T().Skip("TODO: unskip when tree produces collections")
-
 	opts := control.DefaultOptions()
 	opts.ToggleFeatures.UseDeltaTree = true
 
@@ -521,9 +541,15 @@ func runGetPreviewLimits(
 			itemIDs = append(itemIDs, id)
 		}
 
+		expectItemIDs := test.expectedItemIDsInCollection[folderPath]
+
+		if opts.ToggleFeatures.UseDeltaTree && test.expectedItemIDsInCollectionTree != nil {
+			expectItemIDs = test.expectedItemIDsInCollectionTree[folderPath]
+		}
+
 		assert.ElementsMatchf(
 			t,
-			test.expectedItemIDsInCollection[folderPath],
+			expectItemIDs,
 			itemIDs,
 			"item IDs in collection with path:\n\t%q",
 			folderPath)
@@ -542,6 +568,9 @@ type defaultLimitTestExpects struct {
 	numItems             int
 	numContainers        int
 	numItemsPerContainer int
+	// the tree handling behavior may deviate under certain conditions
+	// since it allows one file to slightly step over the byte limit
+	numItemsTreePadding int
 }
 
 type defaultLimitTest struct {
@@ -641,6 +670,7 @@ func defaultLimitsTable() []defaultLimitTest {
 				numItems:             int(defaultPreviewMaxBytes) / 1024 / 1024,
 				numContainers:        1,
 				numItemsPerContainer: int(defaultPreviewMaxBytes) / 1024 / 1024,
+				numItemsTreePadding:  1,
 			},
 		},
 	}
@@ -666,8 +696,6 @@ func (suite *LimiterUnitSuite) TestGet_PreviewLimits_defaultsNoTree() {
 // These tests run a reduced set of checks that really just look for item counts
 // and such. Other tests are expected to provide more comprehensive checks.
 func (suite *LimiterUnitSuite) TestGet_PreviewLimits_defaultsWithTree() {
-	suite.T().Skip("TODO: unskip when tree produces collections")
-
 	opts := control.DefaultOptions()
 	opts.ToggleFeatures.UseDeltaTree = true
 
@@ -798,11 +826,16 @@ func runGetPreviewLimitsDefaults(
 		numItems += len(col.driveItems)
 
 		// Add one to account for the folder permissions item.
+		expected := test.expect.numItemsPerContainer + 1
+		if opts.ToggleFeatures.UseDeltaTree {
+			expected += test.expect.numItemsTreePadding
+		}
+
 		assert.Len(
 			t,
 			col.driveItems,
-			test.expect.numItemsPerContainer+1,
-			"items in container %v",
+			expected,
+			"number of items in collection at:\n\t%+v",
 			col.FullPath())
 	}
 
@@ -810,12 +843,18 @@ func runGetPreviewLimitsDefaults(
 		t,
 		test.expect.numContainers,
 		numContainers,
-		"total containers")
+		"total count of collections")
+
+	// Add one to account for the folder permissions item.
+	expected := test.expect.numItems + test.expect.numContainers
+	if opts.ToggleFeatures.UseDeltaTree {
+		expected += test.expect.numItemsTreePadding
+	}
 
 	// Each container also gets an item so account for that here.
 	assert.Equal(
 		t,
-		test.expect.numItems+test.expect.numContainers,
+		expected,
 		numItems,
-		"total items across all containers")
+		"total sum of item counts in all collections")
 }

--- a/src/internal/m365/collection/drive/limiter_test.go
+++ b/src/internal/m365/collection/drive/limiter_test.go
@@ -714,7 +714,7 @@ func runGetPreviewLimitsDefaults(
 	for containerIdx := 0; containerIdx < test.numContainers; containerIdx++ {
 		page := nextPage{
 			Items: []models.DriveItemable{
-				driveRootFolder(),
+				rootFolder(),
 				driveItem(
 					folderID(containerIdx),
 					folderName(containerIdx),

--- a/src/internal/m365/collection/drive/url_cache_test.go
+++ b/src/internal/m365/collection/drive/url_cache_test.go
@@ -509,7 +509,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			pages: []nextPage{
 				aPage(
 					d.fileWURLAtRoot(aURL(1), false, 1),
-					d.folderAtRoot(2)),
+					d.folderAt(root, 2)),
 			},
 			expectedItemProps: map[string]itemProps{
 				fileID(2): {},

--- a/src/pkg/services/m365/custom/drive_item.go
+++ b/src/pkg/services/m365/custom/drive_item.go
@@ -33,6 +33,15 @@ type DriveItem struct {
 	additionalData       map[string]any
 }
 
+func NewDriveItem(
+	id, name string,
+) *DriveItem {
+	return &DriveItem{
+		id:   ptr.To(id),
+		name: ptr.To(name),
+	}
+}
+
 // Disable revive linter since we want to follow naming scheme used by graph SDK here.
 // nolint: revive
 func (c *DriveItem) GetId() *string {


### PR DESCRIPTION
the tree wasn't properly populating the dirmeta file for folders.  This change is primarily for the addition of that file, but also contains a minor refactor for taking in the folder drive item instead of only getting its properties.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix

#### Issue(s)

* #4689

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
