### PR TITLE
Exclude conversation selectors from export and restore

### DIFF
--- a/src/cli/export/groups.go
+++ b/src/cli/export/groups.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alcionai/corso/src/cli/flags"
 	"github.com/alcionai/corso/src/cli/utils"
 	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/selectors"
 )
 
 // called by export.go to map subcommands to provider-specific handling.
@@ -99,6 +100,10 @@ func exportGroupsCmd(cmd *cobra.Command, args []string) error {
 
 	sel := utils.IncludeGroupsRestoreDataSelectors(ctx, opts)
 	utils.FilterGroupsRestoreInfoSelectors(sel, opts)
+
+	// TODO(pandeyabs): Exclude conversations from export since they are not
+	// supported yet. https://github.com/alcionai/corso/issues/4822
+	sel.Exclude(sel.Conversation(selectors.Any()))
 
 	acceptedGroupsFormatTypes := []string{
 		string(control.DefaultFormat),

--- a/src/cli/restore/groups.go
+++ b/src/cli/restore/groups.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alcionai/corso/src/cli/flags"
 	"github.com/alcionai/corso/src/cli/utils"
 	"github.com/alcionai/corso/src/pkg/dttm"
+	"github.com/alcionai/corso/src/pkg/selectors"
 )
 
 // called by restore.go to map subcommands to provider-specific handling.
@@ -90,6 +91,10 @@ func restoreGroupsCmd(cmd *cobra.Command, args []string) error {
 
 	sel := utils.IncludeGroupsRestoreDataSelectors(ctx, opts)
 	utils.FilterGroupsRestoreInfoSelectors(sel, opts)
+
+	// TODO(pandeyabs): Exclude conversations from restores since they are not
+	// supported yet.
+	sel.Exclude(sel.Conversation(selectors.Any()))
 
 	return runRestore(
 		ctx,


### PR DESCRIPTION
<!-- PR description-->

Group export sanity test is failing because we added conversations to `sel.AllData()`. But we don't have export support for conversations yet.

Adding conv selector to exclude so that it doesn't fail exports for groups libraries and channels. This is a short term change, and will be removed once we have export support https://github.com/alcionai/corso/issues/4822

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
