### PR TITLE
Log if the context expired during retry

### DIFF
--- a/src/pkg/services/m365/api/graph/middleware.go
+++ b/src/pkg/services/m365/api/graph/middleware.go
@@ -232,7 +232,11 @@ func (mw RetryMiddleware) retryRequest(
 	case <-ctx.Done():
 		// Don't retry if the context is marked as done, it will just error out
 		// when we attempt to send the retry anyway.
-		return resp, clues.StackWC(ctx, ctx.Err())
+		err := clues.StackWC(ctx, ctx.Err())
+
+		logger.CtxErr(ctx, err).Info("request context marked done")
+
+		return resp, err
 
 	case <-timer.C:
 	}


### PR DESCRIPTION
#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
