### PR TITLE
Normalize case when checking for user email

### DIFF
--- a/src/cli/backup/exchange_e2e_test.go
+++ b/src/cli/backup/exchange_e2e_test.go
@@ -151,7 +151,10 @@ func runExchangeBackupCategoryTest(suite *BackupExchangeE2ESuite, category path.
 	t.Log("backup results", result)
 
 	// As an offhand check: the result should contain the m365 user's email.
-	assert.Contains(t, result, suite.m365.User.Provider.Name())
+	assert.Contains(
+		t,
+		strings.ToLower(result),
+		strings.ToLower(suite.m365.User.Provider.Name()))
 }
 
 func (suite *BackupExchangeE2ESuite) TestExchangeBackupCmd_ServiceNotEnabled_email() {
@@ -184,7 +187,10 @@ func runExchangeBackupServiceNotEnabledTest(suite *BackupExchangeE2ESuite, categ
 	t.Log("backup results", result)
 
 	// As an offhand check: the result should contain the m365 user's email.
-	assert.Contains(t, result, suite.m365.User.Provider.Name())
+	assert.Contains(
+		t,
+		strings.ToLower(result),
+		strings.ToLower(suite.m365.User.Provider.Name()))
 }
 
 func (suite *BackupExchangeE2ESuite) TestExchangeBackupCmd_userNotFound_email() {
@@ -283,7 +289,10 @@ func (suite *BackupExchangeE2ESuite) TestBackupCreateExchange_fromConfigFile() {
 	t.Log("backup results", result)
 
 	// As an offhand check: the result should contain the m365 user's email.
-	assert.Contains(t, result, suite.m365.User.Provider.Name())
+	assert.Contains(
+		t,
+		strings.ToLower(result),
+		strings.ToLower(suite.m365.User.Provider.Name()))
 }
 
 // AWS flags


### PR DESCRIPTION
Reduce chance of test failures by normalizing the case prior to comparison. This should hopefully reduce spurious test failures.

---

#### Does this PR need a docs update or release note?

- [ ] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [x] :no_entry: No

#### Type of change

- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [x] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Test Plan

- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
