### PR TITLE
Fix handling of recurring events with end date

### DIFF
--- a/src/internal/converters/ics/ics_test.go
+++ b/src/internal/converters/ics/ics_test.go
@@ -193,6 +193,37 @@ func (suite *ICSUnitSuite) TestGetRecurrencePattern() {
 			errCheck: require.NoError,
 		},
 		{
+			name: "daily with end date in different timezone",
+			recurrence: func() models.PatternedRecurrenceable {
+				rec := models.NewPatternedRecurrence()
+				pat := models.NewRecurrencePattern()
+
+				typ, err := models.ParseRecurrencePatternType("daily")
+				require.NoError(suite.T(), err)
+
+				pat.SetTypeEscaped(typ.(*models.RecurrencePatternType))
+				pat.SetInterval(ptr.To(int32(1)))
+
+				rng := models.NewRecurrenceRange()
+
+				rrtype, err := models.ParseRecurrenceRangeType("endDate")
+				require.NoError(suite.T(), err)
+
+				rng.SetTypeEscaped(rrtype.(*models.RecurrenceRangeType))
+
+				edate := serialization.NewDateOnly(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC))
+				rng.SetEndDate(edate)
+				rng.SetRecurrenceTimeZone(ptr.To("India Standard Time"))
+
+				rec.SetPattern(pat)
+				rec.SetRangeEscaped(rng)
+
+				return rec
+			},
+			expect:   "FREQ=DAILY;INTERVAL=1;UNTIL=20210101T182959Z",
+			errCheck: require.NoError,
+		},
+		{
 			name: "weekly",
 			recurrence: func() models.PatternedRecurrenceable {
 				rec := models.NewPatternedRecurrence()
@@ -239,7 +270,7 @@ func (suite *ICSUnitSuite) TestGetRecurrencePattern() {
 
 				return rec
 			},
-			expect:   "FREQ=WEEKLY;INTERVAL=1;UNTIL=20210101T000000Z",
+			expect:   "FREQ=WEEKLY;INTERVAL=1;UNTIL=20210101T235959Z",
 			errCheck: require.NoError,
 		},
 		{


### PR DESCRIPTION
Previously we were not accurately handling the end date of recurring
events. This was because we treated end date to be start of the day
instead of the end of day.
<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* https://github.com/alcionai/corso/issues/3890

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
