### PR TITLE
allow skipping error cases in exchange backup

### DIFF
--- a/src/internal/m365/collection/exchange/backup.go
+++ b/src/internal/m365/collection/exchange/backup.go
@@ -296,6 +296,7 @@ func populateCollections(
 				cl),
 			qp.ProtectedResource.ID(),
 			bh.itemHandler(),
+			bh,
 			addAndRem.Added,
 			addAndRem.Removed,
 			// TODO: produce a feature flag that allows selective

--- a/src/internal/m365/collection/exchange/collection.go
+++ b/src/internal/m365/collection/exchange/collection.go
@@ -288,7 +288,7 @@ func (col *prefetchCollection) streamItems(
 					err,
 					user,
 					id,
-					col.BaseCollection.Opts())
+					col.Opts())
 
 				// Handle known error cases
 				switch {
@@ -481,13 +481,13 @@ func (col *lazyFetchCollection) streamItems(
 			&lazyItemGetter{
 				userID:       user,
 				itemID:       id,
-				category:     col.FullPath().Category(),
+				category:     col.Category(),
 				getter:       col.getter,
 				modTime:      modTime,
 				immutableIDs: col.Opts().ToggleFeatures.ExchangeImmutableIDs,
 				parentPath:   parentPath,
 				skipChecker:  col.skipChecker,
-				opts:         col.BaseCollection.Opts(),
+				opts:         col.Opts(),
 			},
 			id,
 			modTime,

--- a/src/internal/m365/collection/exchange/collection_test.go
+++ b/src/internal/m365/collection/exchange/collection_test.go
@@ -601,6 +601,7 @@ func (suite *CollectionUnitSuite) TestLazyFetchCollection_Items_LazyFetch() {
 			expectItemCount: 3,
 			expectReads: []string{
 				"fisher",
+				"flannigan",
 				"fitzbog",
 			},
 		},
@@ -696,6 +697,8 @@ func (suite *CollectionUnitSuite) TestLazyFetchCollection_Items_LazyFetch() {
 						// collection initializer.
 						assert.NoError(t, err, clues.ToCore(err))
 						assert.Equal(t, modTime, info.Modified(), "ItemInfo mod time")
+					} else {
+						assert.Fail(t, "unexpected read on item %s", item.ID())
 					}
 				}
 
@@ -744,9 +747,10 @@ func (suite *CollectionUnitSuite) TestLazyFetchCollection_Items_skipFailure() {
 				"fitzbog":   start.Add(3 * time.Minute),
 			},
 			expectItemCount:    3,
-			expectSkippedCount: 2,
+			expectSkippedCount: 3,
 			expectReads: []string{
 				"fisher",
+				"flannigan",
 				"fitzbog",
 			},
 		},

