### PR TITLE
Minor refactor of status update code

### DIFF
--- a/src/internal/m365/collection/groups/collection.go
+++ b/src/internal/m365/collection/groups/collection.go
@@ -28,8 +28,8 @@ const (
 	numberOfRetries             = 4
 )
 
-// updateStatus is a utility function used to close a collection's data channel
-// and to send the status update through the channel.
+// updateStatus is a utility function used to send the status update through
+// the channel.
 func updateStatus(
 	ctx context.Context,
 	statusUpdater support.StatusUpdater,


### PR DESCRIPTION
<!-- PR description-->

I missed this change in https://github.com/alcionai/corso/pull/4906. Moving out the status updater code out of `prefetchCollection` scope so that `lazyFetchCollection` can also use it in upcoming PRs.


---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
