### PR TITLE
add unselected collections to tree

### DIFF
--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -538,10 +538,9 @@ func (c *Collections) addFolderToTree(
 	notSelected = shouldSkip(ctx, collectionPath, c.handler, ptr.Val(drv.GetName()))
 	if notSelected {
 		logger.Ctx(ctx).Debugw("path not selected", "skipped_path", collectionPath.String())
-		return nil, nil
 	}
 
-	err = tree.setFolder(ctx, folder)
+	err = tree.setFolder(ctx, folder, notSelected)
 
 	return nil, clues.Stack(err).OrNil()
 }

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -227,7 +227,7 @@ func (c *Collections) makeDriveCollections(
 	// only populate the global excluded items if no delta reset occurred.
 	// if a reset did occur, the collections should already be marked as
 	// "do not merge", therefore everything will get processed as a new addition.
-	if !tree.hadReset {
+	if !tree.hadReset && len(prevDeltaLink) > 0 {
 		p, err := c.handler.CanonicalPath(odConsts.DriveFolderPrefixBuilder(driveID), c.tenantID)
 		if err != nil {
 			err = clues.WrapWC(ctx, err, "making canonical path for item exclusions")

--- a/src/internal/m365/collection/drive/collections_tree_test.go
+++ b/src/internal/m365/collection/drive/collections_tree_test.go
@@ -165,10 +165,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_GetTree() {
 			enumerator: driveEnumerator(
 				d1.newEnumer().with(delta(nil)),
 				d2.newEnumer().with(delta(nil))),
-			metadata: multiDriveMetadata(
-				t,
-				d1.newPrevPaths(t),
-				d2.newPrevPaths(t)),
+			metadata: multiDriveMetadata(t),
 			expect: expected{
 				canUsePrevBackup: assert.True,
 				collections: expectCollections(
@@ -197,10 +194,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_GetTree() {
 							d2.fileAt(root, "r"),
 							d2.folderAt(root),
 							d2.fileAt(folder, "f"))))),
-			metadata: multiDriveMetadata(
-				t,
-				d1.newPrevPaths(t),
-				d2.newPrevPaths(t)),
+			metadata: multiDriveMetadata(t),
 			expect: expected{
 				canUsePrevBackup: assert.True,
 				collections: expectCollections(
@@ -387,8 +381,13 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_GetTree() {
 					expect, _ := test.expect.globalExcludedFileIDs.Get(d)
 					result, rok := globalExcludes.Get(d)
 
-					require.True(t, rok, "drive results have a global excludes entry")
-					assert.Equal(t, expect, result, "global excluded file IDs")
+					if len(test.metadata) > 0 {
+						require.True(t, rok, "drive results have a global excludes entry")
+						assert.Equal(t, expect, result, "global excluded file IDs")
+					} else {
+						require.False(t, rok, "drive results have no global excludes entry")
+						assert.Empty(t, result, "global excluded file IDs")
+					}
 				})
 			}
 		})

--- a/src/internal/m365/collection/drive/delta_tree_test.go
+++ b/src/internal/m365/collection/drive/delta_tree_test.go
@@ -52,7 +52,7 @@ func (suite *DeltaTreeUnitSuite) TestNewNodeyMcNodeFace() {
 		fld    = custom.ToCustomDriveItem(d.folderAt(root))
 	)
 
-	nodeFace := newNodeyMcNodeFace(parent, fld)
+	nodeFace := newNodeyMcNodeFace(parent, fld, false)
 	assert.Equal(t, parent, nodeFace.parent)
 	assert.Equal(t, folderID(), ptr.Val(nodeFace.folder.GetId()))
 	assert.Equal(t, folderName(), ptr.Val(nodeFace.folder.GetName()))
@@ -177,7 +177,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder() {
 			tree := test.tree(t, drive())
 			folder := test.folder()
 
-			err := tree.setFolder(ctx, folder)
+			err := tree.setFolder(ctx, folder, false)
 			test.expectErr(t, err, clues.ToCore(err))
 
 			if err != nil {
@@ -497,7 +497,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder_correctTree()
 	tree := treeWithRoot(t, d)
 
 	set := func(folder *custom.DriveItem) {
-		err := tree.setFolder(ctx, folder)
+		err := tree.setFolder(ctx, folder, false)
 		require.NoError(t, err, clues.ToCore(err))
 	}
 
@@ -600,7 +600,7 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_SetFolder_correctTombst
 	tree := treeWithRoot(t, d)
 
 	set := func(folder *custom.DriveItem) {
-		err := tree.setFolder(ctx, folder)
+		err := tree.setFolder(ctx, folder, false)
 		require.NoError(t, err, clues.ToCore(err))
 	}
 
@@ -1135,10 +1135,10 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 				defer flush()
 
 				tree := treeWithRoot(t, d)
-				err := tree.setFolder(ctx, custom.ToCustomDriveItem(d.packageAtRoot()))
+				err := tree.setFolder(ctx, custom.ToCustomDriveItem(d.packageAtRoot()), false)
 				require.NoError(t, err, clues.ToCore(err))
 
-				err = tree.setFolder(ctx, custom.ToCustomDriveItem(d.folderAt(pkg)))
+				err = tree.setFolder(ctx, custom.ToCustomDriveItem(d.folderAt(pkg)), false)
 				require.NoError(t, err, clues.ToCore(err))
 
 				return tree
@@ -1208,6 +1208,58 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 			},
 		},
 		{
+			name:      "folder hierarchy with unselected root and child and no previous paths",
+			tree:      treeWithUnselectedRootAndFolder,
+			expectErr: require.NoError,
+			prevPaths: map[string]string{},
+			expect: map[string]collectable{
+				rootID: {
+					currPath:                  d.fullPath(t),
+					files:                     map[string]*custom.DriveItem{},
+					folderID:                  rootID,
+					isPackageOrChildOfPackage: false,
+				},
+				folderID(): {
+					currPath: d.fullPath(t, folderName()),
+					files: map[string]*custom.DriveItem{
+						folderID(): custom.ToCustomDriveItem(d.folderAt(root)),
+						fileID():   custom.ToCustomDriveItem(d.fileAt(folder)),
+					},
+					folderID:                  folderID(),
+					isPackageOrChildOfPackage: false,
+				},
+			},
+		},
+		{
+			name:      "folder hierarchy with unselected root and child with previous paths",
+			tree:      treeWithUnselectedRootAndFolder,
+			expectErr: require.NoError,
+			prevPaths: map[string]string{
+				rootID:           d.strPath(t),
+				folderID():       d.strPath(t, folderName()),
+				folderID("nope"): d.strPath(t, folderName("nope")),
+			},
+			expect: map[string]collectable{
+				rootID: {
+					currPath:                  d.fullPath(t),
+					prevPath:                  d.fullPath(t),
+					files:                     map[string]*custom.DriveItem{},
+					folderID:                  rootID,
+					isPackageOrChildOfPackage: false,
+				},
+				folderID(): {
+					currPath: d.fullPath(t, folderName()),
+					prevPath: d.fullPath(t, folderName()),
+					files: map[string]*custom.DriveItem{
+						folderID(): custom.ToCustomDriveItem(d.folderAt(root)),
+						fileID():   custom.ToCustomDriveItem(d.fileAt(folder)),
+					},
+					folderID:                  folderID(),
+					isPackageOrChildOfPackage: false,
+				},
+			},
+		},
+		{
 			name: "root and tombstones",
 			tree: treeWithFileInTombstone,
 			prevPaths: map[string]string{
@@ -1249,7 +1301,13 @@ func (suite *DeltaTreeUnitSuite) TestFolderyMcFolderFace_GenerateCollectables() 
 
 			results, err := tree.generateCollectables()
 			test.expectErr(t, err, clues.ToCore(err))
-			assert.Len(t, results, len(test.expect))
+			assert.Len(
+				t,
+				results,
+				len(test.expect),
+				"count of collections\n\tWanted: %+v\n\tGot: %+v",
+				maps.Keys(test.expect),
+				maps.Keys(results))
 
 			for id, expect := range test.expect {
 				require.Contains(t, results, id)

--- a/src/internal/m365/controller_test.go
+++ b/src/internal/m365/controller_test.go
@@ -651,7 +651,11 @@ func runBackupAndCompare(
 	require.NoError(t, err, clues.ToCore(err))
 	assert.True(t, canUsePreviousBackup, "can use previous backup")
 	// No excludes yet because this isn't an incremental backup.
-	assert.True(t, excludes.Empty())
+	assert.True(
+		t,
+		excludes.Empty(),
+		"global excludes should have no entries, got:\n\t%+v",
+		excludes.Keys())
 
 	t.Logf("Backup enumeration complete in %v\n", time.Since(start))
 


### PR DESCRIPTION
Change the tree processing behavior by allowing unselected directories to populate the tree during enumeration, but flagged as not-selected.  During post processing, those directories will get removed from the collection results.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix

#### Issue(s)

* #4689

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
