### PR TITLE
Skip exchange items which fail to download due to ErrorCorruptData error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] (beta)
 
+### Fixed
+- Handle the case where an email or event cannot be retrieved from Exchange due to an `ErrorCorruptData` error. Corso will skip over the item but report it in the backup summary.
+
 ## [v0.19.0] (beta) - 2024-02-06
 
 ### Added

--- a/src/internal/m365/collection/exchange/collection_test.go
+++ b/src/internal/m365/collection/exchange/collection_test.go
@@ -364,6 +364,17 @@ func (suite *CollectionUnitSuite) TestCollection_SkippedErrors() {
 			},
 			expectedSkipError: fault.EmailSkip(fault.SkipInvalidRecipients, "", "fisher", nil),
 		},
+		{
+			name: "ErrorCorruptData",
+			added: map[string]time.Time{
+				"fisher": {},
+			},
+			expectItemCount: 0,
+			itemGetter: &mock.ItemGetSerialize{
+				GetErr: graphTD.ODataErr(string(graph.ErrorCorruptData)),
+			},
+			expectedSkipError: fault.EmailSkip(fault.SkipCorruptData, "", "fisher", nil),
+		},
 	}
 
 	for _, test := range table {

--- a/src/pkg/fault/skipped.go
+++ b/src/pkg/fault/skipped.go
@@ -36,6 +36,10 @@ const (
 	// SkipInvalidRecipients identifies that an email was skipped because Exchange
 	// believes it is not valid and fails any attempt to read it.
 	SkipInvalidRecipients skipCause = "invalid_recipients_email"
+
+	// SkipCorruptData identifies that an email was skipped because graph reported
+	// that the email data was corrupt and failed all attempts to read it.
+	SkipCorruptData skipCause = "corrupt_data"
 )
 
 var _ print.Printable = &Skipped{}

--- a/src/pkg/services/m365/api/graph/errors.go
+++ b/src/pkg/services/m365/api/graph/errors.go
@@ -50,6 +50,10 @@ const (
 	// are mailbox creation racing with email receipt or a similar issue triggered
 	// due to on-prem->M365 mailbox migration.
 	ErrorInvalidRecipients errorCode = "ErrorInvalidRecipients"
+	// We have seen this graph error with a 500 response while backing up email
+	// messages. It implies that the email message is corrupt and cannot be read.
+	// Associated error message goes like "Data is corrupt.,Invalid global object ID:"
+	ErrorCorruptData errorCode = "ErrorCorruptData"
 	// This error occurs when an attempt is made to create a folder that has
 	// the same name as another folder in the same parent. Such duplicate folder
 	// names are not allowed by graph.
@@ -247,6 +251,10 @@ func IsErrExchangeMailFolderNotFound(err error) bool {
 
 func IsErrInvalidRecipients(err error) bool {
 	return parseODataErr(err).hasErrorCode(err, ErrorInvalidRecipients)
+}
+
+func IsErrCorruptData(err error) bool {
+	return parseODataErr(err).hasErrorCode(err, ErrorCorruptData)
 }
 
 func IsErrCannotOpenFileAttachment(err error) bool {

--- a/src/pkg/services/m365/api/graph/errors_test.go
+++ b/src/pkg/services/m365/api/graph/errors_test.go
@@ -235,7 +235,7 @@ func (suite *GraphErrorsUnitSuite) TestIsErrNotFound() {
 	}
 }
 
-func (suite *GraphErrorsUnitSuite) Test() {
+func (suite *GraphErrorsUnitSuite) TestIsErrInvalidRecipients() {
 	table := []struct {
 		name   string
 		err    error
@@ -265,6 +265,40 @@ func (suite *GraphErrorsUnitSuite) Test() {
 	for _, test := range table {
 		suite.Run(test.name, func() {
 			test.expect(suite.T(), IsErrInvalidRecipients(test.err))
+		})
+	}
+}
+
+func (suite *GraphErrorsUnitSuite) TestIsErrCorruptData() {
+	table := []struct {
+		name   string
+		err    error
+		expect assert.BoolAssertionFunc
+	}{
+		{
+			name:   "nil",
+			err:    nil,
+			expect: assert.False,
+		},
+		{
+			name:   "non-matching",
+			err:    assert.AnError,
+			expect: assert.False,
+		},
+		{
+			name:   "non-matching oDataErr",
+			err:    graphTD.ODataErr("fnords"),
+			expect: assert.False,
+		},
+		{
+			name:   "invalid receipient oDataErr",
+			err:    graphTD.ODataErr(string(ErrorCorruptData)),
+			expect: assert.True,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			test.expect(suite.T(), IsErrCorruptData(test.err))
 		})
 	}
 }


### PR DESCRIPTION
<!-- PR description-->

* We are seeing 500 errors from graph during exchange(email) backup. * Error is `:{"code":"ErrorCorruptData","message":"Data is corrupt., Invalid global object ID: some ID`. 
* Catch the error and add a skip since these items cannot be downloaded from graph. 

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
