### PR TITLE
Pass some backup specific options in a separate struct

### DIFF
--- a/src/cli/backup/backup.go
+++ b/src/cli/backup/backup.go
@@ -176,6 +176,7 @@ func genericCreateCommand(
 	serviceName string,
 	selectorSet []selectors.Selector,
 	ins idname.Cacher,
+	backupConfig control.BackupConfig,
 ) error {
 	var (
 		bIDs []string
@@ -190,7 +191,7 @@ func genericCreateCommand(
 			ictx  = clues.Add(ctx, "resource_owner_selected", owner)
 		)
 
-		bo, err := r.NewBackupWithLookup(ictx, discSel, ins)
+		bo, err := r.NewBackupWithLookup(ictx, discSel, ins, backupConfig)
 		if err != nil {
 			cerr := clues.WrapWC(ictx, err, owner)
 			errs = append(errs, cerr)

--- a/src/cli/backup/exchange.go
+++ b/src/cli/backup/exchange.go
@@ -184,7 +184,8 @@ func createExchangeCmd(cmd *cobra.Command, args []string) error {
 		r,
 		"Exchange",
 		selectorSet,
-		ins)
+		ins,
+		utils.ParseBackupOptions())
 }
 
 func exchangeBackupCreateSelectors(userIDs, cats []string) *selectors.ExchangeBackup {

--- a/src/cli/backup/exchange_e2e_test.go
+++ b/src/cli/backup/exchange_e2e_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/config"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
@@ -364,7 +365,11 @@ func (suite *PreparedBackupExchangeE2ESuite) SetupSuite() {
 
 		sel.Include(scopes)
 
-		bop, err := suite.dpnd.repo.NewBackupWithLookup(ctx, sel.Selector, ins)
+		bop, err := suite.dpnd.repo.NewBackupWithLookup(
+			ctx,
+			sel.Selector,
+			ins,
+			control.DefaultBackupConfig())
 		require.NoError(t, err, clues.ToCore(err))
 
 		err = bop.Run(ctx)
@@ -590,7 +595,10 @@ func (suite *BackupDeleteExchangeE2ESuite) SetupSuite() {
 	sel.Include(sel.MailFolders([]string{api.MailInbox}, selectors.PrefixMatch()))
 
 	for i := 0; i < cap(suite.backupOps); i++ {
-		backupOp, err := suite.dpnd.repo.NewBackup(ctx, sel.Selector)
+		backupOp, err := suite.dpnd.repo.NewBackup(
+			ctx,
+			sel.Selector,
+			control.DefaultBackupConfig())
 		require.NoError(t, err, clues.ToCore(err))
 
 		suite.backupOps[i] = backupOp

--- a/src/cli/backup/exchange_test.go
+++ b/src/cli/backup/exchange_test.go
@@ -121,20 +121,12 @@ func (suite *ExchangeUnitSuite) TestBackupCreateFlags() {
 	// TODO(ashmrtn): Remove flag checks on control.Options to control.Backup once
 	// restore flags are switched over too and we no longer parse flags beyond
 	// connection info into control.Options.
-	assert.Equal(t, flagsTD.FetchParallelism, strconv.Itoa(backupOpts.Parallelism.ItemFetch))
-	assert.Equal(t, flagsTD.DeltaPageSize, strconv.Itoa(int(backupOpts.M365.DeltaPageSize)))
-	assert.Equal(t, control.FailFast, backupOpts.FailureHandling)
 	assert.True(t, backupOpts.Incrementals.ForceFullEnumeration)
 	assert.True(t, backupOpts.Incrementals.ForceItemDataRefresh)
-	assert.True(t, backupOpts.M365.DisableDeltaEndpoint)
-	assert.True(t, backupOpts.M365.ExchangeImmutableIDs)
-	assert.True(t, backupOpts.ServiceRateLimiter.DisableSlidingWindowLimiter)
 
 	assert.Equal(t, flagsTD.FetchParallelism, strconv.Itoa(co.Parallelism.ItemFetch))
 	assert.Equal(t, flagsTD.DeltaPageSize, strconv.Itoa(int(co.DeltaPageSize)))
 	assert.Equal(t, control.FailFast, co.FailureHandling)
-	assert.True(t, co.ToggleFeatures.DisableIncrementals)
-	assert.True(t, co.ToggleFeatures.ForceItemDataDownload)
 	assert.True(t, co.ToggleFeatures.DisableDelta)
 	assert.True(t, co.ToggleFeatures.ExchangeImmutableIDs)
 	assert.True(t, co.ToggleFeatures.DisableSlidingWindowLimiter)

--- a/src/cli/backup/groups.go
+++ b/src/cli/backup/groups.go
@@ -179,7 +179,8 @@ func createGroupsCmd(cmd *cobra.Command, args []string) error {
 		r,
 		"Group",
 		selectorSet,
-		ins)
+		ins,
+		utils.ParseBackupOptions())
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/src/cli/backup/groups_e2e_test.go
+++ b/src/cli/backup/groups_e2e_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/config"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	selTD "github.com/alcionai/corso/src/pkg/selectors/testdata"
@@ -323,7 +324,11 @@ func (suite *PreparedBackupGroupsE2ESuite) SetupSuite() {
 
 		sel.Include(scopes)
 
-		bop, err := suite.dpnd.repo.NewBackupWithLookup(ctx, sel.Selector, ins)
+		bop, err := suite.dpnd.repo.NewBackupWithLookup(
+			ctx,
+			sel.Selector,
+			ins,
+			control.DefaultBackupConfig())
 		require.NoError(t, err, clues.ToCore(err))
 
 		err = bop.Run(ctx)
@@ -549,7 +554,10 @@ func (suite *BackupDeleteGroupsE2ESuite) SetupSuite() {
 	sel.Include(selTD.GroupsBackupChannelScope(sel))
 
 	for i := 0; i < cap(suite.backupOps); i++ {
-		backupOp, err := suite.dpnd.repo.NewBackup(ctx, sel.Selector)
+		backupOp, err := suite.dpnd.repo.NewBackup(
+			ctx,
+			sel.Selector,
+			control.DefaultBackupConfig())
 		require.NoError(t, err, clues.ToCore(err))
 
 		suite.backupOps[i] = backupOp

--- a/src/cli/backup/groups_test.go
+++ b/src/cli/backup/groups_test.go
@@ -166,16 +166,11 @@ func (suite *GroupsUnitSuite) TestBackupCreateFlags() {
 	// TODO(ashmrtn): Remove flag checks on control.Options to control.Backup once
 	// restore flags are switched over too and we no longer parse flags beyond
 	// connection info into control.Options.
-	assert.Equal(t, flagsTD.FetchParallelism, strconv.Itoa(backupOpts.Parallelism.ItemFetch))
-	assert.Equal(t, control.FailFast, backupOpts.FailureHandling)
 	assert.True(t, backupOpts.Incrementals.ForceFullEnumeration)
 	assert.True(t, backupOpts.Incrementals.ForceItemDataRefresh)
-	assert.True(t, backupOpts.M365.DisableDeltaEndpoint)
 
 	assert.Equal(t, flagsTD.FetchParallelism, strconv.Itoa(co.Parallelism.ItemFetch))
 	assert.Equal(t, control.FailFast, co.FailureHandling)
-	assert.True(t, co.ToggleFeatures.DisableIncrementals)
-	assert.True(t, co.ToggleFeatures.ForceItemDataDownload)
 	assert.True(t, co.ToggleFeatures.DisableDelta)
 	assert.True(t, co.ToggleFeatures.DisableLazyItemReader)
 

--- a/src/cli/backup/onedrive.go
+++ b/src/cli/backup/onedrive.go
@@ -170,7 +170,8 @@ func createOneDriveCmd(cmd *cobra.Command, args []string) error {
 		r,
 		"OneDrive",
 		selectorSet,
-		ins)
+		ins,
+		utils.ParseBackupOptions())
 }
 
 func validateOneDriveBackupCreateFlags(users []string) error {

--- a/src/cli/backup/onedrive_e2e_test.go
+++ b/src/cli/backup/onedrive_e2e_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/config"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	selTD "github.com/alcionai/corso/src/pkg/selectors/testdata"
@@ -154,7 +155,11 @@ func (suite *BackupDeleteOneDriveE2ESuite) SetupSuite() {
 	sel.Include(selTD.OneDriveBackupFolderScope(sel))
 
 	for i := 0; i < cap(suite.backupOps); i++ {
-		backupOp, err := suite.dpnd.repo.NewBackupWithLookup(ctx, sel.Selector, ins)
+		backupOp, err := suite.dpnd.repo.NewBackupWithLookup(
+			ctx,
+			sel.Selector,
+			ins,
+			control.DefaultBackupConfig())
 		require.NoError(t, err, clues.ToCore(err))
 
 		suite.backupOps[i] = backupOp

--- a/src/cli/backup/onedrive_test.go
+++ b/src/cli/backup/onedrive_test.go
@@ -113,13 +113,10 @@ func (suite *OneDriveUnitSuite) TestBackupCreateFlags() {
 	// TODO(ashmrtn): Remove flag checks on control.Options to control.Backup once
 	// restore flags are switched over too and we no longer parse flags beyond
 	// connection info into control.Options.
-	assert.Equal(t, control.FailFast, backupOpts.FailureHandling)
 	assert.True(t, backupOpts.Incrementals.ForceFullEnumeration)
 	assert.True(t, backupOpts.Incrementals.ForceItemDataRefresh)
 
 	assert.Equal(t, control.FailFast, co.FailureHandling)
-	assert.True(t, co.ToggleFeatures.DisableIncrementals)
-	assert.True(t, co.ToggleFeatures.ForceItemDataDownload)
 
 	assert.ElementsMatch(t, flagsTD.UsersInput, opts.Users)
 	flagsTD.AssertGenericBackupFlags(t, cmd)

--- a/src/cli/backup/sharepoint.go
+++ b/src/cli/backup/sharepoint.go
@@ -183,7 +183,8 @@ func createSharePointCmd(cmd *cobra.Command, args []string) error {
 		r,
 		"SharePoint",
 		selectorSet,
-		ins)
+		ins,
+		utils.ParseBackupOptions())
 }
 
 func validateSharePointBackupCreateFlags(sites, weburls, cats []string) error {

--- a/src/cli/backup/sharepoint_e2e_test.go
+++ b/src/cli/backup/sharepoint_e2e_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/config"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/selectors/testdata"
@@ -229,7 +230,11 @@ func (suite *PreparedBackupSharepointE2ESuite) SetupSuite() {
 
 		sel.Include(scopes)
 
-		bop, err := suite.dpnd.repo.NewBackupWithLookup(ctx, sel.Selector, ins)
+		bop, err := suite.dpnd.repo.NewBackupWithLookup(
+			ctx,
+			sel.Selector,
+			ins,
+			control.DefaultBackupConfig())
 		require.NoError(t, err, clues.ToCore(err))
 
 		err = bop.Run(ctx)
@@ -410,7 +415,12 @@ func (suite *BackupDeleteSharePointE2ESuite) SetupSuite() {
 	sel := selectors.NewSharePointBackup(sites)
 	sel.Include(testdata.SharePointBackupFolderScope(sel))
 
-	backupOp, err := suite.dpnd.repo.NewBackupWithLookup(ctx, sel.Selector, ins)
+	backupOp, err := suite.dpnd.repo.NewBackupWithLookup(
+		ctx,
+		sel.Selector,
+		ins,
+		control.DefaultBackupConfig())
+
 	require.NoError(t, err, clues.ToCore(err))
 
 	suite.backupOp = backupOp
@@ -419,7 +429,11 @@ func (suite *BackupDeleteSharePointE2ESuite) SetupSuite() {
 	require.NoError(t, err, clues.ToCore(err))
 
 	// secondary backup
-	secondaryBackupOp, err := suite.dpnd.repo.NewBackupWithLookup(ctx, sel.Selector, ins)
+	secondaryBackupOp, err := suite.dpnd.repo.NewBackupWithLookup(
+		ctx,
+		sel.Selector,
+		ins,
+		control.DefaultBackupConfig())
 	require.NoError(t, err, clues.ToCore(err))
 
 	suite.secondaryBackupOp = secondaryBackupOp

--- a/src/cli/backup/sharepoint_test.go
+++ b/src/cli/backup/sharepoint_test.go
@@ -117,13 +117,10 @@ func (suite *SharePointUnitSuite) TestBackupCreateFlags() {
 	// TODO(ashmrtn): Remove flag checks on control.Options to control.Backup once
 	// restore flags are switched over too and we no longer parse flags beyond
 	// connection info into control.Options.
-	assert.Equal(t, control.FailFast, backupOpts.FailureHandling)
 	assert.True(t, backupOpts.Incrementals.ForceFullEnumeration)
 	assert.True(t, backupOpts.Incrementals.ForceItemDataRefresh)
 
 	assert.Equal(t, control.FailFast, co.FailureHandling)
-	assert.True(t, co.ToggleFeatures.DisableIncrementals)
-	assert.True(t, co.ToggleFeatures.ForceItemDataDownload)
 
 	assert.ElementsMatch(t, []string{strings.Join(flagsTD.SiteIDInput, ",")}, opts.SiteID)
 	assert.ElementsMatch(t, flagsTD.WebURLInput, opts.WebURL)

--- a/src/cli/restore/exchange_e2e_test.go
+++ b/src/cli/restore/exchange_e2e_test.go
@@ -115,7 +115,11 @@ func (suite *RestoreExchangeE2ESuite) SetupSuite() {
 
 		sel.Include(scopes)
 
-		bop, err := suite.repo.NewBackupWithLookup(ctx, sel.Selector, ins)
+		bop, err := suite.repo.NewBackupWithLookup(
+			ctx,
+			sel.Selector,
+			ins,
+			control.DefaultBackupConfig())
 		require.NoError(t, err, clues.ToCore(err))
 
 		err = bop.Run(ctx)

--- a/src/cli/utils/options.go
+++ b/src/cli/utils/options.go
@@ -22,8 +22,6 @@ func Control() control.Options {
 	opt.DeltaPageSize = dps
 	opt.DisableMetrics = flags.NoStatsFV
 	opt.SkipReduce = flags.SkipReduceFV
-	opt.ToggleFeatures.DisableIncrementals = flags.DisableIncrementalsFV
-	opt.ToggleFeatures.ForceItemDataDownload = flags.ForceItemDataDownloadFV
 	opt.ToggleFeatures.DisableDelta = flags.DisableDeltaFV
 	opt.ToggleFeatures.DisableSlidingWindowLimiter = flags.DisableSlidingWindowLimiterFV
 	opt.ToggleFeatures.DisableLazyItemReader = flags.DisableLazyItemReaderFV
@@ -46,21 +44,6 @@ func ControlWithConfig(cfg config.RepoDetails) control.Options {
 func ParseBackupOptions() control.BackupConfig {
 	opt := control.DefaultBackupConfig()
 
-	if flags.FailFastFV {
-		opt.FailureHandling = control.FailFast
-	}
-
-	dps := int32(flags.DeltaPageSizeFV)
-	if dps > 500 || dps < 1 {
-		dps = 500
-	}
-
-	opt.M365.DeltaPageSize = dps
-	opt.M365.DisableDeltaEndpoint = flags.DisableDeltaFV
-	opt.M365.ExchangeImmutableIDs = flags.EnableImmutableIDFV
-	opt.M365.UseDriveDeltaTree = flags.UseDeltaTreeFV
-	opt.ServiceRateLimiter.DisableSlidingWindowLimiter = flags.DisableSlidingWindowLimiterFV
-	opt.Parallelism.ItemFetch = flags.FetchParallelismFV
 	opt.Incrementals.ForceFullEnumeration = flags.DisableIncrementalsFV
 	opt.Incrementals.ForceItemDataRefresh = flags.ForceItemDataDownloadFV
 

--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -50,7 +50,8 @@ type Collections struct {
 
 	statusUpdater support.StatusUpdater
 
-	ctrl control.Options
+	ctrl         control.Options
+	backupConfig control.BackupConfig
 
 	// collectionMap allows lookup of the data.BackupCollection
 	// for a OneDrive folder.
@@ -71,6 +72,7 @@ func NewCollections(
 	protectedResource idname.Provider,
 	statusUpdater support.StatusUpdater,
 	ctrlOpts control.Options,
+	backupOpts control.BackupConfig,
 	counter *count.Bus,
 ) *Collections {
 	return &Collections{
@@ -80,6 +82,7 @@ func NewCollections(
 		CollectionMap:     map[string]map[string]*Collection{},
 		statusUpdater:     statusUpdater,
 		ctrl:              ctrlOpts,
+		backupConfig:      backupOpts,
 		counter:           counter,
 	}
 }
@@ -786,14 +789,14 @@ func (c *Collections) PopulateDriveCollections(
 		// recreated multiple times in between a run.
 		seenFolders = map[string]string{}
 
-		limiter = newPagerLimiter(c.ctrl)
+		limiter = newPagerLimiter(c.backupConfig)
 		stats   = &driveEnumerationStats{}
 	)
 
 	ctx = clues.Add(ctx, "invalid_prev_delta", invalidPrevDelta)
 	logger.Ctx(ctx).Infow(
 		"running backup",
-		"limits", c.ctrl.PreviewLimits,
+		"limits", c.backupConfig.PreviewLimits,
 		"effective_limits", limiter.effectiveLimits())
 
 	if !invalidPrevDelta {

--- a/src/internal/m365/collection/drive/collections_test.go
+++ b/src/internal/m365/collection/drive/collections_test.go
@@ -885,6 +885,7 @@ func (suite *CollectionsUnitSuite) TestPopulateDriveCollections() {
 				idname.NewProvider(user, user),
 				nil,
 				control.Options{ToggleFeatures: control.Toggles{}},
+				control.DefaultBackupConfig(),
 				count.New())
 
 			c.CollectionMap[drive.id] = map[string]*Collection{}
@@ -2635,6 +2636,7 @@ func (suite *CollectionsUnitSuite) TestGet() {
 				idname.NewProvider(user, user),
 				func(*support.ControllerOperationStatus) {},
 				control.Options{ToggleFeatures: control.Toggles{}},
+				control.DefaultBackupConfig(),
 				count.New())
 
 			prevDelta := "prev-delta"
@@ -2801,6 +2803,7 @@ func (suite *CollectionsUnitSuite) TestAddURLCacheToDriveCollections() {
 				idname.NewProvider(user, user),
 				func(*support.ControllerOperationStatus) {},
 				control.Options{ToggleFeatures: control.Toggles{}},
+				control.DefaultBackupConfig(),
 				count.New())
 
 			errs := fault.New(true)

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -38,11 +38,11 @@ func (c *Collections) getTree(
 	errs *fault.Bus,
 ) ([]data.BackupCollection, bool, error) {
 	ctx = clues.AddTraceName(ctx, "GetTree")
-	limiter := newPagerLimiter(c.ctrl)
+	limiter := newPagerLimiter(c.backupConfig)
 
 	logger.Ctx(ctx).Infow(
 		"running backup: getting collection data using tree structure",
-		"limits", c.ctrl.PreviewLimits,
+		"limits", c.backupConfig.PreviewLimits,
 		"effective_limits", limiter.effectiveLimits(),
 		"preview_mode", limiter.enabled())
 

--- a/src/internal/m365/collection/drive/collections_tree_test.go
+++ b/src/internal/m365/collection/drive/collections_tree_test.go
@@ -707,7 +707,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_MakeDriveCollections() {
 				test.drive.able,
 				test.prevPaths,
 				deltaURL("prev"),
-				newPagerLimiter(control.DefaultOptions()),
+				newPagerLimiter(control.DefaultBackupConfig()),
 				globalExcludes,
 				c.counter,
 				fault.New(true))
@@ -1123,7 +1123,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 					},
 				},
 			},
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: populateTreeExpected{
 				counts:                        countTD.Expected{},
 				err:                           require.NoError,
@@ -1142,7 +1142,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 				d.newEnumer().with(
 					delta(nil).with(
 						aPage()))),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed: 1,
@@ -1168,7 +1168,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 					delta(nil).with(
 						aPage(),
 						aPage()))),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed: 2,
@@ -1197,7 +1197,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 						aPage(
 							d.folderAt(root),
 							d.folderAt(folder, "chld"))))),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed: 7,
@@ -1234,7 +1234,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 							d.folderAt(root),
 							d.folderAt(folder, "chld"),
 							d.fileAt("chld", "fchld"))))),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed: 7,
@@ -1266,7 +1266,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 				d.newEnumer().with(
 					delta(nil).with(
 						aPage(delItem(folderID(), folderID("parent"), isFolder))))),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed:       1,
@@ -1294,7 +1294,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 				d.newEnumer().with(
 					delta(nil).with(aPage(
 						delItem(folderID(), folderID("parent"), isFolder))))),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed:       1,
@@ -1330,7 +1330,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 							d.folderAt(root),
 							d.fileAt(folder)),
 						aPage(delItem(folderID(), rootID, isFolder))))),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed:       3,
@@ -1364,7 +1364,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 							driveItem(folderID(), folderName("moved"), d.dir(), folderID("parent"), isFolder),
 							driveFile(d.dir(folderName("parent"), folderName()), folderID())),
 						aPage(delItem(folderID(), folderID("parent"), isFolder))))),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed:       4,
