### PR TITLE
add canSkipItemFailure handler func

### DIFF
--- a/src/internal/m365/collection/exchange/backup.go
+++ b/src/internal/m365/collection/exchange/backup.go
@@ -296,6 +296,7 @@ func populateCollections(
 				cl),
 			qp.ProtectedResource.ID(),
 			bh.itemHandler(),
+			bh,
 			addAndRem.Added,
 			addAndRem.Removed,
 			// TODO: produce a feature flag that allows selective

--- a/src/internal/m365/collection/exchange/backup_test.go
+++ b/src/internal/m365/collection/exchange/backup_test.go
@@ -88,6 +88,15 @@ func (bh mockBackupHandler) folderGetter() containerGetter             { return 
 func (bh mockBackupHandler) previewIncludeContainers() []string        { return bh.previewIncludes }
 func (bh mockBackupHandler) previewExcludeContainers() []string        { return bh.previewExcludes }
 
+func (bh mockBackupHandler) CanSkipItemFailure(
+	error,
+	string,
+	string,
+	control.Options,
+) (fault.SkipCause, bool) {
+	return "", false
+}
+
 func (bh mockBackupHandler) NewContainerCache(
 	userID string,
 ) (string, graph.ContainerResolver) {

--- a/src/internal/m365/collection/exchange/collection.go
+++ b/src/internal/m365/collection/exchange/collection.go
@@ -19,6 +19,7 @@ import (
 	"github.com/alcionai/corso/src/internal/m365/support"
 	"github.com/alcionai/corso/src/internal/observe"
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/count"
 	"github.com/alcionai/corso/src/pkg/errs/core"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -68,21 +69,21 @@ func getItemAndInfo(
 	ctx context.Context,
 	getter itemGetterSerializer,
 	userID string,
-	id string,
+	itemID string,
 	useImmutableIDs bool,
 	parentPath string,
 ) ([]byte, *details.ExchangeInfo, error) {
 	item, info, err := getter.GetItem(
 		ctx,
 		userID,
-		id,
+		itemID,
 		fault.New(true)) // temporary way to force a failFast error
 	if err != nil {
 		return nil, nil, clues.WrapWC(ctx, err, "fetching item").
 			Label(fault.LabelForceNoBackupCreation)
 	}
 
-	itemData, err := getter.Serialize(ctx, item, userID, id)
+	itemData, err := getter.Serialize(ctx, item, userID, itemID)
 	if err != nil {
 		return nil, nil, clues.WrapWC(ctx, err, "serializing item")
 	}
@@ -108,6 +109,7 @@ func NewCollection(
 	bc data.BaseCollection,
 	user string,
 	items itemGetterSerializer,
+	canSkipFailChecker canSkipItemFailurer,
 	origAdded map[string]time.Time,
 	origRemoved []string,
 	validModTimes bool,
@@ -140,6 +142,7 @@ func NewCollection(
 			added:          added,
 			removed:        removed,
 			getter:         items,
+			skipChecker:    canSkipFailChecker,
 			statusUpdater:  statusUpdater,
 		}
 	}
@@ -150,6 +153,7 @@ func NewCollection(
 		added:          added,
 		removed:        removed,
 		getter:         items,
+		skipChecker:    canSkipFailChecker,
 		statusUpdater:  statusUpdater,
 		counter:        counter,
 	}
@@ -167,7 +171,8 @@ type prefetchCollection struct {
 	// removed is a list of item IDs that were deleted from, or moved out, of a container
 	removed map[string]struct{}
 
-	getter itemGetterSerializer
+	getter      itemGetterSerializer
+	skipChecker canSkipItemFailurer
 
 	statusUpdater support.StatusUpdater
 }
@@ -194,11 +199,12 @@ func (col *prefetchCollection) streamItems(
 		wg              sync.WaitGroup
 		progressMessage chan<- struct{}
 		user            = col.user
+		dataCategory    = col.Category().String()
 	)
 
 	ctx = clues.Add(
 		ctx,
-		"category", col.Category().String())
+		"category", dataCategory)
 
 	defer func() {
 		close(stream)
@@ -227,7 +233,7 @@ func (col *prefetchCollection) streamItems(
 	defer close(semaphoreCh)
 
 	// delete all removed items
-	for id := range col.removed {
+	for itemID := range col.removed {
 		semaphoreCh <- struct{}{}
 
 		wg.Add(1)
@@ -247,7 +253,7 @@ func (col *prefetchCollection) streamItems(
 			if progressMessage != nil {
 				progressMessage <- struct{}{}
 			}
-		}(id)
+		}(itemID)
 	}
 
 	var (
@@ -256,7 +262,7 @@ func (col *prefetchCollection) streamItems(
 	)
 
 	// add any new items
-	for id := range col.added {
+	for itemID := range col.added {
 		if el.Failure() != nil {
 			break
 		}
@@ -277,8 +283,24 @@ func (col *prefetchCollection) streamItems(
 				col.Opts().ToggleFeatures.ExchangeImmutableIDs,
 				parentPath)
 			if err != nil {
+				// pulled outside the switch due to multiple return values.
+				cause, canSkip := col.skipChecker.CanSkipItemFailure(
+					err,
+					user,
+					id,
+					col.Opts())
+
 				// Handle known error cases
 				switch {
+				case canSkip:
+					// this is a special case handler that allows the item to be skipped
+					// instead of producing an error.
+					errs.AddSkip(ctx, fault.FileSkip(
+						cause,
+						dataCategory,
+						id,
+						id,
+						nil))
 				case errors.Is(err, core.ErrNotFound):
 					// Don't report errors for deleted items as there's no way for us to
 					// back up data that is gone. Record it as a "success", since there's
@@ -349,7 +371,7 @@ func (col *prefetchCollection) streamItems(
 			if progressMessage != nil {
 				progressMessage <- struct{}{}
 			}
-		}(id)
+		}(itemID)
 	}
 
 	wg.Wait()
@@ -377,7 +399,8 @@ type lazyFetchCollection struct {
 	// removed is a list of item IDs that were deleted from, or moved out, of a container
 	removed map[string]struct{}
 
-	getter itemGetterSerializer
+	getter      itemGetterSerializer
+	skipChecker canSkipItemFailurer
 
 	statusUpdater support.StatusUpdater
 
@@ -404,8 +427,7 @@ func (col *lazyFetchCollection) streamItems(
 	var (
 		success         int64
 		progressMessage chan<- struct{}
-
-		user = col.user
+		user            = col.user
 	)
 
 	defer func() {
@@ -459,10 +481,13 @@ func (col *lazyFetchCollection) streamItems(
 			&lazyItemGetter{
 				userID:       user,
 				itemID:       id,
+				category:     col.Category(),
 				getter:       col.getter,
 				modTime:      modTime,
 				immutableIDs: col.Opts().ToggleFeatures.ExchangeImmutableIDs,
 				parentPath:   parentPath,
+				skipChecker:  col.skipChecker,
+				opts:         col.Opts(),
 			},
 			id,
 			modTime,
@@ -481,9 +506,12 @@ type lazyItemGetter struct {
 	getter       itemGetterSerializer
 	userID       string
 	itemID       string
+	category     path.CategoryType
 	parentPath   string
 	modTime      time.Time
 	immutableIDs bool
+	skipChecker  canSkipItemFailurer
+	opts         control.Options
 }
 
 func (lig *lazyItemGetter) GetData(
@@ -498,6 +526,24 @@ func (lig *lazyItemGetter) GetData(
 		lig.immutableIDs,
 		lig.parentPath)
 	if err != nil {
+		cause, canSkip := lig.skipChecker.CanSkipItemFailure(
+			err,
+			lig.userID,
+			lig.itemID,
+			lig.opts)
+		if canSkip {
+			errs.AddSkip(ctx, fault.FileSkip(
+				cause,
+				lig.category.String(),
+				lig.itemID,
+				lig.itemID,
+				nil))
+
+			return nil, nil, false, clues.
+				NewWC(ctx, "error marked as skippable by handler").
+				Label(graph.LabelsSkippable)
+		}
+
 		// If an item was deleted then return an empty file so we don't fail
 		// the backup and return a sentinel error when asked for ItemInfo so
 		// we don't display the item in the backup.

--- a/src/internal/m365/collection/exchange/contacts_backup.go
+++ b/src/internal/m365/collection/exchange/contacts_backup.go
@@ -1,6 +1,8 @@
 package exchange
 
 import (
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
@@ -51,4 +53,12 @@ func (h contactBackupHandler) NewContainerCache(
 		enumer: h.ac,
 		getter: h.ac,
 	}
+}
+
+func (h contactBackupHandler) CanSkipItemFailure(
+	error,
+	string, string,
+	control.Options,
+) (fault.SkipCause, bool) {
+	return "", false
 }

--- a/src/internal/m365/collection/exchange/contacts_backup.go
+++ b/src/internal/m365/collection/exchange/contacts_backup.go
@@ -56,9 +56,9 @@ func (h contactBackupHandler) NewContainerCache(
 }
 
 func (h contactBackupHandler) CanSkipItemFailure(
-	error,
-	string, string,
-	control.Options,
+	err error,
+	resourceID, itemID string,
+	opts control.Options,
 ) (fault.SkipCause, bool) {
 	return "", false
 }

--- a/src/internal/m365/collection/exchange/contacts_backup_test.go
+++ b/src/internal/m365/collection/exchange/contacts_backup_test.go
@@ -41,15 +41,15 @@ func (suite *ContactsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 			expect: assert.False,
 		},
 		{
-			name: "empty skip on 503",
-			err:  nil,
+			name: "false when map is empty",
+			err:  assert.AnError,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{},
 			},
 			expect: assert.False,
 		},
 		{
-			name: "nil error",
+			name: "false on nil error",
 			err:  nil,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{
@@ -59,21 +59,11 @@ func (suite *ContactsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 			expect: assert.False,
 		},
 		{
-			name: "non-matching resource",
+			name: "false even if item matches",
 			err:  assert.AnError,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{
-					"foo": {"bar", itemID},
-				},
-			},
-			expect: assert.False,
-		},
-		{
-			name: "non-matching item",
-			err:  assert.AnError,
-			opts: control.Options{
-				SkipTheseEventsOnInstance503: map[string][]string{
-					resourceID: {"bar", "baz"},
+					resourceID: {itemID},
 				},
 			},
 			expect: assert.False,

--- a/src/internal/m365/collection/exchange/contacts_backup_test.go
+++ b/src/internal/m365/collection/exchange/contacts_backup_test.go
@@ -3,6 +3,7 @@ package exchange
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
@@ -21,11 +22,76 @@ func TestContactsBackupHandlerUnitSuite(t *testing.T) {
 }
 
 func (suite *ContactsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
-	t := suite.T()
+	var (
+		resourceID = uuid.NewString()
+		itemID     = uuid.NewString()
+	)
 
-	h := newContactBackupHandler(api.Client{})
-	cause, result := h.CanSkipItemFailure(nil, "", "", control.Options{})
+	table := []struct {
+		name        string
+		err         error
+		opts        control.Options
+		expect      assert.BoolAssertionFunc
+		expectCause fault.SkipCause
+	}{
+		{
+			name:   "no config",
+			err:    assert.AnError,
+			opts:   control.Options{},
+			expect: assert.False,
+		},
+		{
+			name: "empty skip on 503",
+			err:  nil,
+			opts: control.Options{
+				SkipTheseEventsOnInstance503: map[string][]string{},
+			},
+			expect: assert.False,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			opts: control.Options{
+				SkipTheseEventsOnInstance503: map[string][]string{
+					resourceID: {"bar", itemID},
+				},
+			},
+			expect: assert.False,
+		},
+		{
+			name: "non-matching resource",
+			err:  assert.AnError,
+			opts: control.Options{
+				SkipTheseEventsOnInstance503: map[string][]string{
+					"foo": {"bar", itemID},
+				},
+			},
+			expect: assert.False,
+		},
+		{
+			name: "non-matching item",
+			err:  assert.AnError,
+			opts: control.Options{
+				SkipTheseEventsOnInstance503: map[string][]string{
+					resourceID: {"bar", "baz"},
+				},
+			},
+			expect: assert.False,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
 
-	assert.False(t, result)
-	assert.Equal(t, fault.SkipCause(""), cause)
+			h := newContactBackupHandler(api.Client{})
+			cause, result := h.CanSkipItemFailure(
+				test.err,
+				resourceID,
+				itemID,
+				test.opts)
+
+			test.expect(t, result)
+			assert.Equal(t, test.expectCause, cause)
+		})
+	}
 }

--- a/src/internal/m365/collection/exchange/contacts_backup_test.go
+++ b/src/internal/m365/collection/exchange/contacts_backup_test.go
@@ -1,0 +1,31 @@
+package exchange
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+)
+
+type ContactsBackupHandlerUnitSuite struct {
+	tester.Suite
+}
+
+func TestContactsBackupHandlerUnitSuite(t *testing.T) {
+	suite.Run(t, &ContactsBackupHandlerUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *ContactsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
+	t := suite.T()
+
+	h := newContactBackupHandler(api.Client{})
+	cause, result := h.CanSkipItemFailure(nil, "", "", control.Options{})
+
+	assert.False(t, result)
+	assert.Equal(t, fault.SkipCause(""), cause)
+}

--- a/src/internal/m365/collection/exchange/events_backup.go
+++ b/src/internal/m365/collection/exchange/events_backup.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 
 	"github.com/alcionai/clues"
+
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"

--- a/src/internal/m365/collection/exchange/events_backup.go
+++ b/src/internal/m365/collection/exchange/events_backup.go
@@ -2,6 +2,7 @@ package exchange
 
 import (
 	"errors"
+	"net/http"
 	"slices"
 
 	"github.com/alcionai/clues"
@@ -60,13 +61,26 @@ func (h eventBackupHandler) NewContainerCache(
 	}
 }
 
+// todo: this could be further improved buy specifying the call source and matching that
+// with the expected error.  Might be necessary if we use this for more than one error.
+// But since we only call this in a single place at this time, that additional guard isn't
+// built into the func.
 func (h eventBackupHandler) CanSkipItemFailure(
 	err error,
 	resourceID, itemID string,
 	opts control.Options,
 ) (fault.SkipCause, bool) {
-	// yes, this is intentionally a todo.  I'll get back to it.
-	if !errors.Is(err, clues.New("todo fix me")) {
+	if err == nil {
+		return "", false
+	}
+
+	// this is a bit overly cautious.  we do know that we get 503s with empty response bodies
+	// due to fauilures when getting too many instances.  We don't know for sure if we get
+	// generic, well formed 503s.  But since we're working with specific resources and item
+	// IDs in the first place, that extra caution will help make sure an unexpected error dosn't
+	// slip through the cracks on us.
+	if !errors.Is(err, graph.ErrServiceUnavailableEmptyResp) &&
+		!clues.HasLabel(err, graph.LabelStatus(http.StatusServiceUnavailable)) {
 		return "", false
 	}
 

--- a/src/internal/m365/collection/exchange/events_backup.go
+++ b/src/internal/m365/collection/exchange/events_backup.go
@@ -1,6 +1,12 @@
 package exchange
 
 import (
+	"errors"
+	"slices"
+
+	"github.com/alcionai/clues"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
@@ -51,4 +57,23 @@ func (h eventBackupHandler) NewContainerCache(
 		enumer: h.ac,
 		getter: h.ac,
 	}
+}
+
+func (h eventBackupHandler) CanSkipItemFailure(
+	err error,
+	resourceID, itemID string,
+	opts control.Options,
+) (fault.SkipCause, bool) {
+	// yes, this is intentionally a todo.  I'll get back to it.
+	if !errors.Is(err, clues.New("todo fix me")) {
+		return "", false
+	}
+
+	itemIDs, ok := opts.SkipTheseEventsOnInstance503[resourceID]
+	if !ok {
+		return "", false
+	}
+
+	// strict equals required here.  ids are case sensitive.
+	return fault.SkipKnownEventInstance503s, slices.Contains(itemIDs, itemID)
 }

--- a/src/internal/m365/collection/exchange/events_backup_test.go
+++ b/src/internal/m365/collection/exchange/events_backup_test.go
@@ -1,0 +1,109 @@
+package exchange
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/clues"
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+)
+
+type EventsBackupHandlerUnitSuite struct {
+	tester.Suite
+}
+
+func TestEventsBackupHandlerUnitSuite(t *testing.T) {
+	suite.Run(t, &EventsBackupHandlerUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *EventsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
+	var (
+		resourceID = uuid.NewString()
+		itemID     = uuid.NewString()
+	)
+
+	table := []struct {
+		name        string
+		err         error
+		opts        control.Options
+		expect      assert.BoolAssertionFunc
+		expectCause fault.SkipCause
+	}{
+		{
+			name:   "no config",
+			err:    nil,
+			opts:   control.Options{},
+			expect: assert.False,
+		},
+		{
+			name: "empty skip on 503",
+			err:  nil,
+			opts: control.Options{
+				SkipTheseEventsOnInstance503: map[string][]string{},
+			},
+			expect: assert.False,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			opts: control.Options{
+				SkipTheseEventsOnInstance503: map[string][]string{
+					"foo": []string{"bar", "baz"},
+				},
+			},
+			expect: assert.False,
+		},
+		{
+			name: "non-matching resource",
+			err:  clues.New("fix me I'm wrong"),
+			opts: control.Options{
+				SkipTheseEventsOnInstance503: map[string][]string{
+					"foo": []string{"bar", "baz"},
+				},
+			},
+			expect: assert.False,
+		},
+		{
+			name: "non-matching item",
+			err:  clues.New("fix me I'm wrong"),
+			opts: control.Options{
+				SkipTheseEventsOnInstance503: map[string][]string{
+					resourceID: []string{"bar", "baz"},
+				},
+			},
+			expect: assert.False,
+		},
+		{
+			name: "match on instance 503",
+			err:  clues.New("fix me I'm wrong"),
+			opts: control.Options{
+				SkipTheseEventsOnInstance503: map[string][]string{
+					resourceID: []string{"bar", itemID},
+				},
+			},
+			expect:      assert.True,
+			expectCause: fault.SkipKnownEventInstance503s,
+		},
+	}
+	for _, test := range table {
+		suite.Run(test.name, func() {
+			t := suite.T()
+
+			h := newEventBackupHandler(api.Client{})
+			cause, result := h.CanSkipItemFailure(
+				test.err,
+				resourceID,
+				itemID,
+				test.opts)
+
+			test.expect(t, result)
+			assert.Equal(t, test.expectCause, cause)
+		})
+	}
+}

--- a/src/internal/m365/collection/exchange/events_backup_test.go
+++ b/src/internal/m365/collection/exchange/events_backup_test.go
@@ -1,6 +1,7 @@
 package exchange
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/alcionai/clues"
@@ -12,6 +13,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
+	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
 type EventsBackupHandlerUnitSuite struct {
@@ -37,13 +39,13 @@ func (suite *EventsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 	}{
 		{
 			name:   "no config",
-			err:    nil,
+			err:    graph.ErrServiceUnavailableEmptyResp,
 			opts:   control.Options{},
 			expect: assert.False,
 		},
 		{
 			name: "empty skip on 503",
-			err:  nil,
+			err:  graph.ErrServiceUnavailableEmptyResp,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{},
 			},
@@ -61,7 +63,7 @@ func (suite *EventsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 		},
 		{
 			name: "non-matching resource",
-			err:  clues.New("fix me I'm wrong"),
+			err:  graph.ErrServiceUnavailableEmptyResp,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{
 					"foo": {"bar", itemID},
@@ -71,17 +73,31 @@ func (suite *EventsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 		},
 		{
 			name: "non-matching item",
-			err:  clues.New("fix me I'm wrong"),
+			err:  graph.ErrServiceUnavailableEmptyResp,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{
 					resourceID: {"bar", "baz"},
 				},
 			},
 			expect: assert.False,
+			// the item won't match, but we still return this as the cause
+			expectCause: fault.SkipKnownEventInstance503s,
+		},
+		{
+			name: "match on instance 503 empty resp",
+			err:  graph.ErrServiceUnavailableEmptyResp,
+			opts: control.Options{
+				SkipTheseEventsOnInstance503: map[string][]string{
+					resourceID: {"bar", itemID},
+				},
+			},
+			expect:      assert.True,
+			expectCause: fault.SkipKnownEventInstance503s,
 		},
 		{
 			name: "match on instance 503",
-			err:  clues.New("fix me I'm wrong"),
+			err: clues.New("arbitrary error").
+				Label(graph.LabelStatus(http.StatusServiceUnavailable)),
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{
 					resourceID: {"bar", itemID},

--- a/src/internal/m365/collection/exchange/events_backup_test.go
+++ b/src/internal/m365/collection/exchange/events_backup_test.go
@@ -3,11 +3,11 @@ package exchange
 import (
 	"testing"
 
+	"github.com/alcionai/clues"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/alcionai/clues"
 	"github.com/alcionai/corso/src/internal/tester"
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
@@ -54,7 +54,7 @@ func (suite *EventsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 			err:  nil,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{
-					"foo": []string{"bar", "baz"},
+					resourceID: {"bar", itemID},
 				},
 			},
 			expect: assert.False,
@@ -64,7 +64,7 @@ func (suite *EventsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 			err:  clues.New("fix me I'm wrong"),
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{
-					"foo": []string{"bar", "baz"},
+					"foo": {"bar", itemID},
 				},
 			},
 			expect: assert.False,
@@ -74,7 +74,7 @@ func (suite *EventsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 			err:  clues.New("fix me I'm wrong"),
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{
-					resourceID: []string{"bar", "baz"},
+					resourceID: {"bar", "baz"},
 				},
 			},
 			expect: assert.False,
@@ -84,7 +84,7 @@ func (suite *EventsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 			err:  clues.New("fix me I'm wrong"),
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{
-					resourceID: []string{"bar", itemID},
+					resourceID: {"bar", itemID},
 				},
 			},
 			expect:      assert.True,

--- a/src/internal/m365/collection/exchange/handlers.go
+++ b/src/internal/m365/collection/exchange/handlers.go
@@ -26,6 +26,8 @@ type backupHandler interface {
 	previewIncludeContainers() []string
 	previewExcludeContainers() []string
 	NewContainerCache(userID string) (string, graph.ContainerResolver)
+
+	canSkipItemFailurer
 }
 
 type addedAndRemovedItemGetter interface {
@@ -55,6 +57,14 @@ func BackupHandlers(ac api.Client) map[path.CategoryType]backupHandler {
 		path.EmailCategory:    newMailBackupHandler(ac),
 		path.EventsCategory:   newEventBackupHandler(ac),
 	}
+}
+
+type canSkipItemFailurer interface {
+	CanSkipItemFailure(
+		err error,
+		resourceID, itemID string,
+		opts control.Options,
+	) (fault.SkipCause, bool)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/internal/m365/collection/exchange/mail_backup.go
+++ b/src/internal/m365/collection/exchange/mail_backup.go
@@ -1,6 +1,8 @@
 package exchange
 
 import (
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
@@ -56,4 +58,12 @@ func (h mailBackupHandler) NewContainerCache(
 		enumer: h.ac,
 		getter: h.ac,
 	}
+}
+
+func (h mailBackupHandler) CanSkipItemFailure(
+	error,
+	string, string,
+	control.Options,
+) (fault.SkipCause, bool) {
+	return "", false
 }

--- a/src/internal/m365/collection/exchange/mail_backup.go
+++ b/src/internal/m365/collection/exchange/mail_backup.go
@@ -61,9 +61,9 @@ func (h mailBackupHandler) NewContainerCache(
 }
 
 func (h mailBackupHandler) CanSkipItemFailure(
-	error,
-	string, string,
-	control.Options,
+	err error,
+	resourceID, itemID string,
+	opts control.Options,
 ) (fault.SkipCause, bool) {
 	return "", false
 }

--- a/src/internal/m365/collection/exchange/mail_backup_test.go
+++ b/src/internal/m365/collection/exchange/mail_backup_test.go
@@ -41,15 +41,15 @@ func (suite *MailBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 			expect: assert.False,
 		},
 		{
-			name: "empty skip on 503",
-			err:  nil,
+			name: "false when map is empty",
+			err:  assert.AnError,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{},
 			},
 			expect: assert.False,
 		},
 		{
-			name: "nil error",
+			name: "false on nil error",
 			err:  nil,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{
@@ -59,21 +59,11 @@ func (suite *MailBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 			expect: assert.False,
 		},
 		{
-			name: "non-matching resource",
+			name: "false even if item matches",
 			err:  assert.AnError,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{
-					"foo": {"bar", itemID},
-				},
-			},
-			expect: assert.False,
-		},
-		{
-			name: "non-matching item",
-			err:  assert.AnError,
-			opts: control.Options{
-				SkipTheseEventsOnInstance503: map[string][]string{
-					resourceID: {"bar", "baz"},
+					resourceID: {itemID},
 				},
 			},
 			expect: assert.False,

--- a/src/internal/m365/collection/exchange/mail_backup_test.go
+++ b/src/internal/m365/collection/exchange/mail_backup_test.go
@@ -1,0 +1,31 @@
+package exchange
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/alcionai/corso/src/internal/tester"
+	"github.com/alcionai/corso/src/pkg/control"
+	"github.com/alcionai/corso/src/pkg/fault"
+	"github.com/alcionai/corso/src/pkg/services/m365/api"
+)
+
+type MailBackupHandlerUnitSuite struct {
+	tester.Suite
+}
+
+func TestMailBackupHandlerUnitSuite(t *testing.T) {
+	suite.Run(t, &MailBackupHandlerUnitSuite{Suite: tester.NewUnitSuite(t)})
+}
+
+func (suite *MailBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
+	t := suite.T()
+
+	h := newMailBackupHandler(api.Client{})
+	cause, result := h.CanSkipItemFailure(nil, "", "", control.Options{})
+
+	assert.False(t, result)
+	assert.Equal(t, fault.SkipCause(""), cause)
+}

--- a/src/internal/m365/collection/exchange/mock/item.go
+++ b/src/internal/m365/collection/exchange/mock/item.go
@@ -6,9 +6,14 @@ import (
 	"github.com/microsoft/kiota-abstractions-go/serialization"
 
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
+
+// ---------------------------------------------------------------------------
+// get and serialize item mock
+// ---------------------------------------------------------------------------
 
 type ItemGetSerialize struct {
 	GetData        serialization.Parsable
@@ -43,4 +48,25 @@ func (m *ItemGetSerialize) Serialize(
 
 func DefaultItemGetSerialize() *ItemGetSerialize {
 	return &ItemGetSerialize{}
+}
+
+// ---------------------------------------------------------------------------
+// can skip item failure mock
+// ---------------------------------------------------------------------------
+
+type canSkipFailChecker struct {
+	canSkip bool
+}
+
+func (m canSkipFailChecker) CanSkipItemFailure(
+	error,
+	string,
+	string,
+	control.Options,
+) (fault.SkipCause, bool) {
+	return fault.SkipCause("testing"), m.canSkip
+}
+
+func NeverCanSkipFailChecker() *canSkipFailChecker {
+	return &canSkipFailChecker{}
 }

--- a/src/pkg/services/m365/api/graph/errors.go
+++ b/src/pkg/services/m365/api/graph/errors.go
@@ -156,7 +156,8 @@ func stackWithCoreErr(ctx context.Context, err error, traceDepth int) error {
 		labels = append(labels, core.LabelRootCauseUnknown)
 	}
 
-	stacked := stackWithDepth(ctx, err, 1+traceDepth)
+	stacked := stackWithDepth(ctx, err, 1+traceDepth).
+		Label(LabelStatus(ode.Resp.StatusCode))
 
 	// labeling here because we want the context from stackWithDepth first
 	for _, label := range labels {


### PR DESCRIPTION
adds a new func to the exchange backup handler: canskipItemFailure. This interface allows any handler to evaluate the provided error and runtime config to decide whether that error is able to be marked as skipped instead of return a recoverable error as per standard.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
