### PR TITLE
Extra logging and clues context for folder caches

### DIFF
--- a/src/internal/m365/collection/exchange/contacts_container_cache.go
+++ b/src/internal/m365/collection/exchange/contacts_container_cache.go
@@ -2,6 +2,7 @@ package exchange
 
 import (
 	"context"
+	"time"
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -94,10 +95,12 @@ func (cfc *contactContainerCache) Populate(
 	baseID string,
 	baseContainerPath ...string,
 ) error {
+	start := time.Now()
+
 	logger.Ctx(ctx).Info("populating container cache")
 
 	if err := cfc.init(ctx, baseID, baseContainerPath); err != nil {
-		return clues.WrapWC(ctx, err, "initializing")
+		return clues.Wrap(err, "initializing")
 	}
 
 	el := errs.Local()
@@ -129,10 +132,12 @@ func (cfc *contactContainerCache) Populate(
 	}
 
 	if err := cfc.populatePaths(ctx, errs); err != nil {
-		return clues.WrapWC(ctx, err, "populating paths")
+		return clues.Wrap(err, "populating paths")
 	}
 
-	logger.Ctx(ctx).Info("done populating container cache")
+	logger.Ctx(ctx).Infow(
+		"done populating container cache",
+		"duration", time.Since(start))
 
 	return el.Failure()
 }

--- a/src/internal/m365/collection/exchange/contacts_container_cache.go
+++ b/src/internal/m365/collection/exchange/contacts_container_cache.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
@@ -93,8 +94,10 @@ func (cfc *contactContainerCache) Populate(
 	baseID string,
 	baseContainerPath ...string,
 ) error {
+	logger.Ctx(ctx).Info("populating container cache")
+
 	if err := cfc.init(ctx, baseID, baseContainerPath); err != nil {
-		return clues.Wrap(err, "initializing")
+		return clues.WrapWC(ctx, err, "initializing")
 	}
 
 	el := errs.Local()
@@ -104,8 +107,10 @@ func (cfc *contactContainerCache) Populate(
 		cfc.userID,
 		baseID,
 		false)
+	ctx = clues.Add(ctx, "num_enumerated_containers", len(containers))
+
 	if err != nil {
-		return clues.Wrap(err, "enumerating containers")
+		return clues.WrapWC(ctx, err, "enumerating containers")
 	}
 
 	for _, c := range containers {
@@ -124,8 +129,10 @@ func (cfc *contactContainerCache) Populate(
 	}
 
 	if err := cfc.populatePaths(ctx, errs); err != nil {
-		return clues.Wrap(err, "populating paths")
+		return clues.WrapWC(ctx, err, "populating paths")
 	}
+
+	logger.Ctx(ctx).Info("done populating container cache")
 
 	return el.Failure()
 }

--- a/src/internal/m365/collection/exchange/events_container_cache.go
+++ b/src/internal/m365/collection/exchange/events_container_cache.go
@@ -2,6 +2,7 @@ package exchange
 
 import (
 	"context"
+	"time"
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -68,10 +69,12 @@ func (ecc *eventContainerCache) Populate(
 	baseID string,
 	baseContainerPath ...string,
 ) error {
+	start := time.Now()
+
 	logger.Ctx(ctx).Info("populating container cache")
 
 	if err := ecc.init(ctx); err != nil {
-		return clues.WrapWC(ctx, err, "initializing")
+		return clues.Wrap(err, "initializing")
 	}
 
 	el := errs.Local()
@@ -106,10 +109,12 @@ func (ecc *eventContainerCache) Populate(
 	}
 
 	if err := ecc.populatePaths(ctx, errs); err != nil {
-		return clues.WrapWC(ctx, err, "populating paths")
+		return clues.Wrap(err, "populating paths")
 	}
 
-	logger.Ctx(ctx).Info("done populating container cache")
+	logger.Ctx(ctx).Infow(
+		"done populating container cache",
+		"duration", time.Since(start))
 
 	return el.Failure()
 }

--- a/src/internal/m365/collection/exchange/events_container_cache.go
+++ b/src/internal/m365/collection/exchange/events_container_cache.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
@@ -67,8 +68,10 @@ func (ecc *eventContainerCache) Populate(
 	baseID string,
 	baseContainerPath ...string,
 ) error {
+	logger.Ctx(ctx).Info("populating container cache")
+
 	if err := ecc.init(ctx); err != nil {
-		return clues.Wrap(err, "initializing")
+		return clues.WrapWC(ctx, err, "initializing")
 	}
 
 	el := errs.Local()
@@ -78,8 +81,10 @@ func (ecc *eventContainerCache) Populate(
 		ecc.userID,
 		"",
 		false)
+	ctx = clues.Add(ctx, "num_enumerated_containers", len(containers))
+
 	if err != nil {
-		return clues.Wrap(err, "enumerating containers")
+		return clues.WrapWC(ctx, err, "enumerating containers")
 	}
 
 	for _, c := range containers {
@@ -101,8 +106,10 @@ func (ecc *eventContainerCache) Populate(
 	}
 
 	if err := ecc.populatePaths(ctx, errs); err != nil {
-		return clues.Wrap(err, "populating paths")
+		return clues.WrapWC(ctx, err, "populating paths")
 	}
+
+	logger.Ctx(ctx).Info("done populating container cache")
 
 	return el.Failure()
 }

--- a/src/internal/m365/collection/exchange/mail_container_cache.go
+++ b/src/internal/m365/collection/exchange/mail_container_cache.go
@@ -2,6 +2,7 @@ package exchange
 
 import (
 	"context"
+	"time"
 
 	"github.com/alcionai/clues"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -98,10 +99,12 @@ func (mc *mailContainerCache) Populate(
 	baseID string,
 	baseContainerPath ...string,
 ) error {
+	start := time.Now()
+
 	logger.Ctx(ctx).Info("populating container cache")
 
 	if err := mc.init(ctx); err != nil {
-		return clues.WrapWC(ctx, err, "initializing")
+		return clues.Wrap(err, "initializing")
 	}
 
 	el := errs.Local()
@@ -133,10 +136,12 @@ func (mc *mailContainerCache) Populate(
 	}
 
 	if err := mc.populatePaths(ctx, errs); err != nil {
-		return clues.WrapWC(ctx, err, "populating paths")
+		return clues.Wrap(err, "populating paths")
 	}
 
-	logger.Ctx(ctx).Info("done populating container cache")
+	logger.Ctx(ctx).Infow(
+		"done populating container cache",
+		"duration", time.Since(start))
 
 	return el.Failure()
 }

--- a/src/internal/m365/collection/exchange/mail_container_cache.go
+++ b/src/internal/m365/collection/exchange/mail_container_cache.go
@@ -7,6 +7,7 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
 	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
@@ -97,8 +98,10 @@ func (mc *mailContainerCache) Populate(
 	baseID string,
 	baseContainerPath ...string,
 ) error {
+	logger.Ctx(ctx).Info("populating container cache")
+
 	if err := mc.init(ctx); err != nil {
-		return clues.Wrap(err, "initializing")
+		return clues.WrapWC(ctx, err, "initializing")
 	}
 
 	el := errs.Local()
@@ -108,8 +111,10 @@ func (mc *mailContainerCache) Populate(
 		mc.userID,
 		"",
 		false)
+	ctx = clues.Add(ctx, "num_enumerated_containers", len(containers))
+
 	if err != nil {
-		return clues.Wrap(err, "enumerating containers")
+		return clues.WrapWC(ctx, err, "enumerating containers")
 	}
 
 	for _, c := range containers {
@@ -128,8 +133,10 @@ func (mc *mailContainerCache) Populate(
 	}
 
 	if err := mc.populatePaths(ctx, errs); err != nil {
-		return clues.Wrap(err, "populating paths")
+		return clues.WrapWC(ctx, err, "populating paths")
 	}
+
+	logger.Ctx(ctx).Info("done populating container cache")
 
 	return el.Failure()
 }


### PR DESCRIPTION
Add extra logging and clues to errors when populating container caches for Exchange. This could help track down some things related to time spent getting data.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
