### PR TITLE
Disable export and restore for sharepoint lists

### DIFF
--- a/src/cli/export/sharepoint.go
+++ b/src/cli/export/sharepoint.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/alcionai/corso/src/cli/flags"
 	"github.com/alcionai/corso/src/cli/utils"
+	"github.com/alcionai/corso/src/pkg/selectors"
 )
 
 // called by export.go to map subcommands to provider-specific handling.
@@ -93,6 +94,9 @@ func exportSharePointCmd(cmd *cobra.Command, args []string) error {
 
 	sel := utils.IncludeSharePointRestoreDataSelectors(ctx, opts)
 	utils.FilterSharePointRestoreInfoSelectors(sel, opts)
+
+	// Exclude lists from exports since they are not supported yet.
+	sel.Exclude(sel.Lists(selectors.Any()))
 
 	return runExport(
 		ctx,

--- a/src/cli/restore/sharepoint.go
+++ b/src/cli/restore/sharepoint.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alcionai/corso/src/cli/flags"
 	"github.com/alcionai/corso/src/cli/utils"
 	"github.com/alcionai/corso/src/pkg/dttm"
+	"github.com/alcionai/corso/src/pkg/selectors"
 )
 
 // called by restore.go to map subcommands to provider-specific handling.
@@ -93,6 +94,9 @@ func restoreSharePointCmd(cmd *cobra.Command, args []string) error {
 
 	sel := utils.IncludeSharePointRestoreDataSelectors(ctx, opts)
 	utils.FilterSharePointRestoreInfoSelectors(sel, opts)
+
+	// Exclude lists from restore since they are not supported yet.
+	sel.Exclude(sel.Lists(selectors.Any()))
 
 	return runRestore(
 		ctx,


### PR DESCRIPTION
<!-- PR description-->

We are hitting a sanity test failure during export. `Error: Failed to run SharePoint export: running export: exporting collections: transforming path to drive path: folder path doesn't match expected format for Drive items`. CI [run](https://github.com/alcionai/corso/actions/runs/7304614358/job/19907054349).

After debugging I found out that it's because we don't support exports for lists yet. This PR disables list export and restore.

We are also hitting a panic during list restore, so I am temporarily disabling list restores too. `Error: Failed to run SharePoint restore: panic recovery: file /Users/pandeyab/corso/src/pkg/services/m365/api/lists.go - line 607: runtime error: invalid memory address or nil pointer dereference`. 
Will request @HiteshRepo to investigate restore failure. 

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
