### PR TITLE
Fix possible panic in contacts fetch

### DIFF
--- a/src/pkg/services/m365/api/contacts.go
+++ b/src/pkg/services/m365/api/contacts.go
@@ -186,8 +186,11 @@ func (c Contacts) GetItem(
 		Contacts().
 		ByContactId(itemID).
 		Get(ctx, options)
+	if err != nil {
+		return nil, nil, clues.Stack(err)
+	}
 
-	return cont, ContactInfo(cont), clues.Stack(err).OrNil()
+	return cont, ContactInfo(cont), nil
 }
 
 func (c Contacts) PostItem(


### PR DESCRIPTION
We were not checking for the error returned by the Get method before trying to use the result to get contact info.

<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
