### PR TITLE
Reduce http wrapper test runtime

### DIFF
--- a/src/pkg/services/m365/api/graph/http_wrapper_test.go
+++ b/src/pkg/services/m365/api/graph/http_wrapper_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/alcionai/clues"
 	khttp "github.com/microsoft/kiota-http-go"
@@ -49,6 +50,9 @@ func (suite *HTTPWrapperIntgSuite) TestNewHTTPWrapper() {
 
 	require.NotNil(t, resp)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Test http wrapper config
+	assert.Equal(t, httpWrapperRetryDelay, hw.retryDelay)
 }
 
 type mwForceResp struct {
@@ -179,6 +183,9 @@ func (suite *HTTPWrapperUnitSuite) TestNewHTTPWrapper_http2StreamErrorRetries() 
 				count.New(),
 				appendMiddleware(&mwResp),
 				MaxConnectionRetries(test.retries))
+
+			// Configure retry delay to reduce test time.
+			hw.retryDelay = 1 * time.Millisecond
 
 			_, err := hw.Request(ctx, http.MethodGet, url, nil, nil)
 			require.ErrorAs(t, err, &http2.StreamError{}, clues.ToCore(err))

--- a/src/pkg/services/m365/api/graph/http_wrapper_test.go
+++ b/src/pkg/services/m365/api/graph/http_wrapper_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/alcionai/clues"
 	khttp "github.com/microsoft/kiota-http-go"
@@ -184,8 +183,10 @@ func (suite *HTTPWrapperUnitSuite) TestNewHTTPWrapper_http2StreamErrorRetries() 
 				appendMiddleware(&mwResp),
 				MaxConnectionRetries(test.retries))
 
-			// Configure retry delay to reduce test time.
-			hw.retryDelay = 1 * time.Millisecond
+			// Configure retry delay to reduce test time. Retry delay doesn't
+			// really matter here since all requests will be intercepted by
+			// the test middleware.
+			hw.retryDelay = 0
 
 			_, err := hw.Request(ctx, http.MethodGet, url, nil, nil)
 			require.ErrorAs(t, err, &http2.StreamError{}, clues.ToCore(err))


### PR DESCRIPTION
<!-- PR description-->

Similar to the change made for graph adapter. Reduces `TestHTTPWrapperUnitSuite/TestNewHTTPWrapper_http2StreamErrorRetries` runtime from 40 sec to 0.3sec. 


---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
