### PR TITLE
Add feature flag to disable lazy item reader

### DIFF
--- a/src/cli/backup/groups.go
+++ b/src/cli/backup/groups.go
@@ -75,6 +75,7 @@ func addGroupsCommands(cmd *cobra.Command) *cobra.Command {
 		flags.AddFetchParallelismFlag(c)
 		flags.AddDisableDeltaFlag(c)
 		flags.AddGenericBackupFlags(c)
+		flags.AddDisableLazyItemReader(c)
 
 	case listCommand:
 		c, fs = utils.AddCommand(cmd, groupsListCmd(), utils.MarkPreviewCommand())

--- a/src/cli/backup/groups_test.go
+++ b/src/cli/backup/groups_test.go
@@ -153,6 +153,7 @@ func (suite *GroupsUnitSuite) TestBackupCreateFlags() {
 				"--" + flags.CategoryDataFN, flagsTD.FlgInputs(flagsTD.GroupsCategoryDataInput),
 				"--" + flags.FetchParallelismFN, flagsTD.FetchParallelism,
 				"--" + flags.DisableDeltaFN,
+				"--" + flags.DisableLazyItemReaderFN,
 			},
 			flagsTD.PreparedGenericBackupFlags(),
 			flagsTD.PreparedProviderFlags(),
@@ -176,6 +177,7 @@ func (suite *GroupsUnitSuite) TestBackupCreateFlags() {
 	assert.True(t, co.ToggleFeatures.DisableIncrementals)
 	assert.True(t, co.ToggleFeatures.ForceItemDataDownload)
 	assert.True(t, co.ToggleFeatures.DisableDelta)
+	assert.True(t, co.ToggleFeatures.DisableLazyItemReader)
 
 	assert.ElementsMatch(t, flagsTD.GroupsInput, opts.Groups)
 	flagsTD.AssertGenericBackupFlags(t, cmd)

--- a/src/cli/flags/options.go
+++ b/src/cli/flags/options.go
@@ -10,6 +10,7 @@ const (
 	DeltaPageSizeFN               = "delta-page-size"
 	DisableDeltaFN                = "disable-delta"
 	DisableIncrementalsFN         = "disable-incrementals"
+	DisableLazyItemReaderFN       = "disable-lazy-item-reader"
 	DisableSlidingWindowLimiterFN = "disable-sliding-window-limiter"
 	ForceItemDataDownloadFN       = "force-item-data-download"
 	EnableImmutableIDFN           = "enable-immutable-id"
@@ -29,6 +30,7 @@ var (
 	DeltaPageSizeFV               int
 	DisableDeltaFV                bool
 	DisableIncrementalsFV         bool
+	DisableLazyItemReaderFV       bool
 	DisableSlidingWindowLimiterFV bool
 	ForceItemDataDownloadFV       bool
 	EnableImmutableIDFV           bool
@@ -177,4 +179,20 @@ func AddDisableSlidingWindowLimiterFlag(cmd *cobra.Command) {
 		false,
 		"Disable sliding window rate limiter.")
 	cobra.CheckErr(fs.MarkHidden(DisableSlidingWindowLimiterFN))
+}
+
+// AddDisableLazyItemReader disables lazy item reader, such that we fall back to
+// prefetch reader. This flag is currently only meant for groups conversations
+// backup. Although it can be utilized for other services in future.
+//
+// This flag should only be used if lazy item reader is the default choice and
+// we want to fallback to prefetch reader.
+func AddDisableLazyItemReader(cmd *cobra.Command) {
+	fs := cmd.Flags()
+	fs.BoolVar(
+		&DisableLazyItemReaderFV,
+		DisableLazyItemReaderFN,
+		false,
+		"Disable lazy item reader.")
+	cobra.CheckErr(fs.MarkHidden(DisableLazyItemReaderFN))
 }

--- a/src/cli/utils/options.go
+++ b/src/cli/utils/options.go
@@ -26,6 +26,7 @@ func Control() control.Options {
 	opt.ToggleFeatures.ForceItemDataDownload = flags.ForceItemDataDownloadFV
 	opt.ToggleFeatures.DisableDelta = flags.DisableDeltaFV
 	opt.ToggleFeatures.DisableSlidingWindowLimiter = flags.DisableSlidingWindowLimiterFV
+	opt.ToggleFeatures.DisableLazyItemReader = flags.DisableLazyItemReaderFV
 	opt.ToggleFeatures.ExchangeImmutableIDs = flags.EnableImmutableIDFV
 	opt.ToggleFeatures.UseDeltaTree = flags.UseDeltaTreeFV
 	opt.Parallelism.ItemFetch = flags.FetchParallelismFV

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -433,6 +433,7 @@ func (suite *BackupOpUnitSuite) TestNewBackupOperation_configuredOptionsMatchInp
 			RunMigrations:               true,
 			DisableSlidingWindowLimiter: true,
 			UseDeltaTree:                true,
+			DisableLazyItemReader:       true,
 		},
 		PreviewLimits: control.PreviewItemLimits{
 			MaxItems:             42,

--- a/src/pkg/control/options.go
+++ b/src/pkg/control/options.go
@@ -100,4 +100,13 @@ type Toggles struct {
 
 	// see: https://github.com/alcionai/corso/issues/4688
 	UseDeltaTree bool `json:"useDeltaTree"`
+
+	// AddDisableLazyItemReader disables lazy item reader, such that we fall
+	// back to prefetch reader. This flag is currently only meant for groups
+	// conversations backup. Although it can be utilized for other services
+	// in future.
+	//
+	// This flag should only be used if lazy item reader is the default choice
+	// and we want to fallback to prefetch reader.
+	DisableLazyItemReader bool `json:"disableLazyItemReader"`
 }


### PR DESCRIPTION
<!-- PR description-->
AddDisableLazyItemReader disables lazy item reader, such that we fall
back to prefetch reader. This flag is currently only meant for groups
conversations backup. Although it can be utilized for other services
in future.

This flag should only be used if lazy item reader is the default choice
and we want to fallback to prefetch reader.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* https://github.com/alcionai/corso/issues/4862

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