--- a/src/internal/m365/collection/exchange/collection_test.go
+++ b/src/internal/m365/collection/exchange/collection_test.go
@@ -665,10 +665,10 @@ func (suite *CollectionUnitSuite) TestLazyFetchCollection_Items_LazyFetch() {
 
 				_, rok := test.removed[item.ID()]
 				if rok {
-					assert.True(t, item.Deleted(), "removals should be marked as deleted")
 					dimt, ok := item.(data.ItemModTime)
 					require.True(t, ok, "item implements data.ItemModTime")
 					assert.True(t, dimt.ModTime().After(start), "deleted items should set mod time to now()")
+					assert.True(t, item.Deleted(), "removals should be marked as deleted")
 				}
 
 				modTime, aok := test.added[item.ID()]
@@ -677,7 +677,6 @@ func (suite *CollectionUnitSuite) TestLazyFetchCollection_Items_LazyFetch() {
 					// initializer.
 					assert.Implements(t, (*data.ItemModTime)(nil), item)
 					assert.Equal(t, modTime, item.(data.ItemModTime).ModTime(), "item mod time")
-
 					assert.False(t, item.Deleted(), "additions should not be marked as deleted")
 
 					// Check if the test want's us to read the item's data so the lazy
@@ -818,10 +817,10 @@ func (suite *CollectionUnitSuite) TestLazyFetchCollection_Items_skipFailure() {
 
 				_, rok := test.removed[item.ID()]
 				if rok {
-					assert.True(t, item.Deleted(), "removals should be marked as deleted")
 					dimt, ok := item.(data.ItemModTime)
 					require.True(t, ok, "item implements data.ItemModTime")
 					assert.True(t, dimt.ModTime().After(start), "deleted items should set mod time to now()")
+					assert.True(t, item.Deleted(), "removals should be marked as deleted")
 				}
 
 				modTime, aok := test.added[item.ID()]
@@ -830,7 +829,6 @@ func (suite *CollectionUnitSuite) TestLazyFetchCollection_Items_skipFailure() {
 					// initializer.
 					assert.Implements(t, (*data.ItemModTime)(nil), item)
 					assert.Equal(t, modTime, item.(data.ItemModTime).ModTime(), "item mod time")
-
 					assert.False(t, item.Deleted(), "additions should not be marked as deleted")
 
 					// Check if the test want's us to read the item's data so the lazy
@@ -844,6 +842,8 @@ func (suite *CollectionUnitSuite) TestLazyFetchCollection_Items_skipFailure() {
 						assert.True(t, clues.HasLabel(err, graph.LabelsSkippable), clues.ToCore(err))
 
 						r.Close()
+					} else {
+						assert.Fail(t, "unexpected read on item %s", item.ID())
 					}
 				}
 

--- a/src/internal/m365/collection/exchange/contacts_backup_test.go
+++ b/src/internal/m365/collection/exchange/contacts_backup_test.go
@@ -41,15 +41,15 @@ func (suite *ContactsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 			expect: assert.False,
 		},
 		{
-			name: "empty skip on 503",
-			err:  nil,
+			name: "false when map is empty",
+			err:  assert.AnError,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{},
 			},
 			expect: assert.False,
 		},
 		{
-			name: "nil error",
+			name: "false on nil error",
 			err:  nil,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{
@@ -59,21 +59,11 @@ func (suite *ContactsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 			expect: assert.False,
 		},
 		{
-			name: "non-matching resource",
+			name: "false even if item matches",
 			err:  assert.AnError,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{
-					"foo": {"bar", itemID},
-				},
-			},
-			expect: assert.False,
-		},
-		{
-			name: "non-matching item",
-			err:  assert.AnError,
-			opts: control.Options{
-				SkipTheseEventsOnInstance503: map[string][]string{
-					resourceID: {"bar", "baz"},
+					resourceID: {itemID},
 				},
 			},
 			expect: assert.False,

--- a/src/internal/m365/collection/exchange/events_backup.go
+++ b/src/internal/m365/collection/exchange/events_backup.go
@@ -2,6 +2,7 @@ package exchange
 
 import (
 	"errors"
+	"net/http"
 	"slices"
 
 	"github.com/alcionai/clues"
@@ -60,13 +61,26 @@ func (h eventBackupHandler) NewContainerCache(
 	}
 }
 
+// todo: this could be further improved buy specifying the call source and matching that
+// with the expected error.  Might be necessary if we use this for more than one error.
+// But since we only call this in a single place at this time, that additional guard isn't
+// built into the func.
 func (h eventBackupHandler) CanSkipItemFailure(
 	err error,
 	resourceID, itemID string,
 	opts control.Options,
 ) (fault.SkipCause, bool) {
-	// yes, this is intentionally a todo.  I'll get back to it.
-	if !errors.Is(err, clues.New("todo fix me")) {
+	if err == nil {
+		return "", false
+	}
+
+	// this is a bit overly cautious.  we do know that we get 503s with empty response bodies
+	// due to fauilures when getting too many instances.  We don't know for sure if we get
+	// generic, well formed 503s.  But since we're working with specific resources and item
+	// IDs in the first place, that extra caution will help make sure an unexpected error dosn't
+	// slip through the cracks on us.
+	if !errors.Is(err, graph.ErrServiceUnavailableEmptyResp) &&
+		!clues.HasLabel(err, graph.LabelStatus(http.StatusServiceUnavailable)) {
 		return "", false
 	}
 

--- a/src/internal/m365/collection/exchange/events_backup_test.go
+++ b/src/internal/m365/collection/exchange/events_backup_test.go
@@ -1,6 +1,7 @@
 package exchange
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/alcionai/clues"
@@ -12,6 +13,7 @@ import (
 	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
+	"github.com/alcionai/corso/src/pkg/services/m365/api/graph"
 )
 
 type EventsBackupHandlerUnitSuite struct {
@@ -37,13 +39,13 @@ func (suite *EventsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 	}{
 		{
 			name:   "no config",
-			err:    nil,
+			err:    graph.ErrServiceUnavailableEmptyResp,
 			opts:   control.Options{},
 			expect: assert.False,
 		},
 		{
 			name: "empty skip on 503",
-			err:  nil,
+			err:  graph.ErrServiceUnavailableEmptyResp,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{},
 			},
@@ -61,7 +63,7 @@ func (suite *EventsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 		},
 		{
 			name: "non-matching resource",
-			err:  clues.New("fix me I'm wrong"),
+			err:  graph.ErrServiceUnavailableEmptyResp,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{
 					"foo": {"bar", itemID},
@@ -71,17 +73,31 @@ func (suite *EventsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 		},
 		{
 			name: "non-matching item",
-			err:  clues.New("fix me I'm wrong"),
+			err:  graph.ErrServiceUnavailableEmptyResp,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{
 					resourceID: {"bar", "baz"},
 				},
 			},
 			expect: assert.False,
+			// the item won't match, but we still return this as the cause
+			expectCause: fault.SkipKnownEventInstance503s,
+		},
+		{
+			name: "match on instance 503 empty resp",
+			err:  graph.ErrServiceUnavailableEmptyResp,
+			opts: control.Options{
+				SkipTheseEventsOnInstance503: map[string][]string{
+					resourceID: {"bar", itemID},
+				},
+			},
+			expect:      assert.True,
+			expectCause: fault.SkipKnownEventInstance503s,
 		},
 		{
 			name: "match on instance 503",
-			err:  clues.New("fix me I'm wrong"),
+			err: clues.New("arbitrary error").
+				Label(graph.LabelStatus(http.StatusServiceUnavailable)),
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{
 					resourceID: {"bar", itemID},

--- a/src/internal/m365/collection/exchange/mail_backup_test.go
+++ b/src/internal/m365/collection/exchange/mail_backup_test.go
@@ -41,15 +41,15 @@ func (suite *MailBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 			expect: assert.False,
 		},
 		{
-			name: "empty skip on 503",
-			err:  nil,
+			name: "false when map is empty",
+			err:  assert.AnError,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{},
 			},
 			expect: assert.False,
 		},
 		{
-			name: "nil error",
+			name: "false on nil error",
 			err:  nil,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{
@@ -59,21 +59,11 @@ func (suite *MailBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 			expect: assert.False,
 		},
 		{
-			name: "non-matching resource",
+			name: "false even if item matches",
 			err:  assert.AnError,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{
-					"foo": {"bar", itemID},
-				},
-			},
-			expect: assert.False,
-		},
-		{
-			name: "non-matching item",
-			err:  assert.AnError,
-			opts: control.Options{
-				SkipTheseEventsOnInstance503: map[string][]string{
-					resourceID: {"bar", "baz"},
+					resourceID: {itemID},
 				},
 			},
 			expect: assert.False,

--- a/src/internal/m365/collection/exchange/mock/item.go
+++ b/src/internal/m365/collection/exchange/mock/item.go
@@ -6,9 +6,14 @@ import (
 	"github.com/microsoft/kiota-abstractions-go/serialization"
 
 	"github.com/alcionai/corso/src/pkg/backup/details"
+	"github.com/alcionai/corso/src/pkg/control"
 	"github.com/alcionai/corso/src/pkg/fault"
 	"github.com/alcionai/corso/src/pkg/services/m365/api"
 )
+
+// ---------------------------------------------------------------------------
+// get and serialize item mock
+// ---------------------------------------------------------------------------
 
 type ItemGetSerialize struct {
 	GetData        serialization.Parsable
@@ -43,4 +48,29 @@ func (m *ItemGetSerialize) Serialize(
 
 func DefaultItemGetSerialize() *ItemGetSerialize {
 	return &ItemGetSerialize{}
+}
+
+// ---------------------------------------------------------------------------
+// can skip item failure mock
+// ---------------------------------------------------------------------------
+
+type canSkipFailChecker struct {
+	canSkip bool
+}
+
+func (m canSkipFailChecker) CanSkipItemFailure(
+	error,
+	string,
+	string,
+	control.Options,
+) (fault.SkipCause, bool) {
+	return fault.SkipCause("testing"), m.canSkip
+}
+
+func NeverCanSkipFailChecker() *canSkipFailChecker {
+	return &canSkipFailChecker{}
+}
+
+func AlwaysCanSkipFailChecker() *canSkipFailChecker {
+	return &canSkipFailChecker{true}
 }

--- a/src/internal/m365/collection/exchange/mock/item.go
+++ b/src/internal/m365/collection/exchange/mock/item.go
@@ -70,7 +70,3 @@ func (m canSkipFailChecker) CanSkipItemFailure(
 func NeverCanSkipFailChecker() *canSkipFailChecker {
 	return &canSkipFailChecker{}
 }
-
-func AlwaysCanSkipFailChecker() *canSkipFailChecker {
-	return &canSkipFailChecker{true}
-}

--- a/src/pkg/services/m365/api/graph/errors.go
+++ b/src/pkg/services/m365/api/graph/errors.go
@@ -156,7 +156,8 @@ func stackWithCoreErr(ctx context.Context, err error, traceDepth int) error {
 		labels = append(labels, core.LabelRootCauseUnknown)
 	}
 
-	stacked := stackWithDepth(ctx, err, 1+traceDepth)
+	stacked := stackWithDepth(ctx, err, 1+traceDepth).
+		Label(LabelStatus(ode.Resp.StatusCode))
 
 	// labeling here because we want the context from stackWithDepth first
 	for _, label := range labels {


### PR DESCRIPTION
utilize the previously introduced canSkipItemFailure interface to create skip records for items during backup.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :bug: Bugfix

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
