### PR TITLE
add incremental test coverage for tree backup

### DIFF
--- a/src/internal/m365/collection/drive/collections_tree_test.go
+++ b/src/internal/m365/collection/drive/collections_tree_test.go
@@ -165,10 +165,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_GetTree() {
 			enumerator: driveEnumerator(
 				d1.newEnumer().with(delta(nil)),
 				d2.newEnumer().with(delta(nil))),
-			metadata: multiDriveMetadata(
-				t,
-				d1.newPrevPaths(t),
-				d2.newPrevPaths(t)),
+			metadata: multiDriveMetadata(t),
 			expect: expected{
 				canUsePrevBackup: assert.True,
 				collections: expectCollections(
@@ -197,10 +194,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_GetTree() {
 							d2.fileAt(root, "r"),
 							d2.folderAt(root),
 							d2.fileAt(folder, "f"))))),
-			metadata: multiDriveMetadata(
-				t,
-				d1.newPrevPaths(t),
-				d2.newPrevPaths(t)),
+			metadata: multiDriveMetadata(t),
 			expect: expected{
 				canUsePrevBackup: assert.True,
 				collections: expectCollections(
@@ -387,8 +381,13 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_GetTree() {
 					expect, _ := test.expect.globalExcludedFileIDs.Get(d)
 					result, rok := globalExcludes.Get(d)
 
-					require.True(t, rok, "drive results have a global excludes entry")
-					assert.Equal(t, expect, result, "global excluded file IDs")
+					if len(test.metadata) > 0 {
+						require.True(t, rok, "drive results have a global excludes entry")
+						assert.Equal(t, expect, result, "global excluded file IDs")
+					} else {
+						require.False(t, rok, "drive results have no global excludes entry")
+						assert.Empty(t, result, "global excluded file IDs")
+					}
 				})
 			}
 		})

