### PR TITLE
Download attachments for group mailbox posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - When running `backup details` on an empty backup returns a more helpful error message.
 
+### Known issues
+- Backing up a group mailbox item may fail if it has a very large number of attachments (500+).
+
 ## [v0.18.0] (beta) - 2024-01-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Retry transient 400 "invalidRequest" errors during onedrive & sharepoint backup.
+- Backup attachments associated with group mailbox items.
 
 ### Changed
 - When running `backup details` on an empty backup returns a more helpful error message.

--- a/src/pkg/services/m365/api/conversations.go
+++ b/src/pkg/services/m365/api/conversations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/common/str"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
@@ -63,7 +64,41 @@ func (c Conversations) GetConversationPost(
 		return nil, nil, graph.Stack(ctx, err)
 	}
 
-	return post, conversationPostInfo(post), graph.Stack(ctx, err).OrNil()
+	preview, contentLen, err := getConversationPostContentPreview(post)
+	if err != nil {
+		preview = "malformed or unparseable html" + preview
+	}
+
+	// TODO(pandeyabs): Is this the best way to get embedded attachments?
+	// Attachmentable has inline field also. what about that?
+	if !ptr.Val(post.GetHasAttachments()) && !HasAttachments(post.GetBody()) {
+		return post, conversationPostInfo(post, contentLen, preview), nil
+	}
+
+	attachments, totalSize, err := c.getAttachments(
+		ctx,
+		groupID,
+		conversationID,
+		threadID,
+		postID)
+	if err != nil {
+		// A failure can be caused by having a lot of attachments.
+		// If that happens, we can progres with a two-step approach of:
+		// 1. getting all attachment IDs.
+		// 2. fetching each attachment individually.
+		logger.CtxErr(ctx, err).Info("falling back to fetching attachments by id")
+
+		// attachments, totalSize, err = c.getAttachmentsIterated(ctx, userID, mailID, immutableIDs, errs)
+		// if err != nil {
+		// 	return nil, nil, clues.Stack(err)
+		// }
+	}
+
+	contentLen += totalSize
+
+	post.SetAttachments(attachments)
+
+	return post, conversationPostInfo(post, contentLen, preview), graph.Stack(ctx, err).OrNil()
 }
 
 // ---------------------------------------------------------------------------
