### PR TITLE
use contentt endopint for files larger than 50gb

### DIFF
--- a/src/internal/common/str/str.go
+++ b/src/internal/common/str/str.go
@@ -59,6 +59,19 @@ func First(vs ...string) string {
 	return ""
 }
 
+// FirstIn returns the first entry in the map with a non-zero value
+// when iterating the provided list of keys.
+func FirstIn(m map[string]any, keys ...string) string {
+	for _, key := range keys {
+		v, err := AnyValueToString(key, m)
+		if err == nil && len(v) > 0 {
+			return v
+		}
+	}
+
+	return ""
+}
+
 // Preview reduces the string to the specified size.
 // If the string is longer than the size, the last three
 // characters are replaced with an ellipsis.  Size < 4

--- a/src/internal/common/str/str_test.go
+++ b/src/internal/common/str/str_test.go
@@ -118,3 +118,96 @@ func TestGenerateHash(t *testing.T) {
 		}
 	}
 }
+
+func TestFirstIn(t *testing.T) {
+	table := []struct {
+		name   string
+		m      map[string]any
+		keys   []string
+		expect string
+	}{
+		{
+			name:   "nil map",
+			keys:   []string{"foo", "bar"},
+			expect: "",
+		},
+		{
+			name:   "empty map",
+			m:      map[string]any{},
+			keys:   []string{"foo", "bar"},
+			expect: "",
+		},
+		{
+			name: "no match",
+			m: map[string]any{
+				"baz": "baz",
+			},
+			keys:   []string{"foo", "bar"},
+			expect: "",
+		},
+		{
+			name: "no keys",
+			m: map[string]any{
+				"baz": "baz",
+			},
+			keys:   []string{},
+			expect: "",
+		},
+		{
+			name: "nil match",
+			m: map[string]any{
+				"foo": nil,
+			},
+			keys:   []string{"foo", "bar"},
+			expect: "",
+		},
+		{
+			name: "empty match",
+			m: map[string]any{
+				"foo": "",
+			},
+			keys:   []string{"foo", "bar"},
+			expect: "",
+		},
+		{
+			name: "matches first key",
+			m: map[string]any{
+				"foo": "fnords",
+			},
+			keys:   []string{"foo", "bar"},
+			expect: "fnords",
+		},
+		{
+			name: "matches second key",
+			m: map[string]any{
+				"bar": "smarf",
+			},
+			keys:   []string{"foo", "bar"},
+			expect: "smarf",
+		},
+		{
+			name: "matches second key with nil first match",
+			m: map[string]any{
+				"foo": nil,
+				"bar": "smarf",
+			},
+			keys:   []string{"foo", "bar"},
+			expect: "smarf",
+		},
+		{
+			name: "matches second key with empty first match",
+			m: map[string]any{
+				"foo": "",
+				"bar": "smarf",
+			},
+			keys:   []string{"foo", "bar"},
+			expect: "smarf",
+		},
+	}
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			result := FirstIn(test.m, test.keys...)
+			assert.Equal(t, test.expect, result)
+		})
+	}
+}

