### PR TITLE
Update backup op API to take backup options struct

### DIFF
--- a/src/cli/backup/backup.go
+++ b/src/cli/backup/backup.go
@@ -171,7 +171,7 @@ var defaultSelectorConfig = selectors.Config{OnlyMatchItemNames: true}
 func genericCreateCommand(
 	ctx context.Context,
 	r repository.Repositoryer,
-	opts control.Backup,
+	opts control.BackupConfig,
 	serviceName string,
 	selectorSet []selectors.Selector,
 	ins idname.Cacher,
@@ -189,7 +189,7 @@ func genericCreateCommand(
 			ictx  = clues.Add(ctx, "resource_owner_selected", owner)
 		)
 
-		bo, err := r.NewBackupWithLookup(ictx, opts, discSel, ins)
+		bo, err := r.NewBackupWithLookup(ictx, discSel, ins, opts)
 		if err != nil {
 			cerr := clues.WrapWC(ictx, err, owner)
 			errs = append(errs, cerr)

--- a/src/cli/backup/backup.go
+++ b/src/cli/backup/backup.go
@@ -171,6 +171,7 @@ var defaultSelectorConfig = selectors.Config{OnlyMatchItemNames: true}
 func genericCreateCommand(
 	ctx context.Context,
 	r repository.Repositoryer,
+	opts control.Backup,
 	serviceName string,
 	selectorSet []selectors.Selector,
 	ins idname.Cacher,
@@ -188,7 +189,7 @@ func genericCreateCommand(
 			ictx  = clues.Add(ctx, "resource_owner_selected", owner)
 		)
 
-		bo, err := r.NewBackupWithLookup(ictx, discSel, ins)
+		bo, err := r.NewBackupWithLookup(ictx, opts, discSel, ins)
 		if err != nil {
 			cerr := clues.WrapWC(ictx, err, owner)
 			errs = append(errs, cerr)

--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -182,7 +182,7 @@ func createExchangeCmd(cmd *cobra.Command, args []string) error {
 	return genericCreateCommand(
 		ctx,
 		r,
-		utils.BackupOptions(),
+		utils.ParseBackupOptions(),
 		"Exchange",
 		selectorSet,
 		ins)

--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -182,6 +182,7 @@ func createExchangeCmd(cmd *cobra.Command, args []string) error {
 	return genericCreateCommand(
 		ctx,
 		r,
+		utils.BackupOptions(),
 		"Exchange",
 		selectorSet,
 		ins)

--- a/src/cli/backup/exchange_e2e_test.go
+++ b/src/cli/backup/exchange_e2e_test.go
@@ -366,9 +366,9 @@ func (suite *PreparedBackupExchangeE2ESuite) SetupSuite() {
 
 		bop, err := suite.dpnd.repo.NewBackupWithLookup(
 			ctx,
-			control.DefaultBackupOptions(),
 			sel.Selector,
-			ins)
+			ins,
+			control.DefaultBackupConfig())
 		require.NoError(t, err, clues.ToCore(err))
 
 		err = bop.Run(ctx)
@@ -596,8 +596,8 @@ func (suite *BackupDeleteExchangeE2ESuite) SetupSuite() {
 	for i := 0; i < cap(suite.backupOps); i++ {
 		backupOp, err := suite.dpnd.repo.NewBackup(
 			ctx,
-			control.DefaultBackupOptions(),
-			sel.Selector)
+			sel.Selector,
+			control.DefaultBackupConfig())
 		require.NoError(t, err, clues.ToCore(err))
 
 		suite.backupOps[i] = backupOp

--- a/src/cli/backup/exchange_e2e_test.go
+++ b/src/cli/backup/exchange_e2e_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/config"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
@@ -363,7 +364,11 @@ func (suite *PreparedBackupExchangeE2ESuite) SetupSuite() {
 
 		sel.Include(scopes)
 
-		bop, err := suite.dpnd.repo.NewBackupWithLookup(ctx, sel.Selector, ins)
+		bop, err := suite.dpnd.repo.NewBackupWithLookup(
+			ctx,
+			control.DefaultBackupOptions(),
+			sel.Selector,
+			ins)
 		require.NoError(t, err, clues.ToCore(err))
 
 		err = bop.Run(ctx)
@@ -589,7 +594,10 @@ func (suite *BackupDeleteExchangeE2ESuite) SetupSuite() {
 	sel.Include(sel.MailFolders([]string{api.MailInbox}, selectors.PrefixMatch()))
 
 	for i := 0; i < cap(suite.backupOps); i++ {
-		backupOp, err := suite.dpnd.repo.NewBackup(ctx, sel.Selector)
+		backupOp, err := suite.dpnd.repo.NewBackup(
+			ctx,
+			control.DefaultBackupOptions(),
+			sel.Selector)
 		require.NoError(t, err, clues.ToCore(err))
 
 		suite.backupOps[i] = backupOp

--- a/src/cli/backup/groups.go
+++ b/src/cli/backup/groups.go
@@ -176,7 +176,7 @@ func createGroupsCmd(cmd *cobra.Command, args []string) error {
 	return genericCreateCommand(
 		ctx,
 		r,
-		utils.BackupOptions(),
+		utils.ParseBackupOptions(),
 		"Group",
 		selectorSet,
 		ins)

--- a/src/cli/backup/groups.go
+++ b/src/cli/backup/groups.go
@@ -176,6 +176,7 @@ func createGroupsCmd(cmd *cobra.Command, args []string) error {
 	return genericCreateCommand(
 		ctx,
 		r,
+		utils.BackupOptions(),
 		"Group",
 		selectorSet,
 		ins)

--- a/src/cli/backup/groups_e2e_test.go
+++ b/src/cli/backup/groups_e2e_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/config"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	selTD "github.com/alcionai/corso/src/pkg/selectors/testdata"
@@ -322,7 +323,11 @@ func (suite *PreparedBackupGroupsE2ESuite) SetupSuite() {
 
 		sel.Include(scopes)
 
-		bop, err := suite.dpnd.repo.NewBackupWithLookup(ctx, sel.Selector, ins)
+		bop, err := suite.dpnd.repo.NewBackupWithLookup(
+			ctx,
+			control.DefaultBackupOptions(),
+			sel.Selector,
+			ins)
 		require.NoError(t, err, clues.ToCore(err))
 
 		err = bop.Run(ctx)
@@ -552,7 +557,10 @@ func (suite *BackupDeleteGroupsE2ESuite) SetupSuite() {
 	sel.Include(selTD.GroupsBackupChannelScope(sel))
 
 	for i := 0; i < cap(suite.backupOps); i++ {
-		backupOp, err := suite.dpnd.repo.NewBackup(ctx, sel.Selector)
+		backupOp, err := suite.dpnd.repo.NewBackup(
+			ctx,
+			control.DefaultBackupOptions(),
+			sel.Selector)
 		require.NoError(t, err, clues.ToCore(err))
 
 		suite.backupOps[i] = backupOp

--- a/src/cli/backup/groups_e2e_test.go
+++ b/src/cli/backup/groups_e2e_test.go
@@ -325,9 +325,9 @@ func (suite *PreparedBackupGroupsE2ESuite) SetupSuite() {
 
 		bop, err := suite.dpnd.repo.NewBackupWithLookup(
 			ctx,
-			control.DefaultBackupOptions(),
 			sel.Selector,
-			ins)
+			ins,
+			control.DefaultBackupConfig())
 		require.NoError(t, err, clues.ToCore(err))
 
 		err = bop.Run(ctx)
@@ -559,8 +559,8 @@ func (suite *BackupDeleteGroupsE2ESuite) SetupSuite() {
 	for i := 0; i < cap(suite.backupOps); i++ {
 		backupOp, err := suite.dpnd.repo.NewBackup(
 			ctx,
-			control.DefaultBackupOptions(),
-			sel.Selector)
+			sel.Selector,
+			control.DefaultBackupConfig())
 		require.NoError(t, err, clues.ToCore(err))
 
 		suite.backupOps[i] = backupOp

--- a/src/cli/backup/onedrive.go
+++ b/src/cli/backup/onedrive.go
@@ -168,6 +168,7 @@ func createOneDriveCmd(cmd *cobra.Command, args []string) error {
 	return genericCreateCommand(
 		ctx,
 		r,
+		utils.BackupOptions(),
 		"OneDrive",
 		selectorSet,
 		ins)

--- a/src/cli/backup/onedrive.go
+++ b/src/cli/backup/onedrive.go
@@ -168,7 +168,7 @@ func createOneDriveCmd(cmd *cobra.Command, args []string) error {
 	return genericCreateCommand(
 		ctx,
 		r,
-		utils.BackupOptions(),
+		utils.ParseBackupOptions(),
 		"OneDrive",
 		selectorSet,
 		ins)

--- a/src/cli/backup/onedrive_e2e_test.go
+++ b/src/cli/backup/onedrive_e2e_test.go
@@ -156,9 +156,9 @@ func (suite *BackupDeleteOneDriveE2ESuite) SetupSuite() {
 	for i := 0; i < cap(suite.backupOps); i++ {
 		backupOp, err := suite.dpnd.repo.NewBackupWithLookup(
 			ctx,
-			control.DefaultBackupOptions(),
 			sel.Selector,
-			ins)
+			ins,
+			control.DefaultBackupConfig())
 		require.NoError(t, err, clues.ToCore(err))
 
 		suite.backupOps[i] = backupOp

--- a/src/cli/backup/onedrive_e2e_test.go
+++ b/src/cli/backup/onedrive_e2e_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/config"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	selTD "github.com/alcionai/corso/src/pkg/selectors/testdata"
@@ -153,7 +154,11 @@ func (suite *BackupDeleteOneDriveE2ESuite) SetupSuite() {
 	sel.Include(selTD.OneDriveBackupFolderScope(sel))
 
 	for i := 0; i < cap(suite.backupOps); i++ {
-		backupOp, err := suite.dpnd.repo.NewBackupWithLookup(ctx, sel.Selector, ins)
+		backupOp, err := suite.dpnd.repo.NewBackupWithLookup(
+			ctx,
+			control.DefaultBackupOptions(),
+			sel.Selector,
+			ins)
 		require.NoError(t, err, clues.ToCore(err))
 
 		suite.backupOps[i] = backupOp

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -181,6 +181,7 @@ func createSharePointCmd(cmd *cobra.Command, args []string) error {
 	return genericCreateCommand(
 		ctx,
 		r,
+		utils.BackupOptions(),
 		"SharePoint",
 		selectorSet,
 		ins)

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -181,7 +181,7 @@ func createSharePointCmd(cmd *cobra.Command, args []string) error {
 	return genericCreateCommand(
 		ctx,
 		r,
-		utils.BackupOptions(),
+		utils.ParseBackupOptions(),
 		"SharePoint",
 		selectorSet,
 		ins)

--- a/src/cli/backup/sharepoint_e2e_test.go
+++ b/src/cli/backup/sharepoint_e2e_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/config"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/selectors/testdata"
@@ -110,13 +111,18 @@ func (suite *BackupDeleteSharePointE2ESuite) SetupSuite() {
 		m365SiteID = tconfig.M365SiteID(t)
 		sites      = []string{m365SiteID}
 		ins        = idname.NewCache(map[string]string{m365SiteID: m365SiteID})
+		opts       = control.DefaultBackupOptions()
 	)
 
 	// some tests require an existing backup
 	sel := selectors.NewSharePointBackup(sites)
 	sel.Include(testdata.SharePointBackupFolderScope(sel))
 
-	backupOp, err := suite.dpnd.repo.NewBackupWithLookup(ctx, sel.Selector, ins)
+	backupOp, err := suite.dpnd.repo.NewBackupWithLookup(
+		ctx,
+		opts,
+		sel.Selector,
+		ins)
 	require.NoError(t, err, clues.ToCore(err))
 
 	suite.backupOp = backupOp
@@ -125,7 +131,11 @@ func (suite *BackupDeleteSharePointE2ESuite) SetupSuite() {
 	require.NoError(t, err, clues.ToCore(err))
 
 	// secondary backup
-	secondaryBackupOp, err := suite.dpnd.repo.NewBackupWithLookup(ctx, sel.Selector, ins)
+	secondaryBackupOp, err := suite.dpnd.repo.NewBackupWithLookup(
+		ctx,
+		opts,
+		sel.Selector,
+		ins)
 	require.NoError(t, err, clues.ToCore(err))
 
 	suite.secondaryBackupOp = secondaryBackupOp

--- a/src/cli/backup/sharepoint_e2e_test.go
+++ b/src/cli/backup/sharepoint_e2e_test.go
@@ -111,7 +111,7 @@ func (suite *BackupDeleteSharePointE2ESuite) SetupSuite() {
 		m365SiteID = tconfig.M365SiteID(t)
 		sites      = []string{m365SiteID}
 		ins        = idname.NewCache(map[string]string{m365SiteID: m365SiteID})
-		opts       = control.DefaultBackupOptions()
+		opts       = control.DefaultBackupConfig()
 	)
 
 	// some tests require an existing backup
@@ -120,9 +120,9 @@ func (suite *BackupDeleteSharePointE2ESuite) SetupSuite() {
 
 	backupOp, err := suite.dpnd.repo.NewBackupWithLookup(
 		ctx,
-		opts,
 		sel.Selector,
-		ins)
+		ins,
+		opts)
 	require.NoError(t, err, clues.ToCore(err))
 
 	suite.backupOp = backupOp
@@ -133,9 +133,9 @@ func (suite *BackupDeleteSharePointE2ESuite) SetupSuite() {
 	// secondary backup
 	secondaryBackupOp, err := suite.dpnd.repo.NewBackupWithLookup(
 		ctx,
-		opts,
 		sel.Selector,
-		ins)
+		ins,
+		opts)
 	require.NoError(t, err, clues.ToCore(err))
 
 	suite.secondaryBackupOp = secondaryBackupOp

--- a/src/cli/restore/exchange_e2e_test.go
+++ b/src/cli/restore/exchange_e2e_test.go
@@ -117,9 +117,9 @@ func (suite *RestoreExchangeE2ESuite) SetupSuite() {
 
 		bop, err := suite.repo.NewBackupWithLookup(
 			ctx,
-			control.DefaultBackupOptions(),
 			sel.Selector,
-			ins)
+			ins,
+			control.DefaultBackupConfig())
 		require.NoError(t, err, clues.ToCore(err))
 
 		err = bop.Run(ctx)

--- a/src/cli/restore/exchange_e2e_test.go
+++ b/src/cli/restore/exchange_e2e_test.go
@@ -115,7 +115,11 @@ func (suite *RestoreExchangeE2ESuite) SetupSuite() {
 
 		sel.Include(scopes)
 
-		bop, err := suite.repo.NewBackupWithLookup(ctx, sel.Selector, ins)
+		bop, err := suite.repo.NewBackupWithLookup(
+			ctx,
+			control.DefaultBackupOptions(),
+			sel.Selector,
+			ins)
 		require.NoError(t, err, clues.ToCore(err))
 
 		err = bop.Run(ctx)

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -75,7 +75,7 @@ type BackupResults struct {
 // NewBackupOperation constructs and validates a backup operation.
 func NewBackupOperation(
 	ctx context.Context,
-	opts control.Backup,
+	opts control.BackupConfig,
 	kw *kopia.Wrapper,
 	sw store.BackupStorer,
 	bp inject.BackupProducer,

--- a/src/internal/operations/backup.go
+++ b/src/internal/operations/backup.go
@@ -88,20 +88,23 @@ func NewBackupOperation(
 	// TODO(ashmrtn): Remove this once lower layers of corso are rewired to take
 	// control.Backup instead of control.Options.
 	controlOpts := control.Options{
-		DeltaPageSize:        opts.DeltaPageSize,
+		DeltaPageSize:        opts.M365.DeltaPageSize,
 		FailureHandling:      opts.FailureHandling,
 		ItemExtensionFactory: opts.ItemExtensionFactory,
 		Parallelism:          opts.Parallelism,
 		PreviewLimits:        opts.PreviewLimits,
+		ToggleFeatures: control.Toggles{
+			// M365 config.
+			DisableDelta:         opts.M365.DisableDeltaEndpoint,
+			ExchangeImmutableIDs: opts.M365.ExchangeImmutableIDs,
+			UseDeltaTree:         opts.M365.UseDriveDeltaTree,
+			// Incrementals config.
+			DisableIncrementals:   opts.Incrementals.ForceFullEnumeration,
+			ForceItemDataDownload: opts.Incrementals.ForceItemDataRefresh,
+			// Limiter config.
+			DisableSlidingWindowLimiter: opts.ServiceRateLimiter.DisableSlidingWindowLimiter,
+		},
 	}
-
-	controlOpts.ToggleFeatures.DisableIncrementals = opts.ToggleFeatures.DisableIncrementals
-	controlOpts.ToggleFeatures.ForceItemDataDownload = opts.ToggleFeatures.ForceItemDataDownload
-	controlOpts.ToggleFeatures.DisableDelta = opts.ToggleFeatures.DisableDelta
-	controlOpts.ToggleFeatures.ExchangeImmutableIDs = opts.ToggleFeatures.ExchangeImmutableIDs
-	controlOpts.ToggleFeatures.RunMigrations = opts.ToggleFeatures.RunMigrations
-	controlOpts.ToggleFeatures.DisableSlidingWindowLimiter = opts.ServiceRateLimiter.DisableSlidingWindowLimiter
-	controlOpts.ToggleFeatures.UseDeltaTree = opts.ToggleFeatures.UseDeltaTree
 
 	op := BackupOperation{
 		operation:           newOperation(controlOpts, bus, counter, kw, sw),

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -393,7 +393,7 @@ func checkPopulatedInner(v reflect.Value) error {
 // checkPopulated ensures that input has no zero-valued fields. That helps
 // ensure that even as future updates to input happen in other files the changes
 // are propagated here due to test failures.
-func checkPopulated(t *testing.T, input control.Backup) {
+func checkPopulated(t *testing.T, input control.BackupConfig) {
 	err := checkPopulatedInner(reflect.ValueOf(input))
 	require.NoError(t, err, clues.ToCore(err))
 }
@@ -408,7 +408,7 @@ func (suite *BackupOpUnitSuite) TestNewBackupOperation_configuredOptionsMatchInp
 		&extensions.MockItemExtensionFactory{},
 	}
 
-	opts := control.Backup{
+	opts := control.BackupConfig{
 		DeltaPageSize:        42,
 		FailureHandling:      control.FailAfterRecovery,
 		ItemExtensionFactory: slices.Clone(ext),
@@ -469,9 +469,9 @@ func (suite *BackupOpUnitSuite) TestNewBackupOperation_configuredOptionsMatchInp
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	// This is a sanity check to make sure all fields on the input control.Backup
-	// are populated. This helps ensure that this chunk of code stays updated as
-	// options are added to the struct.
+	// This is a sanity check to make sure all fields on the input
+	// control.BackupConfig are populated. This helps ensure that this chunk of
+	// code stays updated as options are added to the struct.
 	checkPopulated(t, opts)
 
 	var (
@@ -558,7 +558,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_PersistResults() {
 
 			op, err := NewBackupOperation(
 				ctx,
-				control.DefaultBackupOptions(),
+				control.DefaultBackupConfig(),
 				kw,
 				sw,
 				ctrl,
@@ -1612,7 +1612,7 @@ func (suite *BackupOpIntegrationSuite) TestNewBackupOperation() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			opts := control.DefaultBackupOptions()
+			opts := control.DefaultBackupConfig()
 			sel := selectors.Selector{DiscreteOwner: "test"}
 
 			_, err := NewBackupOperation(
@@ -2057,7 +2057,7 @@ func (suite *AssistBackupIntegrationSuite) TestBackupTypesForFailureModes() {
 			cs = append(cs, mc)
 			bp := opMock.NewMockBackupProducer(cs, data.CollectionStats{}, test.injectNonRecoverableErr)
 
-			opts := control.DefaultBackupOptions()
+			opts := control.DefaultBackupConfig()
 			opts.FailureHandling = test.failurePolicy
 			opts.PreviewLimits.Enabled = test.previewBackup
 
@@ -2375,7 +2375,7 @@ func (suite *AssistBackupIntegrationSuite) TestExtensionsIncrementals() {
 			cs = append(cs, mc)
 			bp := opMock.NewMockBackupProducer(cs, data.CollectionStats{}, false)
 
-			opts := control.DefaultBackupOptions()
+			opts := control.DefaultBackupConfig()
 			opts.FailureHandling = failurePolicy
 
 			bo, err := NewBackupOperation(

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -538,7 +538,7 @@ func (suite *BackupOpUnitSuite) TestBackupOperation_PersistResults() {
 
 			op, err := NewBackupOperation(
 				ctx,
-				control.DefaultOptions(),
+				control.DefaultBackupOptions(),
 				kw,
 				sw,
 				ctrl,
@@ -1569,7 +1569,6 @@ func (suite *BackupOpIntegrationSuite) TestNewBackupOperation() {
 		sw   = store.NewWrapper(&kopia.ModelStore{})
 		ctrl = &mock.Controller{}
 		acct = tconfig.NewM365Account(suite.T())
-		opts = control.DefaultOptions()
 	)
 
 	table := []struct {
@@ -1593,6 +1592,7 @@ func (suite *BackupOpIntegrationSuite) TestNewBackupOperation() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
+			opts := control.DefaultBackupOptions()
 			sel := selectors.Selector{DiscreteOwner: "test"}
 
 			_, err := NewBackupOperation(
@@ -2037,7 +2037,7 @@ func (suite *AssistBackupIntegrationSuite) TestBackupTypesForFailureModes() {
 			cs = append(cs, mc)
 			bp := opMock.NewMockBackupProducer(cs, data.CollectionStats{}, test.injectNonRecoverableErr)
 
-			opts := control.DefaultOptions()
+			opts := control.DefaultBackupOptions()
 			opts.FailureHandling = test.failurePolicy
 			opts.PreviewLimits.Enabled = test.previewBackup
 
@@ -2097,7 +2097,6 @@ func (suite *AssistBackupIntegrationSuite) TestExtensionsIncrementals() {
 	var (
 		acct     = tconfig.NewM365Account(suite.T())
 		tenantID = acct.Config[account.AzureTenantIDKey]
-		opts     = control.DefaultOptions()
 		osel     = selectors.NewOneDriveBackup([]string{userID})
 		// Default policy used by SDK clients
 		failurePolicy = control.FailAfterRecovery
@@ -2356,6 +2355,7 @@ func (suite *AssistBackupIntegrationSuite) TestExtensionsIncrementals() {
 			cs = append(cs, mc)
 			bp := opMock.NewMockBackupProducer(cs, data.CollectionStats{}, false)
 
+			opts := control.DefaultBackupOptions()
 			opts.FailureHandling = failurePolicy
 
 			bo, err := NewBackupOperation(

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -409,20 +409,21 @@ func (suite *BackupOpUnitSuite) TestNewBackupOperation_configuredOptionsMatchInp
 	}
 
 	opts := control.BackupConfig{
-		DeltaPageSize:        42,
 		FailureHandling:      control.FailAfterRecovery,
 		ItemExtensionFactory: slices.Clone(ext),
 		Parallelism: control.Parallelism{
 			CollectionBuffer: 4,
 			ItemFetch:        4,
 		},
-		ToggleFeatures: control.BackupToggles{
-			DisableIncrementals:   true,
-			ForceItemDataDownload: true,
-			DisableDelta:          true,
-			ExchangeImmutableIDs:  true,
-			RunMigrations:         true,
-			UseDeltaTree:          true,
+		M365: control.BackupM365Config{
+			DeltaPageSize:        42,
+			DisableDeltaEndpoint: true,
+			ExchangeImmutableIDs: true,
+			UseDriveDeltaTree:    true,
+		},
+		Incrementals: control.IncrementalsConfig{
+			ForceFullEnumeration: true,
+			ForceItemDataRefresh: true,
 		},
 		ServiceRateLimiter: control.RateLimiter{
 			DisableSlidingWindowLimiter: true,
@@ -446,11 +447,13 @@ func (suite *BackupOpUnitSuite) TestNewBackupOperation_configuredOptionsMatchInp
 			ItemFetch:        4,
 		},
 		ToggleFeatures: control.Toggles{
-			DisableIncrementals:         true,
-			ForceItemDataDownload:       true,
-			DisableDelta:                true,
-			ExchangeImmutableIDs:        true,
-			RunMigrations:               true,
+			DisableIncrementals:   true,
+			ForceItemDataDownload: true,
+			DisableDelta:          true,
+			ExchangeImmutableIDs:  true,
+			// This flag isn't currently present in control.BackupConfig because
+			// there's nothing using it right now.
+			RunMigrations:               false,
 			DisableSlidingWindowLimiter: true,
 			UseDeltaTree:                true,
 		},

--- a/src/internal/operations/maintenance_test.go
+++ b/src/internal/operations/maintenance_test.go
@@ -113,7 +113,6 @@ func (suite *MaintenanceOpNightlySuite) TestRepoMaintenance_GarbageCollection() 
 		t        = suite.T()
 		acct     = tconfig.NewM365Account(suite.T())
 		tenantID = acct.Config[account.AzureTenantIDKey]
-		opts     = control.DefaultOptions()
 		osel     = selectors.NewOneDriveBackup([]string{userID})
 		// Default policy used by SDK clients
 		failurePolicy = control.FailAfterRecovery
@@ -174,6 +173,7 @@ func (suite *MaintenanceOpNightlySuite) TestRepoMaintenance_GarbageCollection() 
 			cs = append(cs, mc)
 			bp := opMock.NewMockBackupProducer(cs, data.CollectionStats{}, false)
 
+			opts := control.DefaultBackupOptions()
 			opts.FailureHandling = failurePolicy
 
 			bo, err := NewBackupOperation(

--- a/src/internal/operations/maintenance_test.go
+++ b/src/internal/operations/maintenance_test.go
@@ -173,7 +173,7 @@ func (suite *MaintenanceOpNightlySuite) TestRepoMaintenance_GarbageCollection() 
 			cs = append(cs, mc)
 			bp := opMock.NewMockBackupProducer(cs, data.CollectionStats{}, false)
 
-			opts := control.DefaultBackupOptions()
+			opts := control.DefaultBackupConfig()
 			opts.FailureHandling = failurePolicy
 
 			bo, err := NewBackupOperation(

--- a/src/internal/operations/test/exchange_test.go
+++ b/src/internal/operations/test/exchange_test.go
@@ -234,14 +234,14 @@ func (suite *ExchangeBackupIntgSuite) TestBackup_Run_exchange() {
 }
 
 func (suite *ExchangeBackupIntgSuite) TestBackup_Run_incrementalExchange() {
-	testExchangeContinuousBackups(suite, control.BackupToggles{})
+	testExchangeContinuousBackups(suite, control.BackupM365Config{})
 }
 
 func (suite *ExchangeBackupIntgSuite) TestBackup_Run_incrementalNonDeltaExchange() {
-	testExchangeContinuousBackups(suite, control.BackupToggles{DisableDelta: true})
+	testExchangeContinuousBackups(suite, control.BackupM365Config{DisableDeltaEndpoint: true})
 }
 
-func testExchangeContinuousBackups(suite *ExchangeBackupIntgSuite, toggles control.BackupToggles) {
+func testExchangeContinuousBackups(suite *ExchangeBackupIntgSuite, m365Config control.BackupM365Config) {
 	t := suite.T()
 
 	ctx, flush := tester.NewContext(t)
@@ -274,7 +274,7 @@ func testExchangeContinuousBackups(suite *ExchangeBackupIntgSuite, toggles contr
 		opts       = control.DefaultBackupConfig()
 	)
 
-	opts.ToggleFeatures = toggles
+	opts.M365 = m365Config
 	ctrl, sels := ControllerWithSelector(t, ctx, acct, sel.Selector, nil, nil, counter)
 	sel.DiscreteOwner = sels.ID()
 	sel.DiscreteOwnerName = sels.Name()
@@ -386,7 +386,7 @@ func testExchangeContinuousBackups(suite *ExchangeBackupIntgSuite, toggles contr
 			err error
 			aar pagers.AddedAndRemoved
 			cc  = api.CallConfig{
-				UseImmutableIDs:     toggles.ExchangeImmutableIDs,
+				UseImmutableIDs:     m365Config.ExchangeImmutableIDs,
 				CanMakeDeltaQueries: true,
 			}
 		)

--- a/src/internal/operations/test/exchange_test.go
+++ b/src/internal/operations/test/exchange_test.go
@@ -120,7 +120,7 @@ func (suite *ExchangeBackupIntgSuite) TestBackup_Run_exchange() {
 				mb      = evmock.NewBus()
 				counter = count.New()
 				sel     = test.selector().Selector
-				opts    = control.DefaultOptions()
+				opts    = control.DefaultBackupOptions()
 				whatSet = deeTD.CategoryFromRepoRef
 			)
 
@@ -234,14 +234,14 @@ func (suite *ExchangeBackupIntgSuite) TestBackup_Run_exchange() {
 }
 
 func (suite *ExchangeBackupIntgSuite) TestBackup_Run_incrementalExchange() {
-	testExchangeContinuousBackups(suite, control.Toggles{})
+	testExchangeContinuousBackups(suite, control.BackupToggles{})
 }
 
 func (suite *ExchangeBackupIntgSuite) TestBackup_Run_incrementalNonDeltaExchange() {
-	testExchangeContinuousBackups(suite, control.Toggles{DisableDelta: true})
+	testExchangeContinuousBackups(suite, control.BackupToggles{DisableDelta: true})
 }
 
-func testExchangeContinuousBackups(suite *ExchangeBackupIntgSuite, toggles control.Toggles) {
+func testExchangeContinuousBackups(suite *ExchangeBackupIntgSuite, toggles control.BackupToggles) {
 	t := suite.T()
 
 	ctx, flush := tester.NewContext(t)
@@ -271,7 +271,7 @@ func testExchangeContinuousBackups(suite *ExchangeBackupIntgSuite, toggles contr
 		containers = []string{container1, container2, container3, containerRename}
 		sel        = selectors.NewExchangeBackup([]string{suite.its.user.ID})
 		whatSet    = deeTD.CategoryFromRepoRef
-		opts       = control.DefaultOptions()
+		opts       = control.DefaultBackupOptions()
 	)
 
 	opts.ToggleFeatures = toggles
@@ -970,9 +970,10 @@ func (suite *ExchangeRestoreNightlyIntgSuite) TestRestore_Run_exchangeWithAdvanc
 	baseSel.DiscreteOwner = suite.its.user.ID
 
 	var (
-		mb      = evmock.NewBus()
-		counter = count.New()
-		opts    = control.DefaultOptions()
+		mb          = evmock.NewBus()
+		counter     = count.New()
+		opts        = control.DefaultBackupOptions()
+		controlOpts = control.DefaultOptions()
 	)
 
 	bo, bod := prepNewTestBackupOp(t, ctx, mb, baseSel.Selector, opts, version.Backup, counter)
@@ -1029,7 +1030,7 @@ func (suite *ExchangeRestoreNightlyIntgSuite) TestRestore_Run_exchangeWithAdvanc
 			mb,
 			ctr1,
 			sel,
-			opts,
+			controlOpts,
 			restoreCfg)
 
 		runAndCheckRestore(t, ctx, &ro, mb, false)
@@ -1088,7 +1089,7 @@ func (suite *ExchangeRestoreNightlyIntgSuite) TestRestore_Run_exchangeWithAdvanc
 			mb,
 			ctr2,
 			sel,
-			opts,
+			controlOpts,
 			restoreCfg)
 
 		deets := runAndCheckRestore(t, ctx, &ro, mb, false)
@@ -1149,7 +1150,7 @@ func (suite *ExchangeRestoreNightlyIntgSuite) TestRestore_Run_exchangeWithAdvanc
 			mb,
 			ctr3,
 			sel,
-			opts,
+			controlOpts,
 			restoreCfg)
 
 		deets := runAndCheckRestore(t, ctx, &ro, mb, false)
@@ -1219,7 +1220,7 @@ func (suite *ExchangeRestoreNightlyIntgSuite) TestRestore_Run_exchangeWithAdvanc
 			mb,
 			ctr4,
 			sel,
-			opts,
+			controlOpts,
 			restoreCfg)
 
 		deets := runAndCheckRestore(t, ctx, &ro, mb, false)
@@ -1287,9 +1288,10 @@ func (suite *ExchangeRestoreNightlyIntgSuite) TestRestore_Run_exchangeAlternateP
 	baseSel.DiscreteOwner = suite.its.user.ID
 
 	var (
-		mb      = evmock.NewBus()
-		counter = count.New()
-		opts    = control.DefaultOptions()
+		mb          = evmock.NewBus()
+		counter     = count.New()
+		opts        = control.DefaultBackupOptions()
+		controlOpts = control.DefaultOptions()
 	)
 
 	bo, bod := prepNewTestBackupOp(t, ctx, mb, baseSel.Selector, opts, version.Backup, counter)
@@ -1325,7 +1327,7 @@ func (suite *ExchangeRestoreNightlyIntgSuite) TestRestore_Run_exchangeAlternateP
 		mb,
 		firstCtr,
 		sel,
-		opts,
+		controlOpts,
 		restoreCfg)
 
 	runAndCheckRestore(t, ctx, &ro1, mb, false)
@@ -1384,7 +1386,7 @@ func (suite *ExchangeRestoreNightlyIntgSuite) TestRestore_Run_exchangeAlternateP
 		mb,
 		secondCtr,
 		sel,
-		opts,
+		controlOpts,
 		restoreCfg)
 
 	runAndCheckRestore(t, ctx, &ro2, mb, false)

--- a/src/internal/operations/test/exchange_test.go
+++ b/src/internal/operations/test/exchange_test.go
@@ -120,7 +120,7 @@ func (suite *ExchangeBackupIntgSuite) TestBackup_Run_exchange() {
 				mb      = evmock.NewBus()
 				counter = count.New()
 				sel     = test.selector().Selector
-				opts    = control.DefaultBackupOptions()
+				opts    = control.DefaultBackupConfig()
 				whatSet = deeTD.CategoryFromRepoRef
 			)
 
@@ -271,7 +271,7 @@ func testExchangeContinuousBackups(suite *ExchangeBackupIntgSuite, toggles contr
 		containers = []string{container1, container2, container3, containerRename}
 		sel        = selectors.NewExchangeBackup([]string{suite.its.user.ID})
 		whatSet    = deeTD.CategoryFromRepoRef
-		opts       = control.DefaultBackupOptions()
+		opts       = control.DefaultBackupConfig()
 	)
 
 	opts.ToggleFeatures = toggles
@@ -972,7 +972,7 @@ func (suite *ExchangeRestoreNightlyIntgSuite) TestRestore_Run_exchangeWithAdvanc
 	var (
 		mb          = evmock.NewBus()
 		counter     = count.New()
-		opts        = control.DefaultBackupOptions()
+		opts        = control.DefaultBackupConfig()
 		controlOpts = control.DefaultOptions()
 	)
 
@@ -1290,7 +1290,7 @@ func (suite *ExchangeRestoreNightlyIntgSuite) TestRestore_Run_exchangeAlternateP
 	var (
 		mb          = evmock.NewBus()
 		counter     = count.New()
-		opts        = control.DefaultBackupOptions()
+		opts        = control.DefaultBackupConfig()
 		controlOpts = control.DefaultOptions()
 	)
 

--- a/src/internal/operations/test/group_test.go
+++ b/src/internal/operations/test/group_test.go
@@ -89,7 +89,7 @@ func (suite *GroupsBackupIntgSuite) TestBackup_Run_groups9VersionBumpBackup() {
 	var (
 		mb      = evmock.NewBus()
 		sel     = selectors.NewGroupsBackup([]string{suite.its.group.ID})
-		opts    = control.DefaultOptions()
+		opts    = control.DefaultBackupOptions()
 		whatSet = deeTD.CategoryFromRepoRef
 	)
 
@@ -199,7 +199,7 @@ func (suite *GroupsBackupIntgSuite) TestBackup_Run_groupsBasic() {
 		mb      = evmock.NewBus()
 		counter = count.New()
 		sel     = selectors.NewGroupsBackup([]string{suite.its.group.ID})
-		opts    = control.DefaultOptions()
+		opts    = control.DefaultBackupOptions()
 		whatSet = deeTD.CategoryFromRepoRef
 	)
 
@@ -253,7 +253,7 @@ func (suite *GroupsBackupIntgSuite) TestBackup_Run_groupsExtensions() {
 		mb      = evmock.NewBus()
 		counter = count.New()
 		sel     = selectors.NewGroupsBackup([]string{suite.its.group.ID})
-		opts    = control.DefaultOptions()
+		opts    = control.DefaultBackupOptions()
 		tenID   = tconfig.M365TenantID(t)
 		svc     = path.GroupsService
 		ws      = deeTD.DriveIDFromRepoRef

--- a/src/internal/operations/test/group_test.go
+++ b/src/internal/operations/test/group_test.go
@@ -89,7 +89,7 @@ func (suite *GroupsBackupIntgSuite) TestBackup_Run_groups9VersionBumpBackup() {
 	var (
 		mb      = evmock.NewBus()
 		sel     = selectors.NewGroupsBackup([]string{suite.its.group.ID})
-		opts    = control.DefaultBackupOptions()
+		opts    = control.DefaultBackupConfig()
 		whatSet = deeTD.CategoryFromRepoRef
 	)
 
@@ -199,7 +199,7 @@ func (suite *GroupsBackupIntgSuite) TestBackup_Run_groupsBasic() {
 		mb      = evmock.NewBus()
 		counter = count.New()
 		sel     = selectors.NewGroupsBackup([]string{suite.its.group.ID})
-		opts    = control.DefaultBackupOptions()
+		opts    = control.DefaultBackupConfig()
 		whatSet = deeTD.CategoryFromRepoRef
 	)
 
@@ -253,7 +253,7 @@ func (suite *GroupsBackupIntgSuite) TestBackup_Run_groupsExtensions() {
 		mb      = evmock.NewBus()
 		counter = count.New()
 		sel     = selectors.NewGroupsBackup([]string{suite.its.group.ID})
-		opts    = control.DefaultBackupOptions()
+		opts    = control.DefaultBackupConfig()
 		tenID   = tconfig.M365TenantID(t)
 		svc     = path.GroupsService
 		ws      = deeTD.DriveIDFromRepoRef

--- a/src/internal/operations/test/helper_test.go
+++ b/src/internal/operations/test/helper_test.go
@@ -116,7 +116,7 @@ func prepNewTestBackupOp(
 	ctx context.Context, //revive:disable-line:context-as-argument
 	bus events.Eventer,
 	sel selectors.Selector,
-	opts control.Backup,
+	opts control.BackupConfig,
 	backupVersion int,
 	counter *count.Bus,
 ) (
@@ -195,7 +195,7 @@ func newTestBackupOp(
 	ctx context.Context, //revive:disable-line:context-as-argument
 	bod *backupOpDependencies,
 	bus events.Eventer,
-	opts control.Backup,
+	opts control.BackupConfig,
 	counter *count.Bus,
 ) operations.BackupOperation {
 	bod.ctrl.IDNameLookup = idname.NewCache(map[string]string{bod.sel.ID(): bod.sel.Name()})
@@ -388,7 +388,7 @@ func runMergeBaseGroupsUpdate(
 
 	var (
 		mb      = evmock.NewBus()
-		opts    = control.DefaultBackupOptions()
+		opts    = control.DefaultBackupConfig()
 		whatSet = deeTD.CategoryFromRepoRef
 	)
 
@@ -455,7 +455,7 @@ func runMergeBaseGroupsUpdate(
 
 		var (
 			mb   = evmock.NewBus()
-			opts = control.DefaultBackupOptions()
+			opts = control.DefaultBackupConfig()
 		)
 
 		forcedFull := newTestBackupOp(

--- a/src/internal/operations/test/helper_test.go
+++ b/src/internal/operations/test/helper_test.go
@@ -116,7 +116,7 @@ func prepNewTestBackupOp(
 	ctx context.Context, //revive:disable-line:context-as-argument
 	bus events.Eventer,
 	sel selectors.Selector,
-	opts control.Options,
+	opts control.Backup,
 	backupVersion int,
 	counter *count.Bus,
 ) (
@@ -195,7 +195,7 @@ func newTestBackupOp(
 	ctx context.Context, //revive:disable-line:context-as-argument
 	bod *backupOpDependencies,
 	bus events.Eventer,
-	opts control.Options,
+	opts control.Backup,
 	counter *count.Bus,
 ) operations.BackupOperation {
 	bod.ctrl.IDNameLookup = idname.NewCache(map[string]string{bod.sel.ID(): bod.sel.Name()})
@@ -388,7 +388,7 @@ func runMergeBaseGroupsUpdate(
 
 	var (
 		mb      = evmock.NewBus()
-		opts    = control.DefaultOptions()
+		opts    = control.DefaultBackupOptions()
 		whatSet = deeTD.CategoryFromRepoRef
 	)
 
@@ -455,7 +455,7 @@ func runMergeBaseGroupsUpdate(
 
 		var (
 			mb   = evmock.NewBus()
-			opts = control.DefaultOptions()
+			opts = control.DefaultBackupOptions()
 		)
 
 		forcedFull := newTestBackupOp(

--- a/src/internal/operations/test/onedrive_test.go
+++ b/src/internal/operations/test/onedrive_test.go
@@ -78,7 +78,7 @@ func (suite *OneDriveBackupIntgSuite) TestBackup_Run_oneDrive() {
 		osel    = selectors.NewOneDriveBackup([]string{userID})
 		ws      = deeTD.DriveIDFromRepoRef
 		svc     = path.OneDriveService
-		opts    = control.DefaultBackupOptions()
+		opts    = control.DefaultBackupConfig()
 	)
 
 	osel.Include(selTD.OneDriveBackupFolderScope(osel))
@@ -172,7 +172,7 @@ func runDriveIncrementalTest(
 
 	var (
 		acct    = tconfig.NewM365Account(t)
-		opts    = control.DefaultBackupOptions()
+		opts    = control.DefaultBackupConfig()
 		mb      = evmock.NewBus()
 		counter = count.New()
 		ws      = deeTD.DriveIDFromRepoRef
@@ -879,7 +879,7 @@ func runDriveAssistBaseGroupsUpdate(
 		whatSet = deeTD.CategoryFromRepoRef
 		mb      = evmock.NewBus()
 		counter = count.New()
-		opts    = control.DefaultBackupOptions()
+		opts    = control.DefaultBackupConfig()
 	)
 
 	opts.ItemExtensionFactory = []extensions.CreateItemExtensioner{
@@ -931,7 +931,7 @@ func runDriveAssistBaseGroupsUpdate(
 		var (
 			mb      = evmock.NewBus()
 			counter = count.New()
-			opts    = control.DefaultBackupOptions()
+			opts    = control.DefaultBackupConfig()
 		)
 
 		forcedFull := newTestBackupOp(
@@ -1003,7 +1003,7 @@ func (suite *OneDriveBackupIntgSuite) TestBackup_Run_oneDriveOwnerMigration() {
 
 	var (
 		acct    = tconfig.NewM365Account(t)
-		opts    = control.DefaultBackupOptions()
+		opts    = control.DefaultBackupConfig()
 		mb      = evmock.NewBus()
 		counter = count.New()
 
@@ -1141,7 +1141,7 @@ func (suite *OneDriveBackupIntgSuite) TestBackup_Run_oneDriveExtensions() {
 		osel    = selectors.NewOneDriveBackup([]string{userID})
 		ws      = deeTD.DriveIDFromRepoRef
 		svc     = path.OneDriveService
-		opts    = control.DefaultBackupOptions()
+		opts    = control.DefaultBackupConfig()
 	)
 
 	opts.ItemExtensionFactory = getTestExtensionFactories()
@@ -1260,7 +1260,7 @@ func runDriveRestoreWithAdvancedOptions(
 	var (
 		mb          = evmock.NewBus()
 		counter     = count.New()
-		opts        = control.DefaultBackupOptions()
+		opts        = control.DefaultBackupConfig()
 		controlOpts = control.DefaultOptions()
 	)
 
@@ -1534,7 +1534,7 @@ func runDriveRestoreToAlternateProtectedResource(
 	var (
 		mb          = evmock.NewBus()
 		counter     = count.New()
-		opts        = control.DefaultBackupOptions()
+		opts        = control.DefaultBackupConfig()
 		controlOpts = control.DefaultOptions()
 	)
 

--- a/src/internal/operations/test/onedrive_test.go
+++ b/src/internal/operations/test/onedrive_test.go
@@ -78,7 +78,7 @@ func (suite *OneDriveBackupIntgSuite) TestBackup_Run_oneDrive() {
 		osel    = selectors.NewOneDriveBackup([]string{userID})
 		ws      = deeTD.DriveIDFromRepoRef
 		svc     = path.OneDriveService
-		opts    = control.DefaultOptions()
+		opts    = control.DefaultBackupOptions()
 	)
 
 	osel.Include(selTD.OneDriveBackupFolderScope(osel))
@@ -172,7 +172,7 @@ func runDriveIncrementalTest(
 
 	var (
 		acct    = tconfig.NewM365Account(t)
-		opts    = control.DefaultOptions()
+		opts    = control.DefaultBackupOptions()
 		mb      = evmock.NewBus()
 		counter = count.New()
 		ws      = deeTD.DriveIDFromRepoRef
@@ -879,7 +879,7 @@ func runDriveAssistBaseGroupsUpdate(
 		whatSet = deeTD.CategoryFromRepoRef
 		mb      = evmock.NewBus()
 		counter = count.New()
-		opts    = control.DefaultOptions()
+		opts    = control.DefaultBackupOptions()
 	)
 
 	opts.ItemExtensionFactory = []extensions.CreateItemExtensioner{
@@ -931,7 +931,7 @@ func runDriveAssistBaseGroupsUpdate(
 		var (
 			mb      = evmock.NewBus()
 			counter = count.New()
-			opts    = control.DefaultOptions()
+			opts    = control.DefaultBackupOptions()
 		)
 
 		forcedFull := newTestBackupOp(
@@ -1003,7 +1003,7 @@ func (suite *OneDriveBackupIntgSuite) TestBackup_Run_oneDriveOwnerMigration() {
 
 	var (
 		acct    = tconfig.NewM365Account(t)
-		opts    = control.DefaultOptions()
+		opts    = control.DefaultBackupOptions()
 		mb      = evmock.NewBus()
 		counter = count.New()
 
@@ -1141,7 +1141,7 @@ func (suite *OneDriveBackupIntgSuite) TestBackup_Run_oneDriveExtensions() {
 		osel    = selectors.NewOneDriveBackup([]string{userID})
 		ws      = deeTD.DriveIDFromRepoRef
 		svc     = path.OneDriveService
-		opts    = control.DefaultOptions()
+		opts    = control.DefaultBackupOptions()
 	)
 
 	opts.ItemExtensionFactory = getTestExtensionFactories()
@@ -1258,9 +1258,10 @@ func runDriveRestoreWithAdvancedOptions(
 	// a backup is required to run restores
 
 	var (
-		mb      = evmock.NewBus()
-		counter = count.New()
-		opts    = control.DefaultOptions()
+		mb          = evmock.NewBus()
+		counter     = count.New()
+		opts        = control.DefaultBackupOptions()
+		controlOpts = control.DefaultOptions()
 	)
 
 	bo, bod := prepNewTestBackupOp(t, ctx, mb, sel, opts, version.Backup, counter)
@@ -1298,7 +1299,7 @@ func runDriveRestoreWithAdvancedOptions(
 			mb,
 			ctr,
 			sel,
-			opts,
+			controlOpts,
 			restoreCfg)
 
 		runAndCheckRestore(t, ctx, &ro, mb, false)
@@ -1349,7 +1350,7 @@ func runDriveRestoreWithAdvancedOptions(
 			mb,
 			ctr,
 			sel,
-			opts,
+			controlOpts,
 			restoreCfg)
 
 		deets := runAndCheckRestore(t, ctx, &ro, mb, false)
@@ -1400,7 +1401,7 @@ func runDriveRestoreWithAdvancedOptions(
 			mb,
 			ctr,
 			sel,
-			opts,
+			controlOpts,
 			restoreCfg)
 
 		deets := runAndCheckRestore(t, ctx, &ro, mb, false)
@@ -1465,7 +1466,7 @@ func runDriveRestoreWithAdvancedOptions(
 			mb,
 			ctr,
 			sel,
-			opts,
+			controlOpts,
 			restoreCfg)
 
 		deets := runAndCheckRestore(t, ctx, &ro, mb, false)
@@ -1531,9 +1532,10 @@ func runDriveRestoreToAlternateProtectedResource(
 	// a backup is required to run restores
 
 	var (
-		mb      = evmock.NewBus()
-		counter = count.New()
-		opts    = control.DefaultOptions()
+		mb          = evmock.NewBus()
+		counter     = count.New()
+		opts        = control.DefaultBackupOptions()
+		controlOpts = control.DefaultOptions()
 	)
 
 	bo, bod := prepNewTestBackupOp(t, ctx, mb, sel, opts, version.Backup, counter)
@@ -1565,7 +1567,7 @@ func runDriveRestoreToAlternateProtectedResource(
 			mb,
 			fromCtr,
 			sel,
-			opts,
+			controlOpts,
 			restoreCfg)
 
 		runAndCheckRestore(t, ctx, &ro, mb, false)
@@ -1603,7 +1605,7 @@ func runDriveRestoreToAlternateProtectedResource(
 			mb,
 			toCtr,
 			sel,
-			opts,
+			controlOpts,
 			restoreCfg)
 
 		runAndCheckRestore(t, ctx, &ro, mb, false)

--- a/src/internal/operations/test/sharepoint_test.go
+++ b/src/internal/operations/test/sharepoint_test.go
@@ -99,7 +99,7 @@ func (suite *SharePointBackupIntgSuite) TestBackup_Run_sharePointBasic() {
 		mb      = evmock.NewBus()
 		counter = count.New()
 		sel     = selectors.NewSharePointBackup([]string{suite.its.site.ID})
-		opts    = control.DefaultOptions()
+		opts    = control.DefaultBackupOptions()
 	)
 
 	sel.Include(selTD.SharePointBackupFolderScope(sel))
@@ -129,7 +129,7 @@ func (suite *SharePointBackupIntgSuite) TestBackup_Run_sharePointExtensions() {
 		mb      = evmock.NewBus()
 		counter = count.New()
 		sel     = selectors.NewSharePointBackup([]string{suite.its.site.ID})
-		opts    = control.DefaultOptions()
+		opts    = control.DefaultBackupOptions()
 		tenID   = tconfig.M365TenantID(t)
 		svc     = path.SharePointService
 		ws      = deeTD.DriveIDFromRepoRef
@@ -308,7 +308,8 @@ func (suite *SharePointRestoreNightlyIntgSuite) TestRestore_Run_sharepointDelete
 	var (
 		mb          = evmock.NewBus()
 		counter     = count.New()
-		opts        = control.DefaultOptions()
+		opts        = control.DefaultBackupOptions()
+		controlOpts = control.DefaultOptions()
 		graphClient = suite.its.ac.Stable.Client()
 	)
 
@@ -356,7 +357,7 @@ func (suite *SharePointRestoreNightlyIntgSuite) TestRestore_Run_sharepointDelete
 			mb,
 			ctr,
 			bod.sel,
-			opts,
+			controlOpts,
 			rc)
 
 		runAndCheckRestore(t, ctx, &ro, mb, false)
@@ -407,7 +408,7 @@ func (suite *SharePointRestoreNightlyIntgSuite) TestRestore_Run_sharepointDelete
 			mb,
 			ctr,
 			bod.sel,
-			opts,
+			controlOpts,
 			rc)
 
 		runAndCheckRestore(t, ctx, &ro, mb, false)
@@ -475,7 +476,7 @@ func (suite *SharePointRestoreNightlyIntgSuite) TestRestore_Run_sharepointDelete
 			mb,
 			ctr,
 			bod.sel,
-			opts,
+			controlOpts,
 			rc)
 
 		runAndCheckRestore(t, ctx, &ro, mb, false)

--- a/src/internal/operations/test/sharepoint_test.go
+++ b/src/internal/operations/test/sharepoint_test.go
@@ -99,7 +99,7 @@ func (suite *SharePointBackupIntgSuite) TestBackup_Run_sharePointBasic() {
 		mb      = evmock.NewBus()
 		counter = count.New()
 		sel     = selectors.NewSharePointBackup([]string{suite.its.site.ID})
-		opts    = control.DefaultBackupOptions()
+		opts    = control.DefaultBackupConfig()
 	)
 
 	sel.Include(selTD.SharePointBackupFolderScope(sel))
@@ -129,7 +129,7 @@ func (suite *SharePointBackupIntgSuite) TestBackup_Run_sharePointExtensions() {
 		mb      = evmock.NewBus()
 		counter = count.New()
 		sel     = selectors.NewSharePointBackup([]string{suite.its.site.ID})
-		opts    = control.DefaultBackupOptions()
+		opts    = control.DefaultBackupConfig()
 		tenID   = tconfig.M365TenantID(t)
 		svc     = path.SharePointService
 		ws      = deeTD.DriveIDFromRepoRef
@@ -308,7 +308,7 @@ func (suite *SharePointRestoreNightlyIntgSuite) TestRestore_Run_sharepointDelete
 	var (
 		mb          = evmock.NewBus()
 		counter     = count.New()
-		opts        = control.DefaultBackupOptions()
+		opts        = control.DefaultBackupConfig()
 		controlOpts = control.DefaultOptions()
 		graphClient = suite.its.ac.Stable.Client()
 	)

--- a/src/pkg/repository/backups.go
+++ b/src/pkg/repository/backups.go
@@ -17,6 +17,7 @@ import (
 	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/store"
@@ -41,10 +42,12 @@ type BackupGetter interface {
 type Backuper interface {
 	NewBackup(
 		ctx context.Context,
+		opts control.Backup,
 		self selectors.Selector,
 	) (operations.BackupOperation, error)
 	NewBackupWithLookup(
 		ctx context.Context,
+		opts control.Backup,
 		self selectors.Selector,
 		ins idname.Cacher,
 	) (operations.BackupOperation, error)
@@ -58,9 +61,10 @@ type Backuper interface {
 // NewBackup generates a BackupOperation runner.
 func (r repository) NewBackup(
 	ctx context.Context,
+	opts control.Backup,
 	sel selectors.Selector,
 ) (operations.BackupOperation, error) {
-	return r.NewBackupWithLookup(ctx, sel, nil)
+	return r.NewBackupWithLookup(ctx, opts, sel, nil)
 }
 
 // NewBackupWithLookup generates a BackupOperation runner.
@@ -68,6 +72,7 @@ func (r repository) NewBackup(
 // already generated those values.
 func (r repository) NewBackupWithLookup(
 	ctx context.Context,
+	opts control.Backup,
 	sel selectors.Selector,
 	ins idname.Cacher,
 ) (operations.BackupOperation, error) {
@@ -86,7 +91,7 @@ func (r repository) NewBackupWithLookup(
 
 	return operations.NewBackupOperation(
 		ctx,
-		r.Opts,
+		opts,
 		r.dataLayer,
 		store.NewWrapper(r.modelStore),
 		r.Provider,

--- a/src/pkg/repository/backups.go
+++ b/src/pkg/repository/backups.go
@@ -42,14 +42,14 @@ type BackupGetter interface {
 type Backuper interface {
 	NewBackup(
 		ctx context.Context,
-		opts control.Backup,
 		self selectors.Selector,
+		opts control.BackupConfig,
 	) (operations.BackupOperation, error)
 	NewBackupWithLookup(
 		ctx context.Context,
-		opts control.Backup,
 		self selectors.Selector,
 		ins idname.Cacher,
+		opts control.BackupConfig,
 	) (operations.BackupOperation, error)
 	DeleteBackups(
 		ctx context.Context,
@@ -61,10 +61,10 @@ type Backuper interface {
 // NewBackup generates a BackupOperation runner.
 func (r repository) NewBackup(
 	ctx context.Context,
-	opts control.Backup,
 	sel selectors.Selector,
+	opts control.BackupConfig,
 ) (operations.BackupOperation, error) {
-	return r.NewBackupWithLookup(ctx, opts, sel, nil)
+	return r.NewBackupWithLookup(ctx, sel, nil, opts)
 }
 
 // NewBackupWithLookup generates a BackupOperation runner.
@@ -72,9 +72,9 @@ func (r repository) NewBackup(
 // already generated those values.
 func (r repository) NewBackupWithLookup(
 	ctx context.Context,
-	opts control.Backup,
 	sel selectors.Selector,
 	ins idname.Cacher,
+	opts control.BackupConfig,
 ) (operations.BackupOperation, error) {
 	err := r.ConnectDataProvider(ctx, sel.PathService())
 	if err != nil {

--- a/src/pkg/repository/loadtest/repository_load_test.go
+++ b/src/pkg/repository/loadtest/repository_load_test.go
@@ -132,7 +132,7 @@ func runLoadTest(
 ) {
 	//revive:enable:context-as-argument
 	t.Run(prefix+"_load_test_main", func(t *testing.T) {
-		b, err := r.NewBackup(ctx, bupSel)
+		b, err := r.NewBackup(ctx, control.DefaultBackupOptions(), bupSel)
 		require.NoError(t, err, clues.ToCore(err))
 
 		runBackupLoadTest(t, ctx, &b, service, usersUnderTest)

--- a/src/pkg/repository/loadtest/repository_load_test.go
+++ b/src/pkg/repository/loadtest/repository_load_test.go
@@ -132,7 +132,7 @@ func runLoadTest(
 ) {
 	//revive:enable:context-as-argument
 	t.Run(prefix+"_load_test_main", func(t *testing.T) {
-		b, err := r.NewBackup(ctx, control.DefaultBackupOptions(), bupSel)
+		b, err := r.NewBackup(ctx, bupSel, control.DefaultBackupConfig())
 		require.NoError(t, err, clues.ToCore(err))
 
 		runBackupLoadTest(t, ctx, &b, service, usersUnderTest)

--- a/src/pkg/repository/repository_test.go
+++ b/src/pkg/repository/repository_test.go
@@ -334,7 +334,10 @@ func (suite *RepositoryIntegrationSuite) TestNewBackup() {
 
 	userID := tconfig.M365UserID(t)
 
-	bo, err := r.NewBackup(ctx, selectors.NewExchangeBackup([]string{userID}).Selector)
+	bo, err := r.NewBackup(
+		ctx,
+		control.DefaultBackupOptions(),
+		selectors.NewExchangeBackup([]string{userID}).Selector)
 	require.NoError(t, err, clues.ToCore(err))
 	require.NotNil(t, bo)
 }
@@ -397,7 +400,7 @@ func (suite *RepositoryIntegrationSuite) TestNewBackupAndDelete() {
 	sel.Include(sel.MailFolders([]string{api.MailInbox}, selectors.PrefixMatch()))
 	sel.DiscreteOwner = userID
 
-	bo, err := r.NewBackup(ctx, sel.Selector)
+	bo, err := r.NewBackup(ctx, control.DefaultBackupOptions(), sel.Selector)
 	require.NoError(t, err, clues.ToCore(err))
 	require.NotNil(t, bo)
 

--- a/src/pkg/repository/repository_test.go
+++ b/src/pkg/repository/repository_test.go
@@ -336,8 +336,8 @@ func (suite *RepositoryIntegrationSuite) TestNewBackup() {
 
 	bo, err := r.NewBackup(
 		ctx,
-		control.DefaultBackupOptions(),
-		selectors.NewExchangeBackup([]string{userID}).Selector)
+		selectors.NewExchangeBackup([]string{userID}).Selector,
+		control.DefaultBackupConfig())
 	require.NoError(t, err, clues.ToCore(err))
 	require.NotNil(t, bo)
 }
@@ -400,7 +400,7 @@ func (suite *RepositoryIntegrationSuite) TestNewBackupAndDelete() {
 	sel.Include(sel.MailFolders([]string{api.MailInbox}, selectors.PrefixMatch()))
 	sel.DiscreteOwner = userID
 
-	bo, err := r.NewBackup(ctx, control.DefaultBackupOptions(), sel.Selector)
+	bo, err := r.NewBackup(ctx, sel.Selector, control.DefaultBackupConfig())
 	require.NoError(t, err, clues.ToCore(err))
 	require.NotNil(t, bo)
 


### PR DESCRIPTION
Update the existing backup operation API to take a the new backup
options struct instead of passing in the repo options internally.
This effectively separates init/connect config from backup config

This PR doesn't update lower portions of the stack to use backup
ops, it simply translates the incoming config values to the old
options struct and continues using that. Later PRs will update the
lower portion of the stack

Since this PR has many small changes to update tests it may be
easiest to review by commit

This PR does break the current API that SDK users may rely on so
SDK consumers will need to make changes to use the new options
struct

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issues

- #4896

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
