### PR TITLE
Retry events item enumeration with smaller page size for some cases

### DIFF
--- a/src/pkg/services/m365/api/config.go
+++ b/src/pkg/services/m365/api/config.go
@@ -8,8 +8,9 @@ import (
 )
 
 const (
-	maxNonDeltaPageSize = int32(999)
-	maxDeltaPageSize    = int32(500)
+	maxNonDeltaPageSize    = int32(999)
+	maxDeltaPageSize       = int32(500)
+	minEventsDeltaPageSize = int32(10)
 )
 
 // selectable values, case insensitive

--- a/src/pkg/services/m365/api/events_pager.go
+++ b/src/pkg/services/m365/api/events_pager.go
@@ -201,11 +201,28 @@ func (c Events) NewEventsDeltaPager(
 	userID, containerID, prevDeltaLink string,
 	selectProps ...string,
 ) pagers.DeltaHandler[models.Eventable] {
+	return c.newEventsDeltaPagerWithPageSize(
+		ctx,
+		userID,
+		containerID,
+		prevDeltaLink,
+		c.options.DeltaPageSize,
+		selectProps...)
+}
+
+func (c Events) newEventsDeltaPagerWithPageSize(
+	ctx context.Context,
+	userID string,
+	containerID string,
+	prevDeltaLink string,
+	pageSize int32,
+	selectProps ...string,
+) pagers.DeltaHandler[models.Eventable] {
 	options := &users.ItemCalendarsItemEventsDeltaRequestBuilderGetRequestConfiguration{
 		// do NOT set Top.  It limits the total items received.
 		QueryParameters: &users.ItemCalendarsItemEventsDeltaRequestBuilderGetQueryParameters{},
 		Headers: newPreferHeaders(
-			preferPageSize(c.options.DeltaPageSize),
+			preferPageSize(pageSize),
 			preferImmutableIDs(c.options.ToggleFeatures.ExchangeImmutableIDs)),
 	}
 

--- a/src/pkg/services/m365/api/events_pager.go
+++ b/src/pkg/services/m365/api/events_pager.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/alcionai/clues"
@@ -9,6 +10,7 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
 
 	"github.com/alcionai/corso/src/internal/common/ptr"
+	"github.com/alcionai/corso/src/pkg/logger"
 	"github.com/alcionai/corso/src/pkg/path"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/pagers"
@@ -276,10 +278,44 @@ func (c Events) GetAddedAndRemovedItemIDs(
 		containerID,
 		prevDeltaLink,
 		idAnd()...)
+
+	// Experiments showed that non-delta endpoint didn't have the same performance
+	// degradation that delta endpoint did so a larger page size should be ok.
 	pager := c.NewEventsPager(
 		userID,
 		containerID,
 		idAnd(lastModifiedDateTime)...)
+
+	// Try running the query with the given limits. If we fail to do a delta
+	// enumeration with a 5xx error try rerunning the query with a smaller page
+	// size. We've seen some resources where this consistently happens but a small
+	// page size allows us to make progress.
+	addedRemoved, err := pagers.GetAddedAndRemovedItemIDs[models.Eventable](
+		ctx,
+		pager,
+		deltaPager,
+		prevDeltaLink,
+		config.CanMakeDeltaQueries,
+		config.LimitResults,
+		pagers.AddedAndRemovedByAddtlData[models.Eventable])
+	if err == nil || !errors.Is(err, graph.ErrServiceUnavailableEmptyResp) {
+		return addedRemoved, clues.Stack(err).OrNil()
+	}
+
+	effectivePageSize := minEventsDeltaPageSize
+
+	logger.Ctx(ctx).Infow(
+		"retrying event item query with reduced page size",
+		"delta_pager_effective_page_size", effectivePageSize,
+		"delta_pager_default_page_size", c.options.DeltaPageSize)
+
+	deltaPager = c.newEventsDeltaPagerWithPageSize(
+		ctx,
+		userID,
+		containerID,
+		prevDeltaLink,
+		effectivePageSize,
+		idAnd()...)
 
 	return pagers.GetAddedAndRemovedItemIDs[models.Eventable](
 		ctx,

--- a/src/pkg/services/m365/api/graph/middleware_test.go
+++ b/src/pkg/services/m365/api/graph/middleware_test.go
@@ -43,8 +43,9 @@ func newMWReturns(code int, body []byte, err error) mwReturns {
 	}
 
 	resp := &http.Response{
-		StatusCode: code,
-		Body:       brc,
+		ContentLength: int64(len(body)),
+		StatusCode:    code,
+		Body:          brc,
 	}
 
 	if code == 0 {


### PR DESCRIPTION
Update the events item enumerator to switch to a smaller page size for
the delta pager if we fail enumeration with a 503 error and no content.
We've found that that situation is indicative of the Graph server
being slow and a smaller page size allows us to make progress still

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [x] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test (in another PR)
- [ ] :green_heart: E2E