--- a/src/internal/m365/collection/drive/collection.go
+++ b/src/internal/m365/collection/drive/collection.go
@@ -366,7 +366,7 @@ func downloadContent(
 	itemID := ptr.Val(item.GetId())
 	ctx = clues.Add(ctx, "item_id", itemID)
 
-	content, err := downloadItem(ctx, iaag, item)
+	content, err := downloadItem(ctx, iaag, driveID, item)
 	if err == nil {
 		return content, nil
 	} else if !graph.IsErrUnauthorizedOrBadToken(err) {
@@ -395,7 +395,7 @@ func downloadContent(
 
 	cdi := custom.ToCustomDriveItem(di)
 
-	content, err = downloadItem(ctx, iaag, cdi)
+	content, err = downloadItem(ctx, iaag, driveID, cdi)
 	if err != nil {
 		return nil, clues.Wrap(err, "content download retry")
 	}

--- a/src/internal/m365/collection/drive/collection.go
+++ b/src/internal/m365/collection/drive/collection.go
@@ -426,7 +426,7 @@ func readItemContents(
 		return nil, core.ErrNotFound
 	}
 
-	rc, err := downloadFile(ctx, iaag, props.downloadURL)
+	rc, err := downloadFile(ctx, iaag, props.downloadURL, false)
 	if graph.IsErrUnauthorizedOrBadToken(err) {
 		logger.CtxErr(ctx, err).Debug("stale item in cache")
 	}

--- a/src/internal/m365/collection/drive/helper_test.go
+++ b/src/internal/m365/collection/drive/helper_test.go
@@ -795,7 +795,12 @@ func (h mockBackupHandler[T]) AugmentItemInfo(
 	return h.ItemInfo
 }
 
-func (h *mockBackupHandler[T]) Get(context.Context, string, map[string]string) (*http.Response, error) {
+func (h *mockBackupHandler[T]) Get(
+	context.Context,
+	string,
+	map[string]string,
+	bool,
+) (*http.Response, error) {
 	c := h.getCall
 	h.getCall++
 

--- a/src/internal/m365/collection/drive/item.go
+++ b/src/internal/m365/collection/drive/item.go
@@ -24,7 +24,7 @@ const (
 	acceptHeaderKey        = "Accept"
 	acceptHeaderValue      = "*/*"
 	gigabyte               = 1024 * 1024 * 1024
-	largeFileDownloadLimit = 50 * gigabyte
+	largeFileDownloadLimit = 15 * gigabyte
 )
 
 // downloadUrlKeys is used to find the download URL in a DriveItem response.
@@ -48,7 +48,7 @@ func downloadItem(
 		// the download could take longer than the lifespan of the download token in the cached
 		// url, which will cause us to timeout on every download request, even if we refresh the
 		// download url right before the query.
-		url    = "https://graph.microsoft.com/v1.0/" + driveID + "/items/" + ptr.Val(item.GetId()) + "/content"
+		url    = "https://graph.microsoft.com/v1.0/drives/" + driveID + "/items/" + ptr.Val(item.GetId()) + "/content"
 		reader io.ReadCloser
 		err    error
 	)
@@ -61,7 +61,7 @@ func downloadItem(
 	// smaller files will maintain our current behavior (prefetching the download url with the
 	// url cache).  That pattern works for us in general, and we only need to deviate for very
 	// large file sizes.
-	if ptr.Val(item.GetSize()) > largeFileDownloadLimit {
+	if ptr.Val(item.GetSize()) < largeFileDownloadLimit {
 		url = str.FirstIn(item.GetAdditionalData(), downloadURLKeys...)
 	}
 

--- a/src/internal/m365/collection/drive/item.go
+++ b/src/internal/m365/collection/drive/item.go
@@ -48,9 +48,10 @@ func downloadItem(
 		// the download could take longer than the lifespan of the download token in the cached
 		// url, which will cause us to timeout on every download request, even if we refresh the
 		// download url right before the query.
-		url    = "https://graph.microsoft.com/v1.0/drives/" + driveID + "/items/" + ptr.Val(item.GetId()) + "/content"
-		reader io.ReadCloser
-		err    error
+		url         = "https://graph.microsoft.com/v1.0/drives/" + driveID + "/items/" + ptr.Val(item.GetId()) + "/content"
+		reader      io.ReadCloser
+		err         error
+		isLargeFile = ptr.Val(item.GetSize()) > largeFileDownloadLimit
 	)
 
 	// if this isn't a file, no content is available for download
@@ -61,18 +62,19 @@ func downloadItem(
 	// smaller files will maintain our current behavior (prefetching the download url with the
 	// url cache).  That pattern works for us in general, and we only need to deviate for very
 	// large file sizes.
-	if ptr.Val(item.GetSize()) < largeFileDownloadLimit {
+	if !isLargeFile {
 		url = str.FirstIn(item.GetAdditionalData(), downloadURLKeys...)
 	}
 
-	reader, err = downloadFile(ctx, getter, url)
+	reader, err = downloadFile(ctx, getter, url, isLargeFile)
 
 	return reader, clues.StackWC(ctx, err).OrNil()
 }
 
 type downloadWithRetries struct {
-	getter api.Getter
-	url    string
+	getter      api.Getter
+	requireAuth bool
+	url         string
 }
 
 func (dg *downloadWithRetries) SupportsRange() bool {
@@ -88,7 +90,7 @@ func (dg *downloadWithRetries) Get(
 	// wouldn't work without it (get 416 responses instead of 206).
 	headers[acceptHeaderKey] = acceptHeaderValue
 
-	resp, err := dg.getter.Get(ctx, dg.url, headers)
+	resp, err := dg.getter.Get(ctx, dg.url, headers, dg.requireAuth)
 	if err != nil {
 		return nil, clues.Wrap(err, "getting file")
 	}
@@ -120,6 +122,7 @@ func downloadFile(
 	ctx context.Context,
 	ag api.Getter,
 	url string,
+	requireAuth bool,
 ) (io.ReadCloser, error) {
 	if len(url) == 0 {
 		return nil, clues.NewWC(ctx, "empty file url")
@@ -143,8 +146,9 @@ func downloadFile(
 	rc, err := readers.NewResetRetryHandler(
 		ctx,
 		&downloadWithRetries{
-			getter: ag,
-			url:    url,
+			getter:      ag,
+			requireAuth: requireAuth,
+			url:         url,
 		})
 
 	return rc, clues.Stack(err).OrNil()

--- a/src/internal/m365/collection/drive/item.go
+++ b/src/internal/m365/collection/drive/item.go
@@ -21,8 +21,10 @@ import (
 )
 
 const (
-	acceptHeaderKey   = "Accept"
-	acceptHeaderValue = "*/*"
+	acceptHeaderKey        = "Accept"
+	acceptHeaderValue      = "*/*"
+	gigabyte               = 1024 * 1024 * 1024
+	largeFileDownloadLimit = 50 * gigabyte
 )
 
 // downloadUrlKeys is used to find the download URL in a DriveItem response.
@@ -33,7 +35,8 @@ var downloadURLKeys = []string{
 
 func downloadItem(
 	ctx context.Context,
-	ag api.Getter,
+	getter api.Getter,
+	driveID string,
 	item *custom.DriveItem,
 ) (io.ReadCloser, error) {
 	if item == nil {
@@ -41,31 +44,30 @@ func downloadItem(
 	}
 
 	var (
-		rc     io.ReadCloser
-		isFile = item.GetFile() != nil
+		// very large file content needs to be downloaded through a different endpoint, or else
+		// the download could take longer than the lifespan of the download token in the cached
+		// url, which will cause us to timeout on every download request, even if we refresh the
+		// download url right before the query.
+		url    = "https://graph.microsoft.com/v1.0/" + driveID + "/items/" + ptr.Val(item.GetId()) + "/content"
+		reader io.ReadCloser
 		err    error
 	)
 
-	if isFile {
-		var (
-			url string
-			ad  = item.GetAdditionalData()
-		)
-
-		for _, key := range downloadURLKeys {
-			if v, err := str.AnyValueToString(key, ad); err == nil {
-				url = v
-				break
-			}
-		}
-
-		rc, err = downloadFile(ctx, ag, url)
-		if err != nil {
-			return nil, clues.Stack(err)
-		}
+	// if this isn't a file, no content is available for download
+	if item.GetFile() == nil {
+		return reader, nil
 	}
 
-	return rc, nil
+	// smaller files will maintain our current behavior (prefetching the download url with the
+	// url cache).  That pattern works for us in general, and we only need to deviate for very
+	// large file sizes.
+	if ptr.Val(item.GetSize()) > largeFileDownloadLimit {
+		url = str.FirstIn(item.GetAdditionalData(), downloadURLKeys...)
+	}
+
+	reader, err = downloadFile(ctx, getter, url)
+
+	return reader, clues.StackWC(ctx, err).OrNil()
 }
 
 type downloadWithRetries struct {
@@ -96,7 +98,7 @@ func (dg *downloadWithRetries) Get(
 			resp.Body.Close()
 		}
 
-		return nil, clues.New("malware detected").Label(graph.LabelsMalware)
+		return nil, clues.NewWC(ctx, "malware detected").Label(graph.LabelsMalware)
 	}
 
 	if resp != nil && (resp.StatusCode/100) != 2 {
@@ -107,7 +109,7 @@ func (dg *downloadWithRetries) Get(
 		// upstream error checks can compare the status with
 		// clues.HasLabel(err, graph.LabelStatus(http.KnownStatusCode))
 		return nil, clues.
-			Wrap(clues.New(resp.Status), "non-2xx http response").
+			Wrap(clues.NewWC(ctx, resp.Status), "non-2xx http response").
 			Label(graph.LabelStatus(resp.StatusCode))
 	}
 

--- a/src/internal/m365/collection/drive/item_test.go
+++ b/src/internal/m365/collection/drive/item_test.go
@@ -109,7 +109,11 @@ func (suite *ItemIntegrationSuite) TestItemReader_oneDrive() {
 	}
 
 	// Read data for the file
-	itemData, err := downloadItem(ctx, bh, custom.ToCustomDriveItem(driveItem))
+	itemData, err := downloadItem(
+		ctx,
+		bh,
+		suite.m365.User.DriveID,
+		custom.ToCustomDriveItem(driveItem))
 	require.NoError(t, err, clues.ToCore(err))
 
 	size, err := io.Copy(io.Discard, itemData)
@@ -448,7 +452,11 @@ func (suite *ItemUnitTestSuite) TestDownloadItem() {
 			mg := mockGetter{
 				GetFunc: test.GetFunc,
 			}
-			rc, err := downloadItem(ctx, mg, custom.ToCustomDriveItem(test.itemFunc()))
+			rc, err := downloadItem(
+				ctx,
+				mg,
+				"driveID",
+				custom.ToCustomDriveItem(test.itemFunc()))
 			test.errorExpected(t, err, clues.ToCore(err))
 			test.rcExpected(t, rc)
 		})
@@ -507,7 +515,11 @@ func (suite *ItemUnitTestSuite) TestDownloadItem_ConnectionResetErrorOnFirstRead
 	mg := mockGetter{
 		GetFunc: GetFunc,
 	}
-	rc, err := downloadItem(ctx, mg, custom.ToCustomDriveItem(itemFunc()))
+	rc, err := downloadItem(
+		ctx,
+		mg,
+		"driveID",
+		custom.ToCustomDriveItem(itemFunc()))
 	errorExpected(t, err, clues.ToCore(err))
 	rcExpected(t, rc)
 

--- a/src/internal/m365/collection/drive/site_handler.go
+++ b/src/internal/m365/collection/drive/site_handler.go
@@ -93,8 +93,9 @@ func (h siteBackupHandler) Get(
 	ctx context.Context,
 	url string,
 	headers map[string]string,
+	requireAuth bool,
 ) (*http.Response, error) {
-	return h.ac.Get(ctx, url, headers)
+	return h.ac.Get(ctx, url, headers, requireAuth)
 }
 
 func (h siteBackupHandler) PathPrefix(

--- a/src/internal/m365/collection/drive/url_cache_test.go
+++ b/src/internal/m365/collection/drive/url_cache_test.go
@@ -154,7 +154,8 @@ func (suite *URLCacheIntegrationSuite) TestURLCacheBasic() {
 				http.MethodGet,
 				props.downloadURL,
 				nil,
-				nil)
+				nil,
+				false)
 			require.NoError(t, err, clues.ToCore(err))
 
 			require.NotNil(t, resp)

--- a/src/internal/m365/collection/drive/user_drive_handler.go
+++ b/src/internal/m365/collection/drive/user_drive_handler.go
@@ -93,8 +93,9 @@ func (h userDriveBackupHandler) Get(
 	ctx context.Context,
 	url string,
 	headers map[string]string,
+	requireAuth bool,
 ) (*http.Response, error) {
-	return h.ac.Get(ctx, url, headers)
+	return h.ac.Get(ctx, url, headers, requireAuth)
 }
 
 func (h userDriveBackupHandler) PathPrefix(

--- a/src/internal/m365/service/onedrive/mock/handlers.go
+++ b/src/internal/m365/service/onedrive/mock/handlers.go
@@ -197,7 +197,12 @@ func (h BackupHandler[T]) AugmentItemInfo(
 	return h.ItemInfo
 }
 
-func (h *BackupHandler[T]) Get(context.Context, string, map[string]string) (*http.Response, error) {
+func (h *BackupHandler[T]) Get(
+	context.Context,
+	string,
+	map[string]string,
+	bool,
+) (*http.Response, error) {
 	c := h.getCall
 	h.getCall++
 

--- a/src/pkg/services/m365/api/access.go
+++ b/src/pkg/services/m365/api/access.go
@@ -47,7 +47,7 @@ func (c Access) GetToken(
 			c.Credentials.AzureClientSecret))
 	)
 
-	resp, err := c.Post(ctx, rawURL, headers, body)
+	resp, err := c.Post(ctx, rawURL, headers, body, false)
 	if err != nil {
 		return clues.Stack(err)
 	}

--- a/src/pkg/services/m365/api/client.go
+++ b/src/pkg/services/m365/api/client.go
@@ -68,7 +68,9 @@ func NewClient(
 		return Client{}, clues.Wrap(err, "generating azure authorizer")
 	}
 
-	rqr := graph.NewNoTimeoutHTTPWrapper(counter, graph.AuthorizeRequester(azureAuth))
+	rqr := graph.NewNoTimeoutHTTPWrapper(
+		counter,
+		graph.AuthorizeRequester(azureAuth))
 
 	if co.DeltaPageSize < 1 || co.DeltaPageSize > maxDeltaPageSize {
 		co.DeltaPageSize = maxDeltaPageSize
@@ -137,6 +139,7 @@ type Getter interface {
 		ctx context.Context,
 		url string,
 		headers map[string]string,
+		requireAuth bool,
 	) (*http.Response, error)
 }
 
@@ -145,8 +148,9 @@ func (c Client) Get(
 	ctx context.Context,
 	url string,
 	headers map[string]string,
+	requireAuth bool,
 ) (*http.Response, error) {
-	return c.Requester.Request(ctx, http.MethodGet, url, nil, headers)
+	return c.Requester.Request(ctx, http.MethodGet, url, nil, headers, requireAuth)
 }
 
 // Get performs an ad-hoc get request using its graph.Requester
@@ -155,8 +159,9 @@ func (c Client) Post(
 	url string,
 	headers map[string]string,
 	body io.Reader,
+	requireAuth bool,
 ) (*http.Response, error) {
-	return c.Requester.Request(ctx, http.MethodGet, url, body, headers)
+	return c.Requester.Request(ctx, http.MethodGet, url, body, headers, requireAuth)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/services/m365/api/graph/concurrency_middleware.go
+++ b/src/pkg/services/m365/api/graph/concurrency_middleware.go
@@ -240,7 +240,7 @@ func (mw *RateLimiterMiddleware) Intercept(
 	middlewareIndex int,
 	req *http.Request,
 ) (*http.Response, error) {
-	QueueRequest(req.Context())
+	QueueRequest(getReqCtx(req))
 	return pipeline.Next(req, middlewareIndex)
 }
 
@@ -339,7 +339,7 @@ func (mw *throttlingMiddleware) Intercept(
 	middlewareIndex int,
 	req *http.Request,
 ) (*http.Response, error) {
-	err := mw.tf.Block(req.Context())
+	err := mw.tf.Block(getReqCtx(req))
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/services/m365/api/graph/http_wrapper.go
+++ b/src/pkg/services/m365/api/graph/http_wrapper.go
@@ -36,6 +36,7 @@ type Requester interface {
 		method, url string,
 		body io.Reader,
 		headers map[string]string,
+		requireAuth bool,
 	) (*http.Response, error)
 }
 
@@ -96,6 +97,7 @@ func (hw httpWrapper) Request(
 	method, url string,
 	body io.Reader,
 	headers map[string]string,
+	requireAuth bool,
 ) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
@@ -111,7 +113,11 @@ func (hw httpWrapper) Request(
 	// See https://learn.microsoft.com/en-us/sharepoint/dev/general-development/how-to-avoid-getting-throttled-or-blocked-in-sharepoint-online#how-to-decorate-your-http-traffic
 	req.Header.Set("User-Agent", "ISV|Alcion|Corso/"+version.Version)
 
-	if hw.config.requesterAuth != nil {
+	if requireAuth {
+		if hw.config.requesterAuth == nil {
+			return nil, clues.Wrap(err, "http wrapper misconfigured: missing required authorization")
+		}
+
 		err := hw.config.requesterAuth.addAuthToHeaders(ctx, url, req.Header)
 		if err != nil {
 			return nil, clues.Wrap(err, "setting request auth headers")

--- a/src/pkg/services/m365/api/graph/http_wrapper.go
+++ b/src/pkg/services/m365/api/graph/http_wrapper.go
@@ -58,12 +58,8 @@ func NewHTTPWrapper(
 				transport:   defaultTransport(),
 			},
 		}
-		redirect = func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		}
 		hc = &http.Client{
-			CheckRedirect: redirect,
-			Transport:     rt,
+			Transport: rt,
 		}
 	)
 

--- a/src/pkg/services/m365/api/graph/http_wrapper_test.go
+++ b/src/pkg/services/m365/api/graph/http_wrapper_test.go
@@ -42,7 +42,8 @@ func (suite *HTTPWrapperIntgSuite) TestNewHTTPWrapper() {
 		http.MethodGet,
 		"https://www.google.com",
 		nil,
-		nil)
+		nil,
+		false)
 	require.NoError(t, err, clues.ToCore(err))
 
 	defer resp.Body.Close()
@@ -76,7 +77,7 @@ func (mw *mwForceResp) Intercept(
 	return mw.resp, mw.err
 }
 
-func (suite *HTTPWrapperIntgSuite) TestNewHTTPWrapper_withAuth() {
+func (suite *HTTPWrapperIntgSuite) TestHTTPWrapper_Request_withAuth() {
 	t := suite.T()
 
 	ctx, flush := tester.NewContext(t)
@@ -97,7 +98,8 @@ func (suite *HTTPWrapperIntgSuite) TestNewHTTPWrapper_withAuth() {
 		http.MethodGet,
 		"https://graph.microsoft.com/v1.0/users",
 		nil,
-		nil)
+		nil,
+		true)
 	require.NoError(t, err, clues.ToCore(err))
 
 	defer resp.Body.Close()
@@ -111,7 +113,8 @@ func (suite *HTTPWrapperIntgSuite) TestNewHTTPWrapper_withAuth() {
 		http.MethodGet,
 		"https://www.google.com",
 		nil,
-		nil)
+		nil,
+		true)
 	require.NoError(t, err, clues.ToCore(err))
 
 	defer resp.Body.Close()
@@ -165,7 +168,8 @@ func (suite *HTTPWrapperUnitSuite) TestHTTPWrapper_Request_redirect() {
 		http.MethodGet,
 		"https://graph.microsoft.com/fnords/beaux/regard",
 		nil,
-		map[string]string{"X-Test-Val": "should-be-copied-to-redirect"})
+		map[string]string{"X-Test-Val": "should-be-copied-to-redirect"},
+		false)
 	require.NoError(t, err, clues.ToCore(err))
 
 	defer resp.Body.Close()
@@ -239,7 +243,7 @@ func (suite *HTTPWrapperUnitSuite) TestHTTPWrapper_Request_http2StreamErrorRetri
 			// the test middleware.
 			hw.retryDelay = 0
 
-			_, err := hw.Request(ctx, http.MethodGet, url, nil, nil)
+			_, err := hw.Request(ctx, http.MethodGet, url, nil, nil, false)
 			require.ErrorAs(t, err, &http2.StreamError{}, clues.ToCore(err))
 			require.Equal(t, test.expectRetries, tries, "count of retries")
 		})

--- a/src/pkg/services/m365/api/graph/logging.go
+++ b/src/pkg/services/m365/api/graph/logging.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httputil"
 	"os"
 
+	"github.com/alcionai/clues"
+
 	"github.com/alcionai/corso/src/pkg/logger"
 )
 
@@ -68,4 +70,16 @@ func getRespDump(ctx context.Context, resp *http.Response, getBody bool) string 
 	}
 
 	return string(respDump)
+}
+
+func getReqCtx(req *http.Request) context.Context {
+	if req == nil {
+		return context.Background()
+	}
+
+	return clues.Add(
+		req.Context(),
+		"method", req.Method,
+		"url", LoggableURL(req.URL.String()),
+		"request_content_len", req.ContentLength)
 }

--- a/src/pkg/services/m365/api/graph/middleware.go
+++ b/src/pkg/services/m365/api/graph/middleware.go
@@ -125,10 +125,7 @@ func (mw *LoggingMiddleware) Intercept(
 	}
 
 	ctx := clues.Add(
-		req.Context(),
-		"method", req.Method,
-		"url", LoggableURL(req.URL.String()),
-		"request_content_len", req.ContentLength,
+		getReqCtx(req),
 		"resp_status", resp.Status,
 		"resp_status_code", resp.StatusCode,
 		"resp_content_len", resp.ContentLength)
@@ -156,7 +153,7 @@ func (mw RetryMiddleware) Intercept(
 	middlewareIndex int,
 	req *http.Request,
 ) (*http.Response, error) {
-	ctx := req.Context()
+	ctx := getReqCtx(req)
 	resp, err := pipeline.Next(req, middlewareIndex)
 
 	retriable := IsErrTimeout(err) ||
@@ -249,7 +246,9 @@ func (mw RetryMiddleware) retryRequest(
 				return resp, Wrap(ctx, err, "resetting request body reader")
 			}
 		} else {
-			logger.Ctx(ctx).Error("body is not an io.Seeker: unable to reset request body")
+			logger.
+				Ctx(getReqCtx(req)).
+				Error("body is not an io.Seeker: unable to reset request body")
 		}
 	}
 

--- a/src/pkg/services/m365/api/graph/uploadsession.go
+++ b/src/pkg/services/m365/api/graph/uploadsession.go
@@ -77,7 +77,8 @@ func (iw *largeItemWriter) Write(p []byte) (int, error) {
 		http.MethodPut,
 		iw.url,
 		bytes.NewReader(p),
-		headers)
+		headers,
+		false)
 	if err != nil {
 		return 0, clues.Wrap(err, "uploading item").With(
 			"upload_id", iw.parentID,


### PR DESCRIPTION
avoid the url cache and get the url directly from graph when downloading very large files to avoid failing on token timeouts from downloads that take longer than an hour.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included

#### Type of change

- [x] :bug: Bugfix

#### Test Plan

- [x] :muscle: Manual
- [x] :zap: Unit test
