### PR TITLE
Add config passing test that future PRs will leverage

### DIFF
--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -391,12 +391,20 @@ func checkPopulatedInner(v reflect.Value) error {
 	return errs.OrNil()
 }
 
+// checkPopulated ensures that input has no zero-valued fields. That helps
+// ensure that even as future updates to input happen in other files the changes
+// are propagated here due to test failures.
 func checkPopulated(t *testing.T, input control.Options) {
 	err := checkPopulatedInner(reflect.ValueOf(input))
 	require.NoError(t, err, clues.ToCore(err))
 }
 
-func (suite *BackupOpUnitSuite) TestBackupOperation_OptionPassing() {
+// TestNewBackupOperation_configuredOptionsMatchInputOptions ensures that the
+// passed in options are properly set in the backup operation during
+// intialization. This test is mostly expected to be used while transitioning
+// from passing in backup operation config values during repo connect to during
+// backup op creation.
+func (suite *BackupOpUnitSuite) TestNewBackupOperation_configuredOptionsMatchInputOptions() {
 	ext := []extensions.CreateItemExtensioner{
 		&extensions.MockItemExtensionFactory{},
 	}


### PR DESCRIPTION
We're currently passing some backup options during repo connect which
complicates how SDK users can connect to a corso repo. This PR starts
to lay the groundwork for passing a discrete set of config parameters
to backup operations

This PR adds a test around config values passed into the
NewBackupOperation function. It checks that the config values stored
in the backup operation match what's passed in. It also makes sure
the passed in config parameters have all non-zero values so that
future changes don't silently pass the test when they shouldn't

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
