### PR TITLE
Log and ignore sharing disabled errors when doing permissions restores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ this case, Corso will skip over the item but report this in the backup summary.
 - Guarantee Exchange email restoration when restoring multiple attachments. Some previous restores were failing with `ErrorItemNotFound`.
 - Avoid Graph SDK `Requests must contain extension changes exclusively.` errors by removing server-populated field from restored event items.
 
+### Known issues
+- Restoring OneDrive, SharePoint, or Teams & Groups items shared with external users while the tenant or site is configured to not allow sharing with external users will not restore permissions.
+
 ## [v0.17.0] (beta) - 2023-12-11
 
 ### Changed

--- a/src/internal/m365/collection/drive/permission.go
+++ b/src/internal/m365/collection/drive/permission.go
@@ -475,6 +475,11 @@ func RestorePermissions(
 
 	previous, err := computePreviousMetadata(ctx, itemPath, caches.ParentDirToMeta)
 	if err != nil {
+		if graph.IsErrSharingDisabled(err) {
+			logger.Ctx(ctx).Info("sharing disabled, not restoring permissions")
+			return nil
+		}
+
 		return clues.Wrap(err, "previous metadata")
 	}
 
@@ -500,6 +505,11 @@ func RestorePermissions(
 		caches.OldPermIDToNewID,
 		errs)
 	if err != nil {
+		if graph.IsErrSharingDisabled(err) {
+			logger.Ctx(ctx).Info("sharing disabled, not restoring permissions")
+			return nil
+		}
+
 		return clues.Wrap(err, "updating permissions")
 	}
 

--- a/src/internal/m365/collection/drive/permission.go
+++ b/src/internal/m365/collection/drive/permission.go
@@ -389,13 +389,13 @@ func UpdateLinkShares(
 			continue
 		}
 
-		if err != nil {
-			if graph.IsErrSharingDisabled(err) {
-				logger.Ctx(ctx).Info("unable to restore link share; sharing disabled")
-			} else {
-				el.AddRecoverable(ctx, clues.Stack(err))
-			}
+		if graph.IsErrSharingDisabled(err) {
+			logger.CtxErr(ictx, err).Info("unable to restore link share; sharing disabled")
+			continue
+		}
 
+		if err != nil {
+			el.AddRecoverable(ictx, clues.Stack(err))
 			continue
 		}
 
@@ -504,14 +504,10 @@ func RestorePermissions(
 		permRemoved,
 		caches.OldPermIDToNewID,
 		errs)
-	if err != nil {
-		if graph.IsErrSharingDisabled(err) {
-			logger.Ctx(ctx).Info("sharing disabled, not restoring permissions")
-			return nil
-		}
-
-		return clues.Wrap(err, "updating permissions")
+	if graph.IsErrSharingDisabled(err) {
+		logger.CtxErr(ctx, err).Info("sharing disabled, not restoring permissions")
+		return nil
 	}
 
-	return nil
+	return clues.Wrap(err, "updating permissions").OrNil()
 }

--- a/src/internal/m365/collection/drive/permission.go
+++ b/src/internal/m365/collection/drive/permission.go
@@ -390,7 +390,12 @@ func UpdateLinkShares(
 		}
 
 		if err != nil {
-			el.AddRecoverable(ctx, clues.Stack(err))
+			if graph.IsErrSharingDisabled(err) {
+				logger.Ctx(ctx).Info("unable to restore link share; sharing disabled")
+			} else {
+				el.AddRecoverable(ctx, clues.Stack(err))
+			}
+
 			continue
 		}
 
@@ -475,11 +480,6 @@ func RestorePermissions(
 
 	previous, err := computePreviousMetadata(ctx, itemPath, caches.ParentDirToMeta)
 	if err != nil {
-		if graph.IsErrSharingDisabled(err) {
-			logger.Ctx(ctx).Info("sharing disabled, not restoring permissions")
-			return nil
-		}
-
 		return clues.Wrap(err, "previous metadata")
 	}
 

--- a/src/pkg/services/m365/api/graph/errors.go
+++ b/src/pkg/services/m365/api/graph/errors.go
@@ -77,6 +77,9 @@ const (
 // inner error codes
 const (
 	ResourceLocked errorCode = "resourceLocked"
+	// Returned when either the tenant-wide or site settings don't permit sharing
+	// for external users to some extent.
+	sharingDisabled errorCode = "sharingDisabled"
 )
 
 type errorMessage string
@@ -291,6 +294,10 @@ func IsErrResourceLocked(err error) bool {
 			filters.In([]string{"the service principal for resource"}),
 			filters.In([]string{"this indicate that a subscription within the tenant has lapsed"}),
 			filters.In([]string{"preventing tokens from being issued for it"}))
+}
+
+func IsErrSharingDisabled(err error) bool {
+	return hasInnerErrorCode(err, sharingDisabled)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
We've encountered an error where the user previously had sharing for
one or more external users on an item and then did a backup. They
subsequently disabled sharing for the SharePoint site in either the
tenant-wide config or for the site in particular. Once sharing was
disabled, they attempted a restore which subsequently failed while
trying to restore sharing for the external user

This PR logs and ignores errors about sharing being disabled when
doing a restore

This has been tested manually

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
