### PR TITLE
Beef up Exchange export error handling

### DIFF
--- a/src/internal/converters/eml/eml.go
+++ b/src/internal/converters/eml/eml.go
@@ -54,7 +54,7 @@ func formatAddress(entry models.EmailAddressable) string {
 func FromJSON(ctx context.Context, body []byte) (string, error) {
 	data, err := api.BytesToMessageable(body)
 	if err != nil {
-		return "", clues.Wrap(err, "converting to messageble")
+		return "", clues.WrapWC(ctx, err, "converting to messageble")
 	}
 
 	ctx = clues.Add(ctx, "item_id", ptr.Val(data.GetId()))

--- a/src/internal/m365/collection/exchange/export.go
+++ b/src/internal/m365/collection/exchange/export.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/export"
 	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/metrics"
 	"github.com/alcionai/corso/src/pkg/path"
 )
@@ -59,9 +60,13 @@ func streamItems(
 			reader.Close()
 
 			if err != nil {
+				err = clues.Wrap(err, "reading export item")
+
+				logger.CtxErr(ctx, err).Info("processing collection item")
+
 				ch <- export.Item{
 					ID:    id,
-					Error: clues.Wrap(err, "reading data"),
+					Error: err,
 				}
 
 				continue
@@ -69,9 +74,13 @@ func streamItems(
 
 			email, err := eml.FromJSON(ictx, content)
 			if err != nil {
+				err = clues.Wrap(err, "converting JSON to eml")
+
+				logger.CtxErr(ctx, err).Info("processing collection item")
+
 				ch <- export.Item{
 					ID:    id,
-					Error: clues.Wrap(err, "converting JSON to eml"),
+					Error: err,
 				}
 
 				continue

--- a/src/internal/m365/collection/exchange/export.go
+++ b/src/internal/m365/collection/exchange/export.go
@@ -52,6 +52,8 @@ func streamItems(
 			id := item.ID()
 			name := id + ".eml"
 
+			itemCtx := clues.Add(ictx, "item_file_name", id)
+
 			stats.UpdateResourceCount(path.EmailCategory)
 
 			reader := item.ToReader()
@@ -60,7 +62,7 @@ func streamItems(
 			reader.Close()
 
 			if err != nil {
-				err = clues.Wrap(err, "reading export item")
+				err = clues.WrapWC(itemCtx, err, "reading export item")
 
 				logger.CtxErr(ctx, err).Info("processing collection item")
 
@@ -72,7 +74,7 @@ func streamItems(
 				continue
 			}
 
-			email, err := eml.FromJSON(ictx, content)
+			email, err := eml.FromJSON(itemCtx, content)
 			if err != nil {
 				err = clues.Wrap(err, "converting JSON to eml")
 

--- a/src/internal/m365/collection/exchange/export.go
+++ b/src/internal/m365/collection/exchange/export.go
@@ -52,7 +52,7 @@ func streamItems(
 			id := item.ID()
 			name := id + ".eml"
 
-			itemCtx := clues.Add(ictx, "item_file_name", id)
+			itemCtx := clues.Add(ictx, "stream_item_id", id)
 
 			stats.UpdateResourceCount(path.EmailCategory)
 


### PR DESCRIPTION
Add log statements when errors are encountered so we get full clues
output and make sure context clues are added to returned errors. The
additional logging is necessary because not all corso SDK consumers
will use clues which means they could miss out on valuable information
if they just log the returned errors normally

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
