### PR TITLE
Handle item attachments with missing name

### DIFF
--- a/src/internal/converters/eml/eml.go
+++ b/src/internal/converters/eml/eml.go
@@ -208,6 +208,15 @@ func getItemAttachment(ctx context.Context, attachment models.Attachmentable) (*
 			With("attachment_id", ptr.Val(attachment.GetId()))
 	}
 
+	name := ptr.Val(attachment.GetName())
+	if len(name) == 0 {
+		// Graph as of now does not let us create any attachments
+		// without a name, but we have run into instances where we have
+		// see attachments without a name, possibly from old
+		// data. This is for those cases.
+		name = "Unnamed"
+	}
+
 	switch it := it.(type) {
 	case *models.Message:
 		cb, err := FromMessageable(ctx, it)
@@ -217,7 +226,7 @@ func getItemAttachment(ctx context.Context, attachment models.Attachmentable) (*
 		}
 
 		return &mail.File{
-			Name:     ptr.Val(attachment.GetName()),
+			Name:     name,
 			MimeType: "message/rfc822",
 			Data:     []byte(cb),
 		}, nil

--- a/src/internal/converters/eml/eml_test.go
+++ b/src/internal/converters/eml/eml_test.go
@@ -142,73 +142,73 @@ func (suite *EMLUnitSuite) TestConvert_edge_cases() {
 		testdata.EmailWithinEmail,
 	}
 
-	for _, b := range bodies {
-		tests := []struct {
-			name      string
-			transform func(models.Messageable)
-		}{
-			{
-				name: "just a name",
-				transform: func(msg models.Messageable) {
-					msg.GetFrom().GetEmailAddress().SetName(ptr.To("alphabob"))
-					msg.GetFrom().GetEmailAddress().SetAddress(nil)
-				},
+	tests := []struct {
+		name      string
+		transform func(models.Messageable)
+	}{
+		{
+			name: "just a name",
+			transform: func(msg models.Messageable) {
+				msg.GetFrom().GetEmailAddress().SetName(ptr.To("alphabob"))
+				msg.GetFrom().GetEmailAddress().SetAddress(nil)
 			},
-			{
-				name: "incorrect address",
-				transform: func(msg models.Messageable) {
-					msg.GetFrom().GetEmailAddress().SetAddress(ptr.To("invalid"))
-				},
+		},
+		{
+			name: "incorrect address",
+			transform: func(msg models.Messageable) {
+				msg.GetFrom().GetEmailAddress().SetAddress(ptr.To("invalid"))
 			},
-			{
-				name: "empty attachment",
-				transform: func(msg models.Messageable) {
-					attachments := msg.GetAttachments()
-					err := attachments[0].GetBackingStore().Set("contentBytes", []uint8{})
-					require.NoError(suite.T(), err, "setting attachment content")
-				},
+		},
+		{
+			name: "empty attachment",
+			transform: func(msg models.Messageable) {
+				attachments := msg.GetAttachments()
+				err := attachments[0].GetBackingStore().Set("contentBytes", []uint8{})
+				require.NoError(suite.T(), err, "setting attachment content")
 			},
-			{
-				name: "attachment without name",
-				transform: func(msg models.Messageable) {
-					attachments := msg.GetAttachments()
-					attachments[1].SetName(ptr.To(""))
+		},
+		{
+			name: "attachment without name",
+			transform: func(msg models.Messageable) {
+				attachments := msg.GetAttachments()
+				attachments[1].SetName(ptr.To(""))
 
-					// This test has to be run on a non inline attachment
-					// as inline attachments use contentID instead of name
-					// even when there is a name.
-					assert.False(suite.T(), ptr.Val(attachments[1].GetIsInline()))
-				},
+				// This test has to be run on a non inline attachment
+				// as inline attachments use contentID instead of name
+				// even when there is a name.
+				assert.False(suite.T(), ptr.Val(attachments[1].GetIsInline()))
 			},
-			{
-				name: "attachment with nil name",
-				transform: func(msg models.Messageable) {
-					attachments := msg.GetAttachments()
-					attachments[1].SetName(nil)
+		},
+		{
+			name: "attachment with nil name",
+			transform: func(msg models.Messageable) {
+				attachments := msg.GetAttachments()
+				attachments[1].SetName(nil)
 
-					// This test has to be run on a non inline attachment
-					// as inline attachments use contentID instead of name
-					// even when there is a name.
-					assert.False(suite.T(), ptr.Val(attachments[1].GetIsInline()))
-				},
+				// This test has to be run on a non inline attachment
+				// as inline attachments use contentID instead of name
+				// even when there is a name.
+				assert.False(suite.T(), ptr.Val(attachments[1].GetIsInline()))
 			},
-			{
-				name: "multiple attachments without name",
-				transform: func(msg models.Messageable) {
-					attachments := msg.GetAttachments()
-					attachments[1].SetName(ptr.To(""))
-					attachments[2].SetName(ptr.To(""))
+		},
+		{
+			name: "multiple attachments without name",
+			transform: func(msg models.Messageable) {
+				attachments := msg.GetAttachments()
+				attachments[1].SetName(ptr.To(""))
+				attachments[2].SetName(ptr.To(""))
 
-					// This test has to be run on a non inline attachment
-					// as inline attachments use contentID instead of name
-					// even when there is a name.
-					assert.False(suite.T(), ptr.Val(attachments[1].GetIsInline()))
-					assert.False(suite.T(), ptr.Val(attachments[2].GetIsInline()))
-				},
+				// This test has to be run on a non inline attachment
+				// as inline attachments use contentID instead of name
+				// even when there is a name.
+				assert.False(suite.T(), ptr.Val(attachments[1].GetIsInline()))
+				assert.False(suite.T(), ptr.Val(attachments[2].GetIsInline()))
 			},
-		}
+		},
+	}
 
-		for _, test := range tests {
+	for _, test := range tests {
+		for _, b := range bodies {
 			suite.Run(test.name, func() {
 				t := suite.T()
 

--- a/src/internal/converters/eml/eml_test.go
+++ b/src/internal/converters/eml/eml_test.go
@@ -207,8 +207,8 @@ func (suite *EMLUnitSuite) TestConvert_edge_cases() {
 		},
 	}
 
-	for _, test := range tests {
-		for _, b := range bodies {
+	for _, b := range bodies {
+		for _, test := range tests {
 			suite.Run(test.name, func() {
 				t := suite.T()
 

--- a/src/internal/converters/eml/testdata/email-within-email.json
+++ b/src/internal/converters/eml/testdata/email-within-email.json
@@ -77,6 +77,146 @@
         ],
         "webLink": "https://outlook.office365.com/owa/?AttachmentItemID=AAMkAGJiZmE2NGU4LTQ4YjktNDI1Mi1iMWQzLTQ1MmMxODJkZmQyNABGAAAAAABFdiK7oifWRb4ADuqgSRcnBwBBFDg0JJk7TY1fmsJrh7tNAAAAAAEJAABBFDg0JJk7TY1fmsJrh7tNAAFnbV%2FqAAABEgAQAEUyH0VS3HJBgHDlZdWZl0k%3D&exvsurl=1&viewmodel=ItemAttachment"
       }
+    },
+    {
+      "id": "AAMkAGJiZmE2NGU4LTQ4YjktNDI1Mi1iMWQzLTQ1MmMxODJkZmQyNABGAAAAAABFdiK7oifWRb4ADuqgSRcnBwBBFDg0JJk7TY1fmsJrh7tNAAAAAAEJAABBFDg0JJk7TY1fmsJrh7tNAAFnbV-qAAABEgAQAEUyH0VS3HJBgHDlZdWZl02=",
+      "@odata.type": "#microsoft.graph.itemAttachment",
+      "item@odata.navigationLink": "https://graph.microsoft.com/v1.0/users('7ceb8e03-bdc5-4509-a136-457526165ec0')/messages('')",
+      "item@odata.associationLink": "https://graph.microsoft.com/v1.0/users('7ceb8e03-bdc5-4509-a136-457526165ec0')/messages('')/$ref",
+      "isInline": false,
+      "lastModifiedDateTime": "2024-02-05T09:33:46Z",
+      "name": "Purpose of life part 2",
+      "size": 11840,
+      "item": {
+        "id": "",
+        "@odata.type": "#microsoft.graph.message",
+        "createdDateTime": "2024-02-05T09:33:24Z",
+        "lastModifiedDateTime": "2024-02-05T09:33:46Z",
+        "attachments": [
+          {
+            "id": "AAMkAGJiZmE2NGU4LTQ4YjktNDI1Mi1iMWQzLTQ1MmMxODJkZmQyNABGAAAAAABFdiK7oifWRb4ADuqgSRcnBwBBFDg0JJk7TY1fmsJrh7tNAAAAAAEJAABBFDg0JJk7TY1fmsJrh7tNAAFnbV-qAAACEgAQAEUyH0VS3HJBgHDlZdWZl0kSABAAjBhd4-oQaUS969pTkS-gzA==",
+            "@odata.type": "#microsoft.graph.fileAttachment",
+            "@odata.mediaContentType": "text/calendar",
+            "contentType": "text/calendar",
+            "isInline": false,
+            "lastModifiedDateTime": "2024-02-05T09:33:46Z",
+            "name": "Abidjan.ics",
+            "size": 573,
+            "contentBytes": "QkVHSU46VkNBTEVOREFSDQpQUk9ESUQ6LS8vdHp1cmwub3JnLy9OT05TR01MIE9sc29uIDIwMjNkLy9FTg0KVkVSU0lPTjoyLjANCkJFR0lOOlZUSU1FWk9ORQ0KVFpJRDpBZnJpY2EvQWJpZGphbg0KTEFTVC1NT0RJRklFRDoyMDIzMTIyMlQyMzMzNThaDQpUWlVSTDpodHRwczovL3d3dy50enVybC5vcmcvem9uZWluZm8vQWZyaWNhL0FiaWRqYW4NClgtTElDLUxPQ0FUSU9OOkFmcmljYS9BYmlkamFuDQpYLVBST0xFUFRJQy1UWk5BTUU6TE1UDQpCRUdJTjpTVEFOREFSRA0KVFpOQU1FOkdNVA0KVFpPRkZTRVRGUk9NOi0wMDE2MDgNClRaT0ZGU0VUVE86KzAwMDANCkRUU1RBUlQ6MTkxMjAxMDFUMDAwMDAwDQpFTkQ6U1RBTkRBUkQNCkVORDpWVElNRVpPTkUNCkVORDpWQ0FMRU5EQVINCg=="
+          }
+        ],
+        "body": {
+          "content": "<html><head>\r\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"><style type=\"text/css\" style=\"display:none;\"> P {margin-top:0;margin-bottom:0;} </style></head><body dir=\"ltr\"><div class=\"elementToProof\" style=\"font-family: Aptos, Aptos_EmbeddedFont, Aptos_MSFontService, Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);\">I just realized the purpose of my life is to be a test case. Good to know.<br></div></body></html>",
+          "contentType": "html"
+        },
+        "bodyPreview": "I just realized the purpose of my life is to be a test case. Good to know.",
+        "conversationId": "AAQkAGJiZmE2NGU4LTQ4YjktNDI1Mi1iMWQzLTQ1MmMxODJkZmQyNAAQAFEnxDqYmbJEm8d2l3qfS6A=",
+        "conversationIndex": "AQHaWBYiUSfEOpiZskSbx3aXep9LoA==",
+        "flag": {
+          "flagStatus": "notFlagged"
+        },
+        "from": {
+          "emailAddress": {
+            "address": "JohannaL@10rqc2.onmicrosoft.com",
+            "name": "Johanna Lorenz"
+          }
+        },
+        "hasAttachments": true,
+        "importance": "normal",
+        "internetMessageId": "<SJ0PR04MB7294108E381BCCE5C207B6DEBC472@SJ0PR04MB7294.namprd04.prod.outlook.com>",
+        "isDeliveryReceiptRequested": false,
+        "isDraft": false,
+        "isRead": true,
+        "isReadReceiptRequested": false,
+        "receivedDateTime": "2024-02-05T09:33:12Z",
+        "sender": {
+          "emailAddress": {
+            "address": "JohannaL@10rqc2.onmicrosoft.com",
+            "name": "Johanna Lorenz"
+          }
+        },
+        "sentDateTime": "2024-02-05T09:33:11Z",
+        "subject": "Purpose of life",
+        "toRecipients": [
+          {
+            "emailAddress": {
+              "address": "PradeepG@10rqc2.onmicrosoft.com",
+              "name": "Pradeep Gupta"
+            }
+          }
+        ],
+        "webLink": "https://outlook.office365.com/owa/?AttachmentItemID=AAMkAGJiZmE2NGU4LTQ4YjktNDI1Mi1iMWQzLTQ1MmMxODJkZmQyNABGAAAAAABFdiK7oifWRb4ADuqgSRcnBwBBFDg0JJk7TY1fmsJrh7tNAAAAAAEJAABBFDg0JJk7TY1fmsJrh7tNAAFnbV%2FqAAABEgAQAEUyH0VS3HJBgHDlZdWZl02%3D&exvsurl=1&viewmodel=ItemAttachment"
+      }
+    },
+    {
+      "id": "AAMkAGJiZmE2NGU4LTQ4YjktNDI1Mi1iMWQzLTQ1MmMxODJkZmQyNABGAAAAAABFdiK7oifWRb4ADuqgSRcnBwBBFDg0JJk7TY1fmsJrh7tNAAAAAAEJAABBFDg0JJk7TY1fmsJrh7tNAAFnbV-qAAABEgAQAEUyH0VS3HJBgHDlZdWZl03=",
+      "@odata.type": "#microsoft.graph.itemAttachment",
+      "item@odata.navigationLink": "https://graph.microsoft.com/v1.0/users('7ceb8e03-bdc5-4509-a136-457526165ec0')/messages('')",
+      "item@odata.associationLink": "https://graph.microsoft.com/v1.0/users('7ceb8e03-bdc5-4509-a136-457526165ec0')/messages('')/$ref",
+      "isInline": false,
+      "lastModifiedDateTime": "2024-02-05T09:33:46Z",
+      "name": "Purpose of life part 3",
+      "size": 11840,
+      "item": {
+        "id": "",
+        "@odata.type": "#microsoft.graph.message",
+        "createdDateTime": "2024-02-05T09:33:24Z",
+        "lastModifiedDateTime": "2024-02-05T09:33:46Z",
+        "attachments": [
+          {
+            "id": "AAMkAGJiZmE2NGU4LTQ4YjktNDI1Mi1iMWQzLTQ1MmMxODJkZmQyNABGAAAAAABFdiK7oifWRb4ADuqgSRcnBwBBFDg0JJk7TY1fmsJrh7tNAAAAAAEJAABBFDg0JJk7TY1fmsJrh7tNAAFnbV-qAAACEgAQAEUyH0VS3HJBgHDlZdWZl0kSABAAjBhd4-oQaUS969pTkS-gzA==",
+            "@odata.type": "#microsoft.graph.fileAttachment",
+            "@odata.mediaContentType": "text/calendar",
+            "contentType": "text/calendar",
+            "isInline": false,
+            "lastModifiedDateTime": "2024-02-05T09:33:46Z",
+            "name": "Abidjan.ics",
+            "size": 573,
+            "contentBytes": "QkVHSU46VkNBTEVOREFSDQpQUk9ESUQ6LS8vdHp1cmwub3JnLy9OT05TR01MIE9sc29uIDIwMjNkLy9FTg0KVkVSU0lPTjoyLjANCkJFR0lOOlZUSU1FWk9ORQ0KVFpJRDpBZnJpY2EvQWJpZGphbg0KTEFTVC1NT0RJRklFRDoyMDIzMTIyMlQyMzMzNThaDQpUWlVSTDpodHRwczovL3d3dy50enVybC5vcmcvem9uZWluZm8vQWZyaWNhL0FiaWRqYW4NClgtTElDLUxPQ0FUSU9OOkFmcmljYS9BYmlkamFuDQpYLVBST0xFUFRJQy1UWk5BTUU6TE1UDQpCRUdJTjpTVEFOREFSRA0KVFpOQU1FOkdNVA0KVFpPRkZTRVRGUk9NOi0wMDE2MDgNClRaT0ZGU0VUVE86KzAwMDANCkRUU1RBUlQ6MTkxMjAxMDFUMDAwMDAwDQpFTkQ6U1RBTkRBUkQNCkVORDpWVElNRVpPTkUNCkVORDpWQ0FMRU5EQVINCg=="
+          }
+        ],
+        "body": {
+          "content": "<html><head>\r\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"><style type=\"text/css\" style=\"display:none;\"> P {margin-top:0;margin-bottom:0;} </style></head><body dir=\"ltr\"><div class=\"elementToProof\" style=\"font-family: Aptos, Aptos_EmbeddedFont, Aptos_MSFontService, Calibri, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);\">I just realized the purpose of my life is to be a test case. Good to know.<br></div></body></html>",
+          "contentType": "html"
+        },
+        "bodyPreview": "I just realized the purpose of my life is to be a test case. Good to know.",
+        "conversationId": "AAQkAGJiZmE2NGU4LTQ4YjktNDI1Mi1iMWQzLTQ1MmMxODJkZmQyNAAQAFEnxDqYmbJEm8d2l3qfS6A=",
+        "conversationIndex": "AQHaWBYiUSfEOpiZskSbx3aXep9LoA==",
+        "flag": {
+          "flagStatus": "notFlagged"
+        },
+        "from": {
+          "emailAddress": {
+            "address": "JohannaL@10rqc2.onmicrosoft.com",
+            "name": "Johanna Lorenz"
+          }
+        },
+        "hasAttachments": true,
+        "importance": "normal",
+        "internetMessageId": "<SJ0PR04MB7294108E381BCCE5C207B6DEBC472@SJ0PR04MB7294.namprd04.prod.outlook.com>",
+        "isDeliveryReceiptRequested": false,
+        "isDraft": false,
+        "isRead": true,
+        "isReadReceiptRequested": false,
+        "receivedDateTime": "2024-02-05T09:33:12Z",
+        "sender": {
+          "emailAddress": {
+            "address": "JohannaL@10rqc2.onmicrosoft.com",
+            "name": "Johanna Lorenz"
+          }
+        },
+        "sentDateTime": "2024-02-05T09:33:11Z",
+        "subject": "Purpose of life",
+        "toRecipients": [
+          {
+            "emailAddress": {
+              "address": "PradeepG@10rqc2.onmicrosoft.com",
+              "name": "Pradeep Gupta"
+            }
+          }
+        ],
+        "webLink": "https://outlook.office365.com/owa/?AttachmentItemID=AAMkAGJiZmE2NGU4LTQ4YjktNDI1Mi1iMWQzLTQ1MmMxODJkZmQyNABGAAAAAABFdiK7oifWRb4ADuqgSRcnBwBBFDg0JJk7TY1fmsJrh7tNAAAAAAEJAABBFDg0JJk7TY1fmsJrh7tNAAFnbV%2FqAAABEgAQAEUyH0VS3HJBgHDlZdWZl03%3D&exvsurl=1&viewmodel=ItemAttachment"
+      }
     }
   ],
   "bccRecipients": [],


### PR DESCRIPTION
<!-- PR description-->

Extending the earlier fix in https://github.com/alcionai/corso/pull/5199 to `itemAttachments`. Posts are not impacted here since they don't have attachment types like messages do.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
