### PR TITLE
Fix ics high memory usage by disabling auto wrap text in html2text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Emails attached within other emails are now correctly exported
 - Gracefully handle email and post attachments without name when exporting to eml
 - Use correct timezone for event start and end times in Exchange exports (helps fix issues in relative recurrence patterns)
+- Fixed an issue causing exports dealing with calendar data to have high memory usage
 
 ## [v0.19.0] (beta) - 2024-02-06
 

--- a/src/internal/converters/ics/ics.go
+++ b/src/internal/converters/ics/ics.go
@@ -484,7 +484,14 @@ func updateEventProperties(ctx context.Context, event models.Eventable, iCalEven
 					desc := replacer.Replace(description)
 					iCalEvent.AddProperty("X-ALT-DESC", desc, ics.WithFmtType("text/html"))
 				} else {
-					stripped, err := html2text.FromString(description, html2text.Options{PrettyTables: true})
+					// Disable auto wrap, causes huge memory spikes
+					// https://github.com/jaytaylor/html2text/issues/48
+					prettyTablesOptions := html2text.NewPrettyTablesOptions()
+					prettyTablesOptions.AutoWrapText = false
+
+					stripped, err := html2text.FromString(
+						description,
+						html2text.Options{PrettyTables: true, PrettyTablesOptions: prettyTablesOptions})
 					if err != nil {
 						return clues.Wrap(err, "converting html to text").
 							With("description_length", len(description))


### PR DESCRIPTION
Related: jaytaylor/html2text#48<!-- PR description-->

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [x] :bug: Bugfix
- [ ] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [x] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
