### PR TITLE
add chat members to the backup

### DIFF
--- a/src/internal/m365/collection/teamschats/chat_handler.go
+++ b/src/internal/m365/collection/teamschats/chat_handler.go
@@ -99,6 +99,13 @@ func (bh usersChatsBackupHandler) getItem(
 
 	chat.SetMessages(msgs)
 
+	members, err := bh.ac.GetChatMembers(ctx, chatID, api.CallConfig{})
+	if err != nil {
+		return nil, nil, clues.Stack(err)
+	}
+
+	chat.SetMembers(members)
+
 	return chat, api.TeamsChatInfo(chat), nil
 }
 

--- a/src/pkg/backup/details/entry.go
+++ b/src/pkg/backup/details/entry.go
@@ -103,6 +103,12 @@ func (de Entry) ToLocationIDer(backupVersion int) (LocationIDer, error) {
 		}
 
 		baseLoc = path.Builder{}.Append(p.Root).Append(p.Folders...)
+
+	case TeamsChat:
+		baseLoc = &path.Builder{}
+
+	default:
+		return nil, clues.New("undentified item type").With("item_type", de.ItemInfo.infoType())
 	}
 
 	if baseLoc == nil {

--- a/src/pkg/services/m365/api/teamsChats_pager_test.go
+++ b/src/pkg/services/m365/api/teamsChats_pager_test.go
@@ -61,6 +61,11 @@ func (suite *ChatsPagerIntgSuite) TestEnumerateChats() {
 				ac,
 				chatID,
 				chat.GetLastMessagePreview())
+
+			testEnumerateChatMembers(
+				suite.T(),
+				ac,
+				chatID)
 		})
 	}
 }
@@ -122,4 +127,23 @@ func testEnumerateChatMessages(
 				msgContent)
 		}
 	}
+}
+
+func testEnumerateChatMembers(
+	t *testing.T,
+	ac Chats,
+	chatID string,
+) {
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	cc := CallConfig{}
+
+	members, err := ac.GetChatMembers(ctx, chatID, cc)
+	require.NoError(t, err, clues.ToCore(err))
+
+	// no good way to test members right now.  Even though
+	// the graph api response contains the `userID` and `email`
+	// properties, we can't access them in the sdk model
+	assert.NotEmpty(t, members)
 }


### PR DESCRIPTION
lazily fetch the chat members and add them to the chat during backup item downloads.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Issue(s)

* #5063

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
