### PR TITLE
Configure new corso repos with 8 hr minEpochDuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Events can now be exported from Exchange backups as .ics files.
+- Update repo init configuration to reduce the total number of GET requests sent
+  to the object store when using corso. This affects repos that have many
+  backups created in them per day the most.
 
 ### Fixed
 - Retry transient 400 "invalidRequest" errors during onedrive & sharepoint backup.

--- a/src/internal/kopia/conn.go
+++ b/src/internal/kopia/conn.go
@@ -34,13 +34,8 @@ const (
 	defaultCompressor       = "zstd-better-compression"
 	// Interval of 0 disables scheduling.
 	defaultSchedulingInterval = time.Second * 0
-	defaultMinEpochDuration   = time.Hour * 8
-)
 
-var (
-	ErrSettingDefaultConfig = clues.New("setting default repo config values")
-	ErrorRepoAlreadyExists  = clues.New("repo already exists")
-
+	defaultMinEpochDuration = time.Hour * 8
 	// minEpochDurationLowerBound is the minimum corso will allow the kopia epoch
 	// duration to be set to. This number can still be tuned further, right now
 	// it's just to make sure it's not set to something totally wild.
@@ -58,6 +53,11 @@ var (
 	// the epoch should be changed. This is just the min amount of time since the
 	// last epoch change that's required.
 	minEpochDurationUpperBound = 7 * 24 * time.Hour
+)
+
+var (
+	ErrSettingDefaultConfig = clues.New("setting default repo config values")
+	ErrorRepoAlreadyExists  = clues.New("repo already exists")
 )
 
 // Having all fields set to 0 causes it to keep max-int versions of snapshots.

--- a/src/internal/kopia/conn.go
+++ b/src/internal/kopia/conn.go
@@ -34,6 +34,7 @@ const (
 	defaultCompressor       = "zstd-better-compression"
 	// Interval of 0 disables scheduling.
 	defaultSchedulingInterval = time.Second * 0
+	defaultMinEpochDuration   = time.Hour * 8
 )
 
 var (
@@ -166,6 +167,18 @@ func (w *conn) Initialize(
 
 	if err := w.setDefaultConfigValues(ctx); err != nil {
 		return clues.StackWC(ctx, err)
+	}
+
+	// In theory it should be possible to set this when creating the repo.
+	// However, the existing code paths for repo init in kopia end up clobbering
+	// any custom parameters passed in with default values. It's not clear if
+	// that's intentional or not.
+	if err := w.updatePersistentConfig(
+		ctx,
+		repository.PersistentConfig{
+			MinEpochDuration: ptr.To(defaultMinEpochDuration),
+		}); err != nil {
+		return clues.Stack(err)
 	}
 
 	// Calling with all parameters here will set extend object locks for

--- a/src/internal/kopia/conn_test.go
+++ b/src/internal/kopia/conn_test.go
@@ -284,7 +284,7 @@ func (suite *WrapperIntegrationSuite) TestSetCompressor() {
 		string(policyTree.EffectivePolicy().CompressionPolicy.CompressorName))
 }
 
-func (suite *WrapperIntegrationSuite) TestConfigDefaultsSetOnInitAndNotOnConnect() {
+func (suite *WrapperIntegrationSuite) TestConfigPolicyDefaultsSetOnInitAndNotOnConnect() {
 	newCompressor := "pgzip"
 	newRetentionDaily := policy.OptionalInt(42)
 	newRetention := policy.RetentionPolicy{KeepDaily: &newRetentionDaily}

--- a/src/internal/kopia/conn_test.go
+++ b/src/internal/kopia/conn_test.go
@@ -674,6 +674,13 @@ func (suite *WrapperIntegrationSuite) TestUpdatePersistentConfig() {
 			err := connection.Initialize(ctx, repository.Options{}, repository.Retention{}, repoNameHash)
 			require.NoError(t, err, "initializing repo: %v", clues.ToCore(err))
 
+			// Need to close and reopen the repo due to kopia caching of values.
+			err = connection.Close(ctx)
+			require.NoError(t, err, clues.ToCore(err))
+
+			err = connection.Connect(ctx, repository.Options{}, repoNameHash)
+			require.NoError(t, err, clues.ToCore(err))
+
 			startParams, startBlobConfig, err := connection.getPersistentConfig(ctx)
 			require.NoError(t, err, clues.ToCore(err))
 


### PR DESCRIPTION
We've found that reducing the MinEpochDuration parameter in kopia
can reduce GET requests sent to the object store by a large amount
(>50% in some cases) for repos that run many backups each day

This PR updates the init repo code path to set this parameter to
8hrs instead of the default 24hrs to bring in some of those savings

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
