### PR TITLE
fixes lists delete in CI during sites purge

### DIFF
--- a/src/cmd/purge/scripts/onedrivePurge.ps1
+++ b/src/cmd/purge/scripts/onedrivePurge.ps1
@@ -182,8 +182,8 @@ function Delete-LibraryByPrefix {
         if ($PSCmdlet.ShouldProcess("Name: " + $l.Title + "Remove folder")) {
             Write-Host "Deleting list: "$l.Title
             try {
-                $listInfo = Get-PnPList -Identity $l.Id -Fields Hidden
-
+                $listInfo = Get-PnPList -Identity $l.Id | Select-Object -Property Hidden
+                
                 # Check if the 'hidden' property is true
                 if ($listInfo.Hidden) {
                     Write-Host "List: $($l.Title) is hidden. Skipping..."


### PR DESCRIPTION
fixes lists delete in CI during sites purge

manual testing commad used:
```
pwsh ./onedrivePurge.ps1 -Site "https://10rqc2.sharepoint.com/sites/CorsoCI" -LibraryNameList "Shared Documents","More Documents" -FolderPrefixPurgeList Corso_Restore_,TestRestore,testfolder,incrementals_ci_,Alcion_Restore_,Corso_Test -LibraryPrefixDeleteList Corso_Restore_,TestRestore,testfolder,incrementals_ci_,Alcion_Restore_,Corso_Test -PurgeBeforeTimestamp 2023-12-24T06:03:24Z
```

output
```
Authenticating and connecting to https://10rqc2.sharepoint.com/sites/CorsoCI
Connected to https://10rqc2.sharepoint.com/sites/CorsoCI


Purging library: Shared Documents
Found 0 folders to purge

Purging library: More Documents
Found 0 folders to purge

Deleting library: Corso_Restore_,TestRestore,testfolder,incrementals_ci_,Alcion_Restore_,Corso_Test
Found 8 lists to delete
Deleting list:  Corso_Restore_23-Dec-2023_14-54-05_Sharing Links
List: Corso_Restore_23-Dec-2023_14-54-05_Sharing Links is hidden. Skipping...
Deleting list:  Corso_Restore_23-Dec-2023_15-50-29_Corso_Restore_23-Dec-2023_14-54-05_Sharing Links
List: Corso_Restore_23-Dec-2023_15-50-29_Corso_Restore_23-Dec-2023_14-54-05_Sharing Links is hidden. Skipping...
Deleting list:  Corso_Restore_23-Dec-2023_15-50-29_Sharing Links
List: Corso_Restore_23-Dec-2023_15-50-29_Sharing Links is hidden. Skipping...
Deleting list:  Corso_Test_24-Dec-2023_04-24-09.117728_MockListing
Deleting list:  Corso_Test_24-Dec-2023_05-05-31.706634_MockListing
Deleting list:  Corso_Test_list_api_post_drive_23-Dec-2023_16-50-05.901602
Deleting list:  Corso_Test_list_api_post_drive_24-Dec-2023_04-44-48.244327
Deleting list:  Corso_Test_list_api_post_drive_24-Dec-2023_05-25-51.302396
```

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [x] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)
https://github.com/alcionai/corso/actions/runs/7313019888/job/19924151485

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
