### PR TITLE
Differentiate file suffixes between channel messages and conversations

### DIFF
--- a/src/internal/m365/collection/groups/backup_test.go
+++ b/src/internal/m365/collection/groups/backup_test.go
@@ -61,6 +61,11 @@ func (bh mockBackupHandler) augmentItemInfo(
 	// no-op
 }
 
+//lint:ignore U1000 false linter issue due to generics
+func (bh mockBackupHandler) supportsItemMetadata() bool {
+	return false
+}
+
 func (bh mockBackupHandler) canMakeDeltaQueries() bool {
 	return true
 }

--- a/src/internal/m365/collection/groups/channel_handler.go
+++ b/src/internal/m365/collection/groups/channel_handler.go
@@ -125,6 +125,12 @@ func (bh channelsBackupHandler) augmentItemInfo(
 	// no-op
 }
 
+//lint:ignore U1000 false linter issue due to generics
+func (bh channelsBackupHandler) supportsItemMetadata() bool {
+	// No .data and .meta files for channel messages
+	return false
+}
+
 func channelContainer(ch models.Channelable) container[models.Channelable] {
 	return container[models.Channelable]{
 		storageDirFolders:   path.Elements{ptr.Val(ch.GetId())},

--- a/src/internal/m365/collection/groups/collection.go
+++ b/src/internal/m365/collection/groups/collection.go
@@ -180,9 +180,8 @@ func (col *prefetchCollection[C, I]) streamItems(ctx context.Context, errs *faul
 			defer func() { <-semaphoreCh }()
 
 			// This is a no-op for conversations, as there is no way to detect
-			// deleted items in a conversation. It might be added in the future
-			// if graph supports it, so make sure we put up both .data and .meta
-			// files for deletions.
+			// deleted items. It might be added in future if graph supports it,
+			// so make sure we put up both .data and .meta files for deletions.
 			if col.getAndAugment.supportsItemMetadata() {
 				col.stream <- data.NewDeletedItem(id + metadata.DataFileSuffix)
 				col.stream <- data.NewDeletedItem(id + metadata.MetaFileSuffix)

--- a/src/internal/m365/collection/groups/collection.go
+++ b/src/internal/m365/collection/groups/collection.go
@@ -382,8 +382,7 @@ func (col *lazyFetchCollection[C, I]) streamItems(ctx context.Context, errs *fau
 				"item_id", id,
 				"parent_path", path.LoggableDir(col.LocationPath().String()))
 
-			// Conversation posts carry a .data suffix, while channel messages
-			// don't have any suffix. Metadata files are only supported for conversations.
+			// Channel message files don't carry .data suffix, post files do.
 			dataFile := id
 
 			// Handle metadata before data so that if metadata file fails,
@@ -431,7 +430,7 @@ func (col *lazyFetchCollection[C, I]) streamItems(ctx context.Context, errs *fau
 					modTime:       modTime,
 					getAndAugment: col.getAndAugment,
 					resourceID:    col.protectedResource,
-					itemID:        dataFile,
+					itemID:        id,
 					containerIDs:  col.FullPath().Folders(),
 					contains:      col.contains,
 					parentPath:    col.LocationPath().String(),

--- a/src/internal/m365/collection/groups/collection.go
+++ b/src/internal/m365/collection/groups/collection.go
@@ -179,7 +179,16 @@ func (col *prefetchCollection[C, I]) streamItems(ctx context.Context, errs *faul
 			defer wg.Done()
 			defer func() { <-semaphoreCh }()
 
-			col.stream <- data.NewDeletedItem(id)
+			// This is a no-op for conversations, as there is no way to detect
+			// deleted items in a conversation. It might be added in the future
+			// if graph supports it, so make sure we put up both .data and .meta
+			// files for deletions.
+			if col.getAndAugment.supportsItemMetadata() {
+				col.stream <- data.NewDeletedItem(id + metadata.DataFileSuffix)
+				col.stream <- data.NewDeletedItem(id + metadata.MetaFileSuffix)
+			} else {
+				col.stream <- data.NewDeletedItem(id)
+			}
 
 			atomic.AddInt64(&streamedItems, 1)
 			col.Counter.Inc(count.StreamItemsRemoved)
@@ -202,6 +211,18 @@ func (col *prefetchCollection[C, I]) streamItems(ctx context.Context, errs *faul
 		go func(id string) {
 			defer wg.Done()
 			defer func() { <-semaphoreCh }()
+
+			ictx := clues.Add(
+				ctx,
+				"item_id", id,
+				"parent_path", path.LoggableDir(col.LocationPath().String()))
+
+			// Conversation posts carry a .data suffix, while channel messages
+			// don't have any suffix. Metadata files are only supported for conversations.
+			dataFile := id
+			if col.getAndAugment.supportsItemMetadata() {
+				dataFile += metadata.DataFileSuffix
+			}
 
 			writer := kjson.NewJsonSerializationWriter()
 			defer writer.Close()
@@ -237,24 +258,48 @@ func (col *prefetchCollection[C, I]) streamItems(ctx context.Context, errs *faul
 
 			info.ParentPath = col.LocationPath().String()
 
-			storeItem, err := data.NewPrefetchedItemWithInfo(
+			dataItem, err := data.NewPrefetchedItemWithInfo(
 				io.NopCloser(bytes.NewReader(itemData)),
-				id,
+				dataFile,
 				details.ItemInfo{Groups: info})
 			if err != nil {
-				err := clues.StackWC(ctx, err).Label(fault.LabelForceNoBackupCreation)
-				el.AddRecoverable(ctx, err)
+				err := clues.StackWC(ictx, err).Label(fault.LabelForceNoBackupCreation)
+				el.AddRecoverable(ictx, err)
 
 				return
 			}
 
-			col.stream <- storeItem
+			// Handle metadata before data so that if metadata file fails,
+			// we are not left with an orphaned data file. No op for channel
+			// messages.
+			if col.getAndAugment.supportsItemMetadata() {
+				metaFile := id + metadata.MetaFileSuffix
+
+				// Use modTime from item info as it's the latest.
+				metaItem, err := downloadItemMeta[C, I](
+					ictx,
+					col.getAndAugment,
+					col.contains,
+					metaFile,
+					info.Modified,
+					el)
+				if err != nil {
+					return
+				}
+
+				col.stream <- metaItem
+			}
+
+			// Add data file to collection only if the metadata file(if any) was
+			// successfully added. This also helps to maintain consistency between
+			// prefetch & lazy fetch collection behaviors.
+			col.stream <- dataItem
 
 			atomic.AddInt64(&streamedItems, 1)
 			atomic.AddInt64(&totalBytes, info.Size)
 
 			if col.Counter.Inc(count.StreamItemsAdded)%1000 == 0 {
-				logger.Ctx(ctx).Infow("item stream progress", "stats", col.Counter.Values())
+				logger.Ctx(ictx).Infow("item stream progress", "stats", col.Counter.Values())
 			}
 
 			col.Counter.Add(count.StreamBytesAdded, info.Size)
@@ -399,29 +444,18 @@ func (col *lazyFetchCollection[C, I]) streamItems(ctx context.Context, errs *fau
 				dataFile += metadata.DataFileSuffix
 				metaFile := id + metadata.MetaFileSuffix
 
-				itemMeta, _, err := col.getAndAugment.getItemMetadata(
+				metaItem, err := downloadItemMeta[C, I](
 					ictx,
-					col.contains.container)
-				if err != nil {
-					errs.AddRecoverable(ctx, clues.StackWC(ctx, err))
-
-					return
-				}
-
-				// Skip adding progress reader for metadata files. It doesn't add
-				// much value.
-				storeItem, err := data.NewPrefetchedItem(
-					itemMeta,
+					col.getAndAugment,
+					col.contains,
 					metaFile,
-					// Use the same last modified time as post's.
-					modTime)
+					modTime,
+					el)
 				if err != nil {
-					errs.AddRecoverable(ctx, clues.StackWC(ctx, err))
-
 					return
 				}
 
-				col.stream <- storeItem
+				col.stream <- metaItem
 			}
 
 			col.stream <- data.NewLazyItemWithInfo(
@@ -516,4 +550,37 @@ func (lig *lazyItemGetter[C, I]) GetData(
 		&details.ItemInfo{Groups: info},
 		false,
 		nil
+}
+
+func downloadItemMeta[C graph.GetIDer, I groupsItemer](
+	ctx context.Context,
+	gim getItemMetadataer[C, I],
+	c container[C],
+	metaFile string,
+	modTime time.Time,
+	errs *fault.Bus,
+) (data.Item, error) {
+	itemMeta, _, err := gim.getItemMetadata(
+		ctx,
+		c.container)
+	if err != nil {
+		errs.AddRecoverable(ctx, clues.StackWC(ctx, err))
+
+		return nil, err
+	}
+
+	// Skip adding progress reader for metadata files. It doesn't add
+	// much value.
+	storeItem, err := data.NewPrefetchedItem(
+		itemMeta,
+		metaFile,
+		// Use the same last modified time as post's.
+		modTime)
+	if err != nil {
+		errs.AddRecoverable(ctx, clues.StackWC(ctx, err))
+
+		return nil, err
+	}
+
+	return storeItem, nil
 }

--- a/src/internal/m365/collection/groups/collection.go
+++ b/src/internal/m365/collection/groups/collection.go
@@ -348,8 +348,12 @@ func (col *lazyFetchCollection[C, I]) streamItems(ctx context.Context, errs *fau
 			// deleted items in a conversation. It might be added in the future
 			// if graph supports it, so make sure we put up both .data and .meta
 			// files for deletions.
-			col.stream <- data.NewDeletedItem(id + metadata.DataFileSuffix)
-			col.stream <- data.NewDeletedItem(id + metadata.MetaFileSuffix)
+			if col.getAndAugment.supportsItemMetadata() {
+				col.stream <- data.NewDeletedItem(id + metadata.DataFileSuffix)
+				col.stream <- data.NewDeletedItem(id + metadata.MetaFileSuffix)
+			} else {
+				col.stream <- data.NewDeletedItem(id)
+			}
 
 			atomic.AddInt64(&streamedItems, 1)
 			col.Counter.Inc(count.StreamItemsRemoved)
@@ -378,6 +382,10 @@ func (col *lazyFetchCollection[C, I]) streamItems(ctx context.Context, errs *fau
 				"item_id", id,
 				"parent_path", path.LoggableDir(col.LocationPath().String()))
 
+			// Conversation posts carry a .data suffix, while channel messages
+			// don't have any suffix. Metadata files are only supported for conversations.
+			dataFile := id
+
 			// Handle metadata before data so that if metadata file fails,
 			// we are not left with an orphaned data file.
 			//
@@ -394,15 +402,14 @@ func (col *lazyFetchCollection[C, I]) streamItems(ctx context.Context, errs *fau
 			if err != nil && !errors.Is(err, errMetadataFilesNotSupported) {
 				errs.AddRecoverable(ctx, clues.StackWC(ctx, err))
 
-				return
-			}
+					return
+				}
 
-			if err == nil {
 				// Skip adding progress reader for metadata files. It doesn't add
 				// much value.
 				storeItem, err := data.NewPrefetchedItem(
 					itemMeta,
-					id+metadata.MetaFileSuffix,
+					metaFile,
 					// Use the same last modified time as post's.
 					modTime)
 				if err != nil {
@@ -420,12 +427,12 @@ func (col *lazyFetchCollection[C, I]) streamItems(ctx context.Context, errs *fau
 					modTime:       modTime,
 					getAndAugment: col.getAndAugment,
 					resourceID:    col.protectedResource,
-					itemID:        id,
+					itemID:        dataFile,
 					containerIDs:  col.FullPath().Folders(),
 					contains:      col.contains,
 					parentPath:    col.LocationPath().String(),
 				},
-				id+metadata.DataFileSuffix,
+				dataFile,
 				modTime,
 				col.Counter,
 				el)

--- a/src/internal/m365/collection/groups/collection_test.go
+++ b/src/internal/m365/collection/groups/collection_test.go
@@ -180,6 +180,11 @@ func (getAndAugmentChannelMessage) augmentItemInfo(*details.GroupsInfo, models.C
 	// no-op
 }
 
+//lint:ignore U1000 false linter issue due to generics
+func (getAndAugmentChannelMessage) supportsItemMetadata() bool {
+	return false
+}
+
 func (suite *CollectionUnitSuite) TestPrefetchCollection_streamItems() {
 	var (
 		t             = suite.T()
@@ -320,6 +325,11 @@ func (m *getAndAugmentConversation) getItemMetadata(
 //lint:ignore U1000 false linter issue due to generics
 func (m *getAndAugmentConversation) augmentItemInfo(*details.GroupsInfo, models.Conversationable) {
 	// no-op
+}
+
+//lint:ignore U1000 false linter issue due to generics
+func (m *getAndAugmentConversation) supportsItemMetadata() bool {
+	return true
 }
 
 func (m *getAndAugmentConversation) check(t *testing.T, expected []string) {

--- a/src/internal/m365/collection/groups/conversation_handler.go
+++ b/src/internal/m365/collection/groups/conversation_handler.go
@@ -170,6 +170,11 @@ func (bh conversationsBackupHandler) augmentItemInfo(
 	dgi.Post.Topic = ptr.Val(c.GetTopic())
 }
 
+//lint:ignore U1000 false linter issue due to generics
+func (bh conversationsBackupHandler) supportsItemMetadata() bool {
+	return true
+}
+
 func conversationThreadContainer(
 	c models.Conversationable,
 	t models.ConversationThreadable,

--- a/src/internal/m365/collection/groups/handlers.go
+++ b/src/internal/m365/collection/groups/handlers.go
@@ -36,6 +36,7 @@ type getItemAndAugmentInfoer[C graph.GetIDer, I groupsItemer] interface {
 	getItemer[I]
 	getItemMetadataer[C, I]
 	augmentItemInfoer[C]
+	supportsItemMetadataer[C, I]
 }
 
 type augmentItemInfoer[C graph.GetIDer] interface {
@@ -58,6 +59,10 @@ type getItemMetadataer[C graph.GetIDer, I groupsItemer] interface {
 		ctx context.Context,
 		c C,
 	) (io.ReadCloser, int, error)
+}
+
+type supportsItemMetadataer[C graph.GetIDer, I groupsItemer] interface {
+	supportsItemMetadata() bool
 }
 
 // gets all containers for the resource


### PR DESCRIPTION
<!-- PR description-->

* Introduce a small interface to detect whether a service supports metadata files or not.
* Add parity between prefetch and lazy reader solutions for both conversations and channels.
---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
