### PR TITLE
Improve definition of a Backup

### DIFF
--- a/website/docs/setup/concepts.md
+++ b/website/docs/setup/concepts.md
@@ -23,5 +23,5 @@ application to connect to your *M365 tenant* and transfer data during backup and
 * **Repository** refers to the storage location where Corso securely and efficiently stores encrypted *backups* of your
 *M365 Services* data. See [Repositories](../repos) for more information.
 
-* **Backup** is a copy of your *M365 Services* data to be used for restores in case of deletion, loss, or corruption of the
+* **Backup** is a copy of a resource of your *M365 Services* data to be used for restores in case of deletion, loss, or corruption of the
 original data. Corso performs backups incrementally, and each backup only captures data that has changed between backup iterations.


### PR DESCRIPTION
<!-- PR description-->
After some building, I realized that a backup is a snapshot of a resource, not the whole m365 service. Initially, I assumed that 1 backup takes the whole service per tenant (https://discord.com/channels/1022200980487557130/1022200981376745474/1231385151376719892). This doc update should help clear the confusion more.

---

#### Does this PR need a docs update or release note?

- [x] :white_check_mark: Yes, it's included
- [ ] :clock1: Yes, but in a later PR
- [ ] :no_entry: No

#### Type of change

<!--- Please check the type of change your PR introduces: --->
- [ ] :sunflower: Feature
- [ ] :bug: Bugfix
- [x] :world_map: Documentation
- [ ] :robot: Supportability/Tests
- [ ] :computer: CI/Deployment
- [ ] :broom: Tech Debt/Cleanup

#### Issue(s)

<!-- Can reference multiple issues. Use one of the following "magic words" - "closes, fixes" to auto-close the Github issue. -->
* #<issue>

#### Test Plan

<!-- How will this be tested prior to merging.-->
- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
