### PR TITLE
Code and tests to validate retention config

### DIFF
--- a/src/internal/kopia/retention/opts.go
+++ b/src/internal/kopia/retention/opts.go
@@ -136,3 +136,29 @@ func (r *Opts) setBlobConfigMode(
 
 	return nil
 }
+
+func (r Opts) Verify(ctx context.Context) error {
+	if !r.blobCfg.IsRetentionEnabled() {
+		if r.params.ExtendObjectLocks {
+			return clues.NewWC(
+				ctx,
+				"retention disabled but maintenance lock extension enabled")
+		}
+
+		// Both disabled.
+		return nil
+	}
+
+	// Rest of function handles case where retention is enabled in the blob config
+	// blob.
+	if !r.params.ExtendObjectLocks {
+		return clues.NewWC(
+			ctx,
+			"retention enabled but maintenance lock extension disabled")
+	}
+
+	return clues.Stack(maintenance.CheckExtendRetention(
+		ctx,
+		r.blobCfg,
+		&r.params)).OrNil()
+}

--- a/src/internal/kopia/retention/opts.go
+++ b/src/internal/kopia/retention/opts.go
@@ -137,6 +137,11 @@ func (r *Opts) setBlobConfigMode(
 	return nil
 }
 
+// Verify checks that the config info in r passes kopia's retention validation
+// checks when it comes to locking durations and that if retention is requested
+// in the blob config blob then lock extension is also configured to run during
+// maintenance. If rentention is not enabled in the blob config blob then lock
+// extension should be disabled during maintenance.
 func (r Opts) Verify(ctx context.Context) error {
 	if !r.blobCfg.IsRetentionEnabled() {
 		if r.params.ExtendObjectLocks {


### PR DESCRIPTION
Basic validation checks that make sure maintenance and retention options are consistent with each other. This at least makes sure retention is either enabled and maintenance extends locks or nothing is locked at all.

Going to be part of a set of PRs for validating the kopia config

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
