### PR TITLE
Use more unique data in the kopia SourceInfo for snapshots

### DIFF
--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -4,6 +4,7 @@ run:
 linters:
   enable:
     - errcheck
+    - exhaustive
     - forbidigo
     - gci
     - gofmt
@@ -25,6 +26,11 @@ linters:
     - staticcheck
 
 linters-settings:
+  exhaustive:
+    check:
+      - switch
+    default-signifies-exhaustive: false
+    explicit-exhaustive-switch: true
   gci:
     sections:
       - standard

--- a/src/internal/kopia/conn_test.go
+++ b/src/internal/kopia/conn_test.go
@@ -234,8 +234,8 @@ func (suite *WrapperIntegrationSuite) TestGetPolicyOrDefault_GetsDefault() {
 	}()
 
 	si := snapshot.SourceInfo{
-		Host:     corsoHost,
-		UserName: corsoUser,
+		Host:     "exchangeemail",
+		UserName: "tenantID-resourceID",
 		Path:     "test-path-root",
 	}
 
@@ -271,8 +271,8 @@ func (suite *WrapperIntegrationSuite) TestSetCompressor() {
 	// Check the global policy will be the effective policy in future snapshots
 	// for some source info.
 	si := snapshot.SourceInfo{
-		Host:     corsoHost,
-		UserName: corsoUser,
+		Host:     "exchangeemail",
+		UserName: "tenantID-resourceID",
 		Path:     "test-path-root",
 	}
 

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kopia/kopia/snapshot/snapshotfs"
 	"github.com/kopia/kopia/snapshot/snapshotmaintenance"
 	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 
 	"github.com/alcionai/corso/src/internal/common/prefixmatcher"
 	"github.com/alcionai/corso/src/internal/common/readers"
@@ -31,13 +32,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/store"
-)
-
-const (
-	// TODO(ashmrtnz): These should be some values from upper layer corso,
-	// possibly corresponding to who is making the backup.
-	corsoHost = "corso-host"
-	corsoUser = "corso"
 )
 
 // common manifest tags
@@ -202,24 +196,12 @@ func (w Wrapper) ConsumeBackupCollections(
 		return nil, nil, nil, clues.Wrap(err, "building kopia directories")
 	}
 
