### PR TITLE
deduplicate graph api errors

### DIFF
--- a/src/pkg/services/m365/api/graph/http_wrapper.go
+++ b/src/pkg/services/m365/api/graph/http_wrapper.go
@@ -102,7 +102,9 @@ func (hw httpWrapper) Request(
 	// See https://learn.microsoft.com/en-us/sharepoint/dev/general-development/how-to-avoid-getting-throttled-or-blocked-in-sharepoint-online#how-to-decorate-your-http-traffic
 	req.Header.Set("User-Agent", "ISV|Alcion|Corso/"+version.Version)
 
-	var resp *http.Response
+	retriedErrors := []string{}
+
+	var e error
 
 	// stream errors from http/2 will fail before we reach
 	// client middleware handling, therefore we don't get to
@@ -111,33 +113,41 @@ func (hw httpWrapper) Request(
 	// retry in the event of a `stream error`, which is not
 	// a common expectation.
 	for i := 0; i < hw.config.maxConnectionRetries+1; i++ {
+		if i > 0 {
+			time.Sleep(3 * time.Second)
+		}
+
 		ctx = clues.Add(ctx, "request_retry_iter", i)
 
-		resp, err = hw.client.Do(req)
+		resp, err := hw.client.Do(req)
 		if err == nil {
-			break
+			logResp(ctx, resp)
+			return resp, nil
 		}
 
 		err = stackWithCoreErr(ctx, err, 1)
+		e = err
 
 		var http2StreamErr http2.StreamError
 		if !errors.As(err, &http2StreamErr) {
-			return nil, err
+			// exit most errors without retry
+			break
 		}
 
 		logger.Ctx(ctx).Debug("http2 stream error")
 		events.Inc(events.APICall, "streamerror")
 
-		time.Sleep(3 * time.Second)
+		retriedErrors = append(retriedErrors, err.Error())
 	}
 
-	if err != nil {
-		return nil, err
-	}
+	e = clues.Stack(e).
+		With("retried_errors", retriedErrors).
+		WithTrace(1).
+		OrNil()
 
-	logResp(ctx, resp)
-
-	return resp, nil
+	// no chance of a non-error return here.
+	// we handle that inside the loop.
+	return nil, e
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/services/m365/api/graph/http_wrapper_test.go
+++ b/src/pkg/services/m365/api/graph/http_wrapper_test.go
@@ -182,7 +182,6 @@ func (suite *HTTPWrapperUnitSuite) TestNewHTTPWrapper_http2StreamErrorRetries() 
 
 			_, err := hw.Request(ctx, http.MethodGet, url, nil, nil)
 			require.ErrorAs(t, err, &http2.StreamError{}, clues.ToCore(err))
-
 			require.Equal(t, test.expectRetries, tries, "count of retries")
 		})
 	}

--- a/src/pkg/services/m365/api/graph/service.go
+++ b/src/pkg/services/m365/api/graph/service.go
@@ -400,15 +400,13 @@ func (aw *adapterWrap) Send(
 		err = stackWithCoreErr(ictx, err, 1)
 		e = err
 
-		// exit most errors without retry
-		switch {
-		case IsErrConnectionReset(err) || connectionEnded.Compare(err.Error()):
+		if IsErrConnectionReset(err) || connectionEnded.Compare(err.Error()) {
 			logger.Ctx(ictx).Debug("http connection error")
 			events.Inc(events.APICall, "connectionerror")
-		case IsErrBadJWTToken(err):
+		} else if IsErrBadJWTToken(err) {
 			logger.Ctx(ictx).Debug("bad jwt token")
 			events.Inc(events.APICall, "badjwttoken")
-		default:
+		} else {
 			// exit most errors without retry
 			break
 		}


### PR DESCRIPTION
the graph api service wrapper is currently stacking every retried error, leading to errors that read like, "foo; bar; baz; baz; baz". This output is confusing and unhelpful for debugging.  The changes in this PR reduce that duplication while still adding the prior error cases into the returned context so that the returned errors are easier to grok.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
