### PR TITLE
fix failing gock-based tests

### DIFF
--- a/src/cli/backup/helpers_test.go
+++ b/src/cli/backup/helpers_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/repository"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
-	gmock "github.com/alcionai/corso/src/pkg/services/m365/api/graph/mock"
 	"github.com/alcionai/corso/src/pkg/storage"
 	"github.com/alcionai/corso/src/pkg/storage/testdata"
 )
@@ -37,12 +36,12 @@ import (
 // GockClient produces a new exchange api client that can be
 // mocked using gock.
 func gockClient(creds account.M365Config, counter *count.Bus) (api.Client, error) {
-	s, err := gmock.NewService(creds, counter)
+	s, err := graph.NewGockService(creds, counter)
 	if err != nil {
 		return api.Client{}, err
 	}
 
-	li, err := gmock.NewService(creds, counter, graph.NoTimeout())
+	li, err := graph.NewGockService(creds, counter, graph.NoTimeout())
 	if err != nil {
 		return api.Client{}, err
 	}

--- a/src/internal/operations/test/m365/helper.go
+++ b/src/internal/operations/test/m365/helper.go
@@ -34,7 +34,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
-	gmock "github.com/alcionai/corso/src/pkg/services/m365/api/graph/mock"
 )
 
 // ---------------------------------------------------------------------------
@@ -44,12 +43,12 @@ import (
 // GockClient produces a new exchange api client that can be
 // mocked using gock.
 func GockClient(creds account.M365Config, counter *count.Bus) (api.Client, error) {
-	s, err := gmock.NewService(creds, counter)
+	s, err := graph.NewGockService(creds, counter)
 	if err != nil {
 		return api.Client{}, err
 	}
 
-	li, err := gmock.NewService(creds, counter, graph.NoTimeout())
+	li, err := graph.NewGockService(creds, counter, graph.NoTimeout())
 	if err != nil {
 		return api.Client{}, err
 	}

--- a/src/pkg/services/m365/api/graph/errors.go
+++ b/src/pkg/services/m365/api/graph/errors.go
@@ -146,10 +146,10 @@ func stackWithCoreErr(ctx context.Context, err error, traceDepth int) error {
 	switch {
 	case isErrApplicationThrottled(err):
 		err = clues.Stack(core.ErrApplicationThrottled, err)
-	case isErrUserNotFound(err):
-		err = clues.Stack(core.ErrResourceOwnerNotFound, err)
 	case isErrResourceLocked(err):
 		err = clues.Stack(core.ErrResourceNotAccessible, err)
+	case isErrUserNotFound(err):
+		err = clues.Stack(core.ErrResourceOwnerNotFound, err)
 	case isErrInsufficientAuthorization(err):
 		err = clues.Stack(core.ErrInsufficientAuthorization, err)
 	}

--- a/src/pkg/services/m365/api/groups.go
+++ b/src/pkg/services/m365/api/groups.go
@@ -150,7 +150,7 @@ func (c Groups) GetByID(
 		}
 
 		if errors.Is(err, core.ErrResourceNotAccessible) {
-			return nil, graph.Stack(ctx, err)
+			return nil, err
 		}
 
 		logger.CtxErr(ctx, err).Info("finding group by id, falling back to secondary identifier")
@@ -172,7 +172,7 @@ func (c Groups) GetByID(
 		}
 
 		if errors.Is(err, core.ErrResourceNotAccessible) {
-			return nil, graph.Stack(ctx, err)
+			return nil, err
 		}
 
 		logger.CtxErr(ctx, err).Info("finding group by email, falling back to display name")

--- a/src/pkg/services/m365/api/groups_test.go
+++ b/src/pkg/services/m365/api/groups_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/h2non/gock"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -237,57 +238,30 @@ func (suite *GroupsIntgSuite) TestGroups_GetByID_mockResourceLockedErrs() {
 	gID := uuid.NewString()
 
 	table := []struct {
-		name  string
-		id    string
-		setup func(t *testing.T)
+		name string
+		id   string
+		err  *odataerrors.ODataError
 	}{
 		{
 			name: "by name",
 			id:   "g",
-			setup: func(t *testing.T) {
-				err := graphTD.ODataErr(string(graph.NotAllowed))
-
-				interceptV1Path("groups").
-					Reply(403).
-					JSON(graphTD.ParseableToMap(t, err))
-				interceptV1Path("teams").
-					Reply(403).
-					JSON(graphTD.ParseableToMap(t, err))
-			},
+			err:  graphTD.ODataErr(string(graph.NotAllowed)),
 		},
 		{
 			name: "by id",
 			id:   gID,
-			setup: func(t *testing.T) {
-				err := graphTD.ODataErr(string(graph.NotAllowed))
-
-				interceptV1Path("groups", gID).
-					Reply(403).
-					JSON(graphTD.ParseableToMap(t, err))
-				interceptV1Path("teams", gID).
-					Reply(403).
-					JSON(graphTD.ParseableToMap(t, err))
-			},
+			err:  graphTD.ODataErr(string(graph.NotAllowed)),
 		},
 		{
 			name: "by id - matches error message",
 			id:   gID,
-			setup: func(t *testing.T) {
-				err := graphTD.ODataErrWithMsg(
-					string(graph.AuthenticationError),
-					"AADSTS500014: The service principal for resource 'beefe6b7-f5df-413d-ac2d-abf1e3fd9c0b' "+
-						"is disabled. This indicate that a subscription within the tenant has lapsed, or that the "+
-						"administrator for this tenant has disabled the application, preventing tokens from being "+
-						"issued for it. Trace ID: dead78e1-0830-4edf-bea7-f0a445620100 Correlation ID: "+
-						"deadbeef-7f1e-4578-8215-36004a2c935c Timestamp: 2023-12-05 19:31:01Z")
-
-				interceptV1Path("groups", gID).
-					Reply(403).
-					JSON(graphTD.ParseableToMap(t, err))
-				interceptV1Path("teams", gID).
-					Reply(403).
-					JSON(graphTD.ParseableToMap(t, err))
-			},
+			err: graphTD.ODataErrWithMsg(
+				string(graph.AuthenticationError),
+				"AADSTS500014: The service principal for resource 'beefe6b7-f5df-413d-ac2d-abf1e3fd9c0b' "+
+					"is disabled. This indicate that a subscription within the tenant has lapsed, or that the "+
+					"administrator for this tenant has disabled the application, preventing tokens from being "+
+					"issued for it. Trace ID: dead78e1-0830-4edf-bea7-f0a445620100 Correlation ID: "+
+					"deadbeef-7f1e-4578-8215-36004a2c935c Timestamp: 2023-12-05 19:31:01Z"),
 		},
 	}
 	for _, test := range table {
@@ -299,18 +273,32 @@ func (suite *GroupsIntgSuite) TestGroups_GetByID_mockResourceLockedErrs() {
 			defer flush()
 			defer gock.Off()
 
-			test.setup(t)
+			interceptV1Path("groups", gID).
+				Reply(403).
+				JSON(graphTD.ParseableToMap(t, test.err))
+
+			interceptV1Path("groups").
+				Reply(403).
+				JSON(graphTD.ParseableToMap(t, test.err))
 
 			// Verify both GetByID and GetTeamByID APIs handle this error
 			_, err := suite.its.gockAC.
 				Groups().
 				GetByID(ctx, test.id, CallConfig{})
-			require.ErrorIs(t, err, graph.ErrResourceLocked, clues.ToCore(err))
+			require.ErrorIs(t, err, core.ErrResourceNotAccessible, clues.ToCore(err))
+
+			interceptV1Path("teams", gID).
+				Reply(403).
+				JSON(graphTD.ParseableToMap(t, test.err))
+
+			interceptV1Path("teams").
+				Reply(403).
+				JSON(graphTD.ParseableToMap(t, test.err))
 
 			_, err = suite.its.gockAC.
 				Groups().
 				GetTeamByID(ctx, test.id, CallConfig{})
-			require.ErrorIs(t, err, graph.ErrResourceLocked, clues.ToCore(err))
+			require.ErrorIs(t, err, core.ErrResourceNotAccessible, clues.ToCore(err))
 		})
 	}
 }

--- a/src/pkg/services/m365/api/helper_test.go
+++ b/src/pkg/services/m365/api/helper_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/count"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
-	gmock "github.com/alcionai/corso/src/pkg/services/m365/api/graph/mock"
 )
 
 // ---------------------------------------------------------------------------
@@ -25,12 +24,12 @@ import (
 // GockClient produces a new exchange api client that can be
 // mocked using gock.
 func gockClient(creds account.M365Config, counter *count.Bus) (Client, error) {
-	s, err := gmock.NewService(creds, counter)
+	s, err := graph.NewGockService(creds, counter)
 	if err != nil {
 		return Client{}, err
 	}
 
-	li, err := gmock.NewService(creds, counter, graph.NoTimeout())
+	li, err := graph.NewGockService(creds, counter, graph.NoTimeout())
 	if err != nil {
 		return Client{}, err
 	}


### PR DESCRIPTION
the gock client wrapper wasn't using the graph service wrapper, which meant it wasn't hooking up to the graph errors categorizer.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Supportability/Tests

#### Issue(s)

* #4685

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
