### PR TITLE
Store previous post's ID in details

### DIFF
--- a/src/internal/m365/collection/groups/conversation_handler.go
+++ b/src/internal/m365/collection/groups/conversation_handler.go
@@ -124,13 +124,17 @@ func (bh conversationsBackupHandler) getItem(
 	containerIDs path.Elements, // expects: [conversationID, threadID]
 	postID string,
 ) (models.Postable, *details.GroupsInfo, error) {
+	cc := api.CallConfig{
+		Expand: []string{"inReplyTo"},
+	}
+
 	return bh.ac.GetConversationPost(
 		ctx,
 		groupID,
 		containerIDs[0],
 		containerIDs[1],
 		postID,
-		api.CallConfig{})
+		cc)
 }
 
 //lint:ignore U1000 false linter issue due to generics

--- a/src/pkg/backup/details/groups.go
+++ b/src/pkg/backup/details/groups.go
@@ -65,6 +65,7 @@ type ConversationPostInfo struct {
 	Creator    string    `json:"creator,omitempty"`
 	Preview    string    `json:"preview,omitempty"`
 	Recipients []string  `json:"recipients,omitempty"`
+	InReplyTo  string    `json:"inReplyTo,omitempty"`
 	Size       int64     `json:"size,omitempty"`
 	Topic      string    `json:"topic,omitempty"`
 }

--- a/src/pkg/services/m365/api/conversations.go
+++ b/src/pkg/services/m365/api/conversations.go
@@ -124,7 +124,7 @@ func (c Conversations) GetConversationPost(
 func conversationPostInfo(
 	post models.Postable,
 	size int64,
-	preview, prevPostID string,
+	preview, inReplyToID string,
 ) *details.GroupsInfo {
 	if post == nil {
 		return nil
@@ -139,7 +139,7 @@ func conversationPostInfo(
 		CreatedAt: ptr.Val(post.GetCreatedDateTime()),
 		Creator:   sender,
 		Preview:   preview,
-		InReplyTo: prevPostID,
+		InReplyTo: inReplyToID,
 		Size:      size,
 	}
 

--- a/src/pkg/services/m365/api/conversations_test.go
+++ b/src/pkg/services/m365/api/conversations_test.go
@@ -109,7 +109,7 @@ func (suite *ConversationsAPIUnitSuite) TestConversationPostInfo() {
 			t := suite.T()
 
 			post, expected := test.postAndInfo()
-			result := conversationPostInfo(post, 0, "")
+			result := conversationPostInfo(post, 0, "", "")
 
 			assert.Equal(t, expected, result)
 		})


### PR DESCRIPTION
<!-- PR description-->

* Conversations posts are organized as a tree, not a linked list.
* A recipient may choose to respond to an earlier post(not the latest post), i.e. the mail thread is not always linear. This behavior is similar to exchange. Each post holds a link to its ancestor which can be obtained using `$expand=inReplyTo` while fetching a post.
* Persist the ancestor post's ID in current post's details.
* This will help us construct a reply tree from details file during restore operation. Traversing the reply tree from top to bottom will allow us to do in-order restores, i.e. call `POST /groups/{id}/conversations/{id}/threads/{id}/posts/{id}/reply` for tree objects from top to bottom.


---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
