### PR TITLE
Exit test early if setup fails

### DIFF
--- a/src/internal/operations/test/exchange_test.go
+++ b/src/internal/operations/test/exchange_test.go
@@ -1061,6 +1061,12 @@ func (suite *ExchangeRestoreNightlyIntgSuite) TestRestore_Run_exchangeWithAdvanc
 		checkRestoreCounts(t, ctr1, 0, 0, countItemsInRestore)
 	})
 
+	// Exit the test if the baseline failed as it'll just cause more failures
+	// later.
+	if t.Failed() {
+		return
+	}
+
 	// skip restore
 
 	suite.Run("skip collisions", func() {


### PR DESCRIPTION
Reduce what needs searched through for debugging by exiting early.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup


#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
