### PR TITLE
Add a unit test to check event pager page size fallback

### DIFF
--- a/src/pkg/services/m365/api/events_pager_test.go
+++ b/src/pkg/services/m365/api/events_pager_test.go
@@ -1,9 +1,14 @@
 package api
 
 import (
+	"fmt"
+	"net/http"
+	stdpath "path"
+	"strings"
 	"testing"
 
 	"github.com/alcionai/clues"
+	"github.com/h2non/gock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -12,7 +17,139 @@ import (
 	"github.com/alcionai/corso/src/internal/common/ptr"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/internal/tester/tconfig"
+	"github.com/alcionai/corso/src/pkg/count"
 )
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+type EventsPagerUnitSuite struct {
+	tester.Suite
+}
+
+func TestEventsPagerUnitSuite(t *testing.T) {
+	suite.Run(t, &EventsPagerUnitSuite{
+		Suite: tester.NewUnitSuite(t),
+	})
+}
+
+func (suite *EventsPagerUnitSuite) TestGetAddedAndRemovedItemIDs_SendsCorrectDeltaPageSize() {
+	const (
+		validEmptyResponse = `{
+  "@odata.context": "https://graph.microsoft.com/beta/$metadata#Collection(event)",
+  "value": [],
+  "@odata.deltaLink": "link"
+}`
+
+		// deltaPath helps make gock matching a little easier since it splits out
+		// the hostname from the remainder of the URL. Graph SDK uses the URL
+		// directly though.
+		deltaPath = "/prev-delta"
+		prevDelta = graphAPIHostURL + deltaPath
+
+		userID      = "user-id"
+		containerID = "container-id"
+	)
+
+	deltaTests := []struct {
+		name       string
+		reqPath    string
+		inputDelta string
+	}{
+		{
+			name: "NoPrevDelta",
+			reqPath: stdpath.Join(
+				"/beta",
+				"users",
+				userID,
+				"calendars",
+				containerID,
+				"events",
+				"delta"),
+		},
+		{
+			name:       "HasPrevDelta",
+			reqPath:    deltaPath,
+			inputDelta: prevDelta,
+		},
+	}
+
+	for _, deltaTest := range deltaTests {
+		suite.Run(deltaTest.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			t.Cleanup(flush)
+
+			a := tconfig.NewFakeM365Account(t)
+			creds, err := a.M365Config()
+			require.NoError(t, err, clues.ToCore(err))
+
+			client, err := gockClient(creds, count.New())
+			require.NoError(t, err, clues.ToCore(err))
+
+			t.Cleanup(gock.Off)
+
+			// Number of retries and delay between retries is handled by a kiota
+			// middleware. We can change the default config parameters when setting up
+			// the mock in a later PR.
+			gock.New(graphAPIHostURL).
+				Get(deltaTest.reqPath).
+				Times(4).
+				Reply(http.StatusServiceUnavailable).
+				BodyString("").
+				Type("text/plain")
+
+			gock.New(graphAPIHostURL).
+				Get(deltaTest.reqPath).
+				SetMatcher(gock.NewMatcher()).
+				// Need a custom Matcher since the prefer header is also used for
+				// immutable ID behavior.
+				AddMatcher(func(got *http.Request, want *gock.Request) (bool, error) {
+					var (
+						found         bool
+						preferHeaders = got.Header.Values("Prefer")
+						expected      = fmt.Sprintf(
+							"odata.maxpagesize=%d",
+							minEventsDeltaPageSize)
+					)
+
+					for _, header := range preferHeaders {
+						if strings.Contains(header, expected) {
+							found = true
+							break
+						}
+					}
+
+					assert.Truef(
+						t,
+						found,
+						"header %s not found in set %v",
+						expected,
+						preferHeaders)
+
+					return true, nil
+				}).
+				Reply(http.StatusOK).
+				JSON(validEmptyResponse)
+
+			_, err = client.Events().GetAddedAndRemovedItemIDs(
+				ctx,
+				userID,
+				containerID,
+				deltaTest.inputDelta,
+				CallConfig{
+					CanMakeDeltaQueries: true,
+				})
+			require.NoError(t, err, clues.ToCore(err))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests
+// ---------------------------------------------------------------------------
 
 type EventsPagerIntgSuite struct {
 	tester.Suite


### PR DESCRIPTION
Test that if we exhaust all our retries and still get a 503/no content back we retry with a pager with a smaller page size. This only applies to the delta pager right now.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

Merge after:
* #5194
* #5195

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
