### PR TITLE
lists prefetech

### DIFF
--- a/src/internal/m365/collection/site/backup.go
+++ b/src/internal/m365/collection/site/backup.go
@@ -123,7 +123,7 @@ func CollectPages(
 			el.AddRecoverable(ctx, clues.WrapWC(ctx, err, "creating page collection path"))
 		}
 
-		collection := NewCollection(
+		collection := NewPrefetchCollection(
 			nil,
 			dir,
 			ac,
@@ -182,7 +182,7 @@ func CollectLists(
 			el.AddRecoverable(ctx, clues.WrapWC(ctx, err, "creating list collection path"))
 		}
 
-		collection := NewCollection(
+		collection := NewPrefetchCollection(
 			bh,
 			dir,
 			ac,

--- a/src/internal/m365/collection/site/backup_test.go
+++ b/src/internal/m365/collection/site/backup_test.go
@@ -121,7 +121,8 @@ func (suite *SharePointSuite) TestCollectLists() {
 		creds.AzureTenantID,
 		sel.Lists(selectors.Any())[0],
 		(&MockGraphService{}).UpdateStatus,
-		fault.New(true))
+		fault.New(true),
+		count.New())
 	require.NoError(t, err, clues.ToCore(err))
 	assert.Less(t, 0, len(col))
 }

--- a/src/internal/m365/collection/site/collection.go
+++ b/src/internal/m365/collection/site/collection.go
@@ -165,8 +165,7 @@ func (pc *prefetchCollection) streamLists(
 		pc.stream[path.ListsCategory],
 		pc.statusUpdater,
 		pc.fullPath,
-		&metrics,
-	)
+		&metrics)
 
 	// TODO: Insert correct ID for CollectionProgress
 	progress := observe.CollectionProgress(ctx, pc.fullPath.Category().HumanString(), pc.fullPath.Folders())
@@ -219,8 +218,7 @@ func (pc *prefetchCollection) streamPages(
 		pc.stream[path.PagesCategory],
 		pc.statusUpdater,
 		pc.fullPath,
-		&metrics,
-	)
+		&metrics)
 
 	// TODO: Insert correct ID for CollectionProgress
 	progress := observe.CollectionProgress(ctx, pc.fullPath.Category().HumanString(), pc.fullPath.Folders())

