### PR TITLE
use query params in all handlers

### DIFF
--- a/src/cli/backup/teamschats.go
+++ b/src/cli/backup/teamschats.go
@@ -102,7 +102,7 @@ func teamschatsCreateCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     teamschatsServiceCommand,
 		Aliases: []string{teamsServiceCommand},
-		Short:   "Backup M365 Chats service data",
+		Short:   "Backup M365 Chats data",
 		RunE:    createTeamsChatsCmd,
 		Args:    cobra.NoArgs,
 	}
@@ -170,7 +170,7 @@ func createTeamsChatsCmd(cmd *cobra.Command, args []string) error {
 func teamschatsListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   teamschatsServiceCommand,
-		Short: "List the history of M365 TeamsChats service backups",
+		Short: "List the history of M365 Chats backups",
 		RunE:  listTeamsChatsCmd,
 		Args:  cobra.NoArgs,
 	}
@@ -189,7 +189,7 @@ func listTeamsChatsCmd(cmd *cobra.Command, args []string) error {
 func teamschatsDetailsCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   teamschatsServiceCommand,
-		Short: "Shows the details of a M365 TeamsChats service backup",
+		Short: "Shows the details of a M365 Chats backup",
 		RunE:  detailsTeamsChatsCmd,
 		Args:  cobra.NoArgs,
 	}
@@ -237,7 +237,7 @@ func runDetailsTeamsChatsCmd(cmd *cobra.Command) error {
 func teamschatsDeleteCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   teamschatsServiceCommand,
-		Short: "Delete backed-up M365 TeamsChats service data",
+		Short: "Delete backed-up M365 Chats data",
 		RunE:  deleteTeamsChatsCmd,
 		Args:  cobra.NoArgs,
 	}

--- a/src/cli/export/export.go
+++ b/src/cli/export/export.go
@@ -25,6 +25,7 @@ var exportCommands = []func(cmd *cobra.Command) *cobra.Command{
 	addSharePointCommands,
 	addGroupsCommands,
 	addExchangeCommands,
+	addTeamsChatsCommands,
 }
 
 var defaultAcceptedFormatTypes = []string{string(control.DefaultFormat)}

--- a/src/cli/export/teamschats.go
+++ b/src/cli/export/teamschats.go
@@ -1,0 +1,101 @@
+package export
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/alcionai/corso/src/cli/flags"
+	"github.com/alcionai/corso/src/cli/utils"
+	"github.com/alcionai/corso/src/pkg/control"
+)
+
+// called by export.go to map subcommands to provider-specific handling.
+func addTeamsChatsCommands(cmd *cobra.Command) *cobra.Command {
+	var c *cobra.Command
+
+	switch cmd.Use {
+	case exportCommand:
+		c, _ = utils.AddCommand(cmd, teamschatsExportCmd(), utils.MarkPreviewCommand())
+
+		c.Use = c.Use + " " + teamschatsServiceCommandUseSuffix
+
+		flags.AddBackupIDFlag(c, true)
+		flags.AddTeamsChatsDetailsAndRestoreFlags(c)
+		flags.AddExportConfigFlags(c)
+		flags.AddFailFastFlag(c)
+	}
+
+	return c
+}
+
+const (
+	teamschatsServiceCommand          = "chats"
+	teamschatsServiceCommandUseSuffix = "<destination> --backup <backupId>"
+
+	//nolint:lll
+	teamschatsServiceCommandExportExamples = `# Export a specific chat from the last backup (1234abcd...) to /my-exports
+corso export chats my-exports --backup 1234abcd-12ab-cd34-56de-1234abcd --chat 98765abcdef
+
+# Export all of Bob's chats to the current directory
+corso export chats . --backup 1234abcd-12ab-cd34-56de-1234abcd \
+    --chat '*'
+
+# Export all chats that were created before 2020 to /my-exports
+corso export chats my-exports --backup 1234abcd-12ab-cd34-56de-1234abcd
+    --chat-created-before 2020-01-01T00:00:00`
+)
+
+// `corso export chats [<flag>...] <destination>`
+func teamschatsExportCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     teamschatsServiceCommand,
+		Aliases: []string{teamsServiceCommand},
+		Short:   "Export M365 Chats data",
+		RunE:    exportTeamsChatsCmd,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errors.New("missing export destination")
+			}
+
+			return nil
+		},
+		Example: teamschatsServiceCommandExportExamples,
+	}
+}
+
+// processes an teamschats service export.
+func exportTeamsChatsCmd(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	if utils.HasNoFlagsAndShownHelp(cmd) {
+		return nil
+	}
+
+	opts := utils.MakeTeamsChatsOpts(cmd)
+
+	if flags.RunModeFV == flags.RunModeFlagTest {
+		return nil
+	}
+
+	if err := utils.ValidateTeamsChatsRestoreFlags(flags.BackupIDFV, opts, false); err != nil {
+		return err
+	}
+
+	sel := utils.IncludeTeamsChatsRestoreDataSelectors(ctx, opts)
+	utils.FilterTeamsChatsRestoreInfoSelectors(sel, opts)
+
+	acceptedTeamsChatsFormatTypes := []string{
+		string(control.DefaultFormat),
+		string(control.JSONFormat),
+	}
+
+	return runExport(
+		ctx,
+		cmd,
+		args,
+		opts.ExportCfg,
+		sel.Selector,
+		flags.BackupIDFV,
+		"Chats",
+		acceptedTeamsChatsFormatTypes)
+}

--- a/src/cli/export/teamschats_test.go
+++ b/src/cli/export/teamschats_test.go
@@ -1,0 +1,78 @@
+package export
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/cli/flags"
+	flagsTD "github.com/alcionai/corso/src/cli/flags/testdata"
+	cliTD "github.com/alcionai/corso/src/cli/testdata"
+	"github.com/alcionai/corso/src/cli/utils"
+	"github.com/alcionai/corso/src/internal/tester"
+)
+
+type TeamsChatsUnitSuite struct {
+	tester.Suite
+}
+
+func TestTeamsChatsUnitSuite(t *testing.T) {
+	suite.Run(t, &TeamsChatsUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *TeamsChatsUnitSuite) TestAddTeamsChatsCommands() {
+	expectUse := teamschatsServiceCommand + " " + teamschatsServiceCommandUseSuffix
+
+	table := []struct {
+		name        string
+		use         string
+		expectUse   string
+		expectShort string
+		expectRunE  func(*cobra.Command, []string) error
+	}{
+		{"export teamschats", exportCommand, expectUse, teamschatsExportCmd().Short, exportTeamsChatsCmd},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+			parent := &cobra.Command{Use: exportCommand}
+
+			cmd := cliTD.SetUpCmdHasFlags(
+				t,
+				parent,
+				addTeamsChatsCommands,
+				[]cliTD.UseCobraCommandFn{
+					flags.AddAllProviderFlags,
+					flags.AddAllStorageFlags,
+				},
+				flagsTD.WithFlags(
+					teamschatsServiceCommand,
+					[]string{
+						flagsTD.RestoreDestination,
+						"--" + flags.RunModeFN, flags.RunModeFlagTest,
+						"--" + flags.BackupFN, flagsTD.BackupInput,
+						"--" + flags.FormatFN, flagsTD.FormatType,
+						"--" + flags.ArchiveFN,
+					},
+					flagsTD.PreparedProviderFlags(),
+					flagsTD.PreparedStorageFlags()))
+
+			cliTD.CheckCmdChild(
+				t,
+				parent,
+				3,
+				test.expectUse,
+				test.expectShort,
+				test.expectRunE)
+
+			opts := utils.MakeTeamsChatsOpts(cmd)
+
+			assert.Equal(t, flagsTD.BackupInput, flags.BackupIDFV)
+			assert.Equal(t, flagsTD.Archive, opts.ExportCfg.Archive)
+			assert.Equal(t, flagsTD.FormatType, opts.ExportCfg.Format)
+			flagsTD.AssertStorageFlags(t, cmd)
+		})
+	}
+}

--- a/src/internal/m365/collection/drive/collections.go
+++ b/src/internal/m365/collection/drive/collections.go
@@ -311,7 +311,7 @@ func (c *Collections) Get(
 	}
 
 	// Enumerate drives for the specified resourceOwner
