### PR TITLE
remove the rootID in the tree

### DIFF
--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -181,12 +181,7 @@ func (c *Collections) makeDriveCollections(
 		return nil, nil, pagers.DeltaUpdate{}, clues.Wrap(err, "generating backup tree prefix")
 	}
 
-	root, err := c.handler.GetRootFolder(ctx, driveID)
-	if err != nil {
-		return nil, nil, pagers.DeltaUpdate{}, clues.Wrap(err, "getting root folder")
-	}
-
-	tree := newFolderyMcFolderFace(ppfx, ptr.Val(root.GetId()))
+	tree := newFolderyMcFolderFace(ppfx)
 
 	counter.Add(count.PrevPaths, int64(len(prevPaths)))
 
@@ -665,12 +660,9 @@ func (c *Collections) addFileToTree(
 		}
 	}
 
-	err := tree.addFile(file)
-	if err != nil {
-		return nil, clues.StackWC(ctx, err)
-	}
+	err := tree.addFile(ctx, file)
 
-	return nil, nil
+	return nil, clues.Stack(err).OrNil()
 }
 
 // quality-of-life wrapper that transforms each tombstone in the map

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -227,7 +227,7 @@ func (c *Collections) makeDriveCollections(
 	// only populate the global excluded items if no delta reset occurred.
 	// if a reset did occur, the collections should already be marked as
 	// "do not merge", therefore everything will get processed as a new addition.
-	if !tree.hadReset {
+	if !tree.hadReset && len(prevDeltaLink) > 0 {
 		p, err := c.handler.CanonicalPath(odConsts.DriveFolderPrefixBuilder(driveID), c.tenantID)
 		if err != nil {
 			err = clues.WrapWC(ctx, err, "making canonical path for item exclusions")
@@ -538,10 +538,9 @@ func (c *Collections) addFolderToTree(
 	notSelected = shouldSkip(ctx, collectionPath, c.handler, ptr.Val(drv.GetName()))
 	if notSelected {
 		logger.Ctx(ctx).Debugw("path not selected", "skipped_path", collectionPath.String())
-		return nil, nil
 	}
 
-	err = tree.setFolder(ctx, folder)
+	err = tree.setFolder(ctx, folder, notSelected)
 
 	return nil, clues.Stack(err).OrNil()
 }

--- a/src/internal/m365/collection/drive/collections_tree_test.go
+++ b/src/internal/m365/collection/drive/collections_tree_test.go
@@ -165,10 +165,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_GetTree() {
 			enumerator: driveEnumerator(
 				d1.newEnumer().with(delta(nil)),
 				d2.newEnumer().with(delta(nil))),
-			metadata: multiDriveMetadata(
-				t,
-				d1.newPrevPaths(t),
-				d2.newPrevPaths(t)),
+			metadata: multiDriveMetadata(t),
 			expect: expected{
 				canUsePrevBackup: assert.True,
 				collections: expectCollections(
@@ -197,10 +194,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_GetTree() {
 							d2.fileAt(root, "r"),
 							d2.folderAt(root),
 							d2.fileAt(folder, "f"))))),
-			metadata: multiDriveMetadata(
-				t,
-				d1.newPrevPaths(t),
-				d2.newPrevPaths(t)),
+			metadata: multiDriveMetadata(t),
 			expect: expected{
 				canUsePrevBackup: assert.True,
 				collections: expectCollections(
@@ -387,8 +381,13 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_GetTree() {
 					expect, _ := test.expect.globalExcludedFileIDs.Get(d)
 					result, rok := globalExcludes.Get(d)
 
-					require.True(t, rok, "drive results have a global excludes entry")
-					assert.Equal(t, expect, result, "global excluded file IDs")
+					if len(test.metadata) > 0 {
+						require.True(t, rok, "drive results have a global excludes entry")
+						assert.Equal(t, expect, result, "global excluded file IDs")
+					} else {
+						require.False(t, rok, "drive results have no global excludes entry")
+						assert.Empty(t, result, "global excluded file IDs")
+					}
 				})
 			}
 		})

--- a/src/internal/m365/collection/drive/delta_tree_test.go
+++ b/src/internal/m365/collection/drive/delta_tree_test.go
@@ -36,7 +36,7 @@ func (suite *DeltaTreeUnitSuite) TestNewFolderyMcFolderFace() {
 
 	require.NoError(t, err, clues.ToCore(err))
 
-	folderFace := newFolderyMcFolderFace(p, rootID)
+	folderFace := newFolderyMcFolderFace(p)
 	assert.Equal(t, p, folderFace.prefix)
 	assert.Nil(t, folderFace.root)
 	assert.NotNil(t, folderFace.folderIDToNode)
@@ -884,7 +884,10 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_AddFile() {
 				df   = custom.ToCustomDriveItem(d.fileWSizeAt(test.contentSize, test.parent))
 			)
 
-			err := tree.addFile(df)
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			err := tree.addFile(ctx, df)
 			test.expectErr(t, err, clues.ToCore(err))
 			assert.Equal(t, test.expectFiles, tree.fileIDToParentID)
 
@@ -968,6 +971,9 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_addAndDeleteFile() {
 		fID  = fileID()
 	)
 
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
 	require.Len(t, tree.fileIDToParentID, 0)
 	require.Len(t, tree.deletedFileIDs, 0)
 
@@ -978,7 +984,9 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_addAndDeleteFile() {
 	assert.Len(t, tree.deletedFileIDs, 1)
 	assert.Contains(t, tree.deletedFileIDs, fID)
 
-	err := tree.addFile(custom.ToCustomDriveItem(d.fileAt(root)))
+	err := tree.addFile(
+		ctx,
+		custom.ToCustomDriveItem(d.fileAt(root)))
 	require.NoError(t, err, clues.ToCore(err))
 
 	assert.Len(t, tree.fileIDToParentID, 1)

--- a/src/internal/m365/collection/drive/delta_tree_test.go
+++ b/src/internal/m365/collection/drive/delta_tree_test.go
@@ -52,7 +52,7 @@ func (suite *DeltaTreeUnitSuite) TestNewNodeyMcNodeFace() {
 		fld    = custom.ToCustomDriveItem(d.folderAt(root))
 	)
 
-	nodeFace := newNodeyMcNodeFace(parent, fld)
+	nodeFace := newNodeyMcNodeFace(parent, fld, false)
 	assert.Equal(t, parent, nodeFace.parent)
 	assert.Equal(t, folderID(), ptr.Val(nodeFace.folder.GetId()))
 	assert.Equal(t, folderName(), ptr.Val(nodeFace.folder.GetName()))
@@ -177,7 +177,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 			tree := test.tree(t, drive())
 			folder := test.folder()
 
-			err := tree.setFolder(ctx, folder)
+			err := tree.setFolder(ctx, folder, false)
 			test.expectErr(t, err, clues.ToCore(err))
 
 			if err != nil {
@@ -497,7 +497,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder_correctTree()
 	tree := treeWithRoot(t, d)
 
 	set := func(folder *custom.DriveItem) {
-		err := tree.setFolder(ctx, folder)
+		err := tree.setFolder(ctx, folder, false)
 		require.NoError(t, err, clues.ToCore(err))
 	}
 
@@ -600,7 +600,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder_correctTombst
 	tree := treeWithRoot(t, d)
 
 	set := func(folder *custom.DriveItem) {
-		err := tree.setFolder(ctx, folder)
+		err := tree.setFolder(ctx, folder, false)
 		require.NoError(t, err, clues.ToCore(err))
 	}
 
@@ -1135,10 +1135,10 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 				defer flush()
 
 				tree := treeWithRoot(t, d)
-				err := tree.setFolder(ctx, custom.ToCustomDriveItem(d.packageAtRoot()))
+				err := tree.setFolder(ctx, custom.ToCustomDriveItem(d.packageAtRoot()), false)
 				require.NoError(t, err, clues.ToCore(err))
 
-				err = tree.setFolder(ctx, custom.ToCustomDriveItem(d.folderAt(pkg)))
+				err = tree.setFolder(ctx, custom.ToCustomDriveItem(d.folderAt(pkg)), false)
 				require.NoError(t, err, clues.ToCore(err))
 
 				return tree
@@ -1208,6 +1208,58 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			},
 		},
 		{
+			name:      "folder hierarchy with unselected root and child and no previous paths",
+			tree:      treeWithUnselectedRootAndFolder,
+			expectErr: require.NoError,
+			prevPaths: map[string]string{},
+			expect: map[string]collectable{
+				rootID: {
+					currPath:                  d.fullPath(t),
+					files:                     map[string]*custom.DriveItem{},
+					folderID:                  rootID,
+					isPackageOrChildOfPackage: false,
+				},
+				folderID(): {
+					currPath: d.fullPath(t, folderName()),
+					files: map[string]*custom.DriveItem{
+						folderID(): custom.ToCustomDriveItem(d.folderAt(root)),
+						fileID():   custom.ToCustomDriveItem(d.fileAt(folder)),
+					},
+					folderID:                  folderID(),
+					isPackageOrChildOfPackage: false,
+				},
+			},
+		},
+		{
+			name:      "folder hierarchy with unselected root and child with previous paths",
+			tree:      treeWithUnselectedRootAndFolder,
+			expectErr: require.NoError,
+			prevPaths: map[string]string{
+				rootID:           d.strPath(t),
+				folderID():       d.strPath(t, folderName()),
+				folderID("nope"): d.strPath(t, folderName("nope")),
+			},
+			expect: map[string]collectable{
+				rootID: {
+					currPath:                  d.fullPath(t),
+					prevPath:                  d.fullPath(t),
+					files:                     map[string]*custom.DriveItem{},
+					folderID:                  rootID,
+					isPackageOrChildOfPackage: false,
+				},
+				folderID(): {
+					currPath: d.fullPath(t, folderName()),
+					prevPath: d.fullPath(t, folderName()),
+					files: map[string]*custom.DriveItem{
+						folderID(): custom.ToCustomDriveItem(d.folderAt(root)),
+						fileID():   custom.ToCustomDriveItem(d.fileAt(folder)),
+					},
+					folderID:                  folderID(),
+					isPackageOrChildOfPackage: false,
+				},
+			},
+		},
+		{
 			name: "root and tombstones",
 			tree: treeWithFileInTombstone,
 			prevPaths: map[string]string{
@@ -1249,7 +1301,13 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 
 			results, err := tree.generateCollectables()
 			test.expectErr(t, err, clues.ToCore(err))
-			assert.Len(t, results, len(test.expect))
+			assert.Len(
+				t,
+				results,
+				len(test.expect),
+				"count of collections\n\tWanted: %+v\n\tGot: %+v",
+				maps.Keys(test.expect),
+				maps.Keys(results))
 
 			for id, expect := range test.expect {
 				require.Contains(t, results, id)

--- a/src/internal/m365/collection/drive/helper_test.go
+++ b/src/internal/m365/collection/drive/helper_test.go
@@ -490,11 +490,11 @@ func defaultLoc() path.Elements {
 }
 
 func newTree(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
-	return newFolderyMcFolderFace(defaultTreePfx(t, d), rootID)
+	return newFolderyMcFolderFace(defaultTreePfx(t, d))
 }
 
 func treeWithRoot(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
-	tree := newFolderyMcFolderFace(defaultTreePfx(t, d), rootID)
+	tree := newFolderyMcFolderFace(defaultTreePfx(t, d))
 	root := custom.ToCustomDriveItem(rootFolder())
 
 	//nolint:forbidigo
@@ -505,7 +505,7 @@ func treeWithRoot(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
 }
 
 func treeAfterReset(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
-	tree := newFolderyMcFolderFace(defaultTreePfx(t, d), rootID)
+	tree := newFolderyMcFolderFace(defaultTreePfx(t, d))
 	tree.reset()
 
 	return tree
@@ -546,10 +546,13 @@ func treeWithFolders(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
 }
 
 func treeWithFileAtRoot(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
 	tree := treeWithRoot(t, d)
 
 	f := custom.ToCustomDriveItem(d.fileAt(root))
-	err := tree.addFile(f)
+	err := tree.addFile(ctx, f)
 	require.NoError(t, err, clues.ToCore(err))
 
 	return tree
@@ -563,10 +566,13 @@ func treeWithDeletedFile(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
 }
 
 func treeWithFileInFolder(t *testing.T, d *deltaDrive) *folderyMcFolderFace {
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
 	tree := treeWithFolders(t, d)
 
 	f := custom.ToCustomDriveItem(d.fileAt(folder))
-	err := tree.addFile(f)
+	err := tree.addFile(ctx, f)
 	require.NoError(t, err, clues.ToCore(err))
 
 	return tree
@@ -603,7 +609,7 @@ func fullTreeWithNames(
 
 		// file "r" in root
 		df := custom.ToCustomDriveItem(d.fileAt(root, "r"))
-		err := tree.addFile(df)
+		err := tree.addFile(ctx, df)
 		require.NoError(t, err, clues.ToCore(err))
 
 		// root -> folderID(parentX)
@@ -613,7 +619,7 @@ func fullTreeWithNames(
 
 		// file "p" in folderID(parentX)
 		df = custom.ToCustomDriveItem(d.fileAt(parentFolderSuffix, "p"))
-		err = tree.addFile(df)
+		err = tree.addFile(ctx, df)
 		require.NoError(t, err, clues.ToCore(err))
 
 		// folderID(parentX) -> folderID()
@@ -623,7 +629,7 @@ func fullTreeWithNames(
 
 		// file "f" in folderID()
 		df = custom.ToCustomDriveItem(d.fileAt(folder, "f"))
-		err = tree.addFile(df)
+		err = tree.addFile(ctx, df)
 		require.NoError(t, err, clues.ToCore(err))
 
 		// tombstone - have to set a non-tombstone folder first,
@@ -635,7 +641,7 @@ func fullTreeWithNames(
 
 		// file "t" in tombstone
 		df = custom.ToCustomDriveItem(d.fileAt(tombstoneSuffix, "t"))
-		err = tree.addFile(df)
+		err = tree.addFile(ctx, df)
 		require.NoError(t, err, clues.ToCore(err))
 
 		err = tree.setTombstone(ctx, tomb)

--- a/src/internal/m365/controller_test.go
+++ b/src/internal/m365/controller_test.go
@@ -651,7 +651,11 @@ func runBackupAndCompare(
 	require.NoError(t, err, clues.ToCore(err))
 	assert.True(t, canUsePreviousBackup, "can use previous backup")
 	// No excludes yet because this isn't an incremental backup.
-	assert.True(t, excludes.Empty())
+	assert.True(
+		t,
+		excludes.Empty(),
+		"global excludes should have no entries, got:\n\t%+v",
+		excludes.Keys())
 
 	t.Logf("Backup enumeration complete in %v\n", time.Since(start))
 

--- a/src/internal/operations/test/groups_test.go
+++ b/src/internal/operations/test/groups_test.go
@@ -94,7 +94,7 @@ func (suite *GroupsBackupTreeIntgSuite) SetupSuite() {
 	suite.its = newIntegrationTesterSetup(suite.T())
 }
 
-func (suite *GroupsBackupTreeIntgSuite) TestBackup_Run_groups() {
+func (suite *GroupsBackupTreeIntgSuite) TestBackup_Run_treeGroups() {
 	var (
 		resourceID = suite.its.group.ID
 		sel        = selectors.NewGroupsBackup([]string{resourceID})
@@ -112,14 +112,14 @@ func (suite *GroupsBackupTreeIntgSuite) TestBackup_Run_groups() {
 		sel.Selector)
 }
 
-func (suite *GroupsBackupTreeIntgSuite) TestBackup_Run_incrementalGroups() {
+func (suite *GroupsBackupTreeIntgSuite) TestBackup_Run_treeIncrementalGroups() {
 	opts := control.DefaultOptions()
 	opts.ToggleFeatures.UseDeltaTree = true
 
 	runGroupsIncrementalBackupTests(suite, suite.its, opts)
 }
 
-func (suite *GroupsBackupTreeIntgSuite) TestBackup_Run_extensionsGroups() {
+func (suite *GroupsBackupTreeIntgSuite) TestBackup_Run_treeExtensionsGroups() {
 	var (
 		resourceID = suite.its.group.ID
 		sel        = selectors.NewGroupsBackup([]string{resourceID})

--- a/src/internal/operations/test/onedrive_test.go
+++ b/src/internal/operations/test/onedrive_test.go
@@ -112,7 +112,7 @@ func (suite *OneDriveBackupTreeIntgSuite) SetupSuite() {
 	suite.its = newIntegrationTesterSetup(suite.T())
 }
 
-func (suite *OneDriveBackupTreeIntgSuite) TestBackup_Run_oneDrive() {
+func (suite *OneDriveBackupTreeIntgSuite) TestBackup_Run_treeOneDrive() {
 	var (
 		resourceID = suite.its.secondaryUser.ID
 		sel        = selectors.NewOneDriveBackup([]string{resourceID})
@@ -130,14 +130,14 @@ func (suite *OneDriveBackupTreeIntgSuite) TestBackup_Run_oneDrive() {
 		sel.Selector)
 }
 
-func (suite *OneDriveBackupTreeIntgSuite) TestBackup_Run_incrementalOneDrive() {
+func (suite *OneDriveBackupTreeIntgSuite) TestBackup_Run_treeIncrementalOneDrive() {
 	opts := control.DefaultOptions()
 	opts.ToggleFeatures.UseDeltaTree = true
 
 	runOneDriveIncrementalBackupTests(suite, suite.its, opts)
 }
 
-func (suite *OneDriveBackupTreeIntgSuite) TestBackup_Run_extensionsOneDrive() {
+func (suite *OneDriveBackupTreeIntgSuite) TestBackup_Run_treeExtensionsOneDrive() {
 	var (
 		resourceID = suite.its.secondaryUser.ID
 		sel        = selectors.NewOneDriveBackup([]string{resourceID})

--- a/src/internal/operations/test/sharepoint_test.go
+++ b/src/internal/operations/test/sharepoint_test.go
@@ -100,7 +100,7 @@ func (suite *SharePointBackupTreeIntgSuite) SetupSuite() {
 	suite.its = newIntegrationTesterSetup(suite.T())
 }
 
-func (suite *SharePointBackupTreeIntgSuite) TestBackup_Run_sharePoint() {
+func (suite *SharePointBackupTreeIntgSuite) TestBackup_Run_treeSharePoint() {
 	var (
 		resourceID = suite.its.site.ID
 		sel        = selectors.NewSharePointBackup([]string{resourceID})
@@ -118,14 +118,14 @@ func (suite *SharePointBackupTreeIntgSuite) TestBackup_Run_sharePoint() {
 		sel.Selector)
 }
 
-func (suite *SharePointBackupTreeIntgSuite) TestBackup_Run_incrementalSharePoint() {
+func (suite *SharePointBackupTreeIntgSuite) TestBackup_Run_treeIncrementalSharePoint() {
 	opts := control.DefaultOptions()
 	opts.ToggleFeatures.UseDeltaTree = true
 
 	runSharePointIncrementalBackupTests(suite, suite.its, opts)
 }
 
-func (suite *SharePointBackupTreeIntgSuite) TestBackup_Run_extensionsSharePoint() {
+func (suite *SharePointBackupTreeIntgSuite) TestBackup_Run_treeExtensionsSharePoint() {
 	var (
 		resourceID = suite.its.site.ID
 		sel        = selectors.NewSharePointBackup([]string{resourceID})


### PR DESCRIPTION
Instead of comparing IDs, we can check the drive item's GetRoot() property, which is only non-nil for the root folder.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix

#### Issue(s)

* #4689

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
