### PR TITLE
fix item property selection when getting drive items

### DIFF
--- a/src/pkg/services/m365/api/drive.go
+++ b/src/pkg/services/m365/api/drive.go
@@ -115,13 +115,20 @@ func (c Drives) GetItem(
 	ctx context.Context,
 	driveID, itemID string,
 ) (models.DriveItemable, error) {
+	options := &drives.ItemItemsDriveItemItemRequestBuilderGetRequestConfiguration{
+		QueryParameters: &drives.ItemItemsDriveItemItemRequestBuilderGetQueryParameters{
+			// FIXME: accept a CallConfig instead of hardcoding the select.
+			Select: DefaultDriveItemProps(),
+		},
+	}
+
 	di, err := c.Stable.
 		Client().
 		Drives().
 		ByDriveId(driveID).
 		Items().
 		ByDriveItemId(itemID).
-		Get(ctx, nil)
+		Get(ctx, options)
 	if err != nil {
 		return nil, graph.Wrap(ctx, err, "getting item")
 	}


### PR DESCRIPTION
we already select these properties when paging drive items, we just missed the configuration on per-item GETs.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