--- a/src/internal/m365/collection/drive/helper_test.go
+++ b/src/internal/m365/collection/drive/helper_test.go
@@ -490,22 +490,22 @@ func defaultLoc() path.Elements {
 }
 
 func newTree(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
-	return newFolderyMcFolderFace(defaultTreePfx(t, d), rootID)
+	return newFolderyMcFolderFace(defaultTreePfx(t, d))
 }
 
 func treeWithRoot(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
-	tree := newFolderyMcFolderFace(defaultTreePfx(t, d), rootID)
+	tree := newFolderyMcFolderFace(defaultTreePfx(t, d))
 	root := custom.ToCustomDriveItem(rootFolder())
 
 	//nolint:forbidigo
-	err := tree.setFolder(context.Background(), root)
+	err := tree.setFolder(context.Background(), root, false)
 	require.NoError(t, err, clues.ToCore(err))
 
 	return tree
 }
 
 func treeAfterReset(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
-	tree := newFolderyMcFolderFace(defaultTreePfx(t, d), rootID)
+	tree := newFolderyMcFolderFace(defaultTreePfx(t, d))
 	tree.reset()
 
 	return tree
@@ -535,21 +535,24 @@ func treeWithFolders(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
 	folder := custom.ToCustomDriveItem(d.folderAt("parent"))
 
 	//nolint:forbidigo
-	err := tree.setFolder(context.Background(), parent)
+	err := tree.setFolder(context.Background(), parent, false)
 	require.NoError(t, err, clues.ToCore(err))
 
 	//nolint:forbidigo
-	err = tree.setFolder(context.Background(), folder)
+	err = tree.setFolder(context.Background(), folder, false)
 	require.NoError(t, err, clues.ToCore(err))
 
 	return tree
 }
 
 func treeWithFileAtRoot(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
 	tree := treeWithRoot(t, d)
 
 	f := custom.ToCustomDriveItem(d.fileAt(root))
-	err := tree.addFile(f)
+	err := tree.addFile(ctx, f)
 	require.NoError(t, err, clues.ToCore(err))
 
 	return tree
@@ -563,10 +566,13 @@ func treeWithDeletedFile(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
 }
 
 func treeWithFileInFolder(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
 	tree := treeWithFolders(t, d)
 
 	f := custom.ToCustomDriveItem(d.fileAt(folder))
-	err := tree.addFile(f)
+	err := tree.addFile(ctx, f)
 	require.NoError(t, err, clues.ToCore(err))
 
 	return tree
@@ -579,6 +585,31 @@ func treeWithFileInTombstone(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
 	// because we can't add files to tombstones.
 	tree.tombstones[folderID()].files[fileID()] = custom.ToCustomDriveItem(d.fileAt("tombstone"))
 	tree.fileIDToParentID[fileID()] = folderID()
+
+	return tree
+}
+
+func treeWithUnselectedRootAndFolder(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	tree := treeWithRoot(t, d)
+	tree.root.isNotSelected = true
+
+	err := tree.addFile(ctx, custom.ToCustomDriveItem(d.fileAt(root, "r")))
+	require.NoError(t, err, clues.ToCore(err))
+
+	err = tree.setFolder(ctx, custom.ToCustomDriveItem(d.folderAt(root)), false)
+	require.NoError(t, err, clues.ToCore(err))
+
+	err = tree.addFile(ctx, custom.ToCustomDriveItem(d.fileAt(folder)))
+	require.NoError(t, err, clues.ToCore(err))
+
+	err = tree.setFolder(ctx, custom.ToCustomDriveItem(d.folderAt(root, "nope")), true)
+	require.NoError(t, err, clues.ToCore(err))
+
+	err = tree.addFile(ctx, custom.ToCustomDriveItem(d.fileAt("nope", "n")))
+	require.NoError(t, err, clues.ToCore(err))
 
 	return tree
 }
@@ -603,39 +634,39 @@ func fullTreeWithNames(
 
 		// file "r" in root
 		df := custom.ToCustomDriveItem(d.fileAt(root, "r"))
-		err := tree.addFile(df)
+		err := tree.addFile(ctx, df)
 		require.NoError(t, err, clues.ToCore(err))
 
 		// root -> folderID(parentX)
 		parent := custom.ToCustomDriveItem(d.folderAt(root, parentFolderSuffix))
-		err = tree.setFolder(ctx, parent)
+		err = tree.setFolder(ctx, parent, false)
 		require.NoError(t, err, clues.ToCore(err))
 
 		// file "p" in folderID(parentX)
 		df = custom.ToCustomDriveItem(d.fileAt(parentFolderSuffix, "p"))
-		err = tree.addFile(df)
+		err = tree.addFile(ctx, df)
 		require.NoError(t, err, clues.ToCore(err))
 
 		// folderID(parentX) -> folderID()
 		fld := custom.ToCustomDriveItem(d.folderAt(parentFolderSuffix))
-		err = tree.setFolder(ctx, fld)
+		err = tree.setFolder(ctx, fld, false)
 		require.NoError(t, err, clues.ToCore(err))
 
 		// file "f" in folderID()
 		df = custom.ToCustomDriveItem(d.fileAt(folder, "f"))
-		err = tree.addFile(df)
+		err = tree.addFile(ctx, df)
 		require.NoError(t, err, clues.ToCore(err))
 
 		// tombstone - have to set a non-tombstone folder first,
 		// then add the item,
 		// then tombstone the folder
 		tomb := custom.ToCustomDriveItem(d.folderAt(root, tombstoneSuffix))
-		err = tree.setFolder(ctx, tomb)
+		err = tree.setFolder(ctx, tomb, false)
 		require.NoError(t, err, clues.ToCore(err))
 
 		// file "t" in tombstone
 		df = custom.ToCustomDriveItem(d.fileAt(tombstoneSuffix, "t"))
-		err = tree.addFile(df)
+		err = tree.addFile(ctx, df)
 		require.NoError(t, err, clues.ToCore(err))
 
 		err = tree.setTombstone(ctx, tomb)

--- a/src/internal/m365/controller_test.go
+++ b/src/internal/m365/controller_test.go
@@ -651,7 +651,11 @@ func runBackupAndCompare(
 	require.NoError(t, err, clues.ToCore(err))
 	assert.True(t, canUsePreviousBackup, "can use previous backup")
 	// No excludes yet because this isn't an incremental backup.
-	assert.True(t, excludes.Empty())
+	assert.True(
+		t,
+		excludes.Empty(),
+		"global excludes should have no entries, got:\n\t%+v",
+		excludes.Keys())
 
 	t.Logf("Backup enumeration complete in %v\n", time.Since(start))
 

--- a/src/internal/operations/test/driveish_test.go
+++ b/src/internal/operations/test/driveish_test.go
@@ -1,0 +1,801 @@
+package test_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/alcionai/clues"
+	"github.com/microsoftgraph/msgraph-sdk-go/drives"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
+
+	inMock "github.com/alcionai/corso/src/internal/common/idname/mock"
+	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/internal/common/syncd"
+	"github.com/alcionai/corso/src/internal/events"
+	evmock "github.com/alcionai/corso/src/internal/events/mock"
+	"github.com/alcionai/corso/src/internal/m365"
+	"github.com/alcionai/corso/src/internal/m365/collection/drive"
+	"github.com/alcionai/corso/src/internal/m365/collection/drive/metadata"
+	odConsts "github.com/alcionai/corso/src/internal/m365/service/onedrive/consts"
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/tester/tconfig"
+	"github.com/alcionai/corso/src/internal/version"
+	deeTD "github.com/alcionai/corso/src/pkg/backup/details/testdata"
+	bupMD "github.com/alcionai/corso/src/pkg/backup/metadata"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/count"
+	"github.com/alcionai/corso/src/pkg/dttm"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/selectors"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+)
+
+func runBasicDriveishBackupTests(
+	suite tester.Suite,
+	service path.ServiceType,
+	opts control.Options,
+	sel selectors.Selector,
+) {
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	var (
+		tenID   = tconfig.M365TenantID(t)
+		mb      = evmock.NewBus()
+		counter = count.New()
+		ws      = deeTD.DriveIDFromRepoRef
+	)
+
+	bo, bod := prepNewTestBackupOp(t, ctx, mb, sel, opts, version.Backup, counter)
+	defer bod.close(t, ctx)
+
+	runAndCheckBackup(t, ctx, &bo, mb, false)
+
+	bID := bo.Results.BackupID
+
+	_, expectDeets := deeTD.GetDeetsInBackup(
+		t,
+		ctx,
+		bID,
+		tenID,
+		bod.sel.ID(),
+		service,
+		ws,
+		bod.kms,
+		bod.sss)
+	deeTD.CheckBackupDetails(
+		t,
+		ctx,
+		bID,
+		ws,
+		bod.kms,
+		bod.sss,
+		expectDeets,
+		false)
+}
+
+func runIncrementalDriveishBackupTest(
+	suite tester.Suite,
+	opts control.Options,
+	owner, permissionsUser string,
+	service path.ServiceType,
+	category path.CategoryType,
+	includeContainers func([]string) selectors.Selector,
+	getTestDriveID func(*testing.T, context.Context) string,
+	getTestSiteID func(*testing.T, context.Context) string,
+	getRestoreHandler func(api.Client) drive.RestoreHandler,
+	skipPermissionsTests bool,
+) {
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	var (
+		acct    = tconfig.NewM365Account(t)
+		mb      = evmock.NewBus()
+		counter = count.New()
+		ws      = deeTD.DriveIDFromRepoRef
+
+		// `now` has to be formatted with SimpleDateTimeTesting as
+		// some drives cannot have `:` in file/folder names
+		now = dttm.FormatNow(dttm.SafeForTesting)
+
+		categories      = map[path.CategoryType][][]string{}
+		container1      = fmt.Sprintf("%s%d_%s", incrementalsDestContainerPrefix, 1, now)
+		container2      = fmt.Sprintf("%s%d_%s", incrementalsDestContainerPrefix, 2, now)
+		container3      = fmt.Sprintf("%s%d_%s", incrementalsDestContainerPrefix, 3, now)
+		containerRename = "renamed_folder"
+
+		genDests = []string{container1, container2}
+
+		// container3 does not exist yet. It will get created later on
+		// during the tests.
+		containers = []string{container1, container2, container3}
+	)
+
+	if service == path.GroupsService && category == path.LibrariesCategory {
+		categories[category] = [][]string{{odConsts.SitesPathDir, bupMD.PreviousPathFileName}}
+	} else {
+		categories[category] = [][]string{{bupMD.DeltaURLsFileName}, {bupMD.PreviousPathFileName}}
+	}
+
+	sel := includeContainers(containers)
+
+	creds, err := acct.M365Config()
+	require.NoError(t, err, clues.ToCore(err))
+
+	ctrl, sel := ControllerWithSelector(t, ctx, acct, sel, nil, nil, counter)
+	ac := ctrl.AC.Drives()
+	rh := getRestoreHandler(ctrl.AC)
+
+	roidn := inMock.NewProvider(sel.ID(), sel.Name())
+
+	var (
+		atid    = creds.AzureTenantID
+		driveID = getTestDriveID(t, ctx)
+		siteID  = ""
+		fileDBF = func(id, timeStamp, subject, body string) []byte {
+			return []byte(id + subject)
+		}
+		makeLocRef = func(flds ...string) *path.Builder {
+			elems := append([]string{"root:"}, flds...)
+			return path.Builder{}.Append(elems...)
+		}
+	)
+
+	// Will only be available for groups
+	if getTestSiteID != nil {
+		siteID = getTestSiteID(t, ctx)
+	}
+
+	rrPfx, err := path.BuildPrefix(atid, roidn.ID(), service, category)
+	require.NoError(t, err, clues.ToCore(err))
+
+	// strip the category from the prefix; we primarily want the tenant and resource owner.
+	expectDeets := deeTD.NewInDeets(rrPfx.ToBuilder().Dir().String())
+
+	type containerInfo struct {
+		id     string
+		locRef *path.Builder
+	}
+
+	containerInfos := map[string]containerInfo{}
+
+	mustGetExpectedContainerItems := func(
+		t *testing.T,
+		driveID, destName string,
+		locRef *path.Builder,
+	) {
+		// Use path-based indexing to get the folder's ID.
+		itemURL := fmt.Sprintf(
+			"https://graph.microsoft.com/v1.0/drives/%s/root:/%s",
+			driveID,
+			locRef.String())
+		resp, err := drives.
+			NewItemItemsDriveItemItemRequestBuilder(itemURL, ctrl.AC.Stable.Adapter()).
+			Get(ctx, nil)
+		require.NoError(
+			t,
+			err,
+			"getting drive folder ID for %s: %v",
+			locRef.String(),
+			clues.ToCore(err))
+
+		containerInfos[destName] = containerInfo{
+			id:     ptr.Val(resp.GetId()),
+			locRef: makeLocRef(locRef.Elements()...),
+		}
+		dest := containerInfos[destName]
+
+		items, err := ac.GetItemsInContainerByCollisionKey(
+			ctx,
+			driveID,
+			ptr.Val(resp.GetId()))
+		require.NoError(
+			t,
+			err,
+			"getting container %s items: %v",
+			locRef.String(),
+			clues.ToCore(err))
+
+		// Add the directory and all its ancestors to the cache so we can compare
+		// folders.
+		for pb := dest.locRef; len(pb.Elements()) > 0; pb = pb.Dir() {
+			expectDeets.AddLocation(driveID, pb.String())
+		}
+
+		for _, item := range items {
+			if item.IsFolder {
+				continue
+			}
+
+			expectDeets.AddItem(
+				driveID,
+				dest.locRef.String(),
+				item.ItemID)
+		}
+	}
+
+	// Populate initial test data.
+	// Generate 2 new folders with two items each. Only the first two
+	// folders will be part of the initial backup and
+	// incrementals. The third folder will be introduced partway
+	// through the changes. This should be enough to cover most delta
+	// actions.
+	for _, destName := range genDests {
+		generateContainerOfItems(
+			t,
+			ctx,
+			ctrl,
+			service,
+			category,
+			sel,
+			atid, roidn.ID(), siteID, driveID, destName,
+			2,
+			// Use an old backup version so we don't need metadata files.
+			0,
+			fileDBF)
+
+		// The way we generate containers causes it to duplicate the destName.
+		locRef := path.Builder{}.Append(destName, destName)
+		mustGetExpectedContainerItems(
+			t,
+			driveID,
+			destName,
+			locRef)
+	}
+
+	bo, bod := prepNewTestBackupOp(t, ctx, mb, sel, opts, version.Backup, counter)
+	defer bod.close(t, ctx)
+
+	sel = bod.sel
+
+	// run the initial backup
+	runAndCheckBackup(t, ctx, &bo, mb, false)
+
+	// precheck to ensure the expectedDeets are correct.
+	// if we fail here, the expectedDeets were populated incorrectly.
+	deeTD.CheckBackupDetails(
+		t,
+		ctx,
+		bo.Results.BackupID,
+		ws,
+		bod.kms,
+		bod.sss,
+		expectDeets,
+		true)
+
+	var (
+		newFile     models.DriveItemable
+		newFileName = "new_file.txt"
+		newFileID   string
+
+		permissionIDMappings = syncd.NewMapTo[string]()
+		writePerm            = metadata.Permission{
+			ID:       "perm-id",
+			Roles:    []string{"write"},
+			EntityID: permissionsUser,
+		}
+	)
+
+	// Although established as a table, these tests are not isolated from each other.
+	// Assume that every test's side effects cascade to all following test cases.
+	// The changes are split across the table so that we can monitor the deltas
+	// in isolation, rather than debugging one change from the rest of a series.
+	table := []struct {
+		name string
+		// performs the incremental update required for the test.
+		//revive:disable-next-line:context-as-argument
+		updateFiles         func(t *testing.T, ctx context.Context)
+		itemsRead           int
+		itemsWritten        int
+		nonMetaItemsWritten int
+	}{
+		{
+			name:         "clean incremental, no changes",
+			updateFiles:  func(t *testing.T, ctx context.Context) {},
+			itemsRead:    0,
+			itemsWritten: 0,
+		},
+		{
+			name: "create a new file",
+			updateFiles: func(t *testing.T, ctx context.Context) {
+				targetContainer := containerInfos[container1]
+				driveItem := models.NewDriveItem()
+				driveItem.SetName(&newFileName)
+				driveItem.SetFile(models.NewFile())
+				newFile, err = ac.PostItemInContainer(
+					ctx,
+					driveID,
+					targetContainer.id,
+					driveItem,
+					control.Copy)
+				require.NoErrorf(t, err, "creating new file %v", clues.ToCore(err))
+
+				newFileID = ptr.Val(newFile.GetId())
+
+				expectDeets.AddItem(driveID, targetContainer.locRef.String(), newFileID)
+			},
+			itemsRead:           1, // .data file for newitem
+			itemsWritten:        4, // .data and .meta for newitem, .dirmeta for parent and ancestor
+			nonMetaItemsWritten: 1, // .data file for newitem
+		},
+		{
+			name: "add permission to new file",
+			updateFiles: func(t *testing.T, ctx context.Context) {
+				err = drive.UpdatePermissions(
+					ctx,
+					rh,
+					driveID,
+					ptr.Val(newFile.GetId()),
+					[]metadata.Permission{writePerm},
+					[]metadata.Permission{},
+					permissionIDMappings,
+					fault.New(true))
+				require.NoErrorf(t, err, "adding permission to file %v", clues.ToCore(err))
+				// no expectedDeets: metadata isn't tracked
+			},
+			itemsRead:           1, // .data file for newitem
+			itemsWritten:        3, // .meta for newitem, .dirmeta for parent (.data is not written as it is not updated)
+			nonMetaItemsWritten: 0, // none because the file is considered cached instead of written.
+		},
+		{
+			name: "remove permission from new file",
+			updateFiles: func(t *testing.T, ctx context.Context) {
+				err = drive.UpdatePermissions(
+					ctx,
+					rh,
+					driveID,
+					*newFile.GetId(),
+					[]metadata.Permission{},
+					[]metadata.Permission{writePerm},
+					permissionIDMappings,
+					fault.New(true))
+				require.NoErrorf(t, err, "removing permission from file %v", clues.ToCore(err))
+				// no expectedDeets: metadata isn't tracked
+			},
+			itemsRead:           1, // .data file for newitem
+			itemsWritten:        3, // .meta for newitem, .dirmeta for parent (.data is not written as it is not updated)
+			nonMetaItemsWritten: 0, // none because the file is considered cached instead of written.
+		},
+		{
+			name: "add permission to container",
+			updateFiles: func(t *testing.T, ctx context.Context) {
+				targetContainer := containerInfos[container1].id
+				err = drive.UpdatePermissions(
+					ctx,
+					rh,
+					driveID,
+					targetContainer,
+					[]metadata.Permission{writePerm},
+					[]metadata.Permission{},
+					permissionIDMappings,
+					fault.New(true))
+				require.NoErrorf(t, err, "adding permission to container %v", clues.ToCore(err))
+				// no expectedDeets: metadata isn't tracked
+			},
+			itemsRead:           0,
+			itemsWritten:        2, // .dirmeta for collection
+			nonMetaItemsWritten: 0, // no files updated as update on container
+		},
+		{
+			name: "remove permission from container",
+			updateFiles: func(t *testing.T, ctx context.Context) {
+				targetContainer := containerInfos[container1].id
+				err = drive.UpdatePermissions(
+					ctx,
+					rh,
+					driveID,
+					targetContainer,
+					[]metadata.Permission{},
+					[]metadata.Permission{writePerm},
+					permissionIDMappings,
+					fault.New(true))
+				require.NoErrorf(t, err, "removing permission from container %v", clues.ToCore(err))
+				// no expectedDeets: metadata isn't tracked
+			},
+			itemsRead:           0,
+			itemsWritten:        2, // .dirmeta for collection
+			nonMetaItemsWritten: 0, // no files updated
+		},
+		{
+			name: "update contents of a file",
+			updateFiles: func(t *testing.T, ctx context.Context) {
+				err := ac.PutItemContent(
+					ctx,
+					driveID,
+					ptr.Val(newFile.GetId()),
+					[]byte("new content"))
+				require.NoErrorf(t, err, "updating file contents: %v", clues.ToCore(err))
+				// no expectedDeets: neither file id nor location changed
+			},
+			itemsRead:           1, // .data file for newitem
+			itemsWritten:        4, // .data and .meta for newitem, .dirmeta for parent
+			nonMetaItemsWritten: 1, // .data  file for newitem
+		},
+		{
+			name: "rename a file",
+			updateFiles: func(t *testing.T, ctx context.Context) {
+				driveItem := models.NewDriveItem()
+				name := "renamed_new_file.txt"
+				driveItem.SetName(&name)
+
+				err := ac.PatchItem(
+					ctx,
+					driveID,
+					ptr.Val(newFile.GetId()),
+					driveItem)
+				require.NoError(t, err, "renaming file %v", clues.ToCore(err))
+			},
+			itemsRead:           1, // .data file for newitem
+			itemsWritten:        4, // .data and .meta for newitem, .dirmeta for parent
+			nonMetaItemsWritten: 1, // .data file for newitem
+			// no expectedDeets: neither file id nor location changed
+		},
+		{
+			name: "move a file between folders",
+			updateFiles: func(t *testing.T, ctx context.Context) {
+				dest := containerInfos[container2]
+
+				driveItem := models.NewDriveItem()
+				parentRef := models.NewItemReference()
+				parentRef.SetId(&dest.id)
+				driveItem.SetParentReference(parentRef)
+
+				err := ac.PatchItem(
+					ctx,
+					driveID,
+					ptr.Val(newFile.GetId()),
+					driveItem)
+				require.NoErrorf(t, err, "moving file between folders %v", clues.ToCore(err))
+
+				expectDeets.MoveItem(
+					driveID,
+					containerInfos[container1].locRef.String(),
+					dest.locRef.String(),
+					ptr.Val(newFile.GetId()))
+			},
+			itemsRead:           1, // .data file for newitem
+			itemsWritten:        4, // .data and .meta for newitem, .dirmeta for parent
+			nonMetaItemsWritten: 1, // .data file for moved item
+		},
+		{
+			name: "boomerang a file",
+			updateFiles: func(t *testing.T, ctx context.Context) {
+				dest := containerInfos[container2]
+				temp := containerInfos[container1]
+
+				driveItem := models.NewDriveItem()
+				parentRef := models.NewItemReference()
+				parentRef.SetId(&temp.id)
+				driveItem.SetParentReference(parentRef)
+
+				err := ac.PatchItem(
+					ctx,
+					driveID,
+					ptr.Val(newFile.GetId()),
+					driveItem)
+				require.NoErrorf(t, err, "moving file to temporary folder %v", clues.ToCore(err))
+
+				parentRef.SetId(&dest.id)
+				driveItem.SetParentReference(parentRef)
+
+				err = ac.PatchItem(
+					ctx,
+					driveID,
+					ptr.Val(newFile.GetId()),
+					driveItem)
+				require.NoErrorf(t, err, "moving file back to folder %v", clues.ToCore(err))
+			},
+			itemsRead:           1, // .data file for newitem
+			itemsWritten:        3, // .data and .meta for newitem, .dirmeta for parent
+			nonMetaItemsWritten: 0, // non because the file is considered cached instead of written.
+		},
+		{
+			name: "delete file",
+			updateFiles: func(t *testing.T, ctx context.Context) {
+				err := ac.DeleteItem(
+					ctx,
+					driveID,
+					ptr.Val(newFile.GetId()))
+				require.NoErrorf(t, err, "deleting file %v", clues.ToCore(err))
+
+				expectDeets.RemoveItem(
+					driveID,
+					containerInfos[container2].locRef.String(),
+					ptr.Val(newFile.GetId()))
+			},
+			itemsRead:           0,
+			itemsWritten:        0,
+			nonMetaItemsWritten: 0,
+		},
+		{
+			name: "move a folder to a subfolder",
+			updateFiles: func(t *testing.T, ctx context.Context) {
+				parent := containerInfos[container1]
+				child := containerInfos[container2]
+
+				driveItem := models.NewDriveItem()
+				parentRef := models.NewItemReference()
+				parentRef.SetId(&parent.id)
+				driveItem.SetParentReference(parentRef)
+
+				err := ac.PatchItem(
+					ctx,
+					driveID,
+					child.id,
+					driveItem)
+				require.NoError(t, err, "moving folder", clues.ToCore(err))
+
+				expectDeets.MoveLocation(
+					driveID,
+					child.locRef.String(),
+					parent.locRef.String())
+
+				// Remove parent of moved folder since it's now empty.
+				expectDeets.RemoveLocation(driveID, child.locRef.Dir().String())
+
+				// Update in-memory cache with new location.
+				child.locRef = path.Builder{}.Append(append(
+					parent.locRef.Elements(),
+					child.locRef.LastElem())...)
+				containerInfos[container2] = child
+			},
+			itemsRead:           0,
+			itemsWritten:        7, // 2*2(data and meta of 2 files) + 3 (dirmeta of two moved folders and target)
+			nonMetaItemsWritten: 0,
+		},
+		{
+			name: "rename a folder",
+			updateFiles: func(t *testing.T, ctx context.Context) {
+				child := containerInfos[container2]
+
+				driveItem := models.NewDriveItem()
+				driveItem.SetName(&containerRename)
+
+				err := ac.PatchItem(
+					ctx,
+					driveID,
+					child.id,
+					driveItem)
+				require.NoError(t, err, "renaming folder", clues.ToCore(err))
+
+				containerInfos[containerRename] = containerInfo{
+					id:     child.id,
+					locRef: child.locRef.Dir().Append(containerRename),
+				}
+
+				expectDeets.RenameLocation(
+					driveID,
+					child.locRef.String(),
+					containerInfos[containerRename].locRef.String())
+
+				delete(containerInfos, container2)
+			},
+			itemsRead:           0,
+			itemsWritten:        7, // 2*2(data and meta of 2 files) + 3 (dirmeta of two moved folders and target)
+			nonMetaItemsWritten: 0,
+		},
+		{
+			name: "delete a folder",
+			updateFiles: func(t *testing.T, ctx context.Context) {
+				container := containerInfos[containerRename]
+				err := ac.DeleteItem(
+					ctx,
+					driveID,
+					container.id)
+				require.NoError(t, err, "deleting folder", clues.ToCore(err))
+
+				expectDeets.RemoveLocation(driveID, container.locRef.String())
+
+				delete(containerInfos, containerRename)
+			},
+			itemsRead:           0,
+			itemsWritten:        0,
+			nonMetaItemsWritten: 0,
+		},
+		{
+			name: "add a new folder",
+			updateFiles: func(t *testing.T, ctx context.Context) {
+				generateContainerOfItems(
+					t,
+					ctx,
+					ctrl,
+					service,
+					category,
+					sel,
+					atid, roidn.ID(), siteID, driveID, container3,
+					2,
+					0,
+					fileDBF)
+
+				locRef := path.Builder{}.Append(container3, container3)
+				mustGetExpectedContainerItems(
+					t,
+					driveID,
+					container3,
+					locRef)
+			},
+			itemsRead:           2, // 2 .data for 2 files
+			itemsWritten:        6, // read items + 2 directory meta
+			nonMetaItemsWritten: 2, // 2 .data for 2 files
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			cleanCtrl, err := m365.NewController(
+				ctx,
+				acct,
+				sel.PathService(),
+				control.DefaultOptions(),
+				count.New())
+			require.NoError(t, err, clues.ToCore(err))
+
+			bod.ctrl = cleanCtrl
+
+			var (
+				t       = suite.T()
+				incMB   = evmock.NewBus()
+				counter = count.New()
+				incBO   = newTestBackupOp(
+					t,
+					ctx,
+					bod,
+					incMB,
+					opts,
+					counter)
+			)
+
+			ctx, flush := tester.WithContext(t, ctx)
+			defer flush()
+
+			suite.Run("PreTestSetup", func() {
+				t := suite.T()
+
+				ctx, flush := tester.WithContext(t, ctx)
+				defer flush()
+
+				test.updateFiles(t, ctx)
+			})
+
+			err = incBO.Run(ctx)
+			require.NoError(t, err, clues.ToCore(err))
+
+			bupID := incBO.Results.BackupID
+
+			checkBackupIsInManifests(
+				t,
+				ctx,
+				bod.kw,
+				bod.sw,
+				&incBO,
+				sel,
+				roidn.ID(),
+				maps.Keys(categories)...)
+			checkMetadataFilesExist(
+				t,
+				ctx,
+				bupID,
+				bod.kw,
+				bod.kms,
+				atid,
+				roidn.ID(),
+				service,
+				categories)
+			deeTD.CheckBackupDetails(
+				t,
+				ctx,
+				bupID,
+				ws,
+				bod.kms,
+				bod.sss,
+				expectDeets,
+				true)
+
+			// do some additional checks to ensure the incremental dealt with fewer items.
+			var (
+				expectWrites        = test.itemsWritten
+				expectNonMetaWrites = test.nonMetaItemsWritten
+				expectReads         = test.itemsRead
+				assertReadWrite     = assert.Equal
+			)
+
+			if service == path.GroupsService && category == path.LibrariesCategory {
+				// Groups SharePoint have an extra metadata file at
+				// /libraries/sites/previouspath
+				expectWrites++
+				expectReads++
+
+				// +2 on read/writes to account for metadata: 1 delta and 1 path (for each site)
+				sites, err := ac.Groups().GetAllSites(ctx, owner, fault.New(true))
+				require.NoError(t, err, clues.ToCore(err))
+
+				expectWrites += len(sites) * 2
+				expectReads += len(sites) * 2
+			} else {
+				// +2 on read/writes to account for metadata: 1 delta and 1 path.
+				expectWrites += 2
+				expectReads += 2
+			}
+
+			// Sharepoint can produce a superset of permissions by nature of
+			// its drive type.  Since this counter comparison is a bit hacky
+			// to begin with, it's easiest to assert a <= comparison instead
+			// of fine tuning each test case.
+			if service == path.SharePointService {
+				assertReadWrite = assert.LessOrEqual
+			}
+
+			assertReadWrite(t, expectWrites, incBO.Results.ItemsWritten, "incremental items written")
+			assertReadWrite(t, expectNonMetaWrites, incBO.Results.NonMetaItemsWritten, "incremental non-meta items written")
+			assertReadWrite(t, expectReads, incBO.Results.ItemsRead, "incremental items read")
+
+			assert.NoError(t, incBO.Errors.Failure(), "incremental non-recoverable error", clues.ToCore(incBO.Errors.Failure()))
+			assert.Empty(t, incBO.Errors.Recovered(), "incremental recoverable/iteration errors")
+			assert.Equal(t, 1, incMB.TimesCalled[events.BackupEnd], "incremental backup-end events")
+		})
+	}
+}
+
+func runDriveishBackupWithExtensionsTests(
+	suite tester.Suite,
+	service path.ServiceType,
+	opts control.Options,
+	sel selectors.Selector,
+) {
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	var (
+		tenID   = tconfig.M365TenantID(t)
+		mb      = evmock.NewBus()
+		counter = count.New()
+		ws      = deeTD.DriveIDFromRepoRef
+	)
+
+	opts.ItemExtensionFactory = getTestExtensionFactories()
+
+	bo, bod := prepNewTestBackupOp(t, ctx, mb, sel, opts, version.Backup, counter)
+	defer bod.close(t, ctx)
+
+	runAndCheckBackup(t, ctx, &bo, mb, false)
+
+	bID := bo.Results.BackupID
+
+	deets, expectDeets := deeTD.GetDeetsInBackup(
+		t,
+		ctx,
+		bID,
+		tenID,
+		bod.sel.ID(),
+		service,
+		ws,
+		bod.kms,
+		bod.sss)
+	deeTD.CheckBackupDetails(
+		t,
+		ctx,
+		bID,
+		ws,
+		bod.kms,
+		bod.sss,
+		expectDeets,
+		false)
+
+	// Check that the extensions are in the backup
+	for _, ent := range deets.Entries {
+		if ent.Folder == nil {
+			verifyExtensionData(t, ent.ItemInfo, service)
+		}
+	}
+}

--- a/src/internal/operations/test/groups_test.go
+++ b/src/internal/operations/test/groups_test.go
@@ -94,7 +94,7 @@ func (suite *GroupsBackupTreeIntgSuite) SetupSuite() {
 	suite.its = newIntegrationTesterSetup(suite.T())
 }
 
-func (suite *GroupsBackupTreeIntgSuite) TestBackup_Run_groups() {
+func (suite *GroupsBackupTreeIntgSuite) TestBackup_Run_treeGroups() {
 	var (
 		resourceID = suite.its.group.ID
 		sel        = selectors.NewGroupsBackup([]string{resourceID})
@@ -112,14 +112,14 @@ func (suite *GroupsBackupTreeIntgSuite) TestBackup_Run_groups() {
 		sel.Selector)
 }
 
-func (suite *GroupsBackupTreeIntgSuite) TestBackup_Run_incrementalGroups() {
+func (suite *GroupsBackupTreeIntgSuite) TestBackup_Run_treeIncrementalGroups() {
 	opts := control.DefaultOptions()
 	opts.ToggleFeatures.UseDeltaTree = true
 
 	runGroupsIncrementalBackupTests(suite, suite.its, opts)
 }
 
-func (suite *GroupsBackupTreeIntgSuite) TestBackup_Run_extensionsGroups() {
+func (suite *GroupsBackupTreeIntgSuite) TestBackup_Run_treeExtensionsGroups() {
 	var (
 		resourceID = suite.its.group.ID
 		sel        = selectors.NewGroupsBackup([]string{resourceID})

--- a/src/internal/operations/test/onedrive_test.go
+++ b/src/internal/operations/test/onedrive_test.go
@@ -112,7 +112,7 @@ func (suite *OneDriveBackupTreeIntgSuite) SetupSuite() {
 	suite.its = newIntegrationTesterSetup(suite.T())
 }
 
-func (suite *OneDriveBackupTreeIntgSuite) TestBackup_Run_oneDrive() {
+func (suite *OneDriveBackupTreeIntgSuite) TestBackup_Run_treeOneDrive() {
 	var (
 		resourceID = suite.its.secondaryUser.ID
 		sel        = selectors.NewOneDriveBackup([]string{resourceID})
@@ -130,14 +130,14 @@ func (suite *OneDriveBackupTreeIntgSuite) TestBackup_Run_oneDrive() {
 		sel.Selector)
 }
 
-func (suite *OneDriveBackupTreeIntgSuite) TestBackup_Run_incrementalOneDrive() {
+func (suite *OneDriveBackupTreeIntgSuite) TestBackup_Run_treeIncrementalOneDrive() {
 	opts := control.DefaultOptions()
 	opts.ToggleFeatures.UseDeltaTree = true
 
 	runOneDriveIncrementalBackupTests(suite, suite.its, opts)
 }
 
-func (suite *OneDriveBackupTreeIntgSuite) TestBackup_Run_extensionsOneDrive() {
+func (suite *OneDriveBackupTreeIntgSuite) TestBackup_Run_treeExtensionsOneDrive() {
 	var (
 		resourceID = suite.its.secondaryUser.ID
 		sel        = selectors.NewOneDriveBackup([]string{resourceID})

--- a/src/internal/operations/test/onedrive_test.go
+++ b/src/internal/operations/test/onedrive_test.go
@@ -2,28 +2,22 @@ package test_test
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"sync/atomic"
 	"testing"
 
 	"github.com/alcionai/clues"
-	"github.com/microsoftgraph/msgraph-sdk-go/drives"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/exp/maps"
 
-	inMock "github.com/alcionai/corso/src/internal/common/idname/mock"
 	"github.com/alcionai/corso/src/internal/common/ptr"
-	"github.com/alcionai/corso/src/internal/common/syncd"
 	"github.com/alcionai/corso/src/internal/events"
 	evmock "github.com/alcionai/corso/src/internal/events/mock"
 	"github.com/alcionai/corso/src/internal/m365"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive"
-	"github.com/alcionai/corso/src/internal/m365/collection/drive/metadata"
-	odConsts "github.com/alcionai/corso/src/internal/m365/service/onedrive/consts"
 	"github.com/alcionai/corso/src/internal/model"
 	"github.com/alcionai/corso/src/internal/streamstore"
 	"github.com/alcionai/corso/src/internal/tester"
@@ -36,7 +30,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/control"
 	ctrlTD "github.com/alcionai/corso/src/pkg/control/testdata"
 	"github.com/alcionai/corso/src/pkg/count"
-	"github.com/alcionai/corso/src/pkg/dttm"
 	"github.com/alcionai/corso/src/pkg/extensions"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -65,54 +58,113 @@ func (suite *OneDriveBackupIntgSuite) SetupSuite() {
 }
 
 func (suite *OneDriveBackupIntgSuite) TestBackup_Run_oneDrive() {
-	t := suite.T()
-
-	ctx, flush := tester.NewContext(t)
-	defer flush()
-
 	var (
-		tenID   = tconfig.M365TenantID(t)
-		mb      = evmock.NewBus()
-		counter = count.New()
-		userID  = tconfig.SecondaryM365UserID(t)
-		osel    = selectors.NewOneDriveBackup([]string{userID})
-		ws      = deeTD.DriveIDFromRepoRef
-		svc     = path.OneDriveService
-		opts    = control.DefaultOptions()
+		resourceID = suite.its.secondaryUser.ID
+		sel        = selectors.NewOneDriveBackup([]string{resourceID})
 	)
 
-	osel.Include(selTD.OneDriveBackupFolderScope(osel))
+	sel.Include(selTD.OneDriveBackupFolderScope(sel))
 
-	bo, bod := prepNewTestBackupOp(t, ctx, mb, osel.Selector, opts, version.Backup, counter)
-	defer bod.close(t, ctx)
-
-	runAndCheckBackup(t, ctx, &bo, mb, false)
-
-	bID := bo.Results.BackupID
-
-	_, expectDeets := deeTD.GetDeetsInBackup(
-		t,
-		ctx,
-		bID,
-		tenID,
-		bod.sel.ID(),
-		svc,
-		ws,
-		bod.kms,
-		bod.sss)
-	deeTD.CheckBackupDetails(
-		t,
-		ctx,
-		bID,
-		ws,
-		bod.kms,
-		bod.sss,
-		expectDeets,
-		false)
+	runBasicDriveishBackupTests(
+		suite,
+		path.OneDriveService,
+		control.DefaultOptions(),
+		sel.Selector)
 }
 
 func (suite *OneDriveBackupIntgSuite) TestBackup_Run_incrementalOneDrive() {
-	sel := selectors.NewOneDriveRestore([]string{suite.its.user.ID})
+	runOneDriveIncrementalBackupTests(suite, suite.its, control.DefaultOptions())
+}
+
+func (suite *OneDriveBackupIntgSuite) TestBackup_Run_extensionsOneDrive() {
+	var (
+		resourceID = suite.its.secondaryUser.ID
+		sel        = selectors.NewOneDriveBackup([]string{resourceID})
+	)
+
+	sel.Include(selTD.OneDriveBackupFolderScope(sel))
+
+	runDriveishBackupWithExtensionsTests(
+		suite,
+		path.OneDriveService,
+		control.DefaultOptions(),
+		sel.Selector)
+}
+
+// ---------------------------------------------------------------------------
+// test version using the tree-based drive item processor
+// ---------------------------------------------------------------------------
+
+type OneDriveBackupTreeIntgSuite struct {
+	tester.Suite
+	its intgTesterSetup
+}
+
+func TestOneDriveBackupTreeIntgSuite(t *testing.T) {
+	suite.Run(t, &OneDriveBackupTreeIntgSuite{
+		Suite: tester.NewIntegrationSuite(
+			t,
+			[][]string{tconfig.M365AcctCredEnvs, storeTD.AWSStorageCredEnvs}),
+	})
+}
+
+func (suite *OneDriveBackupTreeIntgSuite) SetupSuite() {
+	suite.its = newIntegrationTesterSetup(suite.T())
+}
+
+func (suite *OneDriveBackupTreeIntgSuite) TestBackup_Run_oneDrive() {
+	var (
+		resourceID = suite.its.secondaryUser.ID
+		sel        = selectors.NewOneDriveBackup([]string{resourceID})
+		opts       = control.DefaultOptions()
+	)
+
+	sel.Include(selTD.OneDriveBackupFolderScope(sel))
+
+	opts.ToggleFeatures.UseDeltaTree = true
+
+	runBasicDriveishBackupTests(
+		suite,
+		path.OneDriveService,
+		opts,
+		sel.Selector)
+}
+
+func (suite *OneDriveBackupTreeIntgSuite) TestBackup_Run_incrementalOneDrive() {
+	opts := control.DefaultOptions()
+	opts.ToggleFeatures.UseDeltaTree = true
+
+	runOneDriveIncrementalBackupTests(suite, suite.its, opts)
+}
+
+func (suite *OneDriveBackupTreeIntgSuite) TestBackup_Run_extensionsOneDrive() {
+	var (
+		resourceID = suite.its.secondaryUser.ID
+		sel        = selectors.NewOneDriveBackup([]string{resourceID})
+		opts       = control.DefaultOptions()
+	)
+
+	sel.Include(selTD.OneDriveBackupFolderScope(sel))
+
+	opts.ToggleFeatures.UseDeltaTree = true
+
+	runDriveishBackupWithExtensionsTests(
+		suite,
+		path.OneDriveService,
+		opts,
+		sel.Selector)
+}
+
+// ---------------------------------------------------------------------------
+// common backup test wrappers
+// ---------------------------------------------------------------------------
+
+func runOneDriveIncrementalBackupTests(
+	suite tester.Suite,
+	its intgTesterSetup,
+	opts control.Options,
+) {
+	sel := selectors.NewOneDriveRestore([]string{its.user.ID})
 
 	ic := func(cs []string) selectors.Selector {
 		sel.Include(sel.Folders(cs, selectors.PrefixMatch()))
@@ -123,10 +175,10 @@ func (suite *OneDriveBackupIntgSuite) TestBackup_Run_incrementalOneDrive() {
 		t *testing.T,
 		ctx context.Context,
 	) string {
-		d, err := suite.its.ac.Users().GetDefaultDrive(ctx, suite.its.user.ID)
+		d, err := its.ac.Users().GetDefaultDrive(ctx, its.user.ID)
 		if err != nil {
 			err = graph.Wrap(ctx, err, "retrieving default user drive").
-				With("user", suite.its.user.ID)
+				With("user", its.user.ID)
 		}
 
 		require.NoError(t, err, clues.ToCore(err))
@@ -141,10 +193,11 @@ func (suite *OneDriveBackupIntgSuite) TestBackup_Run_incrementalOneDrive() {
 		return drive.NewUserDriveRestoreHandler(ac)
 	}
 
-	runDriveIncrementalTest(
+	runIncrementalDriveishBackupTest(
 		suite,
-		suite.its.user.ID,
-		suite.its.user.ID,
+		opts,
+		its.user.ID,
+		its.user.ID,
 		path.OneDriveService,
 		path.FilesCategory,
 		ic,
@@ -154,669 +207,9 @@ func (suite *OneDriveBackupIntgSuite) TestBackup_Run_incrementalOneDrive() {
 		false)
 }
 
-func runDriveIncrementalTest(
-	suite tester.Suite,
-	owner, permissionsUser string,
-	service path.ServiceType,
-	category path.CategoryType,
-	includeContainers func([]string) selectors.Selector,
-	getTestDriveID func(*testing.T, context.Context) string,
-	getTestSiteID func(*testing.T, context.Context) string,
-	getRestoreHandler func(api.Client) drive.RestoreHandler,
-	skipPermissionsTests bool,
-) {
-	t := suite.T()
-
-	ctx, flush := tester.NewContext(t)
-	defer flush()
-
-	var (
-		acct    = tconfig.NewM365Account(t)
-		opts    = control.DefaultOptions()
-		mb      = evmock.NewBus()
-		counter = count.New()
-		ws      = deeTD.DriveIDFromRepoRef
-
-		// `now` has to be formatted with SimpleDateTimeTesting as
-		// some drives cannot have `:` in file/folder names
-		now = dttm.FormatNow(dttm.SafeForTesting)
-
-		categories      = map[path.CategoryType][][]string{}
-		container1      = fmt.Sprintf("%s%d_%s", incrementalsDestContainerPrefix, 1, now)
-		container2      = fmt.Sprintf("%s%d_%s", incrementalsDestContainerPrefix, 2, now)
-		container3      = fmt.Sprintf("%s%d_%s", incrementalsDestContainerPrefix, 3, now)
-		containerRename = "renamed_folder"
-
-		genDests = []string{container1, container2}
-
-		// container3 does not exist yet. It will get created later on
-		// during the tests.
-		containers = []string{container1, container2, container3}
-	)
-
-	if service == path.GroupsService && category == path.LibrariesCategory {
-		categories[category] = [][]string{{odConsts.SitesPathDir, bupMD.PreviousPathFileName}}
-	} else {
-		categories[category] = [][]string{{bupMD.DeltaURLsFileName}, {bupMD.PreviousPathFileName}}
-	}
-
-	sel := includeContainers(containers)
-
-	creds, err := acct.M365Config()
-	require.NoError(t, err, clues.ToCore(err))
-
-	ctrl, sel := ControllerWithSelector(t, ctx, acct, sel, nil, nil, counter)
-	ac := ctrl.AC.Drives()
-	rh := getRestoreHandler(ctrl.AC)
-
-	roidn := inMock.NewProvider(sel.ID(), sel.Name())
-
-	var (
-		atid    = creds.AzureTenantID
-		driveID = getTestDriveID(t, ctx)
-		siteID  = ""
-		fileDBF = func(id, timeStamp, subject, body string) []byte {
-			return []byte(id + subject)
-		}
-		makeLocRef = func(flds ...string) *path.Builder {
-			elems := append([]string{"root:"}, flds...)
-			return path.Builder{}.Append(elems...)
-		}
-	)
-
-	// Will only be available for groups
-	if getTestSiteID != nil {
-		siteID = getTestSiteID(t, ctx)
-	}
-
-	rrPfx, err := path.BuildPrefix(atid, roidn.ID(), service, category)
-	require.NoError(t, err, clues.ToCore(err))
-
-	// strip the category from the prefix; we primarily want the tenant and resource owner.
-	expectDeets := deeTD.NewInDeets(rrPfx.ToBuilder().Dir().String())
-
-	type containerInfo struct {
-		id     string
-		locRef *path.Builder
-	}
-
-	containerInfos := map[string]containerInfo{}
-
-	mustGetExpectedContainerItems := func(
-		t *testing.T,
-		driveID, destName string,
-		locRef *path.Builder,
-	) {
-		// Use path-based indexing to get the folder's ID.
-		itemURL := fmt.Sprintf(
-			"https://graph.microsoft.com/v1.0/drives/%s/root:/%s",
-			driveID,
-			locRef.String())
-		resp, err := drives.
-			NewItemItemsDriveItemItemRequestBuilder(itemURL, ctrl.AC.Stable.Adapter()).
-			Get(ctx, nil)
-		require.NoError(
-			t,
-			err,
-			"getting drive folder ID for %s: %v",
-			locRef.String(),
-			clues.ToCore(err))
-
-		containerInfos[destName] = containerInfo{
-			id:     ptr.Val(resp.GetId()),
-			locRef: makeLocRef(locRef.Elements()...),
-		}
-		dest := containerInfos[destName]
-
-		items, err := ac.GetItemsInContainerByCollisionKey(
-			ctx,
-			driveID,
-			ptr.Val(resp.GetId()))
-		require.NoError(
-			t,
-			err,
-			"getting container %s items: %v",
-			locRef.String(),
-			clues.ToCore(err))
-
-		// Add the directory and all its ancestors to the cache so we can compare
-		// folders.
-		for pb := dest.locRef; len(pb.Elements()) > 0; pb = pb.Dir() {
-			expectDeets.AddLocation(driveID, pb.String())
-		}
-
-		for _, item := range items {
-			if item.IsFolder {
-				continue
-			}
-
-			expectDeets.AddItem(
-				driveID,
-				dest.locRef.String(),
-				item.ItemID)
-		}
-	}
-
-	// Populate initial test data.
-	// Generate 2 new folders with two items each. Only the first two
-	// folders will be part of the initial backup and
-	// incrementals. The third folder will be introduced partway
-	// through the changes. This should be enough to cover most delta
-	// actions.
-	for _, destName := range genDests {
-		generateContainerOfItems(
-			t,
-			ctx,
-			ctrl,
-			service,
-			category,
-			sel,
-			atid, roidn.ID(), siteID, driveID, destName,
-			2,
-			// Use an old backup version so we don't need metadata files.
-			0,
-			fileDBF)
-
-		// The way we generate containers causes it to duplicate the destName.
-		locRef := path.Builder{}.Append(destName, destName)
-		mustGetExpectedContainerItems(
-			t,
-			driveID,
-			destName,
-			locRef)
-	}
-
-	bo, bod := prepNewTestBackupOp(t, ctx, mb, sel, opts, version.Backup, counter)
-	defer bod.close(t, ctx)
-
-	sel = bod.sel
-
-	// run the initial backup
-	runAndCheckBackup(t, ctx, &bo, mb, false)
-
-	// precheck to ensure the expectedDeets are correct.
-	// if we fail here, the expectedDeets were populated incorrectly.
-	deeTD.CheckBackupDetails(
-		t,
-		ctx,
-		bo.Results.BackupID,
-		ws,
-		bod.kms,
-		bod.sss,
-		expectDeets,
-		true)
-
-	var (
-		newFile     models.DriveItemable
-		newFileName = "new_file.txt"
-		newFileID   string
-
-		permissionIDMappings = syncd.NewMapTo[string]()
-		writePerm            = metadata.Permission{
-			ID:       "perm-id",
-			Roles:    []string{"write"},
-			EntityID: permissionsUser,
-		}
-	)
-
-	// Although established as a table, these tests are not isolated from each other.
-	// Assume that every test's side effects cascade to all following test cases.
-	// The changes are split across the table so that we can monitor the deltas
-	// in isolation, rather than debugging one change from the rest of a series.
-	table := []struct {
-		name string
-		// performs the incremental update required for the test.
-		//revive:disable-next-line:context-as-argument
-		updateFiles         func(t *testing.T, ctx context.Context)
-		itemsRead           int
-		itemsWritten        int
-		nonMetaItemsWritten int
-	}{
-		{
-			name:         "clean incremental, no changes",
-			updateFiles:  func(t *testing.T, ctx context.Context) {},
-			itemsRead:    0,
-			itemsWritten: 0,
-		},
-		{
-			name: "create a new file",
-			updateFiles: func(t *testing.T, ctx context.Context) {
-				targetContainer := containerInfos[container1]
-				driveItem := models.NewDriveItem()
-				driveItem.SetName(&newFileName)
-				driveItem.SetFile(models.NewFile())
-				newFile, err = ac.PostItemInContainer(
-					ctx,
-					driveID,
-					targetContainer.id,
-					driveItem,
-					control.Copy)
-				require.NoErrorf(t, err, "creating new file %v", clues.ToCore(err))
-
-				newFileID = ptr.Val(newFile.GetId())
-
-				expectDeets.AddItem(driveID, targetContainer.locRef.String(), newFileID)
-			},
-			itemsRead:           1, // .data file for newitem
-			itemsWritten:        4, // .data and .meta for newitem, .dirmeta for parent and ancestor
-			nonMetaItemsWritten: 1, // .data file for newitem
-		},
-		{
-			name: "add permission to new file",
-			updateFiles: func(t *testing.T, ctx context.Context) {
-				err = drive.UpdatePermissions(
-					ctx,
-					rh,
-					driveID,
-					ptr.Val(newFile.GetId()),
-					[]metadata.Permission{writePerm},
-					[]metadata.Permission{},
-					permissionIDMappings,
-					fault.New(true))
-				require.NoErrorf(t, err, "adding permission to file %v", clues.ToCore(err))
-				// no expectedDeets: metadata isn't tracked
-			},
-			itemsRead:           1, // .data file for newitem
-			itemsWritten:        3, // .meta for newitem, .dirmeta for parent (.data is not written as it is not updated)
-			nonMetaItemsWritten: 0, // none because the file is considered cached instead of written.
-		},
-		{
-			name: "remove permission from new file",
-			updateFiles: func(t *testing.T, ctx context.Context) {
-				err = drive.UpdatePermissions(
-					ctx,
-					rh,
-					driveID,
-					*newFile.GetId(),
-					[]metadata.Permission{},
-					[]metadata.Permission{writePerm},
-					permissionIDMappings,
-					fault.New(true))
-				require.NoErrorf(t, err, "removing permission from file %v", clues.ToCore(err))
-				// no expectedDeets: metadata isn't tracked
-			},
-			itemsRead:           1, // .data file for newitem
-			itemsWritten:        3, // .meta for newitem, .dirmeta for parent (.data is not written as it is not updated)
-			nonMetaItemsWritten: 0, // none because the file is considered cached instead of written.
-		},
-		{
-			name: "add permission to container",
-			updateFiles: func(t *testing.T, ctx context.Context) {
-				targetContainer := containerInfos[container1].id
-				err = drive.UpdatePermissions(
-					ctx,
-					rh,
-					driveID,
-					targetContainer,
-					[]metadata.Permission{writePerm},
-					[]metadata.Permission{},
-					permissionIDMappings,
-					fault.New(true))
-				require.NoErrorf(t, err, "adding permission to container %v", clues.ToCore(err))
-				// no expectedDeets: metadata isn't tracked
-			},
-			itemsRead:           0,
-			itemsWritten:        2, // .dirmeta for collection
-			nonMetaItemsWritten: 0, // no files updated as update on container
-		},
-		{
-			name: "remove permission from container",
-			updateFiles: func(t *testing.T, ctx context.Context) {
-				targetContainer := containerInfos[container1].id
-				err = drive.UpdatePermissions(
-					ctx,
-					rh,
-					driveID,
-					targetContainer,
-					[]metadata.Permission{},
-					[]metadata.Permission{writePerm},
-					permissionIDMappings,
-					fault.New(true))
-				require.NoErrorf(t, err, "removing permission from container %v", clues.ToCore(err))
-				// no expectedDeets: metadata isn't tracked
-			},
-			itemsRead:           0,
-			itemsWritten:        2, // .dirmeta for collection
-			nonMetaItemsWritten: 0, // no files updated
-		},
-		{
-			name: "update contents of a file",
-			updateFiles: func(t *testing.T, ctx context.Context) {
-				err := ac.PutItemContent(
-					ctx,
-					driveID,
-					ptr.Val(newFile.GetId()),
-					[]byte("new content"))
-				require.NoErrorf(t, err, "updating file contents: %v", clues.ToCore(err))
-				// no expectedDeets: neither file id nor location changed
-			},
-			itemsRead:           1, // .data file for newitem
-			itemsWritten:        4, // .data and .meta for newitem, .dirmeta for parent
-			nonMetaItemsWritten: 1, // .data  file for newitem
-		},
-		{
-			name: "rename a file",
-			updateFiles: func(t *testing.T, ctx context.Context) {
-				driveItem := models.NewDriveItem()
-				name := "renamed_new_file.txt"
-				driveItem.SetName(&name)
-
-				err := ac.PatchItem(
-					ctx,
-					driveID,
-					ptr.Val(newFile.GetId()),
-					driveItem)
-				require.NoError(t, err, "renaming file %v", clues.ToCore(err))
-			},
-			itemsRead:           1, // .data file for newitem
-			itemsWritten:        4, // .data and .meta for newitem, .dirmeta for parent
-			nonMetaItemsWritten: 1, // .data file for newitem
-			// no expectedDeets: neither file id nor location changed
-		},
-		{
-			name: "move a file between folders",
-			updateFiles: func(t *testing.T, ctx context.Context) {
-				dest := containerInfos[container2]
-
-				driveItem := models.NewDriveItem()
-				parentRef := models.NewItemReference()
-				parentRef.SetId(&dest.id)
-				driveItem.SetParentReference(parentRef)
-
-				err := ac.PatchItem(
-					ctx,
-					driveID,
-					ptr.Val(newFile.GetId()),
-					driveItem)
-				require.NoErrorf(t, err, "moving file between folders %v", clues.ToCore(err))
-
-				expectDeets.MoveItem(
-					driveID,
-					containerInfos[container1].locRef.String(),
-					dest.locRef.String(),
-					ptr.Val(newFile.GetId()))
-			},
-			itemsRead:           1, // .data file for newitem
-			itemsWritten:        4, // .data and .meta for newitem, .dirmeta for parent
-			nonMetaItemsWritten: 1, // .data file for moved item
-		},
-		{
-			name: "boomerang a file",
-			updateFiles: func(t *testing.T, ctx context.Context) {
-				dest := containerInfos[container2]
-				temp := containerInfos[container1]
-
-				driveItem := models.NewDriveItem()
-				parentRef := models.NewItemReference()
-				parentRef.SetId(&temp.id)
-				driveItem.SetParentReference(parentRef)
-
-				err := ac.PatchItem(
-					ctx,
-					driveID,
-					ptr.Val(newFile.GetId()),
-					driveItem)
-				require.NoErrorf(t, err, "moving file to temporary folder %v", clues.ToCore(err))
-
-				parentRef.SetId(&dest.id)
-				driveItem.SetParentReference(parentRef)
-
-				err = ac.PatchItem(
-					ctx,
-					driveID,
-					ptr.Val(newFile.GetId()),
-					driveItem)
-				require.NoErrorf(t, err, "moving file back to folder %v", clues.ToCore(err))
-			},
-			itemsRead:           1, // .data file for newitem
-			itemsWritten:        3, // .data and .meta for newitem, .dirmeta for parent
-			nonMetaItemsWritten: 0, // non because the file is considered cached instead of written.
-		},
-		{
-			name: "delete file",
-			updateFiles: func(t *testing.T, ctx context.Context) {
-				err := ac.DeleteItem(
-					ctx,
-					driveID,
-					ptr.Val(newFile.GetId()))
-				require.NoErrorf(t, err, "deleting file %v", clues.ToCore(err))
-
-				expectDeets.RemoveItem(
-					driveID,
-					containerInfos[container2].locRef.String(),
-					ptr.Val(newFile.GetId()))
-			},
-			itemsRead:           0,
-			itemsWritten:        0,
-			nonMetaItemsWritten: 0,
-		},
-		{
-			name: "move a folder to a subfolder",
-			updateFiles: func(t *testing.T, ctx context.Context) {
-				parent := containerInfos[container1]
-				child := containerInfos[container2]
-
-				driveItem := models.NewDriveItem()
-				parentRef := models.NewItemReference()
-				parentRef.SetId(&parent.id)
-				driveItem.SetParentReference(parentRef)
-
-				err := ac.PatchItem(
-					ctx,
-					driveID,
-					child.id,
-					driveItem)
-				require.NoError(t, err, "moving folder", clues.ToCore(err))
-
-				expectDeets.MoveLocation(
-					driveID,
-					child.locRef.String(),
-					parent.locRef.String())
-
-				// Remove parent of moved folder since it's now empty.
-				expectDeets.RemoveLocation(driveID, child.locRef.Dir().String())
-
-				// Update in-memory cache with new location.
-				child.locRef = path.Builder{}.Append(append(
-					parent.locRef.Elements(),
-					child.locRef.LastElem())...)
-				containerInfos[container2] = child
-			},
-			itemsRead:           0,
-			itemsWritten:        7, // 2*2(data and meta of 2 files) + 3 (dirmeta of two moved folders and target)
-			nonMetaItemsWritten: 0,
-		},
-		{
-			name: "rename a folder",
-			updateFiles: func(t *testing.T, ctx context.Context) {
-				child := containerInfos[container2]
-
-				driveItem := models.NewDriveItem()
-				driveItem.SetName(&containerRename)
-
-				err := ac.PatchItem(
-					ctx,
-					driveID,
-					child.id,
-					driveItem)
-				require.NoError(t, err, "renaming folder", clues.ToCore(err))
-
-				containerInfos[containerRename] = containerInfo{
-					id:     child.id,
-					locRef: child.locRef.Dir().Append(containerRename),
-				}
-
-				expectDeets.RenameLocation(
-					driveID,
-					child.locRef.String(),
-					containerInfos[containerRename].locRef.String())
-
-				delete(containerInfos, container2)
-			},
-			itemsRead:           0,
-			itemsWritten:        7, // 2*2(data and meta of 2 files) + 3 (dirmeta of two moved folders and target)
-			nonMetaItemsWritten: 0,
-		},
-		{
-			name: "delete a folder",
-			updateFiles: func(t *testing.T, ctx context.Context) {
-				container := containerInfos[containerRename]
-				err := ac.DeleteItem(
-					ctx,
-					driveID,
-					container.id)
-				require.NoError(t, err, "deleting folder", clues.ToCore(err))
-
-				expectDeets.RemoveLocation(driveID, container.locRef.String())
-
-				delete(containerInfos, containerRename)
-			},
-			itemsRead:           0,
-			itemsWritten:        0,
-			nonMetaItemsWritten: 0,
-		},
-		{
-			name: "add a new folder",
-			updateFiles: func(t *testing.T, ctx context.Context) {
-				generateContainerOfItems(
-					t,
-					ctx,
-					ctrl,
-					service,
-					category,
-					sel,
-					atid, roidn.ID(), siteID, driveID, container3,
-					2,
-					0,
-					fileDBF)
-
-				locRef := path.Builder{}.Append(container3, container3)
-				mustGetExpectedContainerItems(
-					t,
-					driveID,
-					container3,
-					locRef)
-			},
-			itemsRead:           2, // 2 .data for 2 files
-			itemsWritten:        6, // read items + 2 directory meta
-			nonMetaItemsWritten: 2, // 2 .data for 2 files
-		},
-	}
-	for _, test := range table {
-		suite.Run(test.name, func() {
-			cleanCtrl, err := m365.NewController(
-				ctx,
-				acct,
-				sel.PathService(),
-				control.DefaultOptions(),
-				count.New())
-			require.NoError(t, err, clues.ToCore(err))
-
-			bod.ctrl = cleanCtrl
-
-			var (
-				t       = suite.T()
-				incMB   = evmock.NewBus()
-				counter = count.New()
-				incBO   = newTestBackupOp(
-					t,
-					ctx,
-					bod,
-					incMB,
-					opts,
-					counter)
-			)
-
-			ctx, flush := tester.WithContext(t, ctx)
-			defer flush()
-
-			suite.Run("PreTestSetup", func() {
-				t := suite.T()
-
-				ctx, flush := tester.WithContext(t, ctx)
-				defer flush()
-
-				test.updateFiles(t, ctx)
-			})
-
-			err = incBO.Run(ctx)
-			require.NoError(t, err, clues.ToCore(err))
-
-			bupID := incBO.Results.BackupID
-
-			checkBackupIsInManifests(
-				t,
-				ctx,
-				bod.kw,
-				bod.sw,
-				&incBO,
-				sel,
-				roidn.ID(),
-				maps.Keys(categories)...)
-			checkMetadataFilesExist(
-				t,
-				ctx,
-				bupID,
-				bod.kw,
-				bod.kms,
-				atid,
-				roidn.ID(),
-				service,
-				categories)
-			deeTD.CheckBackupDetails(
-				t,
-				ctx,
-				bupID,
-				ws,
-				bod.kms,
-				bod.sss,
-				expectDeets,
-				true)
-
-			// do some additional checks to ensure the incremental dealt with fewer items.
-			var (
-				expectWrites        = test.itemsWritten
-				expectNonMetaWrites = test.nonMetaItemsWritten
-				expectReads         = test.itemsRead
-				assertReadWrite     = assert.Equal
-			)
-
-			if service == path.GroupsService && category == path.LibrariesCategory {
-				// Groups SharePoint have an extra metadata file at
-				// /libraries/sites/previouspath
-				expectWrites++
-				expectReads++
-
-				// +2 on read/writes to account for metadata: 1 delta and 1 path (for each site)
-				sites, err := ac.Groups().GetAllSites(ctx, owner, fault.New(true))
-				require.NoError(t, err, clues.ToCore(err))
-
-				expectWrites += len(sites) * 2
-				expectReads += len(sites) * 2
-			} else {
-				// +2 on read/writes to account for metadata: 1 delta and 1 path.
-				expectWrites += 2
-				expectReads += 2
-			}
-
-			// Sharepoint can produce a superset of permissions by nature of
-			// its drive type.  Since this counter comparison is a bit hacky
-			// to begin with, it's easiest to assert a <= comparison instead
-			// of fine tuning each test case.
-			if service == path.SharePointService {
-				assertReadWrite = assert.LessOrEqual
-			}
-
-			assertReadWrite(t, expectWrites, incBO.Results.ItemsWritten, "incremental items written")
-			assertReadWrite(t, expectNonMetaWrites, incBO.Results.NonMetaItemsWritten, "incremental non-meta items written")
-			assertReadWrite(t, expectReads, incBO.Results.ItemsRead, "incremental items read")
-
-			assert.NoError(t, incBO.Errors.Failure(), "incremental non-recoverable error", clues.ToCore(incBO.Errors.Failure()))
-			assert.Empty(t, incBO.Errors.Recovered(), "incremental recoverable/iteration errors")
-			assert.Equal(t, 1, incMB.TimesCalled[events.BackupEnd], "incremental backup-end events")
-		})
-	}
-}
+// ---------------------------------------------------------------------------
+// other drive tests
+// ---------------------------------------------------------------------------
 
 var (
 	_ io.ReadCloser                    = &failFirstRead{}
@@ -1124,62 +517,6 @@ func (suite *OneDriveBackupIntgSuite) TestBackup_Run_oneDriveOwnerMigration() {
 		// 46 is the tenant uuid + "onedrive" + two slashes
 		if len(ent.RepoRef) > 46 {
 			assert.Contains(t, ent.RepoRef, uid)
-		}
-	}
-}
-
-func (suite *OneDriveBackupIntgSuite) TestBackup_Run_oneDriveExtensions() {
-	t := suite.T()
-
-	ctx, flush := tester.NewContext(t)
-	defer flush()
-
-	var (
-		tenID   = tconfig.M365TenantID(t)
-		mb      = evmock.NewBus()
-		counter = count.New()
-		userID  = tconfig.SecondaryM365UserID(t)
-		osel    = selectors.NewOneDriveBackup([]string{userID})
-		ws      = deeTD.DriveIDFromRepoRef
-		svc     = path.OneDriveService
-		opts    = control.DefaultOptions()
-	)
-
-	opts.ItemExtensionFactory = getTestExtensionFactories()
-
-	osel.Include(selTD.OneDriveBackupFolderScope(osel))
-
-	bo, bod := prepNewTestBackupOp(t, ctx, mb, osel.Selector, opts, version.Backup, counter)
-	defer bod.close(t, ctx)
-
-	runAndCheckBackup(t, ctx, &bo, mb, false)
-
-	bID := bo.Results.BackupID
-
-	deets, expectDeets := deeTD.GetDeetsInBackup(
-		t,
-		ctx,
-		bID,
-		tenID,
-		bod.sel.ID(),
-		svc,
-		ws,
-		bod.kms,
-		bod.sss)
-	deeTD.CheckBackupDetails(
-		t,
-		ctx,
-		bID,
-		ws,
-		bod.kms,
-		bod.sss,
-		expectDeets,
-		false)
-
-	// Check that the extensions are in the backup
-	for _, ent := range deets.Entries {
-		if ent.Folder == nil {
-			verifyExtensionData(t, ent.ItemInfo, path.OneDriveService)
 		}
 	}
 }

--- a/src/internal/operations/test/sharepoint_test.go
+++ b/src/internal/operations/test/sharepoint_test.go
@@ -100,7 +100,7 @@ func (suite *SharePointBackupTreeIntgSuite) SetupSuite() {
 	suite.its = newIntegrationTesterSetup(suite.T())
 }
 
-func (suite *SharePointBackupTreeIntgSuite) TestBackup_Run_sharePoint() {
+func (suite *SharePointBackupTreeIntgSuite) TestBackup_Run_treeSharePoint() {
 	var (
 		resourceID = suite.its.site.ID
 		sel        = selectors.NewSharePointBackup([]string{resourceID})
@@ -118,14 +118,14 @@ func (suite *SharePointBackupTreeIntgSuite) TestBackup_Run_sharePoint() {
 		sel.Selector)
 }
 
-func (suite *SharePointBackupTreeIntgSuite) TestBackup_Run_incrementalSharePoint() {
+func (suite *SharePointBackupTreeIntgSuite) TestBackup_Run_treeIncrementalSharePoint() {
 	opts := control.DefaultOptions()
 	opts.ToggleFeatures.UseDeltaTree = true
 
 	runSharePointIncrementalBackupTests(suite, suite.its, opts)
 }
 
-func (suite *SharePointBackupTreeIntgSuite) TestBackup_Run_extensionsSharePoint() {
+func (suite *SharePointBackupTreeIntgSuite) TestBackup_Run_treeExtensionsSharePoint() {
 	var (
 		resourceID = suite.its.site.ID
 		sel        = selectors.NewSharePointBackup([]string{resourceID})


### PR DESCRIPTION
refactors many operations-level drive-based tests with a focus on centralization and re-use, then uses those central tests to run driveish tests using the tree version for all drive-based services.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Supportability/Tests

#### Issue(s)

* #4689

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
