### PR TITLE
fix-ups based on last PR

### DIFF
--- a/src/internal/m365/collection/drive/collection_test.go
+++ b/src/internal/m365/collection/drive/collection_test.go
@@ -300,12 +300,12 @@ func (suite *CollectionUnitSuite) TestCollection() {
 
 func (suite *CollectionUnitSuite) TestCollectionReadError() {
 	var (
-		t                = suite.T()
-		stubItemID       = "fakeItemID"
-		collStatus       = support.ControllerOperationStatus{}
-		wg               = sync.WaitGroup{}
-		size       int64 = defaultFileSize
-		now              = time.Now()
+		t          = suite.T()
+		stubItemID = "fakeItemID"
+		collStatus = support.ControllerOperationStatus{}
+		wg         = sync.WaitGroup{}
+		size       = defaultFileSize
+		now        = time.Now()
 	)
 
 	ctx, flush := tester.NewContext(t)
@@ -370,12 +370,12 @@ func (suite *CollectionUnitSuite) TestCollectionReadError() {
 
 func (suite *CollectionUnitSuite) TestCollectionReadUnauthorizedErrorRetry() {
 	var (
-		t                = suite.T()
-		stubItemID       = "fakeItemID"
-		collStatus       = support.ControllerOperationStatus{}
-		wg               = sync.WaitGroup{}
-		size       int64 = defaultFileSize
-		now              = time.Now()
+		t          = suite.T()
+		stubItemID = "fakeItemID"
+		collStatus = support.ControllerOperationStatus{}
+		wg         = sync.WaitGroup{}
+		size       = defaultFileSize
+		now        = time.Now()
 	)
 
 	ctx, flush := tester.NewContext(t)

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -645,7 +645,7 @@ func (c *Collections) addFileToTree(
 		}
 	}
 
-	err := tree.addFile(parentID, fileID, file)
+	err := tree.addFile(file)
 	if err != nil {
 		return nil, clues.StackWC(ctx, err)
 	}

--- a/src/internal/m365/collection/drive/collections_tree_test.go
+++ b/src/internal/m365/collection/drive/collections_tree_test.go
@@ -278,7 +278,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 			enumerator: driveEnumerator(
 				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
-						aPage(d.folderAtRoot(), d.fileAt(folder))))),
+						aPage(
+							d.folderAt(root),
+							d.fileAt(loc(folder)))))),
 			prevPaths: map[string]string{},
 			expectCounts: countTD.Expected{
 				count.PrevPaths: 0,
@@ -290,7 +292,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 			enumerator: driveEnumerator(
 				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
-						aPage(d.folderAtRoot(), d.fileAt(folder))))),
+						aPage(
+							d.folderAt(root),
+							d.fileAt(loc(folder)))))),
 			prevPaths: map[string]string{
 				folderID(): d.strPath(t, folderName()),
 			},
@@ -333,7 +337,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aReset(),
-						aPage(d.folderAtRoot(), d.fileAt(folder))))),
+						aPage(
+							d.folderAt(root),
+							d.fileAt(loc(folder)))))),
 			prevPaths: map[string]string{},
 			expectCounts: countTD.Expected{
 				count.PrevPaths: 0,
@@ -346,7 +352,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 				d.newEnumer().with(
 					deltaWReset(id(deltaURL), nil).with(
 						aReset(),
-						aPage(d.folderAtRoot(), d.fileAt(folder))))),
+						aPage(
+							d.folderAt(root),
+							d.fileAt(loc(folder)))))),
 			prevPaths: map[string]string{
 				folderID(): d.strPath(t, folderName()),
 			},
@@ -503,13 +511,13 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 						aColl(
 							d.fullPath(t, folderName("parent"), folderName()),
 							nil,
-							fileID()))
+							fileID("f")))
 				},
 				globalExcludedFileIDs: makeExcludeMap(
 					fileID("r"),
 					fileID("p"),
 					fileID("d"),
-					fileID()),
+					fileID("f")),
 			},
 		},
 		{
@@ -547,14 +555,14 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 						aColl(
 							d.fullPath(t, folderName("parent"), folderName()),
 							d.fullPath(t, folderName("parent-prev"), folderName()),
-							fileID()),
+							fileID("f")),
 						aColl(nil, d.fullPath(t, folderName("tombstone-prev"))))
 				},
 				globalExcludedFileIDs: makeExcludeMap(
 					fileID("r"),
 					fileID("p"),
 					fileID("d"),
-					fileID()),
+					fileID("f")),
 			},
 		},
 		{
@@ -592,14 +600,14 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 						aColl(
 							d.fullPath(t, folderName("pa/rent"), folderName()),
 							d.fullPath(t, folderName("parent/prev"), folderName()),
-							fileID()),
+							fileID("f")),
 						aColl(nil, d.fullPath(t, folderName("tombstone/prev"))))
 				},
 				globalExcludedFileIDs: makeExcludeMap(
 					fileID("r"),
 					fileID("p"),
 					fileID("d"),
-					fileID()),
+					fileID("f")),
 			},
 		},
 		{
@@ -637,14 +645,14 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 						aColl(
 							d.fullPath(t, folderName("parent"), folderName()),
 							d.fullPath(t, folderName("parent"), folderName()),
-							fileID()),
+							fileID("f")),
 						aColl(nil, d.fullPath(t, folderName("tombstone"))))
 				},
 				globalExcludedFileIDs: makeExcludeMap(
 					fileID("r"),
 					fileID("p"),
 					fileID("d"),
-					fileID()),
+					fileID("f")),
 			},
 		},
 		{
@@ -682,14 +690,14 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_TurnTreeIntoCollections()
 						aColl(
 							d.fullPath(t, folderName("pa/rent"), folderName()),
 							d.fullPath(t, folderName("pa/rent"), folderName()),
-							fileID()),
+							fileID("f")),
 						aColl(nil, d.fullPath(t, folderName("tombstone/prev"))))
 				},
 				globalExcludedFileIDs: makeExcludeMap(
 					fileID("r"),
 					fileID("p"),
 					fileID("d"),
-					fileID()),
+					fileID("f")),
 			},
 		},
 	}
@@ -843,11 +851,11 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 			enumerator: driveEnumerator(
 				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
-						aPage(d.folderAtRoot()),
-						aPage(d.folderAtRoot("sib")),
+						aPage(d.folderAt(root)),
+						aPage(d.folderAt(root, "sib")),
 						aPage(
-							d.folderAtRoot(),
-							d.folderAt(folder, "chld"))))),
+							d.folderAt(root),
+							d.folderAt(loc(folder), "chld"))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
@@ -876,13 +884,13 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d.folderAtRoot(),
-							d.fileAt(folder)),
+							d.folderAt(root),
+							d.fileAt(loc(folder))),
 						aPage(
-							d.folderAtRoot("sib"),
-							d.fileAt("sib", "fsib")),
+							d.folderAt(root, "sib"),
+							d.fileAt(loc("sib"), "fsib")),
 						aPage(
-							d.folderAtRoot(),
+							d.folderAt(root),
 							d.folderAt(folder, "chld"),
 							d.fileAt("chld", "fchld"))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
@@ -978,8 +986,8 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d.folderAtRoot(),
-							d.fileAt(folder)),
+							d.folderAt(root),
+							d.fileAt(loc(folder))),
 						aPage(delItem(folderID(), rootID, isFolder))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: populateTreeExpected{
@@ -1011,7 +1019,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d.folderAtRoot("parent"),
+							d.folderAt(root, "parent"),
 							driveItem(folderID(), folderName("moved"), d.dir(), folderID("parent"), isFolder),
 							driveFile(d.dir(folderName("parent"), folderName()), folderID())),
 						aPage(delItem(folderID(), folderID("parent"), isFolder))))),
