### PR TITLE
Remove duplicated integration tests for groups

### DIFF
--- a/src/internal/operations/test/m365/groups/groups_test.go
+++ b/src/internal/operations/test/m365/groups/groups_test.go
@@ -58,7 +58,6 @@ func (suite *GroupsBackupIntgSuite) TestBackup_Run_groups() {
 		sel.Selector)
 }
 
-// TODO(pandeyabs): Add incremental tests for channel messages and conversations.
 func (suite *GroupsBackupIntgSuite) TestBackup_Run_incrementalGroups() {
 	runGroupsIncrementalBackupTests(suite, suite.its, control.DefaultOptions())
 }


### PR DESCRIPTION
<!-- PR description-->

* We had a few duplicated tests. Removing them.
* Adding conversations selector for group v9 bump tests. Although technically it's not needed, since we didn't have conversations support prior to v9.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [x] :green_heart: E2E
