### PR TITLE
Don't alert on old compressor

### DIFF
--- a/src/internal/kopia/conn.go
+++ b/src/internal/kopia/conn.go
@@ -59,6 +59,15 @@ const (
 	minEpochDurationUpperBound = 7 * 24 * time.Hour
 )
 
+// allValidCompressors is the set of compression algorithms either currently
+// being used or that were previously used. Use this during the config verify
+// command to avoid spurious errors. We can revisit whether we want to update
+// the config in those old repos at a later time.
+var allValidCompressors = map[compression.Name]struct{}{
+	compression.Name(defaultCompressor): {},
+	compression.Name("s2-default"):      {},
+}
+
 var (
 	ErrSettingDefaultConfig = clues.New("setting default repo config values")
 	ErrorRepoAlreadyExists  = clues.New("repo already exists")
@@ -768,7 +777,7 @@ func (w *conn) verifyDefaultPolicyConfigOptions(
 
 	ctx = clues.Add(ctx, "current_global_policy", globalPol.String())
 
-	if globalPol.CompressionPolicy.CompressorName != defaultCompressor {
+	if _, ok := allValidCompressors[globalPol.CompressionPolicy.CompressorName]; !ok {
 		errs.AddAlert(ctx, fault.NewAlert(
 			"unexpected compressor",
 			corsoWrapperAlertNamespace,

--- a/src/internal/kopia/conn_test.go
+++ b/src/internal/kopia/conn_test.go
@@ -892,6 +892,20 @@ func (suite *ConnRetentionIntegrationSuite) TestVerifyDefaultConfigOptions() {
 			expectAlerts: 1,
 		},
 		{
+			name: "OldValidCompressor",
+			setupRepo: func(ctx context.Context, t *testing.T, con *conn) {
+				pol, err := con.getGlobalPolicyOrEmpty(ctx)
+				require.NoError(t, err, clues.ToCore(err))
+
+				_, err = updateCompressionOnPolicy("s2-default", pol)
+				require.NoError(t, err, clues.ToCore(err))
+
+				err = con.writeGlobalPolicy(ctx, "test", pol)
+				require.NoError(t, err, clues.ToCore(err))
+			},
+			expectAlerts: 0,
+		},
+		{
 			name: "NonDefaultCompression",
 			setupRepo: func(ctx context.Context, t *testing.T, con *conn) {
 				pol, err := con.getGlobalPolicyOrEmpty(ctx)


### PR DESCRIPTION
When verifying the repo config, don't create an alert if the repo has the old s2-default compressor that we temporarily used.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [ ] :muscle: Manual
- [x] :zap: Unit test
- [ ] :green_heart: E2E
