### PR TITLE
Test closing repo without connect works

### DIFF
--- a/src/pkg/repository/repository_test.go
+++ b/src/pkg/repository/repository_test.go
@@ -36,7 +36,11 @@ func TestRepositoryUnitSuite(t *testing.T) {
 	suite.Run(t, &RepositoryUnitSuite{Suite: tester.NewUnitSuite(t)})
 }
 
-func (suite *RepositoryUnitSuite) TestClose() {
+// TestCloseWithoutConnectOrInit ensures SDK users can always call Close() on a
+// Repositoryer handle without having to track if they called the Connect or
+// Init functions. This makes cleanup easier for them because they can just use
+// a defer Close() in some cases instead of having to track state.
+func (suite *RepositoryUnitSuite) TestCloseWithoutConnectOrInit() {
 	t := suite.T()
 
 	ctx, flush := tester.NewContext(t)

--- a/src/pkg/repository/repository_test.go
+++ b/src/pkg/repository/repository_test.go
@@ -36,6 +36,29 @@ func TestRepositoryUnitSuite(t *testing.T) {
 	suite.Run(t, &RepositoryUnitSuite{Suite: tester.NewUnitSuite(t)})
 }
 
+func (suite *RepositoryUnitSuite) TestClose() {
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	t.Cleanup(flush)
+
+	acct := tconfig.NewFakeM365Account(t)
+
+	st, err := storage.NewStorage(storage.ProviderUnknown)
+	require.NoError(t, err, clues.ToCore(err))
+
+	r, err := New(
+		ctx,
+		acct,
+		st,
+		control.DefaultOptions(),
+		NewRepoID)
+	require.NoError(t, err, clues.ToCore(err))
+
+	err = r.Close(ctx)
+	assert.NoError(t, err, clues.ToCore(err))
+}
+
 func (suite *RepositoryUnitSuite) TestInitialize() {
 	table := []struct {
 		name     string


### PR DESCRIPTION
Just make sure we can call Close() on the repository struct even if we have made a connection to kopia or initialized all the internal fields.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