@@ -1047,7 +1055,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 					delta(id(deltaURL), nil).with(
 						aPage(delItem(folderID(), rootID, isFolder)),
 						aPage(
-							d.folderAtRoot(),
+							d.folderAt(root),
 							d.fileAt(folder))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: populateTreeExpected{
@@ -1079,7 +1087,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 					delta(id(deltaURL), nil).with(
 						aPage(delItem(folderID(), rootID, isFolder)),
 						aPage(
-							d.folderAtRoot(),
+							d.folderAt(root),
 							d.fileAt(folder))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: populateTreeExpected{
@@ -1110,15 +1118,15 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d.folderAtRoot(),
-							d.fileAt(folder)),
+							d.folderAt(root),
+							d.fileAt(loc(folder))),
 						aPage(
-							d.folderAtRoot("sib"),
-							d.fileAt("sib", "fsib")),
+							d.folderAt(root, "sib"),
+							d.fileAt(loc("sib"), "fsib")),
 						aPage(
-							d.folderAtRoot(),
-							d.folderAt(folder, "chld"),
-							d.fileAt("chld", "fchld"))))),
+							d.folderAt(root),
+							d.folderAt(loc(folder), "chld"),
+							d.fileAt(loc(folder, "chld"), "fchld"))))),
 			limiter: newPagerLimiter(minimumLimitOpts()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
@@ -1146,15 +1154,15 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d.folderAtRoot(),
-							d.fileAt(folder)),
+							d.folderAt(root),
+							d.fileAt(loc(folder))),
 						aPage(
-							d.folderAtRoot("sib"),
-							d.fileAt("sib", "fsib")),
+							d.folderAt(root, "sib"),
+							d.fileAt(loc("sib"), "fsib")),
 						aPage(
-							d.folderAtRoot(),
-							d.folderAt(folder, "chld"),
-							d.fileAt("chld", "fchld"))))),
+							d.folderAt(root),
+							d.folderAt(loc(folder), "chld"),
+							d.fileAt(loc(folder, "chld"), "fchld"))))),
 			limiter: newPagerLimiter(minimumLimitOpts()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
@@ -1197,17 +1205,17 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 				d.newEnumer().with(
 					delta(id(deltaURL), nil).
 						with(aPage(
-							d.folderAtRoot(),
-							d.fileAt(folder))),
+							d.folderAt(root),
+							d.fileAt(loc(folder)))),
 					delta(id(deltaURL), nil).
 						with(aPage(
-							d.folderAtRoot("sib"),
-							d.fileAt("sib", "fsib"))),
+							d.folderAt(root, "sib"),
+							d.fileAt(loc("sib"), "fsib"))),
 					delta(id(deltaURL), nil).
 						with(aPage(
-							d.folderAtRoot(),
-							d.folderAt(folder, "chld"),
-							d.fileAt("chld", "fchld"))))),
+							d.folderAt(root),
+							d.folderAt(loc(folder), "chld"),
+							d.fileAt(loc(folder, "chld"), "fchld"))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
@@ -1243,8 +1251,8 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d.folderAtRoot(),
-							d.fileAt(folder))),
+							d.folderAt(root),
+							d.fileAt(loc(folder)))),
 					// a (delete,create) pair in the same delta can occur when
 					// a user deletes and restores an item in-between deltas.
 					delta(id(deltaURL), nil).with(
@@ -1252,8 +1260,8 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 							delItem(folderID(), rootID, isFolder),
 							delItem(fileID(), folderID(), isFile)),
 						aPage(
-							d.folderAtRoot(),
-							d.fileAt(folder))))),
+							d.folderAt(root),
+							d.fileAt(loc(folder)))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
@@ -1283,8 +1291,8 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 				d.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d.folderAtRoot(),
-							d.fileAt(folder))),
+							d.folderAt(root),
+							d.fileAt(loc(folder)))),
 					delta(id(deltaURL), nil).with(
 						aPage(
 							driveItem(folderID(), folderName("rename"), d.dir(), rootID, isFolder),
@@ -1321,8 +1329,8 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 					delta(id(deltaURL), nil).with(
 						// first page: create /root/folder and /root/folder/file
 						aPage(
-							d.folderAtRoot(),
-							d.fileAt(folder)),
+							d.folderAt(root),
+							d.fileAt(loc(folder))),
 						// assume the user makes changes at this point:
 						// * create a new /root/folder
 						// * move /root/folder/file from old to new folder (same file ID)
@@ -1503,9 +1511,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			name: "many folders in a hierarchy",
 			tree: treeWithRoot,
 			page: aPage(
-				d.folderAtRoot(),
-				d.folderAtRoot("sib"),
-				d.folderAt(folder, "chld")),
+				d.folderAt(root),
+				d.folderAt(loc(folder), "chld"),
+				d.folderAt(root, "sib")),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1526,7 +1534,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			name: "create->delete",
 			tree: treeWithRoot,
 			page: aPage(
-				d.folderAtRoot(),
+				d.folderAt(root),
 				delItem(folderID(), rootID, isFolder)),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
@@ -1546,7 +1554,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			name: "move->delete",
 			tree: treeWithFolders,
 			page: aPage(
-				d.folderAtRoot("parent"),
+				d.folderAt(root, "parent"),
 				driveItem(folderID(), folderName("moved"), d.dir(folderName("parent")), folderID("parent"), isFolder),
 				delItem(folderID(), folderID("parent"), isFolder)),
 			limiter: newPagerLimiter(control.DefaultOptions()),
@@ -1571,7 +1579,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			tree: treeWithRoot,
 			page: aPage(
 				delItem(folderID(), rootID, isFolder),
-				d.folderAtRoot()),
+				d.folderAt(root)),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1592,7 +1600,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			tree: treeWithRoot,
 			page: aPage(
 				delItem(folderID(), rootID, isFolder),
-				d.folderAtRoot()),
+				d.folderAt(root)),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -1657,7 +1665,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 	var (
 		d      = drive()
-		fld    = custom.ToCustomDriveItem(d.folderAtRoot())
+		fld    = custom.ToCustomDriveItem(d.folderAt(root))
 		subFld = custom.ToCustomDriveItem(driveFolder(d.dir(folderName("parent")), folderID("parent")))
 		pack   = custom.ToCustomDriveItem(driveItem(id(pkg), name(pkg), d.dir(), rootID, isPackage))
 		del    = custom.ToCustomDriveItem(delItem(folderID(), rootID, isFolder))
@@ -1938,7 +1946,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeFolderCollectionPath(
 		},
 		{
 			name:      "folder",
-			folder:    d.folderAtRoot(),
+			folder:    d.folderAt(root),
 			expect:    folderPath.String(),
 			expectErr: require.NoError,
 		},
@@ -1996,7 +2004,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 		{
 			name: "one file at root",
 			tree: treeWithRoot,
-			page: aPage(d.fileAtRoot()),
+			page: aPage(d.fileAt(root)),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 0,
@@ -2015,9 +2023,9 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 			name: "many files in a hierarchy",
 			tree: treeWithRoot,
 			page: aPage(
-				d.fileAtRoot(),
-				d.folderAtRoot(),
-				d.fileAt(folder, "fchld")),
+				d.fileAt(root),
+				d.folderAt(root),
+				d.fileAt(loc(folder), "fchld")),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 0,
@@ -2037,7 +2045,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 			name: "many updates to the same file",
 			tree: treeWithRoot,
 			page: aPage(
-				d.fileAtRoot(),
+				d.fileAt(root),
 				driveItem(fileID(), fileName(1), d.dir(), rootID, isFile),
 				driveItem(fileID(), fileName(2), d.dir(), rootID, isFile)),
 			expect: expected{
@@ -2092,7 +2100,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 			name: "create->delete",
 			tree: treeWithRoot,
 			page: aPage(
-				d.fileAtRoot(),
+				d.fileAt(root),
 				delItem(fileID(), rootID, isFile)),
 			expect: expected{
 				counts: countTD.Expected{
@@ -2110,8 +2118,8 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 			name: "move->delete",
 			tree: treeWithFileAtRoot,
 			page: aPage(
-				d.folderAtRoot(),
-				d.fileAt(folder),
+				d.folderAt(root),
+				d.fileAt(loc(folder)),
 				delItem(fileID(), folderID(), isFile)),
 			expect: expected{
 				counts: countTD.Expected{
@@ -2130,7 +2138,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 			tree: treeWithFileAtRoot,
 			page: aPage(
 				delItem(fileID(), rootID, isFile),
-				d.fileAtRoot()),
+				d.fileAt(root)),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 1,
@@ -2150,7 +2158,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 			tree: treeWithRoot,
 			page: aPage(
 				delItem(fileID(), rootID, isFile),
-				d.fileAtRoot()),
+				d.fileAt(root)),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 1,
@@ -2221,7 +2229,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 		{
 			name:    "add new file",
 			tree:    treeWithRoot,
-			file:    d.fileAtRoot(),
+			file:    d.fileAt(root),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -2239,7 +2247,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 		{
 			name:    "duplicate file",
 			tree:    treeWithFileAtRoot,
-			file:    d.fileAtRoot(),
+			file:    d.fileAt(root),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -2257,7 +2265,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 		{
 			name:    "error file seen before parent",
 			tree:    treeWithRoot,
-			file:    d.fileAt(folder),
+			file:    d.fileAt(loc(folder)),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -2321,7 +2329,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 		{
 			name:    "already at container file limit",
 			tree:    treeWithFileAtRoot,
-			file:    d.fileAtRoot(2),
+			file:    d.fileAt(root, 2),
 			limiter: newPagerLimiter(minimumLimitOpts()),
 			expect: expected{
 				counts: countTD.Expected{
@@ -2340,7 +2348,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 		{
 			name:    "goes over total byte limit",
 			tree:    treeWithRoot,
-			file:    d.fileAtRoot(),
+			file:    d.fileAt(root),
 			limiter: newPagerLimiter(minimumLimitOpts()),
 			expect: expected{
 				counts: countTD.Expected{

--- a/src/internal/m365/collection/drive/collections_tree_test.go
+++ b/src/internal/m365/collection/drive/collections_tree_test.go
@@ -280,7 +280,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 					delta(id(deltaURL), nil).with(
 						aPage(
 							d.folderAt(root),
-							d.fileAt(loc(folder)))))),
+							d.fileAt(folder))))),
 			prevPaths: map[string]string{},
 			expectCounts: countTD.Expected{
 				count.PrevPaths: 0,
@@ -294,7 +294,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 					delta(id(deltaURL), nil).with(
 						aPage(
 							d.folderAt(root),
-							d.fileAt(loc(folder)))))),
+							d.fileAt(folder))))),
 			prevPaths: map[string]string{
 				folderID(): d.strPath(t, folderName()),
 			},
@@ -339,7 +339,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 						aReset(),
 						aPage(
 							d.folderAt(root),
-							d.fileAt(loc(folder)))))),
+							d.fileAt(folder))))),
 			prevPaths: map[string]string{},
 			expectCounts: countTD.Expected{
 				count.PrevPaths: 0,
@@ -354,7 +354,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 						aReset(),
 						aPage(
 							d.folderAt(root),
-							d.fileAt(loc(folder)))))),
+							d.fileAt(folder))))),
 			prevPaths: map[string]string{
 				folderID(): d.strPath(t, folderName()),
 			},
