### PR TITLE
Additional backup config cli tests

### DIFF
--- a/src/cli/backup/exchange_test.go
+++ b/src/cli/backup/exchange_test.go
@@ -145,6 +145,51 @@ func (suite *ExchangeUnitSuite) TestBackupCreateFlags() {
 	flagsTD.AssertStorageFlags(t, cmd)
 }
 
+func (suite *ExchangeUnitSuite) TestBackupCreateDefaultControlFlags() {
+	t := suite.T()
+
+	cliTD.SetUpCmdHasFlags(
+		t,
+		&cobra.Command{Use: createCommand},
+		addExchangeCommands,
+		[]cliTD.UseCobraCommandFn{
+			flags.AddAllProviderFlags,
+			flags.AddAllStorageFlags,
+		},
+		flagsTD.WithFlags(
+			exchangeServiceCommand,
+			[]string{
+				"--" + flags.RunModeFN, flags.RunModeFlagTest,
+			}))
+
+	co := utils.Control()
+	backupOpts := utils.ParseBackupOptions()
+
+	assert.Equal(t, co.Parallelism.ItemFetch, backupOpts.Parallelism.ItemFetch)
+	assert.Equal(t, co.DeltaPageSize, backupOpts.M365.DeltaPageSize)
+	assert.Equal(t, co.FailureHandling, backupOpts.FailureHandling)
+	assert.Equal(
+		t,
+		co.ToggleFeatures.DisableIncrementals,
+		backupOpts.Incrementals.ForceFullEnumeration)
+	assert.Equal(
+		t,
+		co.ToggleFeatures.ForceItemDataDownload,
+		backupOpts.Incrementals.ForceItemDataRefresh)
+	assert.Equal(
+		t,
+		co.ToggleFeatures.DisableDelta,
+		backupOpts.M365.DisableDeltaEndpoint)
+	assert.Equal(
+		t,
+		co.ToggleFeatures.ExchangeImmutableIDs,
+		backupOpts.M365.ExchangeImmutableIDs)
+	assert.Equal(
+		t,
+		co.ToggleFeatures.DisableSlidingWindowLimiter,
+		backupOpts.ServiceRateLimiter.DisableSlidingWindowLimiter)
+}
+
 func (suite *ExchangeUnitSuite) TestBackupListFlags() {
 	t := suite.T()
 

--- a/src/cli/backup/groups_test.go
+++ b/src/cli/backup/groups_test.go
@@ -183,6 +183,51 @@ func (suite *GroupsUnitSuite) TestBackupCreateFlags() {
 	flagsTD.AssertStorageFlags(t, cmd)
 }
 
+func (suite *GroupsUnitSuite) TestBackupCreateDefaultControlFlags() {
+	t := suite.T()
+
+	cliTD.SetUpCmdHasFlags(
+		t,
+		&cobra.Command{Use: createCommand},
+		addGroupsCommands,
+		[]cliTD.UseCobraCommandFn{
+			flags.AddAllProviderFlags,
+			flags.AddAllStorageFlags,
+		},
+		flagsTD.WithFlags(
+			groupsServiceCommand,
+			[]string{
+				"--" + flags.RunModeFN, flags.RunModeFlagTest,
+			}))
+
+	co := utils.Control()
+	backupOpts := utils.ParseBackupOptions()
+
+	assert.Equal(t, co.Parallelism.ItemFetch, backupOpts.Parallelism.ItemFetch)
+	assert.Equal(t, co.DeltaPageSize, backupOpts.M365.DeltaPageSize)
+	assert.Equal(t, co.FailureHandling, backupOpts.FailureHandling)
+	assert.Equal(
+		t,
+		co.ToggleFeatures.DisableIncrementals,
+		backupOpts.Incrementals.ForceFullEnumeration)
+	assert.Equal(
+		t,
+		co.ToggleFeatures.ForceItemDataDownload,
+		backupOpts.Incrementals.ForceItemDataRefresh)
+	assert.Equal(
+		t,
+		co.ToggleFeatures.DisableDelta,
+		backupOpts.M365.DisableDeltaEndpoint)
+	assert.Equal(
+		t,
+		co.ToggleFeatures.ExchangeImmutableIDs,
+		backupOpts.M365.ExchangeImmutableIDs)
+	assert.Equal(
+		t,
+		co.ToggleFeatures.DisableSlidingWindowLimiter,
+		backupOpts.ServiceRateLimiter.DisableSlidingWindowLimiter)
+}
+
 func (suite *GroupsUnitSuite) TestBackupListFlags() {
 	t := suite.T()
 

--- a/src/cli/backup/onedrive_test.go
+++ b/src/cli/backup/onedrive_test.go
@@ -154,6 +154,51 @@ func (suite *OneDriveUnitSuite) TestBackupListFlags() {
 	flagsTD.AssertStorageFlags(t, cmd)
 }
 
+func (suite *OneDriveUnitSuite) TestBackupCreateDefaultControlFlags() {
+	t := suite.T()
+
+	cliTD.SetUpCmdHasFlags(
+		t,
+		&cobra.Command{Use: listCommand},
+		addOneDriveCommands,
+		[]cliTD.UseCobraCommandFn{
+			flags.AddAllProviderFlags,
+			flags.AddAllStorageFlags,
+		},
+		flagsTD.WithFlags(
+			oneDriveServiceCommand,
+			[]string{
+				"--" + flags.RunModeFN, flags.RunModeFlagTest,
+			}))
+
+	co := utils.Control()
+	backupOpts := utils.ParseBackupOptions()
+
+	assert.Equal(t, co.Parallelism.ItemFetch, backupOpts.Parallelism.ItemFetch)
+	assert.Equal(t, co.DeltaPageSize, backupOpts.M365.DeltaPageSize)
+	assert.Equal(t, co.FailureHandling, backupOpts.FailureHandling)
+	assert.Equal(
+		t,
+		co.ToggleFeatures.DisableIncrementals,
+		backupOpts.Incrementals.ForceFullEnumeration)
+	assert.Equal(
+		t,
+		co.ToggleFeatures.ForceItemDataDownload,
+		backupOpts.Incrementals.ForceItemDataRefresh)
+	assert.Equal(
+		t,
+		co.ToggleFeatures.DisableDelta,
+		backupOpts.M365.DisableDeltaEndpoint)
+	assert.Equal(
+		t,
+		co.ToggleFeatures.ExchangeImmutableIDs,
+		backupOpts.M365.ExchangeImmutableIDs)
+	assert.Equal(
+		t,
+		co.ToggleFeatures.DisableSlidingWindowLimiter,
+		backupOpts.ServiceRateLimiter.DisableSlidingWindowLimiter)
+}
+
 func (suite *OneDriveUnitSuite) TestBackupDetailsFlags() {
 	t := suite.T()
 

--- a/src/cli/backup/sharepoint_test.go
+++ b/src/cli/backup/sharepoint_test.go
@@ -132,6 +132,51 @@ func (suite *SharePointUnitSuite) TestBackupCreateFlags() {
 	flagsTD.AssertStorageFlags(t, cmd)
 }
 
+func (suite *SharePointUnitSuite) TestBackupCreateDefaultControlFlags() {
+	t := suite.T()
+
+	cliTD.SetUpCmdHasFlags(
+		t,
+		&cobra.Command{Use: createCommand},
+		addSharePointCommands,
+		[]cliTD.UseCobraCommandFn{
+			flags.AddAllProviderFlags,
+			flags.AddAllStorageFlags,
+		},
+		flagsTD.WithFlags(
+			sharePointServiceCommand,
+			[]string{
+				"--" + flags.RunModeFN, flags.RunModeFlagTest,
+			}))
+
+	co := utils.Control()
+	backupOpts := utils.ParseBackupOptions()
+
+	assert.Equal(t, co.Parallelism.ItemFetch, backupOpts.Parallelism.ItemFetch)
+	assert.Equal(t, co.DeltaPageSize, backupOpts.M365.DeltaPageSize)
+	assert.Equal(t, co.FailureHandling, backupOpts.FailureHandling)
+	assert.Equal(
+		t,
+		co.ToggleFeatures.DisableIncrementals,
+		backupOpts.Incrementals.ForceFullEnumeration)
+	assert.Equal(
+		t,
+		co.ToggleFeatures.ForceItemDataDownload,
+		backupOpts.Incrementals.ForceItemDataRefresh)
+	assert.Equal(
+		t,
+		co.ToggleFeatures.DisableDelta,
+		backupOpts.M365.DisableDeltaEndpoint)
+	assert.Equal(
+		t,
+		co.ToggleFeatures.ExchangeImmutableIDs,
+		backupOpts.M365.ExchangeImmutableIDs)
+	assert.Equal(
+		t,
+		co.ToggleFeatures.DisableSlidingWindowLimiter,
+		backupOpts.ServiceRateLimiter.DisableSlidingWindowLimiter)
+}
+
 func (suite *SharePointUnitSuite) TestBackupListFlags() {
 	t := suite.T()
 


### PR DESCRIPTION
Further derisk moving to a different way of passing backup config values by adding tests ensuring the default (i.e. no flag given) values of the new backup config and the old backup config are the same.

While this code is temporary and can be removed once the switch is made we should probably create tests checking default values at some point so we don't accidentally change them without meaning to

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issues

- #4896

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
