### PR TITLE
Fix inline images for eml exports

### DIFF
--- a/src/internal/converters/eml/eml.go
+++ b/src/internal/converters/eml/eml.go
@@ -21,6 +21,7 @@ import (
 	mail "github.com/xhit/go-simple-mail/v2"
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/internal/common/str"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
@@ -164,9 +165,9 @@ func FromJSON(ctx context.Context, body []byte) (string, error) {
 			}
 
 			if contentID != nil {
-				cids, _ := contentID.(*string)
-				if len(*cids) > 0 {
-					name = *cids
+				cids, _ := str.AnyToString(contentID)
+				if len(cids) > 0 {
+					name = cids
 				}
 			}
 


### PR DESCRIPTION
We have to use `contentId` instead of name for inline attachments as filenames can be duplicated.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