@@ -855,7 +855,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 						aPage(d.folderAt(root, "sib")),
 						aPage(
 							d.folderAt(root),
-							d.folderAt(loc(folder), "chld"))))),
+							d.folderAt(folder, "chld"))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
@@ -885,10 +885,10 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 					delta(id(deltaURL), nil).with(
 						aPage(
 							d.folderAt(root),
-							d.fileAt(loc(folder))),
+							d.fileAt(folder)),
 						aPage(
 							d.folderAt(root, "sib"),
-							d.fileAt(loc("sib"), "fsib")),
+							d.fileAt("sib", "fsib")),
 						aPage(
 							d.folderAt(root),
 							d.folderAt(folder, "chld"),
@@ -987,7 +987,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 					delta(id(deltaURL), nil).with(
 						aPage(
 							d.folderAt(root),
-							d.fileAt(loc(folder))),
+							d.fileAt(folder)),
 						aPage(delItem(folderID(), rootID, isFolder))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: populateTreeExpected{
@@ -1119,14 +1119,14 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 					delta(id(deltaURL), nil).with(
 						aPage(
 							d.folderAt(root),
-							d.fileAt(loc(folder))),
+							d.fileAt(folder)),
 						aPage(
 							d.folderAt(root, "sib"),
-							d.fileAt(loc("sib"), "fsib")),
+							d.fileAt("sib", "fsib")),
 						aPage(
 							d.folderAt(root),
-							d.folderAt(loc(folder), "chld"),
-							d.fileAt(loc(folder, "chld"), "fchld"))))),
+							d.folderAt(folder, "chld"),
+							d.fileAt("chld", "fchld"))))),
 			limiter: newPagerLimiter(minimumLimitOpts()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
@@ -1155,14 +1155,14 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 					delta(id(deltaURL), nil).with(
 						aPage(
 							d.folderAt(root),
-							d.fileAt(loc(folder))),
+							d.fileAt(folder)),
 						aPage(
 							d.folderAt(root, "sib"),
-							d.fileAt(loc("sib"), "fsib")),
+							d.fileAt("sib", "fsib")),
 						aPage(
 							d.folderAt(root),
-							d.folderAt(loc(folder), "chld"),
-							d.fileAt(loc(folder, "chld"), "fchld"))))),
+							d.folderAt(folder, "chld"),
+							d.fileAt("chld", "fchld"))))),
 			limiter: newPagerLimiter(minimumLimitOpts()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
@@ -1206,16 +1206,16 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 					delta(id(deltaURL), nil).
 						with(aPage(
 							d.folderAt(root),
-							d.fileAt(loc(folder)))),
+							d.fileAt(folder))),
 					delta(id(deltaURL), nil).
 						with(aPage(
 							d.folderAt(root, "sib"),
-							d.fileAt(loc("sib"), "fsib"))),
+							d.fileAt("sib", "fsib"))),
 					delta(id(deltaURL), nil).
 						with(aPage(
 							d.folderAt(root),
-							d.folderAt(loc(folder), "chld"),
-							d.fileAt(loc(folder, "chld"), "fchld"))))),
+							d.folderAt(folder, "chld"),
+							d.fileAt("chld", "fchld"))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
@@ -1252,7 +1252,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 					delta(id(deltaURL), nil).with(
 						aPage(
 							d.folderAt(root),
-							d.fileAt(loc(folder)))),
+							d.fileAt(folder))),
 					// a (delete,create) pair in the same delta can occur when
 					// a user deletes and restores an item in-between deltas.
 					delta(id(deltaURL), nil).with(
@@ -1261,7 +1261,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 							delItem(fileID(), folderID(), isFile)),
 						aPage(
 							d.folderAt(root),
-							d.fileAt(loc(folder)))))),
+							d.fileAt(folder))))),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
@@ -1292,7 +1292,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 					delta(id(deltaURL), nil).with(
 						aPage(
 							d.folderAt(root),
-							d.fileAt(loc(folder)))),
+							d.fileAt(folder))),
 					delta(id(deltaURL), nil).with(
 						aPage(
 							driveItem(folderID(), folderName("rename"), d.dir(), rootID, isFolder),
@@ -1330,7 +1330,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 						// first page: create /root/folder and /root/folder/file
 						aPage(
 							d.folderAt(root),
-							d.fileAt(loc(folder))),
+							d.fileAt(folder)),
 						// assume the user makes changes at this point:
 						// * create a new /root/folder
 						// * move /root/folder/file from old to new folder (same file ID)
@@ -1512,7 +1512,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			tree: treeWithRoot,
 			page: aPage(
 				d.folderAt(root),
-				d.folderAt(loc(folder), "chld"),
+				d.folderAt(folder, "chld"),
 				d.folderAt(root, "sib")),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
@@ -2025,7 +2025,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 			page: aPage(
 				d.fileAt(root),
 				d.folderAt(root),
-				d.fileAt(loc(folder), "fchld")),
+				d.fileAt(folder, "fchld")),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 0,
@@ -2119,7 +2119,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 			tree: treeWithFileAtRoot,
 			page: aPage(
 				d.folderAt(root),
-				d.fileAt(loc(folder)),
+				d.fileAt(folder),
 				delItem(fileID(), folderID(), isFile)),
 			expect: expected{
 				counts: countTD.Expected{
@@ -2265,7 +2265,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 		{
 			name:    "error file seen before parent",
 			tree:    treeWithRoot,
-			file:    d.fileAt(loc(folder)),
+			file:    d.fileAt(folder),
 			limiter: newPagerLimiter(control.DefaultOptions()),
 			expect: expected{
 				counts: countTD.Expected{

--- a/src/internal/m365/collection/drive/delta_tree.go
+++ b/src/internal/m365/collection/drive/delta_tree.go
@@ -150,7 +150,8 @@ func (face *folderyMcFolderFace) setFolder(
 		return clues.NewWC(ctx, "missing folder name")
 	}
 
-	if parentFolder == nil && id != face.rootID {
+	if (parentFolder == nil || len(ptr.Val(parentFolder.GetId())) == 0) &&
+		id != face.rootID {
 		return clues.NewWC(ctx, "non-root folder missing parent id")
 	}
 
@@ -326,12 +327,19 @@ func (face *folderyMcFolderFace) hasFile(id string) bool {
 // file was already added to the tree and is getting relocated,
 // this func will update and/or clean up all the old references.
 func (face *folderyMcFolderFace) addFile(
-	parentID, id string,
 	file *custom.DriveItem,
 ) error {
-	if len(parentID) == 0 {
+	var (
+		parentFolder = file.GetParentReference()
+		id           = ptr.Val(file.GetId())
+		parentID     string
+	)
+
+	if parentFolder == nil || len(ptr.Val(parentFolder.GetId())) == 0 {
 		return clues.New("item added without parent folder ID")
 	}
+
+	parentID = ptr.Val(parentFolder.GetId())
 
 	if len(id) == 0 {
 		return clues.New("item added without ID")

--- a/src/internal/m365/collection/drive/delta_tree.go
+++ b/src/internal/m365/collection/drive/delta_tree.go
@@ -468,11 +468,15 @@ func walkTreeAndBuildCollections(
 				"path_suffix", parentPath.Elements())
 	}
 
-	// add the folder itself to the list of files inside the folder.
-	// that will cause the collection processor to generate a metadata
-	// file to hold the folder's permissions.
-	files := maps.Clone(node.files)
-	files[id] = node.folder
+	files := node.files
+
+	if !isRoot {
+		// add the folder itself to the list of files inside the folder.
+		// that will cause the collection processor to generate a metadata
+		// file to hold the folder's permissions.
+		files = maps.Clone(node.files)
+		files[id] = node.folder
+	}
 
 	cbl := collectable{
 		currPath:                  collectionPath,

--- a/src/internal/m365/collection/drive/delta_tree_test.go
+++ b/src/internal/m365/collection/drive/delta_tree_test.go
@@ -49,7 +49,7 @@ func (suite *DeltaTreeUnitSuite) TestNewNodeyMcNodeFace() {
 		t      = suite.T()
 		parent = &nodeyMcNodeFace{}
 		d      = drive()
-		fld    = custom.ToCustomDriveItem(d.folderAtRoot())
+		fld    = custom.ToCustomDriveItem(d.folderAt(root))
 	)
 
 	nodeFace := newNodeyMcNodeFace(parent, fld)
@@ -97,7 +97,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 			tname: "add folder",
 			tree:  treeWithRoot,
 			folder: func() *custom.DriveItem {
-				return custom.ToCustomDriveItem(d.folderAtRoot())
+				return custom.ToCustomDriveItem(d.folderAt(root))
 			},
 			expectErr: assert.NoError,
 		},
@@ -119,7 +119,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 			tname: "missing ID",
 			tree:  treeWithRoot,
 			folder: func() *custom.DriveItem {
-				far := d.folderAtRoot()
+				far := d.folderAt(root)
 				far.SetId(nil)
 
 				return custom.ToCustomDriveItem(far)
@@ -130,7 +130,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 			tname: "missing name",
 			tree:  treeWithRoot,
 			folder: func() *custom.DriveItem {
-				far := d.folderAtRoot()
+				far := d.folderAt(root)
 				far.SetName(nil)
 
 				return custom.ToCustomDriveItem(far)
@@ -141,7 +141,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 			tname: "missing parentID",
 			tree:  treeWithRoot,
 			folder: func() *custom.DriveItem {
-				far := d.folderAtRoot()
+				far := d.folderAt(root)
 				far.SetParentReference(nil)
 
 				return custom.ToCustomDriveItem(far)
@@ -152,7 +152,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 			tname: "already tombstoned",
 			tree:  treeWithTombstone,
 			folder: func() *custom.DriveItem {
-				return custom.ToCustomDriveItem(d.folderAtRoot())
+				return custom.ToCustomDriveItem(d.folderAt(root))
 			},
 			expectErr: assert.NoError,
 		},
@@ -160,7 +160,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 			tname: "add folder before parent",
 			tree:  newTree,
 			folder: func() *custom.DriveItem {
-				return custom.ToCustomDriveItem(d.folderAtRoot())
+				return custom.ToCustomDriveItem(d.folderAt(root))
 			},
 			expectErr: assert.Error,
 		},
@@ -168,7 +168,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 			tname: "folder already exists",
 			tree:  treeWithFolders,
 			folder: func() *custom.DriveItem {
-				return custom.ToCustomDriveItem(d.folderAtRoot())
+				return custom.ToCustomDriveItem(d.folderAt(root))
 			},
 			expectErr: assert.NoError,
 		},
@@ -515,7 +515,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder_correctTree()
 		var di models.DriveItemable
 
 		if parent == rootID {
-			di = d.folderAtRoot(self)
+			di = d.folderAt(root, self)
 		} else {
 			di = driveFolder(
 				d.dir("doesn't matter for this test"),
@@ -614,7 +614,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder_correctTombst
 		var di models.DriveItemable
 
 		if parent == rootID {
-			di = d.folderAtRoot(self)
+			di = d.folderAt(root, self)
 		} else {
 			di = driveFolder(
 				d.dir("doesn't matter for this test"),
@@ -785,7 +785,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 		tree        func(t *testing.T, d *deltaDrive) *folderyMcFolderFace
 		id          string
 		oldParentID string
-		parentID    string
+		parent      location
 		contentSize int64
 		expectErr   assert.ErrorAssertionFunc
 		expectFiles map[string]string
@@ -795,7 +795,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			tree:        treeWithRoot,
 			id:          fileID(),
 			oldParentID: "",
-			parentID:    rootID,
+			parent:      root,
 			contentSize: defaultFileSize,
 			expectErr:   assert.NoError,
 			expectFiles: map[string]string{fileID(): rootID},
@@ -805,7 +805,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			tree:        treeWithFolders,
 			id:          fileID(),
 			oldParentID: "",
-			parentID:    folderID(),
+			parent:      loc("parent", folder),
 			contentSize: 24,
 			expectErr:   assert.NoError,
 			expectFiles: map[string]string{fileID(): folderID()},
@@ -815,7 +815,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			tree:        treeWithFileAtRoot,
 			id:          fileID(),
 			oldParentID: rootID,
-			parentID:    rootID,
+			parent:      root,
 			contentSize: 84,
 			expectErr:   assert.NoError,
 			expectFiles: map[string]string{fileID(): rootID},
@@ -825,7 +825,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			tree:        treeWithFileInFolder,
 			id:          fileID(),
 			oldParentID: folderID(),
-			parentID:    rootID,
+			parent:      root,
 			contentSize: 48,
 			expectErr:   assert.NoError,
 			expectFiles: map[string]string{fileID(): rootID},
@@ -835,7 +835,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			tree:        treeWithFileInTombstone,
 			id:          fileID(),
 			oldParentID: folderID(),
-			parentID:    rootID,
+			parent:      root,
 			contentSize: 2,
 			expectErr:   assert.NoError,
 			expectFiles: map[string]string{fileID(): rootID},
@@ -845,7 +845,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			tree:        treeWithTombstone,
 			id:          "",
 			oldParentID: "",
-			parentID:    folderID(),
+			parent:      loc(folder),
 			contentSize: 4,
 			expectErr:   assert.Error,
 			expectFiles: map[string]string{},
@@ -855,7 +855,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			tree:        treeWithTombstone,
 			id:          fileID(),
 			oldParentID: "",
-			parentID:    folderID(),
+			parent:      loc(folder),
 			contentSize: 8,
 			expectErr:   assert.Error,
 			expectFiles: map[string]string{},
@@ -865,7 +865,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			tree:        treeWithTombstone,
 			id:          fileID(),
 			oldParentID: "",
-			parentID:    folderID("not-in-tree"),
+			parent:      loc("not-in-tree"),
 			contentSize: 16,
 			expectErr:   assert.Error,
 			expectFiles: map[string]string{},
@@ -875,7 +875,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			tree:        treeWithTombstone,
 			id:          fileID(),
 			oldParentID: "",
-			parentID:    "",
+			parent:      location{p: []string{}},
 			contentSize: 16,
 			expectErr:   assert.Error,
 			expectFiles: map[string]string{},
@@ -883,14 +883,14 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 	}
 	for _, test := range table {
 		suite.Run(test.tname, func() {
-			t := suite.T()
-			d := drive()
-			tree := test.tree(t, d)
+			var (
+				t    = suite.T()
+				d    = drive()
+				tree = test.tree(t, d)
+				df   = custom.ToCustomDriveItem(d.fileWSizeAt(test.contentSize, test.parent))
+			)
 
-			err := tree.addFile(
-				test.parentID,
-				test.id,
-				custom.ToCustomDriveItem(d.fileWSizeAt(test.contentSize, test.parentID)))
+			err := tree.addFile(df)
 			test.expectErr(t, err, clues.ToCore(err))
 			assert.Equal(t, test.expectFiles, tree.fileIDToParentID)
 
@@ -898,7 +898,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 				return
 			}
 
-			parent := tree.getNode(test.parentID)
+			parent := tree.getNode(test.parent.id())
 
 			require.NotNil(t, parent)
 			assert.Contains(t, parent.files, fileID())
@@ -907,7 +907,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			assert.Equal(t, 1, countSize.numFiles, "should have one file in the tree")
 			assert.Equal(t, test.contentSize, countSize.totalBytes, "tree should be sized to test file contents")
 
-			if len(test.oldParentID) > 0 && test.oldParentID != test.parentID {
+			if len(test.oldParentID) > 0 && test.oldParentID != test.parent.id() {
 				old := tree.getNode(test.oldParentID)
 
 				require.NotNil(t, old)
@@ -962,10 +962,12 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_DeleteFile() {
 }
 
 func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_addAndDeleteFile() {
-	t := suite.T()
-	d := drive()
-	tree := treeWithRoot(t, d)
-	fID := id(file)
+	var (
+		t    = suite.T()
+		d    = drive()
+		tree = treeWithRoot(t, d)
+		fID  = fileID()
+	)
 
 	require.Len(t, tree.fileIDToParentID, 0)
 	require.Len(t, tree.deletedFileIDs, 0)
@@ -977,7 +979,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_addAndDeleteFile() {
 	assert.Len(t, tree.deletedFileIDs, 1)
 	assert.Contains(t, tree.deletedFileIDs, fID)
 
-	err := tree.addFile(rootID, fID, custom.ToCustomDriveItem(d.fileAtRoot()))
+	err := tree.addFile(custom.ToCustomDriveItem(d.fileAt(root)))
 	require.NoError(t, err, clues.ToCore(err))
 
 	assert.Len(t, tree.fileIDToParentID, 1)
@@ -1023,9 +1025,9 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateExcludeItemIDs(
 			name: "files in folders and tombstones",
 			tree: fullTree,
 			expect: makeExcludeMap(
-				fileID(),
 				fileID("r"),
 				fileID("p"),
+				fileID("f"),
 				fileID("d")),
 		},
 	}
@@ -1085,7 +1087,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 					currPath: d.fullPath(t),
 					files: map[string]*custom.DriveItem{
 						rootID:   custom.ToCustomDriveItem(rootFolder()),
-						fileID(): custom.ToCustomDriveItem(d.fileAtRoot()),
+						fileID(): custom.ToCustomDriveItem(d.fileAt(root)),
 					},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
@@ -1108,7 +1110,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 				folderID("parent"): {
 					currPath: d.fullPath(t, folderName("parent")),
 					files: map[string]*custom.DriveItem{
-						folderID("parent"): custom.ToCustomDriveItem(d.folderAtRoot()),
+						folderID("parent"): custom.ToCustomDriveItem(d.folderAt(root)),
 					},
 					folderID:                  folderID("parent"),
 					isPackageOrChildOfPackage: false,
@@ -1116,8 +1118,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 				folderID(): {
 					currPath: d.fullPath(t, folderName("parent"), folderName()),
 					files: map[string]*custom.DriveItem{
-						folderID(): custom.ToCustomDriveItem(d.folderAt("parent")),
-						fileID():   custom.ToCustomDriveItem(d.fileAt("parent")),
+						folderID(): custom.ToCustomDriveItem(d.folderAt(loc("parent"))),
+						fileID():   custom.ToCustomDriveItem(d.fileAt(loc("parent", folder))),
 					},
 					folderID:                  folderID(),
 					isPackageOrChildOfPackage: false,
@@ -1134,7 +1136,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 				err := tree.setFolder(ctx, custom.ToCustomDriveItem(d.packageAtRoot()))
 				require.NoError(t, err, clues.ToCore(err))
 
-				err = tree.setFolder(ctx, custom.ToCustomDriveItem(d.folderAt(pkg)))
+				err = tree.setFolder(ctx, custom.ToCustomDriveItem(d.folderAt(loc(pkg))))
 				require.NoError(t, err, clues.ToCore(err))
 
 				return tree
@@ -1160,7 +1162,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 				folderID(): {
 					currPath: d.fullPath(t, folderName(pkg), folderName()),
 					files: map[string]*custom.DriveItem{
-						folderID(): custom.ToCustomDriveItem(d.folderAt("parent")),
+						folderID(): custom.ToCustomDriveItem(d.folderAt(loc("parent"))),
 					},
 					folderID:                  folderID(),
 					isPackageOrChildOfPackage: true,
@@ -1189,7 +1191,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 				folderID("parent"): {
 					currPath: d.fullPath(t, folderName("parent")),
 					files: map[string]*custom.DriveItem{
-						folderID("parent"): custom.ToCustomDriveItem(d.folderAtRoot()),
+						folderID("parent"): custom.ToCustomDriveItem(d.folderAt(root)),
 					},
 					folderID:                  folderID("parent"),
 					isPackageOrChildOfPackage: false,
@@ -1200,8 +1202,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 					folderID:                  folderID(),
 					isPackageOrChildOfPackage: false,
 					files: map[string]*custom.DriveItem{
-						folderID(): custom.ToCustomDriveItem(d.folderAt("parent")),
-						fileID():   custom.ToCustomDriveItem(d.fileAt("parent")),
+						folderID(): custom.ToCustomDriveItem(d.folderAt(loc("parent"))),
+						fileID():   custom.ToCustomDriveItem(d.fileAt(loc("parent", folder))),
 					},
 					prevPath: d.fullPath(t, folderName("parent-prev"), folderName()),
 				},

--- a/src/internal/m365/collection/drive/delta_tree_test.go
+++ b/src/internal/m365/collection/drive/delta_tree_test.go
@@ -1074,10 +1074,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expectErr: require.NoError,
 			expect: map[string]collectable{
 				rootID: {
-					currPath: d.fullPath(t),
-					files: map[string]*custom.DriveItem{
-						rootID: custom.ToCustomDriveItem(rootFolder()),
-					},
+					currPath:                  d.fullPath(t),
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 				},
@@ -1091,7 +1089,6 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 				rootID: {
 					currPath: d.fullPath(t),
 					files: map[string]*custom.DriveItem{
-						rootID:   custom.ToCustomDriveItem(rootFolder()),
 						fileID(): custom.ToCustomDriveItem(d.fileAt(root)),
 					},
 					folderID:                  rootID,
@@ -1105,10 +1102,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expectErr: require.NoError,
 			expect: map[string]collectable{
 				rootID: {
-					currPath: d.fullPath(t),
-					files: map[string]*custom.DriveItem{
-						rootID: custom.ToCustomDriveItem(rootFolder()),
-					},
+					currPath:                  d.fullPath(t),
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 				},
@@ -1149,10 +1144,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expectErr: require.NoError,
 			expect: map[string]collectable{
 				rootID: {
-					currPath: d.fullPath(t),
-					files: map[string]*custom.DriveItem{
-						rootID: custom.ToCustomDriveItem(rootFolder()),
-					},
+					currPath:                  d.fullPath(t),
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 				},
@@ -1185,10 +1178,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			},
 			expect: map[string]collectable{
 				rootID: {
-					currPath: d.fullPath(t),
-					files: map[string]*custom.DriveItem{
-						rootID: custom.ToCustomDriveItem(rootFolder()),
-					},
+					currPath:                  d.fullPath(t),
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					prevPath:                  d.fullPath(t),
@@ -1224,10 +1215,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expectErr: require.NoError,
 			expect: map[string]collectable{
 				rootID: {
-					currPath: d.fullPath(t),
-					files: map[string]*custom.DriveItem{
-						rootID: custom.ToCustomDriveItem(rootFolder()),
-					},
+					currPath:                  d.fullPath(t),
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					prevPath:                  d.fullPath(t),

--- a/src/internal/m365/collection/drive/delta_tree_test.go
+++ b/src/internal/m365/collection/drive/delta_tree_test.go
@@ -785,7 +785,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 		tree        func(t *testing.T, d *deltaDrive) *folderyMcFolderFace
 		id          string
 		oldParentID string
-		parent      location
+		parent      any
 		contentSize int64
 		expectErr   assert.ErrorAssertionFunc
 		expectFiles map[string]string
@@ -805,7 +805,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			tree:        treeWithFolders,
 			id:          fileID(),
 			oldParentID: "",
-			parent:      loc("parent", folder),
+			parent:      folder,
 			contentSize: 24,
 			expectErr:   assert.NoError,
 			expectFiles: map[string]string{fileID(): folderID()},
@@ -845,7 +845,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			tree:        treeWithTombstone,
 			id:          "",
 			oldParentID: "",
-			parent:      loc(folder),
+			parent:      folder,
 			contentSize: 4,
 			expectErr:   assert.Error,
 			expectFiles: map[string]string{},
@@ -855,7 +855,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			tree:        treeWithTombstone,
 			id:          fileID(),
 			oldParentID: "",
-			parent:      loc(folder),
+			parent:      folder,
 			contentSize: 8,
 			expectErr:   assert.Error,
 			expectFiles: map[string]string{},
@@ -865,7 +865,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			tree:        treeWithTombstone,
 			id:          fileID(),
 			oldParentID: "",
-			parent:      loc("not-in-tree"),
+			parent:      "not-in-tree",
 			contentSize: 16,
 			expectErr:   assert.Error,
 			expectFiles: map[string]string{},
@@ -875,7 +875,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			tree:        treeWithTombstone,
 			id:          fileID(),
 			oldParentID: "",
-			parent:      location{p: []string{}},
+			parent:      nil,
 			contentSize: 16,
 			expectErr:   assert.Error,
 			expectFiles: map[string]string{},
@@ -898,7 +898,12 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 				return
 			}
 
-			parent := tree.getNode(test.parent.id())
+			parentID := folderID(test.parent)
+			if test.parent == root {
+				parentID = rootID
+			}
+
+			parent := tree.getNode(parentID)
 
 			require.NotNil(t, parent)
 			assert.Contains(t, parent.files, fileID())
@@ -907,7 +912,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 			assert.Equal(t, 1, countSize.numFiles, "should have one file in the tree")
 			assert.Equal(t, test.contentSize, countSize.totalBytes, "tree should be sized to test file contents")
 
-			if len(test.oldParentID) > 0 && test.oldParentID != test.parent.id() {
+			if len(test.oldParentID) > 0 && test.oldParentID != parentID {
 				old := tree.getNode(test.oldParentID)
 
 				require.NotNil(t, old)
@@ -1118,8 +1123,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 				folderID(): {
 					currPath: d.fullPath(t, folderName("parent"), folderName()),
 					files: map[string]*custom.DriveItem{
-						folderID(): custom.ToCustomDriveItem(d.folderAt(loc("parent"))),
-						fileID():   custom.ToCustomDriveItem(d.fileAt(loc("parent", folder))),
+						folderID(): custom.ToCustomDriveItem(d.folderAt("parent")),
+						fileID():   custom.ToCustomDriveItem(d.fileAt(folder)),
 					},
 					folderID:                  folderID(),
 					isPackageOrChildOfPackage: false,
@@ -1136,7 +1141,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 				err := tree.setFolder(ctx, custom.ToCustomDriveItem(d.packageAtRoot()))
 				require.NoError(t, err, clues.ToCore(err))
 
-				err = tree.setFolder(ctx, custom.ToCustomDriveItem(d.folderAt(loc(pkg))))
+				err = tree.setFolder(ctx, custom.ToCustomDriveItem(d.folderAt(pkg)))
 				require.NoError(t, err, clues.ToCore(err))
 
 				return tree
@@ -1162,7 +1167,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 				folderID(): {
 					currPath: d.fullPath(t, folderName(pkg), folderName()),
 					files: map[string]*custom.DriveItem{
-						folderID(): custom.ToCustomDriveItem(d.folderAt(loc("parent"))),
+						folderID(): custom.ToCustomDriveItem(d.folderAt("parent")),
 					},
 					folderID:                  folderID(),
 					isPackageOrChildOfPackage: true,
@@ -1202,8 +1207,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 					folderID:                  folderID(),
 					isPackageOrChildOfPackage: false,
 					files: map[string]*custom.DriveItem{
-						folderID(): custom.ToCustomDriveItem(d.folderAt(loc("parent"))),
-						fileID():   custom.ToCustomDriveItem(d.fileAt(loc("parent", folder))),
+						folderID(): custom.ToCustomDriveItem(d.folderAt("parent")),
+						fileID():   custom.ToCustomDriveItem(d.fileAt(folder)),
 					},
 					prevPath: d.fullPath(t, folderName("parent-prev"), folderName()),
 				},

--- a/src/internal/m365/collection/drive/helper_test.go
+++ b/src/internal/m365/collection/drive/helper_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -315,10 +316,9 @@ func aColl(
 		ids = append(ids, fID+metadata.MetaFileSuffix)
 	}
 
-	// should always expect the folder to have a
-	// dir meta file for permissions.  Not expected
-	// to get added for tombstones.
-	if curr != nil {
+	// should expect all non-root, non-tombstone collections to contain
+	// a dir meta file for storing permissions.
+	if curr != nil && !strings.HasSuffix(curr.Folder(false), root) {
 		ids = append(ids, metadata.DirMetaFileSuffix)
 	}
 

--- a/src/internal/m365/collection/drive/helper_test.go
+++ b/src/internal/m365/collection/drive/helper_test.go
@@ -1471,7 +1471,11 @@ func (dd *deltaDrive) folderAt(
 	return driveItem(
 		folderID(folderSuffixes...),
 		folderName(folderSuffixes...),
-		dd.dir(),
+		// we should be putting in the full location here, not just the
+		// parent suffix.  But that full location would be unused because
+		// our unit tests don't utilize folder subselection (which is the
+		// only reason we need to provide the dir).
+		dd.dir(folderName(parentSuffix)),
 		folderID(parentSuffix),
 		isFolder)
 }

--- a/src/internal/m365/collection/drive/helper_test.go
+++ b/src/internal/m365/collection/drive/helper_test.go
@@ -1488,6 +1488,16 @@ func (dd *deltaDrive) packageAtRoot() models.DriveItemable {
 // assumption is only one suffix per id.  Mostly using
 // the variadic as an "optional" extension.
 func id(v string, suffixes ...any) string {
+	if len(suffixes) > 1 {
+		// this should fail any tests.  we could pass in a
+		// testing.T instead and fail the call here, but that
+		// produces a whole lot of chaff where this check should
+		// still get us the expected failure
+		return fmt.Sprintf(
+			"too many suffixes in the ID; should only be 0 or 1, got %d",
+			len(suffixes))
+	}
+
 	id := fmt.Sprintf("id_%s", v)
 
 	// a bit weird, but acts as a quality of life
@@ -1511,6 +1521,16 @@ func id(v string, suffixes ...any) string {
 // assumption is only one suffix per name.  Mostly using
 // the variadic as an "optional" extension.
 func name(v string, suffixes ...any) string {
+	if len(suffixes) > 1 {
+		// this should fail any tests.  we could pass in a
+		// testing.T instead and fail the call here, but that
+		// produces a whole lot of chaff where this check should
+		// still get us the expected failure
+		return fmt.Sprintf(
+			"too many suffixes in the Name; should only be 0 or 1, got %d",
+			len(suffixes))
+	}
+
 	name := fmt.Sprintf("n_%s", v)
 
 	// a bit weird, but acts as a quality of life

--- a/src/internal/m365/collection/drive/helper_test.go
+++ b/src/internal/m365/collection/drive/helper_test.go
@@ -1371,6 +1371,10 @@ func (dd *deltaDrive) fileAt(
 	return driveItem(
 		fileID(fileSuffixes...),
 		fileName(fileSuffixes...),
+		// the file's parent directory isn't used;
+		// this parameter is an artifact of the driveItem
+		// api and doesn't need to be populated for test
+		// success.
 		dd.dir(),
 		folderID(parentSuffix),
 		isFile)

--- a/src/internal/m365/collection/drive/limiter.go
+++ b/src/internal/m365/collection/drive/limiter.go
@@ -6,7 +6,10 @@ import (
 	"github.com/alcionai/corso/src/pkg/control"
 )
 
-var errHitLimit = clues.New("hit limiter limits")
+var (
+	errHitLimit           = clues.New("hit limiter limits")
+	errHitCollectionLimit = clues.New("hit item limits within the current collection")
+)
 
 type driveEnumerationStats struct {
 	numPages      int
@@ -111,9 +114,22 @@ func (l pagerLimiter) hitItemLimit(itemCount int) bool {
 	return l.enabled() && itemCount >= l.limits.MaxItems
 }
 
-// hitTotalBytesLimit returns true if the limiter is enabled and has reached the limit
+// alreadyHitTotalBytesLimit returns true if the limiter is enabled and has reached the limit
 // for the accumulated byte size of all items (the file contents, not the item metadata)
 // added to collections for this backup.
-func (l pagerLimiter) hitTotalBytesLimit(i int64) bool {
-	return l.enabled() && i >= l.limits.MaxBytes
+func (l pagerLimiter) alreadyHitTotalBytesLimit(i int64) bool {
+	return l.enabled() && i > l.limits.MaxBytes
+}
+
+// willStepOverBytesLimit returns true if the limiter is enabled and the provided addition
+// of bytes is greater than the limit plus some padding (to ensure we can always hit
+// the limit).
+func (l pagerLimiter) willStepOverBytesLimit(current, addition int64) bool {
+	if !l.enabled() {
+		return false
+	}
+
+	limitPlusPadding := int64(float64(l.limits.MaxBytes) * 1.03)
+
+	return (current + addition) > limitPlusPadding
 }

--- a/src/internal/m365/collection/drive/limiter_test.go
+++ b/src/internal/m365/collection/drive/limiter_test.go
@@ -93,8 +93,8 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 					delta(id(deltaURL), nil).with(aPage(
 						d1.fileWSizeAt(1, root, "f1"),
 						d1.folderAt(root),
-						d1.fileWSizeAt(2, loc(folder), "f2"),
-						d1.fileWSizeAt(1, loc(folder), "f3"))))),
+						d1.fileWSizeAt(2, folder, "f2"),
+						d1.fileWSizeAt(1, folder, "f3"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t):               {fileID("f1")},
 				d1.strPath(t, folderName()): {folderID(), fileID("f2")},
@@ -143,10 +143,10 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 							// Repeated items shouldn't count against the limit.
 							d1.fileAt(root, "f1"),
 							d1.folderAt(root),
-							d1.fileAt(loc(folder), "f3"),
-							d1.fileAt(loc(folder), "f4"),
-							d1.fileAt(loc(folder), "f5"),
-							d1.fileAt(loc(folder), "f6"))))),
+							d1.fileAt(folder, "f3"),
+							d1.fileAt(folder, "f4"),
+							d1.fileAt(folder, "f5"),
+							d1.fileAt(folder, "f6"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t):               {fileID("f1"), fileID("f2")},
 				d1.strPath(t, folderName()): {folderID(), fileID("f3")},
@@ -170,10 +170,10 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 							d1.fileAt(root, "f2")),
 						aPage(
 							d1.folderAt(root),
-							d1.fileAt(loc(folder), "f3"),
-							d1.fileAt(loc(folder), "f4"),
-							d1.fileAt(loc(folder), "f5"),
-							d1.fileAt(loc(folder), "f6"))))),
+							d1.fileAt(folder, "f3"),
+							d1.fileAt(folder, "f4"),
+							d1.fileAt(folder, "f5"),
+							d1.fileAt(folder, "f6"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t): {fileID("f1"), fileID("f2")},
 			},
@@ -197,8 +197,8 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 							d1.fileAt(root, "f3")),
 						aPage(
 							d1.folderAt(root),
-							d1.fileAt(loc(folder), "f4"),
-							d1.fileAt(loc(folder), "f5"))))),
+							d1.fileAt(folder, "f4"),
+							d1.fileAt(folder, "f5"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				// Root has an additional item. It's hard to fix that in the code
 				// though.
@@ -221,14 +221,14 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 					delta(id(deltaURL), nil).with(
 						aPage(
 							d1.folderAt(root),
-							d1.fileAt(loc(folder), "f1"),
-							d1.fileAt(loc(folder), "f2")),
+							d1.fileAt(folder, "f1"),
+							d1.fileAt(folder, "f2")),
 						aPage(
 							d1.folderAt(root),
 							// Updated item that shouldn't count against the limit a second time.
-							d1.fileAt(loc(folder), "f2"),
-							d1.fileAt(loc(folder), "f3"),
-							d1.fileAt(loc(folder), "f4"))))),
+							d1.fileAt(folder, "f2"),
+							d1.fileAt(folder, "f3"),
+							d1.fileAt(folder, "f4"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t):               {},
 				d1.strPath(t, folderName()): {folderID(), fileID("f1"), fileID("f2"), fileID("f3")},
@@ -252,12 +252,12 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 							d1.fileAt(root, "f2"),
 							// Put folder 0 at limit.
 							d1.folderAt(root),
-							d1.fileAt(loc(folder), "f3"),
-							d1.fileAt(loc(folder), "f4")),
+							d1.fileAt(folder, "f3"),
+							d1.fileAt(folder, "f4")),
 						aPage(
 							d1.folderAt(root),
 							// Try to move item from root to folder 0 which is already at the limit.
-							d1.fileAt(loc(folder), "f1"))))),
+							d1.fileAt(folder, "f1"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t):               {fileID("f1"), fileID("f2")},
 				d1.strPath(t, folderName()): {folderID(), fileID("f3"), fileID("f4")},
@@ -282,10 +282,10 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 							d1.fileAt(root, "f3")),
 						aPage(
 							d1.folderAt(root),
-							d1.fileAt(loc(folder), "f4")),
+							d1.fileAt(folder, "f4")),
 						aPage(
 							d1.folderAt(root),
-							d1.fileAt(loc(folder), "f5"))))),
+							d1.fileAt(folder, "f5"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t):               {fileID("f1"), fileID("f2"), fileID("f3")},
 				d1.strPath(t, folderName()): {folderID(), fileID("f4"), fileID("f5")},
@@ -310,13 +310,13 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 							d1.fileAt(root, "f3")),
 						aPage(
 							d1.folderAt(root),
-							d1.fileAt(loc(folder), "f4"),
-							d1.fileAt(loc(folder), "f5"),
+							d1.fileAt(folder, "f4"),
+							d1.fileAt(folder, "f5"),
 							// This container shouldn't be returned.
 							d1.folderAt(root, 2),
-							d1.fileAt(loc(2), "f7"),
-							d1.fileAt(loc(2), "f8"),
-							d1.fileAt(loc(2), "f9"))))),
+							d1.fileAt(2, "f7"),
+							d1.fileAt(2, "f8"),
+							d1.fileAt(2, "f9"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t):               {fileID("f1"), fileID("f2"), fileID("f3")},
 				d1.strPath(t, folderName()): {folderID(), fileID("f4"), fileID("f5")},
@@ -341,14 +341,14 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 							d1.fileAt(root, "f3")),
 						aPage(
 							d1.folderAt(root),
-							d1.fileAt(loc(folder), "f4"),
-							d1.fileAt(loc(folder), "f5")),
+							d1.fileAt(folder, "f4"),
+							d1.fileAt(folder, "f5")),
 						aPage(
 							// This container shouldn't be returned.
 							d1.folderAt(root, 2),
-							d1.fileAt(loc(2), "f7"),
-							d1.fileAt(loc(2), "f8"),
-							d1.fileAt(loc(2), "f9"))))),
+							d1.fileAt(2, "f7"),
+							d1.fileAt(2, "f8"),
+							d1.fileAt(2, "f9"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t):               {fileID("f1"), fileID("f2"), fileID("f3")},
 				d1.strPath(t, folderName()): {folderID(), fileID("f4"), fileID("f5")},
@@ -402,10 +402,10 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 							d1.fileAt(root, "f3")),
 						aPage(
 							d1.folderAt(root),
-							d1.fileAt(loc(folder), "f4")),
+							d1.fileAt(folder, "f4")),
 						aPage(
 							d1.folderAt(root),
-							d1.fileAt(loc(folder), "f5"))))),
+							d1.fileAt(folder, "f5"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t):               {fileID("f1"), fileID("f2"), fileID("f3")},
 				d1.strPath(t, folderName()): {folderID(), fileID("f4"), fileID("f5")},

