### PR TITLE
add an authRequried flag for requester requests

### DIFF
--- a/src/internal/m365/collection/drive/collection.go
+++ b/src/internal/m365/collection/drive/collection.go
@@ -426,7 +426,7 @@ func readItemContents(
 		return nil, core.ErrNotFound
 	}
 
-	rc, err := downloadFile(ctx, iaag, props.downloadURL)
+	rc, err := downloadFile(ctx, iaag, props.downloadURL, false)
 	if graph.IsErrUnauthorizedOrBadToken(err) {
 		logger.CtxErr(ctx, err).Debug("stale item in cache")
 	}

--- a/src/internal/m365/collection/drive/helper_test.go
+++ b/src/internal/m365/collection/drive/helper_test.go
@@ -795,7 +795,12 @@ func (h mockBackupHandler[T]) AugmentItemInfo(
 	return h.ItemInfo
 }
 
-func (h *mockBackupHandler[T]) Get(context.Context, string, map[string]string) (*http.Response, error) {
+func (h *mockBackupHandler[T]) Get(
+	context.Context,
+	string,
+	map[string]string,
+	bool,
+) (*http.Response, error) {
 	c := h.getCall
 	h.getCall++
 

--- a/src/internal/m365/collection/drive/item_test.go
+++ b/src/internal/m365/collection/drive/item_test.go
@@ -296,6 +296,7 @@ func (m mockGetter) Get(
 	ctx context.Context,
 	url string,
 	headers map[string]string,
+	requireAuth bool,
 ) (*http.Response, error) {
 	return m.GetFunc(ctx, url)
 }

--- a/src/internal/m365/collection/drive/item_test.go
+++ b/src/internal/m365/collection/drive/item_test.go
@@ -464,6 +464,71 @@ func (suite *ItemUnitTestSuite) TestDownloadItem() {
 	}
 }
 
+func (suite *ItemUnitTestSuite) TestDownloadItem_urlByFileSize() {
+	var (
+		testRc = io.NopCloser(bytes.NewReader([]byte("test")))
+		url    = "https://example.com"
+		okResp = &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       testRc,
+		}
+	)
+
+	table := []struct {
+		name          string
+		itemFunc      func() models.DriveItemable
+		GetFunc       func(ctx context.Context, url string) (*http.Response, error)
+		errorExpected require.ErrorAssertionFunc
+		rcExpected    require.ValueAssertionFunc
+		label         string
+	}{
+		{
+			name: "big file",
+			itemFunc: func() models.DriveItemable {
+				di := api.NewDriveItem("test", false)
+				di.SetAdditionalData(map[string]any{"@microsoft.graph.downloadUrl": url})
+				di.SetSize(ptr.To[int64](20 * gigabyte))
+
+				return di
+			},
+			GetFunc: func(ctx context.Context, url string) (*http.Response, error) {
+				assert.Contains(suite.T(), url, "/content")
+				return okResp, nil
+			},
+		},
+		{
+			name: "small file",
+			itemFunc: func() models.DriveItemable {
+				di := api.NewDriveItem("test", false)
+				di.SetAdditionalData(map[string]any{"@microsoft.graph.downloadUrl": url})
+				di.SetSize(ptr.To[int64](2 * gigabyte))
+
+				return di
+			},
+			GetFunc: func(ctx context.Context, url string) (*http.Response, error) {
+				assert.NotContains(suite.T(), url, "/content")
+				return okResp, nil
+			},
+		},
+	}
+
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			ctx, flush := tester.NewContext(t)
+			defer flush()
+
+			_, err := downloadItem(
+				ctx,
+				mockGetter{GetFunc: test.GetFunc},
+				"driveID",
+				custom.ToCustomDriveItem(test.itemFunc()))
+			require.NoError(t, err, clues.ToCore(err))
+		})
+	}
+}
+
 type errReader struct{}
 
 func (r errReader) Read(p []byte) (int, error) {

--- a/src/internal/m365/collection/drive/site_handler.go
+++ b/src/internal/m365/collection/drive/site_handler.go
@@ -93,8 +93,9 @@ func (h siteBackupHandler) Get(
 	ctx context.Context,
 	url string,
 	headers map[string]string,
+	requireAuth bool,
 ) (*http.Response, error) {
-	return h.ac.Get(ctx, url, headers)
+	return h.ac.Get(ctx, url, headers, requireAuth)
 }
 
 func (h siteBackupHandler) PathPrefix(

--- a/src/internal/m365/collection/drive/url_cache_test.go
+++ b/src/internal/m365/collection/drive/url_cache_test.go
@@ -154,7 +154,8 @@ func (suite *URLCacheIntegrationSuite) TestURLCacheBasic() {
 				http.MethodGet,
 				props.downloadURL,
 				nil,
-				nil)
+				nil,
+				false)
 			require.NoError(t, err, clues.ToCore(err))
 
 			require.NotNil(t, resp)

--- a/src/internal/m365/collection/drive/user_drive_handler.go
+++ b/src/internal/m365/collection/drive/user_drive_handler.go
@@ -93,8 +93,9 @@ func (h userDriveBackupHandler) Get(
 	ctx context.Context,
 	url string,
 	headers map[string]string,
+	requireAuth bool,
 ) (*http.Response, error) {
-	return h.ac.Get(ctx, url, headers)
+	return h.ac.Get(ctx, url, headers, requireAuth)
 }
 
 func (h userDriveBackupHandler) PathPrefix(

--- a/src/internal/m365/service/onedrive/mock/handlers.go
+++ b/src/internal/m365/service/onedrive/mock/handlers.go
@@ -197,7 +197,12 @@ func (h BackupHandler[T]) AugmentItemInfo(
 	return h.ItemInfo
 }
 
-func (h *BackupHandler[T]) Get(context.Context, string, map[string]string) (*http.Response, error) {
+func (h *BackupHandler[T]) Get(
+	context.Context,
+	string,
+	map[string]string,
+	bool,
+) (*http.Response, error) {
 	c := h.getCall
 	h.getCall++
 

--- a/src/pkg/services/m365/api/access.go
+++ b/src/pkg/services/m365/api/access.go
@@ -47,7 +47,7 @@ func (c Access) GetToken(
 			c.Credentials.AzureClientSecret))
 	)
 
-	resp, err := c.Post(ctx, rawURL, headers, body)
+	resp, err := c.Post(ctx, rawURL, headers, body, false)
 	if err != nil {
 		return clues.Stack(err)
 	}

--- a/src/pkg/services/m365/api/client.go
+++ b/src/pkg/services/m365/api/client.go
@@ -68,7 +68,9 @@ func NewClient(
 		return Client{}, clues.Wrap(err, "generating azure authorizer")
 	}
 
-	rqr := graph.NewNoTimeoutHTTPWrapper(counter, graph.AuthorizeRequester(azureAuth))
+	rqr := graph.NewNoTimeoutHTTPWrapper(
+		counter,
+		graph.AuthorizeRequester(azureAuth))
 
 	if co.DeltaPageSize < 1 || co.DeltaPageSize > maxDeltaPageSize {
 		co.DeltaPageSize = maxDeltaPageSize
@@ -137,6 +139,7 @@ type Getter interface {
 		ctx context.Context,
 		url string,
 		headers map[string]string,
+		requireAuth bool,
 	) (*http.Response, error)
 }
 
@@ -145,8 +148,9 @@ func (c Client) Get(
 	ctx context.Context,
 	url string,
 	headers map[string]string,
+	requireAuth bool,
 ) (*http.Response, error) {
-	return c.Requester.Request(ctx, http.MethodGet, url, nil, headers)
+	return c.Requester.Request(ctx, http.MethodGet, url, nil, headers, requireAuth)
 }
 
 // Get performs an ad-hoc get request using its graph.Requester
@@ -155,8 +159,9 @@ func (c Client) Post(
 	url string,
 	headers map[string]string,
 	body io.Reader,
+	requireAuth bool,
 ) (*http.Response, error) {
-	return c.Requester.Request(ctx, http.MethodGet, url, body, headers)
+	return c.Requester.Request(ctx, http.MethodGet, url, body, headers, requireAuth)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/services/m365/api/graph/concurrency_middleware.go
+++ b/src/pkg/services/m365/api/graph/concurrency_middleware.go
@@ -240,7 +240,7 @@ func (mw *RateLimiterMiddleware) Intercept(
 	middlewareIndex int,
 	req *http.Request,
 ) (*http.Response, error) {
-	QueueRequest(req.Context())
+	QueueRequest(getReqCtx(req))
 	return pipeline.Next(req, middlewareIndex)
 }
 
@@ -339,7 +339,7 @@ func (mw *throttlingMiddleware) Intercept(
 	middlewareIndex int,
 	req *http.Request,
 ) (*http.Response, error) {
-	err := mw.tf.Block(req.Context())
+	err := mw.tf.Block(getReqCtx(req))
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/services/m365/api/graph/http_wrapper.go
+++ b/src/pkg/services/m365/api/graph/http_wrapper.go
@@ -115,7 +115,7 @@ func (hw httpWrapper) Request(
 
 	if requireAuth {
 		if hw.config.requesterAuth == nil {
-			return nil, clues.Wrap(err, "http wrapper misconfigured: missing required authorization middleware")
+			return nil, clues.Wrap(err, "http wrapper misconfigured: missing required authorization")
 		}
 
 		err := hw.config.requesterAuth.addAuthToHeaders(ctx, url, req.Header)

--- a/src/pkg/services/m365/api/graph/http_wrapper.go
+++ b/src/pkg/services/m365/api/graph/http_wrapper.go
@@ -36,6 +36,7 @@ type Requester interface {
 		method, url string,
 		body io.Reader,
 		headers map[string]string,
+		requireAuth bool,
 	) (*http.Response, error)
 }
 
@@ -96,6 +97,7 @@ func (hw httpWrapper) Request(
 	method, url string,
 	body io.Reader,
 	headers map[string]string,
+	requireAuth bool,
 ) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
@@ -111,7 +113,11 @@ func (hw httpWrapper) Request(
 	// See https://learn.microsoft.com/en-us/sharepoint/dev/general-development/how-to-avoid-getting-throttled-or-blocked-in-sharepoint-online#how-to-decorate-your-http-traffic
 	req.Header.Set("User-Agent", "ISV|Alcion|Corso/"+version.Version)
 
-	if hw.config.requesterAuth != nil {
+	if requireAuth {
+		if hw.config.requesterAuth == nil {
+			return nil, clues.Wrap(err, "http wrapper misconfigured: missing required authorization middleware")
+		}
+
 		err := hw.config.requesterAuth.addAuthToHeaders(ctx, url, req.Header)
 		if err != nil {
 			return nil, clues.Wrap(err, "setting request auth headers")

--- a/src/pkg/services/m365/api/graph/http_wrapper_test.go
+++ b/src/pkg/services/m365/api/graph/http_wrapper_test.go
@@ -42,7 +42,8 @@ func (suite *HTTPWrapperIntgSuite) TestNewHTTPWrapper() {
 		http.MethodGet,
 		"https://www.google.com",
 		nil,
-		nil)
+		nil,
+		false)
 	require.NoError(t, err, clues.ToCore(err))
 
 	defer resp.Body.Close()
@@ -76,7 +77,7 @@ func (mw *mwForceResp) Intercept(
 	return mw.resp, mw.err
 }
 
-func (suite *HTTPWrapperIntgSuite) TestNewHTTPWrapper_withAuth() {
+func (suite *HTTPWrapperIntgSuite) TestHTTPWrapper_Request_withAuth() {
 	t := suite.T()
 
 	ctx, flush := tester.NewContext(t)
@@ -97,7 +98,8 @@ func (suite *HTTPWrapperIntgSuite) TestNewHTTPWrapper_withAuth() {
 		http.MethodGet,
 		"https://graph.microsoft.com/v1.0/users",
 		nil,
-		nil)
+		nil,
+		true)
 	require.NoError(t, err, clues.ToCore(err))
 
 	defer resp.Body.Close()
@@ -111,7 +113,8 @@ func (suite *HTTPWrapperIntgSuite) TestNewHTTPWrapper_withAuth() {
 		http.MethodGet,
 		"https://www.google.com",
 		nil,
-		nil)
+		nil,
+		true)
 	require.NoError(t, err, clues.ToCore(err))
 
 	defer resp.Body.Close()
@@ -165,7 +168,8 @@ func (suite *HTTPWrapperUnitSuite) TestHTTPWrapper_Request_redirect() {
 		http.MethodGet,
 		"https://graph.microsoft.com/fnords/beaux/regard",
 		nil,
-		map[string]string{"X-Test-Val": "should-be-copied-to-redirect"})
+		map[string]string{"X-Test-Val": "should-be-copied-to-redirect"},
+		false)
 	require.NoError(t, err, clues.ToCore(err))
 
 	defer resp.Body.Close()
@@ -239,7 +243,7 @@ func (suite *HTTPWrapperUnitSuite) TestHTTPWrapper_Request_http2StreamErrorRetri
 			// the test middleware.
 			hw.retryDelay = 0
 
-			_, err := hw.Request(ctx, http.MethodGet, url, nil, nil)
+			_, err := hw.Request(ctx, http.MethodGet, url, nil, nil, false)
 			require.ErrorAs(t, err, &http2.StreamError{}, clues.ToCore(err))
 			require.Equal(t, test.expectRetries, tries, "count of retries")
 		})

--- a/src/pkg/services/m365/api/graph/logging.go
+++ b/src/pkg/services/m365/api/graph/logging.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httputil"
 	"os"
 
+	"github.com/alcionai/clues"
+
 	"github.com/alcionai/corso/src/pkg/logger"
 )
 
@@ -68,4 +70,16 @@ func getRespDump(ctx context.Context, resp *http.Response, getBody bool) string 
 	}
 
 	return string(respDump)
+}
+
+func getReqCtx(req *http.Request) context.Context {
+	if req == nil {
+		return context.Background()
+	}
+
+	return clues.Add(
+		req.Context(),
+		"method", req.Method,
+		"url", LoggableURL(req.URL.String()),
+		"request_content_len", req.ContentLength)
 }

--- a/src/pkg/services/m365/api/graph/middleware.go
+++ b/src/pkg/services/m365/api/graph/middleware.go
@@ -125,10 +125,7 @@ func (mw *LoggingMiddleware) Intercept(
 	}
 
 	ctx := clues.Add(
-		req.Context(),
-		"method", req.Method,
-		"url", LoggableURL(req.URL.String()),
-		"request_content_len", req.ContentLength,
+		getReqCtx(req),
 		"resp_status", resp.Status,
 		"resp_status_code", resp.StatusCode,
 		"resp_content_len", resp.ContentLength)
@@ -156,7 +153,7 @@ func (mw RetryMiddleware) Intercept(
 	middlewareIndex int,
 	req *http.Request,
 ) (*http.Response, error) {
-	ctx := req.Context()
+	ctx := getReqCtx(req)
 	resp, err := pipeline.Next(req, middlewareIndex)
 
 	retriable := IsErrTimeout(err) ||
@@ -249,7 +246,9 @@ func (mw RetryMiddleware) retryRequest(
 				return resp, Wrap(ctx, err, "resetting request body reader")
 			}
 		} else {
-			logger.Ctx(ctx).Error("body is not an io.Seeker: unable to reset request body")
+			logger.
+				Ctx(getReqCtx(req)).
+				Error("body is not an io.Seeker: unable to reset request body")
 		}
 	}
 

--- a/src/pkg/services/m365/api/graph/uploadsession.go
+++ b/src/pkg/services/m365/api/graph/uploadsession.go
@@ -77,7 +77,8 @@ func (iw *largeItemWriter) Write(p []byte) (int, error) {
 		http.MethodPut,
 		iw.url,
 		bytes.NewReader(p),
-		headers)
+		headers,
+		false)
 	if err != nil {
 		return 0, clues.Wrap(err, "uploading item").With(
 			"upload_id", iw.parentID,


### PR DESCRIPTION
this allows us to specify auth necessity on a per-call basis, instead of flooding every call with auth creds.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