@@ -72,25 +107,16 @@ func (c Conversations) GetConversationPost(
 
 func conversationPostInfo(
 	post models.Postable,
+	size int64,
+	preview string,
 ) *details.GroupsInfo {
 	if post == nil {
 		return nil
 	}
 
-	preview, contentLen, err := getConversationPostContentPreview(post)
-	if err != nil {
-		preview = "malformed or unparseable html" + preview
-	}
-
 	var sender string
 	if post.GetSender() != nil && post.GetSender().GetEmailAddress() != nil {
 		sender = ptr.Val(post.GetSender().GetEmailAddress().GetAddress())
-	}
-
-	size := contentLen
-
-	for _, a := range post.GetAttachments() {
-		size += int64(ptr.Val(a.GetSize()))
 	}
 
 	cpi := details.ConversationPostInfo{
@@ -128,3 +154,87 @@ func stripConversationPostHTML(post models.Postable) (string, int64, error) {
 
 	return content, origSize, clues.Stack(err).OrNil()
 }
+
+// getAttachments attempts to get all attachments, including their content, in a singe query.
+// microsoft.graph.itemattachment/item" is returning 403.
+// Compare with mail api. also try with attachments and Attachment() endpoint.
+func (c Conversations) getAttachments(
+	ctx context.Context,
+	groupID, conversationID, threadID, postID string,
+) ([]models.Attachmentable, int64, error) {
+	var (
+		result    = []models.Attachmentable{}
+		totalSize int64
+	)
+
+	cfg := &groups.ItemConversationsItemThreadsItemPostsPostItemRequestBuilderGetRequestConfiguration{
+		QueryParameters: &groups.ItemConversationsItemThreadsItemPostsPostItemRequestBuilderGetQueryParameters{
+			Expand: []string{"attachments"},
+		},
+	}
+
+	post, err := c.LargeItem.
+		Client().
+		Groups().
+		ByGroupId(groupID).
+		Conversations().
+		ByConversationId(conversationID).
+		Threads().
+		ByConversationThreadId(threadID).
+		Posts().
+		ByPostId(postID).
+		Get(ctx, cfg)
+	if err != nil {
+		return nil, 0, graph.Stack(ctx, err)
+	}
+
+	attachments := post.GetAttachments()
+
+	for _, a := range attachments {
+		totalSize += int64(ptr.Val(a.GetSize()))
+		result = append(result, a)
+	}
+
+	return result, totalSize, nil
+}
+
+// // getAttachments attempts to get all attachments, including their content, in a singe query.
+// // microsoft.graph.itemattachment/item" is returning 403.
+// func (c Conversations) getAttachments(
+// 	ctx context.Context,
+// 	groupID, conversationID, threadID, postID string,
+// ) ([]models.Attachmentable, int64, error) {
+// 	var (
+// 		result    = []models.Attachmentable{}
+// 		totalSize int64
+// 	)
+
+// 	cfg := &groups.ItemConversationsItemThreadsItemPostsItemAttachmentsRequestBuilderGetRequestConfiguration{
+// 		QueryParameters: &groups.ItemConversationsItemThreadsItemPostsItemAttachmentsRequestBuilderGetQueryParameters{
+// 			Expand: []string{"microsoft.graph.itemattachment/item"},
+// 		},
+// 	}
+
+// 	attachments, err := c.LargeItem.
+// 		Client().
+// 		Groups().
+// 		ByGroupId(groupID).
+// 		Conversations().
+// 		ByConversationId(conversationID).
+// 		Threads().
+// 		ByConversationThreadId(threadID).
+// 		Posts().
+// 		ByPostId(postID).
+// 		Attachments().
+// 		Get(ctx, cfg)
+// 	if err != nil {
+// 		return nil, 0, graph.Stack(ctx, err)
+// 	}
+
+// 	for _, a := range attachments.GetValue() {
+// 		totalSize += int64(ptr.Val(a.GetSize()))
+// 		result = append(result, a)
+// 	}
+
+// 	return result, totalSize, nil
+// }

--- a/src/pkg/services/m365/api/conversations.go
+++ b/src/pkg/services/m365/api/conversations.go
@@ -66,7 +66,7 @@ func (c Conversations) GetConversationPost(
 
 	preview, contentLen, err := getConversationPostContentPreview(post)
 	if err != nil {
-		preview = "malformed or unparseable html" + preview
+		preview = "malformed or unparseable content body: " + preview
 	}
 
 	if !ptr.Val(post.GetHasAttachments()) && !HasAttachments(post.GetBody()) {

--- a/src/pkg/services/m365/api/conversations_test.go
+++ b/src/pkg/services/m365/api/conversations_test.go
@@ -138,6 +138,7 @@ func (suite *ConversationAPIIntgSuite) SetupSuite() {
 func (suite *ConversationAPIIntgSuite) TestConversations_attachmentListDownload() {
 	pid := "fake-post-id"
 	aid := "fake-attachment-id"
+	contentWithAttachment := "<html><body><img src=\"cid:fake-attach-id\"/></body></html>"
 
 	tests := []struct {
 		name            string
@@ -173,9 +174,6 @@ func (suite *ConversationAPIIntgSuite) TestConversations_attachmentListDownload(
 				itm.SetId(&pid)
 				itm.SetHasAttachments(ptr.To(true))
 
-				attch := models.NewAttachment()
-				attch.SetSize(ptr.To[int32](50))
-
 				// First call to get the post will not expand attachments.
 				interceptV1Path(
 					"groups",
@@ -188,6 +186,9 @@ func (suite *ConversationAPIIntgSuite) TestConversations_attachmentListDownload(
 					pid).
 					Reply(200).
 					JSON(graphTD.ParseableToMap(suite.T(), itm))
+
+				attch := models.NewAttachment()
+				attch.SetSize(ptr.To[int32](50))
 
 				itm.SetAttachments([]models.Attachmentable{attch})
 
@@ -216,10 +217,6 @@ func (suite *ConversationAPIIntgSuite) TestConversations_attachmentListDownload(
 				itm.SetId(&pid)
 				itm.SetHasAttachments(ptr.To(true))
 
-				attch := models.NewAttachment()
-				attch.SetId(&aid)
-				attch.SetSize(ptr.To[int32](200))
-
 				interceptV1Path(
 					"groups",
 					"group",
@@ -231,6 +228,10 @@ func (suite *ConversationAPIIntgSuite) TestConversations_attachmentListDownload(
 					pid).
 					Reply(200).
 					JSON(graphTD.ParseableToMap(suite.T(), itm))
+
+				attch := models.NewAttachment()
+				attch.SetId(&aid)
+				attch.SetSize(ptr.To[int32](200))
 
 				itm.SetAttachments([]models.Attachmentable{attch, attch, attch, attch, attch})
 
@@ -249,6 +250,54 @@ func (suite *ConversationAPIIntgSuite) TestConversations_attachmentListDownload(
 			},
 			attachmentCount: 5,
 			size:            1000,
+			expect:          assert.NoError,
+		},
+		{
+			name: "embedded attachment",
+			setupf: func() {
+				itm := models.NewPost()
+				itm.SetId(&pid)
+
+				body := models.NewItemBody()
+				body.SetContentType(ptr.To(models.HTML_BODYTYPE))
+
+				// Test html content with embedded attachment.
+
+				body.SetContent(ptr.To(contentWithAttachment))
+
+				itm.SetBody(body)
+
+				interceptV1Path(
+					"groups",
+					"group",
+					"conversations",
+					"conv",
+					"threads",
+					"thread",
+					"posts",
+					pid).
+					Reply(200).
+					JSON(graphTD.ParseableToMap(suite.T(), itm))
+
+				attch := models.NewAttachment()
+				attch.SetSize(ptr.To[int32](50))
+				itm.SetAttachments([]models.Attachmentable{attch})
+
+				interceptV1Path(
+					"groups",
+					"group",
+					"conversations",
+					"conv",
+					"threads",
+					"thread",
+					"posts",
+					pid).
+					MatchParam("$expand", "attachments").
+					Reply(200).
+					JSON(graphTD.ParseableToMap(suite.T(), itm))
+			},
+			attachmentCount: 1,
+			size:            50 + int64(len(contentWithAttachment)),
 			expect:          assert.NoError,
 		},
 	}

--- a/website/docs/support/known-issues.md
+++ b/website/docs/support/known-issues.md
@@ -36,4 +36,4 @@ Below is a list of known Corso issues and limitations:
 
 * Restoring the data into a different Group from the one it was backed up from isn't currently supported.
 
-* Backing up a group mailbox item may fail if it has a very large number of attachments (500+).
+* Backing up a group mailbox item may fail if it has a large number of attachments (500+).

--- a/website/docs/support/known-issues.md
+++ b/website/docs/support/known-issues.md
@@ -34,4 +34,6 @@ Below is a list of known Corso issues and limitations:
 
 * Groups and Teams support is available in an early-access status, and may be subject to breaking changes.
 
-* Restoring the data into a different Group from the one it was backed up from isn't currently supported
+* Restoring the data into a different Group from the one it was backed up from isn't currently supported.
+
+* Backing up a group mailbox item may fail if it has a very large number of attachments (500+).


### PR DESCRIPTION
<!-- PR description-->

* Attachment download needed an expand operation. Added that. 
* Added test coverage with gock. Tested with manual backup of posts which contain attachments(embedded/non-embedded). We can't add e2e tests with attachments, since API to create new conversations requires delegated access.
* Note that https://github.com/alcionai/corso/issues/4991 is still an open item. We don't have a resolution for it right now, since attachment endpoint requires delegated token. Defaulting to let the backup fail for "too many attachments" error case. We don't know yet if we'd see that with group mailboxes, and whether it'd be the same error that we saw with exchange (recurring 503s).
---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
