### PR TITLE
Call config verify command during maintenance

### DIFF
--- a/src/internal/kopia/conn.go
+++ b/src/internal/kopia/conn.go
@@ -847,6 +847,8 @@ func (w *conn) verifyDefaultConfigOptions(
 	ctx context.Context,
 	errs *fault.Bus,
 ) {
+	logger.Ctx(ctx).Info("verifying config parameters")
+
 	w.verifyDefaultPolicyConfigOptions(ctx, errs)
 	w.verifyRetentionConfig(ctx, errs)
 }

--- a/src/internal/kopia/wrapper_test.go
+++ b/src/internal/kopia/wrapper_test.go
@@ -198,7 +198,7 @@ func (suite *BasicKopiaIntegrationSuite) TestMaintenance_FirstRun_NoChanges() {
 		Type:   repository.MetadataMaintenance,
 	}
 
-	err = w.RepoMaintenance(ctx, nil, opts)
+	err = w.RepoMaintenance(ctx, nil, opts, fault.New(true))
 	require.NoError(t, err, clues.ToCore(err))
 }
 
@@ -220,7 +220,7 @@ func (suite *BasicKopiaIntegrationSuite) TestMaintenance_WrongUser_NoForce_Fails
 	}
 
 	// This will set the user.
-	err = w.RepoMaintenance(ctx, nil, mOpts)
+	err = w.RepoMaintenance(ctx, nil, mOpts, fault.New(true))
 	require.NoError(t, err, clues.ToCore(err))
 
 	err = k.Close(ctx)
@@ -236,7 +236,7 @@ func (suite *BasicKopiaIntegrationSuite) TestMaintenance_WrongUser_NoForce_Fails
 
 	var notOwnedErr maintenance.NotOwnedError
 
-	err = w.RepoMaintenance(ctx, nil, mOpts)
+	err = w.RepoMaintenance(ctx, nil, mOpts, fault.New(true))
 	assert.ErrorAs(t, err, &notOwnedErr, clues.ToCore(err))
 }
 
@@ -258,7 +258,7 @@ func (suite *BasicKopiaIntegrationSuite) TestMaintenance_WrongUser_Force_Succeed
 	}
 
 	// This will set the user.
-	err = w.RepoMaintenance(ctx, nil, mOpts)
+	err = w.RepoMaintenance(ctx, nil, mOpts, fault.New(true))
 	require.NoError(t, err, clues.ToCore(err))
 
 	err = k.Close(ctx)
@@ -275,13 +275,13 @@ func (suite *BasicKopiaIntegrationSuite) TestMaintenance_WrongUser_Force_Succeed
 	mOpts.Force = true
 
 	// This will set the user.
-	err = w.RepoMaintenance(ctx, nil, mOpts)
+	err = w.RepoMaintenance(ctx, nil, mOpts, fault.New(true))
 	require.NoError(t, err, clues.ToCore(err))
 
 	mOpts.Force = false
 
 	// Running without force should succeed now.
-	err = w.RepoMaintenance(ctx, nil, mOpts)
+	err = w.RepoMaintenance(ctx, nil, mOpts, fault.New(true))
 	require.NoError(t, err, clues.ToCore(err))
 }
 
@@ -733,7 +733,7 @@ func (suite *RetentionIntegrationSuite) TestSetRetentionParameters_And_Maintenan
 	// This will set common maintenance config parameters. There's some interplay
 	// between the maintenance schedule and retention period that we want to check
 	// below.
-	err = w.RepoMaintenance(ctx, nil, mOpts)
+	err = w.RepoMaintenance(ctx, nil, mOpts, fault.New(true))
 	require.NoError(t, err, clues.ToCore(err))
 
 	// Enable retention.
@@ -838,7 +838,7 @@ func (suite *RetentionIntegrationSuite) TestSetAndUpdateRetentionParameters_RunM
 			// This will set common maintenance config parameters. There's some interplay
 			// between the maintenance schedule and retention period that we want to check
 			// below.
-			err = w.RepoMaintenance(ctx, ms, mOpts)
+			err = w.RepoMaintenance(ctx, ms, mOpts, fault.New(true))
 			require.NoError(t, err, clues.ToCore(err))
 
 			// Enable retention.
@@ -882,7 +882,7 @@ func (suite *RetentionIntegrationSuite) TestSetAndUpdateRetentionParameters_RunM
 
 			// Run full maintenance again. This should extend object locks for things if
 			// they exist.
-			err = w.RepoMaintenance(ctx, ms, mOpts)
+			err = w.RepoMaintenance(ctx, ms, mOpts, fault.New(true))
 			require.NoError(t, err, clues.ToCore(err))
 		})
 	}

--- a/src/internal/operations/maintenance.go
+++ b/src/internal/operations/maintenance.go
@@ -78,7 +78,7 @@ func (op *MaintenanceOperation) do(ctx context.Context) error {
 		op.Results.CompletedAt = time.Now()
 	}()
 
-	err := op.operation.kopia.RepoMaintenance(ctx, op.store, op.mOpts)
+	err := op.operation.kopia.RepoMaintenance(ctx, op.store, op.mOpts, op.Errors)
 	if err != nil {
 		op.Status = Failed
 		return clues.Wrap(err, "running maintenance operation")


### PR DESCRIPTION
Add the wiring to actually call the new config verify command during
maintenance

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

merge after:
* #5117
* #5118
* #5122

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