-	// Add some extra tags so we can look things up by reason.
-	tags := maps.Clone(additionalTags)
-	if tags == nil {
-		// Some platforms seem to return nil if the input is nil.
-		tags = map[string]string{}
-	}
-
-	for _, r := range backupReasons {
-		for _, k := range tagKeys(r) {
-			tags[k] = ""
-		}
-	}
-
 	s, err := w.makeSnapshotWithRoot(
 		ctx,
+		backupReasons,
 		assistBase,
 		dirTree,
-		tags,
+		additionalTags,
 		progress)
 	if err != nil {
 		return nil, nil, nil, err
@@ -228,8 +210,65 @@ func (w Wrapper) ConsumeBackupCollections(
 	return s, progress.deets, progress.toMerge, progress.errs.Failure()
 }
 
+type userAndHost struct {
+	user string
+	host string
+}
+
+func hostAndUserFromReasons(reasons []identity.Reasoner) (userAndHost, error) {
+	var (
+		tenant   string
+		resource string
+		// reasonMap is a hash set of the concatenation of the service and category.
+		reasonMap = map[string]struct{}{}
+	)
+
+	for _, reason := range reasons {
+		if tenant == "" {
+			tenant = reason.Tenant()
+		} else if tenant != reason.Tenant() {
+			return userAndHost{}, clues.New("multiple tenant IDs in backup reasons").
+				With(
+					"old_tenant_id", tenant,
+					"new_tenant_id", reason.Tenant())
+		}
+
+		if resource == "" {
+			resource = reason.ProtectedResource()
+		} else if resource != reason.ProtectedResource() {
+			return userAndHost{}, clues.New("multiple protected resource IDs in backup reasons").
+				With(
+					"old_resource_id", resource,
+					"new_resource_id", reason.ProtectedResource())
+		}
+
+		dataType := reason.Service().String() + reason.Category().String()
+		reasonMap[dataType] = struct{}{}
+	}
+
+	allReasons := maps.Keys(reasonMap)
+	slices.Sort(allReasons)
+
+	host := strings.Join(allReasons, "-")
+	user := strings.Join([]string{tenant, resource}, "-")
+
+	if len(user) == 0 {
+		return userAndHost{}, clues.New("empty user value")
+	}
+
+	if len(host) == 0 {
+		return userAndHost{}, clues.New("empty host value")
+	}
+
+	return userAndHost{
+		host: host,
+		user: user,
+	}, nil
+}
+
 func (w Wrapper) makeSnapshotWithRoot(
 	ctx context.Context,
+	backupReasons []identity.Reasoner,
 	prevBases []BackupBase,
 	root fs.Directory,
 	addlTags map[string]string,
@@ -252,11 +291,24 @@ func (w Wrapper) makeSnapshotWithRoot(
 		snapIDs = append(snapIDs, ent.ItemDataSnapshot.ID)
 	}
 
+	// Add some extra tags so we can look things up by reason.
+	allTags := maps.Clone(addlTags)
+	if allTags == nil {
+		// Some platforms seem to return nil if the input is nil.
+		allTags = map[string]string{}
+	}
+
+	for _, r := range backupReasons {
+		for _, k := range tagKeys(r) {
+			allTags[k] = ""
+		}
+	}
+
 	ctx = clues.Add(
 		ctx,
 		"num_assist_snapshots", len(prevBases),
 		"assist_snapshot_ids", snapIDs,
-		"additional_tags", addlTags)
+		"additional_tags", allTags)
 
 	if len(snapIDs) > 0 {
 		logger.Ctx(ctx).Info("using snapshots for kopia-assisted incrementals")
@@ -266,7 +318,7 @@ func (w Wrapper) makeSnapshotWithRoot(
 
 	tags := map[string]string{}
 
-	for k, v := range addlTags {
+	for k, v := range allTags {
 		mk, mv := makeTagKV(k)
 
 		if len(v) == 0 {
@@ -276,7 +328,16 @@ func (w Wrapper) makeSnapshotWithRoot(
 		tags[mk] = v
 	}
 
-	err := repo.WriteSession(
+	// Set the SourceInfo to the tenant ID, resource ID, and the concatenation
+	// of the service/data types being backed up. This will give us unique
+	// values for each set of backups with the assumption that no concurrent
+	// backups for the same set of things is being run on this repo.
+	userHost, err := hostAndUserFromReasons(backupReasons)
+	if err != nil {
+		return nil, clues.StackWC(ctx, err)
+	}
+
+	err = repo.WriteSession(
 		ctx,
 		w.c,
 		repo.WriteSessionOptions{
@@ -288,10 +349,9 @@ func (w Wrapper) makeSnapshotWithRoot(
 		},
 		func(innerCtx context.Context, rw repo.RepositoryWriter) error {
 			si := snapshot.SourceInfo{
-				Host:     corsoHost,
-				UserName: corsoUser,
-				// TODO(ashmrtnz): will this be something useful for snapshot lookups later?
-				Path: root.Name(),
+				Host:     userHost.host,
+				UserName: userHost.user,
+				Path:     root.Name(),
 			}
 
 			trueVal := policy.OptionalBool(true)

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -223,8 +223,12 @@ func hostAndUserFromReasons(reasons []identity.Reasoner) (userAndHost, error) {
 		reasonMap = map[string]struct{}{}
 	)
 
-	for _, reason := range reasons {
-		if tenant == "" {
+	for i, reason := range reasons {
+		// Use a check on the iteration index instead of empty string so we can
+		// differentiate between the first iteration and a reason with an empty
+		// value (should result in an error if there's another reason with a
+		// non-empty value).
+		if i == 0 {
 			tenant = reason.Tenant()
 		} else if tenant != reason.Tenant() {
 			return userAndHost{}, clues.New("multiple tenant IDs in backup reasons").
@@ -233,7 +237,7 @@ func hostAndUserFromReasons(reasons []identity.Reasoner) (userAndHost, error) {
 					"new_tenant_id", reason.Tenant())
 		}
 
-		if resource == "" {
+		if i == 0 {
 			resource = reason.ProtectedResource()
 		} else if resource != reason.ProtectedResource() {
 			return userAndHost{}, clues.New("multiple protected resource IDs in backup reasons").
@@ -252,7 +256,7 @@ func hostAndUserFromReasons(reasons []identity.Reasoner) (userAndHost, error) {
 	host := strings.Join(allReasons, "-")
 	user := strings.Join([]string{tenant, resource}, "-")
 
-	if len(user) == 0 {
+	if len(user) == 0 || user == "-" {
 		return userAndHost{}, clues.New("empty user value")
 	}
 

--- a/src/internal/kopia/wrapper.go
+++ b/src/internal/kopia/wrapper.go
@@ -210,6 +210,9 @@ func (w Wrapper) ConsumeBackupCollections(
 	return s, progress.deets, progress.toMerge, progress.errs.Failure()
 }
 
+// userAndHost is used as a passing mechanism for values that will be fed into
+// kopia's UserName and Host fields for SourceInfo. It exists to avoid returning
+// two strings from the hostAndUserFromReasons function.
 type userAndHost struct {
 	user string
 	host string

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -409,6 +409,39 @@ func (suite *BasicKopiaIntegrationSuite) TestConsumeBackupCollections_SetsSource
 				path.FilesCategory.String(),
 		},
 		{
+			name: "EmptyTenant",
+			reasons: []identity.Reasoner{
+				identity.NewReason("", testUser, path.ExchangeService, path.EmailCategory),
+			},
+			expectError: assert.NoError,
+			expectUser:  "-" + testUser,
+			expectHost:  path.ExchangeService.String() + path.EmailCategory.String(),
+		},
+		{
+			name: "EmptyResource",
+			reasons: []identity.Reasoner{
+				identity.NewReason(testTenant, "", path.ExchangeService, path.EmailCategory),
+			},
+			expectError: assert.NoError,
+			expectUser:  testTenant + "-",
+			expectHost:  path.ExchangeService.String() + path.EmailCategory.String(),
+		},
+		{
+			name: "EmptyTenantAndResource Errors",
+			reasons: []identity.Reasoner{
+				identity.NewReason("", "", path.ExchangeService, path.EmailCategory),
+			},
+			expectError: assert.Error,
+		},
+		{
+			name: "EmptyAndPopulatedTenant Errors",
+			reasons: []identity.Reasoner{
+				identity.NewReason("", testUser, path.ExchangeService, path.EmailCategory),
+				identity.NewReason(testTenant, testUser, path.ExchangeService, path.ContactsCategory),
+			},
+			expectError: assert.Error,
+		},
+		{
 			name: "DifferentTenants Errors",
 			reasons: []identity.Reasoner{
 				identity.NewReason(testTenant+"1", testUser, path.ExchangeService, path.EmailCategory),
@@ -437,8 +470,8 @@ func (suite *BasicKopiaIntegrationSuite) TestConsumeBackupCollections_SetsSource
 
 			for i, reason := range test.reasons {
 				colPath, err := path.Build(
-					reason.Tenant(),
-					reason.ProtectedResource(),
+					testTenant,
+					testUser,
 					reason.Service(),
 					reason.Category(),
 					false,

--- a/src/internal/streamstore/collectables_test.go
+++ b/src/internal/streamstore/collectables_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alcionai/corso/src/internal/kopia"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/backup/identity"
 	"github.com/alcionai/corso/src/pkg/control/repository"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -177,7 +178,16 @@ func (suite *StreamStoreIntgSuite) TestStreamer() {
 				require.NoError(t, err)
 			}
 
-			snapid, err := ss.Write(ctx, fault.New(true))
+			snapid, err := ss.Write(
+				ctx,
+				[]identity.Reasoner{
+					identity.NewReason(
+						deetsPath.Tenant(),
+						deetsPath.ProtectedResource(),
+						path.ExchangeMetadataService,
+						deetsPath.Category()),
+				},
+				fault.New(true))
 			require.NoError(t, err)
 			test.hasSnapID(t, snapid)
 

--- a/src/internal/streamstore/mock/mock.go
+++ b/src/internal/streamstore/mock/mock.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/streamstore"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/backup/identity"
 	"github.com/alcionai/corso/src/pkg/fault"
 )
 
@@ -57,7 +58,11 @@ func (ms Streamer) Read(
 	return col.Unmr(io.NopCloser(bytes.NewReader(bs)))
 }
 
-func (ms Streamer) Write(context.Context, *fault.Bus) (string, error) {
+func (ms Streamer) Write(
+	context.Context,
+	[]identity.Reasoner,
+	*fault.Bus,
+) (string, error) {
 	return "", clues.New("not implemented")
 }
 

--- a/src/pkg/path/service_category_test.go
+++ b/src/pkg/path/service_category_test.go
@@ -210,6 +210,22 @@ func (suite *ServiceCategoryUnitSuite) TestToMetadata() {
 			expect: GroupsMetadataService,
 		},
 		{
+			input:  ExchangeMetadataService,
+			expect: ExchangeMetadataService,
+		},
+		{
+			input:  OneDriveMetadataService,
+			expect: OneDriveMetadataService,
+		},
+		{
+			input:  SharePointMetadataService,
+			expect: SharePointMetadataService,
+		},
+		{
+			input:  GroupsMetadataService,
+			expect: GroupsMetadataService,
+		},
+		{
 			input:  UnknownService,
 			expect: UnknownService,
 		},

--- a/src/pkg/path/service_type.go
+++ b/src/pkg/path/service_type.go
@@ -76,6 +76,7 @@ func (svc ServiceType) HumanString() string {
 }
 
 func (svc ServiceType) ToMetadata() ServiceType {
+	//exhaustive:enforce
 	switch svc {
 	case ExchangeService:
 		return ExchangeMetadataService
@@ -85,6 +86,17 @@ func (svc ServiceType) ToMetadata() ServiceType {
 		return SharePointMetadataService
 	case GroupsService:
 		return GroupsMetadataService
+
+	case ExchangeMetadataService:
+		fallthrough
+	case OneDriveMetadataService:
+		fallthrough
+	case SharePointMetadataService:
+		fallthrough
+	case GroupsMetadataService:
+		fallthrough
+	case UnknownService:
+		return svc
 	}
 
 	return UnknownService


### PR DESCRIPTION
Use unique info for the kopia snapshot source information to help
isolate snapshots for different resources from each other. This will
come in handy both for checkpoint snapshots and regular snapshots if
kopia's retention policy happens to look for things.

Integration tests for this probably won't pass until the next PR in
the series is merged into this PR

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

merge after:
* #5091
* #5092

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
