### PR TITLE
Augment post details with recipient information

### DIFF
--- a/src/internal/m365/collection/groups/conversation_handler.go
+++ b/src/internal/m365/collection/groups/conversation_handler.go
@@ -26,12 +26,12 @@ type conversationsBackupHandler struct {
 func NewConversationBackupHandler(
 	protectedResource string,
 	ac api.Conversations,
-	email string,
+	resourceEmail string,
 ) conversationsBackupHandler {
 	return conversationsBackupHandler{
 		ac:                ac,
 		protectedResource: protectedResource,
-		resourceEmail:     email,
+		resourceEmail:     resourceEmail,
 	}
 }
 
@@ -142,8 +142,9 @@ func (bh conversationsBackupHandler) augmentItemInfo(
 	// recipients if any. Currently we don't have a way to get the unique
 	// recipient list for individual posts due to graph api limitations.
 	//
-	// Store the group mail address so that we can use it to populate the 'To'
-	// field during Post -> EML exports.
+	// Store the group mail address in details so that SDK users can use it.
+	// This information will also be persisted in metadata files so that we
+	// can use it during export & restore.
 	dgi.Post.Recipients = []string{bh.resourceEmail}
 	dgi.Post.Topic = ptr.Val(c.GetTopic())
 }

--- a/src/internal/m365/collection/groups/conversation_handler.go
+++ b/src/internal/m365/collection/groups/conversation_handler.go
@@ -139,7 +139,7 @@ func (bh conversationsBackupHandler) augmentItemInfo(
 	c models.Conversationable,
 ) {
 	// Posts are always sent to the group email address, along with additional
-	// recipients if any. Currently, we don't have a way to get the unique
+	// recipients if any. Currently we don't have a way to get the unique
 	// recipient list for individual posts due to graph api limitations.
 	//
 	// Store the group mail address so that we can use it to populate the 'To'

--- a/src/internal/m365/collection/groups/conversation_handler.go
+++ b/src/internal/m365/collection/groups/conversation_handler.go
@@ -19,15 +19,19 @@ var _ backupHandler[models.Conversationable, models.Postable] = &conversationsBa
 type conversationsBackupHandler struct {
 	ac                api.Conversations
 	protectedResource string
+	// SMTP address for the group
+	resourceEmail string
 }
 
 func NewConversationBackupHandler(
 	protectedResource string,
 	ac api.Conversations,
+	email string,
 ) conversationsBackupHandler {
 	return conversationsBackupHandler{
 		ac:                ac,
 		protectedResource: protectedResource,
+		resourceEmail:     email,
 	}
 }
 
@@ -134,6 +138,13 @@ func (bh conversationsBackupHandler) augmentItemInfo(
 	dgi *details.GroupsInfo,
 	c models.Conversationable,
 ) {
+	// Posts are always sent to the group email address, along with additional
+	// recipients if any. Currently, we don't have a way to get the unique
+	// recipient list for individual posts due to graph api limitations.
+	//
+	// Store the group mail address so that we can use it to populate the 'To'
+	// field during Post -> EML exports.
+	dgi.Post.Recipients = []string{bh.resourceEmail}
 	dgi.Post.Topic = ptr.Val(c.GetTopic())
 }
 

--- a/src/internal/m365/service/groups/backup.go
+++ b/src/internal/m365/service/groups/backup.go
@@ -330,8 +330,7 @@ func backupConversations(
 		bh = groups.NewConversationBackupHandler(
 			bc.producerConfig.ProtectedResource.ID(),
 			bc.apiCli.Conversations(),
-			groupEmail,
-		)
+			groupEmail)
 		colls []data.BackupCollection
 	)
 

--- a/src/internal/m365/service/groups/backup.go
+++ b/src/internal/m365/service/groups/backup.go
@@ -3,6 +3,7 @@ package groups
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/alcionai/clues"
 	"github.com/kopia/kopia/repo/manifest"
@@ -319,10 +320,18 @@ func backupConversations(
 	counter *count.Bus,
 	errs *fault.Bus,
 ) ([]data.BackupCollection, error) {
+	groupEmail := strings.Clone(ptr.Val(bc.group.GetMail()))
+	// This is unlikely, but if it does happen in the wild, we should investigate it.
+	if len(groupEmail) == 0 {
+		return nil, clues.New("group has no mail address")
+	}
+
 	var (
 		bh = groups.NewConversationBackupHandler(
 			bc.producerConfig.ProtectedResource.ID(),
-			bc.apiCli.Conversations())
+			bc.apiCli.Conversations(),
+			groupEmail,
+		)
 		colls []data.BackupCollection
 	)
 

--- a/src/pkg/backup/details/groups.go
+++ b/src/pkg/backup/details/groups.go
@@ -61,11 +61,12 @@ type GroupsInfo struct {
 }
 
 type ConversationPostInfo struct {
-	CreatedAt time.Time `json:"createdAt,omitempty"`
-	Creator   string    `json:"creator,omitempty"`
-	Preview   string    `json:"preview,omitempty"`
-	Size      int64     `json:"size,omitempty"`
-	Topic     string    `json:"topic,omitempty"`
+	CreatedAt  time.Time `json:"createdAt,omitempty"`
+	Creator    string    `json:"creator,omitempty"`
+	Preview    string    `json:"preview,omitempty"`
+	Recipients []string  `json:"recipients,omitempty"`
+	Size       int64     `json:"size,omitempty"`
+	Topic      string    `json:"topic,omitempty"`
 }
 
 type ChannelMessageInfo struct {


### PR DESCRIPTION
<!-- PR description-->
Posts are always sent to the group email address, along with additional
recipients if any. Currently, we don't have a way to get the unique
recipient list for individual posts due to graph api limitations.

Store the group mail address so that we can use it to populate the 'To'
field during Post -> EML exports.


---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