--- a/src/internal/m365/collection/drive/limiter_test.go
+++ b/src/internal/m365/collection/drive/limiter_test.go
@@ -51,9 +51,9 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 			enumerator: driveEnumerator(
 				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(aPage(
-						d1.fileWSizeAtRoot(7, "f1"),
-						d1.fileWSizeAtRoot(1, "f2"),
-						d1.fileWSizeAtRoot(1, "f3"))))),
+						d1.fileWSizeAt(7, root, "f1"),
+						d1.fileWSizeAt(1, root, "f2"),
+						d1.fileWSizeAt(1, root, "f3"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t): {fileID("f2"), fileID("f3")},
 			},
@@ -71,9 +71,9 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 			enumerator: driveEnumerator(
 				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(aPage(
-						d1.fileWSizeAtRoot(1, "f1"),
-						d1.fileWSizeAtRoot(2, "f2"),
-						d1.fileWSizeAtRoot(1, "f3"))))),
+						d1.fileWSizeAt(1, root, "f1"),
+						d1.fileWSizeAt(2, root, "f2"),
+						d1.fileWSizeAt(1, root, "f3"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t): {fileID("f1"), fileID("f2")},
 			},
@@ -91,10 +91,10 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 			enumerator: driveEnumerator(
 				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(aPage(
-						d1.fileWSizeAtRoot(1, "f1"),
-						d1.folderAtRoot(),
-						d1.fileWSizeAt(2, folder, "f2"),
-						d1.fileWSizeAt(1, folder, "f3"))))),
+						d1.fileWSizeAt(1, root, "f1"),
+						d1.folderAt(root),
+						d1.fileWSizeAt(2, loc(folder), "f2"),
+						d1.fileWSizeAt(1, loc(folder), "f3"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t):               {fileID("f1")},
 				d1.strPath(t, folderName()): {folderID(), fileID("f2")},