@@ -1398,7 +1398,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 						aPage(
 							d.folderAt(root),
 							d.fileAt(folder))))),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
 					count.TotalDeleteFoldersProcessed: 1,
@@ -1430,7 +1430,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_singleDelta(
 						aPage(
 							d.folderAt(root),
 							d.fileAt(folder))))),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
 					count.TotalDeleteFoldersProcessed: 1,
@@ -1557,7 +1557,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 							d.folderAt(root),
 							d.folderAt(folder, "chld"),
 							d.fileAt("chld", "fchld"))))),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
 					count.TotalDeltasProcessed:        4,
@@ -1601,7 +1601,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 						with(aPage(
 							d.folderAt(root),
 							d.fileAt(folder))))),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
 					count.TotalDeltasProcessed:        4,
@@ -1643,7 +1643,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 						aPage(
 							d.folderAt(root),
 							d.fileAt(folder))))),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
 					count.TotalDeltasProcessed:        3,
@@ -1678,7 +1678,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 						aPage(
 							driveItem(folderID(), folderName("rename"), d.dir(), rootID, isFolder),
 							driveItem(fileID(), fileName("rename"), d.dir(folderName("rename")), folderID(), isFile))))),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
 					count.TotalDeltasProcessed:        3,
@@ -1725,7 +1725,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_PopulateTree_multiDelta()
 					delta(nil).with(
 						aPage(
 							delItem(folderID(), rootID, isFolder))))),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: populateTreeExpected{
 				counts: countTD.Expected{
 					count.TotalDeltasProcessed:        3,
@@ -1845,7 +1845,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			name:    "nil page",
 			tree:    treeWithRoot,
 			page:    nextPage{},
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: expected{
 				counts:   countTD.Expected{},
 				err:      require.NoError,
@@ -1860,7 +1860,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			name:    "empty page",
 			tree:    treeWithRoot,
 			page:    nextPage{Items: []models.DriveItemable{}},
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: expected{
 				counts:   countTD.Expected{},
 				err:      require.NoError,
@@ -1875,7 +1875,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			name:    "root only",
 			tree:    treeWithRoot,
 			page:    aPage(),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed: 1,
@@ -1895,7 +1895,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 				d.folderAt(root),
 				d.folderAt(folder, "chld"),
 				d.folderAt(root, "sib")),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed: 4,
@@ -1917,7 +1917,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			page: aPage(
 				d.folderAt(root),
 				delItem(folderID(), rootID, isFolder)),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed:       2,
@@ -1938,7 +1938,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 				d.folderAt(root, "parent"),
 				driveItem(folderID(), folderName("moved"), d.dir(folderName("parent")), folderID("parent"), isFolder),
 				delItem(folderID(), folderID("parent"), isFolder)),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed:       3,
@@ -1961,7 +1961,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			page: aPage(
 				delItem(folderID(), rootID, isFolder),
 				d.folderAt(root)),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed:       2,
@@ -1982,7 +1982,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_fold
 			page: aPage(
 				delItem(folderID(), rootID, isFolder),
 				d.folderAt(root)),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalFoldersProcessed:       2,
@@ -2074,7 +2074,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 			name:    "add folder",
 			tree:    treeWithRoot,
 			folder:  fld,
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: expected{
 				countLiveFolders: 2,
 				err:              require.NoError,
@@ -2093,7 +2093,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 			name:    "re-add folder that already exists",
 			tree:    treeWithFolders,
 			folder:  subFld,
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: expected{
 				countLiveFolders: 3,
 				err:              require.NoError,
@@ -2112,7 +2112,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 			name:    "add package",
 			tree:    treeWithRoot,
 			folder:  pack,
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: expected{
 				countLiveFolders: 2,
 				err:              require.NoError,
@@ -2131,7 +2131,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 			name:    "tombstone a folder in a populated tree",
 			tree:    treeWithFolders,
 			folder:  del,
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: expected{
 				countLiveFolders: 2,
 				err:              require.NoError,
@@ -2150,7 +2150,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 			name:    "tombstone new folder in unpopulated tree",
 			tree:    newTree,
 			folder:  del,
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: expected{
 				err: require.NoError,
 				counts: countTD.Expected{
@@ -2168,7 +2168,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 			name:    "re-add tombstone that already exists",
 			tree:    treeWithTombstone,
 			folder:  del,
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: expected{
 				countLiveFolders: 1,
 				err:              require.NoError,
@@ -2187,7 +2187,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFolderToTree() {
 			name:    "add malware",
 			tree:    treeWithRoot,
 			folder:  mal,
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: expected{
 				countLiveFolders: 1,
 				err:              require.NoError,
@@ -2573,7 +2573,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_EnumeratePageOfItems_file
 				tree,
 				d.able,
 				test.page.Items,
-				newPagerLimiter(control.DefaultOptions()),
+				newPagerLimiter(control.DefaultBackupConfig()),
 				counter,
 				fault.New(true))
 			test.expect.err(t, err, clues.ToCore(err))
@@ -2619,7 +2619,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 			name:    "add new file",
 			tree:    treeWithRoot,
 			file:    d.fileAt(root),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalFilesProcessed: 1,
@@ -2637,7 +2637,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 			name:    "duplicate file",
 			tree:    treeWithFileAtRoot,
 			file:    d.fileAt(root),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalFilesProcessed: 1,
@@ -2655,7 +2655,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 			name:    "error file seen before parent",
 			tree:    treeWithRoot,
 			file:    d.fileAt(folder),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalFilesProcessed: 1,
@@ -2671,7 +2671,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 			name:    "malware file",
 			tree:    treeWithRoot,
 			file:    malwareItem(fileID(), fileName(), d.dir(folderName()), rootID, isFile),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalMalwareProcessed: 1,
@@ -2687,7 +2687,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 			name:    "delete non-existing file",
 			tree:    treeWithRoot,
 			file:    delItem(fileID(), folderID(), isFile),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 1,
@@ -2703,7 +2703,7 @@ func (suite *CollectionsTreeUnitSuite) TestCollections_AddFileToTree() {
 			name:    "delete existing file",
 			tree:    treeWithFileAtRoot,
 			file:    delItem(fileID(), rootID, isFile),
-			limiter: newPagerLimiter(control.DefaultOptions()),
+			limiter: newPagerLimiter(control.DefaultBackupConfig()),
 			expect: expected{
 				counts: countTD.Expected{
 					count.TotalDeleteFilesProcessed: 1,

--- a/src/internal/m365/collection/drive/helper_test.go
+++ b/src/internal/m365/collection/drive/helper_test.go
@@ -185,8 +185,8 @@ func defaultMetadataPath(t *testing.T) path.Path {
 // limiter
 // ---------------------------------------------------------------------------
 
-func minimumLimitOpts() control.Options {
-	minLimitOpts := control.DefaultOptions()
+func minimumLimitOpts() control.BackupConfig {
+	minLimitOpts := control.DefaultBackupConfig()
 	minLimitOpts.PreviewLimits.Enabled = true
 	minLimitOpts.PreviewLimits.MaxBytes = 1
 	minLimitOpts.PreviewLimits.MaxContainers = 1
@@ -202,20 +202,20 @@ func minimumLimitOpts() control.Options {
 // ---------------------------------------------------------------------------
 
 func collWithMBH(mbh BackupHandler) *Collections {
-	return NewCollections(
+	opts := control.Options{ToggleFeatures: control.Toggles{
+		UseDeltaTree: true,
+	}}
+
+	return collWithMBHAndOpts(
 		mbh,
-		tenant,
-		idname.NewProvider(user, user),
-		func(*support.ControllerOperationStatus) {},
-		control.Options{ToggleFeatures: control.Toggles{
-			UseDeltaTree: true,
-		}},
-		count.New())
+		opts,
+		control.DefaultBackupConfig())
 }
 
 func collWithMBHAndOpts(
 	mbh BackupHandler,
 	opts control.Options,
+	backupOpts control.BackupConfig,
 ) *Collections {
 	return NewCollections(
 		mbh,
@@ -223,6 +223,7 @@ func collWithMBHAndOpts(
 		idname.NewProvider(user, user),
 		func(*support.ControllerOperationStatus) {},
 		opts,
+		backupOpts,
 		count.New())
 }
 

--- a/src/internal/m365/collection/drive/item_collector_test.go
+++ b/src/internal/m365/collection/drive/item_collector_test.go
@@ -276,6 +276,7 @@ func (suite *OneDriveIntgSuite) TestOneDriveNewCollections() {
 				control.Options{
 					ToggleFeatures: control.Toggles{},
 				},
+				control.DefaultBackupConfig(),
 				count.New())
 
 			ssmb := prefixmatcher.NewStringSetBuilder()

--- a/src/internal/m365/collection/drive/limiter.go
+++ b/src/internal/m365/collection/drive/limiter.go
@@ -18,7 +18,7 @@ type driveEnumerationStats struct {
 	numBytes      int64
 }
 
-func newPagerLimiter(opts control.Options) *pagerLimiter {
+func newPagerLimiter(opts control.BackupConfig) *pagerLimiter {
 	res := &pagerLimiter{limits: opts.PreviewLimits}
 
 	if res.limits.MaxContainers == 0 {

--- a/src/internal/m365/collection/exchange/backup.go
+++ b/src/internal/m365/collection/exchange/backup.go
@@ -86,6 +86,7 @@ func CreateCollections(
 		scope,
 		dps,
 		bpc.Options,
+		bpc.BackupOptions,
 		counter,
 		errs)
 	if err != nil {
@@ -119,6 +120,7 @@ func populateCollections(
 	scope selectors.ExchangeScope,
 	dps metadata.DeltaPaths,
 	ctrlOpts control.Options,
+	backupOpts control.BackupConfig,
 	counter *count.Bus,
 	errs *fault.Bus,
 ) (map[string]data.BackupCollection, error) {
@@ -138,7 +140,7 @@ func populateCollections(
 		// since they only act on a subset of items. Make a copy of the passed in
 		// limits so we can log both the passed in options and what they were set to
 		// if we used default values for some things.
-		effectiveLimits = ctrlOpts.PreviewLimits
+		effectiveLimits = backupOpts.PreviewLimits
 
 		addedItems      int
 		addedContainers int
@@ -182,7 +184,7 @@ func populateCollections(
 	logger.Ctx(ctx).Infow(
 		"filling collections",
 		"len_deltapaths", len(dps),
-		"limits", ctrlOpts.PreviewLimits,
+		"limits", backupOpts.PreviewLimits,
 		"effective_limits", effectiveLimits)
 	counter.Add(count.PrevDeltas, int64(len(dps)))
 

--- a/src/internal/m365/collection/exchange/backup_test.go
+++ b/src/internal/m365/collection/exchange/backup_test.go
@@ -1199,6 +1199,7 @@ func (suite *CollectionPopulationSuite) TestPopulateCollections() {
 					test.scope,
 					dps,
 					ctrlOpts,
+					control.DefaultBackupConfig(),
 					count.New(),
 					fault.New(test.failFast == control.FailFast))
 				test.expectErr(t, err, clues.ToCore(err))
@@ -1542,6 +1543,7 @@ func (suite *CollectionPopulationSuite) TestFilterContainersAndFillCollections_D
 						sc.scope,
 						test.inputMetadata(t, qp.Category),
 						control.Options{FailureHandling: control.FailFast},
+						control.DefaultBackupConfig(),
 						count.New(),
 						fault.New(true))
 					require.NoError(t, err, "getting collections", clues.ToCore(err))
@@ -1709,6 +1711,7 @@ func (suite *CollectionPopulationSuite) TestFilterContainersAndFillCollections_r
 				allScope,
 				dps,
 				control.Options{FailureHandling: control.FailFast},
+				control.DefaultBackupConfig(),
 				count.New(),
 				fault.New(true))
 			require.NoError(t, err, clues.ToCore(err))
@@ -2066,7 +2069,9 @@ func (suite *CollectionPopulationSuite) TestFilterContainersAndFillCollections_P
 			// deadlock.
 			opts := control.DefaultOptions()
 			opts.FailureHandling = control.FailFast
-			opts.PreviewLimits = test.limits
+
+			backupOpts := control.DefaultBackupConfig()
+			backupOpts.PreviewLimits = test.limits
 
 			resolver := newMockResolver(inputContainers...)
 			getter := mockGetter{results: inputItems}
@@ -2090,6 +2095,7 @@ func (suite *CollectionPopulationSuite) TestFilterContainersAndFillCollections_P
 				allScope,
 				dps,
 				opts,
+				backupOpts,
 				count.New(),
 				fault.New(true))
 			require.NoError(t, err, clues.ToCore(err))
@@ -2306,7 +2312,9 @@ func (suite *CollectionPopulationSuite) TestFilterContainersAndFillCollections_P
 			// deadlock.
 			opts := control.DefaultOptions()
 			opts.FailureHandling = control.FailFast
-			opts.PreviewLimits = test.limits
+
+			backupOpts := control.DefaultBackupConfig()
+			backupOpts.PreviewLimits = test.limits
 
 			resolver := newMockResolver(inputContainers...)
 			getter := mockGetter{results: inputItems}
@@ -2328,6 +2336,7 @@ func (suite *CollectionPopulationSuite) TestFilterContainersAndFillCollections_P
 				allScope,
 				dps,
 				opts,
+				backupOpts,
 				count.New(),
 				fault.New(true))
 			require.NoError(t, err, clues.ToCore(err))
@@ -2762,6 +2771,7 @@ func (suite *CollectionPopulationSuite) TestFilterContainersAndFillCollections_i
 						allScope,
 						test.dps,
 						ctrlOpts,
+						control.DefaultBackupConfig(),
 						count.New(),
 						fault.New(true))
 					assert.NoError(t, err, clues.ToCore(err))

--- a/src/internal/m365/collection/site/backup.go
+++ b/src/internal/m365/collection/site/backup.go
@@ -50,6 +50,7 @@ func CollectLibraries(
 			bpc.ProtectedResource,
 			su,
 			bpc.Options,
+			bpc.BackupOptions,
 			counter)
 	)
 

--- a/src/internal/m365/service/onedrive/backup.go
+++ b/src/internal/m365/service/onedrive/backup.go
@@ -60,6 +60,7 @@ func ProduceBackupCollections(
 			bpc.ProtectedResource,
 			su,
 			bpc.Options,
+			bpc.BackupOptions,
 			counter)
 
 		pcfg := observe.ProgressCfg{

--- a/src/internal/m365/service/sharepoint/backup_test.go
+++ b/src/internal/m365/service/sharepoint/backup_test.go
@@ -113,6 +113,7 @@ func (suite *LibrariesBackupUnitSuite) TestUpdateCollections() {
 				idname.NewProvider(siteID, siteID),
 				nil,
 				control.DefaultOptions(),
+				control.DefaultBackupConfig(),
 				count.New())
 
 			c.CollectionMap = collMap

--- a/src/internal/operations/inject/containers.go
+++ b/src/internal/operations/inject/containers.go
@@ -25,6 +25,7 @@ type BackupProducerConfig struct {
 	LastBackupVersion   int
 	MetadataCollections []data.RestoreCollection
 	Options             control.Options
+	BackupOptions       control.BackupConfig
 	ProtectedResource   idname.Provider
 	Selector            selectors.Selector
 }

--- a/src/internal/operations/maintenance_test.go
+++ b/src/internal/operations/maintenance_test.go
@@ -179,6 +179,7 @@ func (suite *MaintenanceOpNightlySuite) TestRepoMaintenance_GarbageCollection() 
 			bo, err := NewBackupOperation(
 				ctx,
 				opts,
+				control.DefaultBackupConfig(),
 				kw,
 				storer,
 				&bp,

--- a/src/internal/operations/test/m365/backup_helper.go
+++ b/src/internal/operations/test/m365/backup_helper.go
@@ -71,6 +71,7 @@ func PrepNewTestBackupOp(
 	bus events.Eventer,
 	sel selectors.Selector,
 	opts control.Options,
+	backupOpts control.BackupConfig,
 	backupVersion int,
 	counter *count.Bus,
 ) (
@@ -129,6 +130,7 @@ func PrepNewTestBackupOp(
 		bod,
 		bus,
 		opts,
+		backupOpts,
 		counter)
 	bo.BackupVersion = backupVersion
 
@@ -150,6 +152,7 @@ func NewTestBackupOp(
 	bod *BackupOpDependencies,
 	bus events.Eventer,
 	opts control.Options,
+	backupOpts control.BackupConfig,
 	counter *count.Bus,
 ) operations.BackupOperation {
 	bod.Ctrl.IDNameLookup = idname.NewCache(map[string]string{bod.Sel.ID(): bod.Sel.Name()})
@@ -157,6 +160,7 @@ func NewTestBackupOp(
 	bo, err := operations.NewBackupOperation(
 		ctx,
 		opts,
+		backupOpts,
 		bod.KW,
 		bod.SW,
 		bod.Ctrl,
@@ -279,6 +283,7 @@ func RunMergeBaseGroupsUpdate(
 		mb,
 		sel,
 		opts,
+		control.DefaultBackupConfig(),
 		version.All8MigrateUserPNToID,
 		count.New())
 	defer bod.Close(t, ctx)
@@ -338,12 +343,15 @@ func RunMergeBaseGroupsUpdate(
 			opts = control.DefaultOptions()
 		)
 
+		opts.ToggleFeatures.UseDeltaTree = true
+
 		forcedFull := NewTestBackupOp(
 			t,
 			ctx,
 			bod,
 			mb,
 			opts,
+			control.DefaultBackupConfig(),
 			count.New())
 		forcedFull.BackupVersion = version.Groups9Update
 

--- a/src/internal/operations/test/m365/driveish.go
+++ b/src/internal/operations/test/m365/driveish.go
@@ -45,6 +45,7 @@ func RunBasicDriveishBackupTests(
 	suite tester.Suite,
 	service path.ServiceType,
 	opts control.Options,
+	backupOpts control.BackupConfig,
 	sel selectors.Selector,
 ) {
 	t := suite.T()
@@ -59,7 +60,15 @@ func RunBasicDriveishBackupTests(
 		ws      = deeTD.DriveIDFromRepoRef
 	)
 
-	bo, bod := PrepNewTestBackupOp(t, ctx, mb, sel, opts, version.Backup, counter)
+	bo, bod := PrepNewTestBackupOp(
+		t,
+		ctx,
+		mb,
+		sel,
+		opts,
+		backupOpts,
+		version.Backup,
+		counter)
 	defer bod.Close(t, ctx)
 
 	RunAndCheckBackup(t, ctx, &bo, mb, false)
@@ -90,6 +99,7 @@ func RunBasicDriveishBackupTests(
 func RunIncrementalDriveishBackupTest(
 	suite tester.Suite,
 	opts control.Options,
+	backupOpts control.BackupConfig,
 	owner, permissionsUser string,
 	service path.ServiceType,
 	category path.CategoryType,
@@ -259,7 +269,15 @@ func RunIncrementalDriveishBackupTest(
 			locRef)
 	}
 
-	bo, bod := PrepNewTestBackupOp(t, ctx, mb, sel, opts, version.Backup, counter)
+	bo, bod := PrepNewTestBackupOp(
+		t,
+		ctx,
+		mb,
+		sel,
+		opts,
+		backupOpts,
+		version.Backup,
+		counter)
 	defer bod.Close(t, ctx)
 
 	sel = bod.Sel
@@ -657,6 +675,7 @@ func RunIncrementalDriveishBackupTest(
 					bod,
 					incMB,
 					opts,
+					backupOpts,
 					counter)
 			)
 
@@ -755,6 +774,7 @@ func RunDriveishBackupWithExtensionsTests(
 	suite tester.Suite,
 	service path.ServiceType,
 	opts control.Options,
+	backupOpts control.BackupConfig,
 	sel selectors.Selector,
 ) {
 	t := suite.T()
@@ -771,7 +791,15 @@ func RunDriveishBackupWithExtensionsTests(
 
 	opts.ItemExtensionFactory = GetTestExtensionFactories()
 
-	bo, bod := PrepNewTestBackupOp(t, ctx, mb, sel, opts, version.Backup, counter)
+	bo, bod := PrepNewTestBackupOp(
+		t,
+		ctx,
+		mb,
+		sel,
+		opts,
+		backupOpts,
+		version.Backup,
+		counter)
 	defer bod.Close(t, ctx)
 
 	RunAndCheckBackup(t, ctx, &bo, mb, false)
@@ -883,6 +911,7 @@ func RunDriveAssistBaseGroupsUpdate(
 		mb,
 		sel,
 		opts,
+		control.DefaultBackupConfig(),
 		version.All8MigrateUserPNToID,
 		counter)
 	defer bod.Close(t, ctx)
@@ -929,6 +958,7 @@ func RunDriveAssistBaseGroupsUpdate(
 			bod,
 			mb,
 			opts,
+			control.DefaultBackupConfig(),
 			counter)
 		forcedFull.BackupVersion = version.Groups9Update
 
@@ -1003,7 +1033,15 @@ func RunDriveRestoreToAlternateProtectedResource(
 		opts    = control.DefaultOptions()
 	)
 
-	bo, bod := PrepNewTestBackupOp(t, ctx, mb, sel, opts, version.Backup, counter)
+	bo, bod := PrepNewTestBackupOp(
+		t,
+		ctx,
+		mb,
+		sel,
+		opts,
+		control.DefaultBackupConfig(),
+		version.Backup,
+		counter)
 	defer bod.Close(t, ctx)
 
 	RunAndCheckBackup(t, ctx, &bo, mb, false)
@@ -1160,7 +1198,15 @@ func RunDriveRestoreWithAdvancedOptions(
 		opts    = control.DefaultOptions()
 	)
 
-	bo, bod := PrepNewTestBackupOp(t, ctx, mb, sel, opts, version.Backup, counter)
+	bo, bod := PrepNewTestBackupOp(
+		t,
+		ctx,
+		mb,
+		sel,
+		opts,
+		control.DefaultBackupConfig(),
+		version.Backup,
+		counter)
 	defer bod.Close(t, ctx)
 
 	RunAndCheckBackup(t, ctx, &bo, mb, false)

--- a/src/internal/operations/test/m365/exchange/exchange_test.go
+++ b/src/internal/operations/test/m365/exchange/exchange_test.go
@@ -125,7 +125,15 @@ func (suite *ExchangeBackupIntgSuite) TestBackup_Run_exchange() {
 				whatSet = deeTD.CategoryFromRepoRef
 			)
 
-			bo, bod := PrepNewTestBackupOp(t, ctx, mb, sel, opts, version.Backup, counter)
+			bo, bod := PrepNewTestBackupOp(
+				t,
+				ctx,
+				mb,
+				sel,
+				opts,
+				control.DefaultBackupConfig(),
+				version.Backup,
+				counter)
 			defer bod.Close(t, ctx)
 
 			sel = bod.Sel
@@ -188,6 +196,7 @@ func (suite *ExchangeBackupIntgSuite) TestBackup_Run_exchange() {
 					bod,
 					incMB,
 					opts,
+					control.DefaultBackupConfig(),
 					counter)
 			)
 
@@ -478,7 +487,15 @@ func testExchangeContinuousBackups(suite *ExchangeBackupIntgSuite, toggles contr
 		}
 	}
 
-	bo, bod := PrepNewTestBackupOp(t, ctx, mb, sel.Selector, opts, version.Backup, counter)
+	bo, bod := PrepNewTestBackupOp(
+		t,
+		ctx,
+		mb,
+		sel.Selector,
+		opts,
+		control.DefaultBackupConfig(),
+		version.Backup,
+		counter)
 	defer bod.Close(t, ctx)
 
 	// run the initial backup
@@ -820,7 +837,14 @@ func testExchangeContinuousBackups(suite *ExchangeBackupIntgSuite, toggles contr
 			ctx, flush := tester.WithContext(t, ctx)
 			defer flush()
 
-			incBO := NewTestBackupOp(t, ctx, bod, incMB, opts, counter)
+			incBO := NewTestBackupOp(
+				t,
+				ctx,
+				bod,
+				incMB,
+				opts,
+				control.DefaultBackupConfig(),
+				counter)
 
 			suite.Run("PreTestSetup", func() {
 				t := suite.T()
@@ -976,7 +1000,15 @@ func (suite *ExchangeRestoreNightlyIntgSuite) TestRestore_Run_exchangeWithAdvanc
 		opts    = control.DefaultOptions()
 	)
 
-	bo, bod := PrepNewTestBackupOp(t, ctx, mb, baseSel.Selector, opts, version.Backup, counter)
+	bo, bod := PrepNewTestBackupOp(
+		t,
+		ctx,
+		mb,
+		baseSel.Selector,
+		opts,
+		control.DefaultBackupConfig(),
+		version.Backup,
+		counter)
 	defer bod.Close(t, ctx)
 
 	RunAndCheckBackup(t, ctx, &bo, mb, false)
@@ -1293,7 +1325,15 @@ func (suite *ExchangeRestoreNightlyIntgSuite) TestRestore_Run_exchangeAlternateP
 		opts    = control.DefaultOptions()
 	)
 
-	bo, bod := PrepNewTestBackupOp(t, ctx, mb, baseSel.Selector, opts, version.Backup, counter)
+	bo, bod := PrepNewTestBackupOp(
+		t,
+		ctx,
+		mb,
+		baseSel.Selector,
+		opts,
+		control.DefaultBackupConfig(),
+		version.Backup,
+		counter)
 	defer bod.Close(t, ctx)
 
 	RunAndCheckBackup(t, ctx, &bo, mb, false)

--- a/src/internal/operations/test/m365/groups/groups_test.go
+++ b/src/internal/operations/test/m365/groups/groups_test.go
@@ -55,11 +55,16 @@ func (suite *GroupsBackupIntgSuite) TestBackup_Run_groups() {
 		suite,
 		path.GroupsService,
 		control.DefaultOptions(),
+		control.DefaultBackupConfig(),
 		sel.Selector)
 }
 
 func (suite *GroupsBackupIntgSuite) TestBackup_Run_incrementalGroups() {
-	runGroupsIncrementalBackupTests(suite, suite.its, control.DefaultOptions())
+	runGroupsIncrementalBackupTests(
+		suite,
+		suite.its,
+		control.DefaultOptions(),
+		control.DefaultBackupConfig())
 }
 
 func (suite *GroupsBackupIntgSuite) TestBackup_Run_extensionsGroups() {
@@ -75,6 +80,7 @@ func (suite *GroupsBackupIntgSuite) TestBackup_Run_extensionsGroups() {
 		suite,
 		path.GroupsService,
 		control.DefaultOptions(),
+		control.DefaultBackupConfig(),
 		sel.Selector)
 }
 
@@ -114,6 +120,7 @@ func (suite *GroupsBackupTreeIntgSuite) TestBackup_Run_treeGroups() {
 		suite,
 		path.GroupsService,
 		opts,
+		control.DefaultBackupConfig(),
 		sel.Selector)
 }
 
@@ -121,7 +128,11 @@ func (suite *GroupsBackupTreeIntgSuite) TestBackup_Run_treeIncrementalGroups() {
 	opts := control.DefaultOptions()
 	opts.ToggleFeatures.UseDeltaTree = true
 
-	runGroupsIncrementalBackupTests(suite, suite.its, opts)
+	runGroupsIncrementalBackupTests(
+		suite,
+		suite.its,
+		opts,
+		control.DefaultBackupConfig())
 }
 
 func (suite *GroupsBackupTreeIntgSuite) TestBackup_Run_treeExtensionsGroups() {
@@ -139,6 +150,7 @@ func (suite *GroupsBackupTreeIntgSuite) TestBackup_Run_treeExtensionsGroups() {
 		suite,
 		path.GroupsService,
 		opts,
+		control.DefaultBackupConfig(),
 		sel.Selector)
 }
 
@@ -150,6 +162,7 @@ func runGroupsIncrementalBackupTests(
 	suite tester.Suite,
 	its IntgTesterSetup,
 	opts control.Options,
+	backupOpts control.BackupConfig,
 ) {
 	sel := selectors.NewGroupsRestore([]string{its.Group.ID})
 
@@ -179,6 +192,7 @@ func runGroupsIncrementalBackupTests(
 	RunIncrementalDriveishBackupTest(
 		suite,
 		opts,
+		backupOpts,
 		its.Group.ID,
 		its.User.ID,
 		path.GroupsService,
@@ -209,7 +223,15 @@ func (suite *GroupsBackupIntgSuite) TestBackup_Run_groupsBasic() {
 		selTD.GroupsBackupChannelScope(sel),
 		selTD.GroupsBackupConversationScope(sel))
 
-	bo, bod := PrepNewTestBackupOp(t, ctx, mb, sel.Selector, opts, version.Backup, counter)
+	bo, bod := PrepNewTestBackupOp(
+		t,
+		ctx,
+		mb,
+		sel.Selector,
+		opts,
+		control.DefaultBackupConfig(),
+		version.Backup,
+		counter)
 	defer bod.Close(t, ctx)
 
 	reasons, err := bod.Sel.Reasons(bod.Acct.ID(), false)
@@ -264,6 +286,7 @@ func (suite *GroupsBackupIntgSuite) TestBackup_Run_groupsBasic() {
 		bod,
 		incMB,
 		opts,
+		control.DefaultBackupConfig(),
 		count.New())
 
 	RunAndCheckBackup(t, ctx, &incBO, incMB, true)

--- a/src/internal/operations/test/m365/onedrive/onedrive_test.go
+++ b/src/internal/operations/test/m365/onedrive/onedrive_test.go
@@ -64,11 +64,16 @@ func (suite *OneDriveBackupIntgSuite) TestBackup_Run_oneDrive() {
 		suite,
 		path.OneDriveService,
 		control.DefaultOptions(),
+		control.DefaultBackupConfig(),
 		sel.Selector)
 }
 
 func (suite *OneDriveBackupIntgSuite) TestBackup_Run_incrementalOneDrive() {
-	runOneDriveIncrementalBackupTests(suite, suite.its, control.DefaultOptions())
+	runOneDriveIncrementalBackupTests(
+		suite,
+		suite.its,
+		control.DefaultOptions(),
+		control.DefaultBackupConfig())
 }
 
 func (suite *OneDriveBackupIntgSuite) TestBackup_Run_extensionsOneDrive() {
@@ -83,6 +88,7 @@ func (suite *OneDriveBackupIntgSuite) TestBackup_Run_extensionsOneDrive() {
 		suite,
 		path.OneDriveService,
 		control.DefaultOptions(),
+		control.DefaultBackupConfig(),
 		sel.Selector)
 }
 
@@ -122,6 +128,7 @@ func (suite *OneDriveBackupTreeIntgSuite) TestBackup_Run_treeOneDrive() {
 		suite,
 		path.OneDriveService,
 		opts,
+		control.DefaultBackupConfig(),
 		sel.Selector)
 }
 
@@ -129,7 +136,11 @@ func (suite *OneDriveBackupTreeIntgSuite) TestBackup_Run_treeIncrementalOneDrive
 	opts := control.DefaultOptions()
 	opts.ToggleFeatures.UseDeltaTree = true
 
-	runOneDriveIncrementalBackupTests(suite, suite.its, opts)
+	runOneDriveIncrementalBackupTests(
+		suite,
+		suite.its,
+		opts,
+		control.DefaultBackupConfig())
 }
 
 func (suite *OneDriveBackupTreeIntgSuite) TestBackup_Run_treeExtensionsOneDrive() {
@@ -147,6 +158,7 @@ func (suite *OneDriveBackupTreeIntgSuite) TestBackup_Run_treeExtensionsOneDrive(
 		suite,
 		path.OneDriveService,
 		opts,
+		control.DefaultBackupConfig(),
 		sel.Selector)
 }
 
@@ -158,6 +170,7 @@ func runOneDriveIncrementalBackupTests(
 	suite tester.Suite,
 	its IntgTesterSetup,
 	opts control.Options,
+	backupOpts control.BackupConfig,
 ) {
 	sel := selectors.NewOneDriveRestore([]string{its.User.ID})
 
@@ -191,6 +204,7 @@ func runOneDriveIncrementalBackupTests(
 	RunIncrementalDriveishBackupTest(
 		suite,
 		opts,
+		backupOpts,
 		its.User.ID,
 		its.User.ID,
 		path.OneDriveService,
@@ -246,7 +260,15 @@ func (suite *OneDriveBackupIntgSuite) TestBackup_Run_oneDriveOwnerMigration() {
 	oldsel := selectors.NewOneDriveBackup([]string{uname})
 	oldsel.Include(selTD.OneDriveBackupFolderScope(oldsel))
 
-	bo, bod := PrepNewTestBackupOp(t, ctx, mb, oldsel.Selector, opts, 0, counter)
+	bo, bod := PrepNewTestBackupOp(
+		t,
+		ctx,
+		mb,
+		oldsel.Selector,
+		opts,
+		control.DefaultBackupConfig(),
+		0,
+		counter)
 	defer bod.Close(t, ctx)
 
 	sel := bod.Sel
@@ -274,7 +296,14 @@ func (suite *OneDriveBackupIntgSuite) TestBackup_Run_oneDriveOwnerMigration() {
 	var (
 		incMB = evmock.NewBus()
 		// the incremental backup op should have a proper user ID for the id.
-		incBO = NewTestBackupOp(t, ctx, bod, incMB, opts, counter)
+		incBO = NewTestBackupOp(
+			t,
+			ctx,
+			bod,
+			incMB,
+			opts,
+			control.DefaultBackupConfig(),
+			counter)
 	)
 
 	require.NotEqualf(

--- a/src/internal/operations/test/m365/sharepoint/sharepoint_test.go
+++ b/src/internal/operations/test/m365/sharepoint/sharepoint_test.go
@@ -59,6 +59,7 @@ func (suite *SharePointBackupIntgSuite) TestBackup_Run_sharePoint() {
 		suite,
 		path.SharePointService,
 		control.DefaultOptions(),
+		control.DefaultBackupConfig(),
 		sel.Selector)
 }
 
@@ -85,6 +86,7 @@ func (suite *SharePointBackupIntgSuite) TestBackup_Run_sharePointList() {
 		mb,
 		sel.Selector,
 		control.DefaultOptions(),
+		control.DefaultBackupConfig(),
 		version.Backup,
 		counter)
 	defer bod.Close(t, ctx)
@@ -124,7 +126,11 @@ func (suite *SharePointBackupIntgSuite) TestBackup_Run_sharePointList() {
 }
 
 func (suite *SharePointBackupIntgSuite) TestBackup_Run_incrementalSharePoint() {
-	runSharePointIncrementalBackupTests(suite, suite.its, control.DefaultOptions())
+	runSharePointIncrementalBackupTests(
+		suite,
+		suite.its,
+		control.DefaultOptions(),
+		control.DefaultBackupConfig())
 }
 
 func (suite *SharePointBackupIntgSuite) TestBackup_Run_extensionsSharePoint() {
@@ -139,6 +145,7 @@ func (suite *SharePointBackupIntgSuite) TestBackup_Run_extensionsSharePoint() {
 		suite,
 		path.SharePointService,
 		control.DefaultOptions(),
+		control.DefaultBackupConfig(),
 		sel.Selector)
 }
 
@@ -178,6 +185,7 @@ func (suite *SharePointBackupTreeIntgSuite) TestBackup_Run_treeSharePoint() {
 		suite,
 		path.SharePointService,
 		opts,
+		control.DefaultBackupConfig(),
 		sel.Selector)
 }
 
@@ -185,7 +193,7 @@ func (suite *SharePointBackupTreeIntgSuite) TestBackup_Run_treeIncrementalShareP
 	opts := control.DefaultOptions()
 	opts.ToggleFeatures.UseDeltaTree = true
 
-	runSharePointIncrementalBackupTests(suite, suite.its, opts)
+	runSharePointIncrementalBackupTests(suite, suite.its, opts, control.DefaultBackupConfig())
 }
 
 func (suite *SharePointBackupTreeIntgSuite) TestBackup_Run_treeExtensionsSharePoint() {
@@ -203,6 +211,7 @@ func (suite *SharePointBackupTreeIntgSuite) TestBackup_Run_treeExtensionsSharePo
 		suite,
 		path.SharePointService,
 		opts,
+		control.DefaultBackupConfig(),
 		sel.Selector)
 }
 
@@ -214,6 +223,7 @@ func runSharePointIncrementalBackupTests(
 	suite tester.Suite,
 	its IntgTesterSetup,
 	opts control.Options,
+	backupOpts control.BackupConfig,
 ) {
 	sel := selectors.NewSharePointRestore([]string{its.Site.ID})
 
@@ -247,6 +257,7 @@ func runSharePointIncrementalBackupTests(
 	RunIncrementalDriveishBackupTest(
 		suite,
 		opts,
+		backupOpts,
 		its.Site.ID,
 		its.User.ID,
 		path.SharePointService,
@@ -392,7 +403,15 @@ func (suite *SharePointRestoreNightlyIntgSuite) TestRestore_Run_sharepointDelete
 	bsel.Filter(bsel.Library(rc.Location))
 	bsel.DiscreteOwner = suite.its.Site.ID
 
-	bo, bod := PrepNewTestBackupOp(t, ctx, mb, bsel.Selector, opts, version.Backup, counter)
+	bo, bod := PrepNewTestBackupOp(
+		t,
+		ctx,
+		mb,
+		bsel.Selector,
+		opts,
+		control.DefaultBackupConfig(),
+		version.Backup,
+		counter)
 	defer bod.Close(t, ctx)
 
 	RunAndCheckBackup(t, ctx, &bo, mb, false)

--- a/src/pkg/control/backup.go
+++ b/src/pkg/control/backup.go
@@ -1,21 +1,8 @@
 package control
 
-import (
-	"github.com/alcionai/corso/src/pkg/extensions"
-)
-
 // DefaultBackupOptions provides a Backup with the default values set.
 func DefaultBackupConfig() BackupConfig {
-	return BackupConfig{
-		FailureHandling: FailAfterRecovery,
-		Parallelism: Parallelism{
-			CollectionBuffer: 4,
-			ItemFetch:        4,
-		},
-		M365: BackupM365Config{
-			DeltaPageSize: 500,
-		},
-	}
+	return BackupConfig{}
 }
 
 // BackupConfig is the set of options used for backup operations. Each set of
@@ -23,12 +10,7 @@ func DefaultBackupConfig() BackupConfig {
 // same set of options for multiple backup operations pass the struct to all
 // operations.
 type BackupConfig struct {
-	FailureHandling      FailurePolicy                      `json:"failureHandling"`
-	ItemExtensionFactory []extensions.CreateItemExtensioner `json:"-"`
-	Parallelism          Parallelism                        `json:"parallelism"`
-	ServiceRateLimiter   RateLimiter                        `json:"serviceRateLimiter"`
-	Incrementals         IncrementalsConfig                 `json:"incrementalsConfig"`
-	M365                 BackupM365Config                   `json:"m365Config"`
+	Incrementals IncrementalsConfig `json:"incrementalsConfig"`
 
 	// PreviewLimits defines the number of items and/or amount of data to fetch on
 	// a best-effort basis for preview backups.
@@ -40,31 +22,6 @@ type BackupConfig struct {
 	// backup data until the set limits without paying attention to what the other
 	// had already backed up.
 	PreviewLimits PreviewItemLimits `json:"previewItemLimits"`
-}
-
-// BackupM365Config contains config options that are specific to backing up data
-// from M365 or Corso features that are only available during M365 backups.
-type BackupM365Config struct {
-	// DeltaPageSize controls the quantity of items fetched in each page during
-	// multi-page queries, such as graph api delta endpoints.
-	DeltaPageSize int32 `json:"deltaPageSize"`
-
-	// DisableDelta prevents backups from calling /delta endpoints and will force
-	// a full enumeration of all items. This is different from
-	// IncrementalsConfig.ForceFullEnumeration in that this does not even
-	// make use of delta endpoints if a delta token is available. This is
-	// necessary when the user has filled up their mailbox storage as Microsoft
-	// prevents the API from being able to make calls to /delta endpoints when a
-	// mailbox is over storage limits.
-	DisableDeltaEndpoint bool `json:"exchangeDeltaEndpoint,omitempty"`
-
-	// ExchangeImmutableIDs denotes whether Corso should store items with
-	// immutable Exchange IDs. This is only safe to set if the previous backup for
-	// incremental backups used immutable IDs or if a full backup is being done.
-	ExchangeImmutableIDs bool `json:"exchangeImmutableIDs,omitempty"`
-
-	// see: https://github.com/alcionai/corso/issues/4688
-	UseDriveDeltaTree bool `json:"useDriveDeltaTree"`
 }
 
 type Parallelism struct {

--- a/src/pkg/control/options.go
+++ b/src/pkg/control/options.go
@@ -17,16 +17,6 @@ type Options struct {
 	Repo                 repository.Options                 `json:"repo"`
 	SkipReduce           bool                               `json:"skipReduce"`
 	ToggleFeatures       Toggles                            `json:"toggleFeatures"`
-	// PreviewItemLimits defines the number of items and/or amount of data to
-	// fetch on a best-effort basis. Right now it's used for preview backups.
-	//
-	// Since this is not split out by service or data categories these limits
-	// apply independently to all data categories that appear in a single backup
-	// where they are set. For example, if doing a teams backup and there's both a
-	// SharePoint site and Messages available, both data categories would try to
-	// backup data until the set limits without paying attention to what the other
-	// had already backed up.
-	PreviewLimits PreviewItemLimits `json:"previewItemLimits"`
 }
 
 // RateLimiter is the set of options applied to any external service facing rate
@@ -68,15 +58,6 @@ func DefaultOptions() Options {
 // The default state for every toggle is false; toggles are only turned on
 // if specified by the caller.
 type Toggles struct {
-	// DisableIncrementals prevents backups from using incremental lookups,
-	// forcing a new, complete backup of all data regardless of prior state.
-	DisableIncrementals bool `json:"exchangeIncrementals,omitempty"`
-	// ForceItemDataDownload disables finding cached items in previous failed
-	// backups (i.e. kopia-assisted incrementals). Data dedupe will still occur
-	// since that is based on content hashes. Items that have not changed since
-	// the previous backup (i.e. in the merge base) will not be redownloaded. Use
-	// DisableIncrementals to control that behavior.
-	ForceItemDataDownload bool `json:"forceItemDataDownload,omitempty"`
 	// DisableDelta prevents backups from using delta based lookups,
 	// forcing a backup by enumerating all items. This is different
 	// from DisableIncrementals in that this does not even makes use of

--- a/src/pkg/repository/backups.go
+++ b/src/pkg/repository/backups.go
@@ -17,6 +17,7 @@ import (
 	"github.com/alcionai/corso/src/internal/version"
 	"github.com/alcionai/corso/src/pkg/backup"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/store"
@@ -42,11 +43,13 @@ type Backuper interface {
 	NewBackup(
 		ctx context.Context,
 		self selectors.Selector,
+		backupConfig control.BackupConfig,
 	) (operations.BackupOperation, error)
 	NewBackupWithLookup(
 		ctx context.Context,
 		self selectors.Selector,
 		ins idname.Cacher,
+		backupConfig control.BackupConfig,
 	) (operations.BackupOperation, error)
 	DeleteBackups(
 		ctx context.Context,
@@ -59,8 +62,9 @@ type Backuper interface {
 func (r repository) NewBackup(
 	ctx context.Context,
 	sel selectors.Selector,
+	backupConfig control.BackupConfig,
 ) (operations.BackupOperation, error) {
-	return r.NewBackupWithLookup(ctx, sel, nil)
+	return r.NewBackupWithLookup(ctx, sel, nil, backupConfig)
 }
 
 // NewBackupWithLookup generates a BackupOperation runner.
@@ -70,6 +74,7 @@ func (r repository) NewBackupWithLookup(
 	ctx context.Context,
 	sel selectors.Selector,
 	ins idname.Cacher,
+	backupConfig control.BackupConfig,
 ) (operations.BackupOperation, error) {
 	err := r.ConnectDataProvider(ctx, sel.PathService())
 	if err != nil {
@@ -87,6 +92,7 @@ func (r repository) NewBackupWithLookup(
 	return operations.NewBackupOperation(
 		ctx,
 		r.Opts,
+		backupConfig,
 		r.dataLayer,
 		store.NewWrapper(r.modelStore),
 		r.Provider,

--- a/src/pkg/repository/loadtest/repository_load_test.go
+++ b/src/pkg/repository/loadtest/repository_load_test.go
@@ -132,7 +132,7 @@ func runLoadTest(
 ) {
 	//revive:enable:context-as-argument
 	t.Run(prefix+"_load_test_main", func(t *testing.T) {
-		b, err := r.NewBackup(ctx, bupSel)
+		b, err := r.NewBackup(ctx, bupSel, control.DefaultBackupConfig())
 		require.NoError(t, err, clues.ToCore(err))
 
 		runBackupLoadTest(t, ctx, &b, service, usersUnderTest)

--- a/src/pkg/repository/repository_test.go
+++ b/src/pkg/repository/repository_test.go
@@ -334,7 +334,10 @@ func (suite *RepositoryIntegrationSuite) TestNewBackup() {
 
 	userID := tconfig.M365UserID(t)
 
-	bo, err := r.NewBackup(ctx, selectors.NewExchangeBackup([]string{userID}).Selector)
+	bo, err := r.NewBackup(
+		ctx,
+		selectors.NewExchangeBackup([]string{userID}).Selector,
+		control.DefaultBackupConfig())
 	require.NoError(t, err, clues.ToCore(err))
 	require.NotNil(t, bo)
 }
@@ -397,7 +400,7 @@ func (suite *RepositoryIntegrationSuite) TestNewBackupAndDelete() {
 	sel.Include(sel.MailFolders([]string{api.MailInbox}, selectors.PrefixMatch()))
 	sel.DiscreteOwner = userID
 
-	bo, err := r.NewBackup(ctx, sel.Selector)
+	bo, err := r.NewBackup(ctx, sel.Selector, control.DefaultBackupConfig())
 	require.NoError(t, err, clues.ToCore(err))
 	require.NotNil(t, bo)
 


### PR DESCRIPTION
Going with this alternative to #4861 and #4884. While those are roughly
where we'd like to end up eventually, this is much easier to get merged
and provides a better developer experience because config values are only
defined in one exported struct

This moves the incremental and backup preview config values to a new
control struct and passes that struct down through the stack with the
original control struct in backup operations. Overall, it allows passing
those config values when the backup operation is created instead of when
the repo is connected to

Manually verified that disable incrementals flags are passed via CLI as
expected

May be easier to review by commit

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [x] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
