### PR TITLE
Update handling of permissions restore failures

### DIFF
--- a/src/internal/m365/collection/drive/permission.go
+++ b/src/internal/m365/collection/drive/permission.go
@@ -214,7 +214,7 @@ func UpdatePermissions(
 
 		pid, ok := oldPermIDToNewID.Load(p.ID)
 		if !ok {
-			logger.Ctx(ictx).Info("Unable to delete permission")
+			el.AddRecoverable(ictx, clues.NewWC(ictx, "finding updated permission id"))
 			continue
 		}
 

--- a/src/internal/m365/collection/drive/permission.go
+++ b/src/internal/m365/collection/drive/permission.go
@@ -285,6 +285,7 @@ func UpdatePermissions(
 		if graph.IsErrUsersCannotBeResolved(err) {
 			oldPermIDToNewID.Store(p.ID, "") // empty to signify that we could not restore
 			logger.CtxErr(ictx, err).Info("Unable to restore permission")
+
 			continue
 		}
 
@@ -394,6 +395,7 @@ func UpdateLinkShares(
 		if graph.IsErrUsersCannotBeResolved(err) {
 			oldLinkShareIDToNewID.Store(ls.ID, "") // empty to signify that we could not restore
 			logger.CtxErr(ictx, err).Info("Unable to restore link share")
+
 			continue
 		}
 
@@ -483,7 +485,7 @@ func RestorePermissions(
 		caches.OldLinkShareIDToNewID,
 		errs)
 	if err != nil {
-		return clues.Wrap(err, "updating link shares")
+		errs.AddRecoverable(ctx, clues.WrapWC(ctx, err, "updating link shares"))
 	}
 
 	previous, err := computePreviousMetadata(ctx, itemPath, caches.ParentDirToMeta)
@@ -517,5 +519,9 @@ func RestorePermissions(
 		return nil
 	}
 
-	return clues.Wrap(err, "updating permissions").OrNil()
+	if err != nil {
+		errs.AddRecoverable(ctx, clues.WrapWC(ctx, err, "updating permissions"))
+	}
+
+	return nil
 }

--- a/src/internal/m365/collection/drive/permission_test.go
+++ b/src/internal/m365/collection/drive/permission_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/common/syncd"
 	"github.com/alcionai/corso/src/internal/m365/collection/drive/metadata"
 	odConsts "github.com/alcionai/corso/src/internal/m365/service/onedrive/consts"
@@ -175,7 +176,10 @@ func runComputeParentPermissionsTest(
 	}
 }
 
-type mockUdip struct{}
+type mockUdip struct {
+	// cannot use []bool as this is not passed by ref
+	success chan bool
+}
 
 func (mockUdip) DeleteItemPermission(
 	ctx context.Context,
@@ -184,13 +188,27 @@ func (mockUdip) DeleteItemPermission(
 	return nil
 }
 
-func (mockUdip) PostItemPermissionUpdate(
+func (m mockUdip) PostItemPermissionUpdate(
 	ctx context.Context,
 	driveID, itemID string,
 	body *drives.ItemItemsItemInvitePostRequestBody,
 ) (drives.ItemItemsItemInviteResponseable, error) {
-	err := graphTD.ODataErrWithMsg("InvalidRequest", string("One or more users could not be resolved"))
-	return nil, err
+	if ptr.Val(body.GetRecipients()[0].GetObjectId()) == "failure" {
+		m.success <- false
+
+		err := graphTD.ODataErrWithMsg("InvalidRequest", string("One or more users could not be resolved"))
+
+		return nil, err
+	}
+
+	m.success <- true
+
+	resp := drives.NewItemItemsItemInviteResponse()
+	perm := models.NewPermission()
+	perm.SetId(ptr.To(itemID))
+	resp.SetValue([]models.Permissionable{perm})
+
+	return resp, nil
 }
 
 func (suite *PermissionsUnitTestSuite) TestPermissionRestoreNonExistentUser() {
@@ -199,20 +217,40 @@ func (suite *PermissionsUnitTestSuite) TestPermissionRestoreNonExistentUser() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
+	successChan := make(chan bool, 3)
+	m := mockUdip{
+		success: successChan,
+	}
+
 	err := UpdatePermissions(
 		ctx,
-		mockUdip{},
+		&m,
 		"drive-id",
 		"item-id",
-		[]metadata.Permission{{Roles: []string{"write"}, EntityID: "user-id"}},
+		[]metadata.Permission{
+			{Roles: []string{"write"}, EntityID: "user-id1"},
+			{Roles: []string{"write"}, EntityID: "failure"},
+			{Roles: []string{"write"}, EntityID: "user-id2"},
+		},
 		[]metadata.Permission{},
 		syncd.NewMapTo[string](),
 		fault.New(true))
 
 	assert.NoError(t, err, "update permissions")
+	close(successChan)
+
+	var successValues []bool
+	for success := range successChan {
+		successValues = append(successValues, success)
+	}
+
+	expectedSuccessValues := []bool{true, false, true}
+	assert.Equal(t, expectedSuccessValues, successValues)
 }
 
-type mockUpils struct{}
+type mockUpils struct {
+	success chan bool
+}
 
 func (mockUpils) DeleteItemPermission(
 	ctx context.Context,
@@ -221,13 +259,34 @@ func (mockUpils) DeleteItemPermission(
 	return nil
 }
 
-func (mockUpils) PostItemLinkShareUpdate(
+func (m mockUpils) PostItemLinkShareUpdate(
 	ctx context.Context,
 	driveID, itemID string,
 	body *drives.ItemItemsItemCreateLinkPostRequestBody,
 ) (models.Permissionable, error) {
-	err := graphTD.ODataErrWithMsg("InvalidRequest", string("One or more users could not be resolved"))
-	return nil, err
+	shouldFail := false
+
+	recip := body.GetAdditionalData()["recipients"].([]map[string]string)
+	for _, r := range recip {
+		if r["objectId"] == "failure" {
+			shouldFail = true
+		}
+	}
+
+	if shouldFail {
+		m.success <- false
+
+		err := graphTD.ODataErrWithMsg("InvalidRequest", string("One or more users could not be resolved"))
+
+		return nil, err
+	}
+
+	m.success <- true
+
+	perm := models.NewPermission()
+	perm.SetId(ptr.To(itemID))
+
+	return perm, nil
 }
 
 func (suite *PermissionsUnitTestSuite) TestLinkShareRestoreNonExistentUser() {
@@ -236,15 +295,34 @@ func (suite *PermissionsUnitTestSuite) TestLinkShareRestoreNonExistentUser() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
+	successChan := make(chan bool, 10) // 7 required
+	m := mockUpils{
+		success: successChan,
+	}
+
 	_, err := UpdateLinkShares(
 		ctx,
-		mockUpils{},
+		&m,
 		"drive-id",
 		"item-id",
-		[]metadata.LinkShare{{Roles: []string{"write"}, Entities: []metadata.Entity{{ID: "user-id"}}}},
+		[]metadata.LinkShare{
+			{Roles: []string{"write"}, Entities: []metadata.Entity{{ID: "user-id"}}},
+			{Roles: []string{"write"}, Entities: []metadata.Entity{{ID: "failure"}}},
+			{Roles: []string{"write"}, Entities: []metadata.Entity{{ID: "user-id"}, {ID: "failure"}}},
+			{Roles: []string{"write"}, Entities: []metadata.Entity{{ID: "user-id"}, {ID: "failure"}, {ID: "user-id"}}},
+		},
 		[]metadata.LinkShare{},
 		syncd.NewMapTo[string](),
 		fault.New(true))
 
 	assert.NoError(t, err, "update permissions")
+	close(successChan)
+
+	var successValues []bool
+	for success := range successChan {
+		successValues = append(successValues, success)
+	}
+
+	expectedSuccessValues := []bool{true, false, false, false}
+	assert.Equal(t, expectedSuccessValues, successValues)
 }

--- a/src/internal/m365/collection/drive/restore.go
+++ b/src/internal/m365/collection/drive/restore.go
@@ -452,7 +452,7 @@ func restoreV1File(
 		return details.ItemInfo{}, clues.Wrap(err, "restoring file")
 	}
 
-	err = RestorePermissions(
+	RestorePermissions(
 		ctx,
 		rh,
 		drivePath.DriveID,
@@ -461,9 +461,6 @@ func restoreV1File(
 		meta,
 		caches,
 		errs)
-	if err != nil {
-		return details.ItemInfo{}, clues.Wrap(err, "restoring item permissions")
-	}
 
 	return itemInfo, nil
 }
@@ -530,7 +527,7 @@ func restoreV6File(
 		return itemInfo, nil
 	}
 
-	err = RestorePermissions(
+	RestorePermissions(
 		ctx,
 		rh,
 		drivePath.DriveID,
@@ -539,9 +536,6 @@ func restoreV6File(
 		meta,
 		caches,
 		errs)
-	if err != nil {
-		return details.ItemInfo{}, clues.Wrap(err, "restoring item permissions")
-	}
 
 	return itemInfo, nil
 }
@@ -581,7 +575,7 @@ func CreateRestoreFolders(
 		return id, nil
 	}
 
-	err = RestorePermissions(
+	RestorePermissions(
 		ctx,
 		rh,
 		drivePath.DriveID,
@@ -590,12 +584,6 @@ func CreateRestoreFolders(
 		folderMetadata,
 		caches,
 		errs)
-
-	if err != nil {
-		// We should not ideally get any errors as we mostly skip
-		// over them with a recoverable error. This is just in case.
-		errs.AddRecoverable(ctx, clues.Wrap(err, "restoring folder permissions"))
-	}
 
 	return id, nil
 }

--- a/src/internal/m365/collection/drive/restore.go
+++ b/src/internal/m365/collection/drive/restore.go
@@ -591,7 +591,13 @@ func CreateRestoreFolders(
 		caches,
 		errs)
 
-	return id, err
+	if err != nil {
+		// We should not ideally get any errors as we mostly skip
+		// over them with a recoverable error. This is just in case.
+		errs.AddRecoverable(ctx, clues.Wrap(err, "restoring folder permissions"))
+	}
+
+	return id, nil
 }
 
 type folderRestorer interface {


### PR DESCRIPTION
- All permissions failures are now recoverable to the granularity of a single permission or link share
- Failure to delete child permissions because the permission was not restored on parent will now not produce any warnings

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
