### PR TITLE
Don't clobber middleware in mock client

### DIFF
--- a/src/pkg/services/m365/api/events_pager_test.go
+++ b/src/pkg/services/m365/api/events_pager_test.go
@@ -1,9 +1,14 @@
 package api
 
 import (
+	"fmt"
+	"net/http"
+	stdpath "path"
+	"strings"
 	"testing"
 
 	"github.com/alcionai/clues"
+	"github.com/h2non/gock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -12,7 +17,139 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
+	"github.com/alcionai/corso/src/pkg/count"
 )
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+type EventsPagerUnitSuite struct {
+	tester.Suite
+}
+
+func TestEventsPagerUnitSuite(t *testing.T) {
+	suite.Run(t, &EventsPagerUnitSuite{
+		Suite: tester.NewUnitSuite(t),
+	})
+}
+
+func (suite *EventsPagerUnitSuite) TestGetAddedAndRemovedItemIDs_SendsCorrectDeltaPageSize() {
+	const (
+		validEmptyResponse = `{
+  "@odata.context": "https://graph.microsoft.com/beta/$metadata#Collection(event)",
+  "value": [],
+  "@odata.deltaLink": "link"
+}`
+
+		// deltaPath helps make gock matching a little easier since it splits out
+		// the hostname from the remainder of the URL. Graph SDK uses the URL
+		// directly though.
+		deltaPath = "/prev-delta"
+		prevDelta = graphAPIHostURL + deltaPath
+
+		userID      = "user-id"
+		containerID = "container-id"
+	)
+
+	deltaTests := []struct {
+		name       string
+		reqPath    string
+		inputDelta string
+	}{
+		{
+			name: "NoPrevDelta",
+			reqPath: stdpath.Join(
+				"/beta",
+				"users",
+				userID,
+				"calendars",
+				containerID,
+				"events",
+				"delta"),
+		},
+		{
+			name:       "HasPrevDelta",
+			reqPath:    deltaPath,
+			inputDelta: prevDelta,
+		},
+	}
+
+	for _, deltaTest := range deltaTests {
+		suite.Run(deltaTest.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			t.Cleanup(flush)
+
+			a := tconfig.NewFakeM365Account(t)
+			creds, err := a.M365Config()
+			require.NoError(t, err, clues.ToCore(err))
+
+			client, err := gockClient(creds, count.New())
+			require.NoError(t, err, clues.ToCore(err))
+
+			t.Cleanup(gock.Off)
+
+			// Number of retries and delay between retries is handled by a kiota
+			// middleware. We can change the default config parameters when setting up
+			// the mock in a later PR.
+			gock.New(graphAPIHostURL).
+				Get(deltaTest.reqPath).
+				Times(4).
+				Reply(http.StatusServiceUnavailable).
+				BodyString("").
+				Type("text/plain")
+
+			gock.New(graphAPIHostURL).
+				Get(deltaTest.reqPath).
+				SetMatcher(gock.NewMatcher()).
+				// Need a custom Matcher since the prefer header is also used for
+				// immutable ID behavior.
+				AddMatcher(func(got *http.Request, want *gock.Request) (bool, error) {
+					var (
+						found         bool
+						preferHeaders = got.Header.Values("Prefer")
+						expected      = fmt.Sprintf(
+							"odata.maxpagesize=%d",
+							minEventsDeltaPageSize)
+					)
+
+					for _, header := range preferHeaders {
+						if strings.Contains(header, expected) {
+							found = true
+							break
+						}
+					}
+
+					assert.Truef(
+						t,
+						found,
+						"header %s not found in set %v",
+						expected,
+						preferHeaders)
+
+					return true, nil
+				}).
+				Reply(http.StatusOK).
+				JSON(validEmptyResponse)
+
+			_, err = client.Events().GetAddedAndRemovedItemIDs(
+				ctx,
+				userID,
+				containerID,
+				deltaTest.inputDelta,
+				CallConfig{
+					CanMakeDeltaQueries: true,
+				})
+			require.NoError(t, err, clues.ToCore(err))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests
+// ---------------------------------------------------------------------------
 
 type EventsPagerIntgSuite struct {
 	tester.Suite

--- a/src/pkg/services/m365/api/helper_test.go
+++ b/src/pkg/services/m365/api/helper_test.go
@@ -38,6 +38,7 @@ func gockClient(creds account.M365Config, counter *count.Bus) (Client, error) {
 		Credentials: creds,
 		Stable:      s,
 		LargeItem:   li,
+		options:     control.DefaultOptions(),
 	}, nil
 }
 


### PR DESCRIPTION
The http mocking library we're using replaces the middleware of the
current transport if we just intercept the client. This switches things
to create a custom client with the proper set of middlewares instead so
that we get both mocking and the middleware

* ensure client has default parameters so things like default page size is set
* create a custom client so that we can both use the mock and have access to the middleware we normally add to the mock

More tuning of the custom client is necessary, for example, reducing the retries/time between retries for our middleware and the kiota middleware.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
