### PR TITLE
ensure the tree limiter handling is correct

### DIFF
--- a/src/internal/m365/collection/drive/collection_test.go
+++ b/src/internal/m365/collection/drive/collection_test.go
@@ -300,12 +300,12 @@ func (suite *CollectionUnitSuite) TestCollection() {
 
 func (suite *CollectionUnitSuite) TestCollectionReadError() {
 	var (
-		t                = suite.T()
-		stubItemID       = "fakeItemID"
-		collStatus       = support.ControllerOperationStatus{}
-		wg               = sync.WaitGroup{}
-		size       int64 = defaultFileSize
-		now              = time.Now()
+		t          = suite.T()
+		stubItemID = "fakeItemID"
+		collStatus = support.ControllerOperationStatus{}
+		wg         = sync.WaitGroup{}
+		size       = defaultFileSize
+		now        = time.Now()
 	)
 
 	ctx, flush := tester.NewContext(t)
@@ -370,12 +370,12 @@ func (suite *CollectionUnitSuite) TestCollectionReadError() {
 
 func (suite *CollectionUnitSuite) TestCollectionReadUnauthorizedErrorRetry() {
 	var (
-		t                = suite.T()
-		stubItemID       = "fakeItemID"
-		collStatus       = support.ControllerOperationStatus{}
-		wg               = sync.WaitGroup{}
-		size       int64 = defaultFileSize
-		now              = time.Now()
+		t          = suite.T()
+		stubItemID = "fakeItemID"
+		collStatus = support.ControllerOperationStatus{}
+		wg         = sync.WaitGroup{}
+		size       = defaultFileSize
+		now        = time.Now()
 	)
 
 	ctx, flush := tester.NewContext(t)

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -638,17 +638,25 @@ func (c *Collections) addFileToTree(
 	if parentNotNil && !alreadySeen {
 		countSize := tree.countLiveFilesAndSizes()
 
+		// Tell the enumerator to exit if we've already hit the total
+		// limit of bytes or items in this backup.
+		if limiter.alreadyHitTotalBytesLimit(countSize.totalBytes) ||
+			limiter.hitItemLimit(countSize.numFiles) {
+			return nil, errHitLimit
+		}
+
 		// Don't add new items if the new collection has already reached it's limit.
 		// item moves and updates are generally allowed through.
-		if limiter.atContainerItemsLimit(len(parentNode.files)) || limiter.hitItemLimit(countSize.numFiles) {
+		if limiter.atContainerItemsLimit(len(parentNode.files)) {
 			return nil, errHitCollectionLimit
 		}
 
 		// Don't include large files that don't fit within the size limit.
-		// Unlike the other checks, which see if we're already at the limit, this check
-		// needs to be forward-facing to ensure we don't go far over the limit.
+		// Unlike the other checks, which see if we're already at the limit,
+		// this check needs to be forward-facing to ensure we don't go far
+		// over the limit
 		// Example case: a 1gb limit and a 25gb file.
-		if limiter.hitTotalBytesLimit(fileSize + countSize.totalBytes) {
+		if limiter.willStepOverBytesLimit(countSize.totalBytes, fileSize) {
 			// don't return errHitLimit here; we only want to skip the
 			// current file.  We may not want to skip files after it.
 			return nil, nil

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -458,6 +458,14 @@ func (c *Collections) enumeratePageOfItems(
 				return err
 			}
 
+			// special case: we only want to add a limited number of files
+			// to each collection.  But if one collection fills up, we don't
+			// want to break out of the whole backup.  That allows us to preview
+			// many folders with a small selection of files in each.
+			if errors.Is(err, errHitCollectionLimit) {
+				continue
+			}
+
 			el.AddRecoverable(ictx, clues.Wrap(err, "adding folder"))
 		}
 	}
@@ -633,15 +641,17 @@ func (c *Collections) addFileToTree(
 		// Don't add new items if the new collection has already reached it's limit.
 		// item moves and updates are generally allowed through.
 		if limiter.atContainerItemsLimit(len(parentNode.files)) || limiter.hitItemLimit(countSize.numFiles) {
-			return nil, errHitLimit
+			return nil, errHitCollectionLimit
 		}
 
-		// Skip large files that don't fit within the size limit.
-		// unlike the other checks, which see if we're already at the limit, this check
+		// Don't include large files that don't fit within the size limit.
+		// Unlike the other checks, which see if we're already at the limit, this check
 		// needs to be forward-facing to ensure we don't go far over the limit.
 		// Example case: a 1gb limit and a 25gb file.
 		if limiter.hitTotalBytesLimit(fileSize + countSize.totalBytes) {
-			return nil, errHitLimit
+			// don't return errHitLimit here; we only want to skip the
+			// current file.  We may not want to skip files after it.
+			return nil, nil
 		}
 	}
 

--- a/src/internal/m365/collection/drive/collections_tree_test.go
+++ b/src/internal/m365/collection/drive/collections_tree_test.go
@@ -2209,10 +2209,18 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 	d := drive()
 
+	unlimitedItemsPerContainer := newPagerLimiter(minimumLimitOpts())
+	unlimitedItemsPerContainer.limits.MaxItemsPerContainer = 9001
+
+	unlimitedTotalBytesAndFiles := newPagerLimiter(minimumLimitOpts())
+	unlimitedTotalBytesAndFiles.limits.MaxBytes = 9001
+	unlimitedTotalBytesAndFiles.limits.MaxItems = 9001
+
 	type expected struct {
 		counts                        countTD.Expected
 		err                           require.ErrorAssertionFunc
 		shouldHitLimit                bool
+		shouldHitCollLimit            bool
 		skipped                       assert.ValueAssertionFunc
 		treeContainsFileIDsWithParent map[string]string
 		countLiveFiles                int
@@ -2330,7 +2338,44 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 			name:    "already at container file limit",
 			tree:    treeWithFileAtRoot,
 			file:    d.fileAt(root, 2),
-			limiter: newPagerLimiter(minimumLimitOpts()),
+			limiter: unlimitedTotalBytesAndFiles,
+			expect: expected{
+				counts: countTD.Expected{
+					count.TotalFilesProcessed: 1,
+				},
+				err:                require.Error,
+				shouldHitCollLimit: true,
+				skipped:            assert.Nil,
+				treeContainsFileIDsWithParent: map[string]string{
+					fileID(): rootID,
+				},
+				countLiveFiles:  1,
+				countTotalBytes: defaultFileSize,
+			},
+		},
+		{
+			name:    "goes over total byte limit",
+			tree:    treeWithRoot,
+			file:    d.fileAt(root),
+			limiter: unlimitedItemsPerContainer,
+			expect: expected{
+				counts: countTD.Expected{
+					count.TotalFilesProcessed: 1,
+				},
+				// no error here, since byte limit shouldn't
+				// make the func return an error.
+				err:                           require.NoError,
+				skipped:                       assert.Nil,
+				treeContainsFileIDsWithParent: map[string]string{},
+				countLiveFiles:                0,
+				countTotalBytes:               0,
+			},
+		},
+		{
+			name:    "already over total byte limit",
+			tree:    treeWithFileAtRoot,
+			file:    d.fileAt(root, 2),
+			limiter: unlimitedItemsPerContainer,
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalFilesProcessed: 1,
@@ -2343,25 +2388,6 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 				},
 				countLiveFiles:  1,
 				countTotalBytes: defaultFileSize,
-			},
-		},
-		{
-			name:    "goes over total byte limit",
-			tree:    treeWithRoot,
-			file:    d.fileAt(root),
-			limiter: newPagerLimiter(minimumLimitOpts()),
-			expect: expected{
-				counts: countTD.Expected{
-					count.TotalFilesProcessed: 1,
-				},
-				// no error here, since byte limit shouldn't
-				// make the func return errHitLimit.
-				err:                           require.NoError,
-				shouldHitLimit:                false,
-				skipped:                       assert.Nil,
-				treeContainsFileIDsWithParent: map[string]string{},
-				countLiveFiles:                0,
-				countTotalBytes:               0,
 			},
 		},
 	}
@@ -2389,8 +2415,12 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 			test.expect.err(t, err, clues.ToCore(err))
 			test.expect.skipped(t, skipped)
 
-			if test.expect.shouldHitLimit {
+			if test.expect.shouldHitCollLimit {
 				require.ErrorIs(t, err, errHitCollectionLimit, clues.ToCore(err))
+			}
+
+			if test.expect.shouldHitLimit {
+				require.ErrorIs(t, err, errHitLimit, clues.ToCore(err))
 			}
 
 			assert.Equal(t, test.expect.treeContainsFileIDsWithParent, tree.fileIDToParentID)

--- a/src/internal/m365/collection/drive/collections_tree_test.go
+++ b/src/internal/m365/collection/drive/collections_tree_test.go
@@ -2354,8 +2354,10 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 				counts: countTD.Expected{
 					count.TotalFilesProcessed: 1,
 				},
-				err:                           require.Error,
-				shouldHitLimit:                true,
+				// no error here, since byte limit shouldn't
+				// make the func return errHitLimit.
+				err:                           require.NoError,
+				shouldHitLimit:                false,
 				skipped:                       assert.Nil,
 				treeContainsFileIDsWithParent: map[string]string{},
 				countLiveFiles:                0,
@@ -2388,7 +2390,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 			test.expect.skipped(t, skipped)
 
 			if test.expect.shouldHitLimit {
-				require.ErrorIs(t, err, errHitLimit, clues.ToCore(err))
+				require.ErrorIs(t, err, errHitCollectionLimit, clues.ToCore(err))
 			}
 
 			assert.Equal(t, test.expect.treeContainsFileIDsWithParent, tree.fileIDToParentID)

--- a/src/internal/m365/collection/drive/delta_tree.go
+++ b/src/internal/m365/collection/drive/delta_tree.go
@@ -468,11 +468,15 @@ func walkTreeAndBuildCollections(
 				"path_suffix", parentPath.Elements())
 	}
 
-	// add the folder itself to the list of files inside the folder.
-	// that will cause the collection processor to generate a metadata
-	// file to hold the folder's permissions.
-	files := maps.Clone(node.files)
-	files[id] = node.folder
+	files := node.files
+
+	if !isRoot {
+		// add the folder itself to the list of files inside the folder.
+		// that will cause the collection processor to generate a metadata
+		// file to hold the folder's permissions.
+		files = maps.Clone(node.files)
+		files[id] = node.folder
+	}
 
 	cbl := collectable{
 		currPath:                  collectionPath,

--- a/src/internal/m365/collection/drive/delta_tree_test.go
+++ b/src/internal/m365/collection/drive/delta_tree_test.go
@@ -1074,10 +1074,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expectErr: require.NoError,
 			expect: map[string]collectable{
 				rootID: {
-					currPath: d.fullPath(t),
-					files: map[string]*custom.DriveItem{
-						rootID: custom.ToCustomDriveItem(rootFolder()),
-					},
+					currPath:                  d.fullPath(t),
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 				},
@@ -1091,7 +1089,6 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 				rootID: {
 					currPath: d.fullPath(t),
 					files: map[string]*custom.DriveItem{
-						rootID:   custom.ToCustomDriveItem(rootFolder()),
 						fileID(): custom.ToCustomDriveItem(d.fileAt(root)),
 					},
 					folderID:                  rootID,
@@ -1105,10 +1102,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expectErr: require.NoError,
 			expect: map[string]collectable{
 				rootID: {
-					currPath: d.fullPath(t),
-					files: map[string]*custom.DriveItem{
-						rootID: custom.ToCustomDriveItem(rootFolder()),
-					},
+					currPath:                  d.fullPath(t),
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 				},
@@ -1149,10 +1144,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expectErr: require.NoError,
 			expect: map[string]collectable{
 				rootID: {
-					currPath: d.fullPath(t),
-					files: map[string]*custom.DriveItem{
-						rootID: custom.ToCustomDriveItem(rootFolder()),
-					},
+					currPath:                  d.fullPath(t),
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 				},
@@ -1185,10 +1178,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			},
 			expect: map[string]collectable{
 				rootID: {
-					currPath: d.fullPath(t),
-					files: map[string]*custom.DriveItem{
-						rootID: custom.ToCustomDriveItem(rootFolder()),
-					},
+					currPath:                  d.fullPath(t),
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					prevPath:                  d.fullPath(t),
@@ -1224,10 +1215,8 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			expectErr: require.NoError,
 			expect: map[string]collectable{
 				rootID: {
-					currPath: d.fullPath(t),
-					files: map[string]*custom.DriveItem{
-						rootID: custom.ToCustomDriveItem(rootFolder()),
-					},
+					currPath:                  d.fullPath(t),
+					files:                     map[string]*custom.DriveItem{},
 					folderID:                  rootID,
 					isPackageOrChildOfPackage: false,
 					prevPath:                  d.fullPath(t),

--- a/src/internal/m365/collection/drive/helper_test.go
+++ b/src/internal/m365/collection/drive/helper_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -315,10 +316,9 @@ func aColl(
 		ids = append(ids, fID+metadata.MetaFileSuffix)
 	}
 
-	// should always expect the folder to have a
-	// dir meta file for permissions.  Not expected
-	// to get added for tombstones.
-	if curr != nil {
+	// should expect all non-root, non-tombstone collections to contain
+	// a dir meta file for storing permissions.
+	if curr != nil && !strings.HasSuffix(curr.Folder(false), root) {
 		ids = append(ids, metadata.DirMetaFileSuffix)
 	}
 

--- a/src/internal/m365/collection/drive/limiter.go
+++ b/src/internal/m365/collection/drive/limiter.go
@@ -114,9 +114,22 @@ func (l pagerLimiter) hitItemLimit(itemCount int) bool {
 	return l.enabled() && itemCount >= l.limits.MaxItems
 }
 
-// hitTotalBytesLimit returns true if the limiter is enabled and has reached the limit
+// alreadyHitTotalBytesLimit returns true if the limiter is enabled and has reached the limit
 // for the accumulated byte size of all items (the file contents, not the item metadata)
 // added to collections for this backup.
-func (l pagerLimiter) hitTotalBytesLimit(i int64) bool {
+func (l pagerLimiter) alreadyHitTotalBytesLimit(i int64) bool {
 	return l.enabled() && i > l.limits.MaxBytes
+}
+
+// willStepOverBytesLimit returns true if the limiter is enabled and the provided addition
+// of bytes is greater than the limit plus some padding (to ensure we can always hit
+// the limit).
+func (l pagerLimiter) willStepOverBytesLimit(current, addition int64) bool {
+	if !l.enabled() {
+		return false
+	}
+
+	limitPlusPadding := int64(float64(l.limits.MaxBytes) * 1.03)
+
+	return (current + addition) > limitPlusPadding
 }

--- a/src/internal/m365/collection/drive/limiter.go
+++ b/src/internal/m365/collection/drive/limiter.go
@@ -6,7 +6,10 @@ import (
 	"github.com/alcionai/corso/src/pkg/control"
 )
 
-var errHitLimit = clues.New("hit limiter limits")
+var (
+	errHitLimit           = clues.New("hit limiter limits")
+	errHitCollectionLimit = clues.New("hit item limits within the current collection")
+)
 
 type driveEnumerationStats struct {
 	numPages      int
@@ -115,5 +118,5 @@ func (l pagerLimiter) hitItemLimit(itemCount int) bool {
 // for the accumulated byte size of all items (the file contents, not the item metadata)
 // added to collections for this backup.
 func (l pagerLimiter) hitTotalBytesLimit(i int64) bool {
-	return l.enabled() && i >= l.limits.MaxBytes
+	return l.enabled() && i > l.limits.MaxBytes
 }

--- a/src/internal/m365/collection/drive/limiter_test.go
+++ b/src/internal/m365/collection/drive/limiter_test.go
@@ -34,6 +34,11 @@ type backupLimitTest struct {
 	// Collection name -> set of item IDs. We can't check item data because
 	// that's not mocked out. Metadata is checked separately.
 	expectedItemIDsInCollection map[string][]string
+	// Collection name -> set of item IDs. We can't check item data because
+	// that's not mocked out. Metadata is checked separately.
+	// the tree version has some different (more accurate) expectations
+	// for success
+	expectedItemIDsInCollectionTree map[string][]string
 }
 
 func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
@@ -50,10 +55,11 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 			},
 			enumerator: driveEnumerator(
 				d1.newEnumer().with(
-					delta(id(deltaURL), nil).with(aPage(
-						d1.fileWSizeAt(7, root, "f1"),
-						d1.fileWSizeAt(1, root, "f2"),
-						d1.fileWSizeAt(1, root, "f3"))))),
+					delta(id(deltaURL), nil).with(
+						aPage(
+							d1.fileWSizeAt(7, root, "f1"),
+							d1.fileWSizeAt(1, root, "f2"),
+							d1.fileWSizeAt(1, root, "f3"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t): {fileID("f2"), fileID("f3")},
 			},
@@ -70,10 +76,11 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 			},
 			enumerator: driveEnumerator(
 				d1.newEnumer().with(
-					delta(id(deltaURL), nil).with(aPage(
-						d1.fileWSizeAt(1, root, "f1"),
-						d1.fileWSizeAt(2, root, "f2"),
-						d1.fileWSizeAt(1, root, "f3"))))),
+					delta(id(deltaURL), nil).with(
+						aPage(
+							d1.fileWSizeAt(1, root, "f1"),
+							d1.fileWSizeAt(2, root, "f2"),
+							d1.fileWSizeAt(1, root, "f3"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t): {fileID("f1"), fileID("f2")},
 			},
@@ -90,11 +97,12 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 			},
 			enumerator: driveEnumerator(
 				d1.newEnumer().with(
-					delta(id(deltaURL), nil).with(aPage(
-						d1.fileWSizeAt(1, root, "f1"),
-						d1.folderAt(root),
-						d1.fileWSizeAt(2, folder, "f2"),
-						d1.fileWSizeAt(1, folder, "f3"))))),
+					delta(id(deltaURL), nil).with(
+						aPage(
+							d1.fileWSizeAt(1, root, "f1"),
+							d1.folderAt(root),
+							d1.fileWSizeAt(2, folder, "f2"),
+							d1.fileWSizeAt(1, folder, "f3"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t):               {fileID("f1")},
 				d1.strPath(t, folderName()): {folderID(), fileID("f2")},
@@ -112,13 +120,14 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 			},
 			enumerator: driveEnumerator(
 				d1.newEnumer().with(
-					delta(id(deltaURL), nil).with(aPage(
-						d1.fileAt(root, "f1"),
-						d1.fileAt(root, "f2"),
-						d1.fileAt(root, "f3"),
-						d1.fileAt(root, "f4"),
-						d1.fileAt(root, "f5"),
-						d1.fileAt(root, "f6"))))),
+					delta(id(deltaURL), nil).with(
+						aPage(
+							d1.fileAt(root, "f1"),
+							d1.fileAt(root, "f2"),
+							d1.fileAt(root, "f3"),
+							d1.fileAt(root, "f4"),
+							d1.fileAt(root, "f5"),
+							d1.fileAt(root, "f6"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t): {fileID("f1"), fileID("f2"), fileID("f3")},
 			},
@@ -200,9 +209,13 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 							d1.fileAt(folder, "f4"),
 							d1.fileAt(folder, "f5"))))),
 			expectedItemIDsInCollection: map[string][]string{
-				// Root has an additional item. It's hard to fix that in the code
-				// though.
+				// Root has an additional item. It's hard to fix that in the code though.
 				d1.strPath(t):               {fileID("f1"), fileID("f2")},
+				d1.strPath(t, folderName()): {folderID(), fileID("f4")},
+			},
+			expectedItemIDsInCollectionTree: map[string][]string{
+				// the tree version doesn't have this problem.
+				d1.strPath(t):               {fileID("f1")},
 				d1.strPath(t, folderName()): {folderID(), fileID("f4")},
 			},
 		},
@@ -250,7 +263,7 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 						aPage(
 							d1.fileAt(root, "f1"),
 							d1.fileAt(root, "f2"),
-							// Put folder 0 at limit.
+							// Put root/folder at limit.
 							d1.folderAt(root),
 							d1.fileAt(folder, "f3"),
 							d1.fileAt(folder, "f4")),
@@ -261,6 +274,13 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t):               {fileID("f1"), fileID("f2")},
 				d1.strPath(t, folderName()): {folderID(), fileID("f3"), fileID("f4")},
+			},
+			expectedItemIDsInCollectionTree: map[string][]string{
+				d1.strPath(t): {fileID("f2")},
+				// note that the tree version allows f1 to get moved.
+				// we've already committed to backing up the file as part of the preview,
+				// it doesn't seem rational to prevent its movement
+				d1.strPath(t, folderName()): {folderID(), fileID("f3"), fileID("f4"), fileID("f1")},
 			},
 		},
 		{
@@ -366,19 +386,21 @@ func backupLimitTable(t *testing.T, d1, d2 *deltaDrive) []backupLimitTest {
 			},
 			enumerator: driveEnumerator(
 				d1.newEnumer().with(
-					delta(id(deltaURL), nil).with(aPage(
-						d1.fileAt(root, "f1"),
-						d1.fileAt(root, "f2"),
-						d1.fileAt(root, "f3"),
-						d1.fileAt(root, "f4"),
-						d1.fileAt(root, "f5")))),
+					delta(id(deltaURL), nil).with(
+						aPage(
+							d1.fileAt(root, "f1"),
+							d1.fileAt(root, "f2"),
+							d1.fileAt(root, "f3"),
+							d1.fileAt(root, "f4"),
+							d1.fileAt(root, "f5")))),
 				d2.newEnumer().with(
-					delta(id(deltaURL), nil).with(aPage(
-						d2.fileAt(root, "f1"),
-						d2.fileAt(root, "f2"),
-						d2.fileAt(root, "f3"),
-						d2.fileAt(root, "f4"),
-						d2.fileAt(root, "f5"))))),
+					delta(id(deltaURL), nil).with(
+						aPage(
+							d2.fileAt(root, "f1"),
+							d2.fileAt(root, "f2"),
+							d2.fileAt(root, "f3"),
+							d2.fileAt(root, "f4"),
+							d2.fileAt(root, "f5"))))),
 			expectedItemIDsInCollection: map[string][]string{
 				d1.strPath(t): {fileID("f1"), fileID("f2"), fileID("f3")},
 				d2.strPath(t): {fileID("f1"), fileID("f2"), fileID("f3")},
@@ -427,8 +449,6 @@ func (suite *LimiterUnitSuite) TestGet_PreviewLimits_noTree() {
 // checks that don't examine metadata, collection states, etc. They really just
 // check the expected items appear.
 func (suite *LimiterUnitSuite) TestGet_PreviewLimits_tree() {
-	suite.T().Skip("TODO: unskip when tree produces collections")
-
 	opts := control.DefaultOptions()
 	opts.ToggleFeatures.UseDeltaTree = true
 
@@ -521,9 +541,15 @@ func runGetPreviewLimits(
 			itemIDs = append(itemIDs, id)
 		}
 
+		expectItemIDs := test.expectedItemIDsInCollection[folderPath]
+
+		if opts.ToggleFeatures.UseDeltaTree && test.expectedItemIDsInCollectionTree != nil {
+			expectItemIDs = test.expectedItemIDsInCollectionTree[folderPath]
+		}
+
 		assert.ElementsMatchf(
 			t,
-			test.expectedItemIDsInCollection[folderPath],
+			expectItemIDs,
 			itemIDs,
 			"item IDs in collection with path:\n\t%q",
 			folderPath)
@@ -666,8 +692,6 @@ func (suite *LimiterUnitSuite) TestGet_PreviewLimits_defaultsNoTree() {
 // These tests run a reduced set of checks that really just look for item counts
 // and such. Other tests are expected to provide more comprehensive checks.
 func (suite *LimiterUnitSuite) TestGet_PreviewLimits_defaultsWithTree() {
-	suite.T().Skip("TODO: unskip when tree produces collections")
-
 	opts := control.DefaultOptions()
 	opts.ToggleFeatures.UseDeltaTree = true
 
@@ -802,7 +826,7 @@ func runGetPreviewLimitsDefaults(
 			t,
 			col.driveItems,
 			test.expect.numItemsPerContainer+1,
-			"items in container %v",
+			"number of items in collection at:\n\t%+v",
 			col.FullPath())
 	}
 
@@ -810,12 +834,12 @@ func runGetPreviewLimitsDefaults(
 		t,
 		test.expect.numContainers,
 		numContainers,
-		"total containers")
+		"total count of collections")
 
 	// Each container also gets an item so account for that here.
 	assert.Equal(
 		t,
 		test.expect.numItems+test.expect.numContainers,
 		numItems,
-		"total items across all containers")
+		"total sum of item counts in all collections")
 }


### PR DESCRIPTION
enables limit testing on the tree version of drive backups, along with any changes or fixes necessary to make the limiter follow (as closely as possible) the behavior from the non-tree backup process.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Supportability/Tests

#### Issue(s)

* #4689

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
