### PR TITLE
Allow for timezone from TZ database

### DIFF
--- a/src/internal/converters/eml/eml.go
+++ b/src/internal/converters/eml/eml.go
@@ -148,8 +148,7 @@ func FromJSON(ctx context.Context, body []byte) (string, error) {
 
 	data, err := api.BytesToMessageable(body)
 	if err != nil {
-		return "", clues.WrapWC(ctx, err, "converting to messageble").
-			With("body_len", len(body))
+		return "", clues.WrapWC(ctx, err, "converting to messageble")
 	}
 
 	ctx = clues.Add(ctx, "item_id", ptr.Val(data.GetId()))

--- a/src/internal/converters/eml/eml.go
+++ b/src/internal/converters/eml/eml.go
@@ -148,7 +148,8 @@ func FromJSON(ctx context.Context, body []byte) (string, error) {
 
 	data, err := api.BytesToMessageable(body)
 	if err != nil {
-		return "", clues.WrapWC(ctx, err, "converting to messageble")
+		return "", clues.WrapWC(ctx, err, "converting to messageble").
+			With("body_len", len(body))
 	}
 
 	ctx = clues.Add(ctx, "item_id", ptr.Val(data.GetId()))

--- a/src/internal/converters/ics/ics.go
+++ b/src/internal/converters/ics/ics.go
@@ -183,9 +183,7 @@ func getRecurrencePattern(
 					parsedTime.Format(string(dttm.M365DateTimeTimeZone)),
 					ptr.Val(rrange.GetRecurrenceTimeZone()))
 				if err != nil {
-					return "", clues.WrapWC(ctx, err, "parsing end time").
-						With("time", parsedTime).
-						With("timezone", ptr.Val(rrange.GetRecurrenceTimeZone()))
+					return "", clues.WrapWC(ctx, err, "parsing end time")
 				}
 
 				recurComponents = append(recurComponents, "UNTIL="+endTime.Format(ICalDateTimeFormat))
@@ -293,9 +291,7 @@ func updateEventProperties(ctx context.Context, event models.Eventable, iCalEven
 	if startString != nil {
 		start, err := GetUTCTime(ptr.Val(startString), ptr.Val(startTimezone))
 		if err != nil {
-			return clues.WrapWC(ctx, err, "parsing start time").
-				With("time", ptr.Val(startString)).
-				With("timezone", ptr.Val(startTimezone))
+			return clues.WrapWC(ctx, err, "parsing start time")
 		}
 
 		if allDay {
@@ -312,9 +308,7 @@ func updateEventProperties(ctx context.Context, event models.Eventable, iCalEven
 	if endString != nil {
 		end, err := GetUTCTime(ptr.Val(endString), ptr.Val(endTimezone))
 		if err != nil {
-			return clues.WrapWC(ctx, err, "parsing end time").
-				With("time", ptr.Val(endString)).
-				With("timezone", ptr.Val(endTimezone))
+			return clues.WrapWC(ctx, err, "parsing end time")
 		}
 
 		if allDay {
@@ -610,9 +604,7 @@ func getCancelledDates(ctx context.Context, event models.Eventable) ([]time.Time
 		// the data just contains date and no time which seems to work
 		start, err := GetUTCTime(ds, tz)
 		if err != nil {
-			return nil, clues.WrapWC(ctx, err, "parsing cancelled event date").
-				With("date", ds).
-				With("timezone", tz)
+			return nil, clues.WrapWC(ctx, err, "parsing cancelled event date")
 		}
 
 		dates = append(dates, start)

--- a/src/internal/converters/ics/ics.go
+++ b/src/internal/converters/ics/ics.go
@@ -183,7 +183,9 @@ func getRecurrencePattern(
 					parsedTime.Format(string(dttm.M365DateTimeTimeZone)),
 					ptr.Val(rrange.GetRecurrenceTimeZone()))
 				if err != nil {
-					return "", clues.WrapWC(ctx, err, "parsing end time")
+					return "", clues.WrapWC(ctx, err, "parsing end time").
+						With("time", parsedTime).
+						With("timezone", ptr.Val(rrange.GetRecurrenceTimeZone()))
 				}
 
 				recurComponents = append(recurComponents, "UNTIL="+endTime.Format(ICalDateTimeFormat))
@@ -291,7 +293,9 @@ func updateEventProperties(ctx context.Context, event models.Eventable, iCalEven
 	if startString != nil {
 		start, err := GetUTCTime(ptr.Val(startString), ptr.Val(startTimezone))
 		if err != nil {
-			return clues.WrapWC(ctx, err, "parsing start time")
+			return clues.WrapWC(ctx, err, "parsing start time").
+				With("time", ptr.Val(startString)).
+				With("timezone", ptr.Val(startTimezone))
 		}
 
 		if allDay {
@@ -308,7 +312,9 @@ func updateEventProperties(ctx context.Context, event models.Eventable, iCalEven
 	if endString != nil {
 		end, err := GetUTCTime(ptr.Val(endString), ptr.Val(endTimezone))
 		if err != nil {
-			return clues.WrapWC(ctx, err, "parsing end time")
+			return clues.WrapWC(ctx, err, "parsing end time").
+				With("time", ptr.Val(endString)).
+				With("timezone", ptr.Val(endTimezone))
 		}
 
 		if allDay {
@@ -604,7 +610,9 @@ func getCancelledDates(ctx context.Context, event models.Eventable) ([]time.Time
 		// the data just contains date and no time which seems to work
 		start, err := GetUTCTime(ds, tz)
 		if err != nil {
-			return nil, clues.WrapWC(ctx, err, "parsing cancelled event date")
+			return nil, clues.WrapWC(ctx, err, "parsing cancelled event date").
+				With("date", ds).
+				With("timezone", tz)
 		}
 
 		dates = append(dates, start)

--- a/src/internal/converters/ics/ics.go
+++ b/src/internal/converters/ics/ics.go
@@ -72,7 +72,6 @@ func getLocationString(location models.Locationable) string {
 }
 
 func GetUTCTime(ts, tz string) (time.Time, error) {
-
 	var (
 		loc *time.Location
 		err error

--- a/src/internal/converters/ics/ics.go
+++ b/src/internal/converters/ics/ics.go
@@ -72,6 +72,12 @@ func getLocationString(location models.Locationable) string {
 }
 
 func GetUTCTime(ts, tz string) (time.Time, error) {
+
+	var (
+		loc *time.Location
+		err error
+	)
+
 	// Timezone is always converted to UTC.  This is the easiest way to
 	// ensure we have the correct time as the .ics file expects the same
 	// timezone everywhere according to the spec.
@@ -80,15 +86,18 @@ func GetUTCTime(ts, tz string) (time.Time, error) {
 		return time.Time{}, clues.Wrap(err, "parsing time").With("given_time_string", ts)
 	}
 
-	timezone, ok := GraphTimeZoneToTZ[tz]
-	if !ok {
-		return it, clues.New("unknown timezone").With("timezone", tz)
-	}
-
-	loc, err := time.LoadLocation(timezone)
+	loc, err = time.LoadLocation(tz)
 	if err != nil {
-		return time.Time{}, clues.Wrap(err, "loading timezone").
-			With("converted_timezone", timezone)
+		timezone, ok := GraphTimeZoneToTZ[tz]
+		if !ok {
+			return it, clues.New("unknown timezone").With("timezone", tz)
+		}
+
+		loc, err = time.LoadLocation(timezone)
+		if err != nil {
+			return time.Time{}, clues.Wrap(err, "loading timezone").
+				With("converted_timezone", timezone)
+		}
 	}
 
 	// embed timezone

--- a/src/internal/converters/ics/ics_test.go
+++ b/src/internal/converters/ics/ics_test.go
@@ -139,6 +139,13 @@ func (suite *ICSUnitSuite) TestGetUTCTime() {
 			errCheck:  require.NoError,
 		},
 		{
+			name:      "timezone from TZ database",
+			timestamp: "2021-01-01T12:00:00Z",
+			timezone:  "America/Los_Angeles",
+			time:      time.Date(2021, 1, 1, 20, 0, 0, 0, time.UTC),
+			errCheck:  require.NoError,
+		},
+		{
 			name:      "invalid time",
 			timestamp: "invalid",
 			timezone:  "UTC",


### PR DESCRIPTION
<!-- PR description-->

Graph sometimes just send timezone value which are available in TZ database. This PR makes sure that we don't always try to convert, but check if the timezone is already in the format that we need first.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
