### PR TITLE
catch basic notFound graph errors

### DIFF
--- a/src/pkg/services/m365/api/graph/testdata/errors.go
+++ b/src/pkg/services/m365/api/graph/testdata/errors.go
@@ -36,6 +36,18 @@ func ODataErrWithMsg(code, message string) *odataerrors.ODataError {
 	return odErr
 }
 
+func ODataErrWithStatus(status int, code string) *odataerrors.ODataError {
+	odErr := odataerrors.NewODataError()
+	merr := odataerrors.NewMainError()
+	merr.SetCode(&code)
+	// graph sdk expects the message to be available
+	merr.SetMessage(&code)
+	odErr.SetErrorEscaped(merr)
+	odErr.SetStatusCode(status)
+
+	return odErr
+}
+
 func ODataInner(innerCode string) *odataerrors.ODataError {
 	odErr := odataerrors.NewODataError()
 	inerr := odataerrors.NewInnerError()


### PR DESCRIPTION
make the NotFound error comparison more lenient so that it catches the broader set of not-found error responses from graph.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
