### PR TITLE
Do not try to add empty attachments to eml export

### DIFF
--- a/src/internal/converters/eml/eml.go
+++ b/src/internal/converters/eml/eml.go
@@ -157,6 +157,16 @@ func FromJSON(ctx context.Context, body []byte) (string, error) {
 				return "", clues.WrapWC(ctx, err, "invalid content bytes")
 			}
 
+			if len(bts) == 0 {
+				// TODO(meain): pass the data through after
+				// https://github.com/xhit/go-simple-mail/issues/96
+				logger.Ctx(ctx).
+					With("attachment_id", ptr.Val(attachment.GetId())).
+					Info("empty attachment")
+
+				continue
+			}
+
 			name := ptr.Val(attachment.GetName())
 
 			contentID, err := attachment.GetBackingStore().Get("contentId")


### PR DESCRIPTION
The upstream library we are currently using errors out if we try to attach an empty file. This PR skips trying to attach empty files.

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
