### PR TITLE
ignore fields containing LookupId while creating list items

### DIFF
--- a/src/pkg/services/m365/api/lists.go
+++ b/src/pkg/services/m365/api/lists.go
@@ -14,13 +14,14 @@ import (
 )
 
 const (
-	AttachmentsColumnName    = "Attachments"
-	EditColumnName           = "Edit"
-	ContentTypeColumnName    = "ContentType"
-	CreatedColumnName        = "Created"
-	ModifiedColumnName       = "Modified"
-	AuthorLookupIDColumnName = "AuthorLookupId"
-	EditorLookupIDColumnName = "EditorLookupId"
+	AttachmentsColumnName       = "Attachments"
+	EditColumnName              = "Edit"
+	ContentTypeColumnName       = "ContentType"
+	CreatedColumnName           = "Created"
+	ModifiedColumnName          = "Modified"
+	AuthorLookupIDColumnName    = "AuthorLookupId"
+	EditorLookupIDColumnName    = "EditorLookupId"
+	AppAuthorLookupIDColumnName = "AppAuthorLookupId"
 
 	ContentTypeColumnDisplayName = "Content Type"
 
@@ -39,6 +40,7 @@ const (
 	DispNameFieldName        = "DispName"
 	LinkTitleFieldNamePart   = "LinkTitle"
 	ChildCountFieldNamePart  = "ChildCount"
+	LookupIDFieldNamePart    = "LookupId"
 
 	ReadOnlyOrHiddenFieldNamePrefix = "_"
 	DescoratorFieldNamePrefix       = "@"
@@ -69,13 +71,11 @@ var legacyColumns = keys.Set{
 }
 
 var readOnlyFieldNames = keys.Set{
-	AttachmentsColumnName:    {},
-	EditColumnName:           {},
-	ContentTypeColumnName:    {},
-	CreatedColumnName:        {},
-	ModifiedColumnName:       {},
-	AuthorLookupIDColumnName: {},
-	EditorLookupIDColumnName: {},
+	AttachmentsColumnName: {},
+	EditColumnName:        {},
+	ContentTypeColumnName: {},
+	CreatedColumnName:     {},
+	ModifiedColumnName:    {},
 }
 
 // ---------------------------------------------------------------------------
@@ -536,7 +536,8 @@ func shouldFilterField(key string, value any) bool {
 		strings.HasPrefix(key, ReadOnlyOrHiddenFieldNamePrefix) ||
 		strings.HasPrefix(key, DescoratorFieldNamePrefix) ||
 		strings.Contains(key, LinkTitleFieldNamePart) ||
-		strings.Contains(key, ChildCountFieldNamePart)
+		strings.Contains(key, ChildCountFieldNamePart) ||
+		strings.Contains(key, LookupIDFieldNamePart)
 }
 
 func retainPrimaryAddressField(additionalData map[string]any) {

--- a/src/pkg/services/m365/api/lists_test.go
+++ b/src/pkg/services/m365/api/lists_test.go
@@ -409,6 +409,7 @@ func (suite *ListsUnitSuite) TestFieldValueSetable() {
 		ReadOnlyOrHiddenFieldNamePrefix + "UIVersionString": "1.0",
 		AuthorLookupIDColumnName:                            "6",
 		EditorLookupIDColumnName:                            "6",
+		AppAuthorLookupIDColumnName:                         "6",
 		"Item" + ChildCountFieldNamePart:                    "0",
 		"Folder" + ChildCountFieldNamePart:                  "0",
 		ModifiedColumnName:                                  "2023-12-13T15:47:51Z",


### PR DESCRIPTION
New field came up while testing: `AppAuthorLookupId`
Ignores fields containing LookupId while creating list items.

#### Does this PR need a docs update or release note?
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :bug: Bugfix

#### Issue(s)
#4754

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
