### PR TITLE
Add a pin to kopia snapshots so they won't be GCed by kopia accidentally

### DIFF
--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -34,6 +34,8 @@ import (
 	"github.com/alcionai/corso/src/pkg/store"
 )
 
+const defaultCorsoPin = "corso"
+
 // common manifest tags
 const (
 	TagBackupID       = "backup-id"
@@ -392,6 +394,10 @@ func (w Wrapper) makeSnapshotWithRoot(
 			}
 
 			man.Tags = tags
+			// Add one pin to keep kopia's retention policy from collecting it if it
+			// ends up enabled for some reason. The value in the pin doesn't matter.
+			// We don't need to remove any pins.
+			man.UpdatePins(append(man.Pins, defaultCorsoPin), nil)
 
 			if _, err := snapshot.SaveSnapshot(innerCtx, rw, man); err != nil {
 				err = clues.WrapWC(ctx, err, "saving snapshot")

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -1151,6 +1151,8 @@ func (suite *KopiaIntegrationSuite) TestBackupCollections() {
 				manifest.ID(stats.SnapshotID))
 			require.NoError(t, err, clues.ToCore(err))
 
+			assert.Contains(t, snap.Pins, defaultCorsoPin)
+
 			man = snap
 		})
 


### PR DESCRIPTION
Internally kopia has the notion of a retention policy. This adds a pin to each snapshot that corso uses kopia to create so that those snapshots won't be subject to kopia's rentention policy. As we disable kopia's retention policy during repo init this just acts as another layer of security to ensure snapshots won't be deleted unexpectedly.

Note that this PR only applies to _new_ snapshots that corso creates.
It doesn't go back and pin older snapshots for already existing backups

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