@@ -113,12 +113,12 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 			enumerator: driveEnumerator(
 				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(aPage(
-						d1.fileAtRoot("f1"),
-						d1.fileAtRoot("f2"),
-						d1.fileAtRoot("f3"),
-						d1.fileAtRoot("f4"),
-						d1.fileAtRoot("f5"),
-						d1.fileAtRoot("f6"))))),
+						d1.fileAt(root, "f1"),
+						d1.fileAt(root, "f2"),
+						d1.fileAt(root, "f3"),
+						d1.fileAt(root, "f4"),
+						d1.fileAt(root, "f5"),
+						d1.fileAt(root, "f6"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t): {fileID("f1"), fileID("f2"), fileID("f3")},
 			},
@@ -137,16 +137,16 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d1.fileAtRoot("f1"),
-							d1.fileAtRoot("f2")),
+							d1.fileAt(root, "f1"),
+							d1.fileAt(root, "f2")),
 						aPage(
 							// Repeated items shouldn't count against the limit.
-							d1.fileAtRoot("f1"),
-							d1.folderAtRoot(),
-							d1.fileAt(folder, "f3"),
-							d1.fileAt(folder, "f4"),
-							d1.fileAt(folder, "f5"),
-							d1.fileAt(folder, "f6"))))),
+							d1.fileAt(root, "f1"),
+							d1.folderAt(root),
+							d1.fileAt(loc(folder), "f3"),
+							d1.fileAt(loc(folder), "f4"),
+							d1.fileAt(loc(folder), "f5"),
+							d1.fileAt(loc(folder), "f6"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t):               {fileID("f1"), fileID("f2")},
 				d1.strPath(t, folderName()): {folderID(), fileID("f3")},
