### PR TITLE
chat handler cleanup

### DIFF
--- a/src/internal/m365/collection/teamsChats/backup.go
+++ b/src/internal/m365/collection/teamsChats/backup.go
@@ -14,7 +14,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
-	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
@@ -38,14 +37,7 @@ func CreateCollections[I chatsItemer](
 		}
 	)
 
-	cc := api.CallConfig{
-		CanMakeDeltaQueries: false,
-	}
-
-	container, err := bh.getContainer(ctx, cc)
-	if err != nil {
-		return nil, false, clues.Stack(err)
-	}
+	container := bh.getContainer()
 
 	counter.Add(count.Containers, 1)
 
@@ -149,7 +141,7 @@ func populateCollection[I chatsItemer](
 		data.NewBaseCollection(
 			p,
 			p,
-			container.humanLocation.Builder(),
+			&path.Builder{},
 			ctrlOpts,
 			false,
 			cl),

--- a/src/internal/m365/collection/teamsChats/backup_test.go
+++ b/src/internal/m365/collection/teamsChats/backup_test.go
@@ -51,15 +51,12 @@ type mockBackupHandler struct {
 }
 
 func (bh mockBackupHandler) container() container[models.Chatable] {
-	return chatContainer()
+	return container[models.Chatable]{}
 }
 
 //lint:ignore U1000 required for interface compliance
-func (bh mockBackupHandler) getContainer(
-	context.Context,
-	api.CallConfig,
-) (container[models.Chatable], error) {
-	return chatContainer(), nil
+func (bh mockBackupHandler) getContainer() container[models.Chatable] {
+	return container[models.Chatable]{}
 }
 
 func (bh mockBackupHandler) getItemIDs(
@@ -85,7 +82,7 @@ func (bh mockBackupHandler) CanonicalPath() (path.Path, error) {
 }
 
 //lint:ignore U1000 false linter issue due to generics
-func (bh mockBackupHandler) getItem(
+func (bh mockBackupHandler) fillItem(
 	_ context.Context,
 	chat models.Chatable,
 ) (models.Chatable, *details.TeamsChatsInfo, error) {

--- a/src/internal/m365/collection/teamsChats/chat_handler.go
+++ b/src/internal/m365/collection/teamsChats/chat_handler.go
@@ -35,11 +35,8 @@ func NewUsersChatsBackupHandler(
 // chats have no containers.  Everything is stored at the root.
 //
 //lint:ignore U1000 required for interface compliance
-func (bh usersChatsBackupHandler) getContainer(
-	ctx context.Context,
-	_ api.CallConfig,
-) (container[models.Chatable], error) {
-	return chatContainer(), nil
+func (bh usersChatsBackupHandler) getContainer() container[models.Chatable] {
+	return container[models.Chatable]{}
 }
 
 //lint:ignore U1000 required for interface compliance
@@ -80,7 +77,7 @@ func (bh usersChatsBackupHandler) CanonicalPath() (path.Path, error) {
 }
 
 //lint:ignore U1000 false linter issue due to generics
-func (bh usersChatsBackupHandler) getItem(
+func (bh usersChatsBackupHandler) fillItem(
 	ctx context.Context,
 	chat models.Chatable,
 ) (models.Chatable, *details.TeamsChatsInfo, error) {
@@ -105,11 +102,4 @@ func (bh usersChatsBackupHandler) getItem(
 	chat.SetMembers(members)
 
 	return chat, api.TeamsChatInfo(chat), nil
-}
-
-func chatContainer() container[models.Chatable] {
-	return container[models.Chatable]{
-		storageDirFolders: path.Elements{},
-		humanLocation:     path.Elements{},
-	}
 }

--- a/src/internal/m365/collection/teamsChats/collection_test.go
+++ b/src/internal/m365/collection/teamsChats/collection_test.go
@@ -148,12 +148,12 @@ func (suite *CollectionUnitSuite) TestNewCollection_state() {
 	}
 }
 
-type getAndAugmentChat struct {
+type fillChat struct {
 	err error
 }
 
 //lint:ignore U1000 false linter issue due to generics
-func (m getAndAugmentChat) getItem(
+func (m fillChat) fillItem(
 	_ context.Context,
 	chat models.Chatable,
 ) (models.Chatable, *details.TeamsChatsInfo, error) {
@@ -207,7 +207,7 @@ func (suite *CollectionUnitSuite) TestLazyFetchCollection_Items_LazyFetch() {
 			ctx, flush := tester.NewContext(t)
 			defer flush()
 
-			getterAugmenter := &getAndAugmentChat{}
+			filler := &fillChat{}
 
 			col := &lazyFetchCollection[models.Chatable]{
 				BaseCollection: data.NewBaseCollection(
@@ -219,7 +219,7 @@ func (suite *CollectionUnitSuite) TestLazyFetchCollection_Items_LazyFetch() {
 					count.New()),
 				items:         test.items,
 				contains:      container[models.Chatable]{},
-				getter:        getterAugmenter,
+				filler:        filler,
 				stream:        make(chan data.Item),
 				statusUpdater: statusUpdater,
 			}
@@ -272,16 +272,16 @@ func (suite *CollectionUnitSuite) TestLazyItem_GetDataErrors() {
 
 			chat := testdata.StubChats(uuid.NewString())[0]
 
-			m := getAndAugmentChat{
+			m := fillChat{
 				err: test.getErr,
 			}
 
 			li := data.NewLazyItemWithInfo(
 				ctx,
-				&lazyItemGetter[models.Chatable]{
+				&lazyItemFiller[models.Chatable]{
 					resourceID: "resourceID",
 					item:       chat,
-					getter:     &m,
+					filler:     &m,
 					modTime:    now,
 					parentPath: parentPath,
 				},
@@ -316,16 +316,16 @@ func (suite *CollectionUnitSuite) TestLazyItem_ReturnsEmptyReaderOnDeletedInFlig
 
 	chat := testdata.StubChats(uuid.NewString())[0]
 
-	m := getAndAugmentChat{
+	m := fillChat{
 		err: core.ErrNotFound,
 	}
 
 	li := data.NewLazyItemWithInfo(
 		ctx,
-		&lazyItemGetter[models.Chatable]{
+		&lazyItemFiller[models.Chatable]{
 			resourceID: "resourceID",
 			item:       chat,
-			getter:     &m,
+			filler:     &m,
 			modTime:    now,
 			parentPath: parentPath,
 		},
@@ -357,14 +357,14 @@ func (suite *CollectionUnitSuite) TestLazyItem() {
 	defer flush()
 
 	chat := testdata.StubChats(uuid.NewString())[0]
-	m := getAndAugmentChat{}
+	m := fillChat{}
 
 	li := data.NewLazyItemWithInfo(
 		ctx,
-		&lazyItemGetter[models.Chatable]{
+		&lazyItemFiller[models.Chatable]{
 			resourceID: "resourceID",
 			item:       chat,
-			getter:     &m,
+			filler:     &m,
 			modTime:    now,
 			parentPath: parentPath,
 		},

--- a/src/internal/m365/collection/teamsChats/handlers.go
+++ b/src/internal/m365/collection/teamsChats/handlers.go
@@ -8,7 +8,6 @@ import (
 	"github.com/alcionai/corso/src/pkg/backup/details"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/selectors"
-	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
@@ -22,8 +21,7 @@ type chatsItemer interface {
 
 type backupHandler[I chatsItemer] interface {
 	getContainerer[I]
-	getItemer[I]
-	getItemer[I]
+	fillItemer[I]
 	getItemIDser[I]
 	includeItemer[I]
 	canonicalPather
@@ -33,10 +31,7 @@ type backupHandler[I chatsItemer] interface {
 // within this handler set, only one container (the root)
 // is expected
 type getContainerer[I chatsItemer] interface {
-	getContainer(
-		ctx context.Context,
-		cc api.CallConfig,
-	) (container[I], error)
+	getContainer() container[I]
 }
 
 // gets all item IDs in the container
@@ -46,8 +41,10 @@ type getItemIDser[I chatsItemer] interface {
 	) ([]I, error)
 }
 
-type getItemer[I chatsItemer] interface {
-	getItem(
+// fillItemer takes a complete item and extends it with data that
+// gets lazily populated during item streaming.
+type fillItemer[I chatsItemer] interface {
+	fillItem(
 		ctx context.Context,
 		i I,
 	) (I, *details.TeamsChatsInfo, error)
@@ -73,8 +70,4 @@ type canonicalPather interface {
 // Container management
 // ---------------------------------------------------------------------------
 
-type container[I chatsItemer] struct {
-	storageDirFolders path.Elements
-	humanLocation     path.Elements
-	container         I
-}
+type container[I chatsItemer] struct{}

--- a/src/internal/m365/service/teamschats/backup.go
+++ b/src/internal/m365/service/teamschats/backup.go
@@ -145,9 +145,13 @@ func backupChats(
 		scope.Category().PathType().HumanString())
 	defer close(progressMessage)
 
+	qp := graph.QueryParams{
+		ProtectedResource: bc.producerConfig.ProtectedResource,
+		TenantID:          bc.creds.AzureTenantID,
+	}
+
 	bh := teamschats.NewUsersChatsBackupHandler(
-		bc.creds.AzureTenantID,
-		bc.producerConfig.ProtectedResource.ID(),
+		qp,
 		bc.apiCli.Chats())
 
 	// Always disable lazy reader for channels until #4321 support is added


### PR DESCRIPTION
container properties weren't used at all.
getItem didn't match the func behavior, since we
already had the item.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
