### PR TITLE
patch byte limit handling

### DIFF
--- a/src/internal/m365/collection/drive/collection_test.go
+++ b/src/internal/m365/collection/drive/collection_test.go
@@ -300,12 +300,12 @@ func (suite *CollectionUnitSuite) TestCollection() {
 
 func (suite *CollectionUnitSuite) TestCollectionReadError() {
 	var (
-		t                = suite.T()
-		stubItemID       = "fakeItemID"
-		collStatus       = support.ControllerOperationStatus{}
-		wg               = sync.WaitGroup{}
-		size       int64 = defaultFileSize
-		now              = time.Now()
+		t          = suite.T()
+		stubItemID = "fakeItemID"
+		collStatus = support.ControllerOperationStatus{}
+		wg         = sync.WaitGroup{}
+		size       = defaultFileSize
+		now        = time.Now()
 	)
 
 	ctx, flush := tester.NewContext(t)
@@ -370,12 +370,12 @@ func (suite *CollectionUnitSuite) TestCollectionReadError() {
 
 func (suite *CollectionUnitSuite) TestCollectionReadUnauthorizedErrorRetry() {
 	var (
-		t                = suite.T()
-		stubItemID       = "fakeItemID"
-		collStatus       = support.ControllerOperationStatus{}
-		wg               = sync.WaitGroup{}
-		size       int64 = defaultFileSize
-		now              = time.Now()
+		t          = suite.T()
+		stubItemID = "fakeItemID"
+		collStatus = support.ControllerOperationStatus{}
+		wg         = sync.WaitGroup{}
+		size       = defaultFileSize
+		now        = time.Now()
 	)
 
 	ctx, flush := tester.NewContext(t)

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -638,17 +638,25 @@ func (c *Collections) addFileToTree(
 	if parentNotNil && !alreadySeen {
 		countSize := tree.countLiveFilesAndSizes()
 
+		// Tell the enumerator to exit if we've already hit the total
+		// limit of bytes or items in this backup.
+		if limiter.alreadyHitTotalBytesLimit(countSize.totalBytes) ||
+			limiter.hitItemLimit(countSize.numFiles) {
+			return nil, errHitLimit
+		}
+
 		// Don't add new items if the new collection has already reached it's limit.
 		// item moves and updates are generally allowed through.
-		if limiter.atContainerItemsLimit(len(parentNode.files)) || limiter.hitItemLimit(countSize.numFiles) {
+		if limiter.atContainerItemsLimit(len(parentNode.files)) {
 			return nil, errHitCollectionLimit
 		}
 
 		// Don't include large files that don't fit within the size limit.
-		// Unlike the other checks, which see if we're already at the limit, this check
-		// needs to be forward-facing to ensure we don't go far over the limit.
+		// Unlike the other checks, which see if we're already at the limit,
+		// this check needs to be forward-facing to ensure we don't go far
+		// over the limit
 		// Example case: a 1gb limit and a 25gb file.
-		if limiter.hitTotalBytesLimit(fileSize + countSize.totalBytes) {
+		if limiter.willStepOverBytesLimit(countSize.totalBytes, fileSize) {
 			// don't return errHitLimit here; we only want to skip the
 			// current file.  We may not want to skip files after it.
 			return nil, nil

--- a/src/internal/m365/collection/drive/collections_tree_test.go
+++ b/src/internal/m365/collection/drive/collections_tree_test.go
@@ -2209,10 +2209,18 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 	d := drive()
 
+	unlimitedItemsPerContainer := newPagerLimiter(minimumLimitOpts())
+	unlimitedItemsPerContainer.limits.MaxItemsPerContainer = 9001
+
+	unlimitedTotalBytesAndFiles := newPagerLimiter(minimumLimitOpts())
+	unlimitedTotalBytesAndFiles.limits.MaxBytes = 9001
+	unlimitedTotalBytesAndFiles.limits.MaxItems = 9001
+
 	type expected struct {
 		counts                        countTD.Expected
 		err                           require.ErrorAssertionFunc
 		shouldHitLimit                bool
+		shouldHitCollLimit            bool
 		skipped                       assert.ValueAssertionFunc
 		treeContainsFileIDsWithParent map[string]string
 		countLiveFiles                int
@@ -2330,7 +2338,44 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 			name:    "already at container file limit",
 			tree:    treeWithFileAtRoot,
 			file:    d.fileAt(root, 2),
-			limiter: newPagerLimiter(minimumLimitOpts()),
+			limiter: unlimitedTotalBytesAndFiles,
+			expect: expected{
+				counts: countTD.Expected{
+					count.TotalFilesProcessed: 1,
+				},
+				err:                require.Error,
+				shouldHitCollLimit: true,
+				skipped:            assert.Nil,
+				treeContainsFileIDsWithParent: map[string]string{
+					fileID(): rootID,
+				},
+				countLiveFiles:  1,
+				countTotalBytes: defaultFileSize,
+			},
+		},
+		{
+			name:    "goes over total byte limit",
+			tree:    treeWithRoot,
+			file:    d.fileAt(root),
+			limiter: unlimitedItemsPerContainer,
+			expect: expected{
+				counts: countTD.Expected{
+					count.TotalFilesProcessed: 1,
+				},
+				// no error here, since byte limit shouldn't
+				// make the func return an error.
+				err:                           require.NoError,
+				skipped:                       assert.Nil,
+				treeContainsFileIDsWithParent: map[string]string{},
+				countLiveFiles:                0,
+				countTotalBytes:               0,
+			},
+		},
+		{
+			name:    "already over total byte limit",
+			tree:    treeWithFileAtRoot,
+			file:    d.fileAt(root, 2),
+			limiter: unlimitedItemsPerContainer,
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalFilesProcessed: 1,
@@ -2343,25 +2388,6 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 				},
 				countLiveFiles:  1,
 				countTotalBytes: defaultFileSize,
-			},
-		},
-		{
-			name:    "goes over total byte limit",
-			tree:    treeWithRoot,
-			file:    d.fileAt(root),
-			limiter: newPagerLimiter(minimumLimitOpts()),
-			expect: expected{
-				counts: countTD.Expected{
-					count.TotalFilesProcessed: 1,
-				},
-				// no error here, since byte limit shouldn't
-				// make the func return errHitLimit.
-				err:                           require.NoError,
-				shouldHitLimit:                false,
-				skipped:                       assert.Nil,
-				treeContainsFileIDsWithParent: map[string]string{},
-				countLiveFiles:                0,
-				countTotalBytes:               0,
 			},
 		},
 	}
@@ -2389,8 +2415,12 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 			test.expect.err(t, err, clues.ToCore(err))
 			test.expect.skipped(t, skipped)
 
-			if test.expect.shouldHitLimit {
+			if test.expect.shouldHitCollLimit {
 				require.ErrorIs(t, err, errHitCollectionLimit, clues.ToCore(err))
+			}
+
+			if test.expect.shouldHitLimit {
+				require.ErrorIs(t, err, errHitLimit, clues.ToCore(err))
 			}
 
 			assert.Equal(t, test.expect.treeContainsFileIDsWithParent, tree.fileIDToParentID)

--- a/src/internal/m365/collection/drive/limiter.go
+++ b/src/internal/m365/collection/drive/limiter.go
@@ -114,9 +114,22 @@ func (l pagerLimiter) hitItemLimit(itemCount int) bool {
 	return l.enabled() && itemCount >= l.limits.MaxItems
 }
 
-// hitTotalBytesLimit returns true if the limiter is enabled and has reached the limit
+// alreadyHitTotalBytesLimit returns true if the limiter is enabled and has reached the limit
 // for the accumulated byte size of all items (the file contents, not the item metadata)
 // added to collections for this backup.
-func (l pagerLimiter) hitTotalBytesLimit(i int64) bool {
+func (l pagerLimiter) alreadyHitTotalBytesLimit(i int64) bool {
 	return l.enabled() && i > l.limits.MaxBytes
+}
+
+// willStepOverBytesLimit returns true if the limiter is enabled and the provided addition
+// of bytes is greater than the limit plus some padding (to ensure we can always hit
+// the limit).
+func (l pagerLimiter) willStepOverBytesLimit(current, addition int64) bool {
+	if !l.enabled() {
+		return false
+	}
+
+	limitPlusPadding := int64(float64(l.limits.MaxBytes) * 1.03)
+
+	return (current + addition) > limitPlusPadding
 }


### PR DESCRIPTION
in the tree version of backups, allow one item to hit or slightly overstep the total byte limits.  Also, stop all enumeration afterward if the backup has hit the total item limits.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix

#### Issue(s)

* #4689

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