@@ -166,14 +166,14 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d1.fileAtRoot("f1"),
-							d1.fileAtRoot("f2")),
+							d1.fileAt(root, "f1"),
+							d1.fileAt(root, "f2")),
 						aPage(
-							d1.folderAtRoot(),
-							d1.fileAt(folder, "f3"),
-							d1.fileAt(folder, "f4"),
-							d1.fileAt(folder, "f5"),
-							d1.fileAt(folder, "f6"))))),
+							d1.folderAt(root),
+							d1.fileAt(loc(folder), "f3"),
+							d1.fileAt(loc(folder), "f4"),
+							d1.fileAt(loc(folder), "f5"),
+							d1.fileAt(loc(folder), "f6"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t): {fileID("f1"), fileID("f2")},
 			},
@@ -192,13 +192,13 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d1.fileAtRoot("f1"),
-							d1.fileAtRoot("f2"),
-							d1.fileAtRoot("f3")),
+							d1.fileAt(root, "f1"),
+							d1.fileAt(root, "f2"),
+							d1.fileAt(root, "f3")),
 						aPage(
-							d1.folderAtRoot(),
-							d1.fileAt(folder, "f4"),
-							d1.fileAt(folder, "f5"))))),
+							d1.folderAt(root),
+							d1.fileAt(loc(folder), "f4"),
+							d1.fileAt(loc(folder), "f5"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				// Root has an additional item. It's hard to fix that in the code
 				// though.
@@ -220,15 +220,15 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d1.folderAtRoot(),
-							d1.fileAt(folder, "f1"),
-							d1.fileAt(folder, "f2")),
+							d1.folderAt(root),
+							d1.fileAt(loc(folder), "f1"),
+							d1.fileAt(loc(folder), "f2")),
 						aPage(
-							d1.folderAtRoot(),
+							d1.folderAt(root),
 							// Updated item that shouldn't count against the limit a second time.
-							d1.fileAt(folder, "f2"),
-							d1.fileAt(folder, "f3"),
-							d1.fileAt(folder, "f4"))))),
+							d1.fileAt(loc(folder), "f2"),
+							d1.fileAt(loc(folder), "f3"),
+							d1.fileAt(loc(folder), "f4"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t):               {},
 				d1.strPath(t, folderName()): {folderID(), fileID("f1"), fileID("f2"), fileID("f3")},