--- a/src/internal/m365/collection/site/collection.go
+++ b/src/internal/m365/collection/site/collection.go
@@ -56,7 +56,8 @@ var (
 // SharePoint.Libraries collections are supported by the oneDrive.Collection
 // as the calls are identical for populating the Collection
 type prefetchCollection struct {
-	// stream is the container for each individual SharePoint item of (page/list)
+	// stream is a container for each individual SharePoint item (page/list) category,
+	// where the category type serves as the key, and the associated channel holds the items.
 	stream map[path.CategoryType]chan data.Item
 	// fullPath indicates the hierarchy within the collection
 	fullPath path.Path

--- a/src/internal/m365/collection/site/collection.go
+++ b/src/internal/m365/collection/site/collection.go
@@ -136,7 +136,7 @@ func (pc *prefetchCollection) streamItems(
 	case path.ListsCategory:
 		pc.streamLists(ctx, errs)
 	case path.PagesCategory:
-		pc.retrievePages(ctx, pc.client, errs)
+		pc.streamPages(ctx, pc.client, errs)
 	}
 }
 
@@ -199,7 +199,7 @@ func (pc *prefetchCollection) streamLists(
 	metrics.Successes = int(objectSuccesses)
 }
 
-func (pc *prefetchCollection) retrievePages(
+func (pc *prefetchCollection) streamPages(
 	ctx context.Context,
 	as api.Sites,
 	errs *fault.Bus,

--- a/src/internal/m365/collection/site/collection.go
+++ b/src/internal/m365/collection/site/collection.go
@@ -155,7 +155,7 @@ func (pc *prefetchCollection) streamLists(
 		objectSuccesses int64
 	)
 
-	defer finishPopulation(
+	defer updateStatus(
 		ctx,
 		pc.stream,
 		pc.statusUpdater,
@@ -209,7 +209,7 @@ func (pc *prefetchCollection) streamPages(
 		el      = errs.Local()
 	)
 
-	defer finishPopulation(
+	defer updateStatus(
 		ctx,
 		pc.stream,
 		pc.statusUpdater,
@@ -363,7 +363,7 @@ func serializeContent(
 	return byteArray, nil
 }
 
-func finishPopulation(
+func updateStatus(
 	ctx context.Context,
 	stream chan data.Item,
 	su support.StatusUpdater,

--- a/src/internal/m365/collection/site/collection_test.go
+++ b/src/internal/m365/collection/site/collection_test.go
@@ -74,6 +74,7 @@ func (suite *SharePointCollectionSuite) TestCollection_Items() {
 
 	tables := []struct {
 		name, itemName string
+		cat            path.CategoryType
 		scope          selectors.SharePointScope
 		getter         getItemByIDer
 		getDir         func(t *testing.T) path.Path
@@ -82,6 +83,7 @@ func (suite *SharePointCollectionSuite) TestCollection_Items() {
 		{
 			name:     "List",
 			itemName: "MockListing",
+			cat:      path.ListsCategory,
 			scope:    sel.Lists(selectors.Any())[0],
 			getter:   &mock.ListHandler{},
 			getDir: func(t *testing.T) path.Path {
@@ -123,6 +125,7 @@ func (suite *SharePointCollectionSuite) TestCollection_Items() {
 		{
 			name:     "Pages",
 			itemName: "MockPages",
+			cat:      path.PagesCategory,
 			scope:    sel.Pages(selectors.Any())[0],
 			getter:   nil,
 			getDir: func(t *testing.T) path.Path {
@@ -167,7 +170,8 @@ func (suite *SharePointCollectionSuite) TestCollection_Items() {
 				test.scope,
 				nil,
 				control.DefaultOptions())
-			col.stream <- test.getItem(t, test.itemName)
+			col.stream[test.cat] = make(chan data.Item, collectionChannelBufferSize)
+			col.stream[test.cat] <- test.getItem(t, test.itemName)
 
 			readItems := []data.Item{}
 

--- a/src/internal/m365/collection/site/collection_test.go
+++ b/src/internal/m365/collection/site/collection_test.go
@@ -3,7 +3,9 @@ package site
 import (
 	"bytes"
 	"io"
+	"slices"
 	"testing"
+	"time"
 
 	"github.com/alcionai/clues"
 	kioser "github.com/microsoft/kiota-serialization-json-go"
@@ -11,10 +13,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/common/readers"
 	"github.com/alcionai/corso/src/internal/data"
 	"github.com/alcionai/corso/src/internal/m365/collection/site/mock"
 	betaAPI "github.com/alcionai/corso/src/internal/m365/service/sharepoint/api"
 	spMock "github.com/alcionai/corso/src/internal/m365/service/sharepoint/mock"
+	"github.com/alcionai/corso/src/internal/m365/support"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/account"
@@ -25,6 +29,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
+	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
 type SharePointCollectionSuite struct {
@@ -63,7 +68,7 @@ func TestSharePointCollectionSuite(t *testing.T) {
 
 // TestListCollection tests basic functionality to create
 // SharePoint collection and to use the data stream channel.
-func (suite *SharePointCollectionSuite) TestCollection_Items() {
+func (suite *SharePointCollectionSuite) TestPrefetchCollection_Items() {
 	var (
 		tenant  = "some"
 		user    = "user"
@@ -192,4 +197,174 @@ func (suite *SharePointCollectionSuite) TestCollection_Items() {
 			assert.Equal(t, test.itemName, info.SharePoint.ItemName)
 		})
 	}
+}
+
+func (suite *SharePointCollectionSuite) TestLazyCollection_Items() {
+	var (
+		t             = suite.T()
+		errs          = fault.New(true)
+		start         = time.Now().Add(-time.Second)
+		statusUpdater = func(*support.ControllerOperationStatus) {}
+	)
+
+	fullPath, err := path.Build(
+		"t", "pr", path.SharePointService, path.ListsCategory, false, "listid")
+	require.NoError(t, err, clues.ToCore(err))
+
+	tables := []struct {
+		name            string
+		items           map[string]time.Time
+		expectItemCount int
+		expectReads     []string
+	}{
+		{
+			name: "no lists",
+		},
+		{
+			name: "added lists",
+			items: map[string]time.Time{
+				"list1": start.Add(time.Minute),
+				"list2": start.Add(2 * time.Minute),
+				"list3": start.Add(3 * time.Minute),
+			},
+			expectItemCount: 3,
+			expectReads: []string{
+				"list1",
+				"list2",
+				"list3",
+			},
+		},
+	}
+
+	for _, test := range tables {
+		suite.Run(test.name, func() {
+			itemCount := 0
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			getter := &mock.ListHandler{}
+			defer getter.Check(t, test.expectReads)
+
+			col := &lazyFetchCollection{
+				stream:        make(chan data.Item),
+				fullPath:      fullPath,
+				items:         test.items,
+				getter:        getter,
+				statusUpdater: statusUpdater,
+			}
+
+			for item := range col.Items(ctx, errs) {
+				itemCount++
+
+				modTime, aok := test.items[item.ID()]
+				require.True(t, aok, "item must have been added: %q", item.ID())
+				assert.Implements(t, (*data.ItemModTime)(nil), item)
+				assert.Equal(t, modTime, item.(data.ItemModTime).ModTime(), "item mod time")
+
+				if slices.Contains(test.expectReads, item.ID()) {
+					r := item.ToReader()
+
+					_, err := io.ReadAll(r)
+					assert.NoError(t, err, clues.ToCore(err))
+
+					r.Close()
+
+					assert.Implements(t, (*data.ItemInfo)(nil), item)
+					info, err := item.(data.ItemInfo).Info()
+
+					assert.NoError(t, err, clues.ToCore(err))
+					assert.Equal(t, modTime, info.Modified(), "ItemInfo mod time")
+				}
+			}
+
+			assert.NoError(t, errs.Failure())
+			assert.Equal(
+				t,
+				test.expectItemCount,
+				itemCount,
+				"should see all expected items")
+		})
+	}
+}
+
+func (suite *SharePointCollectionSuite) TestLazyItem() {
+	var (
+		t   = suite.T()
+		now = time.Now()
+	)
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	lh := mock.ListHandler{}
+
+	li := data.NewLazyItemWithInfo(
+		ctx,
+		&lazyItemGetter{
+			itemID:  "itemID",
+			getter:  &lh,
+			modTime: now,
+		},
+		"itemID",
+		now,
+		count.New(),
+		fault.New(true))
+
+	assert.Equal(
+		t,
+		now,
+		li.ModTime(),
+		"item mod time")
+
+	r, err := readers.NewVersionedRestoreReader(li.ToReader())
+	require.NoError(t, err, clues.ToCore(err))
+
+	assert.Equal(t, readers.DefaultSerializationVersion, r.Format().Version)
+	assert.False(t, r.Format().DelInFlight)
+
+	readData, err := io.ReadAll(r)
+	require.NoError(t, err, "reading item data: %v", clues.ToCore(err))
+	assert.NotEmpty(t, readData, "read item data")
+
+	info, err := li.Info()
+	require.NoError(t, err, "getting item info: %v", clues.ToCore(err))
+	assert.Equal(t, now, info.Modified())
+}
+
+func (suite *SharePointCollectionSuite) TestLazyItem_ReturnsEmptyReaderOnDeletedInFlight() {
+	var (
+		t   = suite.T()
+		now = time.Now()
+	)
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	lh := mock.ListHandler{
+		Err: graph.ErrDeletedInFlight,
+	}
+
+	li := data.NewLazyItemWithInfo(
+		ctx,
+		&lazyItemGetter{
+			itemID:  "itemID",
+			getter:  &lh,
+			modTime: now,
+		},
+		"itemID",
+		now,
+		count.New(),
+		fault.New(true))
+
+	assert.False(t, li.Deleted(), "item shouldn't be marked deleted")
+	assert.Equal(
+		t,
+		now,
+		li.ModTime(),
+		"item mod time")
+
+	r, err := readers.NewVersionedRestoreReader(li.ToReader())
+	assert.ErrorIs(t, err, graph.ErrDeletedInFlight, "item should be marked deleted in flight")
+	assert.Nil(t, r)
 }

--- a/src/internal/m365/collection/site/collection_test.go
+++ b/src/internal/m365/collection/site/collection_test.go
@@ -160,7 +160,7 @@ func (suite *SharePointCollectionSuite) TestCollection_Items() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			col := NewCollection(
+			col := NewPrefetchCollection(
 				test.getter,
 				test.getDir(t),
 				suite.ac,

--- a/src/internal/m365/collection/site/mock/list.go
+++ b/src/internal/m365/collection/site/mock/list.go
@@ -2,22 +2,28 @@ package mock
 
 import (
 	"context"
+	"slices"
+	"testing"
 
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 )
 
 type ListHandler struct {
-	List models.Listable
-	Err  error
+	List    models.Listable
+	ListIDs []string
+	Err     error
 }
 
 func (lh *ListHandler) GetItemByID(
 	ctx context.Context,
 	itemID string,
 ) (models.Listable, *details.SharePointInfo, error) {
+	lh.ListIDs = append(lh.ListIDs, itemID)
+
 	ls := models.NewList()
 
 	lh.List = ls
@@ -28,6 +34,13 @@ func (lh *ListHandler) GetItemByID(
 	}
 
 	return ls, info, lh.Err
+}
+
+func (lh *ListHandler) Check(t *testing.T, expected []string) {
+	slices.Sort(lh.ListIDs)
+	slices.Sort(expected)
+
+	assert.Equal(t, expected, lh.ListIDs, "expected calls")
 }
 
 type ListRestoreHandler struct {

--- a/src/internal/m365/service/sharepoint/backup.go
+++ b/src/internal/m365/service/sharepoint/backup.go
@@ -65,7 +65,8 @@ func ProduceBackupCollections(
 				creds.AzureTenantID,
 				scope,
 				su,
-				errs)
+				errs,
+				counter)
 			if err != nil {
 				el.AddRecoverable(ctx, err)
 				continue

--- a/src/pkg/services/m365/api/lists_pager_test.go
+++ b/src/pkg/services/m365/api/lists_pager_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/alcionai/clues"
 	"github.com/h2non/gock"
@@ -14,6 +15,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
+	"github.com/alcionai/corso/src/pkg/dttm"
 	graphTD "github.com/alcionai/corso/src/pkg/services/m365/api/graph/testdata"
 )
 
@@ -39,15 +41,16 @@ func (suite *ListsPagerIntgSuite) TestEnumerateLists_withAssociatedRelationships
 		t  = suite.T()
 		ac = suite.its.gockAC.Lists()
 
-		listID            = "fake-list-id"
-		siteID            = suite.its.site.id
-		textColumnDefID   = "fake-text-column-id"
-		textColumnDefName = "itemName"
-		numColumnDefID    = "fake-num-column-id"
-		numColumnDefName  = "itemSize"
-		colLinkID         = "fake-collink-id"
-		cTypeID           = "fake-ctype-id"
-		listItemID        = "fake-list-item-id"
+		listID               = "fake-list-id"
+		listLastModifiedTime = time.Now()
+		siteID               = suite.its.site.id
+		textColumnDefID      = "fake-text-column-id"
+		textColumnDefName    = "itemName"
+		numColumnDefID       = "fake-num-column-id"
+		numColumnDefName     = "itemSize"
+		colLinkID            = "fake-collink-id"
+		cTypeID              = "fake-ctype-id"
+		listItemID           = "fake-list-item-id"
 
 		fieldsData = map[string]any{
 			"itemName": "item1",
@@ -60,7 +63,8 @@ func (suite *ListsPagerIntgSuite) TestEnumerateLists_withAssociatedRelationships
 
 	defer gock.Off()
 
-	suite.setStubListAndItsRelationShip(listID,
+	suite.setStubListAndItsRelationShip(
+		listID,
 		siteID,
 		textColumnDefID,
 		textColumnDefName,
@@ -69,11 +73,24 @@ func (suite *ListsPagerIntgSuite) TestEnumerateLists_withAssociatedRelationships
 		colLinkID,
 		cTypeID,
 		listItemID,
+		listLastModifiedTime,
 		fieldsData)
 
 	lists, err := ac.GetLists(ctx, suite.its.site.id, CallConfig{})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(lists))
+	assert.Equal(t, listID, ptr.Val(lists[0].GetId()))
+
+	expectedLmt, err := dttm.ExtractTime(listLastModifiedTime.String())
+	require.NoError(t, err)
+
+	actualLmt, err := dttm.ExtractTime(ptr.Val(lists[0].GetLastModifiedDateTime()).String())
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		expectedLmt,
+		actualLmt)
 
 	for _, list := range lists {
 		suite.testEnumerateListItems(ctx, list, listItemID, fieldsData)
@@ -242,10 +259,12 @@ func (suite *ListsPagerIntgSuite) setStubListAndItsRelationShip(
 	colLinkID,
 	cTypeID,
 	listItemID string,
+	listLastModifiedTime time.Time,
 	fieldsData map[string]any,
 ) {
 	list := models.NewList()
-	list.SetId(&listID)
+	list.SetId(ptr.To(listID))
+	list.SetLastModifiedDateTime(ptr.To(listLastModifiedTime))
 
 	listCol := models.NewListCollectionResponse()
 	listCol.SetValue([]models.Listable{list})


### PR DESCRIPTION
refactors sharepoint lists collection by:
- renaming `Collection` interface as `preFetchCollection` interface
- making `finishPopulation` method as independent function 
- seralizing list using `serializeContent` function

#### Does this PR need a docs update or release note?
- [x] :no_entry: No

#### Type of change
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)
#4754 

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
