### PR TITLE
Check for and retry 404s with no content

### DIFF
--- a/src/pkg/services/m365/api/graph/service.go
+++ b/src/pkg/services/m365/api/graph/service.go
@@ -442,6 +442,13 @@ func (aw *adapterWrap) Send(
 			// to limit the scope of this fix.
 			logger.Ctx(ictx).Debug("invalid request")
 			events.Inc(events.APICall, "invalidgetrequest")
+		} else if errors.Is(err, ErrNotFoundEmptyResp) {
+			// We've started seeing 404s with no content being returned for messages
+			// message attachments, and events. Attempting to manually fetch the items
+			// succeeds. Therefore we want to retry these to see if we can work around
+			// the problem.
+			logger.Ctx(ictx).Debug("404 with no content")
+			events.Inc(events.APICall, "notfoundnocontent")
 		} else {
 			// exit most errors without retry
 			break

--- a/src/pkg/services/m365/api/graph/service.go
+++ b/src/pkg/services/m365/api/graph/service.go
@@ -442,7 +442,7 @@ func (aw *adapterWrap) Send(
 			// to limit the scope of this fix.
 			logger.Ctx(ictx).Debug("invalid request")
 			events.Inc(events.APICall, "invalidgetrequest")
-		} else if errors.Is(err, ErrNotFoundEmptyResp) {
+		} else if requestInfo.Method.String() == http.MethodGet && errors.Is(err, ErrNotFoundEmptyResp) {
 			// We've started seeing 404s with no content being returned for messages
 			// message attachments, and events. Attempting to manually fetch the items
 			// succeeds. Therefore we want to retry these to see if we can work around


### PR DESCRIPTION
We've started seeing 404 errors with no content being returned. Check for these in the http wrapper we use and retry them.

While graph SDK returns an error for this sort of situation it's a very basic error since it normally expects to parse info out of the response body. Therefore it should be safe to inject our own error that we can check for.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