@@ -248,16 +248,16 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d1.fileAtRoot("f1"),
-							d1.fileAtRoot("f2"),
+							d1.fileAt(root, "f1"),
+							d1.fileAt(root, "f2"),
 							// Put folder 0 at limit.
-							d1.folderAtRoot(),
-							d1.fileAt(folder, "f3"),
-							d1.fileAt(folder, "f4")),
+							d1.folderAt(root),
+							d1.fileAt(loc(folder), "f3"),
+							d1.fileAt(loc(folder), "f4")),
 						aPage(
-							d1.folderAtRoot(),
+							d1.folderAt(root),
 							// Try to move item from root to folder 0 which is already at the limit.
-							d1.fileAt(folder, "f1"))))),
+							d1.fileAt(loc(folder), "f1"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t):               {fileID("f1"), fileID("f2")},
 				d1.strPath(t, folderName()): {folderID(), fileID("f3"), fileID("f4")},
@@ -277,15 +277,15 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d1.fileAtRoot("f1"),
-							d1.fileAtRoot("f2"),
-							d1.fileAtRoot("f3")),
+							d1.fileAt(root, "f1"),
+							d1.fileAt(root, "f2"),
+							d1.fileAt(root, "f3")),
 						aPage(
-							d1.folderAtRoot(),
-							d1.fileAt(folder, "f4")),
+							d1.folderAt(root),
+							d1.fileAt(loc(folder), "f4")),
 						aPage(
-							d1.folderAtRoot(),
-							d1.fileAt(folder, "f5"))))),
+							d1.folderAt(root),
+							d1.fileAt(loc(folder), "f5"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t):               {fileID("f1"), fileID("f2"), fileID("f3")},
 				d1.strPath(t, folderName()): {folderID(), fileID("f4"), fileID("f5")},
