### PR TITLE
centralize core err interpretation

### DIFF
--- a/src/cli/backup/helpers_test.go
+++ b/src/cli/backup/helpers_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/repository"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
-	gmock "github.com/alcionai/corso/src/pkg/services/m365/api/graph/mock"
 	"github.com/alcionai/corso/src/pkg/storage"
 	"github.com/alcionai/corso/src/pkg/storage/testdata"
 )
@@ -37,12 +36,12 @@ import (
 // GockClient produces a new exchange api client that can be
 // mocked using gock.
 func gockClient(creds account.M365Config, counter *count.Bus) (api.Client, error) {
-	s, err := gmock.NewService(creds, counter)
+	s, err := graph.NewGockService(creds, counter)
 	if err != nil {
 		return api.Client{}, err
 	}
 
-	li, err := gmock.NewService(creds, counter, graph.NoTimeout())
+	li, err := graph.NewGockService(creds, counter, graph.NoTimeout())
 	if err != nil {
 		return api.Client{}, err
 	}

--- a/src/internal/m365/controller.go
+++ b/src/internal/m365/controller.go
@@ -255,15 +255,7 @@ func (r resourceGetter) GetResourceIDAndNameFrom(
 
 	id, name, err = r.getter.GetIDAndName(ctx, owner, api.CallConfig{})
 	if err != nil {
-		if graph.IsErrUserNotFound(err) {
-			return nil, clues.Stack(core.ErrResourceOwnerNotFound, err)
-		}
-
-		if graph.IsErrResourceLocked(err) {
-			return nil, clues.Stack(graph.ErrResourceLocked, err)
-		}
-
-		return nil, err
+		return nil, clues.Stack(err)
 	}
 
 	if len(id) == 0 || len(name) == 0 {

--- a/src/internal/m365/service/exchange/enabled_test.go
+++ b/src/internal/m365/service/exchange/enabled_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/errs/core"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 	graphTD "github.com/alcionai/corso/src/pkg/services/m365/api/graph/testdata"
@@ -91,9 +92,10 @@ func (suite *EnabledUnitSuite) TestIsServiceEnabled() {
 			name: "overlapping resourcenotfound",
 			mock: func(ctx context.Context) getMailInboxer {
 				odErr := graphTD.ODataErrWithMsg(string(graph.ResourceNotFound), "User not found")
+				err := clues.Stack(core.ErrResourceOwnerNotFound, odErr)
 
 				return mockGMB{
-					mailboxErr: graph.Stack(ctx, odErr),
+					mailboxErr: graph.Stack(ctx, err),
 				}
 			},
 			expect:    assert.False,

--- a/src/internal/m365/service/onedrive/enabled.go
+++ b/src/internal/m365/service/onedrive/enabled.go
@@ -6,7 +6,6 @@ import (
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
-	"github.com/alcionai/corso/src/pkg/errs/core"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
@@ -25,14 +24,6 @@ func IsServiceEnabled(
 		// answers the question the caller is asking.
 		if clues.HasLabel(err, graph.LabelsMysiteNotFound) || clues.HasLabel(err, graph.LabelsNoSharePointLicense) {
 			return false, nil
-		}
-
-		if graph.IsErrUserNotFound(err) {
-			return false, clues.Stack(core.ErrResourceOwnerNotFound, err)
-		}
-
-		if graph.IsErrResourceLocked(err) {
-			return false, clues.Stack(graph.ErrResourceLocked, err)
 		}
 
 		return false, clues.Stack(err)

--- a/src/internal/operations/test/m365/helper.go
+++ b/src/internal/operations/test/m365/helper.go
@@ -34,7 +34,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
-	gmock "github.com/alcionai/corso/src/pkg/services/m365/api/graph/mock"
 )
 
 // ---------------------------------------------------------------------------
@@ -44,12 +43,12 @@ import (
 // GockClient produces a new exchange api client that can be
 // mocked using gock.
 func GockClient(creds account.M365Config, counter *count.Bus) (api.Client, error) {
-	s, err := gmock.NewService(creds, counter)
+	s, err := graph.NewGockService(creds, counter)
 	if err != nil {
 		return api.Client{}, err
 	}
 
-	li, err := gmock.NewService(creds, counter, graph.NoTimeout())
+	li, err := graph.NewGockService(creds, counter, graph.NoTimeout())
 	if err != nil {
 		return api.Client{}, err
 	}

--- a/src/pkg/errs/errs.go
+++ b/src/pkg/errs/errs.go
@@ -24,10 +24,7 @@ type ErrCheck func(error) bool
 // checks.  This allows us to apply those comparison checks instead of relying
 // only on sentinels.
 var externalToInternalCheck = map[*core.Err][]ErrCheck{
-	core.ErrApplicationThrottled:      {graph.IsErrApplicationThrottled},
-	core.ErrResourceNotAccessible:     {graph.IsErrResourceLocked},
-	core.ErrResourceOwnerNotFound:     {graph.IsErrItemNotFound},
-	core.ErrInsufficientAuthorization: {graph.IsErrInsufficientAuthorization},
+	core.ErrResourceOwnerNotFound: {graph.IsErrItemNotFound},
 }
 
 // Internal returns the internal errors and error checking functions which

--- a/src/pkg/errs/errs_test.go
+++ b/src/pkg/errs/errs_test.go
@@ -57,12 +57,6 @@ func (suite *ErrUnitSuite) TestInternal_checks() {
 		expect          assert.BoolAssertionFunc
 	}{
 		{
-			get:             core.ErrApplicationThrottled,
-			err:             graphTD.ODataErr(string(graph.ApplicationThrottled)),
-			expectHasChecks: assert.NotEmpty,
-			expect:          assert.True,
-		},
-		{
 			get:             core.ErrRepoAlreadyExists,
 			err:             graphTD.ODataErr(string(graph.ApplicationThrottled)),
 			expectHasChecks: assert.Empty,
@@ -83,18 +77,6 @@ func (suite *ErrUnitSuite) TestInternal_checks() {
 		{
 			get:             core.ErrResourceOwnerNotFound,
 			err:             graphTD.ODataErr(string(graph.ErrorItemNotFound)),
-			expectHasChecks: assert.NotEmpty,
-			expect:          assert.True,
-		},
-		{
-			get:             core.ErrResourceNotAccessible,
-			err:             graph.ErrResourceLocked,
-			expectHasChecks: assert.NotEmpty,
-			expect:          assert.True,
-		},
-		{
-			get:             core.ErrInsufficientAuthorization,
-			err:             graphTD.ODataErr(string(graph.AuthorizationRequestDenied)),
 			expectHasChecks: assert.NotEmpty,
 			expect:          assert.True,
 		},
@@ -137,10 +119,6 @@ func (suite *ErrUnitSuite) TestIs() {
 		{
 			target: core.ErrResourceNotAccessible,
 			err:    graph.ErrResourceLocked,
-		},
-		{
-			target: core.ErrInsufficientAuthorization,
-			err:    graphTD.ODataErr(string(graph.AuthorizationRequestDenied)),
 		},
 	}
 	for _, test := range table {

--- a/src/pkg/services/m365/api/graph/errors.go
+++ b/src/pkg/services/m365/api/graph/errors.go
@@ -18,6 +18,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/jwt"
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/common/str"
+	"github.com/alcionai/corso/src/pkg/errs/core"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/filters"
 	"github.com/alcionai/corso/src/pkg/services/m365/custom"
@@ -134,7 +135,26 @@ var (
 	ErrTokenExpired = clues.New("jwt token expired")
 )
 
-func IsErrApplicationThrottled(err error) bool {
+func stackErrsCore(ctx context.Context, err error, traceDepth int) error {
+	if err == nil {
+		return nil
+	}
+
+	switch {
+	case isErrApplicationThrottled(err):
+		return clues.StackWC(ctx, core.ErrApplicationThrottled, err).WithTrace(traceDepth + 1)
+	case isErrUserNotFound(err):
+		return clues.StackWC(ctx, core.ErrResourceOwnerNotFound, err).WithTrace(traceDepth + 1)
+	case isErrResourceLocked(err):
+		return clues.StackWC(ctx, core.ErrResourceNotAccessible, err).WithTrace(traceDepth + 1)
+	case isErrInsufficientAuthorization(err):
+		return clues.StackWC(ctx, core.ErrInsufficientAuthorization, err).WithTrace(traceDepth + 1)
+	}
+
+	return err
+}
+
+func isErrApplicationThrottled(err error) bool {
 	return parseODataErr(err).hasErrorCode(err, ApplicationThrottled)
 }
 
@@ -142,7 +162,7 @@ func IsErrAuthenticationError(err error) bool {
 	return parseODataErr(err).hasErrorCode(err, AuthenticationError)
 }
 
-func IsErrInsufficientAuthorization(err error) bool {
+func isErrInsufficientAuthorization(err error) bool {
 	return parseODataErr(err).hasErrorCode(err, AuthorizationRequestDenied)
 }
 
@@ -189,7 +209,7 @@ func IsErrExchangeMailFolderNotFound(err error) bool {
 	return parseODataErr(err).hasErrorCode(err, ResourceNotFound, ErrorItemNotFound, MailboxNotEnabledForRESTAPI)
 }
 
-func IsErrUserNotFound(err error) bool {
+func isErrUserNotFound(err error) bool {
 	ode := parseODataErr(err)
 
 	if ode.hasErrorCode(err, RequestResourceNotFound, invalidUser) {
@@ -281,7 +301,7 @@ func IsErrSiteNotFound(err error) bool {
 	return parseODataErr(err).hasErrorMessage(err, requestedSiteCouldNotBeFound)
 }
 
-func IsErrResourceLocked(err error) bool {
+func isErrResourceLocked(err error) bool {
 	ode := parseODataErr(err)
 
 	return errors.Is(err, ErrResourceLocked) ||

--- a/src/pkg/services/m365/api/graph/errors.go
+++ b/src/pkg/services/m365/api/graph/errors.go
@@ -147,10 +147,10 @@ func stackWithCoreErr(ctx context.Context, err error, traceDepth int) error {
 	switch {
 	case isErrApplicationThrottled(err):
 		err = clues.Stack(core.ErrApplicationThrottled, err)
-	case isErrUserNotFound(err):
-		err = clues.Stack(core.ErrResourceOwnerNotFound, err)
 	case isErrResourceLocked(err):
 		err = clues.Stack(core.ErrResourceNotAccessible, err)
+	case isErrUserNotFound(err):
+		err = clues.Stack(core.ErrResourceOwnerNotFound, err)
 	case isErrInsufficientAuthorization(err):
 		err = clues.Stack(core.ErrInsufficientAuthorization, err)
 	}

--- a/src/pkg/services/m365/api/graph/errors_test.go
+++ b/src/pkg/services/m365/api/graph/errors_test.go
@@ -85,7 +85,7 @@ func (suite *GraphErrorsUnitSuite) TestIsErrApplicationThrottled() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			test.expect(suite.T(), IsErrApplicationThrottled(test.err))
+			test.expect(suite.T(), isErrApplicationThrottled(test.err))
 		})
 	}
 }
@@ -153,7 +153,7 @@ func (suite *GraphErrorsUnitSuite) TestIsErrInsufficientAuthorization() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			test.expect(suite.T(), IsErrInsufficientAuthorization(test.err))
+			test.expect(suite.T(), isErrInsufficientAuthorization(test.err))
 		})
 	}
 }
@@ -481,7 +481,7 @@ func (suite *GraphErrorsUnitSuite) TestIsErrUserNotFound() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			test.expect(suite.T(), IsErrUserNotFound(test.err))
+			test.expect(suite.T(), isErrUserNotFound(test.err))
 		})
 	}
 }
@@ -968,7 +968,7 @@ func (suite *GraphErrorsUnitSuite) TestIsErrResourceLocked() {
 	}
 	for _, test := range table {
 		suite.Run(test.name, func() {
-			test.expect(suite.T(), IsErrResourceLocked(test.err))
+			test.expect(suite.T(), isErrResourceLocked(test.err))
 		})
 	}
 }

--- a/src/pkg/services/m365/api/graph/http_wrapper.go
+++ b/src/pkg/services/m365/api/graph/http_wrapper.go
@@ -120,8 +120,12 @@ func (hw httpWrapper) Request(
 			break
 		}
 
-		if IsErrApplicationThrottled(err) {
-			return nil, Stack(ctx, clues.Stack(core.ErrApplicationThrottled, err))
+		err = stackErrsCore(ctx, err, 1)
+
+		// force an early exit on throttling issues.
+		// those retries are already handled in middleware.
+		if errors.Is(err, core.ErrApplicationThrottled) {
+			return nil, err
 		}
 
 		var http2StreamErr http2.StreamError

--- a/src/pkg/services/m365/api/graph/http_wrapper.go
+++ b/src/pkg/services/m365/api/graph/http_wrapper.go
@@ -120,7 +120,7 @@ func (hw httpWrapper) Request(
 			break
 		}
 
-		err = stackErrsCore(ctx, err, 1)
+		err = stackWithCoreErr(ctx, err, 1)
 
 		// force an early exit on throttling issues.
 		// those retries are already handled in middleware.
@@ -130,7 +130,7 @@ func (hw httpWrapper) Request(
 
 		var http2StreamErr http2.StreamError
 		if !errors.As(err, &http2StreamErr) {
-			return nil, Stack(ctx, err)
+			return nil, err
 		}
 
 		logger.Ctx(ctx).Debug("http2 stream error")
@@ -140,7 +140,7 @@ func (hw httpWrapper) Request(
 	}
 
 	if err != nil {
-		return nil, Stack(ctx, err)
+		return nil, err
 	}
 
 	logResp(ctx, resp)

--- a/src/pkg/services/m365/api/graph/http_wrapper.go
+++ b/src/pkg/services/m365/api/graph/http_wrapper.go
@@ -102,7 +102,9 @@ func (hw httpWrapper) Request(
 	// See https://learn.microsoft.com/en-us/sharepoint/dev/general-development/how-to-avoid-getting-throttled-or-blocked-in-sharepoint-online#how-to-decorate-your-http-traffic
 	req.Header.Set("User-Agent", "ISV|Alcion|Corso/"+version.Version)
 
-	var resp *http.Response
+	retriedErrors := []string{}
+
+	var e error
 
 	// stream errors from http/2 will fail before we reach
 	// client middleware handling, therefore we don't get to
@@ -111,33 +113,41 @@ func (hw httpWrapper) Request(
 	// retry in the event of a `stream error`, which is not
 	// a common expectation.
 	for i := 0; i < hw.config.maxConnectionRetries+1; i++ {
+		if i > 0 {
+			time.Sleep(3 * time.Second)
+		}
+
 		ctx = clues.Add(ctx, "request_retry_iter", i)
 
-		resp, err = hw.client.Do(req)
+		resp, err := hw.client.Do(req)
 		if err == nil {
-			break
+			logResp(ctx, resp)
+			return resp, nil
 		}
 
 		err = stackWithCoreErr(ctx, err, 1)
+		e = err
 
 		var http2StreamErr http2.StreamError
 		if !errors.As(err, &http2StreamErr) {
-			return nil, err
+			// exit most errors without retry
+			break
 		}
 
 		logger.Ctx(ctx).Debug("http2 stream error")
 		events.Inc(events.APICall, "streamerror")
 
-		time.Sleep(3 * time.Second)
+		retriedErrors = append(retriedErrors, err.Error())
 	}
 
-	if err != nil {
-		return nil, err
-	}
+	e = clues.Stack(e).
+		With("retried_errors", retriedErrors).
+		WithTrace(1).
+		OrNil()
 
-	logResp(ctx, resp)
-
-	return resp, nil
+	// no chance of a non-error return here.
+	// we handle that inside the loop.
+	return nil, e
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/services/m365/api/graph/http_wrapper.go
+++ b/src/pkg/services/m365/api/graph/http_wrapper.go
@@ -14,7 +14,6 @@ import (
 	"github.com/alcionai/corso/src/internal/events"
 	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/count"
-	"github.com/alcionai/corso/src/pkg/errs/core"
 	"github.com/alcionai/corso/src/pkg/logger"
 )
 
@@ -115,18 +114,11 @@ func (hw httpWrapper) Request(
 		ctx = clues.Add(ctx, "request_retry_iter", i)
 
 		resp, err = hw.client.Do(req)
-
 		if err == nil {
 			break
 		}
 
 		err = stackWithCoreErr(ctx, err, 1)
-
-		// force an early exit on throttling issues.
-		// those retries are already handled in middleware.
-		if errors.Is(err, core.ErrApplicationThrottled) {
-			return nil, err
-		}
 
 		var http2StreamErr http2.StreamError
 		if !errors.As(err, &http2StreamErr) {

--- a/src/pkg/services/m365/api/graph/http_wrapper_test.go
+++ b/src/pkg/services/m365/api/graph/http_wrapper_test.go
@@ -182,7 +182,6 @@ func (suite *HTTPWrapperUnitSuite) TestNewHTTPWrapper_http2StreamErrorRetries() 
 
 			_, err := hw.Request(ctx, http.MethodGet, url, nil, nil)
 			require.ErrorAs(t, err, &http2.StreamError{}, clues.ToCore(err))
-
 			require.Equal(t, test.expectRetries, tries, "count of retries")
 		})
 	}

--- a/src/pkg/services/m365/api/graph/service.go
+++ b/src/pkg/services/m365/api/graph/service.go
@@ -403,7 +403,7 @@ func (aw *adapterWrap) Send(
 			break
 		}
 
-		err = stackErrsCore(ictx, err, 1)
+		err = stackWithCoreErr(ictx, err, 1)
 
 		// force an early exit on throttling issues.
 		// those retries are already handled in middleware.
@@ -427,11 +427,15 @@ func (aw *adapterWrap) Send(
 			logger.Ctx(ictx).Debug("invalid request")
 			events.Inc(events.APICall, "invalidrequest")
 		default:
-			return nil, clues.StackWC(ictx, err).WithTrace(1)
+			return nil, err
 		}
 
 		time.Sleep(aw.retryDelay)
 	}
 
-	return sp, clues.Stack(err).OrNil()
+	if err != nil {
+		return nil, err
+	}
+
+	return sp, nil
 }

--- a/src/pkg/services/m365/api/graph/service.go
+++ b/src/pkg/services/m365/api/graph/service.go
@@ -13,13 +13,11 @@ import (
 	khttp "github.com/microsoft/kiota-http-go"
 	msgraphsdkgo "github.com/microsoftgraph/msgraph-sdk-go"
 	msgraphgocore "github.com/microsoftgraph/msgraph-sdk-go-core"
-	"github.com/pkg/errors"
 
 	"github.com/alcionai/corso/src/internal/common/crash"
 	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/events"
 	"github.com/alcionai/corso/src/pkg/count"
-	"github.com/alcionai/corso/src/pkg/errs/core"
 	"github.com/alcionai/corso/src/pkg/filters"
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -404,12 +402,6 @@ func (aw *adapterWrap) Send(
 		}
 
 		err = stackWithCoreErr(ictx, err, 1)
-
-		// force an early exit on throttling issues.
-		// those retries are already handled in middleware.
-		if errors.Is(err, core.ErrApplicationThrottled) {
-			return nil, err
-		}
 
 		// exit most errors without retry
 		switch {

--- a/src/pkg/services/m365/api/groups.go
+++ b/src/pkg/services/m365/api/groups.go
@@ -11,6 +11,7 @@ import (
 	msgraphgocore "github.com/microsoftgraph/msgraph-sdk-go-core"
 	"github.com/microsoftgraph/msgraph-sdk-go/groups"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/pkg/errors"
 
 	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/common/ptr"
@@ -133,10 +134,6 @@ func (c Groups) GetTeamByID(
 
 	t, err := c.Stable.Client().Teams().ByTeamId(identifier).Get(ctx, nil)
 	if err != nil {
-		if graph.IsErrResourceLocked(err) {
-			return nil, graph.Stack(ctx, clues.Stack(graph.ErrResourceLocked, err))
-		}
-
 		return nil, graph.Wrap(ctx, err, "finding team by ID")
 	}
 
@@ -172,8 +169,8 @@ func (c Groups) GetByID(
 			return group, nil
 		}
 
-		if graph.IsErrResourceLocked(err) {
-			return nil, graph.Stack(ctx, clues.Stack(graph.ErrResourceLocked, err))
+		if errors.Is(err, core.ErrResourceNotAccessible) {
+			return nil, graph.Stack(ctx, err)
 		}
 
 		logger.CtxErr(ctx, err).Info("finding group by id, falling back to secondary identifier")
@@ -194,8 +191,8 @@ func (c Groups) GetByID(
 			return getGroupFromResponse(ctx, resp)
 		}
 
-		if graph.IsErrResourceLocked(err) {
-			err = clues.Stack(graph.ErrResourceLocked, err)
+		if errors.Is(err, core.ErrResourceNotAccessible) {
+			return nil, graph.Stack(ctx, err)
 		}
 
 		logger.CtxErr(ctx, err).Info("finding group by email, falling back to display name")
@@ -211,10 +208,6 @@ func (c Groups) GetByID(
 
 	resp, err := c.Stable.Client().Groups().Get(ctx, opts)
 	if err != nil {
-		if graph.IsErrResourceLocked(err) {
-			err = clues.Stack(graph.ErrResourceLocked, err)
-		}
-
 		return nil, graph.Wrap(ctx, err, "finding group by display name")
 	}
 

--- a/src/pkg/services/m365/api/groups.go
+++ b/src/pkg/services/m365/api/groups.go
@@ -170,7 +170,7 @@ func (c Groups) GetByID(
 		}
 
 		if errors.Is(err, core.ErrResourceNotAccessible) {
-			return nil, graph.Stack(ctx, err)
+			return nil, err
 		}
 
 		logger.CtxErr(ctx, err).Info("finding group by id, falling back to secondary identifier")
@@ -192,7 +192,7 @@ func (c Groups) GetByID(
 		}
 
 		if errors.Is(err, core.ErrResourceNotAccessible) {
-			return nil, graph.Stack(ctx, err)
+			return nil, err
 		}
 
 		logger.CtxErr(ctx, err).Info("finding group by email, falling back to display name")

--- a/src/pkg/services/m365/api/helper_test.go
+++ b/src/pkg/services/m365/api/helper_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/count"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
-	gmock "github.com/alcionai/corso/src/pkg/services/m365/api/graph/mock"
 )
 
 // ---------------------------------------------------------------------------
@@ -25,12 +24,12 @@ import (
 // GockClient produces a new exchange api client that can be
 // mocked using gock.
 func gockClient(creds account.M365Config, counter *count.Bus) (Client, error) {
-	s, err := gmock.NewService(creds, counter)
+	s, err := graph.NewGockService(creds, counter)
 	if err != nil {
 		return Client{}, err
 	}
 
-	li, err := gmock.NewService(creds, counter, graph.NoTimeout())
+	li, err := graph.NewGockService(creds, counter, graph.NoTimeout())
 	if err != nil {
 		return Client{}, err
 	}

--- a/src/pkg/services/m365/api/sites.go
+++ b/src/pkg/services/m365/api/sites.go
@@ -157,10 +157,6 @@ func (c Sites) GetByID(
 				err = clues.Stack(core.ErrResourceOwnerNotFound, err)
 			}
 
-			if graph.IsErrResourceLocked(err) {
-				err = clues.Stack(graph.ErrResourceLocked, err)
-			}
-
 			return nil, err
 		}
 
@@ -201,10 +197,6 @@ func (c Sites) GetByID(
 		// error code, instead of something more sensible.
 		if graph.IsErrItemNotFound(err) {
 			err = clues.Stack(core.ErrResourceOwnerNotFound, err)
-		}
-
-		if graph.IsErrResourceLocked(err) {
-			return nil, graph.Stack(ctx, clues.Stack(graph.ErrResourceLocked, err))
 		}
 
 		return nil, err

--- a/src/pkg/services/m365/api/users.go
+++ b/src/pkg/services/m365/api/users.go
@@ -137,10 +137,6 @@ func (c Users) GetByID(
 		ByUserId(identifier).
 		Get(ctx, options)
 	if err != nil {
-		if graph.IsErrResourceLocked(err) {
-			err = clues.Stack(graph.ErrResourceLocked, err)
-		}
-
 		return nil, graph.Stack(ctx, err)
 	}
 
@@ -198,12 +194,8 @@ func EvaluateMailboxError(err error) error {
 	}
 
 	// must occur before MailFolderNotFound, due to overlapping cases.
-	if graph.IsErrUserNotFound(err) {
-		return clues.Stack(core.ErrResourceOwnerNotFound, err)
-	}
-
-	if graph.IsErrResourceLocked(err) {
-		return clues.Stack(graph.ErrResourceLocked, err)
+	if errors.Is(err, core.ErrResourceOwnerNotFound) || errors.Is(err, core.ErrResourceNotAccessible) {
+		return err
 	}
 
 	if graph.IsErrExchangeMailFolderNotFound(err) || graph.IsErrAuthenticationError(err) {

--- a/src/pkg/services/m365/api/users_test.go
+++ b/src/pkg/services/m365/api/users_test.go
@@ -81,16 +81,16 @@ func (suite *UsersUnitSuite) TestEvaluateMailboxError() {
 		},
 		{
 			name: "mail inbox err - user not found",
-			err:  graphTD.ODataErr(string(graph.RequestResourceNotFound)),
+			err:  core.ErrResourceOwnerNotFound,
 			expect: func(t *testing.T, err error) {
 				assert.ErrorIs(t, err, core.ErrResourceOwnerNotFound, clues.ToCore(err))
 			},
 		},
 		{
 			name: "mail inbox err - resoruceLocked",
-			err:  graphTD.ODataErr(string(graph.NotAllowed)),
+			err:  core.ErrResourceNotAccessible,
 			expect: func(t *testing.T, err error) {
-				assert.ErrorIs(t, err, graph.ErrResourceLocked, clues.ToCore(err))
+				assert.ErrorIs(t, err, core.ErrResourceNotAccessible, clues.ToCore(err))
 			},
 		},
 		{


### PR DESCRIPTION
now that we have a core error library, we can start swapping out the percolation of graph api errors with core error sentinels.  This PR begins that process by adding a centralized transformer to the graph service handlers that ensures all calls produce the same set of core errors according to some standard categorizations. This is just an initial step, and does not transfer all graph errors into core sentinels.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Supportability/Tests

#### Issue(s)

* #4685 

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
