### PR TITLE
introduce telemetry alerts

### DIFF
--- a/src/internal/operations/helpers.go
+++ b/src/internal/operations/helpers.go
@@ -75,6 +75,8 @@ func LogFaultErrors(ctx context.Context, fe *fault.Errors, prefix string) {
 	}
 
 	for i, alert := range fe.Alerts {
-		log.With("alert", alert).Infof("%s alert %d of %d: %s", pfxMsg, i+1, la, alert.Message)
+		if alert.Type == fault.AlertTypeUserVisible {
+			log.With("alert", alert).Infof("%s alert %d of %d: %s", pfxMsg, i+1, la, alert.Message)
+		}
 	}
 }

--- a/src/pkg/fault/alert_test.go
+++ b/src/pkg/fault/alert_test.go
@@ -48,6 +48,26 @@ func (suite *AlertUnitSuite) TestNewAlert() {
 	a := fault.NewAlert("message-to-show", "ns", "item_id", "item_name", addtl)
 
 	expect := fault.Alert{
+		Type: fault.AlertTypeUserVisible,
+		Item: fault.Item{
+			Namespace:  "ns",
+			ID:         "item_id",
+			Name:       "item_name",
+			Additional: addtl,
+		},
+		Message: "message-to-show",
+	}
+
+	assert.Equal(t, expect, *a)
+}
+
+func (suite *AlertUnitSuite) TestNewTelemetryAlert() {
+	t := suite.T()
+	addtl := map[string]any{"foo": "bar"}
+	a := fault.NewTelemetryAlert("message-to-show", "ns", "item_id", "item_name", addtl)
+
+	expect := fault.Alert{
+		Type: fault.AlertTypeInternalTelemetry,
 		Item: fault.Item{
 			Namespace:  "ns",
 			ID:         "item_id",


### PR DESCRIPTION
Introduces a new type of alert- internal_telemetry- which can be used separately from user-visible alerts to provide more precise contextual identification.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :robot: Supportability/Tests

#### Test Plan

- [x] :zap: Unit test