@@ -305,18 +305,18 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d1.fileAtRoot("f1"),
-							d1.fileAtRoot("f2"),
-							d1.fileAtRoot("f3")),
+							d1.fileAt(root, "f1"),
+							d1.fileAt(root, "f2"),
+							d1.fileAt(root, "f3")),
 						aPage(
-							d1.folderAtRoot(),
-							d1.fileAt(folder, "f4"),
-							d1.fileAt(folder, "f5"),
+							d1.folderAt(root),
+							d1.fileAt(loc(folder), "f4"),
+							d1.fileAt(loc(folder), "f5"),
 							// This container shouldn't be returned.
-							d1.folderAtRoot(2),
-							d1.fileAt(2, "f7"),
-							d1.fileAt(2, "f8"),
-							d1.fileAt(2, "f9"))))),
+							d1.folderAt(root, 2),
+							d1.fileAt(loc(2), "f7"),
+							d1.fileAt(loc(2), "f8"),
+							d1.fileAt(loc(2), "f9"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t):               {fileID("f1"), fileID("f2"), fileID("f3")},
 				d1.strPath(t, folderName()): {folderID(), fileID("f4"), fileID("f5")},
@@ -336,19 +336,19 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d1.fileAtRoot("f1"),
-							d1.fileAtRoot("f2"),
-							d1.fileAtRoot("f3")),
+							d1.fileAt(root, "f1"),
+							d1.fileAt(root, "f2"),
+							d1.fileAt(root, "f3")),
 						aPage(
-							d1.folderAtRoot(),
-							d1.fileAt(folder, "f4"),
-							d1.fileAt(folder, "f5")),
+							d1.folderAt(root),
+							d1.fileAt(loc(folder), "f4"),
+							d1.fileAt(loc(folder), "f5")),
 						aPage(
 							// This container shouldn't be returned.
-							d1.folderAtRoot(2),
-							d1.fileAt(2, "f7"),
-							d1.fileAt(2, "f8"),
-							d1.fileAt(2, "f9"))))),
+							d1.folderAt(root, 2),
+							d1.fileAt(loc(2), "f7"),
+							d1.fileAt(loc(2), "f8"),
+							d1.fileAt(loc(2), "f9"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t):               {fileID("f1"), fileID("f2"), fileID("f3")},
 				d1.strPath(t, folderName()): {folderID(), fileID("f4"), fileID("f5")},
@@ -367,18 +367,18 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 			enumerator: driveEnumerator(
 				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(aPage(
-						d1.fileAtRoot("f1"),
-						d1.fileAtRoot("f2"),
-						d1.fileAtRoot("f3"),
-						d1.fileAtRoot("f4"),
-						d1.fileAtRoot("f5")))),
+						d1.fileAt(root, "f1"),
+						d1.fileAt(root, "f2"),
+						d1.fileAt(root, "f3"),
+						d1.fileAt(root, "f4"),
+						d1.fileAt(root, "f5")))),
 				d2.newEnumer().with(
 					delta(id(deltaURL), nil).with(aPage(
-						d2.fileAtRoot("f1"),
-						d2.fileAtRoot("f2"),
-						d2.fileAtRoot("f3"),
-						d2.fileAtRoot("f4"),
-						d2.fileAtRoot("f5"))))),
+						d2.fileAt(root, "f1"),
+						d2.fileAt(root, "f2"),
+						d2.fileAt(root, "f3"),
+						d2.fileAt(root, "f4"),
+						d2.fileAt(root, "f5"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t): {fileID("f1"), fileID("f2"), fileID("f3")},
 				d2.strPath(t): {fileID("f1"), fileID("f2"), fileID("f3")},
@@ -397,15 +397,15 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 				d1.newEnumer().with(
 					delta(id(deltaURL), nil).with(
 						aPage(
-							d1.fileAtRoot("f1"),
-							d1.fileAtRoot("f2"),
-							d1.fileAtRoot("f3")),
+							d1.fileAt(root, "f1"),
+							d1.fileAt(root, "f2"),
+							d1.fileAt(root, "f3")),
 						aPage(
-							d1.folderAtRoot(),
-							d1.fileAt(folder, "f4")),
+							d1.folderAt(root),
+							d1.fileAt(loc(folder), "f4")),
 						aPage(
-							d1.folderAtRoot(),
-							d1.fileAt(folder, "f5"))))),
+							d1.folderAt(root),
+							d1.fileAt(loc(folder), "f5"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t):               {fileID("f1"), fileID("f2"), fileID("f3")},
 				d1.strPath(t, folderName()): {folderID(), fileID("f4"), fileID("f5")},

--- a/src/internal/m365/collection/drive/url_cache_test.go
+++ b/src/internal/m365/collection/drive/url_cache_test.go
@@ -509,7 +509,7 @@ func (suite *URLCacheUnitSuite) TestGetItemProperties() {
 			pages: []nextPage{
 				aPage(
 					d.fileWURLAtRoot(aURL(1), false, 1),
-					d.folderAtRoot(2)),
+					d.folderAt(root, 2)),
 			},
 			expectedItemProps: map[string]itemProps{
 				fileID(2): {},


### PR DESCRIPTION
makes two changes:
1. has `addFile` take in only a drive item, instead of ids and an item.
2. removes the file/folderAtRoot() generators in favor of *At(root, ...)

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Supportability/Tests

#### Issue(s)

* #4689

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
