### PR TITLE
Sanitize JSON input if it's invalid on the first attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 this case, Corso will skip over the item but report this in the backup summary.
 - Guarantee Exchange email restoration when restoring multiple attachments. Some previous restores were failing with `ErrorItemNotFound`.
 - Avoid Graph SDK `Requests must contain extension changes exclusively.` errors by removing server-populated field from restored event items.
+- Handle cases where Exchange backup stored invalid JSON blobs if there were special characters in the user content. These would result in errors during restore or restore errors.
 
 ### Known issues
 - Restoring OneDrive, SharePoint, or Teams & Groups items shared with external users while the tenant or site is configured to not allow sharing with external users will not restore permissions.

--- a/src/internal/m365/collection/exchange/restore.go
+++ b/src/internal/m365/collection/exchange/restore.go
@@ -88,7 +88,7 @@ func RestoreCollection(
 				ctr)
 			if err != nil {
 				if !graph.IsErrItemAlreadyExistsConflict(err) {
-					el.AddRecoverable(ictx, err)
+					el.AddRecoverable(ictx, clues.Wrap(err, "restoring item"))
 				}
 
 				continue

--- a/src/internal/m365/controller_test.go
+++ b/src/internal/m365/controller_test.go
@@ -778,6 +778,24 @@ func (suite *ControllerIntegrationSuite) TestRestoreAndBackup_core() {
 
 	table := []restoreBackupInfo{
 		{
+			name:    "EmailWithSpecialCharacters",
+			service: path.ExchangeService,
+			collections: []stub.ColInfo{
+				{
+					PathElements: []string{api.MailInbox},
+					Category:     path.EmailCategory,
+					Items: []stub.ItemInfo{
+						{
+							Name: "someencodeditemID",
+							Data: exchMock.MessageWithSpecialCharacters(
+								subjectText + "-1"),
+							LookupKey: subjectText + "-1",
+						},
+					},
+				},
+			},
+		},
+		{
 			name:    "EmailsWithAttachments",
 			service: path.ExchangeService,
 			collections: []stub.ColInfo{

--- a/src/internal/m365/service/exchange/export_test.go
+++ b/src/internal/m365/service/exchange/export_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alcionai/corso/src/internal/data"
 	dataMock "github.com/alcionai/corso/src/internal/data/mock"
 	"github.com/alcionai/corso/src/internal/m365/collection/exchange"
+	exchMock "github.com/alcionai/corso/src/internal/m365/service/exchange/mock"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/control"
@@ -54,6 +55,29 @@ func (suite *ExportUnitSuite) TestGetItems() {
 						&dataMock.Item{
 							ItemID: "id1",
 							Reader: io.NopCloser(bytes.NewReader(emailBodyBytes)),
+						},
+					},
+				},
+			},
+			expectedItems: []export.Item{
+				{
+					ID:   "id1",
+					Name: "id1.eml",
+					Body: io.NopCloser(bytes.NewReader(emailBodyBytes)),
+				},
+			},
+		},
+		{
+			name:    "single item with special characters",
+			version: 1,
+			backingCollection: data.NoFetchRestoreCollection{
+				Collection: dataMock.Collection{
+					Path: p,
+					ItemData: []data.Item{
+						&dataMock.Item{
+							ItemID: "id1",
+							Reader: io.NopCloser(bytes.NewReader(
+								exchMock.MessageWithSpecialCharacters("special characters"))),
 						},
 					},
 				},

--- a/src/internal/m365/service/exchange/mock/mail.go
+++ b/src/internal/m365/service/exchange/mock/mail.go
@@ -101,7 +101,23 @@ const (
 		],
 		"webLink":"https://outlook.office365.com/owa/?ItemID=AAMkAGZmNjNlYjI3LWJlZWYtNGI4Mi04YjMyLTIxYThkNGQ4NmY1MwBGAAAAAADCNgjhM9QmQYWNcI7hCpPrBwDSEBNbUIB9RL6ePDeF3FIYAAAAAAEMAADSEBNbUIB9RL6ePDeF3FIYAAB3XwIkAAA%%3D&exvsurl=1&viewmodel=ReadMessageItem"
 	}`
+
+	emailWithSpecialCharacters = `{
+		"importance": "normal",
+		"internetMessageId": "<SJ0PR17MB562266A1E61A8EA12F5FB17BC3529@SJ0PR17MB5622.namprd17.prod.outlook.com>",
+		"sentDateTime": "2022-09-26T23:15:46Z",
+		"receivedDateTime": "2022-09-26T23:20:46Z",
+    "body":{
+      "content":"abcd` + string(rune(8)) + string(rune(8)) + `\"",
+      "contentType":"text"
+    },
+    "subject":"%s"
+  }`
 )
+
+func MessageWithSpecialCharacters(subject string) []byte {
+	return []byte(fmt.Sprintf(emailWithSpecialCharacters, subject))
+}
 
 // MessageBytes returns bytes for a Messageable item.
 // Contents verified as working with sample data from kiota-serialization-json-go v0.5.5

--- a/src/pkg/services/m365/api/consts.go
+++ b/src/pkg/services/m365/api/consts.go
@@ -7,4 +7,7 @@ const (
 	DefaultContacts = "Contacts"
 	MailInbox       = "Inbox"
 	MsgFolderRoot   = "msgfolderroot"
+
+	// Kiota JSON invalid JSON error message.
+	invalidJSON = "invalid json type"
 )

--- a/src/pkg/services/m365/api/contacts.go
+++ b/src/pkg/services/m365/api/contacts.go
@@ -11,6 +11,7 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/internal/common/sanitize"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
@@ -253,6 +254,10 @@ func (c Contacts) DeleteItem(
 // ---------------------------------------------------------------------------
 
 func BytesToContactable(bytes []byte) (models.Contactable, error) {
+	// Sanitize item content so we don't get invalid JSON errors due to
+	// unescaped special characters.
+	bytes = sanitize.JSONBytes(bytes)
+
 	v, err := CreateFromBytes(bytes, models.CreateContactFromDiscriminatorValue)
 	if err != nil {
 		return nil, clues.Wrap(err, "deserializing bytes to contact")

--- a/src/pkg/services/m365/api/events.go
+++ b/src/pkg/services/m365/api/events.go
@@ -17,6 +17,7 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/internal/common/sanitize"
 	"github.com/alcionai/corso/src/internal/common/str"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/dttm"
@@ -557,6 +558,10 @@ func (c Events) PostLargeAttachment(
 // ---------------------------------------------------------------------------
 
 func BytesToEventable(body []byte) (models.Eventable, error) {
+	// Sanitize item content so we don't get invalid JSON errors due to
+	// unescaped special characters.
+	body = sanitize.JSONBytes(body)
+
 	v, err := CreateFromBytes(body, models.CreateEventFromDiscriminatorValue)
 	if err != nil {
 		return nil, clues.Wrap(err, "deserializing bytes to event")

--- a/src/pkg/services/m365/api/mail.go
+++ b/src/pkg/services/m365/api/mail.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/alcionai/clues"
 	"github.com/microsoft/kiota-abstractions-go/serialization"
@@ -597,14 +598,27 @@ func (c Mail) PostLargeAttachment(
 // Serialization
 // ---------------------------------------------------------------------------
 
-func BytesToMessageable(body []byte) (models.Messageable, error) {
-	// Sanitize item content so we don't get invalid JSON errors due to
-	// unescaped special characters.
-	body = sanitize.JSONBytes(body)
-
+func bytesToMessageable(body []byte) (serialization.Parsable, error) {
 	v, err := CreateFromBytes(body, models.CreateMessageFromDiscriminatorValue)
 	if err != nil {
-		return nil, clues.Wrap(err, "deserializing bytes to message")
+		if !strings.Contains(err.Error(), invalidJSON) {
+			return nil, clues.Wrap(err, "deserializing bytes to message")
+		}
+
+		// If the JSON was invalid try sanitizing and deserializing again.
+		// Sanitizing should transform characters < 0x20 according to the spec where
+		// possible. The resulting JSON may still be invalid though.
+		body = sanitize.JSONBytes(body)
+		v, err = CreateFromBytes(body, models.CreateMessageFromDiscriminatorValue)
+	}
+
+	return v, clues.Stack(err).OrNil()
+}
+
+func BytesToMessageable(body []byte) (models.Messageable, error) {
+	v, err := bytesToMessageable(body)
+	if err != nil {
+		return nil, clues.Stack(err)
 	}
 
 	return v.(models.Messageable), nil

--- a/src/pkg/services/m365/api/mail.go
+++ b/src/pkg/services/m365/api/mail.go
@@ -13,6 +13,7 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/internal/common/sanitize"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/dttm"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -597,6 +598,10 @@ func (c Mail) PostLargeAttachment(
 // ---------------------------------------------------------------------------
 
 func BytesToMessageable(body []byte) (models.Messageable, error) {
+	// Sanitize item content so we don't get invalid JSON errors due to
+	// unescaped special characters.
+	body = sanitize.JSONBytes(body)
+
 	v, err := CreateFromBytes(body, models.CreateMessageFromDiscriminatorValue)
 	if err != nil {
 		return nil, clues.Wrap(err, "deserializing bytes to message")

--- a/src/pkg/services/m365/api/mail_test.go
+++ b/src/pkg/services/m365/api/mail_test.go
@@ -178,6 +178,20 @@ func (suite *MailAPIUnitSuite) TestBytesToMessagable() {
 			checkError:  assert.NoError,
 			checkObject: assert.NotNil,
 		},
+		{
+			name:        "malformed JSON bytes passes sanitization",
+			byteArray:   exchMock.MessageWithSpecialCharacters("m365 mail support test"),
+			checkError:  assert.NoError,
+			checkObject: assert.NotNil,
+		},
+		{
+			name: "invalid JSON bytes",
+			byteArray: append(
+				exchMock.MessageWithSpecialCharacters("m365 mail support test"),
+				[]byte("}")...),
+			checkError:  assert.Error,
+			checkObject: assert.Nil,
+		},
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {

--- a/src/pkg/services/m365/api/mail_test.go
+++ b/src/pkg/services/m365/api/mail_test.go
@@ -159,6 +159,19 @@ func (suite *MailAPIUnitSuite) TestMailInfo() {
 	}
 }
 
+// TestBytesToMessagable_InvalidError tests that the error message kiota returns
+// for invalid JSON matches what we check for. This helps keep things in sync
+// when kiota is updated.
+func (suite *MailAPIUnitSuite) TestBytesToMessagable_InvalidError() {
+	t := suite.T()
+	input := exchMock.MessageWithSpecialCharacters("m365 mail support test")
+
+	_, err := CreateFromBytes(input, models.CreateMessageFromDiscriminatorValue)
+	require.Error(t, err, clues.ToCore(err))
+
+	assert.Contains(t, err.Error(), invalidJSON)
+}
+
 func (suite *MailAPIUnitSuite) TestBytesToMessagable() {
 	table := []struct {
 		name        string


### PR DESCRIPTION
Add code and tests for sanitizing emails

Also adds code for sanitizing events and contacts but we can remove
that if we'd like to address it if/when needed. We haven't yet seen
or tried to create instances of those

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
