### PR TITLE
Fix contains check for exchange nightly tests

### DIFF
--- a/src/cli/backup/exchange_e2e_test.go
+++ b/src/cli/backup/exchange_e2e_test.go
@@ -150,8 +150,8 @@ func runExchangeBackupCategoryTest(suite *BackupExchangeE2ESuite, category path.
 	result := recorder.String()
 	t.Log("backup results", result)
 
-	// as an offhand check: the result should contain the m365 user id
-	assert.Contains(t, result, suite.m365.User.ID)
+	// As an offhand check: the result should contain the m365 user's email.
+	assert.Contains(t, result, suite.m365.User.Provider.Name())
 }
 
 func (suite *BackupExchangeE2ESuite) TestExchangeBackupCmd_ServiceNotEnabled_email() {
@@ -183,8 +183,8 @@ func runExchangeBackupServiceNotEnabledTest(suite *BackupExchangeE2ESuite, categ
 	result := recorder.String()
 	t.Log("backup results", result)
 
-	// as an offhand check: the result should contain the m365 user id
-	assert.Contains(t, result, suite.m365.User.ID)
+	// As an offhand check: the result should contain the m365 user's email.
+	assert.Contains(t, result, suite.m365.User.Provider.Name())
 }
 
 func (suite *BackupExchangeE2ESuite) TestExchangeBackupCmd_userNotFound_email() {
@@ -282,8 +282,8 @@ func (suite *BackupExchangeE2ESuite) TestBackupCreateExchange_fromConfigFile() {
 	result := suite.dpnd.recorder.String()
 	t.Log("backup results", result)
 
-	// as an offhand check: the result should contain the m365 user id
-	assert.Contains(t, result, suite.m365.User.ID)
+	// As an offhand check: the result should contain the m365 user's email.
+	assert.Contains(t, result, suite.m365.User.Provider.Name())
 }
 
 // AWS flags


### PR DESCRIPTION
Data being checked drifted due to recent changes in the test helper
and possible CLI output changes

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
