### PR TITLE
fix up the backup failure output message

### DIFF
--- a/src/cli/backup/backup.go
+++ b/src/cli/backup/backup.go
@@ -2,7 +2,6 @@ package backup
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -197,12 +196,11 @@ func genericCreateCommand(
 			cerr := clues.WrapWC(ictx, err, owner)
 			errs = append(errs, cerr)
 
-			meta, err := json.Marshal(cerr.Core().Values)
-			if err != nil {
-				meta = []byte("Unable to marshal error metadata")
-			}
-
-			Errf(ictx, "%s\nMessage: %v\nMetadata:%s", "Unable to complete backup", err, meta)
+			Errf(
+				ictx,
+				"%s\nCause: %s",
+				"Unable to initiate backup",
+				err.Error())
 
 			continue
 		}
@@ -227,12 +225,11 @@ func genericCreateCommand(
 			cerr := clues.Wrap(err, owner)
 			errs = append(errs, cerr)
 
-			meta, err := json.Marshal(cerr.Core().Values)
-			if err != nil {
-				meta = []byte("Unable to marshal error metadata")
-			}
-
-			Errf(ictx, "%s\nMessage: %v\nMetadata:%s", "Unable to complete backup", err, meta)
+			Errf(
+				ictx,
+				"%s\nCause: %s",
+				"Unable to complete backup",
+				err.Error())
 
 			continue
 		}


### PR DESCRIPTION
metadata is too much data to be useful to an end user, meanwhile err is getting clobbered.

before
```
Error: Unable to complete backup
Message: <nil>
Metadata:{"assist_bases":"0","backup_id":"40940295-3611-42fb-ac27-5b80691ba793","base_backup_id":"832fff09-4988-4a3e-a0d0-4e51b197ea14","can_use_metadata":"true","can_use_previous_backup":"true","categories":"[Chats]","clues_trace":"c3bbd0e6","collection_count":"2","disable_assist_backup":"false","incremental":"true","merge_bases":"1","repo_ref":"fb8afbaa-e94c-4ea5-8a8a-24aff04d7874/chats/311d2a89-4c80-4da4-86ef-a08d8d6f0f94/chats/19:311d2a89-4c80-4da4-86ef-a08d8d6f0f94_817c2506-de4a-4795-971e-371ea75a03ed@unq.gbl.spaces","resource_owner_id":"311d2a89-4c80-4da4-86ef-a08d8d6f0f94","resource_owner_name":"rfinders@10rqc2.onmicrosoft.com","resource_owner_selected":"rfinders@10rqc2.onmicrosoft.com","service":"service(5)","tenant_id":"fb8afbaa-e94c-4ea5-8a8a-24aff04d7874"}
```
after
```
Error: Unable to complete backup
Cause: running backup: merging details: merging merge backup base details: getting updated info for entry: getting previous item location: unable to extract LocationRef from RepoRef
```

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
