### PR TITLE
Pass reasons down when making snapshots with the streamstore

### DIFF
--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -4,6 +4,7 @@ run:
 linters:
   enable:
     - errcheck
+    - exhaustive
     - forbidigo
     - gci
     - gofmt
@@ -25,6 +26,11 @@ linters:
     - staticcheck
 
 linters-settings:
+  exhaustive:
+    check:
+      - switch
+    default-signifies-exhaustive: false
+    explicit-exhaustive-switch: true
   gci:
     sections:
       - standard

--- a/src/internal/streamstore/collectables_test.go
+++ b/src/internal/streamstore/collectables_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alcionai/corso/src/internal/kopia"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/backup/identity"
 	"github.com/alcionai/corso/src/pkg/control/repository"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
@@ -177,7 +178,17 @@ func (suite *StreamStoreIntgSuite) TestStreamer() {
 				require.NoError(t, err)
 			}
 
-			snapid, err := ss.Write(ctx, fault.New(true))
+			snapid, err := ss.Write(
+				ctx,
+				[]identity.Reasoner{
+					identity.NewReason(
+						deetsPath.Tenant(),
+						deetsPath.ProtectedResource(),
+						path.ExchangeMetadataService,
+						deetsPath.Category(),
+					),
+				},
+				fault.New(true))
 			require.NoError(t, err)
 			test.hasSnapID(t, snapid)
 

--- a/src/internal/streamstore/collectables_test.go
+++ b/src/internal/streamstore/collectables_test.go
@@ -185,8 +185,7 @@ func (suite *StreamStoreIntgSuite) TestStreamer() {
 						deetsPath.Tenant(),
 						deetsPath.ProtectedResource(),
 						path.ExchangeMetadataService,
-						deetsPath.Category(),
-					),
+						deetsPath.Category()),
 				},
 				fault.New(true))
 			require.NoError(t, err)

--- a/src/internal/streamstore/mock/mock.go
+++ b/src/internal/streamstore/mock/mock.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/alcionai/corso/src/internal/streamstore"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/backup/identity"
 	"github.com/alcionai/corso/src/pkg/fault"
 )
 
@@ -57,7 +58,11 @@ func (ms Streamer) Read(
 	return col.Unmr(io.NopCloser(bytes.NewReader(bs)))
 }
 
-func (ms Streamer) Write(context.Context, *fault.Bus) (string, error) {
+func (ms Streamer) Write(
+	context.Context,
+	[]identity.Reasoner,
+	*fault.Bus,
+) (string, error) {
 	return "", clues.New("not implemented")
 }
 

--- a/src/pkg/path/service_category_test.go
+++ b/src/pkg/path/service_category_test.go
@@ -210,6 +210,22 @@ func (suite *ServiceCategoryUnitSuite) TestToMetadata() {
 			expect: GroupsMetadataService,
 		},
 		{
+			input:  ExchangeMetadataService,
+			expect: ExchangeMetadataService,
+		},
+		{
+			input:  OneDriveMetadataService,
+			expect: OneDriveMetadataService,
+		},
+		{
+			input:  SharePointMetadataService,
+			expect: SharePointMetadataService,
+		},
+		{
+			input:  GroupsMetadataService,
+			expect: GroupsMetadataService,
+		},
+		{
 			input:  UnknownService,
 			expect: UnknownService,
 		},

--- a/src/pkg/path/service_type.go
+++ b/src/pkg/path/service_type.go
@@ -76,6 +76,7 @@ func (svc ServiceType) HumanString() string {
 }
 
 func (svc ServiceType) ToMetadata() ServiceType {
+	//exhaustive:enforce
 	switch svc {
 	case ExchangeService:
 		return ExchangeMetadataService
@@ -85,6 +86,17 @@ func (svc ServiceType) ToMetadata() ServiceType {
 		return SharePointMetadataService
 	case GroupsService:
 		return GroupsMetadataService
+
+	case ExchangeMetadataService:
+		fallthrough
+	case OneDriveMetadataService:
+		fallthrough
+	case SharePointMetadataService:
+		fallthrough
+	case GroupsMetadataService:
+		fallthrough
+	case UnknownService:
+		return svc
 	}
 
 	return UnknownService

--- a/src/pkg/repository/repository_unexported_test.go
+++ b/src/pkg/repository/repository_unexported_test.go
@@ -886,13 +886,16 @@ func (suite *RepositoryModelIntgSuite) TestGetBackupDetails() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
+			sel := selectors.NewExchangeBackup([]string{brunhilda})
+			sel.Include(sel.MailFolders(selectors.Any()))
+
 			b := writeBackup(
 				t,
 				ctx,
 				suite.kw,
 				suite.sw,
 				tenantID, "snapID", test.writeBupID,
-				selectors.NewExchangeBackup([]string{brunhilda}).Selector,
+				sel.Selector,
 				brunhilda, brunhilda,
 				test.deets,
 				&fault.Errors{},
@@ -993,13 +996,16 @@ func (suite *RepositoryModelIntgSuite) TestGetBackupErrors() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
+			sel := selectors.NewExchangeBackup([]string{brunhilda})
+			sel.Include(sel.MailFolders(selectors.Any()))
+
 			b := writeBackup(
 				t,
 				ctx,
 				suite.kw,
 				suite.sw,
 				tenantID, "snapID", test.writeBupID,
-				selectors.NewExchangeBackup([]string{brunhilda}).Selector,
+				sel.Selector,
 				brunhilda, brunhilda,
 				test.deets,
 				test.errors,

--- a/src/pkg/repository/repository_unexported_test.go
+++ b/src/pkg/repository/repository_unexported_test.go
@@ -803,13 +803,16 @@ func writeBackup(
 		sstore = streamstore.NewStreamer(kw, tID, serv)
 	)
 
-	err := sstore.Collect(ctx, streamstore.DetailsCollector(deets))
+	reasons, err := sel.Reasons(tID, false)
+	require.NoError(t, err, clues.ToCore(err))
+
+	err = sstore.Collect(ctx, streamstore.DetailsCollector(deets))
 	require.NoError(t, err, "collecting details in streamstore")
 
 	err = sstore.Collect(ctx, streamstore.FaultErrorsCollector(fe))
 	require.NoError(t, err, "collecting errors in streamstore")
 
-	ssid, err := sstore.Write(ctx, errs)
+	ssid, err := sstore.Write(ctx, reasons, errs)
 	require.NoError(t, err, "writing to streamstore")
 
 	tags := map[string]string{


### PR DESCRIPTION
Provides more safety for long-running streamstore snapshots and
fixes test errors due to API expectation changes in #5093

This PR will result in the addition of Reason tags to details
snapshots in kopia. However, because those Reasons are metadata
Reasons they shouldn't interfere with base backup lookups

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

merge after:
* #5091
* #5092
* #5093

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
