### PR TITLE
restores metadata column for sharepoint lists

### DIFF
--- a/src/pkg/services/m365/api/consts.go
+++ b/src/pkg/services/m365/api/consts.go
@@ -57,6 +57,10 @@ const (
 	HyperlinkDescriptionKey = "Description"
 	HyperlinkURLKey         = "Url"
 
+	MetadataLabelKey    = "Label"
+	MetadataTermGUIDKey = "TermGuid"
+	MetadataWssIDKey    = "WssId"
+
 	LinkTitleFieldNamePart  = "LinkTitle"
 	ChildCountFieldNamePart = "ChildCount"
 	LookupIDFieldNamePart   = "LookupId"

--- a/src/pkg/services/m365/api/lists.go
+++ b/src/pkg/services/m365/api/lists.go
@@ -367,7 +367,10 @@ func cloneColumnDefinitionable(orig models.ColumnDefinitionable) models.ColumnDe
 	return newColumn
 }
 
-func setColumnType(newColumn *models.ColumnDefinition, orig models.ColumnDefinitionable) {
+func setColumnType(
+	newColumn *models.ColumnDefinition,
+	orig models.ColumnDefinitionable,
+) {
 	switch {
 	case orig.GetText() != nil:
 		newColumn.SetText(orig.GetText())
@@ -456,6 +459,10 @@ func retrieveFieldData(orig models.FieldValueSetable, columnNames map[string]any
 		additionalData[fieldName] = concatenatedHyperlink
 	}
 
+	if metadataField, fieldName, ok := hasMetadataFields(additionalData); ok {
+		additionalData[fieldName] = metadataField[MetadataLabelKey]
+	}
+
 	fields.SetAdditionalData(additionalData)
 
 	return fields
@@ -505,6 +512,22 @@ func hasHyperLinkFields(additionalData map[string]any) (map[string]any, string, 
 
 		if keys.HasKeys(nestedFields,
 			[]string{HyperlinkDescriptionKey, HyperlinkURLKey}...) {
+			return nestedFields, fieldName, true
+		}
+	}
+
+	return nil, "", false
+}
+
+func hasMetadataFields(additionalData map[string]any) (map[string]any, string, bool) {
+	for fieldName, value := range additionalData {
+		nestedFields, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if keys.HasKeys(nestedFields,
+			[]string{MetadataLabelKey, MetadataTermGUIDKey, MetadataWssIDKey}...) {
 			return nestedFields, fieldName, true
 		}
 	}

--- a/src/pkg/services/m365/api/lists_test.go
+++ b/src/pkg/services/m365/api/lists_test.go
@@ -709,13 +709,12 @@ func (suite *ListsUnitSuite) TestHasMetadataFields() {
 	tests := []struct {
 		name              string
 		additionalData    map[string]any
-		expectedFields    map[string]any
+		expectedFields    []map[string]any
 		expectedFieldName string
-		expectedResult    string
 		hasMetadataFields bool
 	}{
 		{
-			name: "Has all metadata fields",
+			name: "Single metadata fields, has all keys",
 			additionalData: map[string]any{
 				"MdCol": map[string]any{
 					MetadataLabelKey:    ptr.To("Engineering"),
@@ -723,16 +722,49 @@ func (suite *ListsUnitSuite) TestHasMetadataFields() {
 					MetadataWssIDKey:    ptr.To(4),
 				},
 			},
-			expectedFields: map[string]any{
-				MetadataLabelKey:    ptr.To("Engineering"),
-				MetadataTermGUIDKey: ptr.To("6b5d3ce9-3043-499f-8be6-e92fb57bed96"),
-				MetadataWssIDKey:    ptr.To(4),
+			expectedFields: []map[string]any{
+				{
+					MetadataLabelKey:    ptr.To("Engineering"),
+					MetadataTermGUIDKey: ptr.To("6b5d3ce9-3043-499f-8be6-e92fb57bed96"),
+					MetadataWssIDKey:    ptr.To(4),
+				},
 			},
 			expectedFieldName: "MdCol",
 			hasMetadataFields: true,
 		},
 		{
-			name: "Missing few metadata fields",
+			name: "Multiple metadata fields, has all keys",
+			additionalData: map[string]any{
+				"MdCol": []any{
+					map[string]any{
+						MetadataLabelKey:    ptr.To("Engineering"),
+						MetadataTermGUIDKey: ptr.To("6b5d3ce9-3043-499f-8be6-e92fb57bed96"),
+						MetadataWssIDKey:    ptr.To(4),
+					},
+					map[string]any{
+						MetadataLabelKey:    ptr.To("Marketing"),
+						MetadataTermGUIDKey: ptr.To("312347ce-3043-499f-8be6-e92fb57bed96"),
+						MetadataWssIDKey:    ptr.To(2),
+					},
+				},
+			},
+			expectedFields: []map[string]any{
+				{
+					MetadataLabelKey:    ptr.To("Engineering"),
+					MetadataTermGUIDKey: ptr.To("6b5d3ce9-3043-499f-8be6-e92fb57bed96"),
+					MetadataWssIDKey:    ptr.To(4),
+				},
+				{
+					MetadataLabelKey:    ptr.To("Marketing"),
+					MetadataTermGUIDKey: ptr.To("312347ce-3043-499f-8be6-e92fb57bed96"),
+					MetadataWssIDKey:    ptr.To(2),
+				},
+			},
+			expectedFieldName: "MdCol",
+			hasMetadataFields: true,
+		},
+		{
+			name: "Single metadata fields, missing few keys",
 			additionalData: map[string]any{
 				"MdCol": map[string]any{
 					MetadataLabelKey: ptr.To("Engineering"),
@@ -750,6 +782,54 @@ func (suite *ListsUnitSuite) TestHasMetadataFields() {
 			assert.Equal(t, test.expectedFields, nestedFields)
 			assert.Equal(t, test.expectedFieldName, fName)
 			assert.Equal(t, test.hasMetadataFields, isMetadata)
+		})
+	}
+}
+
+func (suite *ListsUnitSuite) TestConcatenateMetadataFields() {
+	t := suite.T()
+
+	tests := []struct {
+		name              string
+		metadataFields    []map[string]any
+		expectedFieldName string
+		expectedResult    string
+		hasMetadataFields bool
+		columnNames       map[string]any
+	}{
+		{
+			name: "Single metadata fields",
+			metadataFields: []map[string]any{
+				{
+					MetadataLabelKey:    ptr.To("Engineering"),
+					MetadataTermGUIDKey: ptr.To("6b5d3ce9-3043-499f-8be6-e92fb57bed96"),
+					MetadataWssIDKey:    ptr.To(4),
+				},
+			},
+			expectedResult: "Engineering",
+		},
+		{
+			name: "Multiple metadata fields",
+			metadataFields: []map[string]any{
+				{
+					MetadataLabelKey:    ptr.To("Engineering"),
+					MetadataTermGUIDKey: ptr.To("6b5d3ce9-3043-499f-8be6-e92fb57bed96"),
+					MetadataWssIDKey:    ptr.To(4),
+				},
+				{
+					MetadataLabelKey:    ptr.To("Marketing"),
+					MetadataTermGUIDKey: ptr.To("312347ce-3043-499f-8be6-e92fb57bed96"),
+					MetadataWssIDKey:    ptr.To(2),
+				},
+			},
+			expectedResult: "Engineering,Marketing",
+		},
+	}
+
+	for _, test := range tests {
+		suite.Run(test.name, func() {
+			res := concatenateMetadataFields(test.metadataFields)
+			assert.Equal(t, test.expectedResult, res)
 		})
 	}
 }

--- a/src/pkg/services/m365/api/lists_test.go
+++ b/src/pkg/services/m365/api/lists_test.go
@@ -703,6 +703,57 @@ func (suite *ListsUnitSuite) TestConcatenateHyperlinkFields() {
 	}
 }
 
+func (suite *ListsUnitSuite) TestHasMetadataFields() {
+	t := suite.T()
+
+	tests := []struct {
+		name              string
+		additionalData    map[string]any
+		expectedFields    map[string]any
+		expectedFieldName string
+		expectedResult    string
+		hasMetadataFields bool
+	}{
+		{
+			name: "Has all metadata fields",
+			additionalData: map[string]any{
+				"MdCol": map[string]any{
+					MetadataLabelKey:    ptr.To("Engineering"),
+					MetadataTermGUIDKey: ptr.To("6b5d3ce9-3043-499f-8be6-e92fb57bed96"),
+					MetadataWssIDKey:    ptr.To(4),
+				},
+			},
+			expectedFields: map[string]any{
+				MetadataLabelKey:    ptr.To("Engineering"),
+				MetadataTermGUIDKey: ptr.To("6b5d3ce9-3043-499f-8be6-e92fb57bed96"),
+				MetadataWssIDKey:    ptr.To(4),
+			},
+			expectedFieldName: "MdCol",
+			hasMetadataFields: true,
+		},
+		{
+			name: "Missing few metadata fields",
+			additionalData: map[string]any{
+				"MdCol": map[string]any{
+					MetadataLabelKey: ptr.To("Engineering"),
+				},
+			},
+			expectedFields:    nil,
+			expectedFieldName: "",
+			hasMetadataFields: false,
+		},
+	}
+
+	for _, test := range tests {
+		suite.Run(test.name, func() {
+			nestedFields, fName, isMetadata := hasMetadataFields(test.additionalData)
+			assert.Equal(t, test.expectedFields, nestedFields)
+			assert.Equal(t, test.expectedFieldName, fName)
+			assert.Equal(t, test.hasMetadataFields, isMetadata)
+		})
+	}
+}
+
 type ListsAPIIntgSuite struct {
 	tester.Suite
 	its intgTesterSetup


### PR DESCRIPTION
restores metadata column for sharepoint lists.

Similar to `Hyperlink` and `Column` columns, `Metadata` column too is unrecognizable from GRAPH API response. Hence identifying from the field column names.

`Metadata` fields are like tags. A `Metadata` fields can be configured to hold multiple values/tags

**Original List with `Metadata` column (Department) with single value/tag**:
![Metadata-List](https://github.com/alcionai/corso/assets/48874082/0b913a2a-46d5-4d9c-83f9-69a5236b1024)

**Restored List with `Metadata` column with single value/tag**:
![Restored-Metadata-List](https://github.com/alcionai/corso/assets/48874082/9420012b-345c-4fac-90c3-c0d421b2edfb)

**Original List with `Metadata` column (Department) with multiple value/tag**:
![Metadata-List-Multi](https://github.com/alcionai/corso/assets/48874082/054ef4a1-c46e-48ba-b410-a95b540cde33)

**Restored List with `Metadata` column with multiple value/tag**:
![Restored-Multi-Metadata-List](https://github.com/alcionai/corso/assets/48874082/ef6c904b-e431-4a85-9ef2-f08bcf8e21e4)


#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [x] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)
#5084 

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
