### PR TITLE
add new control opt for skipping event 503s

### DIFF
--- a/src/internal/m365/collection/exchange/backup.go
+++ b/src/internal/m365/collection/exchange/backup.go
@@ -296,6 +296,7 @@ func populateCollections(
 				cl),
 			qp.ProtectedResource.ID(),
 			bh.itemHandler(),
+			bh,
 			addAndRem.Added,
 			addAndRem.Removed,
 			// TODO: produce a feature flag that allows selective

--- a/src/internal/m365/collection/exchange/backup_test.go
+++ b/src/internal/m365/collection/exchange/backup_test.go
@@ -89,10 +89,9 @@ func (bh mockBackupHandler) previewIncludeContainers() []string        { return 
 func (bh mockBackupHandler) previewExcludeContainers() []string        { return bh.previewExcludes }
 
 func (bh mockBackupHandler) CanSkipItemFailure(
-	error,
-	string,
-	string,
-	control.Options,
+	err error,
+	resourceID string,
+	opts control.Options,
 ) (fault.SkipCause, bool) {
 	return "", false
 }

--- a/src/internal/m365/collection/exchange/backup_test.go
+++ b/src/internal/m365/collection/exchange/backup_test.go
@@ -88,6 +88,15 @@ func (bh mockBackupHandler) folderGetter() containerGetter             { return 
 func (bh mockBackupHandler) previewIncludeContainers() []string        { return bh.previewIncludes }
 func (bh mockBackupHandler) previewExcludeContainers() []string        { return bh.previewExcludes }
 
+func (bh mockBackupHandler) CanSkipItemFailure(
+	error,
+	string,
+	string,
+	control.Options,
+) (fault.SkipCause, bool) {
+	return "", false
+}
+
 func (bh mockBackupHandler) NewContainerCache(
 	userID string,
 ) (string, graph.ContainerResolver) {

--- a/src/internal/m365/collection/exchange/collection.go
+++ b/src/internal/m365/collection/exchange/collection.go
@@ -19,6 +19,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/support"
 	"github.com/alcionai/corso/src/internal/observe"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/count"
 	"github.com/alcionai/corso/src/pkg/errs/core"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -68,21 +69,21 @@ func getItemAndInfo(
 	ctx context.Context,
 	getter itemGetterSerializer,
 	userID string,
-	id string,
+	itemID string,
 	useImmutableIDs bool,
 	parentPath string,
 ) ([]byte, *details.ExchangeInfo, error) {
 	item, info, err := getter.GetItem(
 		ctx,
 		userID,
-		id,
+		itemID,
 		fault.New(true)) // temporary way to force a failFast error
 	if err != nil {
 		return nil, nil, clues.WrapWC(ctx, err, "fetching item").
 			Label(fault.LabelForceNoBackupCreation)
 	}
 
-	itemData, err := getter.Serialize(ctx, item, userID, id)
+	itemData, err := getter.Serialize(ctx, item, userID, itemID)
 	if err != nil {
 		return nil, nil, clues.WrapWC(ctx, err, "serializing item")
 	}
@@ -108,6 +109,7 @@ func NewCollection(
 	bc data.BaseCollection,
 	user string,
 	items itemGetterSerializer,
+	canSkipFailChecker canSkipItemFailurer,
 	origAdded map[string]time.Time,
 	origRemoved []string,
 	validModTimes bool,
@@ -140,6 +142,7 @@ func NewCollection(
 			added:          added,
 			removed:        removed,
 			getter:         items,
+			skipChecker:    canSkipFailChecker,
 			statusUpdater:  statusUpdater,
 		}
 	}
@@ -150,6 +153,7 @@ func NewCollection(
 		added:          added,
 		removed:        removed,
 		getter:         items,
+		skipChecker:    canSkipFailChecker,
 		statusUpdater:  statusUpdater,
 		counter:        counter,
 	}
@@ -167,7 +171,8 @@ type prefetchCollection struct {
 	// removed is a list of item IDs that were deleted from, or moved out, of a container
 	removed map[string]struct{}
 
-	getter itemGetterSerializer
+	getter      itemGetterSerializer
+	skipChecker canSkipItemFailurer
 
 	statusUpdater support.StatusUpdater
 }
@@ -194,11 +199,12 @@ func (col *prefetchCollection) streamItems(
 		wg              sync.WaitGroup
 		progressMessage chan<- struct{}
 		user            = col.user
+		dataCategory    = col.Category().String()
 	)
 
 	ctx = clues.Add(
 		ctx,
-		"category", col.Category().String())
+		"category", dataCategory)
 
 	defer func() {
 		close(stream)
@@ -227,7 +233,7 @@ func (col *prefetchCollection) streamItems(
 	defer close(semaphoreCh)
 
 	// delete all removed items
-	for id := range col.removed {
+	for itemID := range col.removed {
 		semaphoreCh <- struct{}{}
 
 		wg.Add(1)
@@ -247,7 +253,7 @@ func (col *prefetchCollection) streamItems(
 			if progressMessage != nil {
 				progressMessage <- struct{}{}
 			}
-		}(id)
+		}(itemID)
 	}
 
 	var (
@@ -256,7 +262,7 @@ func (col *prefetchCollection) streamItems(
 	)
 
 	// add any new items
-	for id := range col.added {
+	for itemID := range col.added {
 		if el.Failure() != nil {
 			break
 		}
@@ -277,8 +283,24 @@ func (col *prefetchCollection) streamItems(
 				col.Opts().ToggleFeatures.ExchangeImmutableIDs,
 				parentPath)
 			if err != nil {
+				// pulled outside the switch due to multiple return values.
+				cause, canSkip := col.skipChecker.CanSkipItemFailure(
+					err,
+					user,
+					id,
+					col.Opts())
+
 				// Handle known error cases
 				switch {
+				case canSkip:
+					// this is a special case handler that allows the item to be skipped
+					// instead of producing an error.
+					errs.AddSkip(ctx, fault.FileSkip(
+						cause,
+						dataCategory,
+						id,
+						id,
+						nil))
 				case errors.Is(err, core.ErrNotFound):
 					// Don't report errors for deleted items as there's no way for us to
 					// back up data that is gone. Record it as a "success", since there's
@@ -349,7 +371,7 @@ func (col *prefetchCollection) streamItems(
 			if progressMessage != nil {
 				progressMessage <- struct{}{}
 			}
-		}(id)
+		}(itemID)
 	}
 
 	wg.Wait()
@@ -377,7 +399,8 @@ type lazyFetchCollection struct {
 	// removed is a list of item IDs that were deleted from, or moved out, of a container
 	removed map[string]struct{}
 
-	getter itemGetterSerializer
+	getter      itemGetterSerializer
+	skipChecker canSkipItemFailurer
 
 	statusUpdater support.StatusUpdater
 
@@ -404,8 +427,7 @@ func (col *lazyFetchCollection) streamItems(
 	var (
 		success         int64
 		progressMessage chan<- struct{}
-
-		user = col.user
+		user            = col.user
 	)
 
 	defer func() {
@@ -459,10 +481,13 @@ func (col *lazyFetchCollection) streamItems(
 			&lazyItemGetter{
 				userID:       user,
 				itemID:       id,
+				category:     col.Category(),
 				getter:       col.getter,
 				modTime:      modTime,
 				immutableIDs: col.Opts().ToggleFeatures.ExchangeImmutableIDs,
 				parentPath:   parentPath,
+				skipChecker:  col.skipChecker,
+				opts:         col.Opts(),
 			},
 			id,
 			modTime,
@@ -481,9 +506,12 @@ type lazyItemGetter struct {
 	getter       itemGetterSerializer
 	userID       string
 	itemID       string
+	category     path.CategoryType
 	parentPath   string
 	modTime      time.Time
 	immutableIDs bool
+	skipChecker  canSkipItemFailurer
+	opts         control.Options
 }
 
 func (lig *lazyItemGetter) GetData(
@@ -498,6 +526,24 @@ func (lig *lazyItemGetter) GetData(
 		lig.immutableIDs,
 		lig.parentPath)
 	if err != nil {
+		cause, canSkip := lig.skipChecker.CanSkipItemFailure(
+			err,
+			lig.userID,
+			lig.itemID,
+			lig.opts)
+		if canSkip {
+			errs.AddSkip(ctx, fault.FileSkip(
+				cause,
+				lig.category.String(),
+				lig.itemID,
+				lig.itemID,
+				nil))
+
+			return nil, nil, false, clues.
+				NewWC(ctx, "error marked as skippable by handler").
+				Label(graph.LabelsSkippable)
+		}
+
 		// If an item was deleted then return an empty file so we don't fail
 		// the backup and return a sentinel error when asked for ItemInfo so
 		// we don't display the item in the backup.

--- a/src/internal/m365/collection/exchange/collection.go
+++ b/src/internal/m365/collection/exchange/collection.go
@@ -526,22 +526,24 @@ func (lig *lazyItemGetter) GetData(
 		lig.immutableIDs,
 		lig.parentPath)
 	if err != nil {
-		cause, canSkip := lig.skipChecker.CanSkipItemFailure(
-			err,
-			lig.userID,
-			lig.itemID,
-			lig.opts)
-		if canSkip {
-			errs.AddSkip(ctx, fault.FileSkip(
-				cause,
-				lig.category.String(),
+		if lig.skipChecker != nil {
+			cause, canSkip := lig.skipChecker.CanSkipItemFailure(
+				err,
+				lig.userID,
 				lig.itemID,
-				lig.itemID,
-				nil))
+				lig.opts)
+			if canSkip {
+				errs.AddSkip(ctx, fault.FileSkip(
+					cause,
+					lig.category.String(),
+					lig.itemID,
+					lig.itemID,
+					nil))
 
-			return nil, nil, false, clues.
-				NewWC(ctx, "error marked as skippable by handler").
-				Label(graph.LabelsSkippable)
+				return nil, nil, false, clues.
+					NewWC(ctx, "error marked as skippable by handler").
+					Label(graph.LabelsSkippable)
+			}
 		}
 
 		// If an item was deleted then return an empty file so we don't fail

--- a/src/internal/m365/collection/exchange/collection_test.go
+++ b/src/internal/m365/collection/exchange/collection_test.go
@@ -1081,10 +1081,11 @@ func (suite *CollectionUnitSuite) TestLazyFetchCollection_Items_skipFailure() {
 					// data fetch is executed.
 					if slices.Contains(test.expectReads, item.ID()) {
 						r := item.ToReader()
-						defer r.Close()
 
 						_, err := io.ReadAll(r)
 						test.expectErr(t, err)
+
+						r.Close()
 					} else {
 						assert.Fail(t, "unexpected read on item %s", item.ID())
 					}

--- a/src/internal/m365/collection/exchange/contacts_backup.go
+++ b/src/internal/m365/collection/exchange/contacts_backup.go
@@ -1,6 +1,8 @@
 package exchange
 
 import (
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
@@ -51,4 +53,12 @@ func (h contactBackupHandler) NewContainerCache(
 		enumer: h.ac,
 		getter: h.ac,
 	}
+}
+
+func (h contactBackupHandler) CanSkipItemFailure(
+	err error,
+	resourceID, itemID string,
+	opts control.Options,
+) (fault.SkipCause, bool) {
+	return "", false
 }

--- a/src/internal/m365/collection/exchange/contacts_backup.go
+++ b/src/internal/m365/collection/exchange/contacts_backup.go
@@ -57,7 +57,7 @@ func (h contactBackupHandler) NewContainerCache(
 
 func (h contactBackupHandler) CanSkipItemFailure(
 	err error,
-	resourceID, itemID string,
+	resourceID string,
 	opts control.Options,
 ) (fault.SkipCause, bool) {
 	return "", false

--- a/src/internal/m365/collection/exchange/contacts_backup_test.go
+++ b/src/internal/m365/collection/exchange/contacts_backup_test.go
@@ -1,0 +1,87 @@
+package exchange
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+)
+
+type ContactsBackupHandlerUnitSuite struct {
+	tester.Suite
+}
+
+func TestContactsBackupHandlerUnitSuite(t *testing.T) {
+	suite.Run(t, &ContactsBackupHandlerUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *ContactsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
+	var (
+		resourceID = uuid.NewString()
+		itemID     = uuid.NewString()
+	)
+
+	table := []struct {
+		name        string
+		err         error
+		opts        control.Options
+		expect      assert.BoolAssertionFunc
+		expectCause fault.SkipCause
+	}{
+		{
+			name:   "no config",
+			err:    assert.AnError,
+			opts:   control.Options{},
+			expect: assert.False,
+		},
+		{
+			name: "false when map is empty",
+			err:  assert.AnError,
+			opts: control.Options{
+				SkipTheseEventsOnInstance503: map[string][]string{},
+			},
+			expect: assert.False,
+		},
+		{
+			name: "false on nil error",
+			err:  nil,
+			opts: control.Options{
+				SkipTheseEventsOnInstance503: map[string][]string{
+					resourceID: {"bar", itemID},
+				},
+			},
+			expect: assert.False,
+		},
+		{
+			name: "false even if item matches",
+			err:  assert.AnError,
+			opts: control.Options{
+				SkipTheseEventsOnInstance503: map[string][]string{
+					resourceID: {itemID},
+				},
+			},
+			expect: assert.False,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			h := newContactBackupHandler(api.Client{})
+			cause, result := h.CanSkipItemFailure(
+				test.err,
+				resourceID,
+				itemID,
+				test.opts)
+
+			test.expect(t, result)
+			assert.Equal(t, test.expectCause, cause)
+		})
+	}
+}

--- a/src/internal/m365/collection/exchange/contacts_backup_test.go
+++ b/src/internal/m365/collection/exchange/contacts_backup_test.go
@@ -22,10 +22,7 @@ func TestContactsBackupHandlerUnitSuite(t *testing.T) {
 }
 
 func (suite *ContactsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
-	var (
-		resourceID = uuid.NewString()
-		itemID     = uuid.NewString()
-	)
+	resourceID := uuid.NewString()
 
 	table := []struct {
 		name        string
@@ -44,7 +41,7 @@ func (suite *ContactsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 			name: "false when map is empty",
 			err:  assert.AnError,
 			opts: control.Options{
-				SkipTheseEventsOnInstance503: map[string][]string{},
+				SkipEventsOnInstance503ForResources: map[string]struct{}{},
 			},
 			expect: assert.False,
 		},
@@ -52,18 +49,18 @@ func (suite *ContactsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 			name: "false on nil error",
 			err:  nil,
 			opts: control.Options{
-				SkipTheseEventsOnInstance503: map[string][]string{
-					resourceID: {"bar", itemID},
+				SkipEventsOnInstance503ForResources: map[string]struct{}{
+					resourceID: {},
 				},
 			},
 			expect: assert.False,
 		},
 		{
-			name: "false even if item matches",
+			name: "false even if resource matches",
 			err:  assert.AnError,
 			opts: control.Options{
-				SkipTheseEventsOnInstance503: map[string][]string{
-					resourceID: {itemID},
+				SkipEventsOnInstance503ForResources: map[string]struct{}{
+					resourceID: {},
 				},
 			},
 			expect: assert.False,
@@ -77,7 +74,6 @@ func (suite *ContactsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 			cause, result := h.CanSkipItemFailure(
 				test.err,
 				resourceID,
-				itemID,
 				test.opts)
 
 			test.expect(t, result)

--- a/src/internal/m365/collection/exchange/events_backup.go
+++ b/src/internal/m365/collection/exchange/events_backup.go
@@ -3,7 +3,6 @@ package exchange
 import (
 	"errors"
 	"net/http"
-	"slices"
 
 	"github.com/alcionai/clues"
 
@@ -67,7 +66,7 @@ func (h eventBackupHandler) NewContainerCache(
 // built into the func.
 func (h eventBackupHandler) CanSkipItemFailure(
 	err error,
-	resourceID, itemID string,
+	resourceID string,
 	opts control.Options,
 ) (fault.SkipCause, bool) {
 	if err == nil {
@@ -84,11 +83,8 @@ func (h eventBackupHandler) CanSkipItemFailure(
 		return "", false
 	}
 
-	itemIDs, ok := opts.SkipTheseEventsOnInstance503[resourceID]
-	if !ok {
-		return "", false
-	}
+	_, ok := opts.SkipEventsOnInstance503ForResources[resourceID]
 
 	// strict equals required here.  ids are case sensitive.
-	return fault.SkipKnownEventInstance503s, slices.Contains(itemIDs, itemID)
+	return fault.SkipKnownEventInstance503s, ok
 }

--- a/src/internal/m365/collection/exchange/events_backup_test.go
+++ b/src/internal/m365/collection/exchange/events_backup_test.go
@@ -1,0 +1,125 @@
+package exchange
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/alcionai/clues"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
+)
+
+type EventsBackupHandlerUnitSuite struct {
+	tester.Suite
+}
+
+func TestEventsBackupHandlerUnitSuite(t *testing.T) {
+	suite.Run(t, &EventsBackupHandlerUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *EventsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
+	var (
+		resourceID = uuid.NewString()
+		itemID     = uuid.NewString()
+	)
+
+	table := []struct {
+		name        string
+		err         error
+		opts        control.Options
+		expect      assert.BoolAssertionFunc
+		expectCause fault.SkipCause
+	}{
+		{
+			name:   "no config",
+			err:    graph.ErrServiceUnavailableEmptyResp,
+			opts:   control.Options{},
+			expect: assert.False,
+		},
+		{
+			name: "empty skip on 503",
+			err:  graph.ErrServiceUnavailableEmptyResp,
+			opts: control.Options{
+				SkipTheseEventsOnInstance503: map[string][]string{},
+			},
+			expect: assert.False,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			opts: control.Options{
+				SkipTheseEventsOnInstance503: map[string][]string{
+					resourceID: {"bar", itemID},
+				},
+			},
+			expect: assert.False,
+		},
+		{
+			name: "non-matching resource",
+			err:  graph.ErrServiceUnavailableEmptyResp,
+			opts: control.Options{
+				SkipTheseEventsOnInstance503: map[string][]string{
+					"foo": {"bar", itemID},
+				},
+			},
+			expect: assert.False,
+		},
+		{
+			name: "non-matching item",
+			err:  graph.ErrServiceUnavailableEmptyResp,
+			opts: control.Options{
+				SkipTheseEventsOnInstance503: map[string][]string{
+					resourceID: {"bar", "baz"},
+				},
+			},
+			expect: assert.False,
+			// the item won't match, but we still return this as the cause
+			expectCause: fault.SkipKnownEventInstance503s,
+		},
+		{
+			name: "match on instance 503 empty resp",
+			err:  graph.ErrServiceUnavailableEmptyResp,
+			opts: control.Options{
+				SkipTheseEventsOnInstance503: map[string][]string{
+					resourceID: {"bar", itemID},
+				},
+			},
+			expect:      assert.True,
+			expectCause: fault.SkipKnownEventInstance503s,
+		},
+		{
+			name: "match on instance 503",
+			err: clues.New("arbitrary error").
+				Label(graph.LabelStatus(http.StatusServiceUnavailable)),
+			opts: control.Options{
+				SkipTheseEventsOnInstance503: map[string][]string{
+					resourceID: {"bar", itemID},
+				},
+			},
+			expect:      assert.True,
+			expectCause: fault.SkipKnownEventInstance503s,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			h := newEventBackupHandler(api.Client{})
+			cause, result := h.CanSkipItemFailure(
+				test.err,
+				resourceID,
+				itemID,
+				test.opts)
+
+			test.expect(t, result)
+			assert.Equal(t, test.expectCause, cause)
+		})
+	}
+}

--- a/src/internal/m365/collection/exchange/events_backup_test.go
+++ b/src/internal/m365/collection/exchange/events_backup_test.go
@@ -35,10 +35,11 @@ func (suite *EventsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 		expectCause fault.SkipCause
 	}{
 		{
-			name:   "no config",
-			err:    graph.ErrServiceUnavailableEmptyResp,
-			opts:   control.Options{},
-			expect: assert.False,
+			name:        "no config",
+			err:         graph.ErrServiceUnavailableEmptyResp,
+			opts:        control.Options{},
+			expect:      assert.False,
+			expectCause: fault.SkipKnownEventInstance503s,
 		},
 		{
 			name: "empty skip on 503",
@@ -46,7 +47,8 @@ func (suite *EventsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 			opts: control.Options{
 				SkipEventsOnInstance503ForResources: map[string]struct{}{},
 			},
-			expect: assert.False,
+			expect:      assert.False,
+			expectCause: fault.SkipKnownEventInstance503s,
 		},
 		{
 			name: "nil error",
@@ -66,7 +68,8 @@ func (suite *EventsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 					"foo": {},
 				},
 			},
-			expect: assert.False,
+			expect:      assert.False,
+			expectCause: fault.SkipKnownEventInstance503s,
 		},
 		{
 			name: "match on instance 503 empty resp",

--- a/src/internal/m365/collection/exchange/handlers.go
+++ b/src/internal/m365/collection/exchange/handlers.go
@@ -26,6 +26,8 @@ type backupHandler interface {
 	previewIncludeContainers() []string
 	previewExcludeContainers() []string
 	NewContainerCache(userID string) (string, graph.ContainerResolver)
+
+	canSkipItemFailurer
 }
 
 type addedAndRemovedItemGetter interface {
@@ -55,6 +57,14 @@ func BackupHandlers(ac api.Client) map[path.CategoryType]backupHandler {
 		path.EmailCategory:    newMailBackupHandler(ac),
 		path.EventsCategory:   newEventBackupHandler(ac),
 	}
+}
+
+type canSkipItemFailurer interface {
+	CanSkipItemFailure(
+		err error,
+		resourceID, itemID string,
+		opts control.Options,
+	) (fault.SkipCause, bool)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/internal/m365/collection/exchange/handlers.go
+++ b/src/internal/m365/collection/exchange/handlers.go
@@ -62,7 +62,7 @@ func BackupHandlers(ac api.Client) map[path.CategoryType]backupHandler {
 type canSkipItemFailurer interface {
 	CanSkipItemFailure(
 		err error,
-		resourceID, itemID string,
+		resourceID string,
 		opts control.Options,
 	) (fault.SkipCause, bool)
 }

--- a/src/internal/m365/collection/exchange/mail_backup.go
+++ b/src/internal/m365/collection/exchange/mail_backup.go
@@ -62,7 +62,7 @@ func (h mailBackupHandler) NewContainerCache(
 
 func (h mailBackupHandler) CanSkipItemFailure(
 	err error,
-	resourceID, itemID string,
+	resourceID string,
 	opts control.Options,
 ) (fault.SkipCause, bool) {
 	return "", false

--- a/src/internal/m365/collection/exchange/mail_backup.go
+++ b/src/internal/m365/collection/exchange/mail_backup.go
@@ -1,6 +1,8 @@
 package exchange
 
 import (
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
@@ -56,4 +58,12 @@ func (h mailBackupHandler) NewContainerCache(
 		enumer: h.ac,
 		getter: h.ac,
 	}
+}
+
+func (h mailBackupHandler) CanSkipItemFailure(
+	err error,
+	resourceID, itemID string,
+	opts control.Options,
+) (fault.SkipCause, bool) {
+	return "", false
 }

--- a/src/internal/m365/collection/exchange/mail_backup_test.go
+++ b/src/internal/m365/collection/exchange/mail_backup_test.go
@@ -1,0 +1,87 @@
+package exchange
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+)
+
+type MailBackupHandlerUnitSuite struct {
+	tester.Suite
+}
+
+func TestMailBackupHandlerUnitSuite(t *testing.T) {
+	suite.Run(t, &MailBackupHandlerUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *MailBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
+	var (
+		resourceID = uuid.NewString()
+		itemID     = uuid.NewString()
+	)
+
+	table := []struct {
+		name        string
+		err         error
+		opts        control.Options
+		expect      assert.BoolAssertionFunc
+		expectCause fault.SkipCause
+	}{
+		{
+			name:   "no config",
+			err:    assert.AnError,
+			opts:   control.Options{},
+			expect: assert.False,
+		},
+		{
+			name: "false when map is empty",
+			err:  assert.AnError,
+			opts: control.Options{
+				SkipTheseEventsOnInstance503: map[string][]string{},
+			},
+			expect: assert.False,
+		},
+		{
+			name: "false on nil error",
+			err:  nil,
+			opts: control.Options{
+				SkipTheseEventsOnInstance503: map[string][]string{
+					resourceID: {"bar", itemID},
+				},
+			},
+			expect: assert.False,
+		},
+		{
+			name: "false even if item matches",
+			err:  assert.AnError,
+			opts: control.Options{
+				SkipTheseEventsOnInstance503: map[string][]string{
+					resourceID: {itemID},
+				},
+			},
+			expect: assert.False,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			h := newMailBackupHandler(api.Client{})
+			cause, result := h.CanSkipItemFailure(
+				test.err,
+				resourceID,
+				itemID,
+				test.opts)
+
+			test.expect(t, result)
+			assert.Equal(t, test.expectCause, cause)
+		})
+	}
+}

--- a/src/internal/m365/collection/exchange/mail_backup_test.go
+++ b/src/internal/m365/collection/exchange/mail_backup_test.go
@@ -22,10 +22,7 @@ func TestMailBackupHandlerUnitSuite(t *testing.T) {
 }
 
 func (suite *MailBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
-	var (
-		resourceID = uuid.NewString()
-		itemID     = uuid.NewString()
-	)
+	resourceID := uuid.NewString()
 
 	table := []struct {
 		name        string
@@ -44,7 +41,7 @@ func (suite *MailBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 			name: "false when map is empty",
 			err:  assert.AnError,
 			opts: control.Options{
-				SkipTheseEventsOnInstance503: map[string][]string{},
+				SkipEventsOnInstance503ForResources: map[string]struct{}{},
 			},
 			expect: assert.False,
 		},
@@ -52,18 +49,18 @@ func (suite *MailBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 			name: "false on nil error",
 			err:  nil,
 			opts: control.Options{
-				SkipTheseEventsOnInstance503: map[string][]string{
-					resourceID: {"bar", itemID},
+				SkipEventsOnInstance503ForResources: map[string]struct{}{
+					resourceID: {},
 				},
 			},
 			expect: assert.False,
 		},
 		{
-			name: "false even if item matches",
+			name: "false even if resource matches",
 			err:  assert.AnError,
 			opts: control.Options{
-				SkipTheseEventsOnInstance503: map[string][]string{
-					resourceID: {itemID},
+				SkipEventsOnInstance503ForResources: map[string]struct{}{
+					resourceID: {},
 				},
 			},
 			expect: assert.False,
@@ -77,7 +74,6 @@ func (suite *MailBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 			cause, result := h.CanSkipItemFailure(
 				test.err,
 				resourceID,
-				itemID,
 				test.opts)
 
 			test.expect(t, result)

--- a/src/internal/m365/collection/exchange/mock/item.go
+++ b/src/internal/m365/collection/exchange/mock/item.go
@@ -6,9 +6,14 @@ import (
 	"github.com/microsoft/kiota-abstractions-go/serialization"
 
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
+
+// ---------------------------------------------------------------------------
+// get and serialize item mock
+// ---------------------------------------------------------------------------
 
 type ItemGetSerialize struct {
 	GetData        serialization.Parsable
@@ -43,4 +48,25 @@ func (m *ItemGetSerialize) Serialize(
 
 func DefaultItemGetSerialize() *ItemGetSerialize {
 	return &ItemGetSerialize{}
+}
+
+// ---------------------------------------------------------------------------
+// can skip item failure mock
+// ---------------------------------------------------------------------------
+
+type canSkipFailChecker struct {
+	canSkip bool
+}
+
+func (m canSkipFailChecker) CanSkipItemFailure(
+	error,
+	string,
+	string,
+	control.Options,
+) (fault.SkipCause, bool) {
+	return fault.SkipCause("testing"), m.canSkip
+}
+
+func NeverCanSkipFailChecker() *canSkipFailChecker {
+	return &canSkipFailChecker{}
 }

--- a/src/internal/m365/collection/exchange/mock/item.go
+++ b/src/internal/m365/collection/exchange/mock/item.go
@@ -59,10 +59,9 @@ type canSkipFailChecker struct {
 }
 
 func (m canSkipFailChecker) CanSkipItemFailure(
-	error,
-	string,
-	string,
-	control.Options,
+	err error,
+	resourceID string,
+	opts control.Options,
 ) (fault.SkipCause, bool) {
 	return fault.SkipCause("testing"), m.canSkip
 }

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -420,6 +420,9 @@ func (suite *BackupOpUnitSuite) TestNewBackupOperation_configuredOptionsMatchInp
 			MaxPages:             46,
 			Enabled:              true,
 		},
+		SkipTheseEventsOnInstance503: map[string][]string{
+			"resource": {"item1", "item2"},
+		},
 	}
 
 	t := suite.T()

--- a/src/internal/operations/backup_test.go
+++ b/src/internal/operations/backup_test.go
@@ -420,8 +420,8 @@ func (suite *BackupOpUnitSuite) TestNewBackupOperation_configuredOptionsMatchInp
 			MaxPages:             46,
 			Enabled:              true,
 		},
-		SkipTheseEventsOnInstance503: map[string][]string{
-			"resource": {"item1", "item2"},
+		SkipEventsOnInstance503ForResources: map[string]struct{}{
+			"resource": {},
 		},
 	}
 

--- a/src/pkg/control/options.go
+++ b/src/pkg/control/options.go
@@ -28,11 +28,10 @@ type Options struct {
 	// had already backed up.
 	PreviewLimits PreviewItemLimits `json:"previewItemLimits"`
 
-	// resourceID -> []calendarEventID
-	// specifying a resource:event tuple in this map allows that event to produce
+	// specifying a resource tuple in this map allows that resource to produce
 	// a Skip instead of a recoverable error in case of a failure due to 503 when
-	// retrieving the item data.
-	SkipTheseEventsOnInstance503 map[string][]string
+	// retrieving calendar event item data.
+	SkipEventsOnInstance503ForResources map[string]struct{}
 }
 
 // RateLimiter is the set of options applied to any external service facing rate

--- a/src/pkg/control/options.go
+++ b/src/pkg/control/options.go
@@ -28,7 +28,10 @@ type Options struct {
 	// had already backed up.
 	PreviewLimits PreviewItemLimits `json:"previewItemLimits"`
 
-	// resourceID -> []eventID
+	// resourceID -> []calendarEventID
+	// specifying a resource:event tuple in this map allows that event to produce
+	// a Skip instead of a recoverable error in case of a failure due to 503 when
+	// retrieving the item data.
 	SkipTheseEventsOnInstance503 map[string][]string
 }
 

--- a/src/pkg/control/options.go
+++ b/src/pkg/control/options.go
@@ -27,6 +27,9 @@ type Options struct {
 	// backup data until the set limits without paying attention to what the other
 	// had already backed up.
 	PreviewLimits PreviewItemLimits `json:"previewItemLimits"`
+
+	// resourceID -> []eventID
+	SkipTheseEventsOnInstance503 map[string][]string
 }
 
 // RateLimiter is the set of options applied to any external service facing rate

--- a/src/pkg/fault/skipped.go
+++ b/src/pkg/fault/skipped.go
@@ -12,34 +12,39 @@ type AddSkipper interface {
 	AddSkip(ctx context.Context, s *Skipped)
 }
 
-// skipCause identifies the well-known conditions to Skip an item.  It is
+// SkipCause identifies the well-known conditions to Skip an item.  It is
 // important that skip cause enumerations do not overlap with general error
 // handling.  Skips must be well known, well documented, and consistent.
 // Transient failures, undocumented or unknown conditions, and arbitrary
 // handling should never produce a skipped item. Those cases should get
 // handled as normal errors.
-type skipCause string
+type SkipCause string
 
 const (
 	// SkipMalware identifies a malware detection case.  Files that graph
 	// api identifies as malware cannot be downloaded or uploaded, and will
 	// permanently fail any attempts to backup or restore.
-	SkipMalware skipCause = "malware_detected"
+	SkipMalware SkipCause = "malware_detected"
 
 	// SkipOneNote identifies that a file was skipped because it
 	// was a OneNote file that remains inaccessible (503 server response)
 	// regardless of the number of retries.
 	//nolint:lll
 	// https://support.microsoft.com/en-us/office/restrictions-and-limitations-in-onedrive-and-sharepoint-64883a5d-228e-48f5-b3d2-eb39e07630fa#onenotenotebooks
-	SkipOneNote skipCause = "inaccessible_one_note_file"
+	SkipOneNote SkipCause = "inaccessible_one_note_file"
 
 	// SkipInvalidRecipients identifies that an email was skipped because Exchange
 	// believes it is not valid and fails any attempt to read it.
-	SkipInvalidRecipients skipCause = "invalid_recipients_email"
+	SkipInvalidRecipients SkipCause = "invalid_recipients_email"
 
 	// SkipCorruptData identifies that an email was skipped because graph reported
 	// that the email data was corrupt and failed all attempts to read it.
-	SkipCorruptData skipCause = "corrupt_data"
+	SkipCorruptData SkipCause = "corrupt_data"
+
+	// SkipKnownEventInstance503s identifies cases where we have a pre-configured list
+	// of event IDs where the events are known to fail with a 503 due to there being
+	// too many instances to retrieve from graph api.
+	SkipKnownEventInstance503s SkipCause = "known_event_instance_503"
 )
 
 var _ print.Printable = &Skipped{}
@@ -70,7 +75,7 @@ func (s *Skipped) String() string {
 }
 
 // HasCause compares the underlying cause against the parameter.
-func (s *Skipped) HasCause(c skipCause) bool {
+func (s *Skipped) HasCause(c SkipCause) bool {
 	if s == nil {
 		return false
 	}
@@ -105,27 +110,27 @@ func (s Skipped) Values(bool) []string {
 }
 
 // ContainerSkip produces a Container-kind Item for tracking skipped items.
-func ContainerSkip(cause skipCause, namespace, id, name string, addtl map[string]any) *Skipped {
+func ContainerSkip(cause SkipCause, namespace, id, name string, addtl map[string]any) *Skipped {
 	return itemSkip(ContainerType, cause, namespace, id, name, addtl)
 }
 
 // EmailSkip produces a Email-kind Item for tracking skipped items.
-func EmailSkip(cause skipCause, user, id string, addtl map[string]any) *Skipped {
+func EmailSkip(cause SkipCause, user, id string, addtl map[string]any) *Skipped {
 	return itemSkip(EmailType, cause, user, id, "", addtl)
 }
 
 // FileSkip produces a File-kind Item for tracking skipped items.
-func FileSkip(cause skipCause, namespace, id, name string, addtl map[string]any) *Skipped {
+func FileSkip(cause SkipCause, namespace, id, name string, addtl map[string]any) *Skipped {
 	return itemSkip(FileType, cause, namespace, id, name, addtl)
 }
 
 // OnwerSkip produces a ResourceOwner-kind Item for tracking skipped items.
-func OwnerSkip(cause skipCause, namespace, id, name string, addtl map[string]any) *Skipped {
+func OwnerSkip(cause SkipCause, namespace, id, name string, addtl map[string]any) *Skipped {
 	return itemSkip(ResourceOwnerType, cause, namespace, id, name, addtl)
 }
 
 // itemSkip produces a Item of the provided type for tracking skipped items.
-func itemSkip(t ItemType, cause skipCause, namespace, id, name string, addtl map[string]any) *Skipped {
+func itemSkip(t ItemType, cause SkipCause, namespace, id, name string, addtl map[string]any) *Skipped {
 	return &Skipped{
 		Item: Item{
 			Namespace:  namespace,

--- a/src/pkg/services/m365/api/graph/errors.go
+++ b/src/pkg/services/m365/api/graph/errors.go
@@ -156,7 +156,8 @@ func stackWithCoreErr(ctx context.Context, err error, traceDepth int) error {
 		labels = append(labels, core.LabelRootCauseUnknown)
 	}
 
-	stacked := stackWithDepth(ctx, err, 1+traceDepth)
+	stacked := stackWithDepth(ctx, err, 1+traceDepth).
+		Label(LabelStatus(ode.Resp.StatusCode))
 
 	// labeling here because we want the context from stackWithDepth first
 	for _, label := range labels {


### PR DESCRIPTION
adds a new control option for skipping certain event item 503 failures. Also adds a skip cause for that case.  And exports the skipCause value for future preparation.

Next PR will make use of these values.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
