### PR TITLE
move M365 creds rotation logic to code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,8 +177,8 @@ jobs:
       # run the tests
       - name: Integration Tests
         env:
-          AZURE_CLIENT_ID: ${{ secrets[env.AZURE_CLIENT_ID_NAME] }}
-          AZURE_CLIENT_SECRET: ${{ secrets[env.AZURE_CLIENT_SECRET_NAME] }}
+          AZURE_CLIENT_ID: ${{ secrets[CLIENT_ID] }},${{ secrets[CLIENT_ID_2] }},${{ secrets[CLIENT_ID_3] }},${{ secrets[CLIENT_ID_4] }}
+          AZURE_CLIENT_SECRET: ${{ secrets[CLIENT_SECRET] }},${{ secrets[CLIENT_SECRET_2] }},${{ secrets[CLIENT_SECRET_3] }},${{ secrets[CLIENT_SECRET_4] }}
           AZURE_TENANT_ID: ${{ secrets.TENANT_ID }}
           CORSO_CI_TESTS: true
           CORSO_M365_TEST_USER_ID: ${{ vars.CORSO_M365_TEST_USER_ID }}
@@ -259,8 +259,8 @@ jobs:
       # run the tests
       - name: Retention Tests
         env:
-          AZURE_CLIENT_ID: ${{ secrets[env.AZURE_CLIENT_ID_NAME] }}
-          AZURE_CLIENT_SECRET: ${{ secrets[env.AZURE_CLIENT_SECRET_NAME] }}
+          AZURE_CLIENT_ID: ${{ secrets[CLIENT_ID] }},${{ secrets[CLIENT_ID_2] }},${{ secrets[CLIENT_ID_3] }},${{ secrets[CLIENT_ID_4] }}
+          AZURE_CLIENT_SECRET: ${{ secrets[CLIENT_SECRET] }},${{ secrets[CLIENT_SECRET_2] }},${{ secrets[CLIENT_SECRET_3] }},${{ secrets[CLIENT_SECRET_4] }}
           AZURE_TENANT_ID: ${{ secrets.TENANT_ID }}
           CORSO_RETENTION_TESTS: true
           CORSO_M365_TEST_USER_ID: ${{ vars.CORSO_M365_TEST_USER_ID }}

--- a/src/pkg/credentials/m365.go
+++ b/src/pkg/credentials/m365.go
@@ -1,7 +1,9 @@
 package credentials
 
 import (
+	"math/rand"
 	"os"
+	"strings"
 
 	"github.com/alcionai/clues"
 )
@@ -24,6 +26,18 @@ func GetM365() M365 {
 	// var AzureClientID, AzureClientSecret string
 	AzureClientID := os.Getenv(AzureClientID)
 	AzureClientSecret := os.Getenv(AzureClientSecret)
+
+	randomNumber := rand.Intn(4) + 1
+
+	if strings.Contains(AzureClientID, ",") {
+		AzureClientIDs := strings.Split(AzureClientID, ",")
+		AzureClientID = AzureClientIDs[randomNumber]
+	}
+
+	if strings.Contains(AzureClientID, ",") {
+		AzureClientSecrets := strings.Split(AzureClientSecret, ",")
+		AzureClientSecret = AzureClientSecrets[randomNumber]
+	}
 
 	return M365{
 		AzureClientID:     AzureClientID,


### PR DESCRIPTION
moves M365 creds rotation logic to code

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [x] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)
#5080 

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [x] :zap: Unit test
- [x] :green_heart: E2E
