### PR TITLE
Fixup a few calls for adding clues to errors

### DIFF
--- a/src/internal/m365/collection/exchange/container_resolver.go
+++ b/src/internal/m365/collection/exchange/container_resolver.go
@@ -100,7 +100,7 @@ func (cr *containerResolver) refreshContainer(
 		return nil, true, nil
 	} else if err != nil {
 		// This is some other error, just return it.
-		return nil, false, clues.WrapWC(ctx, err, "refreshing container")
+		return nil, false, clues.Wrap(err, "refreshing container")
 	}
 
 	return c, false, nil
@@ -218,7 +218,7 @@ func (cr *containerResolver) idToPath(
 				locPath: nil,
 				cached:  true,
 				deleted: false,
-			}, clues.WrapWC(ctx, err, "refreshing container")
+			}, clues.Wrap(err, "refreshing container")
 		}
 
 		if shouldDelete {


### PR DESCRIPTION
Called functions add clues so there's no need to add them ourselves.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