-	pager := c.handler.NewDrivePager(c.protectedResource.ID(), nil)
+	pager := c.handler.NewDrivePager(nil)
 
 	drives, err := api.GetAllDrives(ctx, pager)
 	if err != nil {
@@ -439,7 +439,7 @@ func (c *Collections) Get(
 				continue
 			}
 
-			p, err := c.handler.CanonicalPath(odConsts.DriveFolderPrefixBuilder(driveID), c.tenantID)
+			p, err := c.handler.CanonicalPath(odConsts.DriveFolderPrefixBuilder(driveID))
 			if err != nil {
 				return nil, false, clues.WrapWC(ictx, err, "making exclude prefix")
 			}
@@ -504,7 +504,7 @@ func (c *Collections) Get(
 
 	// generate tombstones for drives that were removed.
 	for driveID := range driveTombstones {
-		prevDrivePath, err := c.handler.PathPrefix(c.tenantID, driveID)
+		prevDrivePath, err := c.handler.PathPrefix(driveID)
 		if err != nil {
 			return nil, false, clues.WrapWC(ctx, err, "making drive tombstone for previous path").Label(count.BadPathPrefix)
 		}
@@ -532,7 +532,7 @@ func (c *Collections) Get(
 	alertIfPrevPathsHaveCollisions(ctx, driveIDToPrevPaths, c.counter, errs)
 
 	// add metadata collections
-	pathPrefix, err := c.handler.MetadataPathPrefix(c.tenantID)
+	pathPrefix, err := c.handler.MetadataPathPrefix()
 	if err != nil {
 		// It's safe to return here because the logic for starting an
 		// incremental backup should eventually find that the metadata files are
@@ -729,7 +729,7 @@ func (c *Collections) getCollectionPath(
 		pb = path.Builder{}.Append(path.Split(ptr.Val(item.GetParentReference().GetPath()))...)
 	}
 
-	collectionPath, err := c.handler.CanonicalPath(pb, c.tenantID)
+	collectionPath, err := c.handler.CanonicalPath(pb)
 	if err != nil {
 		return nil, clues.Wrap(err, "making item path")
 	}

--- a/src/internal/m365/collection/drive/collections_test.go
+++ b/src/internal/m365/collection/drive/collections_test.go
@@ -2639,7 +2639,7 @@ func (suite *CollectionsUnitSuite) TestGet() {
 
 			prevDelta := "prev-delta"
 
-			pathPrefix, err := mbh.MetadataPathPrefix(tenant)
+			pathPrefix, err := mbh.MetadataPathPrefix()
 			require.NoError(t, err, clues.ToCore(err))
 
 			mc, err := graph.MakeMetadataCollection(

--- a/src/internal/m365/collection/drive/collections_tree.go
+++ b/src/internal/m365/collection/drive/collections_tree.go
@@ -68,7 +68,7 @@ func (c *Collections) getTree(
 		driveTombstones[driveID] = struct{}{}
 	}
 
-	pager := c.handler.NewDrivePager(c.protectedResource.ID(), nil)
+	pager := c.handler.NewDrivePager(nil)
 
 	drives, err := api.GetAllDrives(ctx, pager)
 	if err != nil {
@@ -176,7 +176,7 @@ func (c *Collections) makeDriveCollections(
 ) ([]data.BackupCollection, map[string]string, pagers.DeltaUpdate, error) {
 	driveID := ptr.Val(drv.GetId())
 
-	ppfx, err := c.handler.PathPrefix(c.tenantID, driveID)
+	ppfx, err := c.handler.PathPrefix(driveID)
 	if err != nil {
 		return nil, nil, pagers.DeltaUpdate{}, clues.Wrap(err, "generating backup tree prefix")
 	}
@@ -228,7 +228,7 @@ func (c *Collections) makeDriveCollections(
 	// if a reset did occur, the collections should already be marked as
 	// "do not merge", therefore everything will get processed as a new addition.
 	if !tree.hadReset && len(prevDeltaLink) > 0 {
-		p, err := c.handler.CanonicalPath(odConsts.DriveFolderPrefixBuilder(driveID), c.tenantID)
+		p, err := c.handler.CanonicalPath(odConsts.DriveFolderPrefixBuilder(driveID))
 		if err != nil {
 			err = clues.WrapWC(ctx, err, "making canonical path for item exclusions")
 			return nil, nil, pagers.DeltaUpdate{}, err
@@ -552,7 +552,7 @@ func (c *Collections) makeFolderCollectionPath(
 ) (path.Path, error) {
 	if folder.GetRoot() != nil {
 		pb := odConsts.DriveFolderPrefixBuilder(driveID)
-		collectionPath, err := c.handler.CanonicalPath(pb, c.tenantID)
+		collectionPath, err := c.handler.CanonicalPath(pb)
 
 		return collectionPath, clues.WrapWC(ctx, err, "making canonical root path").OrNil()
 	}
@@ -571,7 +571,7 @@ func (c *Collections) makeFolderCollectionPath(
 	folderPath := path.Split(ptr.Val(folder.GetParentReference().GetPath()))
 	folderPath = append(folderPath, name)
 	pb := path.Builder{}.Append(folderPath...)
-	collectionPath, err := c.handler.CanonicalPath(pb, c.tenantID)
+	collectionPath, err := c.handler.CanonicalPath(pb)
 
 	return collectionPath, clues.WrapWC(ctx, err, "making folder collection path").OrNil()
 }
@@ -684,7 +684,7 @@ func (c *Collections) makeDriveTombstones(
 			break
 		}
 
-		prevDrivePath, err := c.handler.PathPrefix(c.tenantID, driveID)
+		prevDrivePath, err := c.handler.PathPrefix(driveID)
 		if err != nil {
 			err = clues.WrapWC(ctx, err, "making drive tombstone for previous path").Label(count.BadPathPrefix)
 			el.AddRecoverable(ctx, err)
@@ -712,7 +712,7 @@ func (c *Collections) makeMetadataCollections(
 ) []data.BackupCollection {
 	colls := []data.BackupCollection{}
 
-	pathPrefix, err := c.handler.MetadataPathPrefix(c.tenantID)
+	pathPrefix, err := c.handler.MetadataPathPrefix()
 	if err != nil {
 		logger.CtxErr(ctx, err).Info("making metadata collection path prefixes")
 

--- a/src/internal/m365/collection/drive/group_handler_test.go
+++ b/src/internal/m365/collection/drive/group_handler_test.go
@@ -7,9 +7,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
+	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
 type GroupBackupHandlerUnitSuite struct {
@@ -37,9 +39,17 @@ func (suite *GroupBackupHandlerUnitSuite) TestPathPrefix() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
-			h := NewGroupBackupHandler(resourceOwner, "site-id", api.Drives{}, nil)
+			groupQP := graph.QueryParams{
+				TenantID:          tenantID,
+				ProtectedResource: idname.NewProvider(resourceOwner, resourceOwner),
+			}
+			siteQP := graph.QueryParams{
+				TenantID:          tenantID,
+				ProtectedResource: idname.NewProvider("site-id", "site-id"),
+			}
+			h := NewGroupBackupHandler(groupQP, siteQP, api.Drives{}, nil)
 
-			result, err := h.PathPrefix(tenantID, "drive-id")
+			result, err := h.PathPrefix("drive-id")
 			test.expectErr(t, err, clues.ToCore(err))
 
 			if result != nil {
@@ -66,9 +76,17 @@ func (suite *GroupBackupHandlerUnitSuite) TestSitePathPrefix() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
-			h := NewGroupBackupHandler(resourceOwner, "site-id", api.Drives{}, nil)
+			groupQP := graph.QueryParams{
+				TenantID:          tenantID,
+				ProtectedResource: idname.NewProvider(resourceOwner, resourceOwner),
+			}
+			siteQP := graph.QueryParams{
+				TenantID:          tenantID,
+				ProtectedResource: idname.NewProvider("site-id", "site-id"),
+			}
+			h := NewGroupBackupHandler(groupQP, siteQP, api.Drives{}, nil)
 
-			result, err := h.SitePathPrefix(tenantID)
+			result, err := h.SitePathPrefix()
 			test.expectErr(t, err, clues.ToCore(err))
 
 			if result != nil {
@@ -95,9 +113,17 @@ func (suite *GroupBackupHandlerUnitSuite) TestMetadataPathPrefix() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
-			h := NewGroupBackupHandler(resourceOwner, "site-id", api.Drives{}, nil)
+			groupQP := graph.QueryParams{
+				TenantID:          tenantID,
+				ProtectedResource: idname.NewProvider(resourceOwner, resourceOwner),
+			}
+			siteQP := graph.QueryParams{
+				TenantID:          tenantID,
+				ProtectedResource: idname.NewProvider("site-id", "site-id"),
+			}
+			h := NewGroupBackupHandler(groupQP, siteQP, api.Drives{}, nil)
 
-			result, err := h.MetadataPathPrefix(tenantID)
+			result, err := h.MetadataPathPrefix()
 			test.expectErr(t, err, clues.ToCore(err))
 
 			if result != nil {
@@ -124,10 +150,18 @@ func (suite *GroupBackupHandlerUnitSuite) TestCanonicalPath() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
-			h := NewGroupBackupHandler(resourceOwner, "site-id", api.Drives{}, nil)
+			groupQP := graph.QueryParams{
+				TenantID:          tenantID,
+				ProtectedResource: idname.NewProvider(resourceOwner, resourceOwner),
+			}
+			siteQP := graph.QueryParams{
+				TenantID:          tenantID,
+				ProtectedResource: idname.NewProvider("site-id", "site-id"),
+			}
+			h := NewGroupBackupHandler(groupQP, siteQP, api.Drives{}, nil)
 			p := path.Builder{}.Append("prefix")
 
-			result, err := h.CanonicalPath(p, tenantID)
+			result, err := h.CanonicalPath(p)
 			test.expectErr(t, err, clues.ToCore(err))
 
 			if result != nil {

--- a/src/internal/m365/collection/drive/handlers.go
+++ b/src/internal/m365/collection/drive/handlers.go
@@ -40,19 +40,23 @@ type BackupHandler interface {
 	GetItemPermissioner
 	GetItemer
 	GetRootFolderer
-	NewDrivePagerer
 	EnumerateDriveItemsDeltaer
+
+	// NewDrivePager produces a pager that fetches all drives for the
+	// protected resource in the handler.  Differs from the restore
+	// drive pager in that it does not acccept a resource parameter.
+	NewDrivePager(fields []string) pagers.NonDeltaHandler[models.Driveable]
 
 	// PathPrefix constructs the service and category specific path prefix for
 	// the given values.
-	PathPrefix(tenantID, driveID string) (path.Path, error)
+	PathPrefix(driveID string) (path.Path, error)
 
 	// MetadataPathPrefix returns the prefix path for metadata
-	MetadataPathPrefix(tenantID string) (path.Path, error)
+	MetadataPathPrefix() (path.Path, error)
 
 	// CanonicalPath constructs the service and category specific path for
 	// the given values.
-	CanonicalPath(folders *path.Builder, tenantID string) (path.Path, error)
+	CanonicalPath(folders *path.Builder) (path.Path, error)
 
 	// ServiceCat returns the service and category used by this implementation.
 	ServiceCat() (path.ServiceType, path.CategoryType)
@@ -65,10 +69,6 @@ type BackupHandler interface {
 	// scope wrapper funcs
 	IsAllPass() bool
 	IncludesDir(dir string) bool
-}
-
-type NewDrivePagerer interface {
-	NewDrivePager(resourceOwner string, fields []string) pagers.NonDeltaHandler[models.Driveable]
 }
 
 type GetItemPermissioner interface {
@@ -104,13 +104,14 @@ type RestoreHandler interface {
 	GetItemsByCollisionKeyser
 	GetRootFolderer
 	ItemInfoAugmenter
-	NewDrivePagerer
 	NewItemContentUploader
 	PostDriver
 	PostItemInContainerer
 	DeleteItemPermissioner
 	UpdateItemPermissioner
 	UpdateItemLinkSharer
+
+	NewDrivePagerer
 }
 
 type DeleteItemer interface {
@@ -194,4 +195,14 @@ type GetRootFolderer interface {
 		ctx context.Context,
 		driveID string,
 	) (models.DriveItemable, error)
+}
+
+// NewDrivePagerer produces a pager that fetches all drives for the
+// protected resource in the handler.  Differs from the backup
+// drive pager in that it accepts a resource parameter.
+type NewDrivePagerer interface {
+	NewDrivePager(
+		protectedResourceID string,
+		fields []string,
+	) pagers.NonDeltaHandler[models.Driveable]
 }

--- a/src/internal/m365/collection/drive/helper_test.go
+++ b/src/internal/m365/collection/drive/helper_test.go
@@ -717,6 +717,8 @@ type mockBackupHandler[T any] struct {
 	GetErrs  []error
 
 	RootFolder models.DriveItemable
+
+	TenantID string
 }
 
 func stubRootFolder() models.DriveItemable {
@@ -752,6 +754,7 @@ func defaultOneDriveBH(resourceOwner string) *mockBackupHandler[models.DriveItem
 		GetResps:             []*http.Response{nil},
 		GetErrs:              []error{clues.New("not defined")},
 		RootFolder:           stubRootFolder(),
+		TenantID:             "tenantID",
 	}
 }
 
@@ -777,6 +780,7 @@ func defaultSharePointBH(resourceOwner string) *mockBackupHandler[models.DriveIt
 		GetResps:             []*http.Response{nil},
 		GetErrs:              []error{clues.New("not defined")},
 		RootFolder:           stubRootFolder(),
+		TenantID:             "tenantID",
 	}
 }
 
@@ -790,8 +794,8 @@ func defaultDriveBHWith(
 	return mbh
 }
 
-func (h mockBackupHandler[T]) PathPrefix(tID, driveID string) (path.Path, error) {
-	pp, err := h.PathPrefixFn(tID, h.ProtectedResource.ID(), driveID)
+func (h mockBackupHandler[T]) PathPrefix(driveID string) (path.Path, error) {
+	pp, err := h.PathPrefixFn(h.TenantID, h.ProtectedResource.ID(), driveID)
 	if err != nil {
 		return nil, err
 	}
@@ -799,8 +803,8 @@ func (h mockBackupHandler[T]) PathPrefix(tID, driveID string) (path.Path, error)
 	return pp, h.PathPrefixErr
 }
 
-func (h mockBackupHandler[T]) MetadataPathPrefix(tID string) (path.Path, error) {
-	pp, err := h.MetadataPathPrefixFn(tID, h.ProtectedResource.ID())
+func (h mockBackupHandler[T]) MetadataPathPrefix() (path.Path, error) {
+	pp, err := h.MetadataPathPrefixFn(h.TenantID, h.ProtectedResource.ID())
 	if err != nil {
 		return nil, err
 	}
@@ -808,8 +812,8 @@ func (h mockBackupHandler[T]) MetadataPathPrefix(tID string) (path.Path, error) 
 	return pp, h.MetadataPathPrefixErr
 }
 
-func (h mockBackupHandler[T]) CanonicalPath(pb *path.Builder, tID string) (path.Path, error) {
-	cp, err := h.CanonPathFn(pb, tID, h.ProtectedResource.ID())
+func (h mockBackupHandler[T]) CanonicalPath(pb *path.Builder) (path.Path, error) {
+	cp, err := h.CanonPathFn(pb, h.TenantID, h.ProtectedResource.ID())
 	if err != nil {
 		return nil, err
 	}
@@ -821,7 +825,7 @@ func (h mockBackupHandler[T]) ServiceCat() (path.ServiceType, path.CategoryType)
 	return h.Service, h.Category
 }
 
-func (h mockBackupHandler[T]) NewDrivePager(string, []string) pagers.NonDeltaHandler[models.Driveable] {
+func (h mockBackupHandler[T]) NewDrivePager([]string) pagers.NonDeltaHandler[models.Driveable] {
 	return h.DriveItemEnumeration.drivePager()
 }
 

--- a/src/internal/m365/collection/drive/item_collector_test.go
+++ b/src/internal/m365/collection/drive/item_collector_test.go
@@ -265,10 +265,13 @@ func (suite *OneDriveIntgSuite) TestOneDriveNewCollections() {
 			colls := NewCollections(
 				&userDriveBackupHandler{
 					baseUserDriveHandler: baseUserDriveHandler{
+						qp: graph.QueryParams{
+							ProtectedResource: idname.NewProvider(suite.userID, suite.userID),
+							TenantID:          suite.creds.AzureClientID,
+						},
 						ac: suite.ac.Drives(),
 					},
-					userID: test.user,
-					scope:  scope,
+					scope: scope,
 				},
 				creds.AzureTenantID,
 				idname.NewProvider(test.user, test.user),

--- a/src/internal/m365/collection/drive/item_test.go
+++ b/src/internal/m365/collection/drive/item_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/common/str"
 	"github.com/alcionai/corso/src/internal/tester"
@@ -117,10 +118,13 @@ func (suite *ItemIntegrationSuite) TestItemReader_oneDrive() {
 
 	bh := &userDriveBackupHandler{
 		baseUserDriveHandler: baseUserDriveHandler{
+			qp: graph.QueryParams{
+				ProtectedResource: idname.NewProvider(suite.user, suite.user),
+				TenantID:          suite.service.credentials.AzureTenantID,
+			},
 			ac: suite.service.ac.Drives(),
 		},
-		userID: suite.user,
-		scope:  sc,
+		scope: sc,
 	}
 
 	// Read data for the file

--- a/src/internal/m365/collection/drive/site_handler_test.go
+++ b/src/internal/m365/collection/drive/site_handler_test.go
@@ -7,8 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
 type LibraryBackupHandlerUnitSuite struct {
@@ -36,9 +38,17 @@ func (suite *LibraryBackupHandlerUnitSuite) TestPathPrefix() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
-			h := siteBackupHandler{service: path.SharePointService, siteID: resourceOwner}
+			h := siteBackupHandler{
+				baseSiteHandler: baseSiteHandler{
+					qp: graph.QueryParams{
+						ProtectedResource: idname.NewProvider(resourceOwner, resourceOwner),
+						TenantID:          tenantID,
+					},
+				},
+				service: path.SharePointService,
+			}
 
-			result, err := h.PathPrefix(tenantID, "driveID")
+			result, err := h.PathPrefix("driveID")
 			test.expectErr(t, err, clues.ToCore(err))
 
 			if result != nil {
@@ -65,9 +75,17 @@ func (suite *LibraryBackupHandlerUnitSuite) TestMetadataPathPrefix() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
-			h := siteBackupHandler{service: path.SharePointService, siteID: resourceOwner}
+			h := siteBackupHandler{
+				baseSiteHandler: baseSiteHandler{
+					qp: graph.QueryParams{
+						ProtectedResource: idname.NewProvider(resourceOwner, resourceOwner),
+						TenantID:          tenantID,
+					},
+				},
+				service: path.SharePointService,
+			}
 
-			result, err := h.MetadataPathPrefix(tenantID)
+			result, err := h.MetadataPathPrefix()
 			test.expectErr(t, err, clues.ToCore(err))
 
 			if result != nil {
@@ -94,10 +112,18 @@ func (suite *LibraryBackupHandlerUnitSuite) TestCanonicalPath() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
-			h := siteBackupHandler{service: path.SharePointService, siteID: resourceOwner}
+			h := siteBackupHandler{
+				baseSiteHandler: baseSiteHandler{
+					qp: graph.QueryParams{
+						ProtectedResource: idname.NewProvider(resourceOwner, resourceOwner),
+						TenantID:          tenantID,
+					},
+				},
+				service: path.SharePointService,
+			}
 			p := path.Builder{}.Append("prefix")
 
-			result, err := h.CanonicalPath(p, tenantID)
+			result, err := h.CanonicalPath(p)
 			test.expectErr(t, err, clues.ToCore(err))
 
 			if result != nil {

--- a/src/internal/m365/collection/drive/user_drive_handler_test.go
+++ b/src/internal/m365/collection/drive/user_drive_handler_test.go
@@ -7,8 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/common/idname"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
 type ItemBackupHandlerUnitSuite struct {
@@ -36,9 +38,16 @@ func (suite *ItemBackupHandlerUnitSuite) TestPathPrefix() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
-			h := userDriveBackupHandler{userID: resourceOwner}
+			h := userDriveBackupHandler{
+				baseUserDriveHandler: baseUserDriveHandler{
+					qp: graph.QueryParams{
+						ProtectedResource: idname.NewProvider(resourceOwner, resourceOwner),
+						TenantID:          tenantID,
+					},
+				},
+			}
 
-			result, err := h.PathPrefix(tenantID, "driveID")
+			result, err := h.PathPrefix("driveID")
 			test.expectErr(t, err, clues.ToCore(err))
 
 			if result != nil {
@@ -65,9 +74,16 @@ func (suite *ItemBackupHandlerUnitSuite) TestMetadataPathPrefix() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
-			h := userDriveBackupHandler{userID: resourceOwner}
+			h := userDriveBackupHandler{
+				baseUserDriveHandler: baseUserDriveHandler{
+					qp: graph.QueryParams{
+						ProtectedResource: idname.NewProvider(resourceOwner, resourceOwner),
+						TenantID:          tenantID,
+					},
+				},
+			}
 
-			result, err := h.MetadataPathPrefix(tenantID)
+			result, err := h.MetadataPathPrefix()
 			test.expectErr(t, err, clues.ToCore(err))
 
 			if result != nil {
@@ -94,10 +110,17 @@ func (suite *ItemBackupHandlerUnitSuite) TestCanonicalPath() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			t := suite.T()
-			h := userDriveBackupHandler{userID: resourceOwner}
+			h := userDriveBackupHandler{
+				baseUserDriveHandler: baseUserDriveHandler{
+					qp: graph.QueryParams{
+						ProtectedResource: idname.NewProvider(resourceOwner, resourceOwner),
+						TenantID:          tenantID,
+					},
+				},
+			}
 			p := path.Builder{}.Append("prefix")
 
-			result, err := h.CanonicalPath(p, tenantID)
+			result, err := h.CanonicalPath(p)
 			test.expectErr(t, err, clues.ToCore(err))
 
 			if result != nil {

--- a/src/internal/m365/collection/groups/backup.go
+++ b/src/internal/m365/collection/groups/backup.go
@@ -181,7 +181,7 @@ func populateCollections[C graph.GetIDer, I groupsItemer](
 			logger.Ctx(ictx).Info("missing delta url")
 		}
 
-		currPath, err := bh.canonicalPath(c.storageDirFolders, qp.TenantID)
+		currPath, err := bh.canonicalPath(c.storageDirFolders)
 		if err != nil {
 			err = clues.StackWC(ctx, err).Label(count.BadCollPath)
 			el.AddRecoverable(ctx, err)

--- a/src/internal/m365/collection/groups/handlers.go
+++ b/src/internal/m365/collection/groups/handlers.go
@@ -81,10 +81,7 @@ type includeContainerer[C graph.GetIDer] interface {
 // canonicalPath constructs the service and category specific path for
 // the given builder.
 type canonicalPather interface {
-	canonicalPath(
-		storageDir path.Elements,
-		tenantID string,
-	) (path.Path, error)
+	canonicalPath(storageDir path.Elements) (path.Path, error)
 }
 
 // canMakeDeltaQueries evaluates whether the handler can support a

--- a/src/internal/m365/collection/site/backup.go
+++ b/src/internal/m365/collection/site/backup.go
@@ -253,7 +253,7 @@ func populateListsCollections(
 			}
 		}
 
-		currPath, err := bh.CanonicalPath(storageDir, tenantID)
+		currPath, err := bh.CanonicalPath(storageDir)
 		if err != nil {
 			el.AddRecoverable(ctx, clues.WrapWC(ctx, err, "creating list collection path"))
 			return nil, err

--- a/src/internal/m365/collection/site/backup_test.go
+++ b/src/internal/m365/collection/site/backup_test.go
@@ -67,7 +67,7 @@ func (suite *SharePointBackupUnitSuite) TestCollectLists() {
 	}{
 		{
 			name:                 "one list",
-			mock:                 siteMock.NewListHandler(siteMock.StubLists("one"), siteID, nil),
+			mock:                 siteMock.NewListHandler(siteMock.StubLists("one"), suite.creds.AzureTenantID, siteID, nil),
 			expectErr:            require.NoError,
 			expectColls:          2,
 			expectNewColls:       1,
@@ -76,7 +76,7 @@ func (suite *SharePointBackupUnitSuite) TestCollectLists() {
 		},
 		{
 			name:                 "many lists",
-			mock:                 siteMock.NewListHandler(siteMock.StubLists("one", "two"), siteID, nil),
+			mock:                 siteMock.NewListHandler(siteMock.StubLists("one", "two"), suite.creds.AzureTenantID, siteID, nil),
 			expectErr:            require.NoError,
 			expectColls:          3,
 			expectNewColls:       2,
@@ -85,7 +85,7 @@ func (suite *SharePointBackupUnitSuite) TestCollectLists() {
 		},
 		{
 			name:                 "with error",
-			mock:                 siteMock.NewListHandler(siteMock.StubLists("one"), siteID, errors.New("some error")),
+			mock:                 siteMock.NewListHandler(siteMock.StubLists("one"), suite.creds.AzureTenantID, siteID, errors.New("some error")),
 			expectErr:            require.Error,
 			expectColls:          0,
 			expectNewColls:       0,
@@ -286,7 +286,7 @@ func (suite *SharePointBackupUnitSuite) TestPopulateListsCollections_incremental
 
 			cs, err := populateListsCollections(
 				ctx,
-				siteMock.NewListHandler(test.lists, siteID, nil),
+				siteMock.NewListHandler(test.lists, suite.creds.AzureTenantID, siteID, nil),
 				bpc,
 				ac,
 				suite.creds.AzureTenantID,
@@ -417,8 +417,12 @@ func (suite *SharePointSuite) TestCollectLists() {
 	}
 
 	sel := selectors.NewSharePointBackup([]string{siteID})
+	qp := graph.QueryParams{
+		ProtectedResource: bpc.ProtectedResource,
+		TenantID:          creds.AzureTenantID,
+	}
 
-	bh := NewListsBackupHandler(bpc.ProtectedResource.ID(), ac.Lists())
+	bh := NewListsBackupHandler(qp, ac.Lists())
 
 	col, _, err := CollectLists(
 		ctx,

--- a/src/internal/m365/collection/site/collection_test.go
+++ b/src/internal/m365/collection/site/collection_test.go
@@ -312,10 +312,11 @@ func (suite *SharePointCollectionSuite) TestLazyCollection_Items() {
 		errs          = fault.New(true)
 		start         = time.Now().Add(-time.Second)
 		statusUpdater = func(*support.ControllerOperationStatus) {}
+		tenant        = "t"
 	)
 
 	fullPath, err := path.Build(
-		"t",
+		tenant,
 		"pr",
 		path.SharePointService,
 		path.ListsCategory,
@@ -326,7 +327,7 @@ func (suite *SharePointCollectionSuite) TestLazyCollection_Items() {
 	locPath := path.Elements{"full"}.Builder()
 
 	prevPath, err := path.Build(
-		"t",
+		tenant,
 		"pr",
 		path.SharePointService,
 		path.ListsCategory,
@@ -367,7 +368,7 @@ func (suite *SharePointCollectionSuite) TestLazyCollection_Items() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			getter := mock.NewListHandler(nil, "", nil)
+			getter := mock.NewListHandler(nil, tenant, "", nil)
 			defer getter.Check(t, test.expectReads)
 
 			col := NewLazyFetchCollection(
@@ -425,7 +426,7 @@ func (suite *SharePointCollectionSuite) TestLazyItem() {
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	lh := mock.NewListHandler(nil, "", nil)
+	lh := mock.NewListHandler(nil, "tenant", "", nil)
 
 	li := data.NewLazyItemWithInfo(
 		ctx,
@@ -469,7 +470,7 @@ func (suite *SharePointCollectionSuite) TestLazyItem_ReturnsEmptyReaderOnDeleted
 	ctx, flush := tester.NewContext(t)
 	defer flush()
 
-	lh := mock.NewListHandler(nil, "", core.ErrNotFound)
+	lh := mock.NewListHandler(nil, "tenant", "", core.ErrNotFound)
 
 	li := data.NewLazyItemWithInfo(
 		ctx,

--- a/src/internal/m365/collection/site/handlers.go
+++ b/src/internal/m365/collection/site/handlers.go
@@ -20,10 +20,7 @@ type backupHandler interface {
 // canonicalPath constructs the service and category specific path for
 // the given builder.
 type canonicalPather interface {
-	CanonicalPath(
-		storageDir path.Elements,
-		tenantID string,
-	) (path.Path, error)
+	CanonicalPath(storageDir path.Elements) (path.Path, error)
 }
 
 type getItemByIDer interface {

--- a/src/internal/m365/collection/site/lists_handler.go
+++ b/src/internal/m365/collection/site/lists_handler.go
@@ -9,31 +9,34 @@ import (
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
+	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
 var _ backupHandler = &listsBackupHandler{}
 
 type listsBackupHandler struct {
-	ac                api.Lists
-	protectedResource string
+	ac api.Lists
+	qp graph.QueryParams
 }
 
-func NewListsBackupHandler(protectedResource string, ac api.Lists) listsBackupHandler {
+func NewListsBackupHandler(
+	qp graph.QueryParams,
+	ac api.Lists,
+) listsBackupHandler {
 	return listsBackupHandler{
-		ac:                ac,
-		protectedResource: protectedResource,
+		ac: ac,
+		qp: qp,
 	}
 }
 
 func (bh listsBackupHandler) CanonicalPath(
 	storageDirFolders path.Elements,
-	tenantID string,
 ) (path.Path, error) {
 	return storageDirFolders.
 		Builder().
 		ToDataLayerPath(
-			tenantID,
-			bh.protectedResource,
+			bh.qp.TenantID,
+			bh.qp.ProtectedResource.ID(),
 			path.SharePointService,
 			path.ListsCategory,
 			false)
@@ -43,11 +46,11 @@ func (bh listsBackupHandler) GetItemByID(
 	ctx context.Context,
 	itemID string,
 ) (models.Listable, *details.SharePointInfo, error) {
-	return bh.ac.GetListByID(ctx, bh.protectedResource, itemID)
+	return bh.ac.GetListByID(ctx, bh.qp.ProtectedResource.ID(), itemID)
 }
 
 func (bh listsBackupHandler) GetItems(ctx context.Context, cc api.CallConfig) ([]models.Listable, error) {
-	return bh.ac.GetLists(ctx, bh.protectedResource, cc)
+	return bh.ac.GetLists(ctx, bh.qp.ProtectedResource.ID(), cc)
 }
 
 var _ restoreHandler = &listsRestoreHandler{}

--- a/src/internal/m365/collection/teamsChats/backup.go
+++ b/src/internal/m365/collection/teamsChats/backup.go
@@ -14,7 +14,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
-	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
@@ -38,14 +37,7 @@ func CreateCollections[I chatsItemer](
 		}
 	)
 
-	cc := api.CallConfig{
-		CanMakeDeltaQueries: false,
-	}
-
-	container, err := bh.getContainer(ctx, cc)
-	if err != nil {
-		return nil, false, clues.Stack(err)
-	}
+	container := bh.getContainer()
 
 	counter.Add(count.Containers, 1)
 
@@ -149,7 +141,7 @@ func populateCollection[I chatsItemer](
 		data.NewBaseCollection(
 			p,
 			p,
-			container.humanLocation.Builder(),
+			&path.Builder{},
 			ctrlOpts,
 			false,
 			cl),

--- a/src/internal/m365/collection/teamsChats/backup_test.go
+++ b/src/internal/m365/collection/teamsChats/backup_test.go
@@ -51,15 +51,12 @@ type mockBackupHandler struct {
 }
 
 func (bh mockBackupHandler) container() container[models.Chatable] {
-	return chatContainer()
+	return container[models.Chatable]{}
 }
 
 //lint:ignore U1000 required for interface compliance
-func (bh mockBackupHandler) getContainer(
-	context.Context,
-	api.CallConfig,
-) (container[models.Chatable], error) {
-	return chatContainer(), nil
+func (bh mockBackupHandler) getContainer() container[models.Chatable] {
+	return container[models.Chatable]{}
 }
 
 func (bh mockBackupHandler) getItemIDs(
@@ -85,7 +82,7 @@ func (bh mockBackupHandler) CanonicalPath() (path.Path, error) {
 }
 
 //lint:ignore U1000 false linter issue due to generics
-func (bh mockBackupHandler) getItem(
+func (bh mockBackupHandler) fillItem(
 	_ context.Context,
 	chat models.Chatable,
 ) (models.Chatable, *details.TeamsChatsInfo, error) {

--- a/src/internal/m365/collection/teamsChats/backup_test.go
+++ b/src/internal/m365/collection/teamsChats/backup_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/alcionai/corso/src/internal/common/idname"
 	inMock "github.com/alcionai/corso/src/internal/common/idname/mock"
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/data"
@@ -86,7 +87,6 @@ func (bh mockBackupHandler) CanonicalPath() (path.Path, error) {
 //lint:ignore U1000 false linter issue due to generics
 func (bh mockBackupHandler) getItem(
 	_ context.Context,
-	_ string,
 	chat models.Chatable,
 ) (models.Chatable, *details.TeamsChatsInfo, error) {
 	chatID := ptr.Val(chat.GetId())
@@ -285,7 +285,11 @@ func (suite *BackupIntgSuite) TestCreateCollections() {
 		tenant            = tconfig.M365TenantID(suite.T())
 		protectedResource = tconfig.M365TeamID(suite.T())
 		resources         = []string{protectedResource}
-		handler           = NewUsersChatsBackupHandler(tenant, protectedResource, suite.ac.Chats())
+		qp                = graph.QueryParams{
+			ProtectedResource: idname.NewProvider(protectedResource, protectedResource),
+			TenantID:          tenant,
+		}
+		handler = NewUsersChatsBackupHandler(qp, suite.ac.Chats())
 	)
 
 	tests := []struct {

--- a/src/internal/m365/collection/teamsChats/chat_handler.go
+++ b/src/internal/m365/collection/teamsChats/chat_handler.go
@@ -35,11 +35,8 @@ func NewUsersChatsBackupHandler(
 // chats have no containers.  Everything is stored at the root.
 //
 //lint:ignore U1000 required for interface compliance
-func (bh usersChatsBackupHandler) getContainer(
-	ctx context.Context,
-	_ api.CallConfig,
-) (container[models.Chatable], error) {
-	return chatContainer(), nil
+func (bh usersChatsBackupHandler) getContainer() container[models.Chatable] {
+	return container[models.Chatable]{}
 }
 
 //lint:ignore U1000 required for interface compliance
@@ -80,7 +77,7 @@ func (bh usersChatsBackupHandler) CanonicalPath() (path.Path, error) {
 }
 
 //lint:ignore U1000 false linter issue due to generics
-func (bh usersChatsBackupHandler) getItem(
+func (bh usersChatsBackupHandler) fillItem(
 	ctx context.Context,
 	chat models.Chatable,
 ) (models.Chatable, *details.TeamsChatsInfo, error) {
@@ -105,11 +102,4 @@ func (bh usersChatsBackupHandler) getItem(
 	chat.SetMembers(members)
 
 	return chat, api.TeamsChatInfo(chat), nil
-}
-
-func chatContainer() container[models.Chatable] {
-	return container[models.Chatable]{
-		storageDirFolders: path.Elements{},
-		humanLocation:     path.Elements{},
-	}
 }

--- a/src/internal/m365/collection/teamsChats/chat_handler.go
+++ b/src/internal/m365/collection/teamsChats/chat_handler.go
@@ -12,24 +12,23 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
+	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
 var _ backupHandler[models.Chatable] = &usersChatsBackupHandler{}
 
 type usersChatsBackupHandler struct {
-	ac                  api.Chats
-	protectedResourceID string
-	tenantID            string
+	ac api.Chats
+	qp graph.QueryParams
 }
 
 func NewUsersChatsBackupHandler(
-	tenantID, protectedResourceID string,
+	qp graph.QueryParams,
 	ac api.Chats,
 ) usersChatsBackupHandler {
 	return usersChatsBackupHandler{
-		ac:                  ac,
-		protectedResourceID: protectedResourceID,
-		tenantID:            tenantID,
+		ac: ac,
+		qp: qp,
 	}
 }
 
@@ -53,7 +52,7 @@ func (bh usersChatsBackupHandler) getItemIDs(
 
 	return bh.ac.GetChats(
 		ctx,
-		bh.protectedResourceID,
+		bh.qp.ProtectedResource.ID(),
 		cc)
 }
 
@@ -74,8 +73,8 @@ func (bh usersChatsBackupHandler) includeItem(
 
 func (bh usersChatsBackupHandler) CanonicalPath() (path.Path, error) {
 	return path.BuildPrefix(
-		bh.tenantID,
-		bh.protectedResourceID,
+		bh.qp.TenantID,
+		bh.qp.ProtectedResource.ID(),
 		path.TeamsChatsService,
 		path.ChatsCategory)
 }
@@ -83,7 +82,6 @@ func (bh usersChatsBackupHandler) CanonicalPath() (path.Path, error) {
 //lint:ignore U1000 false linter issue due to generics
 func (bh usersChatsBackupHandler) getItem(
 	ctx context.Context,
-	userID string,
 	chat models.Chatable,
 ) (models.Chatable, *details.TeamsChatsInfo, error) {
 	if chat == nil {

--- a/src/internal/m365/collection/teamsChats/collection.go
+++ b/src/internal/m365/collection/teamsChats/collection.go
@@ -208,10 +208,7 @@ func (lig *lazyItemGetter[I]) GetData(
 	writer := kjson.NewJsonSerializationWriter()
 	defer writer.Close()
 
-	item, info, err := lig.getter.getItem(
-		ctx,
-		lig.resourceID,
-		lig.item)
+	item, info, err := lig.getter.getItem(ctx, lig.item)
 	if err != nil {
 		// For items that were deleted in flight, add the skip label so that
 		// they don't lead to recoverable failures during backup.

--- a/src/internal/m365/collection/teamsChats/collection_test.go
+++ b/src/internal/m365/collection/teamsChats/collection_test.go
@@ -155,7 +155,6 @@ type getAndAugmentChat struct {
 //lint:ignore U1000 false linter issue due to generics
 func (m getAndAugmentChat) getItem(
 	_ context.Context,
-	_ string,
 	chat models.Chatable,
 ) (models.Chatable, *details.TeamsChatsInfo, error) {
 	chat.SetTopic(chat.GetId())

--- a/src/internal/m365/collection/teamsChats/collection_test.go
+++ b/src/internal/m365/collection/teamsChats/collection_test.go
@@ -148,12 +148,12 @@ func (suite *CollectionUnitSuite) TestNewCollection_state() {
 	}
 }
 
-type getAndAugmentChat struct {
+type fillChat struct {
 	err error
 }
 
 //lint:ignore U1000 false linter issue due to generics
-func (m getAndAugmentChat) getItem(
+func (m fillChat) fillItem(
 	_ context.Context,
 	chat models.Chatable,
 ) (models.Chatable, *details.TeamsChatsInfo, error) {
@@ -207,7 +207,7 @@ func (suite *CollectionUnitSuite) TestLazyFetchCollection_Items_LazyFetch() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			getterAugmenter := &getAndAugmentChat{}
+			filler := &fillChat{}
 
 			col := &lazyFetchCollection[models.Chatable]{
 				BaseCollection: data.NewBaseCollection(
@@ -219,7 +219,7 @@ func (suite *CollectionUnitSuite) TestLazyFetchCollection_Items_LazyFetch() {
 					count.New()),
 				items:         test.items,
 				contains:      container[models.Chatable]{},
-				getter:        getterAugmenter,
+				filler:        filler,
 				stream:        make(chan data.Item),
 				statusUpdater: statusUpdater,
 			}
@@ -272,16 +272,16 @@ func (suite *CollectionUnitSuite) TestLazyItem_GetDataErrors() {
 
 			chat := testdata.StubChats(uuid.NewString())[0]
 
-			m := getAndAugmentChat{
+			m := fillChat{
 				err: test.getErr,
 			}
 
 			li := data.NewLazyItemWithInfo(
 				ctx,
-				&lazyItemGetter[models.Chatable]{
+				&lazyItemFiller[models.Chatable]{
 					resourceID: "resourceID",
 					item:       chat,
-					getter:     &m,
+					filler:     &m,
 					modTime:    now,
 					parentPath: parentPath,
 				},
@@ -316,16 +316,16 @@ func (suite *CollectionUnitSuite) TestLazyItem_ReturnsEmptyReaderOnDeletedInFlig
 
 	chat := testdata.StubChats(uuid.NewString())[0]
 
-	m := getAndAugmentChat{
+	m := fillChat{
 		err: core.ErrNotFound,
 	}
 
 	li := data.NewLazyItemWithInfo(
 		ctx,
-		&lazyItemGetter[models.Chatable]{
+		&lazyItemFiller[models.Chatable]{
 			resourceID: "resourceID",
 			item:       chat,
-			getter:     &m,
+			filler:     &m,
 			modTime:    now,
 			parentPath: parentPath,
 		},
@@ -357,14 +357,14 @@ func (suite *CollectionUnitSuite) TestLazyItem() {
 	defer flush()
 
 	chat := testdata.StubChats(uuid.NewString())[0]
-	m := getAndAugmentChat{}
+	m := fillChat{}
 
 	li := data.NewLazyItemWithInfo(
 		ctx,
-		&lazyItemGetter[models.Chatable]{
+		&lazyItemFiller[models.Chatable]{
 			resourceID: "resourceID",
 			item:       chat,
-			getter:     &m,
+			filler:     &m,
 			modTime:    now,
 			parentPath: parentPath,
 		},

--- a/src/internal/m365/collection/teamsChats/handlers.go
+++ b/src/internal/m365/collection/teamsChats/handlers.go
@@ -49,7 +49,6 @@ type getItemIDser[I chatsItemer] interface {
 type getItemer[I chatsItemer] interface {
 	getItem(
 		ctx context.Context,
-		protectedResource string,
 		i I,
 	) (I, *details.TeamsChatsInfo, error)
 }

--- a/src/internal/m365/collection/teamsChats/handlers.go
+++ b/src/internal/m365/collection/teamsChats/handlers.go
@@ -8,7 +8,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
-	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
@@ -22,8 +21,7 @@ type chatsItemer interface {
 
 type backupHandler[I chatsItemer] interface {
 	getContainerer[I]
-	getItemer[I]
-	getItemer[I]
+	fillItemer[I]
 	getItemIDser[I]
 	includeItemer[I]
 	canonicalPather
@@ -33,10 +31,7 @@ type backupHandler[I chatsItemer] interface {
 // within this handler set, only one container (the root)
 // is expected
 type getContainerer[I chatsItemer] interface {
-	getContainer(
-		ctx context.Context,
-		cc api.CallConfig,
-	) (container[I], error)
+	getContainer() container[I]
 }
 
 // gets all item IDs in the container
@@ -46,8 +41,10 @@ type getItemIDser[I chatsItemer] interface {
 	) ([]I, error)
 }
 
-type getItemer[I chatsItemer] interface {
-	getItem(
+// fillItemer takes a complete item and extends it with data that
+// gets lazily populated during item streaming.
+type fillItemer[I chatsItemer] interface {
+	fillItem(
 		ctx context.Context,
 		i I,
 	) (I, *details.TeamsChatsInfo, error)
@@ -73,8 +70,4 @@ type canonicalPather interface {
 // Container management
 // ---------------------------------------------------------------------------
 
-type container[I chatsItemer] struct {
-	storageDirFolders path.Elements
-	humanLocation     path.Elements
-	container         I
-}
+type container[I chatsItemer] struct{}

--- a/src/internal/m365/export.go
+++ b/src/internal/m365/export.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/service/groups"
 	"github.com/alcionai/corso/src/internal/m365/service/onedrive"
 	"github.com/alcionai/corso/src/internal/m365/service/sharepoint"
+	"github.com/alcionai/corso/src/internal/m365/service/teamschats"
 	"github.com/alcionai/corso/src/internal/operations/inject"
 	"github.com/alcionai/corso/src/pkg/path"
 )
@@ -30,6 +31,9 @@ func (ctrl *Controller) NewServiceHandler(
 
 	case path.ExchangeService:
 		return exchange.NewExchangeHandler(ctrl.AC, ctrl.resourceHandler), nil
+
+	case path.TeamsChatsService:
+		return teamschats.NewTeamsChatsHandler(ctrl.AC, ctrl.resourceHandler), nil
 	}
 
 	return nil, clues.New("unrecognized service").

--- a/src/internal/m365/service/groups/export_test.go
+++ b/src/internal/m365/service/groups/export_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/alcionai/clues"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/alcionai/corso/src/internal/data"
@@ -79,7 +80,7 @@ func (suite *ExportUnitSuite) TestExportRestoreCollections_messages() {
 	)
 
 	p, err := path.Build("t", "pr", path.GroupsService, path.ChannelMessagesCategory, false, containerName)
-	assert.NoError(t, err, "build path")
+	require.NoError(t, err, clues.ToCore(err))
 
 	dcs := []data.RestoreCollection{
 		data.FetchRestoreCollection{
@@ -106,7 +107,7 @@ func (suite *ExportUnitSuite) TestExportRestoreCollections_messages() {
 			dcs,
 			stats,
 			fault.New(true))
-	assert.NoError(t, err, "export collections error")
+	require.NoError(t, err, clues.ToCore(err))
 	assert.Len(t, ecs, 1, "num of collections")
 
 	assert.Equal(t, expectedPath, ecs[0].BasePath(), "base dir")
@@ -117,7 +118,7 @@ func (suite *ExportUnitSuite) TestExportRestoreCollections_messages() {
 
 	for item := range ecs[0].Items(ctx) {
 		b, err := io.ReadAll(item.Body)
-		assert.NoError(t, err, clues.ToCore(err))
+		require.NoError(t, err, clues.ToCore(err))
 
 		// count up size for tests
 		size += len(b)
@@ -181,7 +182,7 @@ func (suite *ExportUnitSuite) TestExportRestoreCollections_libraries() {
 		false,
 		odConsts.SitesPathDir,
 		siteID)
-	assert.NoError(t, err, "build path")
+	require.NoError(t, err, clues.ToCore(err))
 
 	dcs := []data.RestoreCollection{
 		data.FetchRestoreCollection{
@@ -210,7 +211,7 @@ func (suite *ExportUnitSuite) TestExportRestoreCollections_libraries() {
 		dcs,
 		stats,
 		fault.New(true))
-	assert.NoError(t, err, "export collections error")
+	require.NoError(t, err, clues.ToCore(err))
 	assert.Len(t, ecs, 1, "num of collections")
 
 	assert.Equal(t, expectedPath, ecs[0].BasePath(), "base dir")
@@ -222,7 +223,7 @@ func (suite *ExportUnitSuite) TestExportRestoreCollections_libraries() {
 	for item := range ecs[0].Items(ctx) {
 		// unwrap the body from stats reader
 		b, err := io.ReadAll(item.Body)
-		assert.NoError(t, err, clues.ToCore(err))
+		require.NoError(t, err, clues.ToCore(err))
 
 		size += len(b)
 		bitem := io.NopCloser(bytes.NewBuffer(b))

--- a/src/internal/m365/service/onedrive/backup.go
+++ b/src/internal/m365/service/onedrive/backup.go
@@ -62,8 +62,13 @@ func (oneDriveBackup) ProduceBackupCollections(
 
 		logger.Ctx(ctx).Debug("creating OneDrive collections")
 
+		qp := graph.QueryParams{
+			ProtectedResource: bpc.ProtectedResource,
+			TenantID:          tenantID,
+		}
+
 		nc := drive.NewCollections(
-			drive.NewUserDriveBackupHandler(ac.Drives(), bpc.ProtectedResource.ID(), scope),
+			drive.NewUserDriveBackupHandler(qp, ac.Drives(), scope),
 			tenantID,
 			bpc.ProtectedResource,
 			su,

--- a/src/internal/m365/service/onedrive/mock/handlers.go
+++ b/src/internal/m365/service/onedrive/mock/handlers.go
@@ -71,6 +71,8 @@ type BackupHandler[T any] struct {
 	GetErrs  []error
 
 	RootFolder models.DriveItemable
+
+	TenantID string
 }
 
 func stubRootFolder() models.DriveItemable {
@@ -106,6 +108,7 @@ func DefaultOneDriveBH(resourceOwner string) *BackupHandler[models.DriveItemable
 		GetResps:             []*http.Response{nil},
 		GetErrs:              []error{clues.New("not defined")},
 		RootFolder:           stubRootFolder(),
+		TenantID:             "tenantID",
 	}
 }
 
@@ -131,6 +134,7 @@ func DefaultSharePointBH(resourceOwner string) *BackupHandler[models.DriveItemab
 		GetResps:             []*http.Response{nil},
 		GetErrs:              []error{clues.New("not defined")},
 		RootFolder:           stubRootFolder(),
+		TenantID:             "tenantID",
 	}
 }
 
@@ -144,8 +148,8 @@ func DefaultDriveBHWith(
 	return mbh
 }
 
-func (h BackupHandler[T]) PathPrefix(tID, driveID string) (path.Path, error) {
-	pp, err := h.PathPrefixFn(tID, h.ProtectedResource.ID(), driveID)
+func (h BackupHandler[T]) PathPrefix(driveID string) (path.Path, error) {
+	pp, err := h.PathPrefixFn(h.TenantID, h.ProtectedResource.ID(), driveID)
 	if err != nil {
 		return nil, err
 	}
@@ -153,8 +157,8 @@ func (h BackupHandler[T]) PathPrefix(tID, driveID string) (path.Path, error) {
 	return pp, h.PathPrefixErr
 }
 
-func (h BackupHandler[T]) MetadataPathPrefix(tID string) (path.Path, error) {
-	pp, err := h.MetadataPathPrefixFn(tID, h.ProtectedResource.ID())
+func (h BackupHandler[T]) MetadataPathPrefix() (path.Path, error) {
+	pp, err := h.MetadataPathPrefixFn(h.TenantID, h.ProtectedResource.ID())
 	if err != nil {
 		return nil, err
 	}
@@ -162,8 +166,8 @@ func (h BackupHandler[T]) MetadataPathPrefix(tID string) (path.Path, error) {
 	return pp, h.MetadataPathPrefixErr
 }
 
-func (h BackupHandler[T]) CanonicalPath(pb *path.Builder, tID string) (path.Path, error) {
-	cp, err := h.CanonPathFn(pb, tID, h.ProtectedResource.ID())
+func (h BackupHandler[T]) CanonicalPath(pb *path.Builder) (path.Path, error) {
+	cp, err := h.CanonPathFn(pb, h.TenantID, h.ProtectedResource.ID())
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +179,7 @@ func (h BackupHandler[T]) ServiceCat() (path.ServiceType, path.CategoryType) {
 	return h.Service, h.Category
 }
 
-func (h BackupHandler[T]) NewDrivePager(string, []string) pagers.NonDeltaHandler[models.Driveable] {
+func (h BackupHandler[T]) NewDrivePager([]string) pagers.NonDeltaHandler[models.Driveable] {
 	return h.DriveItemEnumeration.DrivePager()
 }
 

--- a/src/internal/m365/service/sharepoint/backup.go
+++ b/src/internal/m365/service/sharepoint/backup.go
@@ -62,9 +62,14 @@ func (sharePointBackup) ProduceBackupCollections(
 
 		var spcs []data.BackupCollection
 
+		qp := graph.QueryParams{
+			ProtectedResource: bpc.ProtectedResource,
+			TenantID:          creds.AzureClientID,
+		}
+
 		switch scope.Category().PathType() {
 		case path.ListsCategory:
-			bh := site.NewListsBackupHandler(bpc.ProtectedResource.ID(), ac.Lists())
+			bh := site.NewListsBackupHandler(qp, ac.Lists())
 
 			spcs, canUsePreviousBackup, err = site.CollectLists(
 				ctx,
@@ -86,8 +91,8 @@ func (sharePointBackup) ProduceBackupCollections(
 				ctx,
 				bpc,
 				drive.NewSiteBackupHandler(
+					qp,
 					ac.Drives(),
-					bpc.ProtectedResource.ID(),
 					scope,
 					bpc.Selector.PathService()),
 				creds.AzureTenantID,

--- a/src/internal/m365/service/sharepoint/backup_test.go
+++ b/src/internal/m365/service/sharepoint/backup_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
+	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
 // ---------------------------------------------------------------------------
@@ -54,9 +55,14 @@ func (suite *LibrariesBackupUnitSuite) TestUpdateCollections() {
 		siteID   = "site"
 	)
 
+	qp := graph.QueryParams{
+		ProtectedResource: idname.NewProvider(siteID, siteID),
+		TenantID:          tenantID,
+	}
+
 	pb := path.Builder{}.Append(testBaseDrivePath.Elements()...)
-	ep, err := drive.NewSiteBackupHandler(api.Drives{}, siteID, nil, path.SharePointService).
-		CanonicalPath(pb, tenantID)
+	ep, err := drive.NewSiteBackupHandler(qp, api.Drives{}, nil, path.SharePointService).
+		CanonicalPath(pb)
 	require.NoError(suite.T(), err, clues.ToCore(err))
 
 	tests := []struct {

--- a/src/internal/m365/service/teamschats/backup.go
+++ b/src/internal/m365/service/teamschats/backup.go
@@ -145,9 +145,13 @@ func backupChats(
 		scope.Category().PathType().HumanString())
 	defer close(progressMessage)
 
+	qp := graph.QueryParams{
+		ProtectedResource: bc.producerConfig.ProtectedResource,
+		TenantID:          bc.creds.AzureTenantID,
+	}
+
 	bh := teamschats.NewUsersChatsBackupHandler(
-		bc.creds.AzureTenantID,
-		bc.producerConfig.ProtectedResource.ID(),
+		qp,
 		bc.apiCli.Chats())
 
 	// Always disable lazy reader for channels until #4321 support is added

--- a/src/internal/m365/service/teamschats/export.go
+++ b/src/internal/m365/service/teamschats/export.go
@@ -1,0 +1,119 @@
+package teamschats
+
+import (
+	"context"
+
+	"github.com/alcionai/clues"
+
+	"github.com/alcionai/corso/src/internal/common/idname"
+	"github.com/alcionai/corso/src/internal/data"
+	"github.com/alcionai/corso/src/internal/m365/collection/teamschats"
+	"github.com/alcionai/corso/src/internal/m365/resource"
+	"github.com/alcionai/corso/src/internal/operations/inject"
+	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/export"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/metrics"
+	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+)
+
+var _ inject.ServiceHandler = &teamsChatsHandler{}
+
+func NewTeamsChatsHandler(
+	apiClient api.Client,
+	resourceGetter idname.GetResourceIDAndNamer,
+) *teamsChatsHandler {
+	return &teamsChatsHandler{
+		baseTeamsChatsHandler: baseTeamsChatsHandler{},
+		apiClient:             apiClient,
+		resourceGetter:        resourceGetter,
+	}
+}
+
+// ========================================================================== //
+//                          baseTeamsChatsHandler
+// ========================================================================== //
+
+// baseTeamsChatsHandler contains logic for tracking data and doing operations
+// (e.x. export) that don't require contact with external M356 services.
+type baseTeamsChatsHandler struct{}
+
+func (h *baseTeamsChatsHandler) CacheItemInfo(v details.ItemInfo) {}
+
+// ProduceExportCollections will create the export collections for the
+// given restore collections.
+func (h *baseTeamsChatsHandler) ProduceExportCollections(
+	ctx context.Context,
+	backupVersion int,
+	exportCfg control.ExportConfig,
+	dcs []data.RestoreCollection,
+	stats *metrics.ExportStats,
+	errs *fault.Bus,
+) ([]export.Collectioner, error) {
+	var (
+		el = errs.Local()
+		ec = make([]export.Collectioner, 0, len(dcs))
+	)
+
+	for _, dc := range dcs {
+		category := dc.FullPath().Category()
+
+		switch category {
+		case path.ChatsCategory:
+			folders := dc.FullPath().Folders()
+			pth := path.Builder{}.Append(category.HumanString()).Append(folders...)
+
+			ec = append(
+				ec,
+				teamschats.NewExportCollection(
+					pth.String(),
+					[]data.RestoreCollection{dc},
+					backupVersion,
+					exportCfg,
+					stats))
+		default:
+			return nil, clues.NewWC(ctx, "data category not supported").
+				With("category", category)
+		}
+	}
+
+	return ec, el.Failure()
+}
+
+// ========================================================================== //
+//                              teamschatsHandler
+// ========================================================================== //
+
+// teamsChatsHandler contains logic for handling data and performing operations
+// (e.x. restore) regardless of whether they require contact with external M365
+// services or not.
+type teamsChatsHandler struct {
+	baseTeamsChatsHandler
+	apiClient      api.Client
+	resourceGetter idname.GetResourceIDAndNamer
+}
+
+func (h *teamsChatsHandler) IsServiceEnabled(
+	ctx context.Context,
+	resourceID string,
+) (bool, error) {
+	// TODO(ashmrtn): Move free function implementation to this function.
+	res, err := IsServiceEnabled(ctx, h.apiClient.Users(), resourceID)
+	return res, clues.Stack(err).OrNil()
+}
+
+func (h *teamsChatsHandler) PopulateProtectedResourceIDAndName(
+	ctx context.Context,
+	resourceID string, // Can be either ID or name.
+	ins idname.Cacher,
+) (idname.Provider, error) {
+	if h.resourceGetter == nil {
+		return nil, clues.StackWC(ctx, resource.ErrNoResourceLookup)
+	}
+
+	pr, err := h.resourceGetter.GetResourceIDAndNameFrom(ctx, resourceID, ins)
+
+	return pr, clues.Wrap(err, "identifying resource owner").OrNil()
+}

--- a/src/internal/m365/service/teamschats/export_test.go
+++ b/src/internal/m365/service/teamschats/export_test.go
@@ -1,0 +1,140 @@
+package teamschats
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/alcionai/clues"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/data"
+	dataMock "github.com/alcionai/corso/src/internal/data/mock"
+	teamschatMock "github.com/alcionai/corso/src/internal/m365/service/teamschats/mock"
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/internal/version"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/export"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/metrics"
+	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+)
+
+type ExportUnitSuite struct {
+	tester.Suite
+}
+
+func TestExportUnitSuite(t *testing.T) {
+	suite.Run(t, &ExportUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+type finD struct {
+	id   string
+	key  string
+	name string
+	err  error
+}
+
+func (fd finD) FetchItemByName(ctx context.Context, name string) (data.Item, error) {
+	if fd.err != nil {
+		return nil, fd.err
+	}
+
+	if name == fd.id {
+		return &dataMock.Item{
+			ItemID: fd.id,
+			Reader: io.NopCloser(bytes.NewBufferString(`{"` + fd.key + `": "` + fd.name + `"}`)),
+		}, nil
+	}
+
+	return nil, assert.AnError
+}
+
+func (suite *ExportUnitSuite) TestExportRestoreCollections_chats() {
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	var (
+		category      = path.ChatsCategory
+		itemID        = "itemID"
+		dii           = teamschatMock.ItemInfo()
+		content       = `{"topic": "` + dii.TeamsChats.Chat.Topic + `"}`
+		body          = io.NopCloser(bytes.NewBufferString(content))
+		exportCfg     = control.ExportConfig{}
+		expectedPath  = category.HumanString()
+		expectedItems = []export.Item{
+			{
+				ID:   itemID,
+				Name: itemID + ".json",
+				// Body: body, not checked
+			},
+		}
+	)
+
+	p, err := path.BuildPrefix("t", "pr", path.TeamsChatsService, category)
+	require.NoError(t, err, clues.ToCore(err))
+
+	dcs := []data.RestoreCollection{
+		data.FetchRestoreCollection{
+			Collection: dataMock.Collection{
+				Path: p,
+				ItemData: []data.Item{
+					&dataMock.Item{
+						ItemID: itemID,
+						Reader: body,
+					},
+				},
+			},
+			FetchItemByNamer: finD{
+				id:   itemID,
+				key:  "id",
+				name: itemID,
+			},
+		},
+	}
+
+	stats := metrics.NewExportStats()
+
+	ecs, err := NewTeamsChatsHandler(api.Client{}, nil).
+		ProduceExportCollections(
+			ctx,
+			int(version.Backup),
+			exportCfg,
+			dcs,
+			stats,
+			fault.New(true))
+	require.NoError(t, err, clues.ToCore(err))
+	assert.Len(t, ecs, 1, "num of collections")
+
+	assert.Equal(t, expectedPath, ecs[0].BasePath(), "base dir")
+
+	fitems := []export.Item{}
+
+	size := 0
+
+	for item := range ecs[0].Items(ctx) {
+		b, err := io.ReadAll(item.Body)
+		require.NoError(t, err, clues.ToCore(err))
+
+		// count up size for tests
+		size += len(b)
+
+		// have to nil out body, otherwise assert fails due to
+		// pointer memory location differences
+		item.Body = nil
+		fitems = append(fitems, item)
+	}
+
+	assert.Equal(t, expectedItems, fitems, "items")
+
+	expectedStats := metrics.NewExportStats()
+	expectedStats.UpdateBytes(category, int64(size))
+	expectedStats.UpdateResourceCount(category)
+	assert.Equal(t, expectedStats.GetStats(), stats.GetStats(), "stats")
+}

--- a/src/internal/m365/service/teamschats/restore.go
+++ b/src/internal/m365/service/teamschats/restore.go
@@ -1,0 +1,100 @@
+package teamschats
+
+import (
+	"context"
+	"errors"
+
+	"github.com/alcionai/clues"
+
+	"github.com/alcionai/corso/src/internal/data"
+	"github.com/alcionai/corso/src/internal/m365/support"
+	"github.com/alcionai/corso/src/internal/operations/inject"
+	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/count"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/logger"
+	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
+)
+
+// ConsumeRestoreCollections will restore the specified data collections
+func (h *teamsChatsHandler) ConsumeRestoreCollections(
+	ctx context.Context,
+	rcc inject.RestoreConsumerConfig,
+	dcs []data.RestoreCollection,
+	errs *fault.Bus,
+	ctr *count.Bus,
+) (*details.Details, *data.CollectionStats, error) {
+	if len(dcs) == 0 {
+		return nil, nil, clues.WrapWC(ctx, data.ErrNoData, "performing restore")
+	}
+
+	// TODO(ashmrtn): We should stop relying on the context for rate limiter stuff
+	// and instead configure this when we make the handler instance. We can't
+	// initialize it in the NewHandler call right now because those functions
+	// aren't (and shouldn't be) returning a context along with the handler. Since
+	// that call isn't directly calling into this function even if we did
+	// initialize the rate limiter there it would be lost because it wouldn't get
+	// stored in an ancestor of the context passed to this function.
+	ctx = graph.BindRateLimiterConfig(
+		ctx,
+		graph.LimiterCfg{Service: path.TeamsChatsService})
+
+	var (
+		deets          = &details.Builder{}
+		restoreMetrics support.CollectionMetrics
+		el             = errs.Local()
+	)
+
+	// Reorder collections so that the parents directories are created
+	// before the child directories; a requirement for permissions.
+	data.SortRestoreCollections(dcs)
+
+	// Iterate through the data collections and restore the contents of each
+	for _, dc := range dcs {
+		if el.Failure() != nil {
+			break
+		}
+
+		var (
+			err      error
+			category = dc.FullPath().Category()
+			metrics  support.CollectionMetrics
+			ictx     = clues.Add(ctx,
+				"category", category,
+				"restore_location", clues.Hide(rcc.RestoreConfig.Location),
+				"protected_resource", clues.Hide(dc.FullPath().ProtectedResource()),
+				"full_path", dc.FullPath())
+		)
+
+		switch dc.FullPath().Category() {
+		case path.ChatsCategory:
+			// chats cannot be restored using Graph API.
+			// a delegated token is required, and Corso has no
+			// good way of obtaining such a token.
+			logger.Ctx(ictx).Debug("Skipping restore for channel messages")
+		default:
+			return nil, nil, clues.NewWC(ictx, "data category not supported").
+				With("category", category)
+		}
+
+		restoreMetrics = support.CombineMetrics(restoreMetrics, metrics)
+
+		if err != nil {
+			el.AddRecoverable(ictx, err)
+		}
+
+		if errors.Is(err, context.Canceled) {
+			break
+		}
+	}
+
+	status := support.CreateStatus(
+		ctx,
+		support.Restore,
+		len(dcs),
+		restoreMetrics,
+		rcc.RestoreConfig.Location)
+
+	return deets.Details(), status.ToCollectionStats(), el.Failure()
+}

--- a/src/internal/m365/service/teamschats/restore_test.go
+++ b/src/internal/m365/service/teamschats/restore_test.go
@@ -1,0 +1,54 @@
+package teamschats
+
+import (
+	"testing"
+
+	"github.com/alcionai/clues"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/data"
+	"github.com/alcionai/corso/src/internal/data/mock"
+	"github.com/alcionai/corso/src/internal/operations/inject"
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/path"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+)
+
+type RestoreUnitSuite struct {
+	tester.Suite
+}
+
+func TestRestoreUnitSuite(t *testing.T) {
+	suite.Run(t, &RestoreUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *RestoreUnitSuite) TestConsumeRestoreCollections_noErrorOnChats() {
+	t := suite.T()
+
+	ctx, flush := tester.NewContext(t)
+	defer flush()
+
+	rcc := inject.RestoreConsumerConfig{}
+	pth, err := path.BuildPrefix(
+		"t",
+		"pr",
+		path.TeamsChatsService,
+		path.ChatsCategory)
+	require.NoError(t, err, clues.ToCore(err))
+
+	dcs := []data.RestoreCollection{
+		mock.Collection{Path: pth},
+	}
+
+	_, _, err = NewTeamsChatsHandler(api.Client{}, nil).
+		ConsumeRestoreCollections(
+			ctx,
+			rcc,
+			dcs,
+			fault.New(false),
+			nil)
+	assert.NoError(t, err, "Chats restore")
+}

--- a/src/internal/operations/pathtransformer/restore_path_transformer.go
+++ b/src/internal/operations/pathtransformer/restore_path_transformer.go
@@ -142,6 +142,7 @@ func makeRestorePathsForEntry(
 	//   * OneDrive/SharePoint (needs drive information)
 	switch true {
 	case ent.Exchange != nil ||
+		ent.TeamsChats != nil ||
 		(ent.Groups != nil && ent.Groups.ItemType == details.GroupsChannelMessage) ||
 		(ent.SharePoint != nil && ent.SharePoint.ItemType == details.SharePointList):
 		// TODO(ashmrtn): Eventually make Events have it's own function to handle

--- a/src/internal/operations/pathtransformer/restore_path_transformer_test.go
+++ b/src/internal/operations/pathtransformer/restore_path_transformer_test.go
@@ -399,6 +399,30 @@ func (suite *RestorePathTransformerUnitSuite) TestGetPaths() {
 				},
 			},
 		},
+		{
+			name:          "TeamsChats Chats",
+			backupVersion: version.Groups9Update,
+			input: []*details.Entry{
+				{
+					RepoRef:     testdata.ExchangeEmailItemPath3.RR.String(),
+					LocationRef: testdata.ExchangeEmailItemPath3.Loc.String(),
+					ItemInfo: details.ItemInfo{
+						Exchange: &details.ExchangeInfo{
+							ItemType: details.ExchangeMail,
+						},
+					},
+				},
+			},
+			expectErr: assert.NoError,
+			expected: []expectPaths{
+				{
+					storage: testdata.ExchangeEmailItemPath3.RR.String(),
+					restore: toRestore(
+						testdata.ExchangeEmailItemPath3.RR,
+						testdata.ExchangeEmailItemPath3.Loc.Elements()...),
+				},
+			},
+		},
 	}
 
 	for _, test := range table {


### PR DESCRIPTION
backup handlers are all re-using the same inputs for tenantID and protected resource ID.  In some cases we're storing those values in the handler, other cases we don't. This pr seeks to normalize backup handler design by expecting a common structure for holding the resource and tenant ids.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
