### PR TITLE
fix nightly user not found tests

### DIFF
--- a/src/cli/backup/exchange_e2e_test.go
+++ b/src/cli/backup/exchange_e2e_test.go
@@ -222,7 +222,8 @@ func runExchangeBackupUserNotFoundTest(suite *BackupExchangeE2ESuite, category p
 	assert.Contains(
 		t,
 		err.Error(),
-		"not found in tenant", "error missing user not found")
+		"resource owner not found",
+		"error missing user not found")
 	assert.NotContains(t, err.Error(), "runtime error", "panic happened")
 
 	t.Logf("backup error message: %s", err.Error())

--- a/src/cli/backup/groups_e2e_test.go
+++ b/src/cli/backup/groups_e2e_test.go
@@ -182,7 +182,8 @@ func runGroupsBackupGroupNotFoundTest(suite *BackupGroupsE2ESuite, category stri
 	assert.Contains(
 		t,
 		err.Error(),
-		"not found in tenant", "error missing group not found")
+		"resource owner not found",
+		"error missing user not found")
 	assert.NotContains(t, err.Error(), "runtime error", "panic happened")
 
 	t.Logf("backup error message: %s", err.Error())

--- a/src/cli/backup/onedrive_e2e_test.go
+++ b/src/cli/backup/onedrive_e2e_test.go
@@ -94,7 +94,7 @@ func (suite *NoBackupOneDriveE2ESuite) TestOneDriveBackupCmd_userNotInTenant() {
 	cmd := cliTD.StubRootCmd(
 		"backup", "create", "onedrive",
 		"--"+flags.ConfigFileFN, suite.dpnd.configFilePath,
-		"--"+flags.UserFN, "foo@nothere.com")
+		"--"+flags.UserFN, "foo@not-there.com")
 	cli.BuildCommandTree(cmd)
 
 	cmd.SetOut(&recorder)
@@ -107,7 +107,8 @@ func (suite *NoBackupOneDriveE2ESuite) TestOneDriveBackupCmd_userNotInTenant() {
 	assert.Contains(
 		t,
 		err.Error(),
-		"not found in tenant", "error missing user not found")
+		"resource owner not found",
+		"error missing user not found")
 	assert.NotContains(t, err.Error(), "runtime error", "panic happened")
 
 	t.Logf("backup error message: %s", err.Error())


### PR DESCRIPTION
Tests got out of date due to brittle comparisons on error message strings.  No good solution for the brittleness, unfortunately.  But we can fix the failure.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix
- [x] :robot: Supportability/Tests

#### Test Plan

- [x] :muscle: Manual
- [x] :green_heart: E2E
