### PR TITLE
ignore lists with webTemplateExtensionsList template while creation

### DIFF
--- a/src/internal/m365/collection/site/restore.go
+++ b/src/internal/m365/collection/site/restore.go
@@ -209,7 +209,7 @@ func RestoreListCollection(
 				restoreContainerName)
 
 			if err != nil &&
-				errors.Is(err, api.ErrInvalidTemplateError) {
+				errors.Is(err, api.ErrCannotCreateWebTemplateExtension) {
 				continue
 			}
 

--- a/src/internal/m365/collection/site/restore.go
+++ b/src/internal/m365/collection/site/restore.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"runtime/trace"
-	"strings"
 
 	"github.com/alcionai/clues"
 
@@ -210,7 +209,7 @@ func RestoreListCollection(
 				restoreContainerName)
 
 			if err != nil &&
-				strings.Contains(err.Error(), api.ErrInvalidTemplateError.Error()) {
+				errors.Is(err, api.ErrInvalidTemplateError) {
 				continue
 			}
 

--- a/src/internal/m365/collection/site/restore.go
+++ b/src/internal/m365/collection/site/restore.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"runtime/trace"
+	"strings"
 
 	"github.com/alcionai/clues"
 
@@ -207,6 +208,12 @@ func RestoreListCollection(
 				itemData,
 				siteID,
 				restoreContainerName)
+
+			if err != nil &&
+				strings.Contains(err.Error(), api.ErrInvalidTemplateError.Error()) {
+				continue
+			}
+
 			if err != nil {
 				el.AddRecoverable(ctx, err)
 				continue

--- a/src/internal/m365/collection/site/restore_test.go
+++ b/src/internal/m365/collection/site/restore_test.go
@@ -104,7 +104,7 @@ func (suite *SharePointRestoreSuite) TestListCollection_Restore_invalidListTempl
 
 	_, err := restoreListItem(ctx, lrh, mockData, suite.siteID, destName)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), api.ErrInvalidTemplateError.Error())
+	assert.Contains(t, err.Error(), api.ErrCannotCreateWebTemplateExtension.Error())
 }
 
 func deleteList(

--- a/src/pkg/services/m365/api/lists.go
+++ b/src/pkg/services/m365/api/lists.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/alcionai/clues"
@@ -13,7 +12,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
-var ErrInvalidTemplateError = fmt.Errorf("invalid list template(%s)", WebTemplateExtensionsListTemplateName)
+var ErrCannotCreateWebTemplateExtension = clues.New("unable to create webTemplateExtension type lists")
 
 const (
 	AttachmentsColumnName    = "Attachments"
@@ -252,7 +251,7 @@ func (c Lists) PostList(
 	if newList != nil &&
 		newList.GetList() != nil &&
 		ptr.Val(newList.GetList().GetTemplate()) == WebTemplateExtensionsListTemplateName {
-		return nil, clues.StackWC(ctx, ErrInvalidTemplateError)
+		return nil, clues.StackWC(ctx, ErrCannotCreateWebTemplateExtension)
 	}
 
 	// Restore to List base to M365 back store

--- a/src/pkg/services/m365/api/lists.go
+++ b/src/pkg/services/m365/api/lists.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/alcionai/clues"
@@ -11,6 +12,8 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
+
+var ErrInvalidTemplateError = fmt.Errorf("invalid list template(%s)", WebTemplateExtensionsListTemplateName)
 
 const (
 	AttachmentsColumnName    = "Attachments"
@@ -41,6 +44,8 @@ const (
 
 	ReadOnlyOrHiddenFieldNamePrefix = "_"
 	DescoratorFieldNamePrefix       = "@"
+
+	WebTemplateExtensionsListTemplateName = "webTemplateExtensionsList"
 )
 
 var addressFieldNames = []string{
@@ -243,6 +248,12 @@ func (c Lists) PostList(
 
 	// this ensure all columns, contentTypes are set to the newList
 	newList := ToListable(oldList, newListName)
+
+	if newList != nil &&
+		newList.GetList() != nil &&
+		ptr.Val(newList.GetList().GetTemplate()) == WebTemplateExtensionsListTemplateName {
+		return nil, clues.StackWC(ctx, ErrInvalidTemplateError)
+	}
 
 	// Restore to List base to M365 back store
 	restoredList, err := c.Stable.

--- a/src/pkg/services/m365/api/lists_test.go
+++ b/src/pkg/services/m365/api/lists_test.go
@@ -690,6 +690,38 @@ func (suite *ListsAPIIntgSuite) TestLists_PostList() {
 	require.NoError(t, err)
 }
 
+func (suite *ListsAPIIntgSuite) TestLists_PostList_invalidTemplate() {
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	var (
+		acl      = suite.its.ac.Lists()
+		siteID   = suite.its.site.id
+		listName = testdata.DefaultRestoreConfig("list_api_post_list").Location
+	)
+
+	writer := kjson.NewJsonSerializationWriter()
+	defer writer.Close()
+
+	overrideListInfo := models.NewListInfo()
+	overrideListInfo.SetTemplate(ptr.To(WebTemplateExtensionsListTemplateName))
+
+	_, list := getFieldsDataAndList()
+	list.SetList(overrideListInfo)
+
+	err := writer.WriteObjectValue("", list)
+	require.NoError(t, err)
+
+	oldListByteArray, err := writer.GetSerializedContent()
+	require.NoError(t, err)
+
+	_, err = acl.PostList(ctx, siteID, listName, oldListByteArray)
+	require.Error(t, err)
+	assert.Equal(t, ErrInvalidTemplateError.Error(), err.Error())
+}
+
 func (suite *ListsAPIIntgSuite) TestLists_DeleteList() {
 	t := suite.T()
 

--- a/src/pkg/services/m365/api/lists_test.go
+++ b/src/pkg/services/m365/api/lists_test.go
@@ -719,7 +719,7 @@ func (suite *ListsAPIIntgSuite) TestLists_PostList_invalidTemplate() {
 
 	_, err = acl.PostList(ctx, siteID, listName, oldListByteArray)
 	require.Error(t, err)
-	assert.Equal(t, ErrInvalidTemplateError.Error(), err.Error())
+	assert.Equal(t, ErrCannotCreateWebTemplateExtension.Error(), err.Error())
 }
 
 func (suite *ListsAPIIntgSuite) TestLists_DeleteList() {


### PR DESCRIPTION
ignore lists with `webTemplateExtensionsList` template while creation in order to avoid `invalid template` graph error

#### Does this PR need a docs update or release note?
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature

#### Issue(s)
#4754 

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
