### PR TITLE
Tool to test invalid json->messagable

### DIFF
--- a/src/internal/converters/eml/tools/main.go
+++ b/src/internal/converters/eml/tools/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+)
+
+func main() {
+	// Open the JSON file
+	jsonFile, err := os.Open("data.json")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer jsonFile.Close()
+
+	// Read the file contents
+	byteValue, _ := io.ReadAll(jsonFile)
+
+	// Declare an empty interface for holding the JSON data
+	var jsonData interface{}
+
+	if !json.Valid(byteValue) {
+		fmt.Println("INVALID JSON")
+	}
+
+	_, err = api.BytesToMessageable(byteValue)
+	if err != nil {
+		fmt.Println("Error converting to messagable", err)
+	}
+
+	// Unmarshal the byteValue into the jsonData interface
+	err = json.Unmarshal(byteValue, &jsonData)
+	if err != nil {
+		fmt.Println("Error parsing JSON:", err)
+		return
+	}
+
+	// Marshal the data back into JSON for pretty output
+	prettyJSON, err := json.MarshalIndent(jsonData, "", "    ")
+	if err != nil {
+		fmt.Println("Error marshalling JSON:", err)
+		return
+	}
+
+	// Print the pretty JSON
+	fmt.Println(string(prettyJSON))
+
+	if !json.Valid(byteValue) {
+		fmt.Println("INVALID JSON")
+	}
+
+	_, err = api.BytesToMessageable(byteValue)
+	if err != nil {
+		fmt.Println("Error converting to messagable", err)
+	}
+	fmt.Println()
+}


### PR DESCRIPTION
Tool to test invalid JSON.

To run - create `data.json` and run `go run main.go`

e.g.
```
INVALID JSON
Error converting to messagable deserializing bytes to message: deserializing bytes into base m365 object: invalid json type
Error parsing JSON: invalid character '\x1a' in string literal
```

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
