### PR TITLE
Make it less error prone to add new services

### DIFF
--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -4,6 +4,7 @@ run:
 linters:
   enable:
     - errcheck
+    - exhaustive
     - forbidigo
     - gci
     - gofmt
@@ -25,6 +26,11 @@ linters:
     - staticcheck
 
 linters-settings:
+  exhaustive:
+    check:
+      - switch
+    default-signifies-exhaustive: false
+    explicit-exhaustive-switch: true
   gci:
     sections:
       - standard

--- a/src/pkg/path/service_category_test.go
+++ b/src/pkg/path/service_category_test.go
@@ -210,6 +210,22 @@ func (suite *ServiceCategoryUnitSuite) TestToMetadata() {
 			expect: GroupsMetadataService,
 		},
 		{
+			input:  ExchangeMetadataService,
+			expect: ExchangeMetadataService,
+		},
+		{
+			input:  OneDriveMetadataService,
+			expect: OneDriveMetadataService,
+		},
+		{
+			input:  SharePointMetadataService,
+			expect: SharePointMetadataService,
+		},
+		{
+			input:  GroupsMetadataService,
+			expect: GroupsMetadataService,
+		},
+		{
 			input:  UnknownService,
 			expect: UnknownService,
 		},

--- a/src/pkg/path/service_type.go
+++ b/src/pkg/path/service_type.go
@@ -76,6 +76,9 @@ func (svc ServiceType) HumanString() string {
 }
 
 func (svc ServiceType) ToMetadata() ServiceType {
+	res := UnknownService
+
+	//exhaustive:enforce
 	switch svc {
 	case ExchangeService:
 		return ExchangeMetadataService
@@ -85,7 +88,18 @@ func (svc ServiceType) ToMetadata() ServiceType {
 		return SharePointMetadataService
 	case GroupsService:
 		return GroupsMetadataService
+
+	case ExchangeMetadataService:
+		fallthrough
+	case OneDriveMetadataService:
+		fallthrough
+	case SharePointMetadataService:
+		fallthrough
+	case GroupsMetadataService:
+		fallthrough
+	case UnknownService:
+		res = svc
 	}
 
-	return UnknownService
+	return res
 }


### PR DESCRIPTION
Make it somewhat less error prone to add new service types by requiring the transform from the non-metadata service type to metadata service type to handle every case. This should help avoid no test failures/build failures/lint failures when adding a new service type by directing devs to the code that needs updated.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [x] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

related to:
* #5091
* #5092
* #5093
* #5094

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
