### PR TITLE
isolate the actual error from this query

### DIFF
--- a/src/internal/m365/collection/exchange/contacts_backup_test.go
+++ b/src/internal/m365/collection/exchange/contacts_backup_test.go
@@ -41,15 +41,15 @@ func (suite *ContactsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 			expect: assert.False,
 		},
 		{
-			name: "empty skip on 503",
-			err:  nil,
+			name: "false when map is empty",
+			err:  assert.AnError,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{},
 			},
 			expect: assert.False,
 		},
 		{
-			name: "nil error",
+			name: "false on nil error",
 			err:  nil,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{
@@ -59,21 +59,11 @@ func (suite *ContactsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 			expect: assert.False,
 		},
 		{
-			name: "non-matching resource",
+			name: "false even if item matches",
 			err:  assert.AnError,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{
-					"foo": {"bar", itemID},
-				},
-			},
-			expect: assert.False,
-		},
-		{
-			name: "non-matching item",
-			err:  assert.AnError,
-			opts: control.Options{
-				SkipTheseEventsOnInstance503: map[string][]string{
-					resourceID: {"bar", "baz"},
+					resourceID: {itemID},
 				},
 			},
 			expect: assert.False,

--- a/src/internal/m365/collection/exchange/events_backup.go
+++ b/src/internal/m365/collection/exchange/events_backup.go
@@ -74,6 +74,11 @@ func (h eventBackupHandler) CanSkipItemFailure(
 		return "", false
 	}
 
+	// this is a bit overly cautious.  we do know that we get 503s with empty response bodies
+	// due to fauilures when getting too many instances.  We don't know for sure if we get
+	// generic, well formed 503s.  But since we're working with specific resources and item
+	// IDs in the first place, that extra caution will help make sure an unexpected error dosn't
+	// slip through the cracks on us.
 	if !errors.Is(err, graph.ErrServiceUnavailableEmptyResp) &&
 		!clues.HasLabel(err, graph.LabelStatus(http.StatusServiceUnavailable)) {
 		return "", false

--- a/src/internal/m365/collection/exchange/events_backup_test.go
+++ b/src/internal/m365/collection/exchange/events_backup_test.go
@@ -39,13 +39,13 @@ func (suite *EventsBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 	}{
 		{
 			name:   "no config",
-			err:    nil,
+			err:    graph.ErrServiceUnavailableEmptyResp,
 			opts:   control.Options{},
 			expect: assert.False,
 		},
 		{
 			name: "empty skip on 503",
-			err:  nil,
+			err:  graph.ErrServiceUnavailableEmptyResp,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{},
 			},

--- a/src/internal/m365/collection/exchange/mail_backup_test.go
+++ b/src/internal/m365/collection/exchange/mail_backup_test.go
@@ -41,15 +41,15 @@ func (suite *MailBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 			expect: assert.False,
 		},
 		{
-			name: "empty skip on 503",
-			err:  nil,
+			name: "false when map is empty",
+			err:  assert.AnError,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{},
 			},
 			expect: assert.False,
 		},
 		{
-			name: "nil error",
+			name: "false on nil error",
 			err:  nil,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{
@@ -59,21 +59,11 @@ func (suite *MailBackupHandlerUnitSuite) TestHandler_CanSkipItemFailure() {
 			expect: assert.False,
 		},
 		{
-			name: "non-matching resource",
+			name: "false even if item matches",
 			err:  assert.AnError,
 			opts: control.Options{
 				SkipTheseEventsOnInstance503: map[string][]string{
-					"foo": {"bar", itemID},
-				},
-			},
-			expect: assert.False,
-		},
-		{
-			name: "non-matching item",
-			err:  assert.AnError,
-			opts: control.Options{
-				SkipTheseEventsOnInstance503: map[string][]string{
-					resourceID: {"bar", "baz"},
+					resourceID: {itemID},
 				},
 			},
 			expect: assert.False,

--- a/src/pkg/services/m365/api/graph/errors.go
+++ b/src/pkg/services/m365/api/graph/errors.go
@@ -156,7 +156,8 @@ func stackWithCoreErr(ctx context.Context, err error, traceDepth int) error {
 		labels = append(labels, core.LabelRootCauseUnknown)
 	}
 
-	stacked := stackWithDepth(ctx, err, 1+traceDepth)
+	stacked := stackWithDepth(ctx, err, 1+traceDepth).
+		Label(LabelStatus(ode.Resp.StatusCode))
 
 	// labeling here because we want the context from stackWithDepth first
 	for _, label := range labels {


### PR DESCRIPTION
I couldn't the exact error, so this is the best approximation i could come up with.

---

#### Does this PR need a docs update or release note?

- [x] :no_entry: No

#### Type of change

- [x] :sunflower: Feature

#### Test Plan

- [x] :zap: Unit test
- [x] :green_heart: E2E
