### PR TITLE
hide failed-items flag

### DIFF
--- a/src/cli/backup/backup.go
+++ b/src/cli/backup/backup.go
@@ -334,7 +334,7 @@ func genericListCommand(
 		fe.PrintItems(
 			ctx,
 			!ifShow(flags.ListAlertsFV),
-			!ifShow(flags.ListFailedItemsFV),
+			!ifShow(flags.FailedItemsFV),
 			!ifShow(flags.ListSkippedItemsFV),
 			!ifShow(flags.ListRecoveredErrorsFV))
 

--- a/src/cli/flags/backup_list.go
+++ b/src/cli/flags/backup_list.go
@@ -12,9 +12,11 @@ func AddAllBackupListFlags(cmd *cobra.Command) {
 }
 
 func AddFailedItemsFN(cmd *cobra.Command) {
-	cmd.Flags().StringVar(
-		&ListFailedItemsFV, FailedItemsFN, Show,
+	fs := cmd.Flags()
+	fs.StringVar(
+		&FailedItemsFV, FailedItemsFN, Show,
 		"Toggles showing or hiding the list of items that failed.")
+	cobra.CheckErr(fs.MarkHidden(FailedItemsFN))
 }
 
 func AddSkippedItemsFN(cmd *cobra.Command) {

--- a/src/cli/flags/options.go
+++ b/src/cli/flags/options.go
@@ -17,9 +17,9 @@ const (
 	FailFastFN                    = "fail-fast"
 	FailedItemsFN                 = "failed-items"
 	FetchParallelismFN            = "fetch-parallelism"
+	NoPermissionsFN               = "no-permissions"
 	NoStatsFN                     = "no-stats"
 	RecoveredErrorsFN             = "recovered-errors"
-	NoPermissionsFN               = "no-permissions"
 	RunModeFN                     = "run-mode"
 	SkippedItemsFN                = "skipped-items"
 	SkipReduceFN                  = "skip-reduce"
@@ -40,12 +40,12 @@ var (
 	ListAlertsFV                  string
 	ListSkippedItemsFV            string
 	ListRecoveredErrorsFV         string
+	NoPermissionsFV               bool
 	NoStatsFV                     bool
 	// RunMode describes the type of run, such as:
 	// flagtest, dry, run.  Should default to 'run'.
-	RunModeFV       string
-	NoPermissionsFV bool
-	SkipReduceFV    bool
+	RunModeFV    string
+	SkipReduceFV bool
 )
 
 // well-known flag values

--- a/src/cli/flags/options.go
+++ b/src/cli/flags/options.go
@@ -35,9 +35,9 @@ var (
 	ForceItemDataDownloadFV       bool
 	EnableImmutableIDFV           bool
 	FailFastFV                    bool
+	FailedItemsFV                 string
 	FetchParallelismFV            int
 	ListAlertsFV                  string
-	ListFailedItemsFV             string
 	ListSkippedItemsFV            string
 	ListRecoveredErrorsFV         string
 	NoStatsFV                     bool

--- a/src/cli/flags/testdata/backup_list.go
+++ b/src/cli/flags/testdata/backup_list.go
@@ -20,7 +20,7 @@ func PreparedBackupListFlags() []string {
 
 func AssertBackupListFlags(t *testing.T, cmd *cobra.Command) {
 	assert.Equal(t, flags.Show, flags.ListAlertsFV)
-	assert.Equal(t, flags.Show, flags.ListFailedItemsFV)
+	assert.Equal(t, flags.Show, flags.FailedItemsFV)
 	assert.Equal(t, flags.Show, flags.ListSkippedItemsFV)
 	assert.Equal(t, flags.Show, flags.ListRecoveredErrorsFV)
 }

--- a/src/go.mod
+++ b/src/go.mod
@@ -53,13 +53,15 @@ require (
 	gotest.tools/v3 v3.5.1
 )
 
-require github.com/emersion/go-vcard v0.0.0-20230815062825-8fda7d206ec9
+require (
+	github.com/arran4/golang-ical v0.2.3
+	github.com/emersion/go-vcard v0.0.0-20230815062825-8fda7d206ec9
+)
 
 require (
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/andybalholm/brotli v1.0.6 // indirect
-	github.com/arran4/golang-ical v0.2.3 // indirect
 	github.com/aws/aws-sdk-go v1.48.6 // indirect
 	github.com/cention-sany/utf7 v0.0.0-20170124080048-26cad61bd60a // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect


### PR DESCRIPTION
This flag is a guaranteed no-op since the error handling settings that allow for no-failure backups are not exposed in the CLI either.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
